### PR TITLE
feat(proxy): fail closed on unknown-cost models to prevent denial of wallet

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2367,6 +2367,23 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "is active as a reminder that hard enforcement is relaxed."
         ),
     )
+    block_unknown_cost_models: bool | None = Field(
+        None,
+        description=(
+            "Fail closed against Denial of Wallet (OWASP LLM10 Unbounded "
+            "Consumption). When True, the proxy rejects LLM API requests for "
+            "models whose per-token cost it cannot determine, e.g. a brand new "
+            "model reached via a wildcard route like 'anthropic/*' that is not "
+            "yet in the model cost map. Such models produce a $0 cost that never "
+            "moves the spend counters, so any configured key/user/team budget "
+            "would silently never trip and could be spent without limit. "
+            "Explicitly free deployments (input_cost_per_token and "
+            "output_cost_per_token set to 0) are unaffected. To serve an "
+            "unmapped model under this flag, add it to "
+            "model_prices_and_context_window.json or set explicit per-token "
+            "pricing on the deployment. Default is False."
+        ),
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -285,16 +285,54 @@ def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
     return False
 
 
+def _classify_model_from_cost_map(model_name: str) -> ModelCostClass:
+    """Classify a model's per-token pricing from litellm's global cost map.
+
+    Used when no Router is configured (the proxy routes directly through
+    litellm), so the unknown-cost guard still measures cost instead of waving
+    the request through. ``get_model_info`` raises for unmapped models, which is
+    exactly the unknown-cost case the guard must fail closed on.
+    """
+    safe_name = str(model_name).replace("\n", "").replace("\r", "")
+    try:
+        model_info = litellm.get_model_info(model_name)
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            "No cost map entry for model %s (no router configured): %s; treating "
+            "as unknown cost",
+            safe_name,
+            str(e),
+        )
+        return ModelCostClass.UNKNOWN
+
+    input_cost = model_info.get("input_cost_per_token")
+    output_cost = model_info.get("output_cost_per_token")
+    if input_cost is None or output_cost is None:
+        return ModelCostClass.UNKNOWN
+    if input_cost > 0 or output_cost > 0:
+        return ModelCostClass.KNOWN_POSITIVE
+    return ModelCostClass.EXPLICIT_ZERO
+
+
+def _classify_model_cost(model_name: str, llm_router: Router | None) -> ModelCostClass:
+    """Classify a model's per-token pricing via the router when one is present
+    (resolving wildcard/pattern deployments the way cost tracking does) or the
+    global litellm cost map otherwise."""
+    if llm_router is not None:
+        return _classify_model_group_cost(model_name, llm_router)
+    return _classify_model_from_cost_map(model_name)
+
+
 def _request_has_unknown_cost_model(
     model: str | list[str] | None, llm_router: Router | None
 ) -> bool:
-    """Return True if any requested model group has a cost LiteLLM cannot
-    determine, meaning its spend cannot be measured for budget enforcement."""
-    if model is None or llm_router is None:
+    """Return True if any requested model has a cost LiteLLM cannot determine,
+    meaning its spend cannot be measured for budget enforcement."""
+    if model is None:
         return False
     model_list = [model] if isinstance(model, str) else model
     return any(
-        _classify_model_group_cost(model_name, llm_router) == ModelCostClass.UNKNOWN
+        _classify_model_cost(model_name, llm_router) == ModelCostClass.UNKNOWN
         for model_name in model_list
     )
 
