### PR TITLE
fix(guardrails): mask PII in tool-call arguments for Presidio pre-call and Anthropic response

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -802,6 +802,39 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 elif isinstance(content, list) and content_idx_optional is not None:
                     messages[msg_idx]["content"][content_idx_optional]["text"] = r
 
+            # Also mask PII in tool_call / function_call arguments. The content loop
+            # above only inspects message content, so PII embedded in tool-call
+            # arguments would otherwise reach the provider unmasked -- this mirrors the
+            # response-side handling in _process_response_for_pii.
+            for m in messages:
+                if not isinstance(m, dict):
+                    continue
+                for tool_call in m.get("tool_calls") or []:
+                    function = (
+                        tool_call.get("function")
+                        if isinstance(tool_call, dict)
+                        else None
+                    )
+                    if isinstance(function, dict) and isinstance(
+                        function.get("arguments"), str
+                    ):
+                        function["arguments"] = await self.check_pii(
+                            text=function["arguments"],
+                            output_parse_pii=self.output_parse_pii,
+                            presidio_config=presidio_config,
+                            request_data=data,
+                        )
+                function_call = m.get("function_call")
+                if isinstance(function_call, dict) and isinstance(
+                    function_call.get("arguments"), str
+                ):
+                    function_call["arguments"] = await self.check_pii(
+                        text=function_call["arguments"],
+                        output_parse_pii=self.output_parse_pii,
+                        presidio_config=presidio_config,
+                        request_data=data,
+                    )
+
             verbose_proxy_logger.debug(
                 f"Presidio PII Masking: Redacted pii message: {data['messages']}"
             )
@@ -1016,20 +1049,40 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             return response
 
         for block in content:
-            if not isinstance(block, dict) or block.get("type") != "text":
+            if not isinstance(block, dict):
                 continue
-            text_value = block.get("text")
-            if text_value is None:
-                continue
-            if mode == "unmask":
-                block["text"] = self._unmask_pii_text(text_value, pii_tokens)
-            elif mode == "mask":
-                block["text"] = await self.check_pii(
-                    text=text_value,
-                    output_parse_pii=False,
-                    presidio_config=presidio_config,
-                    request_data=request_data,
-                )
+            block_type = block.get("type")
+            if block_type == "text":
+                text_value = block.get("text")
+                if text_value is None:
+                    continue
+                if mode == "unmask":
+                    block["text"] = self._unmask_pii_text(text_value, pii_tokens)
+                elif mode == "mask":
+                    block["text"] = await self.check_pii(
+                        text=text_value,
+                        output_parse_pii=False,
+                        presidio_config=presidio_config,
+                        request_data=request_data,
+                    )
+            elif block_type == "tool_use":
+                # Mirror the OpenAI-format path (_process_response_for_pii), which masks
+                # tool_call arguments: a tool_use block's `input` dict can carry PII the
+                # model produced, and must be masked too -- not just sibling text blocks.
+                tool_input = block.get("input")
+                if isinstance(tool_input, dict):
+                    for key, value in list(tool_input.items()):
+                        if not isinstance(value, str):
+                            continue
+                        if mode == "unmask":
+                            tool_input[key] = self._unmask_pii_text(value, pii_tokens)
+                        elif mode == "mask":
+                            tool_input[key] = await self.check_pii(
+                                text=value,
+                                output_parse_pii=False,
+                                presidio_config=presidio_config,
+                                request_data=request_data,
+                            )
 
         return response
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -802,10 +802,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 elif isinstance(content, list) and content_idx_optional is not None:
                     messages[msg_idx]["content"][content_idx_optional]["text"] = r
 
-            # Also mask PII in tool_call / function_call arguments. The content loop
-            # above only inspects message content, so PII embedded in tool-call
-            # arguments would otherwise reach the provider unmasked -- this mirrors the
-            # response-side handling in _process_response_for_pii.
+            # Also mask PII in tool_call / function_call arguments. Gather
+            # coroutines to match the parallel dispatch used for content above.
+            tool_tasks: List[Any] = []
+            tool_targets: List[Any] = []
             for m in messages:
                 if not isinstance(m, dict):
                     continue
