### PR TITLE
fix(bedrock_mantle): add SigV4 fallback to chat completions auth

### DIFF
--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -31,7 +31,7 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
     Transformation config for Amazon Bedrock Mantle OpenAI-compatible API.
     """
 
-    def __init__(self, aws_signer: Optional[BaseAWSLLM] = None):
+    def __init__(self, aws_signer: BaseAWSLLM | None = None):
         super().__init__()
         self._aws_signer = aws_signer or BaseAWSLLM()
 

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -62,7 +62,7 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
             or get_secret_str("BEDROCK_MANTLE_API_BASE")
             or f"https://bedrock-mantle.{region}.api.aws/v1"
         )
-        dynamic_api_key = api_key or get_secret_str("BEDROCK_MANTLE_API_KEY")
+        dynamic_api_key = self._resolve_bearer_token(api_key)
         return api_base, dynamic_api_key
 
     def validate_environment(

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -4,8 +4,10 @@ Amazon Bedrock Mantle - OpenAI-compatible inference engine in Amazon Bedrock.
 API docs: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html
 
 Base URL: https://bedrock-mantle.{region}.api.aws/v1
-Auth: AWS Bedrock API key as Bearer token (set via BEDROCK_MANTLE_API_KEY env var)
-      or region-aware key via BEDROCK_MANTLE_{REGION}_API_KEY.
+Auth: Bearer token (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the
+      standard AWS_BEARER_TOKEN_BEDROCK) when present; otherwise AWS SigV4
+      (service "bedrock") over the standard credential chain. See
+      BedrockMantleAuthMixin in common_utils.
 """
 
 from typing import Iterator, AsyncIterator, Any, List, Optional, Tuple, Union
