### PR TITLE
fix(health): bridge litellm_metadata into logging object in _batch_he…

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -101,25 +101,24 @@ class HealthCheckHelpers:
         """
         import litellm
 
-        # Bridge identity/tracking metadata into the logging object so callback
-        # handlers receive user_api_key_alias, tags, etc. in model_call_details.
-        #
-        # completion() does this via update_environment_variables (main.py), but
-        # alist_batches never makes that call. The @client decorator skips
-        # function_setup() when litellm_logging_obj already exists in kwargs
-        # (injected by ahealth_check), leaving litellm_params["metadata"] empty.
+        # alist_batches never calls update_environment_variables and @client skips
+        # function_setup() when litellm_logging_obj already exists in kwargs.
         _logging_obj = filtered_model_params.get("litellm_logging_obj")
         _litellm_metadata = filtered_model_params.get("litellm_metadata")
         if _logging_obj is not None and isinstance(_litellm_metadata, dict):
+            _metadata_copy = _litellm_metadata.copy()
+            _litellm_params: Dict = {
+                "metadata": _metadata_copy,
+                "litellm_metadata": _metadata_copy,
+            }
+            _api_base = filtered_model_params.get("api_base")
+            if _api_base:
+                _litellm_params["api_base"] = _api_base
             _logging_obj.update_environment_variables(
                 model=filtered_model_params.get("model"),
                 user="",
                 optional_params={},
-                litellm_params={
-                    "api_base": filtered_model_params.get("api_base", ""),
-                    "metadata": _litellm_metadata.copy(),
-                    "litellm_metadata": _litellm_metadata.copy(),
-                },
+                litellm_params=_litellm_params,
             )
 
         if custom_llm_provider in LIST_BATCHES_SUPPORTED_PROVIDERS:

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -101,6 +101,27 @@ class HealthCheckHelpers:
         """
         import litellm
 
+        # Bridge identity/tracking metadata into the logging object so callback
+        # handlers receive user_api_key_alias, tags, etc. in model_call_details.
+        #
+        # completion() does this via update_environment_variables (main.py), but
+        # alist_batches never makes that call. The @client decorator skips
+        # function_setup() when litellm_logging_obj already exists in kwargs
+        # (injected by ahealth_check), leaving litellm_params["metadata"] empty.
+        _logging_obj = filtered_model_params.get("litellm_logging_obj")
+        _litellm_metadata = filtered_model_params.get("litellm_metadata")
+        if _logging_obj is not None and isinstance(_litellm_metadata, dict):
+            _logging_obj.update_environment_variables(
+                model=filtered_model_params.get("model"),
+                user="",
+                optional_params={},
+                litellm_params={
+                    "api_base": "",
+                    "metadata": _litellm_metadata.copy(),
+                    "litellm_metadata": _litellm_metadata.copy(),
+                },
+            )
+
         if custom_llm_provider in LIST_BATCHES_SUPPORTED_PROVIDERS:
             return await litellm.alist_batches(**filtered_model_params)
         else:

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -116,7 +116,7 @@ class HealthCheckHelpers:
                 user="",
                 optional_params={},
                 litellm_params={
-                    "api_base": "",
+                    "api_base": filtered_model_params.get("api_base", ""),
                     "metadata": _litellm_metadata.copy(),
                     "litellm_metadata": _litellm_metadata.copy(),
                 },

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -14,6 +14,7 @@ from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
 from litellm.main import ahealth_check
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import LIST_BATCHES_SUPPORTED_PROVIDERS
 
 
 def test_update_model_params_with_health_check_tracking_information():