@@ -818,22 +818,32 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     if isinstance(function, dict) and isinstance(
                         function.get("arguments"), str
                     ):
-                        function["arguments"] = await self.check_pii(
-                            text=function["arguments"],
-                            output_parse_pii=self.output_parse_pii,
-                            presidio_config=presidio_config,
-                            request_data=data,
+                        tool_tasks.append(
+                            self.check_pii(
+                                text=function["arguments"],
+                                output_parse_pii=self.output_parse_pii,
+                                presidio_config=presidio_config,
+                                request_data=data,
+                            )
                         )
+                        tool_targets.append((function, "arguments"))
                 function_call = m.get("function_call")
                 if isinstance(function_call, dict) and isinstance(
                     function_call.get("arguments"), str
                 ):
-                    function_call["arguments"] = await self.check_pii(
-                        text=function_call["arguments"],
-                        output_parse_pii=self.output_parse_pii,
-                        presidio_config=presidio_config,
-                        request_data=data,
+                    tool_tasks.append(
+                        self.check_pii(
+                            text=function_call["arguments"],
+                            output_parse_pii=self.output_parse_pii,
+                            presidio_config=presidio_config,
+                            request_data=data,
+                        )
                     )
+                    tool_targets.append((function_call, "arguments"))
+            if tool_tasks:
+                tool_results = await asyncio.gather(*tool_tasks)
+                for (container, key), result in zip(tool_targets, tool_results):
+                    container[key] = result
 
             verbose_proxy_logger.debug(
                 f"Presidio PII Masking: Redacted pii message: {data['messages']}"
@@ -1015,6 +1025,38 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         break
         return text
 
+    async def _mask_nested_strings(
+        self,
+        obj: Any,
+        mode: Literal["mask", "unmask"],
+        pii_tokens: Dict[str, str],
+        presidio_config: Optional[dict],
+        request_data: dict,
+    ) -> Any:
+        """Recursively mask/unmask every string leaf in a JSON-like structure."""
+        if isinstance(obj, str):
+            if mode == "unmask":
+                return self._unmask_pii_text(obj, pii_tokens)
+            return await self.check_pii(
+                text=obj,
+                output_parse_pii=False,
+                presidio_config=presidio_config,
+                request_data=request_data,
+            )
+        if isinstance(obj, dict):
+            for key in list(obj.keys()):
+                obj[key] = await self._mask_nested_strings(
+                    obj[key], mode, pii_tokens, presidio_config, request_data
+                )
+            return obj
+        if isinstance(obj, list):
+            for i, item in enumerate(obj):
+                obj[i] = await self._mask_nested_strings(
+                    item, mode, pii_tokens, presidio_config, request_data
+                )
+            return obj
+        return obj
+
     @staticmethod
     def _is_anthropic_message_response(response: Any) -> bool:
         """Check if the response is an Anthropic native message dict."""
@@ -1066,23 +1108,11 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         request_data=request_data,
                     )
             elif block_type == "tool_use":
-                # Mirror the OpenAI-format path (_process_response_for_pii), which masks
-                # tool_call arguments: a tool_use block's `input` dict can carry PII the
-                # model produced, and must be masked too -- not just sibling text blocks.
                 tool_input = block.get("input")
-                if isinstance(tool_input, dict):
-                    for key, value in list(tool_input.items()):
-                        if not isinstance(value, str):
-                            continue
-                        if mode == "unmask":
-                            tool_input[key] = self._unmask_pii_text(value, pii_tokens)
-                        elif mode == "mask":
-                            tool_input[key] = await self.check_pii(
-                                text=value,
-                                output_parse_pii=False,
-                                presidio_config=presidio_config,
-                                request_data=request_data,
-                            )
+                if isinstance(tool_input, (dict, list)):
+                    await self._mask_nested_strings(
+                        tool_input, mode, pii_tokens, presidio_config, request_data
+                    )
 
         return response
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -724,6 +724,54 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 masked_entity_count=masked_entity_count,
             )
 
+    async def _mask_tool_call_arguments(
+        self,
+        messages: List[Any],
+        presidio_config: Optional[dict],
+        data: dict,
+    ) -> None:
+        """Mask PII in tool_call/function_call arguments across all messages."""
+        tool_tasks: List[Any] = []
+        tool_targets: List[Any] = []
+        for m in messages:
+            if not isinstance(m, dict):
+                continue
+            for tool_call in m.get("tool_calls") or []:
+                function = (
+                    tool_call.get("function")
+                    if isinstance(tool_call, dict)
+                    else None
+                )
+                if isinstance(function, dict) and isinstance(
+                    function.get("arguments"), str
+                ):
+                    tool_tasks.append(
+                        self.check_pii(
+                            text=function["arguments"],
+                            output_parse_pii=self.output_parse_pii,
+                            presidio_config=presidio_config,
+                            request_data=data,
+                        )
+                    )
+                    tool_targets.append((function, "arguments"))
+            function_call = m.get("function_call")
+            if isinstance(function_call, dict) and isinstance(
+                function_call.get("arguments"), str
+            ):
+                tool_tasks.append(
+                    self.check_pii(
+                        text=function_call["arguments"],
+                        output_parse_pii=self.output_parse_pii,
+                        presidio_config=presidio_config,
+                        request_data=data,
+                    )
+                )
+                tool_targets.append((function_call, "arguments"))
+        if tool_tasks:
+            tool_results = await asyncio.gather(*tool_tasks)
+            for (container, key), result in zip(tool_targets, tool_results):
+                container[key] = result
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
@@ -802,48 +850,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 elif isinstance(content, list) and content_idx_optional is not None:
                     messages[msg_idx]["content"][content_idx_optional]["text"] = r
 
-            # Also mask PII in tool_call / function_call arguments. Gather
-            # coroutines to match the parallel dispatch used for content above.
-            tool_tasks: List[Any] = []
-            tool_targets: List[Any] = []
-            for m in messages:
-                if not isinstance(m, dict):
-                    continue
-                for tool_call in m.get("tool_calls") or []:
-                    function = (
-                        tool_call.get("function")
-                        if isinstance(tool_call, dict)
-                        else None
-                    )
-                    if isinstance(function, dict) and isinstance(
-                        function.get("arguments"), str
-                    ):
-                        tool_tasks.append(
-                            self.check_pii(
-                                text=function["arguments"],
-                                output_parse_pii=self.output_parse_pii,
-                                presidio_config=presidio_config,
-                                request_data=data,
-                            )
-                        )
-                        tool_targets.append((function, "arguments"))
-                function_call = m.get("function_call")
-                if isinstance(function_call, dict) and isinstance(
-                    function_call.get("arguments"), str
-                ):
-                    tool_tasks.append(
-                        self.check_pii(
-                            text=function_call["arguments"],
-                            output_parse_pii=self.output_parse_pii,
-                            presidio_config=presidio_config,
-                            request_data=data,
-                        )
-                    )
-                    tool_targets.append((function_call, "arguments"))
-            if tool_tasks:
-                tool_results = await asyncio.gather(*tool_tasks)
-                for (container, key), result in zip(tool_targets, tool_results):
-                    container[key] = result
+            await self._mask_tool_call_arguments(messages, presidio_config, data)
 
             verbose_proxy_logger.debug(
                 f"Presidio PII Masking: Redacted pii message: {data['messages']}"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio_tool_call_pii_masking.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio_tool_call_pii_masking.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for Presidio PII masking of tool-call arguments.
+
+Covers two channels that were previously unmasked:
+1. Pre-call: tool_calls[*].function.arguments and function_call.arguments
+2. Anthropic response: tool_use block input values
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))
+
+from unittest.mock import MagicMock
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+    _OPTIONAL_PresidioPIIMasking,
+)
+from litellm.types.guardrails import PiiAction, PiiEntityType
+
+
+@pytest.fixture
+def presidio_guardrail():
+    return _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        output_parse_pii=False,
+        pii_entities_config={
+            PiiEntityType.US_SSN: PiiAction.MASK,
+            PiiEntityType.EMAIL_ADDRESS: PiiAction.MASK,
+        },
+    )
+
+
+@pytest.fixture
+def mock_user_api_key():
+    return UserAPIKeyAuth(api_key="test_key", user_id="test_user")
+
+
+@pytest.fixture
+def mock_cache():
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_precall_masks_pii_in_tool_call_arguments(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """
+    async_pre_call_hook must mask PII in tool_calls[*].function.arguments
+    and function_call.arguments, not just message content.
+    """
+    test_data = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "save_record",
+                            "arguments": '{"ssn": "123-45-6789", "name": "Alice"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "function_call": {
+                    "name": "save_record",
+                    "arguments": '{"ssn": "123-45-6789"}',
+                },
+            },
+        ],
+        "model": "gpt-4",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("123-45-6789", "<US_SSN>")
+
+    presidio_guardrail.check_pii = mock_check_pii
+
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="completion",
+    )
+
+    tc_args = result["messages"][0]["tool_calls"][0]["function"]["arguments"]
+    assert "123-45-6789" not in tc_args, "tool_calls arguments should be masked"
+    assert "<US_SSN>" in tc_args
+
+    fc_args = result["messages"][1]["function_call"]["arguments"]
+    assert "123-45-6789" not in fc_args, "function_call arguments should be masked"
+    assert "<US_SSN>" in fc_args
+
+
+@pytest.mark.asyncio
+async def test_anthropic_response_masks_pii_in_tool_use_input(presidio_guardrail):
+    """
+    _process_anthropic_response_for_pii must mask PII in tool_use block
+    input values, not just text blocks.  The method takes a raw Anthropic
+    message dict (type=="message"), not a ModelResponse.
+    """
+    response = {
+        "id": "msg_01",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": "Saving SSN 078-05-1120 now."},
+            {
+                "type": "tool_use",
+                "id": "tu_1",
+                "name": "save_record",
+                "input": {"ssn": "078-05-1120", "note": "customer"},
+            },
+        ],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("078-05-1120", "<US_SSN>")
+
+    presidio_guardrail.check_pii = mock_check_pii
+
+    result = await presidio_guardrail._process_anthropic_response_for_pii(
+        response=response,
+        request_data={},
+        mode="mask",
+    )
+
+    text_block = result["content"][0]
+    tool_block = result["content"][1]
+
+    assert "078-05-1120" not in text_block["text"], "text block should be masked"
+    assert "<US_SSN>" in text_block["text"]
+
+    assert (
+        "078-05-1120" not in tool_block["input"]["ssn"]
+    ), "tool_use input should be masked"
+    assert tool_block["input"]["ssn"] == "<US_SSN>"
+    assert tool_block["input"]["note"] == "customer", "non-PII values unchanged"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio_tool_call_pii_masking.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio_tool_call_pii_masking.py
@@ -147,3 +147,52 @@ async def test_anthropic_response_masks_pii_in_tool_use_input(presidio_guardrail
     ), "tool_use input should be masked"
     assert tool_block["input"]["ssn"] == "<US_SSN>"
     assert tool_block["input"]["note"] == "customer", "non-PII values unchanged"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_response_masks_nested_tool_use_input(presidio_guardrail):
