### PR TITLE
fix(cloudflare): correct content-type header typo

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -71,7 +71,7 @@ class CloudflareChatConfig(BaseConfig):
             )
         headers = {
             "accept": "application/json",
-            "content-type": "apbplication/json",
+            "content-type": "application/json",
             "Authorization": "Bearer " + api_key,
         }
         return headers

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -25,3 +25,19 @@ def test_get_complete_url_encodes_model_path_segment():
             optional_params={},
             litellm_params={},
         )
+
+
+def test_validate_environment_content_type():
+    """Test that the content-type header is correctly set to application/json."""
+    config = CloudflareChatConfig()
+    headers = config.validate_environment(
+        headers={},
+        model="@cf/meta/llama",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={},
+        litellm_params={},
+        api_key="fake-key",
+    )
+
+    assert headers["content-type"] == "application/json"
+    assert headers["Authorization"] == "Bearer fake-key"


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Corrected the content-type header from "apbplication/json" to "application/json" in litellm/llms/cloudflare/chat/transformation.py to fix APIConnectionError when routing to Cloudflare Workers AI
or AI Gateway.

### Test run output
```bash
$ pytest tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/y_ohi/program/litellm
configfile: pyproject.toml
plugins: respx-0.22.0, anyio-4.13.0, xdist-3.8.0, postgresql-7.0.2, timeout-2.4.0, cov-5.0.0, mock-3.15.1, asyncio-1.3.0, requests-mock-1.12.1, recording-0.13.4, rerunfailures-15.1
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collecting ... collecting 0 items                                                             collected 2 items                                                              

tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py ..  [100%]

============================== 2 passed in 1.02s ===============================
```

## Type

🐛 Bug Fix

## Changes

Fixed a typo in the content-type header for Cloudflare API requests.