@@ -13,19 +15,25 @@ from typing import Iterator, AsyncIterator, Any, List, Optional, Tuple, Union
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.bedrock_mantle.common_utils import (
+    BEDROCK_MANTLE_DEFAULT_REGION,
+    BedrockMantleAuthMixin,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.router import GenericLiteLLMParams
 
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
 
-BEDROCK_MANTLE_DEFAULT_REGION = "us-east-1"
 
-
-class BedrockMantleChatConfig(OpenAILikeChatConfig):
+class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
     """
     Transformation config for Amazon Bedrock Mantle OpenAI-compatible API.
     """
+
+    def __init__(self, aws_signer: Optional[BaseAWSLLM] = None):
+        super().__init__()
+        self._aws_signer = aws_signer or BaseAWSLLM()
 
     @property
     def custom_llm_provider(self) -> Optional[str]:

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -73,14 +73,19 @@ class BedrockMantleAuthMixin:
         bearer = self._resolve_bearer_token(api_key)
         if not bearer:
             # SigV4 path. Pin the credential-scope region to the region of the actual
-            # signing URL (api_base is already region-resolved) so the SigV4 scope and
-            # the URL host can never disagree. Also drop any caller Authorization so
-            # _sign_request's restore-original-Authorization step cannot override the
-            # SigV4 header.
+            # signing URL so the SigV4 scope and the URL host can never disagree, even
+            # when a stale api_base and aws_region_name point at different regions.
+            # Fall back to _resolve_region only for custom proxy hosts that do not
+            # match the standard Mantle URL pattern. Also drop any caller Authorization
+            # so _sign_request's restore-original-Authorization step cannot override
+            # the SigV4 header.
+            host_match = MANTLE_HOST_RE.match(api_base.rstrip("/"))
             optional_params = {
                 **optional_params,
-                "aws_region_name": self._resolve_region(
-                    {**optional_params, "api_base": api_base}
+                "aws_region_name": (
+                    host_match.group(1)
+                    if host_match
+                    else self._resolve_region({**optional_params, "api_base": api_base})
                 ),
             }
             headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -10,7 +10,7 @@ through BedrockMantleAuthMixin so the two paths can never drift apart.
 """
 
 import re
-from typing import Optional, Tuple
+from typing import Tuple
 
 from botocore.exceptions import (
     CredentialRetrievalError,
@@ -34,7 +34,7 @@ class BedrockMantleAuthMixin:
     _aws_signer: BaseAWSLLM
 
     @staticmethod
-    def _resolve_bearer_token(api_key: Optional[str]) -> Optional[str]:
+    def _resolve_bearer_token(api_key: str | None) -> str | None:
         return (
             api_key
             or get_secret_str("BEDROCK_MANTLE_API_KEY")
@@ -65,11 +65,11 @@ class BedrockMantleAuthMixin:
         optional_params: dict,
         request_data: dict,
         api_base: str,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None,
-        stream: Optional[bool] = None,
-        fake_stream: Optional[bool] = None,
-    ) -> Tuple[dict, Optional[bytes]]:
+        api_key: str | None = None,
+        model: str | None = None,
+        stream: bool | None = None,
+        fake_stream: bool | None = None,
+    ) -> Tuple[dict, bytes | None]:
         bearer = self._resolve_bearer_token(api_key)
         if not bearer:
             # SigV4 path. Pin the credential-scope region to the region of the actual

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -1,0 +1,110 @@
+"""
+Shared auth and region resolution for the Amazon Bedrock Mantle backends.
+
+Mantle authenticates with a Bearer token when one is available
+(litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the standard
+AWS_BEARER_TOKEN_BEDROCK); otherwise it falls back to AWS SigV4 (service
+"bedrock") over the standard credential chain (IAM role / access key / profile /
+web identity). The Chat Completions and Responses backends share this behaviour
+through BedrockMantleAuthMixin so the two paths can never drift apart.
+"""
+
+import re
+from typing import Optional, Tuple
+
+from botocore.exceptions import (
+    CredentialRetrievalError,
+    NoCredentialsError,
+    PartialCredentialsError,
+    ProfileNotFound,
+)
+
+from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.secret_managers.main import get_secret_str
+
+BEDROCK_MANTLE_DEFAULT_REGION = "us-east-1"
+
+# Standard Mantle host: https://bedrock-mantle.<region>.api.aws (group 1 = region).
+MANTLE_HOST_RE = re.compile(
+    r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE
+)
+
+
+class BedrockMantleAuthMixin:
+    _aws_signer: BaseAWSLLM
+
+    @staticmethod
+    def _resolve_bearer_token(api_key: Optional[str]) -> Optional[str]:
+        return (
+            api_key
+            or get_secret_str("BEDROCK_MANTLE_API_KEY")
+            or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
+        )
+
+    @staticmethod
+    def _resolve_region(params: dict) -> str:
+        region = params.get("aws_region_name")
+        if region:
+            BaseAWSLLM._validate_aws_region_name(region)
+            return region
+        base = params.get("api_base") or get_secret_str("BEDROCK_MANTLE_API_BASE")
+        if base:
+            match = MANTLE_HOST_RE.match(base.rstrip("/"))
+            if match:
+                return match.group(1)
+        return (
+            get_secret_str("BEDROCK_MANTLE_REGION")
+            or get_secret_str("AWS_REGION_NAME")
+            or get_secret_str("AWS_REGION")
+            or BEDROCK_MANTLE_DEFAULT_REGION
+        )
+
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> Tuple[dict, Optional[bytes]]:
+        bearer = self._resolve_bearer_token(api_key)
+        if not bearer:
+            # SigV4 path. Pin the credential-scope region to the region of the actual
+            # signing URL (api_base is already region-resolved) so the SigV4 scope and
+            # the URL host can never disagree. Also drop any caller Authorization so
+            # _sign_request's restore-original-Authorization step cannot override the
+            # SigV4 header.
+            optional_params = {
+                **optional_params,
+                "aws_region_name": self._resolve_region(
+                    {**optional_params, "api_base": api_base}
+                ),
+            }
+            headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
+        try:
+            return self._aws_signer._sign_request(
+                service_name="bedrock",
+                headers=headers,
+                optional_params=optional_params,
+                request_data=request_data,
+                api_base=api_base,
+                api_key=bearer,
+                model=model,
+                stream=stream,
+                fake_stream=fake_stream,
+            )
+        except (
+            NoCredentialsError,
+            PartialCredentialsError,
+            ProfileNotFound,
+            CredentialRetrievalError,
+        ) as e:
+            raise ValueError(
+                "Bedrock Mantle auth failed: no Bearer token and no usable AWS "
+                "credentials. Set BEDROCK_MANTLE_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) "
+                "or pass api_key for Bearer auth, or provide AWS credentials "
+                "(IAM role / access key / profile / web identity) for SigV4."
+            ) from e

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -87,13 +87,9 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
         self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]
     ) -> dict:
         litellm_params = litellm_params or GenericLiteLLMParams()
-        api_key = (
-            litellm_params.api_key
-            or get_secret_str("BEDROCK_MANTLE_API_KEY")
-            or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
-        )
-        if api_key:
-            headers["Authorization"] = f"Bearer {api_key}"
+        bearer = self._resolve_bearer_token(litellm_params.api_key)
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
         if litellm_params.aws_bedrock_project_id:
             headers["OpenAI-Project"] = litellm_params.aws_bedrock_project_id
         return headers

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -15,25 +15,19 @@ role / access key / profile / web identity), signed via the shared
 BaseAWSLLM._sign_request after the request body is finalized.
 """
 
-import re
-from typing import Any, Dict, List, Optional, Tuple
-
-from botocore.exceptions import (
-    CredentialRetrievalError,
-    NoCredentialsError,
-    PartialCredentialsError,
-    ProfileNotFound,
-)
+from typing import Any, Dict, List, Optional
 
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.llms.bedrock_mantle.common_utils import (
+    MANTLE_HOST_RE,
+    BedrockMantleAuthMixin,
+)
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import ResponsesAPIOptionalRequestParams
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
-
-BEDROCK_MANTLE_DEFAULT_REGION = "us-east-1"
 
 # Checked longest/most-specific first so a full endpoint URL collapses to host
 # in one pass and the appended path never doubles.
@@ -45,18 +39,13 @@ _BASE_SUFFIXES_TO_STRIP = (
     "/v1",
 )
 
-# Standard Mantle host: https://bedrock-mantle.<region>.api.aws (group 1 = region).
-_MANTLE_HOST_RE = re.compile(
-    r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE
-)
-
 # Per Bedrock Mantle Responses API validation errors.
 _BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES = frozenset(
     {"function", "mcp", "custom", "namespace", "tool_search"}
 )
 
 
-class BedrockMantleResponsesAPIConfig(OpenAIResponsesAPIConfig):
+class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPIConfig):
     def __init__(
         self,
         aws_signer: Optional[BaseAWSLLM] = None,
@@ -69,24 +58,6 @@ class BedrockMantleResponsesAPIConfig(OpenAIResponsesAPIConfig):
     @property
     def custom_llm_provider(self) -> LlmProviders:
         return LlmProviders.BEDROCK_MANTLE
-
-    @staticmethod
-    def _resolve_region(params: dict) -> str:
-        region = params.get("aws_region_name")
-        if region:
-            BaseAWSLLM._validate_aws_region_name(region)
-            return region
-        base = params.get("api_base") or get_secret_str("BEDROCK_MANTLE_API_BASE")
-        if base:
-            match = _MANTLE_HOST_RE.match(base.rstrip("/"))
-            if match:
-                return match.group(1)
-        return (
-            get_secret_str("BEDROCK_MANTLE_REGION")
-            or get_secret_str("AWS_REGION_NAME")
-            or get_secret_str("AWS_REGION")
-            or BEDROCK_MANTLE_DEFAULT_REGION
-        )
 
     def get_complete_url(
         self,
@@ -107,7 +78,7 @@ class BedrockMantleResponsesAPIConfig(OpenAIResponsesAPIConfig):
         # For the standard Mantle host (including the default-region base that
         # responses/main.py auto-injects into litellm_params.api_base), pin to the
         # single resolved region so aws_region_name wins; preserve custom proxy hosts.
-        if _MANTLE_HOST_RE.match(base):
+        if MANTLE_HOST_RE.match(base):
             base = f"https://bedrock-mantle.{region}.api.aws"
         path = "/openai/v1/responses" if self.use_openai_path else "/v1/responses"
         return f"{base}{path}"
@@ -182,58 +153,3 @@ class BedrockMantleResponsesAPIConfig(OpenAIResponsesAPIConfig):
             params.pop("tools", None)
 
         return params
-
-    def sign_request(
-        self,
-        headers: dict,
-        optional_params: dict,
-        request_data: dict,
-        api_base: str,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None,
-        stream: Optional[bool] = None,
-        fake_stream: Optional[bool] = None,
-    ) -> Tuple[dict, Optional[bytes]]:
-        bearer = (
-            api_key
-            or get_secret_str("BEDROCK_MANTLE_API_KEY")
-            or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
-        )
-        if not bearer:
-            # SigV4 path. Pin the credential-scope region to the region of the actual
-            # signing URL (api_base, already region-resolved by get_complete_url) so the
-            # SigV4 scope and the URL host can never disagree. Resolve from api_base first,
-            # then fall back to the regular precedence. Also drop any caller Authorization
-            # so _sign_request's restore-original-Authorization step cannot override the
-            # SigV4 header.
-            optional_params = {
-                **optional_params,
-                "aws_region_name": self._resolve_region(
-                    {**optional_params, "api_base": api_base}
-                ),
-            }
-            headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
-        try:
-            return self._aws_signer._sign_request(
-                service_name="bedrock",
-                headers=headers,
-                optional_params=optional_params,
-                request_data=request_data,
-                api_base=api_base,
-                api_key=bearer,
-                model=model,
-                stream=stream,
-                fake_stream=fake_stream,
-            )
-        except (
-            NoCredentialsError,
-            PartialCredentialsError,
-            ProfileNotFound,
-            CredentialRetrievalError,
-        ) as e:
-            raise ValueError(
-                "Bedrock Mantle auth failed: no Bearer token and no usable AWS "
-                "credentials. Set BEDROCK_MANTLE_API_KEY (or AWS_BEARER_TOKEN_BEDROCK) "
-                "or pass api_key for Bearer auth, or provide AWS credentials "
-                "(IAM role / access key / profile / web identity) for SigV4."
-            ) from e

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -171,6 +171,13 @@ class TestBedrockMantleConfig:
         _, api_key = cfg._get_openai_compatible_provider_info(None, "explicit-key")
         assert api_key == "explicit-key"
 
+    def test_api_key_from_aws_bearer_token_bedrock_env(self, monkeypatch):
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "standard-bearer")
+        cfg = BedrockMantleChatConfig()
+        _, api_key = cfg._get_openai_compatible_provider_info(None, None)
+        assert api_key == "standard-bearer"
+
     def test_get_supported_openai_params(self):
         cfg = BedrockMantleChatConfig()
         params = cfg.get_supported_openai_params("openai.gpt-oss-120b")

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -318,6 +318,42 @@ class TestBedrockMantleChatAuth:
 
         assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
 
+    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
+        self, monkeypatch
+    ):
+        # If a caller (e.g. proxy) passes a stale api_base in one region and an
+        # aws_region_name in a different region, the SigV4 credential scope must
+        # match the URL host or Bedrock rejects the request with 401. Without the
+        # fix, sign_request would prefer aws_region_name and sign for us-west-2
+        # while POSTing to eu-west-1.
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        for var in (
+            "BEDROCK_MANTLE_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "BEDROCK_MANTLE_REGION",
+            "BEDROCK_MANTLE_API_BASE",
+            "AWS_REGION",
+            "AWS_REGION_NAME",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        cfg = BedrockMantleChatConfig(aws_signer=BaseAWSLLM())
+        headers, _ = cfg.sign_request(
+            headers={},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+                "aws_region_name": "us-west-2",
+            },
+            request_data={"input": "hi"},
+            api_base="https://bedrock-mantle.eu-west-1.api.aws/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-west-2/bedrock/aws4_request" not in headers["Authorization"]
+
     def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
         from unittest.mock import MagicMock
 

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -181,6 +181,164 @@ class TestBedrockMantleConfig:
         assert "max_tokens" in params
 
 
+class TestBedrockMantleChatAuth:
+    """Chat Completions must use the same Bearer-or-SigV4 auth as the Responses
+    backend. These fail on a config that inherits the no-op default sign_request.
+    """
+
+    def _signer_that_forbids_credentials(self):
+        from unittest.mock import MagicMock
+
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        signer = BaseAWSLLM()
+        signer.get_credentials = MagicMock(
+            side_effect=AssertionError("SigV4 must not run when a Bearer token exists")
+        )
+        return signer
+
+    def test_bearer_token_skips_sigv4(self, monkeypatch):
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        signer = self._signer_that_forbids_credentials()
+        cfg = BedrockMantleChatConfig(aws_signer=signer)
+
+        headers, signed_body = cfg.sign_request(
+            headers={},
+            optional_params={},
+            request_data={"model": "openai.gpt-oss-120b", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+            api_key="bearer-from-arg",
+        )
+
+        assert headers["Authorization"] == "Bearer bearer-from-arg"
+        assert json.loads(signed_body) == {
+            "model": "openai.gpt-oss-120b",
+            "messages": [],
+        }
+        signer.get_credentials.assert_not_called()
+
+    def test_mantle_env_key_used_as_bearer(self, monkeypatch):
+        monkeypatch.setenv("BEDROCK_MANTLE_API_KEY", "env-mantle-key")
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        signer = self._signer_that_forbids_credentials()
+        cfg = BedrockMantleChatConfig(aws_signer=signer)
+
+        headers, _ = cfg.sign_request(
+            headers={},
+            optional_params={},
+            request_data={"input": "hi"},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert headers["Authorization"] == "Bearer env-mantle-key"
+        signer.get_credentials.assert_not_called()
+
+    def test_aws_bearer_token_bedrock_used_as_bearer(self, monkeypatch):
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+        monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "standard-bearer")
+        signer = self._signer_that_forbids_credentials()
+        cfg = BedrockMantleChatConfig(aws_signer=signer)
+
+        headers, _ = cfg.sign_request(
+            headers={},
+            optional_params={},
+            request_data={"input": "hi"},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert headers["Authorization"] == "Bearer standard-bearer"
+        signer.get_credentials.assert_not_called()
+
+    def test_no_bearer_signs_with_sigv4(self, monkeypatch):
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+        cfg = BedrockMantleChatConfig(aws_signer=BaseAWSLLM())
+        headers, signed_body = cfg.sign_request(
+            headers={},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+                "aws_session_token": "session-token-test",
+                "aws_region_name": "us-east-2",
+            },
+            request_data={"model": "openai.gpt-oss-120b", "messages": []},
+            api_base="https://bedrock-mantle.us-east-2.api.aws/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+        assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
+        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert headers["X-Amz-Security-Token"] == "session-token-test"
+        assert json.loads(signed_body) == {
+            "model": "openai.gpt-oss-120b",
+            "messages": [],
+        }
+
+    def test_sigv4_region_resolved_from_api_base_host(self, monkeypatch):
+        # Chat passes the OpenAI-mapped optional_params (no aws_region_name) to
+        # sign_request, so the SigV4 credential scope has to come from the already
+        # region-resolved api_base host or it would disagree with the URL -> 401.
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        for var in (
+            "BEDROCK_MANTLE_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "BEDROCK_MANTLE_REGION",
+            "BEDROCK_MANTLE_API_BASE",
+            "AWS_REGION",
+            "AWS_REGION_NAME",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        cfg = BedrockMantleChatConfig(aws_signer=BaseAWSLLM())
+        headers, _ = cfg.sign_request(
+            headers={},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+            },
+            request_data={"input": "hi"},
+            api_base="https://bedrock-mantle.eu-west-1.api.aws/v1/chat/completions",
+            api_key=None,
+        )
+
+        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+
+    def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from botocore.exceptions import NoCredentialsError
+
+        from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+        monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+        signer = BaseAWSLLM()
+        signer.get_credentials = MagicMock(side_effect=NoCredentialsError())
+        cfg = BedrockMantleChatConfig(aws_signer=signer)
+
+        with pytest.raises(ValueError) as exc:
+            cfg.sign_request(
+                headers={},
+                optional_params={"aws_region_name": "us-east-2"},
+                request_data={"input": "hi"},
+                api_base="https://bedrock-mantle.us-east-2.api.aws/v1/chat/completions",
+                api_key=None,
+            )
+
+        msg = str(exc.value)
+        assert "Bearer" in msg
+        assert "SigV4" in msg or "IAM" in msg
+
+
 class TestBedrockMantleProjectHeader:
     def test_validate_environment_sets_openai_project_header(self):
         cfg = BedrockMantleChatConfig()

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -345,6 +345,66 @@ class TestBedrockMantleChatAuth:
         assert "Bearer" in msg
         assert "SigV4" in msg or "IAM" in msg
 
+    def test_completion_no_bearer_signs_with_sigv4_end_to_end(self, monkeypatch):
+        # The full completion chain (not just sign_request in isolation) must reach
+        # the SigV4 path when no Bearer token exists: with api_key=None the parent
+        # validate_environment must not short-circuit before sign_request runs.
+        for var in (
+            "BEDROCK_MANTLE_API_KEY",
+            "AWS_BEARER_TOKEN_BEDROCK",
+            "BEDROCK_MANTLE_API_BASE",
+            "BEDROCK_MANTLE_REGION",
+            "AWS_REGION_NAME",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+        monkeypatch.setenv(
+            "AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0"
+        )
+        monkeypatch.setenv("AWS_REGION", "us-east-2")
+
+        requests = []
+
+        def mock_post(self, url, data=None, headers=None, **kwargs):
+            requests.append({"url": url, "headers": headers or {}})
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "id": "chatcmpl-test",
+                    "object": "chat.completion",
+                    "created": 1733529600,
+                    "model": "openai.gpt-oss-120b",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "ok"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
+        ):
+            response = litellm.completion(
+                model="bedrock_mantle/openai.gpt-oss-120b",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert response.choices[0].message.content == "ok"
+        assert len(requests) == 1
+        authorization = requests[0]["headers"]["Authorization"]
+        assert authorization.startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-2/bedrock/aws4_request" in authorization
+        assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
+
 
 class TestBedrockMantleProjectHeader:
     def test_validate_environment_sets_openai_project_header(self):


### PR DESCRIPTION
## Relevant issues

Based on the work of @6matt in #30693; this branch carries those commits onto `litellm_internal_staging` so we can run CI, with a follow-up that delegates Bearer-token resolution in both configs to the shared mixin. Credit for the original fix goes to @6matt

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Ran a live proxy against real Bedrock Mantle with a chat model that has no `api_key` configured, so it must fall back to SigV4 over default AWS credentials (no Bearer token in the environment).

dev_config.yaml entry used for the run (not part of this PR):

```yaml
  - model_name: mantle-gpt-oss-120b
    litellm_params:
      model: bedrock_mantle/openai.gpt-oss-120b
      aws_region_name: us-east-1
```

```bash
AWS_PROFILE=... AWS_REGION=us-east-1 python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/dev_config.yaml --detailed_debug 2>&1 | tee litellm.log
```

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{"model": "mantle-gpt-oss-120b", "messages": [{"role": "user", "content": "Say hello in exactly one short sentence."}]}'
```

Response:

```json
{
    "id": "chatcmpl-710687e4-6053-42aa-8d64-dd6b8dd7008b",
    "model": "mantle-gpt-oss-120b",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {"content": "Hello!", "role": "assistant"}
        }
    ],
    "usage": {"completion_tokens": 99, "prompt_tokens": 75, "total_tokens": 174}
}
```

The proxy log confirms the outbound request to Mantle was signed with SigV4 (note `X-Amz-Date`, `X-Amz-Security-Token`, and an `Authorization` header whose masked value begins with `AW`, i.e. `AWS4-HMAC-SHA256`, not `Bearer`):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions \
-H 'Content-Type: application/json' -H 'X-Amz-Date: 20260617T224704Z' -H 'X-Amz-Security-Token: IQ****w=' -H 'Authorization: AW****ec' \
-d '{'model': 'openai.gpt-oss-120b', 'messages': [{'role': 'user', 'content': 'Say hello in exactly one short sentence.'}], 'stream': False}'
```

Before this change the same config returns an auth error because the chat backend never signs the request and sends no credentials.

## Type

🐛 Bug Fix

## Changes

`BedrockMantleResponsesAPIConfig` authenticates with a Bearer token when one is available and otherwise falls back to AWS SigV4 over the standard credential chain, but `BedrockMantleChatConfig` was Bearer-only. The chat HTTP handler already calls the `sign_request` hook on the provider config; the chat config simply inherited the no-op `BaseConfig.sign_request`, so the same provider behaved differently across its two backends and chat-completions users were forced to set a static key even when IAM-role or default AWS credentials were available.

This factors the Bearer-or-SigV4 logic out of the responses config into a shared `BedrockMantleAuthMixin` in `litellm/llms/bedrock_mantle/common_utils.py` and applies it to both configs, so the two paths can never drift apart. The Bearer precedence is `litellm_params.api_key`, then `BEDROCK_MANTLE_API_KEY`, then the standard `AWS_BEARER_TOKEN_BEDROCK`; with no token it SigV4-signs for service `bedrock` with the region pinned to the already region-resolved request host. The chat config takes an injected `aws_signer` so the SigV4 branch is unit-testable with a mock signer instead of monkeypatching.

Two pre-existing chat-config inconsistencies are fixed along the way. The chat path now honors `AWS_BEARER_TOKEN_BEDROCK` as a Bearer source the way the responses path already did, and the misleading `BEDROCK_MANTLE_{REGION}_API_KEY` region-aware fallback advertised in the chat docstring (which the code never read) is removed.

Tests extend `tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py` with a `TestBedrockMantleChatAuth` class covering Bearer-skips-SigV4, the `BEDROCK_MANTLE_API_KEY` and `AWS_BEARER_TOKEN_BEDROCK` Bearer sources, SigV4 signing with the credential scope resolved from the request host, and a clear `ValueError` when neither a token nor usable credentials exist. Each case fails against the no-op `sign_request` the chat config inherited before this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication for outbound Bedrock Mantle requests (Bearer vs SigV4 and region scoping); behavior change for chat without API keys, with broad unit/e2e test coverage.
> 
> **Overview**
> **Bedrock Mantle chat completions** now use the same **Bearer-or-SigV4** auth as the Responses backend, instead of inheriting a no-op `sign_request` and failing when only IAM/default AWS credentials are available.
> 
> Auth is centralized in **`BedrockMantleAuthMixin`** (`common_utils.py`): Bearer from `api_key` → `BEDROCK_MANTLE_API_KEY` → `AWS_BEARER_TOKEN_BEDROCK`, else SigV4 for service `bedrock`. On SigV4, the signing region is **pinned to the Mantle host in `api_base`** (not a mismatched `aws_region_name`), with caller `Authorization` stripped so SigV4 is not overridden.
> 
> `BedrockMantleChatConfig` and `BedrockMantleResponsesAPIConfig` both mix in the shared helper; duplicate auth/region logic is removed from Responses. Chat gains injectable `aws_signer` for tests, honors `AWS_BEARER_TOKEN_BEDROCK`, and drops the unused `BEDROCK_MANTLE_{REGION}_API_KEY` doc claim.
> 
> Tests add **`TestBedrockMantleChatAuth`** (Bearer paths, SigV4, region mismatch, missing creds, e2e `litellm.completion`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949815a9ebf86570f19497d54e49d35192facd20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->