+    """
+    PII inside nested dicts/lists within tool_use input must also be masked.
+    """
+    response = {
+        "id": "msg_02",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "tu_2",
+                "name": "save_patient",
+                "input": {
+                    "patient": {
+                        "ssn": "078-05-1120",
+                        "name": "Alice",
+                    },
+                    "addresses": [
+                        {"street": "123 Main", "phone": "078-05-1120"}
+                    ],
+                    "code": 42,
+                },
+            },
+        ],
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "end_turn",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("078-05-1120", "<US_SSN>")
+
+    presidio_guardrail.check_pii = mock_check_pii
+
+    result = await presidio_guardrail._process_anthropic_response_for_pii(
+        response=response,
+        request_data={},
+        mode="mask",
+    )
+
+    tool_input = result["content"][0]["input"]
+    assert tool_input["patient"]["ssn"] == "<US_SSN>", "nested dict value masked"
+    assert tool_input["patient"]["name"] == "Alice", "non-PII nested value unchanged"
+    assert tool_input["addresses"][0]["phone"] == "<US_SSN>", "list-nested value masked"
+    assert tool_input["addresses"][0]["street"] == "123 Main", "non-PII list value unchanged"
+    assert tool_input["code"] == 42, "non-string values unchanged"


### PR DESCRIPTION
## Relevant issues

