### PR TITLE
fix(logging): fall back to adapter dict in google_genai generate_content logging

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3305,7 +3305,11 @@ class Logging(LiteLLMLoggingBaseClass):
         elif isinstance(result, dict):
             dict_result = result
         else:
-            raise ValueError("Google GenAI Generate Content: httpx_response is None")
+            raise ValueError(
+                f"Google GenAI Generate Content: no valid httpx_response "
+                f"(got {type(httpx_response).__name__!r}) and result is not a dict "
+                f"(got {type(result).__name__!r}); cannot log response"
+            )
         result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3294,10 +3294,18 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         import httpx
 
+        # The adapter path (generate_content_provider_config is None) routes
+        # through litellm.completion and hands us an already transformed
+        # generate_content dict with no raw httpx_response recorded. Fall back to
+        # that dict instead of crashing the logging worker (#30707); the native
+        # path still uses the raw httpx_response as before.
         httpx_response = self.model_call_details.get("httpx_response", None)
-        if httpx_response is None:
+        if httpx_response is not None and isinstance(httpx_response, httpx.Response):
+            dict_result = httpx_response.json()
+        elif isinstance(result, dict):
+            dict_result = result
+        else:
             raise ValueError("Google GenAI Generate Content: httpx_response is None")
-        dict_result = httpx_response.json()
         result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),

--- a/tests/test_litellm/google_genai/test_generate_content_logging.py
+++ b/tests/test_litellm/google_genai/test_generate_content_logging.py
@@ -1,0 +1,84 @@
+"""Logging-path tests for the google_genai generate_content adapter (#30707).
+
+The adapter path (``generate_content_provider_config is None``) routes through
+``litellm.completion`` and hands the success-logging handler an already
+transformed generate_content dict, with no raw ``httpx.Response`` recorded. The
+handler must fall back to that dict instead of crashing the logging worker.
+"""
+
+import os
+import sys
+import time
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.types.utils import ModelResponse
+
+
+def _make_logging_obj() -> LitellmLogging:
+    logging_obj = LitellmLogging(
+        model="gemini-3.1-flash-lite",
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="30707-test",
+        function_id="30707-test",
+    )
+    # set in update_environment_variables() during a real call; the response
+    # transform reads it, so provide it for the isolated handler test.
+    logging_obj.optional_params = {}
+    return logging_obj
+
+
+def _generate_content_dict() -> dict:
+    return {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "Hello there"}], "role": "model"},
+                "finishReason": "STOP",
+                "index": 0,
+                "safetyRatings": [],
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 2,
+            "totalTokenCount": 7,
+        },
+        # the adapter adds a convenience top-level text field
+        "text": "Hello there",
+    }
+
+
+def test_adapter_path_logs_without_httpx_response():
+    """No httpx_response (adapter path) must not raise; the transformed dict is used."""
+    logging_obj = _make_logging_obj()
+    logging_obj.model_call_details["httpx_response"] = None
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=_generate_content_dict()
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.choices[0].message.content == "Hello there"
+    assert result.usage.total_tokens == 7
+
+
+def test_httpx_response_path_still_used_when_present():
+    """When a raw httpx_response exists it is still the source of truth."""
+    logging_obj = _make_logging_obj()
+    logging_obj.model_call_details["httpx_response"] = httpx.Response(
+        status_code=200, json=_generate_content_dict()
+    )
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=None
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.choices[0].message.content == "Hello there"


### PR DESCRIPTION
## Title
fix(logging): fall back to adapter dict in google_genai generate_content logging

## Relevant issues
Fixes #30707

## What this does
The `google_genai.generate_content()` **adapter path** (taken when `generate_content_provider_config is None`, e.g. a `model_group_alias` mapping a `gemini-*` name to an OpenAI-compatible deployment) routes through `litellm.completion` and hands the success-logging handler an already transformed generate_content dict. No raw `httpx.Response` is recorded for that path.

`_handle_non_streaming_google_genai_generate_content_response_logging` assumed a raw `httpx.Response` was always available and raised:

```
ValueError: Google GenAI Generate Content: httpx_response is None
```

The actual call returns HTTP 200 to the caller, but the background logging worker crashes:

```
LiteLLM:ERROR: logging_worker.py:103 - LoggingWorker error: [Non-Blocking] LiteLLM.Success_Call Error: Google GenAI Generate Content: httpx_response is None
```

This falls back to the transformed dict when no `httpx_response` is present, mirroring the existing `anthropic_messages` logging handler (which already handles both the raw-response and adapter paths). The native path still uses the raw `httpx_response` as before.

## Type
🐛 Bug Fix

## Testing
New `tests/test_litellm/google_genai/test_generate_content_logging.py`:
- `test_adapter_path_logs_without_httpx_response` — no `httpx_response` (adapter path) no longer raises; the transformed dict yields a `ModelResponse`.
- `test_httpx_response_path_still_used_when_present` — the native path still uses the raw response.

```
$ uv run pytest tests/test_litellm/google_genai/ tests/test_litellm/litellm_core_utils/test_litellm_logging.py -q
173 passed
```

black + ruff clean.