### PR TITLE
chore: make pr template linear portion clearer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Linear ticket
 
-<!-- if you are an internal contributor, add the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->
+<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->
 
 ## Pre-Submission checklist
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

Docs-only change to the PR template, so no unit tests apply

## Why

This is a copy of #30750 on a `litellm_`-prefixed branch so the required CircleCI checks run; CircleCI only triggers on `litellm_`-prefixed branches, so the original `mateo-berri-patch-1` branch could not be merged because that required check never ran

Reasoning for the change itself: an internal contributor wrote "No need. External contributor" in the Linear section, so their agent didn't have enough context to know the instruction applied to them. This clarifies that internal contributors are typically those whose GitHub username is postfixed with `-berri` or `-berriai`, and spells out the "Resolves " prefix needed for the magic link

## Screenshots / Proof of Fix

Docs-only change to `.github/pull_request_template.md`. The Linear ticket comment now reads:

`<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->`

## Type

📖 Documentation

## Changes

Clarifies the Linear ticket section of the PR template so internal contributors recognize the instruction applies to them and know to prefix the ticket with "Resolves "