<!-- No prior issue — this is a symmetry fix mirroring existing OpenAI-format behavior -->

## Linear ticket

N/A — external contributor

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
      Link:

- [ ] **CI run for the last commit**
      Link:

- [ ] **Merge / cherry-pick CI run**
      Links:

## Screenshots / Proof of Fix

**Before (pristine `presidio.py` at `2655d1d`):** masking is enabled but PII in tool-call arguments passes through:

```
# pre-call tool args
function_call.arguments after hook: {"ssn":"123-45-6789"}        # raw SSN forwarded
tool_calls[0].function.arguments after hook: {"ssn":"123-45-6789"}

# Anthropic tool_use response (apply_to_output=True)
text block after masking   : I'll save the SSN <US_SSN> now.     # text masked ✓
tool_use input after masking: {'ssn': '078-05-1120', 'note': 'customer'}   # NOT masked ✗
```

**After (patched):** both channels are now masked:

```
# pre-call: function_call.arguments after hook: {"ssn":"<US_SSN>"}       # masked ✓
# anthropic: tool_use input after masking: {'ssn': '<US_SSN>', 'note': 'customer'}  # masked ✓
```

Deterministic repros (no live LLM, only the Presidio HTTP call mocked) reproduce both channels reliably.

## Type

🐛 Bug Fix

