### PR TITLE
fix(logging): log generate_content adapter responses with no httpx_response

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3634,26 +3634,24 @@ class Logging(LiteLLMLoggingBaseClass):
     def _handle_non_streaming_google_genai_generate_content_response_logging(
         self, result: Any
     ) -> ModelResponse:
-        """
-        Handles logging for Google GenAI generate content responses.
-        """
         import httpx
 
+        if isinstance(result, ModelResponse):
+            return result
         httpx_response = self.model_call_details.get("httpx_response", None)
-        if httpx_response is None:
-            raise ValueError("Google GenAI Generate Content: httpx_response is None")
-        dict_result = httpx_response.json()
-        result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
+        if httpx_response is not None and isinstance(httpx_response, httpx.Response):
+            dict_result = httpx_response.json()
+        elif isinstance(result, dict):
+            dict_result = result
+        else:
+            raise ValueError("Google GenAI Generate Content: no usable response to log")
+        return litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),
             model=self.model,
             logging_obj=self,
-            raw_response=httpx.Response(
-                status_code=200,
-                headers={},
-            ),
+            raw_response=httpx.Response(status_code=200, headers={}),
         )
-        return result
 
     def _handle_a2a_response_logging(self, result: Any) -> Any:
         """

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3406,3 +3406,102 @@ def test_handle_anthropic_messages_response_logging_degrades_on_unparseable_resp
     assert isinstance(result, ModelResponse)
     assert result.model == "openai/my-local"
     assert result.usage.prompt_tokens == 4  # type: ignore[attr-defined]
+
+
+# ── generate_content logging handler ──────────────────────────────────────────
+
+_GENAI_DICT = {
+    "candidates": [
+        {
+            "content": {"parts": [{"text": "hello world"}], "role": "model"},
+            "finishReason": "STOP",
+            "index": 0,
+            "safetyRatings": [],
+        }
+    ],
+    "usageMetadata": {
+        "promptTokenCount": 10,
+        "candidatesTokenCount": 5,
+        "totalTokenCount": 15,
+    },
+    "text": "hello world",
+}
+
+
+def _generate_content_logging_obj():
+    lo = LitellmLogging(
+        model="gemini-1.5-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="gc-test-1",
+        function_id="gc-test-1",
+    )
+    lo.optional_params = {}
+    return lo
+
+
+def test_generate_content_logging_adapter_dict_path():
+    """INV-1: adapter path returns a dict and no httpx_response -> must return ModelResponse, not raise."""
+    logging_obj = _generate_content_logging_obj()
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=_GENAI_DICT
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.choices[0].message.content == "hello world"  # type: ignore[union-attr]
+    assert result.usage.prompt_tokens == 10  # type: ignore[attr-defined]
+    assert result.usage.completion_tokens == 5  # type: ignore[attr-defined]
+
+
+def test_generate_content_logging_model_response_passthrough():
+    """INV-1: when result is already a ModelResponse, return it as-is."""
+    logging_obj = _generate_content_logging_obj()
+    model_response = ModelResponse()
+
+    returned = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=model_response
+    )
+
+    assert returned is model_response
+
+
+def test_generate_content_logging_native_httpx_path():
+    """INV-2: native path with a real httpx.Response must still return a valid ModelResponse
+    (same transform, same content/usage from the dict — service_tier not checked since it
+    comes from response headers which the synthetic raw_response has none of)."""
+    import json
+    import httpx
+
+    logging_obj = _generate_content_logging_obj()
+    real_httpx = httpx.Response(
+        status_code=200,
+        content=json.dumps(_GENAI_DICT).encode(),
+        headers={"content-type": "application/json"},
+    )
+    logging_obj.model_call_details["httpx_response"] = real_httpx
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=None
+    )
+
+    assert isinstance(result, ModelResponse)
+    assert result.choices[0].message.content == "hello world"  # type: ignore[union-attr]
+    assert result.usage.prompt_tokens == 10  # type: ignore[attr-defined]
+
+
+def test_generate_content_logging_unusable_result_raises():
+    """INV-3: genuinely unusable result (None, no httpx_response) must raise ValueError.
+
+    The match string "no usable response to log" is specific to the fixed error message.
+    The original buggy code raised 'httpx_response is None', which does NOT match, so this
+    test correctly fails on the original code and passes only after the fix.
+    """
+    logging_obj = _generate_content_logging_obj()
+
+    with pytest.raises(ValueError, match="no usable response to log"):
+        logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+            result=None
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #30707

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run the proxy and issue a `generate_content` request to a Gemini model routed through the adapter path (a model without a native `generate_content` provider config), then confirm the request log row is written and no `httpx_response is None` error appears:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

curl -s -X POST "http://localhost:4000/v1beta/models/gemini-2.5-flash:generateContent" \
  -H "Authorization: Bearer sk-..." \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"say hello"}]}]}'
```

Then check `litellm.log` has no `Google GenAI Generate Content: httpx_response is None` traceback, and the request appears at http://localhost:4000/ui/?page=logs

## Type

🐛 Bug Fix

## Changes

The `generate_content` / `agenerate_content` success-logging handler raised `ValueError: Google GenAI Generate Content: httpx_response is None` whenever `httpx_response` was absent from `model_call_details`. That is exactly the case on the adapter path: when a model has no native `generate_content_provider_config`, the request is translated to a chat completion and the handler receives a `dict` result with no raw `httpx.Response`. The exception aborted the success-logging dispatch, so callback integrations (Langfuse, OpenTelemetry) and spend logs silently dropped the response for these calls.

The handler now mirrors the sibling Anthropic handler: it returns the result directly when it is already a `ModelResponse`, uses `httpx_response.json()` when a real `httpx.Response` is present, falls back to the `dict` result otherwise, and only raises when there is genuinely nothing usable to log. The native path keeps its existing synthetic `raw_response`, so its logged `ModelResponse` is unchanged.

Regression tests cover the adapter dict path, the already-a-ModelResponse passthrough, the native `httpx.Response` path, and the unusable-result error case.
