### PR TITLE
fix(sensitive_data_masker): fully mask secrets at or below the reveal threshold

### DIFF
--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -12,6 +12,7 @@ class SensitiveDataMasker:
         visible_prefix: int = 4,
         visible_suffix: int = 4,
         mask_char: str = "*",
+        mask_short_values: bool = True,
     ):
         self.sensitive_patterns = sensitive_patterns or {
             "password",
@@ -38,13 +39,16 @@ class SensitiveDataMasker:
         self.visible_prefix = visible_prefix
         self.visible_suffix = visible_suffix
         self.mask_char = mask_char
+        self.mask_short_values = mask_short_values
 
     def _mask_value(self, value: str) -> str:
         value_str = str(value)
         if not value_str:
             return value
         if len(value_str) <= (self.visible_prefix + self.visible_suffix):
-            return self.mask_char * len(value_str)
+            return (
+                self.mask_char * len(value_str) if self.mask_short_values else value_str
+            )
 
         masked_length = len(value_str) - (self.visible_prefix + self.visible_suffix)
 

--- a/litellm/litellm_core_utils/sensitive_data_masker.py
+++ b/litellm/litellm_core_utils/sensitive_data_masker.py
@@ -40,10 +40,12 @@ class SensitiveDataMasker:
         self.mask_char = mask_char
 
     def _mask_value(self, value: str) -> str:
-        if not value or len(str(value)) < (self.visible_prefix + self.visible_suffix):
-            return value
-
         value_str = str(value)
+        if not value_str:
+            return value
+        if len(value_str) <= (self.visible_prefix + self.visible_suffix):
+            return self.mask_char * len(value_str)
+
         masked_length = len(value_str) - (self.visible_prefix + self.visible_suffix)
 
         # Handle the case where visible_suffix is 0 to avoid showing the entire string

--- a/litellm/proxy/_experimental/mcp_server/mcp_debug.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_debug.py
@@ -122,7 +122,6 @@ class MCPDebug:
         },
         visible_prefix=6,
         visible_suffix=4,
-        mask_short_values=False,
     )
 
     @staticmethod

--- a/litellm/proxy/_experimental/mcp_server/mcp_debug.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_debug.py
@@ -122,6 +122,7 @@ class MCPDebug:
         },
         visible_prefix=6,
         visible_suffix=4,
+        mask_short_values=False,
     )
 
     @staticmethod

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -38,6 +38,7 @@ class CooldownCache:
             visible_prefix=50,  # Show first 50 characters
             visible_suffix=0,  # Show last 0 characters
             mask_char="*",  # Use * for masking
