### PR TITLE
test(batches): add external e2e batch lifecycle suite

### DIFF
--- a/tests/batch_e2e_external/README.md
+++ b/tests/batch_e2e_external/README.md
@@ -1,0 +1,103 @@
+# External Batch E2E Suite
+
+End-to-end tests for the **/files** + **/batches** lifecycle against a **live,
+published LiteLLM proxy image**, driven by the real OpenAI SDK with an external
+user's API key. Nothing is mocked.
+
+> **This suite is NOT part of CI/CD.** No GitHub workflow references this folder,
+> and every test is gated behind the `batch_e2e` marker. It is meant to be run
+> by an external test suite after an image is published.
+
+## What it verifies
+
+For every configured **case** (a *routing strategy* × *provider*) it walks the
+full lifecycle and asserts each step:
+
+```
+create file (purpose="batch")
+  -> create batch
+  -> retrieve batch
+  -> list batches
+  -> (optional) await completion + fetch output
+  -> cancel batch
+  -> delete file
+```
+
+### Three routing scenarios
+
+These map 1:1 to the proxy's file-create routing priority in
+`litellm/proxy/openai_files_endpoints/files_endpoints.py`:
+
+| Strategy | How it routes | Notes |
+|---|---|---|
+| `model_param` | `model` in the request body | Proxy encodes the model into the file/batch id; downstream calls need no extra hint. No DB. |
+| `target_model_names` | Managed files, load-balanced across the named models | **Requires a DB-backed deployment.** |
+| `custom_llm_provider` | `custom-llm-provider` header, repeated on every call | No DB. |
+
+## Hard-fail contract
+
+This suite exists to catch client-level regressions, so it does **not** skip:
+
+- A supported op **must succeed**. Any failure fails the test — including a
+  missing DB for the `target_model_names` scenario.
+- Misconfiguration (missing/!malformed env) **fails the session**, it is not skipped.
+- An op declared unsupported for a provider (`expected_unsupported`) **must raise
+  the declared error**. Success there, or a different error, is a failure. This
+  is how a documented contract gap is told apart from a regression.
+
+## Running
+
+```bash
+export LITELLM_E2E_BASE_URL="https://my-published-proxy.example.com"
+export LITELLM_E2E_API_KEY="sk-..."         # the user-specific key
+export LITELLM_E2E_CONFIG="@./e2e_config.json"   # inline JSON also accepted
+
+pytest -m batch_e2e tests/batch_e2e_external
+```
+
+## Configuration (`LITELLM_E2E_CONFIG`)
+
+Either inline JSON or `@/path/to/file.json`.
+
+```jsonc
+{
+  "endpoint": "/v1/chat/completions",   // default
+  "await_completion": false,            // poll to terminal + fetch output (slow)
+  "completion_timeout_s": 900,
+  "cases": [
+    {
+      "strategy": "custom_llm_provider",
+      "provider": "openai",
+      "request_model": "gpt-4o"          // model written into the .jsonl body
+    },
+    {
+      "strategy": "model_param",
+      "provider": "azure",
+      "model": "azure-gpt-4o",           // a model name in the deployment's model_list
+      "request_model": "gpt-4o"
+    },
+    {
+      "strategy": "target_model_names",
+      "provider": "vertex_ai",
+      "target_model_names": "gemini-batch-group",
+      "request_model": "gemini-1.5-flash-001",
+      "expected_unsupported": {          // declared, sanctioned contract gaps
+        "cancel": { "status": 400, "match": "not supported" }
+      }
+    }
+  ]
+}
+```
+
+### `cases[]` fields
+
+| Field | Required | Meaning |
+|---|---|---|
+| `strategy` | yes | `model_param` \| `target_model_names` \| `custom_llm_provider` |
+| `provider` | yes | Provider label (used in the test id and for `custom_llm_provider`). |
+| `request_model` | yes | Model string written into the generated `.jsonl` request body. |
+| `model` | for `model_param` | Model name present in the deployment's `model_list`. |
+| `target_model_names` | for `target_model_names` | Managed-files model group name. |
+| `expected_unsupported` | no | Map of `op -> { status?, match? }`. Ops: `file`, `create`, `retrieve`, `list`, `cancel`, `delete`. |
+
+Case ids are `"{strategy}-{provider}"` and must be unique.