@@ -140,3 +141,161 @@ async def test_ahealth_check_failure_masks_raw_request_headers():
         assert headers["Content-Type"] == "application/json"
 
     print(f"Masked Authorization header: {headers.get('Authorization', 'NOT FOUND')}")
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_bridges_metadata_into_logging_obj():
+    """_batch_health_check must call update_environment_variables on the
+    pre-injected logging object so callbacks receive identity/tracking fields
+    in model_call_details["litellm_params"]["metadata"]."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {
+        "tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME],
+        "user_api_key_alias": "health-check-key",
+    }
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "api_base": "https://api.openai.com",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    mock_logging_obj.update_environment_variables.assert_called_once()
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
+    assert call_kwargs["model"] == "openai/gpt-4"
+    assert call_kwargs["litellm_params"]["metadata"] == litellm_metadata
+    assert call_kwargs["litellm_params"]["litellm_metadata"] == litellm_metadata
+    assert call_kwargs["litellm_params"]["metadata"] is call_kwargs["litellm_params"]["litellm_metadata"]
+    assert call_kwargs["litellm_params"]["api_base"] == "https://api.openai.com"
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_omits_api_base_when_absent():
+    """api_base must not appear in litellm_params when the provider resolves
+    it implicitly (bedrock, vertex, gemini)."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "bedrock/anthropic.claude-v2",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.acompletion", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="bedrock",
+            model_params={"model": "bedrock/anthropic.claude-v2"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
+    assert "api_base" not in call_kwargs["litellm_params"]
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_skips_bridge_when_no_metadata():
+    """When litellm_metadata is absent, update_environment_variables must not
+    be called — avoids crashing on non-health-check batch calls."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "litellm_logging_obj": mock_logging_obj,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    mock_logging_obj.update_environment_variables.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_skips_bridge_when_no_logging_obj():
+    """When litellm_logging_obj is absent, update_environment_variables must
+    not be called."""
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_uses_alist_batches_for_supported_providers():
+    """Providers in LIST_BATCHES_SUPPORTED_PROVIDERS dispatch to alist_batches."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    for provider in LIST_BATCHES_SUPPORTED_PROVIDERS:
+        filtered_model_params = {
+            "model": f"{provider}/some-model",
+            "litellm_logging_obj": mock_logging_obj,
+            "litellm_metadata": litellm_metadata,
+        }
+
+        with patch(
+            "litellm.alist_batches", new_callable=AsyncMock, return_value={}
+        ) as mock_alist:
+            await HealthCheckHelpers._batch_health_check(
+                custom_llm_provider=provider,
+                model_params={"model": f"{provider}/some-model"},
+                filtered_model_params=filtered_model_params,
+            )
+            mock_alist.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_falls_back_to_acompletion_for_unsupported():
+    """Providers not in LIST_BATCHES_SUPPORTED_PROVIDERS fall back to acompletion."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "bedrock/anthropic.claude-v2",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    model_params = {"model": "bedrock/anthropic.claude-v2", "messages": []}
+
+    with (
+        patch("litellm.alist_batches", new_callable=AsyncMock) as mock_alist,
+        patch("litellm.acompletion", new_callable=AsyncMock, return_value={}) as mock_acompletion,
+    ):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="bedrock",
+            model_params=model_params,
+            filtered_model_params=filtered_model_params,
+        )
+        mock_alist.assert_not_called()
+        mock_acompletion.assert_called_once_with(**model_params)


### PR DESCRIPTION

Description
## Summary

Callback handlers receive empty `litellm_params` metadata for batch-mode health check
calls, making it impossible for logging callbacks to resolve caller identity or
health-check tracking tags.

## Problem

`ahealth_check()` in `main.py` creates a `litellm_logging_obj` and injects it into
`model_params`. It also adds `litellm_metadata` (containing tags, `user_api_key_auth`)
via `_update_model_params_with_health_check_tracking_information()`.

When `_batch_health_check()` calls `litellm.alist_batches(**filtered_model_params)`,
the `@client` decorator on `alist_batches` finds the pre-existing `litellm_logging_obj`
in kwargs and skips `function_setup()` — which is the code path that normally bridges
`litellm_metadata` into `litellm_params["metadata"]`.

Unlike `completion()` (which explicitly calls `logging_obj.update_environment_variables()`
with the metadata), `alist_batches` / `list_batches` never makes that call.

**Result:** `model_call_details["litellm_params"]["metadata"]` stays empty for batch
health checks. Callback handlers cannot access tracking information (tags,
user_api_key_alias, user_api_key_user_id, etc.) and fall back to default/unknown values.

## Fix

Call `update_environment_variables()` on the logging object inside
`_batch_health_check()` before dispatching to `alist_batches` or `acompletion`,
bridging `litellm_metadata` so callbacks receive the identity and tracking fields
in `model_call_details`.

## Testing

- Configured a model with `mode: batch` and a logging callback
- Before fix: callback receives empty metadata, identity fields resolve to defaults
- After fix: callback correctly receives `tags`, `user_api_key_alias`, etc.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to internal health-check logging only; no auth or request-path behavior changes beyond richer callback metadata.
> 
> **Overview**
> Batch-mode health checks were leaving **`model_call_details["litellm_params"]["metadata"]`** empty for logging callbacks because **`alist_batches`** does not call **`update_environment_variables`** like **`completion()`** does, and the **`@client`** path skips **`function_setup()`** when **`ahealth_check`** already injects **`litellm_logging_obj`**.
> 
> **`_batch_health_check`** now copies **`litellm_metadata`** (tags, internal health-check API key auth, etc.) onto that logging object before **`alist_batches`** or the **`acompletion`** fallback, so callbacks see the same identity and tracking fields as other health-check modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffa35083666e612f493e98af5befe1a3b18d7e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->