+            mask_short_values=False,  # Truncate long messages only; keep short ones readable
         )
 
     def _common_add_cooldown_logic(

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -148,6 +148,27 @@ def test_short_secrets_are_fully_masked():
     assert masked["api_key"] == "*****"
 
 
+def test_mask_short_values_false_keeps_short_values_readable():
+    """
+    mask_short_values=False opts out of full masking so short values are returned
+    as-is. This preserves the truncation use (e.g. CooldownCache shows the first 50
+    chars of an exception and only masks longer tails), while longer values are still
+    partially masked.
+    """
+    masker = SensitiveDataMasker(
+        visible_prefix=50, visible_suffix=0, mask_short_values=False
+    )
+
+    short = "Test exception for structure validation"
+    assert masker._mask_value(short) == short
+
+    long_value = "x" * 60
+    masked = masker._mask_value(long_value)
+    assert masked.startswith("x" * 50)
+    assert masked.endswith("*" * 10)
+    assert len(masked) == 60
+
+
 def test_cost_per_token_fields_not_masked():
     """
     Regression test: cost fields like input_cost_per_token contain "token" in their name

--- a/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
+++ b/tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py
@@ -126,6 +126,28 @@ def test_lists_with_sensitive_keys_are_masked():
     assert masked["tags"] == ["prod", "test"]
 
 
+def test_short_secrets_are_fully_masked():
+    """
+    Regression test: secrets at or below the reveal threshold (visible_prefix +
+    visible_suffix, 8 by default) were returned verbatim instead of masked.
+    An exactly-8-char value hit masked_length == 0 and round-tripped unchanged;
+    anything shorter hit the early return. Both leaked short credentials (e.g. an
+    8-char redis password) in plaintext through mask_dict.
+    """
+    masker = SensitiveDataMasker()
+
+    # Boundary: exactly 8 chars previously returned verbatim.
+    assert masker._mask_value("abcd1234") == "********"
+    # Below threshold previously hit the early return and leaked verbatim.
+    assert masker._mask_value("sk-12") == "*****"
+    # Values above the threshold must still partially reveal, not over-mask.
+    assert masker._mask_value("abcd12345") == "abcd*2345"
+
+    masked = masker.mask_dict({"redis_password": "pass1234", "api_key": "sk-7a"})
+    assert masked["redis_password"] == "********"
+    assert masked["api_key"] == "*****"
+
+
 def test_cost_per_token_fields_not_masked():
     """
     Regression test: cost fields like input_cost_per_token contain "token" in their name

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
@@ -41,9 +41,12 @@ class TestMask:
     def test_empty_returns_none_label(self):
         assert MCPDebug._mask("") == "(none)"
 
-    def test_short_value_unchanged(self):
-        # visible_prefix=6 + visible_suffix=4 = 10, so <= 10 chars unchanged
-        assert MCPDebug._mask("sk-1234") == "sk-1234"
+    def test_short_value_masked(self):
+        # Short auth values must not be echoed verbatim in debug headers, even though
+        # visible_prefix + visible_suffix would otherwise reveal the whole value.
+        masked = MCPDebug._mask("sk-1234")
+        assert "sk-1234" not in masked
+        assert set(masked) == {"*"}
 
     def test_long_value_masked(self):
         result = MCPDebug._mask("Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
@@ -47,6 +47,7 @@ class TestMask:
         masked = MCPDebug._mask("sk-1234")
         assert "sk-1234" not in masked
         assert set(masked) == {"*"}
+        assert len(masked) == len("sk-1234")
 
     def test_long_value_masked(self):
         result = MCPDebug._mask("Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9")


### PR DESCRIPTION
## Relevant issues

None filed; found this while reading through the sensitive data masker, so I'm reporting and fixing it in the same PR

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on the changed files (`tests/test_litellm/litellm_core_utils/test_sensitive_data_masker.py`, `tests/test_litellm/router_utils/test_cooldown_cache.py`, `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py`)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

`SensitiveDataMasker._mask_value` is supposed to reveal only the first `visible_prefix` and last `visible_suffix` characters of a secret. On `litellm_internal_staging` it returns any value whose length is at or below `visible_prefix + visible_suffix` (8 by default) verbatim. A value of exactly 8 chars falls through the length guard and computes `masked_length == 0`, so it rebuilds the original with no mask characters; anything shorter hits the early `return value`

Running the default masker against a few values, before vs after this branch:

```
before (current litellm_internal_staging)        after (this branch)
'abcd1234' (8) -> 'abcd1234'                      'abcd1234' -> '********'
'pass1234' (8) -> 'pass1234'                      'pass1234' -> '********'
'sk-12'    (5) -> 'sk-12'                         'sk-12'    -> '*****'
'abcd12345'(9) -> 'abcd*2345'                     'abcd12345'-> 'abcd*2345'  (unchanged)
```

`mask_dict` is what `_redis.py`, `caching_routes.py`, `s3_v2.py`, and the audit-log path call, so a short redis password, api key, or token was being written to logs and the UI in plaintext. To reproduce end to end on a running proxy, configure a redis password of 8 or fewer characters and open the cache/settings view at http://localhost:4000/ui/?page=settings; before this change the password renders in full, after it renders fully masked

## Type

🐛 Bug Fix

## Changes

`_mask_value` now fully masks any value whose length is at or below `visible_prefix + visible_suffix` instead of returning it unchanged, which matches what the sibling `mask_sensitive_keys` helper in the same module already does for short values

Full masking of short values is the right default for secret masking, so the masker gains a `mask_short_values` flag (default `True`, secure) and every secret-masking caller now has short values fully masked. The one exception is `CooldownCache`, which reuses this masker only to truncate exception message text (not secrets) to the first 50 characters and depends on short messages staying readable, so it passes `False`. `MCPDebug`, which previews auth tokens in debug response headers, keeps the secure default so short auth values are never echoed verbatim

Tests cover the exactly-8-char boundary, a shorter value, a longer value that must still partially reveal, and the `mask_short_values=False` truncation path used by `CooldownCache`