--- a/tests/batch_e2e_external/config.py
+++ b/tests/batch_e2e_external/config.py
@@ -1,0 +1,202 @@
+"""
+Environment-driven configuration for the external batch e2e suite.
+
+Everything that varies per deployment (proxy URL, the user API key, which
+providers / models / routing scenarios to exercise) is supplied through the
+environment. Nothing is hardcoded.
+
+Hard-fail contract: if anything required is missing or malformed, loading the
+config raises. There are no silent defaults that would let a misconfigured run
+pass. This suite exists to catch regressions, so "not configured" is a failure,
+not a skip.
+
+Required environment variables:
+  LITELLM_E2E_BASE_URL   Base URL of the published LiteLLM proxy image.
+  LITELLM_E2E_API_KEY    The (user-specific) API key the external suite runs as.
+  LITELLM_E2E_CONFIG     The case matrix. Either inline JSON, or "@/path/to.json"
+                         to read it from a file. See README.md for the schema.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+# Routing scenarios this suite knows how to exercise. These map 1:1 to the
+# proxy's file-create routing priority in
+# litellm/proxy/openai_files_endpoints/files_endpoints.py.
+STRATEGY_MODEL_PARAM = "model_param"  # `model=` -> model creds, id encodes model
+STRATEGY_TARGET_MODEL_NAMES = "target_model_names"  # managed files, requires DB
+STRATEGY_CUSTOM_LLM_PROVIDER = "custom_llm_provider"  # `custom-llm-provider` header
+
+VALID_STRATEGIES = {
+    STRATEGY_MODEL_PARAM,
+    STRATEGY_TARGET_MODEL_NAMES,
+    STRATEGY_CUSTOM_LLM_PROVIDER,
+}
+
+# Batch lifecycle operations, in execution order.
+OP_FILE = "file"
+OP_CREATE = "create"
+OP_RETRIEVE = "retrieve"
+OP_LIST = "list"
+OP_CANCEL = "cancel"
+OP_DELETE = "delete"
+
+ALL_OPS = [OP_FILE, OP_CREATE, OP_RETRIEVE, OP_LIST, OP_CANCEL, OP_DELETE]
+
+
+class ConfigError(RuntimeError):
+    """Raised when the suite is not configured correctly. Always fatal."""
+
+
+@dataclass
+class ExpectedError:
+    """A declared, known contract gap for a (provider, op).
+
+    When present for an op, the suite asserts the call raises an error matching
+    this spec. Anything else -- success, or a different error -- is a failure.
+    """
+
+    status: Optional[int] = None
+    match: Optional[str] = None  # case-insensitive substring expected in the error
+
+
+@dataclass
+class Case:
+    """One row of the test matrix: a routing strategy against one provider."""
+
+    strategy: str
+    provider: str
+    request_model: str  # model string written into the .jsonl request body
+    # strategy-specific routing handles
+    model: Optional[str] = None  # STRATEGY_MODEL_PARAM
+    target_model_names: Optional[str] = None  # STRATEGY_TARGET_MODEL_NAMES
+    # known unsupported ops -> expected error (the only sanctioned non-success)
+    expected_unsupported: Dict[str, ExpectedError] = field(default_factory=dict)
+
+    @property
+    def id(self) -> str:
+        return f"{self.strategy}-{self.provider}"
+
+
+@dataclass
+class Settings:
+    base_url: str
+    api_key: str
+    endpoint: str
+    await_completion: bool
+    completion_timeout_s: int
+    cases: List[Case]
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise ConfigError(
+            f"{name} is required for the external batch e2e suite but was not set."
+        )
+    return value
+
+
+def _load_raw_config(raw: str) -> Dict[str, Any]:
+    if raw.startswith("@"):
+        path = raw[1:]
+        try:
+            with open(path, "r") as f:
+                raw = f.read()
+        except OSError as e:
+            raise ConfigError(f"Could not read LITELLM_E2E_CONFIG file {path!r}: {e}")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ConfigError(f"LITELLM_E2E_CONFIG is not valid JSON: {e}")
+    if not isinstance(parsed, dict):
+        raise ConfigError("LITELLM_E2E_CONFIG must be a JSON object.")
+    return parsed
+
+
+def _parse_expected_unsupported(
+    raw: Dict[str, Any], case_id: str
+) -> Dict[str, ExpectedError]:
+    expected: Dict[str, ExpectedError] = {}
+    for op, spec in raw.items():
+        if op not in ALL_OPS:
+            raise ConfigError(
+                f"case {case_id!r}: unknown op {op!r} in expected_unsupported; "
+                f"valid ops are {ALL_OPS}."
+            )
+        if not isinstance(spec, dict):
+            raise ConfigError(
+                f"case {case_id!r}: expected_unsupported[{op!r}] must be an object."
+            )
+        expected[op] = ExpectedError(status=spec.get("status"), match=spec.get("match"))
+    return expected
+
+
+def _parse_case(raw: Dict[str, Any], index: int) -> Case:
+    strategy = raw.get("strategy")
+    if strategy not in VALID_STRATEGIES:
+        raise ConfigError(
+            f"cases[{index}]: strategy must be one of {sorted(VALID_STRATEGIES)}, "
+            f"got {strategy!r}."
+        )
+    provider = raw.get("provider")
+    if not provider:
+        raise ConfigError(f"cases[{index}]: 'provider' is required.")
+    request_model = raw.get("request_model")
+    if not request_model:
+        raise ConfigError(f"cases[{index}]: 'request_model' is required.")
+
+    model = raw.get("model")
+    target_model_names = raw.get("target_model_names")
+    if strategy == STRATEGY_MODEL_PARAM and not model:
+        raise ConfigError(
+            f"cases[{index}]: strategy '{STRATEGY_MODEL_PARAM}' requires 'model'."
+        )
+    if strategy == STRATEGY_TARGET_MODEL_NAMES and not target_model_names:
+        raise ConfigError(
+            f"cases[{index}]: strategy '{STRATEGY_TARGET_MODEL_NAMES}' requires "
+            f"'target_model_names'."
+        )
+
+    case_id = f"{strategy}-{provider}"
+    expected_unsupported = _parse_expected_unsupported(
+        raw.get("expected_unsupported", {}) or {}, case_id
+    )
+    return Case(
+        strategy=strategy,
+        provider=provider,
+        request_model=request_model,
+        model=model,
+        target_model_names=target_model_names,
+        expected_unsupported=expected_unsupported,
+    )
+
+
+def load_settings() -> Settings:
+    """Load and validate the suite configuration. Raises ConfigError on any gap."""
+    base_url = _require_env("LITELLM_E2E_BASE_URL")
+    api_key = _require_env("LITELLM_E2E_API_KEY")
+    raw = _load_raw_config(_require_env("LITELLM_E2E_CONFIG"))
+
+    cases_raw = raw.get("cases")
+    if not isinstance(cases_raw, list) or not cases_raw:
+        raise ConfigError(
+            "LITELLM_E2E_CONFIG.cases must be a non-empty list of case objects."
+        )
+    cases = [_parse_case(c, i) for i, c in enumerate(cases_raw)]
+
+    ids = [c.id for c in cases]
+    duplicates = {i for i in ids if ids.count(i) > 1}
+    if duplicates:
+        raise ConfigError(f"duplicate cases in matrix: {sorted(duplicates)}.")
+
+    return Settings(
+        base_url=base_url,
+        api_key=api_key,
+        endpoint=raw.get("endpoint", "/v1/chat/completions"),
+        await_completion=bool(raw.get("await_completion", False)),
+        completion_timeout_s=int(raw.get("completion_timeout_s", 900)),
+        cases=cases,
+    )

--- a/tests/batch_e2e_external/conftest.py
+++ b/tests/batch_e2e_external/conftest.py
@@ -1,0 +1,50 @@
+"""
+Pytest wiring for the external batch e2e suite.
+
+This suite is opt-in. It is never collected by CI (no workflow references this
+folder) and is gated behind the ``batch_e2e`` marker. It runs against a live,
+published LiteLLM proxy image using the real OpenAI SDK -- no mocks, no VCR.
+
+Hard-fail contract: configuration is loaded once at session start. If anything
+required is missing or malformed the whole session errors out, rather than
+silently skipping coverage.
+"""
+
+import pytest
+from openai import OpenAI
+
+from .config import Settings, load_settings
+
+_SETTINGS: Settings = None  # type: ignore[assignment]
+
+
+def _get_settings() -> Settings:
+    """Load + cache the config once. Raises ConfigError (fatal) if misconfigured."""
+    global _SETTINGS
+    if _SETTINGS is None:
+        _SETTINGS = load_settings()
+    return _SETTINGS
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "batch_e2e: external end-to-end batch lifecycle tests (live providers).",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    """Expand the test matrix from the configured cases at collection time."""
+    if "case" in metafunc.fixturenames:
+        cases = _get_settings().cases
+        metafunc.parametrize("case", cases, ids=[c.id for c in cases])
+
+
+@pytest.fixture(scope="session")
+def settings() -> Settings:
+    return _get_settings()
+
+
+@pytest.fixture(scope="session")
+def client(settings: Settings) -> OpenAI:
+    return OpenAI(base_url=settings.base_url, api_key=settings.api_key)

--- a/tests/batch_e2e_external/helpers.py
+++ b/tests/batch_e2e_external/helpers.py
@@ -1,0 +1,93 @@
+"""Runtime helpers for the external batch e2e suite."""
+
+import json
+import os
+import tempfile
+import time
+from typing import Callable
+
+from .config import ExpectedError
+
+# Terminal batch states. Once a batch reaches any of these it will not change.
+TERMINAL_STATES = {"completed", "failed", "cancelled", "expired"}
+
+
+def build_input_jsonl(request_model: str, endpoint: str) -> str:
+    """Write a minimal two-request batch input file and return its path.
+
+    Generated per case so the model name always matches the deployment under
+    test instead of relying on stale committed fixtures.
+    """
+    rows = [
+        {
+            "custom_id": "e2e-request-1",
+            "method": "POST",
+            "url": endpoint,
+            "body": {
+                "model": request_model,
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Hello world!"},
+                ],
+                "max_tokens": 10,
+            },
+        },
+        {
+            "custom_id": "e2e-request-2",
+            "method": "POST",
+            "url": endpoint,
+            "body": {
+                "model": request_model,
+                "messages": [
+                    {"role": "user", "content": "Say hi in one word."},
+                ],
+                "max_tokens": 10,
+            },
+        },
+    ]
+    fd, path = tempfile.mkstemp(suffix=".jsonl", prefix="batch_e2e_")
+    with os.fdopen(fd, "w") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+    return path
+
+
+def _error_text(err: Exception) -> str:
+    return str(getattr(err, "message", None) or err)
+
+
+def assert_expected_error(call: Callable[[], object], spec: ExpectedError) -> None:
+    """Assert that ``call`` raises an error matching the declared expectation.
+
+    A success, or an error that does not match the spec, is a failure -- this is
+    how we distinguish a sanctioned, documented contract gap from a regression.
+    """
+    try:
+        call()
+    except Exception as err:  # noqa: BLE001 - we re-assert on the caught error
+        if spec.status is not None:
+            actual = getattr(err, "status_code", None)
+            assert (
+                actual == spec.status
+            ), f"expected status {spec.status} but got {actual!r}: {_error_text(err)}"
+        if spec.match is not None:
+            assert (
+                spec.match.lower() in _error_text(err).lower()
+            ), f"expected error to contain {spec.match!r} but got: {_error_text(err)}"
+        return
+    raise AssertionError(f"expected an error matching {spec} but the call succeeded.")
+
+
+def poll_until_terminal(retrieve: Callable[[], object], timeout_s: int):
+    """Poll ``retrieve`` until the batch reaches a terminal state or times out."""
+    deadline = time.monotonic() + timeout_s
+    last = None
+    while time.monotonic() < deadline:
+        last = retrieve()
+        if getattr(last, "status", None) in TERMINAL_STATES:
+            return last
+        time.sleep(15)
+    raise AssertionError(
+        f"batch did not reach a terminal state within {timeout_s}s; "
+        f"last status={getattr(last, 'status', None)!r}"
+    )

--- a/tests/batch_e2e_external/strategies.py
+++ b/tests/batch_e2e_external/strategies.py
@@ -1,0 +1,119 @@
+"""
+Routing strategies -- one per scenario.
+
+Each strategy knows how to issue every batch-lifecycle call for one routing
+mode. The lifecycle test never branches on the scenario; it drives a strategy.
+The three strategies correspond directly to the proxy's file-create routing
+priority (litellm/proxy/openai_files_endpoints/files_endpoints.py):
+
+  ModelParamStrategy        - `model=` on file create. The proxy encodes the
+                              model into the returned file/batch id, so NO extra
+                              routing hint is needed on downstream calls.
+  TargetModelNamesStrategy  - managed files (DB-backed, load-balanced). The
+                              `target_model_names` hint is repeated on list.
+  CustomLlmProviderStrategy - the `custom-llm-provider` header, repeated on
+                              every call.
+"""
+
+from typing import Any, Dict
+
+from .config import (
+    STRATEGY_CUSTOM_LLM_PROVIDER,
+    STRATEGY_MODEL_PARAM,
+    STRATEGY_TARGET_MODEL_NAMES,
+    Case,
+)
+
+
+class _BaseStrategy:
+    def __init__(self, case: Case, endpoint: str):
+        self.case = case
+        self.endpoint = endpoint
+
+    # --- routing hints injected per call; overridden by subclasses --------
+    def _create_file_kwargs(self) -> Dict[str, Any]:
+        return {}
+
+    def _call_kwargs(self) -> Dict[str, Any]:
+        """Hints repeated on retrieve/cancel/delete/create-batch."""
+        return {}
+
+    def _list_kwargs(self) -> Dict[str, Any]:
+        return {}
+
+    # --- lifecycle operations --------------------------------------------
+    def create_file(self, client, input_path: str):
+        return client.files.create(
+            file=open(input_path, "rb"),
+            purpose="batch",
+            **self._create_file_kwargs(),
+        )
+
+    def create_batch(self, client, input_file_id: str):
+        return client.batches.create(
+            input_file_id=input_file_id,
+            endpoint=self.endpoint,
+            completion_window="24h",
+            metadata={"e2e": self.case.id},
+            **self._call_kwargs(),
+        )
+
+    def retrieve_batch(self, client, batch_id: str):
+        return client.batches.retrieve(batch_id, **self._call_kwargs())
+
+    def list_batches(self, client):
+        return client.batches.list(**self._list_kwargs())
+
+    def cancel_batch(self, client, batch_id: str):
+        return client.batches.cancel(batch_id, **self._call_kwargs())
+
+    def delete_file(self, client, file_id: str):
+        return client.files.delete(file_id, **self._call_kwargs())
+
+
+class ModelParamStrategy(_BaseStrategy):
+    """Scenario 1: `model=` -> model credentials, id carries the model."""
+
+    def _create_file_kwargs(self) -> Dict[str, Any]:
+        # `model` is not a first-class param on files.create in the OpenAI SDK;
+        # the proxy reads it from the request body.
+        return {"extra_body": {"model": self.case.model}}
+
+    # downstream calls need nothing: the model is encoded in the id.
+
+
+class TargetModelNamesStrategy(_BaseStrategy):
+    """Scenario 2: managed files via `target_model_names` (requires DB)."""
+
+    def _create_file_kwargs(self) -> Dict[str, Any]:
+        return {"extra_body": {"target_model_names": self.case.target_model_names}}
+
+    def _list_kwargs(self) -> Dict[str, Any]:
+        return {"extra_query": {"target_model_names": self.case.target_model_names}}
+
+
+class CustomLlmProviderStrategy(_BaseStrategy):
+    """Scenario 3: route purely via the `custom-llm-provider` header."""
+
+    def _header(self) -> Dict[str, Any]:
+        return {"extra_headers": {"custom-llm-provider": self.case.provider}}
+
+    def _create_file_kwargs(self) -> Dict[str, Any]:
+        return self._header()
+
+    def _call_kwargs(self) -> Dict[str, Any]:
+        return self._header()
+
+    def _list_kwargs(self) -> Dict[str, Any]:
+        return self._header()
+
+
+_REGISTRY = {
+    STRATEGY_MODEL_PARAM: ModelParamStrategy,
+    STRATEGY_TARGET_MODEL_NAMES: TargetModelNamesStrategy,
+    STRATEGY_CUSTOM_LLM_PROVIDER: CustomLlmProviderStrategy,
+}
+
+
+def build_strategy(case: Case, endpoint: str) -> _BaseStrategy:
+    return _REGISTRY[case.strategy](case, endpoint)

--- a/tests/batch_e2e_external/test_batch_lifecycle.py
+++ b/tests/batch_e2e_external/test_batch_lifecycle.py
@@ -1,0 +1,113 @@
+"""
+End-to-end batch lifecycle against a LIVE, published LiteLLM image.
+
+Real OpenAI SDK -> real proxy -> real providers. No mocks, no VCR.
+Opt-in only:  pytest -m batch_e2e tests/batch_e2e_external
+
+For each configured case (routing strategy x provider) the suite walks the full
+lifecycle: create file -> create batch -> retrieve -> list -> cancel -> delete.
+
+Hard-fail contract:
+  * A supported op MUST succeed. Any failure -- including a missing DB for the
+    managed-files (target_model_names) scenario -- fails the test. We catch
+    regressions here, at the client boundary, rather than letting them ship.
+  * An op declared unsupported for a provider (config.expected_unsupported) MUST
+    raise the declared error. Success there, or a different error, is a failure.
+"""
+
+import os
+
+import pytest
+
+from .config import (
+    OP_CANCEL,
+    OP_CREATE,
+    OP_DELETE,
+    OP_FILE,
+    OP_LIST,
+    OP_RETRIEVE,
+    Case,
+    Settings,
+)
+from .helpers import assert_expected_error, build_input_jsonl, poll_until_terminal
+from .strategies import build_strategy
+
+pytestmark = pytest.mark.batch_e2e
+
+
+def _run(case: Case, op: str, supported_call, unsupported_call=None):
+    """Run an op, honouring the declared support contract for this provider.
+
+    Returns the call's result when the op is supported, else asserts the
+    declared error was raised and returns None.
+    """
+    expected = case.expected_unsupported.get(op)
+    if expected is None:
+        return supported_call()
+    assert_expected_error(unsupported_call or supported_call, expected)
+    return None
+
+
+def test_batch_lifecycle(case: Case, client, settings: Settings):
+    strat = build_strategy(case, settings.endpoint)
+    input_path = build_input_jsonl(case.request_model, settings.endpoint)
+
+    file_id = None
+    batch_id = None
+    try:
+        # 1. create file (purpose="batch") --------------------------------
+        file_obj = _run(case, OP_FILE, lambda: strat.create_file(client, input_path))
+        if file_obj is None:
+            return  # file creation is the declared contract gap; nothing downstream
+        assert file_obj.id, "file create returned no id"
+        file_id = file_obj.id
+
+        # 2. create batch -------------------------------------------------
+        batch = _run(case, OP_CREATE, lambda: strat.create_batch(client, file_id))
+        if batch is None:
+            return
+        assert batch.id, "batch create returned no id"
+        batch_id = batch.id
+
+        # 3. retrieve batch -----------------------------------------------
+        retrieved = _run(
+            case, OP_RETRIEVE, lambda: strat.retrieve_batch(client, batch_id)
+        )
+        if retrieved is not None:
+            assert retrieved.id == batch_id
+
+        # 4. list batches -------------------------------------------------
+        listing = _run(case, OP_LIST, lambda: strat.list_batches(client))
+        if listing is not None:
+            assert any(
+                b.id == batch_id for b in listing.data
+            ), f"created batch {batch_id} not present in list response"
+
+        # 5. (optional) await completion + fetch output -------------------
+        if settings.await_completion and OP_RETRIEVE not in case.expected_unsupported:
+            done = poll_until_terminal(
+                lambda: strat.retrieve_batch(client, batch_id),
+                settings.completion_timeout_s,
+            )
+            if done.status == "completed" and getattr(done, "output_file_id", None):
+                content = client.files.content(done.output_file_id)
+                assert content.content, "completed batch returned empty output"
+
+        # 6. cancel batch -------------------------------------------------
+        cancelled = _run(case, OP_CANCEL, lambda: strat.cancel_batch(client, batch_id))
+        if cancelled is not None:
+            assert cancelled.status in (
+                "cancelling",
+                "cancelled",
+            ), f"unexpected status after cancel: {cancelled.status}"
+
+    finally:
+        # 7. delete file (best-effort cleanup, but still contract-checked) -
+        if file_id is not None:
+            deleted = _run(case, OP_DELETE, lambda: strat.delete_file(client, file_id))
+            if deleted is not None:
+                assert deleted.deleted is True, "file delete did not report deleted"
+        try:
+            os.remove(input_path)
+        except OSError:
+            pass


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Summary

Adds an opt-in, external end-to-end test suite for the /files + /batches lifecycle under `tests/batch_e2e_external/`. It is meant to run against a published LiteLLM proxy image from an outside test runner using a user-specific API key, not as part of CI/CD. No GitHub workflow references the folder and every test is gated behind a `batch_e2e` marker, so default CI collection never picks it up.

The suite drives the real OpenAI SDK against a live proxy hitting real providers; nothing is mocked. For each configured case (a routing strategy crossed with a provider) it walks create file -> create batch -> retrieve -> list -> cancel -> delete, with optional await-completion plus output fetch.

It covers the three routing scenarios that map to the proxy's file-create routing priority in `litellm/proxy/openai_files_endpoints/files_endpoints.py`:

- `model_param`: model supplied on file create; the proxy encodes the model into the returned id so downstream calls need no extra hint
- `target_model_names`: managed files, load-balanced; requires a DB-backed deployment
- `custom_llm_provider`: the `custom-llm-provider` header repeated on every call

Hard-fail by design so client regressions are caught here rather than shipped. A supported op must succeed; any failure (including a missing DB for the managed-files scenario) fails the test. Misconfiguration fails the session instead of skipping. An op declared unsupported for a provider must raise the declared error, which is how a sanctioned contract gap is told apart from a regression.

The matrix, providers, models and proxy URL/key are all supplied via env (`LITELLM_E2E_BASE_URL`, `LITELLM_E2E_API_KEY`, `LITELLM_E2E_CONFIG`); see the folder README for the config schema.

Draft for now; it needs a published image URL and a user-specific API key to actually run end to end, which we don't have wired up yet.

## Test plan

This suite only runs against an external published image with a real user key, neither of which is available yet, so there is no live proof-of-run to attach in this draft. Local verification so far is limited to collection behavior: unconfigured runs hard-error at collection, and a configured matrix expands to one test per case. Live runbook output will follow once an image and key are provisioned.

## Type

✅ Test

## Changes

New `tests/batch_e2e_external/` package: env-driven config loader and matrix, per-scenario routing strategies, lifecycle helpers (input generation, expected-error matcher, terminal-state polling), the single parametrized lifecycle test, conftest wiring (marker + collection-time matrix expansion + live client fixture), and a README.