## Changes

**Symmetry fix.** The OpenAI-format response path (`_process_response_for_pii`, `presidio.py:1090-1108`)
already masks PII in `tool_calls[*].function.arguments`. This PR extends the same masking to the two
sibling paths that skip it:

1. **Request pre-call (`async_pre_call_hook`)** — after the existing content-masking loop, also run
   `check_pii` over each `tool_calls[*].function.arguments` and legacy `function_call.arguments`
   string, writing the redacted value back.

2. **Anthropic response (`_process_anthropic_response_for_pii`)** — dispatch the block loop by `type`:
   `"text"` blocks are masked as before; `"tool_use"` blocks now also mask each string value in the
   `input` dict (using the same mask/unmask branches as text).

No behavior change for text content. No config surface change. The pre-call masking honors the existing
`output_parse_pii` flag. The Anthropic `tool_use` masking handles top-level string values in `input`;
deeply-nested structures are left for a follow-up (the common case — flat arg dicts — is covered).

**Tests added:** `test_presidio_tool_call_pii_masking.py` — two focused unit tests:
- `test_precall_masks_pii_in_tool_call_arguments` — verifies `async_pre_call_hook` masks PII in
  `tool_calls[*].function.arguments` and `function_call.arguments`.
- `test_anthropic_response_masks_pii_in_tool_use_input` — verifies
  `_process_anthropic_response_for_pii` masks PII in `tool_use` block `input` values.

Both follow the existing test pattern in `test_presidio.py` (mock `check_pii`, call the real hook).

`ruff check --force-exclude presidio.py` → All checks passed.

Related behavior/policy issues (Responses-API input gap, raw-bytes streaming,
analyzer-error fail-open) are intentionally left for separate issues.