### PR TITLE
fix(bedrock): drop internal MCP params from Invoke request bodies

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -8,7 +8,10 @@ import httpx
 
 import litellm
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.core_helpers import map_finish_reason
+from litellm.litellm_core_utils.core_helpers import (
+    filter_internal_params,
+    map_finish_reason,
+)
 from litellm.litellm_core_utils.logging_utils import track_llm_api_timing
 from litellm.litellm_core_utils.prompt_templates.factory import (
     cohere_message_pt,
@@ -162,12 +165,13 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
             provider=provider,
             custom_prompt_dict=custom_prompt_dict,
         )
-        inference_params = copy.deepcopy(optional_params)
-        inference_params = {
-            k: v
-            for k, v in inference_params.items()
-            if k not in self.aws_authentication_params
-        }
+        inference_params = filter_internal_params(
+            {
+                k: v
+                for k, v in copy.deepcopy(optional_params).items()
+                if k not in self.aws_authentication_params
+            }
+        )
         request_data: dict = {}
         if provider == "cohere":
             if model.startswith("cohere.command-r"):

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -39,3 +39,38 @@ def test_transform_request_drops_stream_chunk_size(config, model):
     )
 
     assert "stream_chunk_size" not in json.dumps(request_body)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "mistral.mistral-7b-instruct-v0:2",
+        "amazon.titan-text-express-v1",
+        "ai21.j2-ultra-v1",
+        "meta.llama3-8b-instruct-v1:0",
+    ],
+)
+def test_transform_request_drops_internal_mcp_params(model):
+    """skip_mcp_handler, _skip_mcp_handler and mcp_handler_context are
+    LiteLLM-internal MCP control flags, not Bedrock inference parameters. The
+    invoke path splats inference_params straight into the request body, so
+    without filtering they reach AWS and the request is rejected with
+    'extraneous key is not permitted'. Regression for
+    https://github.com/BerriAI/litellm/issues/30371."""
+    request_body = AmazonInvokeConfig().transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "max_tokens": 10,
+            "skip_mcp_handler": True,
+            "_skip_mcp_handler": True,
+            "mcp_handler_context": {"server": "x"},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    serialized = json.dumps(request_body)
+    assert "skip_mcp_handler" not in serialized
+    assert "mcp_handler_context" not in serialized
+    assert "max_tokens" in serialized


### PR DESCRIPTION
## Relevant issues

Fixes #30371. Part of the broader internal-param leakage class tracked in #30301

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy on `mistral.mistral-7b-instruct-v0:2` over the Bedrock Invoke path, hitting real Bedrock through `AWS_BEARER_TOKEN_BEDROCK`. The internal flag is forced into `optional_params` with `allowed_openai_params` so it reaches the transform exactly as the MCP handler would set it in production.

Config:

```yaml
model_list:
  - model_name: bedrock-mistral-invoke
    litellm_params:
      model: bedrock/mistral.mistral-7b-instruct-v0:2
      aws_region_name: us-east-1
```

Request (identical before and after):

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-mistral-invoke","messages":[{"role":"user","content":"Say hello in 3 words"}],"max_tokens":30,"allowed_openai_params":["skip_mcp_handler"],"skip_mcp_handler":true}'
```

Before (on `litellm_internal_staging`), Bedrock rejects the leaked key:

```json
{
  "error": {
    "message": "litellm.BadRequestError: BedrockException - {\"message\":\"Validation Error: 1 validation error for TextToTextCompletionRequest\nskip_mcp_handler\n  Extra inputs are not permitted [type=extra_forbidden, input_value=True, input_type=bool]\"}. Received Model Group=bedrock-mistral-invoke",
    "code": "400"
  }
}
```

After (this branch), the same request reaches Bedrock cleanly and returns a completion:

```json
{
  "choices": [
    {
      "finish_reason": "length",
      "message": {
        "content": "\nHello, there! Here are three words to say hello:\n\n1. Hi,\n2. Hello,\n3. Greet",
        "role": "assistant"
      }
    }
  ]
}
```

A control request injecting `mcp_handler_context` instead of `skip_mcp_handler` likewise fails before and succeeds after

## Type

🐛 Bug Fix

## Changes

`AmazonInvokeConfig.transform_request` deep-copied `optional_params`, stripped the AWS auth keys, then splatted the remainder straight into the provider request body (`{"prompt": prompt, **inference_params}`). LiteLLM-internal MCP control flags (`skip_mcp_handler`, `_skip_mcp_handler`, `mcp_handler_context`) are not Bedrock inference parameters, so on the non-Anthropic Invoke models (mistral, titan, ai21, llama, cohere) that build their body off `inference_params` they reached AWS and the request was rejected with "Extra inputs are not permitted".

The Converse path already guards against this by routing its params through `filter_internal_params`; the Invoke path simply never did. This change runs `inference_params` through that same shared helper at the single point where the body is assembled, so the internal keys are removed for every Invoke vendor at once. The fix also collapses the prior deep-copy-then-reassign into one expression.

The regression test in the mapped test file asserts the three internal keys never serialize into the Invoke body across mistral, titan, ai21 and llama, while a legitimate param survives. It fails on `litellm_internal_staging` and passes here
