### PR TITLE
fix: preserve bedrock passthrough messages in logs

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -804,6 +804,8 @@ async def handle_bedrock_passthrough_router_model(
     data["method"] = request.method
     data["endpoint"] = endpoint
     data["data"] = request_body
+    if isinstance(request_body.get("messages"), list):
+        data["messages"] = request_body["messages"]
     data["custom_llm_provider"] = "bedrock"
 
     # Use the common passthrough processing to handle metadata and hooks

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1423,6 +1423,65 @@ class TestBedrockLLMProxyRoute:
             assert result == "success"
 
     @pytest.mark.asyncio
+    async def test_bedrock_router_passthrough_preserves_messages_for_logging(self):
+        from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+            handle_bedrock_passthrough_router_model,
+        )
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "POST"
+        mock_request.headers = {"content-type": "application/json"}
+        mock_request.query_params = {}
+        mock_request.url = MagicMock()
+        mock_request.url.path = "/bedrock/model/test-model/converse"
+
+        request_messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"text": "Give me 5 Kubernetes image security best practices."}
+                ],
+            }
+        ]
+        mock_request_body = {
+            "messages": request_messages,
+            "inferenceConfig": {"maxTokens": 4096, "temperature": 1},
+        }
+
+        mock_processor = Mock()
+        mock_processor.base_passthrough_process_llm_request = AsyncMock(
+            return_value="success"
+        )
+
+        with patch(
+            "litellm.proxy.common_request_processing.ProxyBaseLLMRequestProcessing",
+            return_value=mock_processor,
+        ) as mock_processor_cls:
+            result = await handle_bedrock_passthrough_router_model(
+                model="test-model",
+                endpoint="model/test-model/converse",
+                request=mock_request,
+                request_body=mock_request_body,
+                llm_router=Mock(),
+                user_api_key_dict=Mock(),
+                proxy_logging_obj=Mock(),
+                general_settings={},
+                proxy_config=None,
+                select_data_generator=None,
+                user_model=None,
+                user_temperature=None,
+                user_request_timeout=None,
+                user_max_tokens=None,
+                user_api_base=None,
+                version=None,
+            )
+
+        initialized_data = mock_processor_cls.call_args.kwargs["data"]
+        assert initialized_data["data"] == mock_request_body
+        assert initialized_data["messages"] == request_messages
+        assert result == "success"
+
+    @pytest.mark.asyncio
     async def test_bedrock_error_handling_returns_actual_error(self):
         """
         Test that when Bedrock API returns an error, it is properly propagated to the user


### PR DESCRIPTION
## Relevant issues

Fixes #30724

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link: pending

- [ ] CI run for the last commit
       Link: pending

- [ ] Merge / cherry-pick CI run
       Links: pending

## Screenshots / Proof of Fix

Before the fix, the focused regression test failed because Bedrock router pass-through initialized common request processing without a top-level `messages` value for logging:

```text
KeyError: 'messages'
```

After the fix, the focused regression and nearby Bedrock pass-through tests pass locally:

```bash
.\.venv\Scripts\python.exe -m pytest tests\test_litellm\proxy\pass_through_endpoints\test_llm_pass_through_endpoints.py::TestBedrockLLMProxyRoute::test_bedrock_router_passthrough_preserves_messages_for_logging -q
.\.venv\Scripts\python.exe -m pytest tests\test_litellm\proxy\pass_through_endpoints\test_llm_pass_through_endpoints.py::TestBedrockLLMProxyRoute -q
.\.venv\Scripts\python.exe -m pytest tests\test_litellm\proxy\pass_through_endpoints\test_llm_pass_through_endpoints.py -q
```

Results:

```text
1 passed
6 passed
57 passed
```

Also ran:

```bash
.\.venv\Scripts\python.exe -m ruff check litellm\proxy\pass_through_endpoints\llm_passthrough_endpoints.py
git diff --check
```

Results:

```text
All checks passed
git diff --check passed
```

I did not run a live Bedrock/S3 integration test because that requires external AWS credentials and networked provider calls.

## Type

Bug Fix
Test

## Changes

- Preserve Bedrock pass-through request `messages` on the top-level request data used by LiteLLM's common logging path.
- Keep the original provider payload under `data[data]`, so the forwarded Bedrock request body is unchanged.
- Add regression coverage for Bedrock router pass-through logging data initialization.
- No new dependencies.
- No public API changes.