@@ -311,20 +349,15 @@ def _block_unknown_cost_models_check(
     inference requests whose per-token cost LiteLLM cannot determine. An
     unpriced model yields a $0 cost that never moves the spend counters, so any
     budget protecting the caller would silently never trip; a cap that can't
-    measure spend is no cap at all. Explicitly free deployments (cost configured
-    as 0) are unaffected because their budget checks are already skipped
-    upstream.
+    measure spend is no cap at all. Cost is resolved via the router when present
+    and the global litellm cost map otherwise, so the guard holds even on a
+    proxy that routes directly through litellm. Explicitly free deployments
+    (cost configured as 0) are unaffected because their budget checks are
+    already skipped upstream.
     """
     if not enabled:
         return
     if not RouteChecks.is_llm_api_route(route=route):
-        return
-    if llm_router is None:
-        verbose_proxy_logger.warning(
-            "block_unknown_cost_models is enabled but no router is configured, so "
-            "unknown-cost models cannot be detected; the OWASP LLM10 Denial of "
-            "Wallet guard is inactive for this request."
-        )
         return
     if not _request_has_unknown_cost_model(model=model, llm_router=llm_router):
         return
@@ -731,17 +764,13 @@ async def common_checks(
         # Fail closed on unbounded consumption (OWASP LLM10 Denial of Wallet):
         # refuse models whose cost can't be measured, since their spend (and
         # therefore any budget) can't be enforced. Opt-in via general_settings.
-        # Fall back to ``general_settings.completion_model`` when the request
-        # body has no ``model``, mirroring ``common_request_processing`` which
-        # applies that default downstream; otherwise an unpriced server
-        # default would bypass the guard at auth time.
+        # ``general_settings.completion_model`` takes precedence over the request
+        # body model in ``common_request_processing``, so classify it first;
+        # otherwise an unpriced server default would bypass the guard even when
+        # the request names a priced model.
         _block_unknown_cost_models_check(
             enabled=general_settings.get("block_unknown_cost_models") is True,
-            model=(
-                _model
-                if _model is not None
-                else general_settings.get("completion_model")
-            ),
+            model=general_settings.get("completion_model") or _model,
             llm_router=llm_router,
             route=route,
         )

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -256,7 +256,13 @@ def _is_model_cost_zero(
 
 
 def _as_cost(value: object) -> float | None:
-    """Return value as a float cost, or None if it isn't a number."""
+    """Return value as a float cost, or None if it isn't a number.
+
+    ``bool`` is excluded even though it subclasses ``int``, so a misconfigured
+    ``input_cost_per_token: true`` can't be coerced into a $1 price.
+    """
+    if isinstance(value, bool):
+        return None
     return float(value) if isinstance(value, (int, float)) else None
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -90,6 +90,7 @@ from litellm.repositories.table_repositories import (
 from litellm.repositories.team_repository import TeamRepository
 from litellm.repositories.user_repository import UserRepository
 from litellm.router import Router
+from litellm.types.router import DeploymentTypedDict
 from litellm.utils import get_utc_datetime
 
 from .auth_checks_organization import organization_role_based_access_check
@@ -173,13 +174,13 @@ class ModelCostClass(str, Enum):
 def _classify_model_group_cost(model_name: str, llm_router: Router) -> ModelCostClass:
     """Classify one model group's per-token pricing, memoized per router.
 
-    Uses the router's get_model_group_info so pattern/wildcard deployments
-    (e.g. ``anthropic/*``) resolve the same way they do during cost tracking.
-    A zero cost is only trusted when explicitly configured; a zero defaulted
-    from sparse auto-registration is treated as UNKNOWN. The classification is
-    cached on the router so the free-model bypass (``_is_model_cost_zero``) and
-    the unknown-cost block check (``_request_has_unknown_cost_model``) share a
-    single ``get_model_group_info`` lookup per model per request.
+    Classifies every deployment the request could route to (see
+    ``_compute_model_group_cost_class``); a zero cost is only trusted when
+    explicitly configured, and a zero defaulted from sparse auto-registration is
+    treated as UNKNOWN. The classification is cached on the router so the
+    free-model bypass (``_is_model_cost_zero``) and the unknown-cost block check
+    (``_request_has_unknown_cost_model``) share a single resolution per model
+    per request.
     See: https://github.com/BerriAI/litellm/issues/24770
     """
     cache = _get_router_cost_class_cache(llm_router)
@@ -197,9 +198,17 @@ def _classify_model_group_cost(model_name: str, llm_router: Router) -> ModelCost
 def _compute_model_group_cost_class(
     model_name: str, llm_router: Router
 ) -> ModelCostClass:
+    """Classify a model group from every deployment a request could route to.
+
+    A request to a model group is load balanced across its deployments, so the
+    group is only safe to trust when every deployment's cost is measurable.
+    Aggregating with ``get_model_group_info`` keeps the maximum cost across
+    deployments, which would hide an unpriced deployment behind a priced one and
+    let calls that land on it record $0; classifying each deployment avoids that.
+    """
     safe_name = str(model_name).replace("\n", "").replace("\r", "")
     try:
-        model_group_info = llm_router.get_model_group_info(model_group=model_name)
+        deployments = llm_router.get_model_list(model_name=model_name)
     except Exception as e:
         verbose_proxy_logger.debug(
             "Error classifying cost for model %s: %s; treating as unknown cost",
@@ -208,33 +217,20 @@ def _compute_model_group_cost_class(
         )
         return ModelCostClass.UNKNOWN
 
-    if model_group_info is None:
+    if not deployments:
         verbose_proxy_logger.debug(
-            "No model group info found for %s; treating as unknown cost", safe_name
+            "No deployments found for %s; treating as unknown cost", safe_name
         )
         return ModelCostClass.UNKNOWN
 
-    input_cost = model_group_info.input_cost_per_token
-    output_cost = model_group_info.output_cost_per_token
-    if input_cost is None or output_cost is None:
-        verbose_proxy_logger.debug(
-            "Model %s has undefined cost (input: %s, output: %s); treating as "
-            "unknown cost",
-            safe_name,
-            input_cost,
-            output_cost,
-        )
-        return ModelCostClass.UNKNOWN
-    if input_cost > 0 or output_cost > 0:
-        return ModelCostClass.KNOWN_POSITIVE
-    if _is_cost_explicitly_configured(model_name, llm_router):
-        return ModelCostClass.EXPLICIT_ZERO
-    verbose_proxy_logger.debug(
-        "Model %s has zero cost but no explicit cost configuration; treating as "
-        "unknown cost (enforce budget)",
-        safe_name,
+    classes = tuple(
+        _classify_deployment_cost(deployment, llm_router) for deployment in deployments
     )
-    return ModelCostClass.UNKNOWN
+    if any(c == ModelCostClass.UNKNOWN for c in classes):
+        return ModelCostClass.UNKNOWN
+    if all(c == ModelCostClass.EXPLICIT_ZERO for c in classes):
+        return ModelCostClass.EXPLICIT_ZERO
+    return ModelCostClass.KNOWN_POSITIVE
 
 
 def _is_model_cost_zero(
@@ -259,30 +255,62 @@ def _is_model_cost_zero(
     )
 
 
-def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
-    """
-    Check if any deployment serving this model group has cost fields
-    explicitly set in its litellm.model_cost entry.
+def _as_cost(value: object) -> float | None:
+    """Return value as a float cost, or None if it isn't a number."""
+    return float(value) if isinstance(value, (int, float)) else None
 
-    Uses ``Router.get_model_list`` so wildcard deployments (e.g. ``anthropic/*``)
-    are resolved against the concrete requested model, matching how
-    ``get_model_group_info`` reads pricing, instead of relying on an exact
-    ``model_name`` equality that wildcards never satisfy.
 
-    When Router._create_deployment() registers a model not in the global
-    cost map, it creates a sparse entry like {"id": "<hash>"} with no cost
-    fields. _get_model_info_helper() then defaults missing costs to 0.
-    This function detects that scenario by checking the raw model_cost entry.
+def _classify_deployment_cost(
+    deployment: DeploymentTypedDict, llm_router: Router
+) -> ModelCostClass:
+    """Classify a single router deployment's per-token pricing.
+
+    The cost is resolved the way cost tracking resolves it
+    (``get_deployment_model_info`` reads the built-in cost map for known models
+    and defaults unmapped models to $0). A positive cost is KNOWN_POSITIVE; a
+    zero is only trusted as EXPLICIT_ZERO when both input and output pricing are
+    explicitly set on the deployment, otherwise it is a sparse auto-registration
+    default and treated as UNKNOWN. ``get_model_list`` rewrites wildcard
+    deployments to the concrete requested model, so the resolved cost reflects
+    the model that will actually run.
     """
-    deployments = llm_router.get_model_list(model_name=model) or []
-    for deployment in deployments:
-        model_id = deployment.get("model_info", {}).get("id")
-        if model_id is None:
-            continue
-        raw_entry = litellm.model_cost.get(model_id, {})
-        if "input_cost_per_token" in raw_entry or "output_cost_per_token" in raw_entry:
-            return True
-    return False
+    litellm_params = deployment["litellm_params"]
+    model_info = deployment.get("model_info")
+    model_info_dict = (
+        cast("dict[str, object]", model_info) if isinstance(model_info, dict) else {}
+    )
+
+    underlying_model = litellm_params.get("model")
+    model_id = model_info_dict.get("id")
+    resolved_info = None
+    if isinstance(underlying_model, str) and isinstance(model_id, str):
+        try:
+            resolved_info = llm_router.get_deployment_model_info(
+                model_id=model_id, model_name=underlying_model
+            )
+        except Exception:
+            resolved_info = None
+
+    resolved_input = (
+        _as_cost(resolved_info.get("input_cost_per_token")) if resolved_info else None
+    )
+    resolved_output = (
+        _as_cost(resolved_info.get("output_cost_per_token")) if resolved_info else None
+    )
+    if (resolved_input is not None and resolved_input > 0) or (
+        resolved_output is not None and resolved_output > 0
+    ):
+        return ModelCostClass.KNOWN_POSITIVE
+
+    explicit_input = _as_cost(litellm_params.get("input_cost_per_token"))
+    if explicit_input is None:
+        explicit_input = _as_cost(model_info_dict.get("input_cost_per_token"))
+    explicit_output = _as_cost(litellm_params.get("output_cost_per_token"))
+    if explicit_output is None:
+        explicit_output = _as_cost(model_info_dict.get("output_cost_per_token"))
+    if explicit_input is not None and explicit_output is not None:
+        return ModelCostClass.EXPLICIT_ZERO
+    return ModelCostClass.UNKNOWN
 
 
 def _classify_model_from_cost_map(model_name: str) -> ModelCostClass:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -171,32 +171,41 @@ class ModelCostClass(str, Enum):
     UNKNOWN = "unknown"
 
 
-def _classify_model_group_cost(model_name: str, llm_router: Router) -> ModelCostClass:
+def _cost_class_cache_key(model_name: str, team_id: str | None) -> str:
+    """Cache key scoped by team, since a team can map a public model name to its
+    own deployments and the router resolves a different deployment set per team."""
+    return f"{team_id or ''}\x00{model_name}"
+
+
+def _classify_model_group_cost(
+    model_name: str, llm_router: Router, team_id: str | None = None
+) -> ModelCostClass:
     """Classify one model group's per-token pricing, memoized per router.
 
-    Classifies every deployment the request could route to (see
+    Classifies every deployment the request could route to for this team (see
     ``_compute_model_group_cost_class``); a zero cost is only trusted when
     explicitly configured, and a zero defaulted from sparse auto-registration is
     treated as UNKNOWN. The classification is cached on the router so the
     free-model bypass (``_is_model_cost_zero``) and the unknown-cost block check
     (``_request_has_unknown_cost_model``) share a single resolution per model
-    per request.
+    per team per request.
     See: https://github.com/BerriAI/litellm/issues/24770
     """
     cache = _get_router_cost_class_cache(llm_router)
+    cache_key = _cost_class_cache_key(model_name, team_id)
     if cache is not None:
-        cached = cache.get(model_name)
+        cached = cache.get(cache_key)
         if cached is not None:
             return ModelCostClass(cached)
 
-    classification = _compute_model_group_cost_class(model_name, llm_router)
+    classification = _compute_model_group_cost_class(model_name, llm_router, team_id)
     if cache is not None:
-        cache[model_name] = classification.value
+        cache[cache_key] = classification.value
     return classification
 
 
 def _compute_model_group_cost_class(
-    model_name: str, llm_router: Router
+    model_name: str, llm_router: Router, team_id: str | None = None
 ) -> ModelCostClass:
     """Classify a model group from every deployment a request could route to.
 
@@ -205,10 +214,13 @@ def _compute_model_group_cost_class(
     Aggregating with ``get_model_group_info`` keeps the maximum cost across
     deployments, which would hide an unpriced deployment behind a priced one and
     let calls that land on it record $0; classifying each deployment avoids that.
+    ``team_id`` is threaded into ``get_model_list`` so the guard evaluates the
+    same deployment set the router will route to (a team can shadow a priced
+    public model name with its own unpriced deployment).
     """
     safe_name = str(model_name).replace("\n", "").replace("\r", "")
     try:
-        deployments = llm_router.get_model_list(model_name=model_name)
+        deployments = llm_router.get_model_list(model_name=model_name, team_id=team_id)
     except Exception as e:
         verbose_proxy_logger.debug(
             "Error classifying cost for model %s: %s; treating as unknown cost",
@@ -234,14 +246,17 @@ def _compute_model_group_cost_class(
 
 
 def _is_model_cost_zero(
-    model: Optional[Union[str, List[str]]], llm_router: Optional[Router]
+    model: Optional[Union[str, List[str]]],
+    llm_router: Optional[Router],
+    team_id: str | None = None,
 ) -> bool:
     """
     Check if a model has zero cost (explicitly configured $0 pricing).
 
     Returns True only when every requested model group is an explicitly
     configured free deployment. Unmapped / unknown-cost models return False so
-    spend-based budget checks are still enforced.
+    spend-based budget checks are still enforced. ``team_id`` scopes the lookup
+    to the deployment set the router resolves for that team.
     See: https://github.com/BerriAI/litellm/issues/24770
     """
     if model is None or llm_router is None:
@@ -249,7 +264,7 @@ def _is_model_cost_zero(
 
     model_list = [model] if isinstance(model, str) else model
     return all(
-        _classify_model_group_cost(model_name, llm_router)
+        _classify_model_group_cost(model_name, llm_router, team_id)
         == ModelCostClass.EXPLICIT_ZERO
         for model_name in model_list
     )
@@ -350,17 +365,21 @@ def _classify_model_from_cost_map(model_name: str) -> ModelCostClass:
     return ModelCostClass.EXPLICIT_ZERO
 
 
-def _classify_model_cost(model_name: str, llm_router: Router | None) -> ModelCostClass:
+def _classify_model_cost(
+    model_name: str, llm_router: Router | None, team_id: str | None = None
+) -> ModelCostClass:
     """Classify a model's per-token pricing via the router when one is present
-    (resolving wildcard/pattern deployments the way cost tracking does) or the
-    global litellm cost map otherwise."""
+    (resolving wildcard/pattern deployments the way cost tracking does, scoped to
+    the team) or the global litellm cost map otherwise."""
     if llm_router is not None:
-        return _classify_model_group_cost(model_name, llm_router)
+        return _classify_model_group_cost(model_name, llm_router, team_id)
     return _classify_model_from_cost_map(model_name)
 
 
 def _request_has_unknown_cost_model(
-    model: str | list[str] | None, llm_router: Router | None
+    model: str | list[str] | None,
+    llm_router: Router | None,
+    team_id: str | None = None,
 ) -> bool:
     """Return True if any requested model has a cost LiteLLM cannot determine,
     meaning its spend cannot be measured for budget enforcement."""
@@ -368,7 +387,7 @@ def _request_has_unknown_cost_model(
         return False
     model_list = [model] if isinstance(model, str) else model
     return any(
-        _classify_model_cost(model_name, llm_router) == ModelCostClass.UNKNOWN
+        _classify_model_cost(model_name, llm_router, team_id) == ModelCostClass.UNKNOWN
         for model_name in model_list
     )
 
@@ -378,6 +397,7 @@ def _block_unknown_cost_models_check(
     model: str | list[str] | None,
     llm_router: Router | None,
     route: str,
+    team_id: str | None = None,
 ) -> None:
     """Fail closed against Denial of Wallet (OWASP LLM10 Unbounded Consumption).
 
@@ -387,15 +407,18 @@ def _block_unknown_cost_models_check(
     budget protecting the caller would silently never trip; a cap that can't
     measure spend is no cap at all. Cost is resolved via the router when present
     and the global litellm cost map otherwise, so the guard holds even on a
-    proxy that routes directly through litellm. Explicitly free deployments
-    (cost configured as 0) are unaffected because their budget checks are
-    already skipped upstream.
+    proxy that routes directly through litellm. ``team_id`` scopes the lookup to
+    the deployments the router will route to for the caller's team. Explicitly
+    free deployments (cost configured as 0) are unaffected because their budget
+    checks are already skipped upstream.
     """
     if not enabled:
         return
     if not RouteChecks.is_llm_api_route(route=route):
         return
-    if not _request_has_unknown_cost_model(model=model, llm_router=llm_router):
+    if not _request_has_unknown_cost_model(
+        model=model, llm_router=llm_router, team_id=team_id
+    ):
         return
 
     model_str = model if isinstance(model, str) else ", ".join(model or [])
@@ -809,6 +832,7 @@ async def common_checks(
             model=general_settings.get("completion_model") or _model,
             llm_router=llm_router,
             route=route,
+            team_id=valid_token.team_id if valid_token else None,
         )
 
         # 3. If team is in budget

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -135,10 +135,11 @@ def _log_budget_lookup_failure(entity: str, error: Exception) -> None:
     )
 
 
-def _get_router_zero_cost_cache(llm_router: Router) -> Optional[Dict[str, bool]]:
+def _get_router_cost_class_cache(llm_router: Router) -> Optional[Dict[str, str]]:
     """
-    Return the router's per-instance zero-cost cache, or ``None`` for objects
-    that don't expose one (e.g. ``MagicMock`` stand-ins in unit tests).
+    Return the router's per-instance model-cost classification cache (model name
+    -> ``ModelCostClass`` value), or ``None`` for objects that don't expose one
+    (e.g. ``MagicMock`` stand-ins in unit tests).
 
     The cache lives on the ``Router`` instance so it:
         * is invalidated by ``Router._invalidate_model_group_info_cache`` on
@@ -147,7 +148,7 @@ def _get_router_zero_cost_cache(llm_router: Router) -> Optional[Dict[str, bool]]
         * dies with the router itself — no risk of CPython reusing the
           previous router's ``id()`` and serving its cached entries.
     """
-    cache = getattr(llm_router, "_zero_cost_cache", None)
+    cache = getattr(llm_router, "_model_cost_class_cache", None)
     return cache if isinstance(cache, dict) else None
 
 
@@ -170,14 +171,32 @@ class ModelCostClass(str, Enum):
 
 
 def _classify_model_group_cost(model_name: str, llm_router: Router) -> ModelCostClass:
-    """Classify one model group's per-token pricing.
+    """Classify one model group's per-token pricing, memoized per router.
 
     Uses the router's get_model_group_info so pattern/wildcard deployments
     (e.g. ``anthropic/*``) resolve the same way they do during cost tracking.
     A zero cost is only trusted when explicitly configured; a zero defaulted
-    from sparse auto-registration is treated as UNKNOWN.
+    from sparse auto-registration is treated as UNKNOWN. The classification is
+    cached on the router so the free-model bypass (``_is_model_cost_zero``) and
+    the unknown-cost block check (``_request_has_unknown_cost_model``) share a
+    single ``get_model_group_info`` lookup per model per request.
     See: https://github.com/BerriAI/litellm/issues/24770
     """
+    cache = _get_router_cost_class_cache(llm_router)
+    if cache is not None:
+        cached = cache.get(model_name)
+        if cached is not None:
+            return ModelCostClass(cached)
+
+    classification = _compute_model_group_cost_class(model_name, llm_router)
+    if cache is not None:
+        cache[model_name] = classification.value
+    return classification
+
+
+def _compute_model_group_cost_class(
+    model_name: str, llm_router: Router
+) -> ModelCostClass:
     safe_name = str(model_name).replace("\n", "").replace("\r", "")
     try:
         model_group_info = llm_router.get_model_group_info(model_group=model_name)
@@ -233,26 +252,11 @@ def _is_model_cost_zero(
         return False
 
     model_list = [model] if isinstance(model, str) else model
-    zero_cost_cache = _get_router_zero_cost_cache(llm_router)
-
-    for model_name in model_list:
-        if zero_cost_cache is not None:
-            cached = zero_cost_cache.get(model_name)
-            if cached is not None:
-                if cached is False:
-                    return False
-                continue
-
-        is_explicit_zero = (
-            _classify_model_group_cost(model_name, llm_router)
-            == ModelCostClass.EXPLICIT_ZERO
-        )
-        if zero_cost_cache is not None:
-            zero_cost_cache[model_name] = is_explicit_zero
-        if not is_explicit_zero:
-            return False
-
-    return True
+    return all(
+        _classify_model_group_cost(model_name, llm_router)
+        == ModelCostClass.EXPLICIT_ZERO
+        for model_name in model_list
+    )
 
 
 def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
@@ -310,6 +314,13 @@ def _block_unknown_cost_models_check(
     if not enabled:
         return
     if not RouteChecks.is_llm_api_route(route=route):
+        return
+    if llm_router is None:
+        verbose_proxy_logger.warning(
+            "block_unknown_cost_models is enabled but no router is configured, so "
+            "unknown-cost models cannot be detected; the OWASP LLM10 Denial of "
+            "Wallet guard is inactive for this request."
+        )
         return
     if not _request_has_unknown_cost_model(model=model, llm_router=llm_router):
         return

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -309,6 +309,8 @@ def _classify_deployment_cost(
     if explicit_output is None:
         explicit_output = _as_cost(model_info_dict.get("output_cost_per_token"))
     if explicit_input is not None and explicit_output is not None:
+        if explicit_input > 0 or explicit_output > 0:
+            return ModelCostClass.KNOWN_POSITIVE
         return ModelCostClass.EXPLICIT_ZERO
     return ModelCostClass.UNKNOWN
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -374,8 +374,8 @@ def _classify_model_from_cost_map(model_name: str) -> ModelCostClass:
         )
         return ModelCostClass.UNKNOWN
 
-    input_cost = model_info.get("input_cost_per_token")
-    output_cost = model_info.get("output_cost_per_token")
+    input_cost = _as_cost(model_info.get("input_cost_per_token"))
+    output_cost = _as_cost(model_info.get("output_cost_per_token"))
     if input_cost is None or output_cost is None:
         return ModelCostClass.UNKNOWN
     if input_cost > 0 or output_cost > 0:
@@ -836,23 +836,23 @@ async def common_checks(
     # Run before apply_key_tags_pre_auth injects key metadata.tags into request_body.
     _reject_clientside_metadata_tags_check(general_settings, request_body, route)
 
+    # Fail closed on unbounded consumption (OWASP LLM10 Denial of Wallet): refuse
+    # models whose cost can't be measured, since their spend (and therefore any
+    # budget) can't be enforced. Runs regardless of skip_budget_checks: that flag
+    # is derived from the request model, but common_request_processing gives
+    # general_settings.completion_model precedence, so an explicitly-free request
+    # model would otherwise skip the guard and let an unpriced server default
+    # through. Classifying completion_model first closes that gap. Opt-in.
+    _block_unknown_cost_models_check(
+        enabled=general_settings.get("block_unknown_cost_models") is True,
+        model=general_settings.get("completion_model") or _model,
+        llm_router=llm_router,
+        route=route,
+        team_id=valid_token.team_id if valid_token else None,
+    )
+
     # If this is a free model, skip all budget checks
     if not skip_budget_checks:
-        # Fail closed on unbounded consumption (OWASP LLM10 Denial of Wallet):
-        # refuse models whose cost can't be measured, since their spend (and
-        # therefore any budget) can't be enforced. Opt-in via general_settings.
-        # ``general_settings.completion_model`` takes precedence over the request
-        # body model in ``common_request_processing``, so classify it first;
-        # otherwise an unpriced server default would bypass the guard even when
-        # the request names a priced model.
-        _block_unknown_cost_models_check(
-            enabled=general_settings.get("block_unknown_cost_models") is True,
-            model=general_settings.get("completion_model") or _model,
-            llm_router=llm_router,
-            route=route,
-            team_id=valid_token.team_id if valid_token else None,
-        )
-
         # 3. If team is in budget
         with tracer.trace("litellm.proxy.auth.common_checks.team_max_budget_check"):
             await _team_max_budget_check(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -261,17 +261,21 @@ def _is_model_cost_zero(
 
 def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
     """
-    Check if any deployment in the model group has cost fields explicitly
-    set in its litellm.model_cost entry.
+    Check if any deployment serving this model group has cost fields
+    explicitly set in its litellm.model_cost entry.
+
+    Uses ``Router.get_model_list`` so wildcard deployments (e.g. ``anthropic/*``)
+    are resolved against the concrete requested model, matching how
+    ``get_model_group_info`` reads pricing, instead of relying on an exact
+    ``model_name`` equality that wildcards never satisfy.
 
     When Router._create_deployment() registers a model not in the global
     cost map, it creates a sparse entry like {"id": "<hash>"} with no cost
     fields. _get_model_info_helper() then defaults missing costs to 0.
     This function detects that scenario by checking the raw model_cost entry.
     """
-    for deployment in llm_router.model_list:
-        if deployment.get("model_name") != model:
-            continue
+    deployments = llm_router.get_model_list(model_name=model) or []
+    for deployment in deployments:
         model_id = deployment.get("model_info", {}).get("id")
         if model_id is None:
             continue
@@ -727,9 +731,17 @@ async def common_checks(
         # Fail closed on unbounded consumption (OWASP LLM10 Denial of Wallet):
         # refuse models whose cost can't be measured, since their spend (and
         # therefore any budget) can't be enforced. Opt-in via general_settings.
+        # Fall back to ``general_settings.completion_model`` when the request
+        # body has no ``model``, mirroring ``common_request_processing`` which
+        # applies that default downstream; otherwise an unpriced server
+        # default would bypass the guard at auth time.
         _block_unknown_cost_models_check(
             enabled=general_settings.get("block_unknown_cost_models") is True,
-            model=_model,
+            model=(
+                _model
+                if _model is not None
+                else general_settings.get("completion_model")
+            ),
             llm_router=llm_router,
             route=route,
         )

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -286,14 +286,15 @@ def _classify_deployment_cost(
 ) -> ModelCostClass:
     """Classify a single router deployment's per-token pricing.
 
-    The cost is resolved the way cost tracking resolves it
-    (``get_deployment_model_info`` reads the built-in cost map for known models
-    and defaults unmapped models to $0). A positive cost is KNOWN_POSITIVE; a
-    zero is only trusted as EXPLICIT_ZERO when both input and output pricing are
-    explicitly set on the deployment, otherwise it is a sparse auto-registration
-    default and treated as UNKNOWN. ``get_model_list`` rewrites wildcard
-    deployments to the concrete requested model, so the resolved cost reflects
-    the model that will actually run.
+    Explicit per-deployment pricing wins. For a registered deployment the cost
+    is resolved the way cost tracking resolves it (``get_deployment_model_info``
+    reads the built-in cost map for known models and defaults unmapped models to
+    $0), so a positive cost is KNOWN_POSITIVE and a defaulted zero stays UNKNOWN.
+    For a wildcard/pattern deployment there is no per-deployment cost entry;
+    ``get_model_list`` has rewritten the underlying model to the concrete
+    requested one, so it is priced against the global cost map, which keeps
+    wildcard routes to mapped models (e.g. ``anthropic/*`` -> a known model)
+    usable while still failing closed on genuinely unmapped ones.
     """
     litellm_params = deployment["litellm_params"]
     model_info = deployment.get("model_info")
@@ -301,28 +302,7 @@ def _classify_deployment_cost(
         cast("dict[str, object]", model_info) if isinstance(model_info, dict) else {}
     )
 
-    underlying_model = litellm_params.get("model")
-    model_id = model_info_dict.get("id")
-    resolved_info = None
-    if isinstance(underlying_model, str) and isinstance(model_id, str):
-        try:
-            resolved_info = llm_router.get_deployment_model_info(
-                model_id=model_id, model_name=underlying_model
-            )
-        except Exception:
-            resolved_info = None
-
-    resolved_input = (
-        _as_cost(resolved_info.get("input_cost_per_token")) if resolved_info else None
-    )
-    resolved_output = (
-        _as_cost(resolved_info.get("output_cost_per_token")) if resolved_info else None
-    )
-    if (resolved_input is not None and resolved_input > 0) or (
-        resolved_output is not None and resolved_output > 0
-    ):
-        return ModelCostClass.KNOWN_POSITIVE
-
+    # Explicit per-deployment pricing is authoritative.
     explicit_input = _as_cost(litellm_params.get("input_cost_per_token"))
     if explicit_input is None:
         explicit_input = _as_cost(model_info_dict.get("input_cost_per_token"))
@@ -333,7 +313,45 @@ def _classify_deployment_cost(
         if explicit_input > 0 or explicit_output > 0:
             return ModelCostClass.KNOWN_POSITIVE
         return ModelCostClass.EXPLICIT_ZERO
-    return ModelCostClass.UNKNOWN
+
+    underlying_model = litellm_params.get("model")
+    # get_model_list rewrites the concrete requested model into model_name for
+    # wildcard deployments; prefer it when litellm_params still holds the
+    # pattern, so cost is resolved for the model that will actually run.
+    model_name_value = deployment.get("model_name")
+    if (
+        isinstance(underlying_model, str)
+        and "*" in underlying_model
+        and isinstance(model_name_value, str)
+        and model_name_value
+    ):
+        underlying_model = model_name_value
+    if not isinstance(underlying_model, str) or not underlying_model:
+        return ModelCostClass.UNKNOWN
+    model_id = model_info_dict.get("id")
+
+    # Registered deployment: trust the cost that cost tracking would use. A
+    # positive cost is known; a zero here is a sparse auto-registration default,
+    # so it stays unknown (a zero that was deliberate is handled above).
+    if isinstance(model_id, str):
+        try:
+            resolved_info = llm_router.get_deployment_model_info(
+                model_id=model_id, model_name=underlying_model
+            )
+        except Exception:
+            resolved_info = None
+        if resolved_info is not None:
+            resolved_input = _as_cost(resolved_info.get("input_cost_per_token"))
+            resolved_output = _as_cost(resolved_info.get("output_cost_per_token"))
+            if (resolved_input is not None and resolved_input > 0) or (
+                resolved_output is not None and resolved_output > 0
+            ):
+                return ModelCostClass.KNOWN_POSITIVE
+            return ModelCostClass.UNKNOWN
+
+    # Wildcard / unregistered deployment: get_model_list rewrites the underlying
+    # model to the concrete requested one, so price it via the global cost map.
+    return _classify_model_from_cost_map(underlying_model)
 
 
 def _classify_model_from_cost_map(model_name: str) -> ModelCostClass:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -13,6 +13,7 @@ import asyncio
 import math
 import re
 import time
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type, Union, cast
 
 from fastapi import HTTPException, Request, status
@@ -150,27 +151,88 @@ def _get_router_zero_cost_cache(llm_router: Router) -> Optional[Dict[str, bool]]
     return cache if isinstance(cache, dict) else None
 
 
+class ModelCostClass(str, Enum):
+    """Tri-state classification of a model group's per-token pricing.
+
+    EXPLICIT_ZERO  pricing is configured and is exactly $0 (a deliberately free
+                   deployment); safe to bypass spend-based budget checks.
+    KNOWN_POSITIVE pricing is configured and greater than $0; budgets are
+                   enforceable because spend can be measured.
+    UNKNOWN        pricing cannot be determined (model not in the cost map,
+                   sparse auto-registration with no cost fields, or a lookup
+                   error). Spend cannot be measured, so a budget protecting the
+                   caller would silently never trip.
+    """
+
+    EXPLICIT_ZERO = "explicit_zero"
+    KNOWN_POSITIVE = "known_positive"
+    UNKNOWN = "unknown"
+
+
+def _classify_model_group_cost(model_name: str, llm_router: Router) -> ModelCostClass:
+    """Classify one model group's per-token pricing.
+
+    Uses the router's get_model_group_info so pattern/wildcard deployments
+    (e.g. ``anthropic/*``) resolve the same way they do during cost tracking.
+    A zero cost is only trusted when explicitly configured; a zero defaulted
+    from sparse auto-registration is treated as UNKNOWN.
+    See: https://github.com/BerriAI/litellm/issues/24770
+    """
+    safe_name = str(model_name).replace("\n", "").replace("\r", "")
+    try:
+        model_group_info = llm_router.get_model_group_info(model_group=model_name)
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            "Error classifying cost for model %s: %s; treating as unknown cost",
+            safe_name,
+            str(e),
+        )
+        return ModelCostClass.UNKNOWN
+
+    if model_group_info is None:
+        verbose_proxy_logger.debug(
+            "No model group info found for %s; treating as unknown cost", safe_name
+        )
+        return ModelCostClass.UNKNOWN
+
+    input_cost = model_group_info.input_cost_per_token
+    output_cost = model_group_info.output_cost_per_token
+    if input_cost is None or output_cost is None:
+        verbose_proxy_logger.debug(
+            "Model %s has undefined cost (input: %s, output: %s); treating as "
+            "unknown cost",
+            safe_name,
+            input_cost,
+            output_cost,
+        )
+        return ModelCostClass.UNKNOWN
+    if input_cost > 0 or output_cost > 0:
+        return ModelCostClass.KNOWN_POSITIVE
+    if _is_cost_explicitly_configured(model_name, llm_router):
+        return ModelCostClass.EXPLICIT_ZERO
+    verbose_proxy_logger.debug(
+        "Model %s has zero cost but no explicit cost configuration; treating as "
+        "unknown cost (enforce budget)",
+        safe_name,
+    )
+    return ModelCostClass.UNKNOWN
+
+
 def _is_model_cost_zero(
     model: Optional[Union[str, List[str]]], llm_router: Optional[Router]
 ) -> bool:
     """
-    Check if a model has zero cost (no configured pricing).
+    Check if a model has zero cost (explicitly configured $0 pricing).
 
-    Uses the router's get_model_group_info method to get pricing information.
-
-    Args:
-        model: The model name or list of model names
-        llm_router: The LiteLLM router instance
-
-    Returns:
-        bool: True if all costs for the model are zero, False otherwise
+    Returns True only when every requested model group is an explicitly
+    configured free deployment. Unmapped / unknown-cost models return False so
+    spend-based budget checks are still enforced.
+    See: https://github.com/BerriAI/litellm/issues/24770
     """
     if model is None or llm_router is None:
         return False
 
-    # Handle list of models
     model_list = [model] if isinstance(model, str) else model
-
     zero_cost_cache = _get_router_zero_cost_cache(llm_router)
 
     for model_name in model_list:
@@ -180,75 +242,16 @@ def _is_model_cost_zero(
                 if cached is False:
                     return False
                 continue
-        try:
-            # Use router's get_model_group_info method directly for better reliability
-            model_group_info = llm_router.get_model_group_info(model_group=model_name)
 
-            if model_group_info is None:
-                # Model not found or no pricing info available
-                # Conservative approach: assume it has cost
-                verbose_proxy_logger.debug(
-                    f"No model group info found for {model_name}, assuming it has cost"
-                )
-                if zero_cost_cache is not None:
-                    zero_cost_cache[model_name] = False
-                return False
-
-            # Check costs for this model
-            # Only allow bypass if BOTH costs are explicitly set to 0 (not None)
-            input_cost = model_group_info.input_cost_per_token
-            output_cost = model_group_info.output_cost_per_token
-
-            # If costs are not explicitly configured (None), assume it has cost
-            if input_cost is None or output_cost is None:
-                verbose_proxy_logger.debug(
-                    f"Model {model_name} has undefined cost (input: {input_cost}, output: {output_cost}), assuming it has cost"
-                )
-                if zero_cost_cache is not None:
-                    zero_cost_cache[model_name] = False
-                return False
-
-            # If either cost is non-zero, return False
-            if input_cost > 0 or output_cost > 0:
-                verbose_proxy_logger.debug(
-                    f"Model {model_name} has non-zero cost (input: {input_cost}, output: {output_cost})"
-                )
-                if zero_cost_cache is not None:
-                    zero_cost_cache[model_name] = False
-                return False
-
-            # Costs are 0 — verify this is from explicit configuration,
-            # not from defaulted sparse auto-registration entries.
-            # See: https://github.com/BerriAI/litellm/issues/24770
-            safe_name = str(model_name).replace("\n", "").replace("\r", "")
-            if not _is_cost_explicitly_configured(model_name, llm_router):
-                verbose_proxy_logger.debug(
-                    "Model %s has zero cost but no explicit cost "
-                    "configuration in model_cost entry — treating as unknown "
-                    "cost (enforce budget)",
-                    safe_name,
-                )
-                if zero_cost_cache is not None:
-                    zero_cost_cache[model_name] = False
-                return False
-
-            verbose_proxy_logger.debug(
-                "Model %s has zero cost explicitly configured (input: %s, output: %s)",
-                safe_name,
-                input_cost,
-                output_cost,
-            )
-            if zero_cost_cache is not None:
-                zero_cost_cache[model_name] = True
-
-        except Exception as e:
-            # If we can't determine the cost, assume it has cost (conservative approach)
-            verbose_proxy_logger.debug(
-                f"Error checking cost for model {model_name}: {str(e)}, assuming it has cost"
-            )
+        is_explicit_zero = (
+            _classify_model_group_cost(model_name, llm_router)
+            == ModelCostClass.EXPLICIT_ZERO
+        )
+        if zero_cost_cache is not None:
+            zero_cost_cache[model_name] = is_explicit_zero
+        if not is_explicit_zero:
             return False
 
-    # All models checked have zero cost
     return True
 
 
@@ -272,6 +275,60 @@ def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
         if "input_cost_per_token" in raw_entry or "output_cost_per_token" in raw_entry:
             return True
     return False
+
+
+def _request_has_unknown_cost_model(
+    model: str | list[str] | None, llm_router: Router | None
+) -> bool:
+    """Return True if any requested model group has a cost LiteLLM cannot
+    determine, meaning its spend cannot be measured for budget enforcement."""
+    if model is None or llm_router is None:
+        return False
+    model_list = [model] if isinstance(model, str) else model
+    return any(
+        _classify_model_group_cost(model_name, llm_router) == ModelCostClass.UNKNOWN
+        for model_name in model_list
+    )
+
+
+def _block_unknown_cost_models_check(
+    enabled: bool,
+    model: str | list[str] | None,
+    llm_router: Router | None,
+    route: str,
+) -> None:
+    """Fail closed against Denial of Wallet (OWASP LLM10 Unbounded Consumption).
+
+    When ``enabled`` (general_settings.block_unknown_cost_models), reject
+    inference requests whose per-token cost LiteLLM cannot determine. An
+    unpriced model yields a $0 cost that never moves the spend counters, so any
+    budget protecting the caller would silently never trip; a cap that can't
+    measure spend is no cap at all. Explicitly free deployments (cost configured
+    as 0) are unaffected because their budget checks are already skipped
+    upstream.
+    """
+    if not enabled:
+        return
+    if not RouteChecks.is_llm_api_route(route=route):
+        return
+    if not _request_has_unknown_cost_model(model=model, llm_router=llm_router):
+        return
+
+    model_str = model if isinstance(model, str) else ", ".join(model or [])
+    raise ProxyException(
+        message=(
+            f"Budget enforcement failed closed: LiteLLM does not know the cost "
+            f"of model '{model_str}', so its spend cannot be tracked and a "
+            f"configured budget cannot be enforced (OWASP LLM10 Denial of "
+            f"Wallet). Add the model to the cost map "
+            f"(model_prices_and_context_window.json) or set input_cost_per_token "
+            f"and output_cost_per_token on the deployment. To allow models with "
+            f"unknown cost, disable general_settings.block_unknown_cost_models."
+        ),
+        type=ProxyErrorTypes.bad_request_error,
+        param="model",
+        code=status.HTTP_400_BAD_REQUEST,
+    )
 
 
 async def _run_project_checks(
@@ -656,6 +713,16 @@ async def common_checks(
 
     # If this is a free model, skip all budget checks
     if not skip_budget_checks:
+        # Fail closed on unbounded consumption (OWASP LLM10 Denial of Wallet):
+        # refuse models whose cost can't be measured, since their spend (and
+        # therefore any budget) can't be enforced. Opt-in via general_settings.
+        _block_unknown_cost_models_check(
+            enabled=general_settings.get("block_unknown_cost_models") is True,
+            model=_model,
+            llm_router=llm_router,
+            route=route,
+        )
+
         # 3. If team is in budget
         with tracer.trace("litellm.proxy.auth.common_checks.team_max_budget_check"):
             await _team_max_budget_check(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1358,7 +1358,7 @@ async def _user_api_key_auth_builder(
                         from litellm.proxy.auth.auth_checks import _is_model_cost_zero
 
                         skip_budget_checks = _is_model_cost_zero(
-                            model=model, llm_router=llm_router
+                            model=model, llm_router=llm_router, team_id=team_id
                         )
                         if skip_budget_checks:
                             verbose_proxy_logger.info(
@@ -1776,7 +1776,7 @@ async def _user_api_key_auth_builder(
                 from litellm.proxy.auth.auth_checks import _is_model_cost_zero
 
                 skip_budget_checks = _is_model_cost_zero(
-                    model=model, llm_router=llm_router
+                    model=model, llm_router=llm_router, team_id=valid_token.team_id
                 )
                 if skip_budget_checks:
                     verbose_proxy_logger.info(
@@ -2384,6 +2384,7 @@ async def _run_centralized_common_checks(
         route=route,
         request=request,
         llm_router=llm_router,
+        team_id=user_api_key_auth_obj.team_id,
     )
 
     # Merge x-litellm-tags into request_data BEFORE common_checks runs.
@@ -2488,6 +2489,7 @@ def _should_skip_budget_checks(
     route: str,
     request: Optional[Request],
     llm_router: Optional[Any],
+    team_id: str | None = None,
 ) -> bool:
     model = _get_model_from_request_context(
         request_data=request_data,
@@ -2496,7 +2498,7 @@ def _should_skip_budget_checks(
         llm_router=llm_router,
     )
     if model is not None and llm_router is not None:
-        return _is_model_cost_zero(model=model, llm_router=llm_router)
+        return _is_model_cost_zero(model=model, llm_router=llm_router, team_id=team_id)
     return False
 
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -507,12 +507,14 @@ class Router:
         # touches *before* the first ``set_model_list`` below (which calls
         # that invalidation as part of building the model index).
         self._access_groups_cache: Optional[Dict[str, List[str]]] = None
-        # Per-router cache for the proxy auth-layer "is this model explicitly
-        # zero-cost?" check. Lives on the router so it is invalidated alongside
-        # ``_cached_get_model_group_info`` and dies with the router (no
+        # Per-router cache mapping model name -> ``ModelCostClass`` value for the
+        # proxy auth layer's pricing classification. Both the free-model bypass
+        # and the unknown-cost block check read it, so a model is resolved at
+        # most once per request. Lives on the router so it is invalidated
+        # alongside ``_cached_get_model_group_info`` and dies with the router (no
         # ``id()``-reuse risk after GC). See
-        # ``litellm.proxy.auth.auth_checks._is_model_cost_zero``.
-        self._zero_cost_cache: Dict[str, bool] = {}
+        # ``litellm.proxy.auth.auth_checks._classify_model_group_cost``.
+        self._model_cost_class_cache: Dict[str, str] = {}
 
         if model_list is not None:
             # set_model_list will build indices automatically
@@ -10326,13 +10328,13 @@ class Router:
         """Invalidate the cached model group info.
 
         Call this whenever self.model_list is modified to ensure the cache is rebuilt.
-        Also clears the auth-layer zero-cost cache, which depends on the same
-        ``ModelGroupInfo`` data — without this, an in-place pricing update on
-        an existing deployment (same model count) would keep a stale ``True``
-        result and bypass budget enforcement.
+        Also clears the auth-layer cost classification cache, which depends on the
+        same ``ModelGroupInfo`` data; without this, an in-place pricing update on
+        an existing deployment (same model count) would keep a stale
+        classification and bypass budget enforcement.
         """
         self._cached_get_model_group_info.cache_clear()
-        self._zero_cost_cache.clear()
+        self._model_cost_class_cache.clear()
 
     def _invalidate_access_groups_cache(self) -> None:
         """Invalidate the cached access groups.

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -300,6 +300,39 @@ class TestClassifyModelGroupCost:
             == ModelCostClass.EXPLICIT_ZERO
         )
 
+    def test_wildcard_route_to_mapped_model_is_known_positive(self):
+        """A wildcard deployment reaching a model that IS in the cost map must
+        classify KNOWN_POSITIVE (and stay usable), while a genuinely unmapped
+        concrete model on the same wildcard stays UNKNOWN. Guards against the
+        wildcard route being classified UNKNOWN wholesale."""
+        # Inject a mapped concrete model so the test doesn't depend on the live
+        # cost map; setup/teardown snapshot and restore litellm.model_cost.
+        litellm.model_cost["anthropic/mapped-via-wildcard-test"] = {
+            "input_cost_per_token": 0.000003,
+            "output_cost_per_token": 0.000004,
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+        }
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "anthropic/*",
+                    "litellm_params": {
+                        "model": "anthropic/*",
+                        "api_key": "sk-fake",
+                    },
+                },
+            ]
+        )
+        assert (
+            _classify_model_group_cost("anthropic/mapped-via-wildcard-test", router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+        assert (
+            _classify_model_group_cost("anthropic/brand-new-unmapped-zzz", router)
+            == ModelCostClass.UNKNOWN
+        )
+
 
 class TestRequestHasUnknownCostModel:
     """Detector backing the fail-closed check."""
@@ -747,9 +780,9 @@ class TestClassifyDeploymentCost:
         }
         assert _classify_deployment_cost(deployment, router) == ModelCostClass.UNKNOWN
 
-    def test_get_deployment_model_info_error_falls_back_to_explicit(self):
-        # If resolving the deployment's cost raises, the classifier must still
-        # honor an explicit deployment price rather than propagate the error.
+    def test_explicit_price_short_circuits_resolution(self):
+        # An explicit deployment price is authoritative, so the classifier honors
+        # it without consulting (or being broken by) the cost resolver.
         router = MagicMock(spec=Router)
         router.get_deployment_model_info.side_effect = RuntimeError("boom")
         deployment = {
@@ -765,6 +798,19 @@ class TestClassifyDeploymentCost:
             _classify_deployment_cost(deployment, router)
             == ModelCostClass.KNOWN_POSITIVE
         )
+        router.get_deployment_model_info.assert_not_called()
+
+    def test_resolution_error_is_treated_as_unknown(self):
+        # With no explicit price, a cost-resolution error must fail closed to
+        # UNKNOWN (the underlying model is unmapped), never propagate or assume free.
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.side_effect = RuntimeError("boom")
+        deployment = {
+            "model_name": "err-unpriced",
+            "litellm_params": {"model": "openai/totally-unmapped-err-zzz"},
+            "model_info": {"id": "err-unpriced-id"},
+        }
+        assert _classify_deployment_cost(deployment, router) == ModelCostClass.UNKNOWN
         router.get_deployment_model_info.assert_called_once()
 
     def test_explicit_cost_from_model_info_when_absent_in_litellm_params(self):
@@ -796,6 +842,54 @@ class TestClassifyDeploymentCost:
             "model_name": "resolved-paid",
             "litellm_params": {"model": "openai/resolved-paid"},
             "model_info": {"id": "resolved-paid-id"},
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+
+    def test_unresolved_deployment_falls_back_to_cost_map(self):
+        # When per-deployment resolution yields nothing (wildcard/unregistered),
+        # the concrete model is priced from the global cost map: mapped models
+        # stay usable, unmapped ones fail closed.
+        litellm.model_cost["anthropic/fallback-mapped-test"] = {
+            "input_cost_per_token": 0.000003,
+            "output_cost_per_token": 0.000004,
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+        }
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.return_value = None
+        mapped = {
+            "model_name": "anthropic/fallback-mapped-test",
+            "litellm_params": {"model": "anthropic/fallback-mapped-test"},
+            "model_info": {"id": "wc-id"},
+        }
+        assert (
+            _classify_deployment_cost(mapped, router) == ModelCostClass.KNOWN_POSITIVE
+        )
+        unmapped = {
+            "model_name": "anthropic/fallback-unmapped-zzz",
+            "litellm_params": {"model": "anthropic/fallback-unmapped-zzz"},
+            "model_info": {"id": "wc-id2"},
+        }
+        assert _classify_deployment_cost(unmapped, router) == ModelCostClass.UNKNOWN
+
+    def test_retained_wildcard_pattern_uses_concrete_model_name(self):
+        # If litellm_params still holds the wildcard pattern, the concrete
+        # model_name the router resolved is used for pricing.
+        litellm.model_cost["anthropic/retained-pattern-mapped"] = {
+            "input_cost_per_token": 0.000003,
+            "output_cost_per_token": 0.000004,
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+        }
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.return_value = None
+        deployment = {
+            "model_name": "anthropic/retained-pattern-mapped",
+            "litellm_params": {"model": "anthropic/*"},
+            "model_info": {"id": "wc-id3"},
         }
         assert (
             _classify_deployment_cost(deployment, router)

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -9,6 +9,7 @@ See: https://github.com/BerriAI/litellm/issues/24770
 
 import copy
 import logging
+from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
@@ -397,6 +398,41 @@ class TestBlockUnknownCostModelsCheck:
                 route="/v1/chat/completions",
             )
 
+    def test_flag_on_allows_wildcard_with_explicit_zero_cost(self):
+        """
+        Wildcard deployments with explicit ``input_cost_per_token=0`` /
+        ``output_cost_per_token=0`` must classify as EXPLICIT_ZERO for any
+        concrete model they match, so the fail-closed guard does not block
+        legitimately free traffic. Before the fix, ``_is_cost_explicitly_configured``
+        compared the requested model against ``deployment["model_name"]`` directly,
+        which never matched a wildcard pattern like ``free-wildcard/*`` and
+        misclassified the request as UNKNOWN.
+        """
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "free-wildcard/*",
+                    "litellm_params": {
+                        "model": "openai/free-wildcard/*",
+                        "api_key": "sk-fake",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                    "model_info": {
+                        "id": "free-wildcard-id",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                },
+            ]
+        )
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model="free-wildcard/any-concrete-model",
+            llm_router=router,
+            route="/v1/chat/completions",
+        )
+
 
 class TestBlockUnknownCostModelsViaCommonChecks:
     """End-to-end wiring through common_checks (the actual auth call site)."""
@@ -408,11 +444,15 @@ class TestBlockUnknownCostModelsViaCommonChecks:
         litellm.model_cost = self._saved_model_cost
 
     async def _run_common_checks(
-        self, model: str, general_settings: dict, proxy_logging
+        self,
+        model: str,
+        general_settings: dict,
+        proxy_logging,
+        request_body: Optional[dict] = None,
     ):
         router = _router_with_mixed_costs()
         return await common_checks(
-            request_body={"model": model},
+            request_body=request_body if request_body is not None else {"model": model},
             team_object=None,
             user_object=None,
             end_user_object=None,
@@ -452,6 +492,41 @@ class TestBlockUnknownCostModelsViaCommonChecks:
             model="paid-model",
             general_settings={"block_unknown_cost_models": True},
             proxy_logging=mock_proxy_logging,
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_unmapped_completion_model_default_blocked_when_flag_on(
+        self, mock_proxy_logging
+    ):
+        """When a request omits ``model`` but ``general_settings.completion_model``
+        names an unpriced model, the fail-closed guard must classify the
+        server default; otherwise ``common_request_processing`` would silently
+        substitute the default after auth, reopening the Denial-of-Wallet gap."""
+        with pytest.raises(ProxyException) as exc_info:
+            await self._run_common_checks(
+                model="",
+                general_settings={
+                    "block_unknown_cost_models": True,
+                    "completion_model": _UNMAPPED_MODEL,
+                },
+                proxy_logging=mock_proxy_logging,
+                request_body={},
+            )
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_known_completion_model_default_allowed_when_flag_on(
+        self, mock_proxy_logging
+    ):
+        result = await self._run_common_checks(
+            model="",
+            general_settings={
+                "block_unknown_cost_models": True,
+                "completion_model": "paid-model",
+            },
+            proxy_logging=mock_proxy_logging,
+            request_body={},
         )
         assert result is True
 

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -813,3 +813,8 @@ class TestAsCost:
         assert _as_cost(None) is None
         assert _as_cost("0.0") is None
         assert _as_cost({"input_cost_per_token": 1}) is None
+
+    def test_bool_is_not_a_cost(self):
+        # bool subclasses int, but a misconfigured `cost: true` is not a $1 price.
+        assert _as_cost(True) is None
+        assert _as_cost(False) is None

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -8,10 +8,84 @@ See: https://github.com/BerriAI/litellm/issues/24770
 """
 
 import copy
+from unittest.mock import MagicMock
+
+import pytest
 
 import litellm
-from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import (
+    ModelCostClass,
+    _block_unknown_cost_models_check,
+    _classify_model_group_cost,
+    _is_model_cost_zero,
+    _request_has_unknown_cost_model,
+    common_checks,
+)
+from litellm.proxy.utils import ProxyLogging
 from litellm.router import Router
+
+
+def _router_with_mixed_costs() -> Router:
+    """Router exposing the three cost classes through one wildcard plus two
+    explicitly-priced deployments, so tests don't depend on the live cost map:
+
+    * ``anthropic/*`` -> unmapped concrete models resolve to UNKNOWN cost
+    * ``paid-model``  -> explicit positive pricing (KNOWN_POSITIVE)
+    * ``free-model``  -> explicit $0 pricing (EXPLICIT_ZERO)
+    """
+    return Router(
+        model_list=[
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*", "api_key": "sk-fake"},
+            },
+            {
+                "model_name": "paid-model",
+                "litellm_params": {
+                    "model": "openai/some-paid-model",
+                    "api_key": "sk-fake",
+                    "input_cost_per_token": 0.000002,
+                    "output_cost_per_token": 0.000008,
+                },
+                "model_info": {
+                    "id": "paid-model-id",
+                    "input_cost_per_token": 0.000002,
+                    "output_cost_per_token": 0.000008,
+                },
+            },
+            {
+                "model_name": "free-model",
+                "litellm_params": {
+                    "model": "ollama/llama2",
+                    "api_base": "http://localhost:11434",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+                "model_info": {
+                    "id": "free-model-id",
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+            },
+        ]
+    )
+
+
+# A model id that cannot appear in any cost map (neither remote nor backup),
+# so it deterministically resolves to UNKNOWN cost through the wildcard route.
+_UNMAPPED_MODEL = "anthropic/brand-new-unmapped-model-xyz"
+
+
+@pytest.fixture
+def mock_proxy_logging() -> ProxyLogging:
+    proxy_logging = ProxyLogging(user_api_key_cache=None)
+
+    async def _noop_budget_alerts(*args, **kwargs):
+        return None
+
+    proxy_logging.budget_alerts = _noop_budget_alerts
+    return proxy_logging
 
 
 class TestUnmappedModelBudgetEnforcement:
@@ -183,3 +257,196 @@ class TestUnmappedModelBudgetEnforcement:
 
         result = _is_model_cost_zero(model="paid-model", llm_router=mock_router)
         assert result is False
+
+
+class TestClassifyModelGroupCost:
+    """The tri-state classifier must distinguish 'free' from 'unknown' cost."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_unmapped_wildcard_model_is_unknown(self):
+        router = _router_with_mixed_costs()
+        assert (
+            _classify_model_group_cost(_UNMAPPED_MODEL, router)
+            == ModelCostClass.UNKNOWN
+        )
+
+    def test_explicitly_priced_model_is_known_positive(self):
+        router = _router_with_mixed_costs()
+        assert (
+            _classify_model_group_cost("paid-model", router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+
+    def test_explicitly_free_model_is_explicit_zero(self):
+        router = _router_with_mixed_costs()
+        assert (
+            _classify_model_group_cost("free-model", router)
+            == ModelCostClass.EXPLICIT_ZERO
+        )
+
+
+class TestRequestHasUnknownCostModel:
+    """Detector backing the fail-closed check."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_unmapped_model_is_unknown(self):
+        router = _router_with_mixed_costs()
+        assert _request_has_unknown_cost_model(_UNMAPPED_MODEL, router) is True
+
+    def test_known_paid_model_is_not_unknown(self):
+        router = _router_with_mixed_costs()
+        assert _request_has_unknown_cost_model("paid-model", router) is False
+
+    def test_explicitly_free_model_is_not_unknown(self):
+        router = _router_with_mixed_costs()
+        assert _request_has_unknown_cost_model("free-model", router) is False
+
+    def test_any_unmapped_model_in_list_is_unknown(self):
+        router = _router_with_mixed_costs()
+        assert (
+            _request_has_unknown_cost_model(["paid-model", _UNMAPPED_MODEL], router)
+            is True
+        )
+
+    def test_none_model_is_not_unknown(self):
+        router = _router_with_mixed_costs()
+        assert _request_has_unknown_cost_model(None, router) is False
+
+
+class TestBlockUnknownCostModelsCheck:
+    """Fail-closed gate (OWASP LLM10 Denial of Wallet) on unknown-cost models."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_flag_off_allows_unmapped_model(self):
+        router = _router_with_mixed_costs()
+        # No exception: the flag is opt-in, default behavior is unchanged.
+        _block_unknown_cost_models_check(
+            enabled=False,
+            model=_UNMAPPED_MODEL,
+            llm_router=router,
+            route="/v1/chat/completions",
+        )
+
+    def test_flag_on_blocks_unmapped_model(self):
+        router = _router_with_mixed_costs()
+        with pytest.raises(ProxyException) as exc_info:
+            _block_unknown_cost_models_check(
+                enabled=True,
+                model=_UNMAPPED_MODEL,
+                llm_router=router,
+                route="/v1/chat/completions",
+            )
+        assert str(exc_info.value.code) == "400"
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+        assert "block_unknown_cost_models" in exc_info.value.message
+
+    def test_flag_on_allows_known_paid_model(self):
+        router = _router_with_mixed_costs()
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model="paid-model",
+            llm_router=router,
+            route="/v1/chat/completions",
+        )
+
+    def test_flag_on_allows_explicitly_free_model(self):
+        router = _router_with_mixed_costs()
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model="free-model",
+            llm_router=router,
+            route="/v1/chat/completions",
+        )
+
+    def test_flag_on_ignores_non_llm_route(self):
+        router = _router_with_mixed_costs()
+        # Management routes never call an LLM, so there is no spend to enforce.
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model=_UNMAPPED_MODEL,
+            llm_router=router,
+            route="/key/generate",
+        )
+
+    def test_flag_on_blocks_list_containing_unmapped_model(self):
+        router = _router_with_mixed_costs()
+        with pytest.raises(ProxyException):
+            _block_unknown_cost_models_check(
+                enabled=True,
+                model=["paid-model", _UNMAPPED_MODEL],
+                llm_router=router,
+                route="/v1/chat/completions",
+            )
+
+
+class TestBlockUnknownCostModelsViaCommonChecks:
+    """End-to-end wiring through common_checks (the actual auth call site)."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    async def _run_common_checks(
+        self, model: str, general_settings: dict, proxy_logging
+    ):
+        router = _router_with_mixed_costs()
+        return await common_checks(
+            request_body={"model": model},
+            team_object=None,
+            user_object=None,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings=general_settings,
+            route="/v1/chat/completions",
+            llm_router=router,
+            proxy_logging_obj=proxy_logging,
+            valid_token=UserAPIKeyAuth(token="test-token"),
+            request=MagicMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_unmapped_model_allowed_when_flag_off(self, mock_proxy_logging):
+        # Demonstrates the Denial-of-Wallet gap: without the flag, an unmapped
+        # model (whose spend can't be tracked) passes auth unimpeded.
+        result = await self._run_common_checks(
+            model=_UNMAPPED_MODEL,
+            general_settings={},
+            proxy_logging=mock_proxy_logging,
+        )
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_unmapped_model_blocked_when_flag_on(self, mock_proxy_logging):
+        with pytest.raises(ProxyException) as exc_info:
+            await self._run_common_checks(
+                model=_UNMAPPED_MODEL,
+                general_settings={"block_unknown_cost_models": True},
+                proxy_logging=mock_proxy_logging,
+            )
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_known_model_allowed_when_flag_on(self, mock_proxy_logging):
+        result = await self._run_common_checks(
+            model="paid-model",
+            general_settings={"block_unknown_cost_models": True},
+            proxy_logging=mock_proxy_logging,
+        )
+        assert result is True

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -246,16 +246,18 @@ class TestUnmappedModelBudgetEnforcement:
         compute a correct answer, just without caching."""
         from unittest.mock import MagicMock
 
-        from litellm.types.router import ModelGroupInfo
-
         mock_router = MagicMock(spec=Router)
-        mock_router.model_list = []
-        mock_router.get_model_group_info.return_value = ModelGroupInfo(
-            model_group="paid-model",
-            providers=["openai"],
-            input_cost_per_token=0.001,
-            output_cost_per_token=0.002,
-        )
+        mock_router.get_model_list.return_value = [
+            {
+                "model_name": "paid-model",
+                "litellm_params": {"model": "openai/some-paid-model"},
+                "model_info": {"id": "paid-id"},
+            }
+        ]
+        mock_router.get_deployment_model_info.return_value = {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+        }
         # Strip the attribute so the helper falls back to the no-cache path.
         del mock_router._model_cost_class_cache
 
@@ -432,6 +434,44 @@ class TestBlockUnknownCostModelsCheck:
             route="/v1/chat/completions",
         )
 
+    def test_flag_on_blocks_mixed_group_with_unpriced_deployment(self):
+        """A model group that load balances across a priced and an unpriced
+        deployment must be blocked: get_model_group_info reports the maximum
+        cost across deployments, so the priced one would mask the unpriced one,
+        yet a call routed to the unpriced deployment records $0 and bypasses
+        budgets."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "mixed-group",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-fake",
+                    },
+                    "model_info": {"id": "mixed-priced"},
+                },
+                {
+                    "model_name": "mixed-group",
+                    "litellm_params": {
+                        "model": "openai/totally-unmapped-deployment-zzz",
+                        "api_key": "sk-fake",
+                    },
+                    "model_info": {"id": "mixed-unpriced"},
+                },
+            ]
+        )
+        assert (
+            _classify_model_group_cost("mixed-group", router) == ModelCostClass.UNKNOWN
+        )
+        with pytest.raises(ProxyException) as exc_info:
+            _block_unknown_cost_models_check(
+                enabled=True,
+                model="mixed-group",
+                llm_router=router,
+                route="/v1/chat/completions",
+            )
+        assert "mixed-group" in exc_info.value.message
+
 
 class TestBlockUnknownCostModelsViaCommonChecks:
     """End-to-end wiring through common_checks (the actual auth call site)."""
@@ -560,16 +600,16 @@ class TestCostClassificationCaching:
     def teardown_method(self):
         litellm.model_cost = self._saved_model_cost
 
-    def test_both_callers_share_a_single_get_model_group_info_lookup(self):
+    def test_both_callers_share_a_single_deployment_lookup(self):
         router = _router_with_mixed_costs()
         lookups = {"count": 0}
-        original_get_model_group_info = router.get_model_group_info
+        original_get_model_list = router.get_model_list
 
-        def counting_get_model_group_info(*args, **kwargs):
+        def counting_get_model_list(*args, **kwargs):
             lookups["count"] += 1
-            return original_get_model_group_info(*args, **kwargs)
+            return original_get_model_list(*args, **kwargs)
 
-        router.get_model_group_info = counting_get_model_group_info
+        router.get_model_list = counting_get_model_list
 
         # First caller resolves and caches the classification (one lookup).
         assert _request_has_unknown_cost_model(_UNMAPPED_MODEL, router) is True
@@ -597,7 +637,7 @@ class TestCostClassificationCaching:
         def fail_if_called(*args, **kwargs):
             raise AssertionError("classification cache was bypassed")
 
-        router.get_model_group_info = fail_if_called
+        router.get_model_list = fail_if_called
         assert (
             _classify_model_group_cost("paid-model", router)
             == ModelCostClass.KNOWN_POSITIVE

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -8,6 +8,7 @@ See: https://github.com/BerriAI/litellm/issues/24770
 """
 
 import copy
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -209,7 +210,10 @@ class TestUnmappedModelBudgetEnforcement:
         )
         # Warm the cache as zero-cost.
         assert _is_model_cost_zero(model="ramping-model", llm_router=router) is True
-        assert router._zero_cost_cache.get("ramping-model") is True
+        assert (
+            router._model_cost_class_cache.get("ramping-model")
+            == ModelCostClass.EXPLICIT_ZERO.value
+        )
 
         # In-place pricing update: same deployment count, same router id,
         # same model name. The pre-fix cache key was
@@ -232,13 +236,13 @@ class TestUnmappedModelBudgetEnforcement:
         )
 
         # Cache must have been cleared by ``_invalidate_model_group_info_cache``.
-        assert router._zero_cost_cache == {}
+        assert router._model_cost_class_cache == {}
         # Subsequent call sees the new pricing and enforces budget.
         assert _is_model_cost_zero(model="ramping-model", llm_router=router) is False
 
-    def test_handles_router_without_zero_cost_cache_attribute(self):
+    def test_handles_router_without_cost_class_cache_attribute(self):
         """Tolerate router-like objects (e.g. ``MagicMock`` stand-ins) that
-        do not expose ``_zero_cost_cache`` — the auth check must still
+        do not expose ``_model_cost_class_cache`` — the auth check must still
         compute a correct answer, just without caching."""
         from unittest.mock import MagicMock
 
@@ -253,7 +257,7 @@ class TestUnmappedModelBudgetEnforcement:
             output_cost_per_token=0.002,
         )
         # Strip the attribute so the helper falls back to the no-cache path.
-        del mock_router._zero_cost_cache
+        del mock_router._model_cost_class_cache
 
         result = _is_model_cost_zero(model="paid-model", llm_router=mock_router)
         assert result is False
@@ -450,3 +454,84 @@ class TestBlockUnknownCostModelsViaCommonChecks:
             proxy_logging=mock_proxy_logging,
         )
         assert result is True
+
+
+class TestCostClassificationCaching:
+    """The free-model bypass and the unknown-cost block check must share one
+    per-router classification, so a model is resolved at most once per request."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_both_callers_share_a_single_get_model_group_info_lookup(self):
+        router = _router_with_mixed_costs()
+        lookups = {"count": 0}
+        original_get_model_group_info = router.get_model_group_info
+
+        def counting_get_model_group_info(*args, **kwargs):
+            lookups["count"] += 1
+            return original_get_model_group_info(*args, **kwargs)
+
+        router.get_model_group_info = counting_get_model_group_info
+
+        # First caller resolves and caches the classification (one lookup).
+        assert _request_has_unknown_cost_model(_UNMAPPED_MODEL, router) is True
+        lookups_after_first = lookups["count"]
+        assert lookups_after_first >= 1
+
+        # The other caller for the same model must reuse the cached class with
+        # no additional router lookup (this is the double-lookup regression).
+        assert _is_model_cost_zero(model=_UNMAPPED_MODEL, llm_router=router) is False
+        assert lookups["count"] == lookups_after_first
+
+        assert (
+            router._model_cost_class_cache[_UNMAPPED_MODEL]
+            == ModelCostClass.UNKNOWN.value
+        )
+
+    def test_cache_hit_does_not_call_router_again(self):
+        router = _router_with_mixed_costs()
+        assert (
+            _classify_model_group_cost("paid-model", router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+
+        # Once cached, a stale router lookup must never be consulted again.
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("classification cache was bypassed")
+
+        router.get_model_group_info = fail_if_called
+        assert (
+            _classify_model_group_cost("paid-model", router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+
+
+class TestBlockUnknownCostModelsWithoutRouter:
+    """When the flag is on but no router is configured, the guard cannot
+    classify cost; it must surface a warning instead of silently no-opping."""
+
+    def test_router_none_warns_and_allows(self, caplog):
+        logger = logging.getLogger("LiteLLM Proxy")
+        previous_propagate = logger.propagate
+        logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+                # Must not raise: cost is unknowable without a router, so the
+                # request is allowed through (behavior unchanged), but loudly.
+                _block_unknown_cost_models_check(
+                    enabled=True,
+                    model=_UNMAPPED_MODEL,
+                    llm_router=None,
+                    route="/v1/chat/completions",
+                )
+        finally:
+            logger.propagate = previous_propagate
+
+        assert any(
+            "block_unknown_cost_models" in record.getMessage()
+            for record in caplog.records
+        )

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -17,7 +17,9 @@ import litellm
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
 from litellm.proxy.auth.auth_checks import (
     ModelCostClass,
+    _as_cost,
     _block_unknown_cost_models_check,
+    _classify_deployment_cost,
     _classify_model_group_cost,
     _is_model_cost_zero,
     _request_has_unknown_cost_model,
@@ -681,3 +683,133 @@ class TestBlockUnknownCostModelsWithoutRouter:
             llm_router=None,
             route="/v1/chat/completions",
         )
+
+
+class TestClassifyDeploymentCost:
+    """Per-deployment classifier branches the group-level tests don't reach,
+    including the fallback that runs when a deployment never resolves through
+    ``get_deployment_model_info`` (no ``model_info.id``)."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_positive_explicit_cost_without_model_id_is_known_positive(self):
+        # Regression: a deployment that never reaches get_deployment_model_info
+        # (no model_info.id) but carries a positive explicit price must be
+        # KNOWN_POSITIVE, not EXPLICIT_ZERO. Misclassifying it free would make
+        # _is_model_cost_zero return True and silently skip every budget check.
+        router = MagicMock(spec=Router)
+        deployment = {
+            "model_name": "no-id-paid",
+            "litellm_params": {
+                "model": "openai/some-paid-model",
+                "input_cost_per_token": 0.000002,
+                "output_cost_per_token": 0.000008,
+            },
+            "model_info": {},
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+        router.get_deployment_model_info.assert_not_called()
+
+    def test_zero_explicit_cost_without_model_id_is_explicit_zero(self):
+        router = MagicMock(spec=Router)
+        deployment = {
+            "model_name": "no-id-free",
+            "litellm_params": {
+                "model": "openai/some-free-model",
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            },
+            "model_info": {},
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.EXPLICIT_ZERO
+        )
+
+    def test_no_explicit_cost_and_no_resolution_is_unknown(self):
+        # No model_info.id, no explicit price, nothing to resolve: fail closed
+        # to UNKNOWN rather than silently treating it as free.
+        router = MagicMock(spec=Router)
+        deployment = {
+            "model_name": "no-id-unpriced",
+            "litellm_params": {"model": "openai/whatever"},
+            "model_info": None,
+        }
+        assert _classify_deployment_cost(deployment, router) == ModelCostClass.UNKNOWN
+
+    def test_get_deployment_model_info_error_falls_back_to_explicit(self):
+        # If resolving the deployment's cost raises, the classifier must still
+        # honor an explicit deployment price rather than propagate the error.
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.side_effect = RuntimeError("boom")
+        deployment = {
+            "model_name": "err-priced",
+            "litellm_params": {
+                "model": "openai/some-paid-model",
+                "input_cost_per_token": 0.000002,
+                "output_cost_per_token": 0.000008,
+            },
+            "model_info": {"id": "err-priced-id"},
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+        router.get_deployment_model_info.assert_called_once()
+
+    def test_explicit_cost_from_model_info_when_absent_in_litellm_params(self):
+        # The explicit price lives only in model_info; the model_info fallback
+        # must still classify it as explicitly free.
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.return_value = None
+        deployment = {
+            "model_name": "mi-free",
+            "litellm_params": {"model": "openai/mi-free"},
+            "model_info": {
+                "id": "mi-free-id",
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            },
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.EXPLICIT_ZERO
+        )
+
+    def test_resolved_positive_cost_is_known_positive(self):
+        router = MagicMock(spec=Router)
+        router.get_deployment_model_info.return_value = {
+            "input_cost_per_token": 0.000003,
+            "output_cost_per_token": 0.000009,
+        }
+        deployment = {
+            "model_name": "resolved-paid",
+            "litellm_params": {"model": "openai/resolved-paid"},
+            "model_info": {"id": "resolved-paid-id"},
+        }
+        assert (
+            _classify_deployment_cost(deployment, router)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+
+
+class TestAsCost:
+    """``_as_cost`` coerces only real numbers, so non-numeric pricing values
+    can't masquerade as a measurable cost."""
+
+    def test_numbers_pass_through_as_float(self):
+        assert _as_cost(0) == 0.0
+        assert _as_cost(5) == 5.0
+        assert _as_cost(0.000002) == 0.000002
+
+    def test_non_numbers_become_none(self):
+        assert _as_cost(None) is None
+        assert _as_cost("0.0") is None
+        assert _as_cost({"input_cost_per_token": 1}) is None

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -21,6 +21,7 @@ from litellm.proxy.auth.auth_checks import (
     _block_unknown_cost_models_check,
     _classify_deployment_cost,
     _classify_model_group_cost,
+    _cost_class_cache_key,
     _is_model_cost_zero,
     _request_has_unknown_cost_model,
     common_checks,
@@ -213,7 +214,9 @@ class TestUnmappedModelBudgetEnforcement:
         # Warm the cache as zero-cost.
         assert _is_model_cost_zero(model="ramping-model", llm_router=router) is True
         assert (
-            router._model_cost_class_cache.get("ramping-model")
+            router._model_cost_class_cache.get(
+                _cost_class_cache_key("ramping-model", None)
+            )
             == ModelCostClass.EXPLICIT_ZERO.value
         )
 
@@ -624,7 +627,7 @@ class TestCostClassificationCaching:
         assert lookups["count"] == lookups_after_first
 
         assert (
-            router._model_cost_class_cache[_UNMAPPED_MODEL]
+            router._model_cost_class_cache[_cost_class_cache_key(_UNMAPPED_MODEL, None)]
             == ModelCostClass.UNKNOWN.value
         )
 
@@ -818,3 +821,77 @@ class TestAsCost:
         # bool subclasses int, but a misconfigured `cost: true` is not a $1 price.
         assert _as_cost(True) is None
         assert _as_cost(False) is None
+
+
+class TestTeamScopedCostClassification:
+    """A team can shadow a priced public model name with its own unpriced
+    deployment; the guard must classify the deployment set the router resolves
+    for that team, not the global one, or the team route bypasses budgets."""
+
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
+
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def _router_with_team_shadow(self) -> Router:
+        # Global "shared-model" is priced; team "teamX" exposes the same public
+        # name backed by its own unmapped (unpriced) deployment.
+        return Router(
+            model_list=[
+                {
+                    "model_name": "shared-model",
+                    "litellm_params": {
+                        "model": "openai/gpt-4o-mini",
+                        "api_key": "sk-fake",
+                    },
+                    "model_info": {"id": "global-priced"},
+                },
+                {
+                    "model_name": "shared-model-team-teamX",
+                    "litellm_params": {
+                        "model": "openai/team-unmapped-zzz",
+                        "api_key": "sk-fake",
+                    },
+                    "model_info": {
+                        "id": "team-unpriced",
+                        "team_id": "teamX",
+                        "team_public_model_name": "shared-model",
+                    },
+                },
+            ]
+        )
+
+    def test_team_unpriced_shadow_is_blocked(self):
+        router = self._router_with_team_shadow()
+        # The global view only sees the priced deployment, which is why a
+        # team-unaware guard would wrongly let the team request through.
+        assert (
+            _classify_model_group_cost("shared-model", router, None)
+            == ModelCostClass.KNOWN_POSITIVE
+        )
+        assert (
+            _classify_model_group_cost("shared-model", router, "teamX")
+            == ModelCostClass.UNKNOWN
+        )
+        with pytest.raises(ProxyException) as exc_info:
+            _block_unknown_cost_models_check(
+                enabled=True,
+                model="shared-model",
+                llm_router=router,
+                route="/v1/chat/completions",
+                team_id="teamX",
+            )
+        assert "shared-model" in exc_info.value.message
+
+    def test_non_team_request_not_overblocked(self):
+        router = self._router_with_team_shadow()
+        # A non-team caller routes to the priced global deployment, so the guard
+        # must not block it just because some team shadows the name.
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model="shared-model",
+            llm_router=router,
+            route="/v1/chat/completions",
+            team_id=None,
+        )

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -627,6 +627,36 @@ class TestBlockUnknownCostModelsViaCommonChecks:
             )
         assert "brand-new-unmapped-model-xyz" in exc_info.value.message
 
+    @pytest.mark.asyncio
+    async def test_free_request_model_does_not_skip_guard_for_unpriced_default(
+        self, mock_proxy_logging
+    ):
+        """skip_budget_checks is derived from the request model upstream, but
+        completion_model overrides that model in common_request_processing. A
+        caller sending an explicitly-free model (so skip_budget_checks=True) must
+        still hit the guard when the server default is unpriced; gating the guard
+        on skip_budget_checks would let the unpriced default run untracked."""
+        router = _router_with_mixed_costs()
+        with pytest.raises(ProxyException) as exc_info:
+            await common_checks(
+                request_body={"model": "free-model"},
+                team_object=None,
+                user_object=None,
+                end_user_object=None,
+                global_proxy_spend=None,
+                general_settings={
+                    "block_unknown_cost_models": True,
+                    "completion_model": _UNMAPPED_MODEL,
+                },
+                route="/v1/chat/completions",
+                llm_router=router,
+                proxy_logging_obj=mock_proxy_logging,
+                valid_token=UserAPIKeyAuth(token="test-token"),
+                request=MagicMock(),
+                skip_budget_checks=True,
+            )
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+
 
 class TestCostClassificationCaching:
     """The free-model bypass and the unknown-cost block check must share one

--- a/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
+++ b/tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py
@@ -8,7 +8,6 @@ See: https://github.com/BerriAI/litellm/issues/24770
 """
 
 import copy
-import logging
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -530,6 +529,26 @@ class TestBlockUnknownCostModelsViaCommonChecks:
         )
         assert result is True
 
+    @pytest.mark.asyncio
+    async def test_unpriced_completion_model_overrides_priced_request_model(
+        self, mock_proxy_logging
+    ):
+        """``completion_model`` takes precedence over the request body model in
+        ``common_request_processing``, so an unpriced server default must be
+        blocked even when the request itself names a priced model; otherwise the
+        priced model in the body masks the unpriced model that actually runs."""
+        with pytest.raises(ProxyException) as exc_info:
+            await self._run_common_checks(
+                model="paid-model",
+                general_settings={
+                    "block_unknown_cost_models": True,
+                    "completion_model": _UNMAPPED_MODEL,
+                },
+                proxy_logging=mock_proxy_logging,
+                request_body={"model": "paid-model"},
+            )
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+
 
 class TestCostClassificationCaching:
     """The free-model bypass and the unknown-cost block check must share one
@@ -586,27 +605,39 @@ class TestCostClassificationCaching:
 
 
 class TestBlockUnknownCostModelsWithoutRouter:
-    """When the flag is on but no router is configured, the guard cannot
-    classify cost; it must surface a warning instead of silently no-opping."""
+    """A proxy that routes directly through litellm (no Router) must still
+    enforce the guard via the global cost map, not silently pass the request."""
 
-    def test_router_none_warns_and_allows(self, caplog):
-        logger = logging.getLogger("LiteLLM Proxy")
-        previous_propagate = logger.propagate
-        logger.propagate = True
-        try:
-            with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
-                # Must not raise: cost is unknowable without a router, so the
-                # request is allowed through (behavior unchanged), but loudly.
-                _block_unknown_cost_models_check(
-                    enabled=True,
-                    model=_UNMAPPED_MODEL,
-                    llm_router=None,
-                    route="/v1/chat/completions",
-                )
-        finally:
-            logger.propagate = previous_propagate
+    def setup_method(self):
+        self._saved_model_cost = copy.deepcopy(litellm.model_cost)
 
-        assert any(
-            "block_unknown_cost_models" in record.getMessage()
-            for record in caplog.records
+    def teardown_method(self):
+        litellm.model_cost = self._saved_model_cost
+
+    def test_no_router_blocks_unmapped_model(self):
+        # No router and no cost map entry: spend can't be measured, so the
+        # Denial-of-Wallet guard must fail closed instead of waving it through.
+        with pytest.raises(ProxyException) as exc_info:
+            _block_unknown_cost_models_check(
+                enabled=True,
+                model=_UNMAPPED_MODEL,
+                llm_router=None,
+                route="/v1/chat/completions",
+            )
+        assert "brand-new-unmapped-model-xyz" in exc_info.value.message
+
+    def test_no_router_allows_cost_mapped_model(self):
+        # A model whose cost litellm knows is measurable, so it must pass even
+        # without a router.
+        litellm.model_cost["nrouter-known-model"] = {
+            "input_cost_per_token": 0.000001,
+            "output_cost_per_token": 0.000002,
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+        _block_unknown_cost_models_check(
+            enabled=True,
+            model="nrouter-known-model",
+            llm_router=None,
+            route="/v1/chat/completions",
         )

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22076,6 +22076,11 @@ export interface components {
              */
             background_health_checks?: boolean | null;
             /**
+             * Block Unknown Cost Models
+             * @description Fail closed against Denial of Wallet (OWASP LLM10 Unbounded Consumption). When True, the proxy rejects LLM API requests for models whose per-token cost it cannot determine, e.g. a brand new model reached via a wildcard route like 'anthropic/*' that is not yet in the model cost map. Such models produce a $0 cost that never moves the spend counters, so any configured key/user/team budget would silently never trip and could be spent without limit. Explicitly free deployments (input_cost_per_token and output_cost_per_token set to 0) are unaffected. To serve an unmapped model under this flag, add it to model_prices_and_context_window.json or set explicit per-token pricing on the deployment. Default is False.
+             */
+            block_unknown_cost_models?: boolean | null;
+            /**
              * Cancel On Disconnect
              * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
              */


### PR DESCRIPTION

## Relevant issues

Closes a Denial-of-Wallet exposure under OWASP LLM10 (Unbounded Consumption). Follow-on hardening to the unmapped-model budget work in #24770; that change made the pre-call gate conservative, but the spend bypass itself was still open

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (currently 5/5)

## Type

New Feature (security hardening)

## Changes

When a request targets a model whose per-token cost LiteLLM cannot determine, the computed cost is 0. A brand new model reached through a wildcard route like `anthropic/*` that is not yet in `model_prices_and_context_window.json`, or a sparsely auto-registered deployment, both hit this path. Because key, user and team budgets are enforced from accumulated spend, a 0 cost never moves the spend counters, so a configured budget silently never trips and the model can be called without limit. This is the Denial-of-Wallet case from the OWASP LLM10 list; a cap that opens when it cannot measure spend is no cap at all.

This adds an opt-in `general_settings.block_unknown_cost_models`. When enabled, `common_checks` refuses LLM API requests for unknown-cost models with a clear 400 that tells the operator to map the model or set `input_cost_per_token` and `output_cost_per_token` on the deployment. Explicitly free deployments (cost configured as 0) keep working because their budget checks are already skipped upstream, non-LLM routes are untouched, and with the flag off behavior is unchanged so existing users can still adopt new models before the cost map catches up.

The pricing lookup is unified behind a single `ModelCostClass` classifier (explicit-zero, known-positive, unknown) that both the existing `_is_model_cost_zero` skip gate and the new fail-closed check share, so the two always agree on what "unknown" means. `ModelCostClass` is a `str, Enum` compared by value to stay robust to LiteLLM's test-suite module reloading

Tests extend the mapped regression file `tests/test_litellm/proxy/auth/test_unmapped_model_budget_enforcement.py`: the classifier across the three cost classes, the unknown-cost detector (including list inputs), the fail-closed gate (flag on/off, known, free, non-LLM route, list), and end-to-end wiring through `common_checks` for both flag states. I verified the wiring test is a real regression by removing the call from `common_checks` and watching `test_unmapped_model_blocked_when_flag_on` fail with "DID NOT RAISE", then restored it

Follow-up to review feedback on this PR: the free-model bypass and the unknown-cost block check now share a single `get_model_group_info` lookup per model per request. `_classify_model_group_cost` is memoized behind a per-router classification cache (`_model_cost_class_cache`, replacing the bool-only `_zero_cost_cache`) that both callers read, and it is invalidated alongside the existing model-group-info cache so an in-place pricing update still takes effect immediately. When the flag is enabled but no router is configured the guard falls back to the global litellm cost map so the protection still holds on a routerless proxy

Several further rounds of review hardening followed, each with a regression test that fails before the fix. Cost is classified per deployment rather than per model group, so a mixed group where one deployment is priced and another is not no longer hides the unpriced one behind the group's maximum cost; if any routable deployment is unknown-cost the whole request is treated as unknown. Classification is scoped by the caller's team and keyed by team in the cache, so the guard evaluates the same deployment set the router will actually route to. Wildcard routes that resolve to a concrete model already in the cost map stay usable, since `get_model_list` rewrites the wildcard to the requested model before pricing. The guard now runs even when budget checks are skipped: `skip_budget_checks` is derived from the request model, but `common_request_processing` gives `general_settings.completion_model` precedence, so an explicitly-free request model could otherwise skip the guard and let an unpriced server default through. A positive explicit cost on a deployment with no `model_info.id` is treated as known-positive rather than slipping through as free, and a boolean cost value is no longer coerced into a number so a misconfigured `input_cost_per_token: true` can't masquerade as a measurable price

The new `general_settings.block_unknown_cost_models` field changes the proxy OpenAPI spec, so `ui/litellm-dashboard/src/lib/http/schema.d.ts` was regenerated via `npm run gen:api` to keep the UI API type sync check green

## Screenshots / Proof of Fix

Live proxy on `localhost:4000` backed by Postgres, config with `anthropic/*` and `gemini/*` wildcards, hitting real provider APIs. A virtual key was minted with `["anthropic/*", "gemini/*"]` access and a $5 budget, mirroring the wildcard scenario where the gap shows up.

Flag OFF (`block_unknown_cost_models: false`), the gap: LiteLLM does not refuse the unpriced model, it forwards upstream. A real-but-unmapped model would have succeeded here while spend tracked as $0

```
$ curl /v1/chat/completions  -d '{"model":"gemini/gemini-9.9-fictional-zzz", ...}'
{"error":{"message":"litellm.NotFoundError: GeminiException - ... \"code\": 404,
  \"message\": \"models/gemini-9.9-fictional-zzz is not found ...\" ...","code":"404"}}
HTTP_STATUS:404
```

Flag ON (`block_unknown_cost_models: true`), a known mapped model still works (real Gemini call, real tokens billed):

```
$ curl /v1/chat/completions  -d '{"model":"gemini/gemini-2.5-flash","messages":[{"role":"user","content":"Reply with exactly this phrase and nothing else: budget guard works"}],"max_tokens":512}'
content: 'budget guard works'
finish_reason: stop
usage: {'completion_tokens': 59, 'prompt_tokens': 13, 'total_tokens': 72, ...}
HTTP_STATUS:200
```

Flag ON, the same unknown-cost models are refused before any upstream call. First the `anthropic/*` wildcard case from the original report, then a Gemini one:

```
$ curl /v1/chat/completions  -d '{"model":"anthropic/claude-fable-6-unreleased", ...}'
{"error":{"message":"Budget enforcement failed closed: LiteLLM does not know the cost of model 'anthropic/claude-fable-6-unreleased', so its spend cannot be tracked and a configured budget cannot be enforced (OWASP LLM10 Denial of Wallet). Add the model to the cost map (model_prices_and_context_window.json) or set input_cost_per_token and output_cost_per_token on the deployment. To allow models with unknown cost, disable general_settings.block_unknown_cost_models.","type":"bad_request_error","param":"model","code":"400"}}
HTTP_STATUS:400

$ curl /v1/chat/completions  -d '{"model":"gemini/gemini-9.9-fictional-zzz", ...}'
{"error":{"message":"Budget enforcement failed closed: LiteLLM does not know the cost of model 'gemini/gemini-9.9-fictional-zzz', so its spend cannot be tracked and a configured budget cannot be enforced (OWASP LLM10 Denial of Wallet). ...","type":"bad_request_error","param":"model","code":"400"}}
HTTP_STATUS:400
```

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1781745797510489?thread_ts=1781745797.510489&cid=C0B13QZPM8B)
