### PR TITLE
docs: fix 3 broken docs links (sigstore cosign + litellm enterprise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ Support for more providers. Missing a provider or LLM Platform, raise a [feature
 
 ### Verify Docker Image Signatures
 
-All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/overview/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
+All LiteLLM Docker images published to GHCR are signed with [cosign](https://docs.sigstore.dev/cosign/). Every release is signed with the same key introduced in [commit `0112e53`](https://github.com/BerriAI/litellm/commit/0112e53046018d726492c814b3644b7d376029d0).
 
 **Verify using the pinned commit hash (recommended):**
 
@@ -458,7 +458,7 @@ For companies that need better security, user management and professional suppor
 [Talk to founders](https://enterprise.litellm.ai/demo)
 
 This covers:
-- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/proxy/enterprise):**
+- ✅ **Features under the [LiteLLM Commercial License](https://docs.litellm.ai/docs/enterprise):**
 - ✅ **Feature Prioritization**
 - ✅ **Custom Integrations**
 - ✅ **Professional Support - Dedicated discord + slack**

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -6,4 +6,4 @@ Code in this folder is licensed under a commercial license. Please review the [L
 
 👉 **Using in an Enterprise / Need specific features ?** Meet with us [here](https://enterprise.litellm.ai/demo?month=2024-02)
 
-See all Enterprise Features here 👉 [Docs](https://docs.litellm.ai/docs/proxy/enterprise)
+See all Enterprise Features here 👉 [Docs](https://docs.litellm.ai/docs/enterprise)


### PR DESCRIPTION
## Summary

Three broken links in current README/enterprise docs were returning HTTP 404:

- `docs.sigstore.dev/cosign/overview/` → `docs.sigstore.dev/cosign/`
  (the `/overview` subpath was removed in the new sigstore docs site)
- `docs.litellm.ai/docs/proxy/enterprise` → `docs.litellm.ai/docs/enterprise`
  (the `/proxy/` prefix was dropped in the new docs structure; appears in 2 places: README and enterprise/README)

All replacements verified to return HTTP 200. Minimal diff, no code changes.

## Files

- `README.md` (sigstore cosign link + LiteLLM Commercial License link)
- `enterprise/README.md` (Enterprise Features Docs link)