### PR TITLE
build(docker): build the Admin UI in a cached stage for the monolith image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,8 @@ build/
 *.egg-info/
 .DS_Store
 **/node_modules
+ui/litellm-dashboard/.next
+ui/litellm-dashboard/out
 *.log
 .env
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,31 @@
+# syntax=docker/dockerfile:1.7
+
 # Base image for building
 ARG LITELLM_BUILD_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:31da6565f35af6401031c1d7aa91dc84ac76c5c48edd17fb90f0ed9e3173c7a9
 
 # Runtime image
 ARG LITELLM_RUNTIME_IMAGE=cgr.dev/chainguard/wolfi-base@sha256:31da6565f35af6401031c1d7aa91dc84ac76c5c48edd17fb90f0ed9e3173c7a9
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.11.7@sha256:240fb85ab0f263ef12f492d8476aa3a2e4e1e333f7d67fbdd923d00a506a516a
+ARG UI_BUILD_IMAGE=node:20.18-alpine3.20
 
 FROM $UV_IMAGE AS uvbin
+
+# UI builder — mirrors ui/Dockerfile so the monolith ships a UI built from this
+# source tree. The npm cache mount plus the buildx layer cache make rebuilds
+# fast; replaces the slow out-of-band build_ui.sh refresh of the committed bundle.
+FROM $UI_BUILD_IMAGE AS ui-builder
+
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    npm_config_fund=false \
+    npm_config_audit=false
+
+WORKDIR /ui
+
+COPY ui/litellm-dashboard/package.json ui/litellm-dashboard/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci --prefer-offline
+
+COPY ui/litellm-dashboard/ ./
+RUN npm run build
 
 # Builder stage
 FROM $LITELLM_BUILD_IMAGE AS builder
@@ -46,6 +66,13 @@ RUN uv sync --frozen --no-install-project --no-install-workspace --no-default-gr
 
 # Copy full source tree
 COPY . .
+
+# Replace the committed _experimental/out bundle with a UI built from this exact
+# source. Clearing first drops the committed bundle's content-hashed chunks,
+# which COPY would otherwise leave behind. build_admin_ui.sh still runs after,
+# applying the enterprise custom-color override when present.
+RUN rm -rf litellm/proxy/_experimental/out
+COPY --from=ui-builder /ui/out/. litellm/proxy/_experimental/out/
 
 # Build Admin UI before final sync
 RUN sed -i 's/\r$//' docker/build_admin_ui.sh && chmod +x docker/build_admin_ui.sh && ./docker/build_admin_ui.sh


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3808

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3808/implement-fast-non-componentized-ui-ci-build-step

## Pre-Submission checklist

- [ ] I have added meaningful tests (see note below)
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

Note on tests: this is a Dockerfile change with no unit-test harness. The proof of fix is the timed builds and the shipped-bundle inspection below; the UI build itself is already exercised on every PR by `.github/workflows/test-litellm-ui-build.yml`.

## Type

🚄 Infrastructure

## Changes

The release orchestrator builds the monolith (`litellm` variant) from the root `Dockerfile`, and that build never actually rebuilds the UI; it ships whatever is committed to `litellm/proxy/_experimental/out`. Refreshing the UI for a release therefore meant running `build_ui.sh` out of band (nvm bootstrap, uncached `npm ci`, `next build`) and committing the regenerated bundle. The componentized stack already builds the UI quickly via `ui/Dockerfile` with an npm cache mount and a buildx layer cache; this gives the monolith the same fast path.

A new `ui-builder` stage mirrors `ui/Dockerfile` and its static export overlays `_experimental/out` right before the project `uv sync`, so the monolith ships a UI built from the exact source being released. The destination is cleared first because `COPY` merges directories, which would otherwise leave the committed bundle's content-hashed chunks behind alongside the fresh ones (verified: without the clear the image carried two Next.js build IDs and 797 files; with it, one build ID and 658 files). `build_admin_ui.sh` still runs afterward so the enterprise custom-color override is preserved, and the committed bundle stays in the tree for the PyPI wheel and source runs.

No changes are needed in `project-releaser`. `release-docker-build.yml` already passes `cache-from/to: type=gha,scope=release-orchestrator-litellm`, so the npm-install layer persists across releases keyed on `package-lock.json`. An unchanged-UI release hits the cache; a UI-only change reruns only `next build`; a lockfile bump pays the install once.

## Screenshots / Proof of Fix

Timed local builds against this `Dockerfile` (real `npm ci` + `next build`, no mocks):

```
# Today's per-release UI refresh (core of build_ui.sh; warm host npm cache;
# excludes the nvm + node bootstrap build_ui.sh also pays every release)
$ npm ci --prefer-offline   -> real 7.43s
$ npm run build             -> real 19.18s   (next build, static export to ./out, 17M)

# Fix: ui-builder stage, cold (--no-cache, cache miss / first build)
$ docker build --no-cache --target ui-builder .   -> real 60.51s
  (includes node:alpine pull + ~18s image export that does not recur)

# Fix: ui-builder stage, warm (unchanged lockfile + UI source)
$ docker build --target ui-builder .   -> real 1.91s   (6 CACHED layers)

# Fix: UI source change (lockfile unchanged -> npm ci stays cached)
$ docker build --target ui-builder .   -> real 28.14s
  #10 [ui-builder 4/6] RUN ... npm ci --prefer-offline    CACHED
  #12 [ui-builder 6/6] RUN npm run build                  (re-ran)
```

Full monolith image built end-to-end and the shipped bundle confirmed to be the freshly built UI:

```
$ docker build -t lit3808-full -f Dockerfile .   -> real 77.53s (warm caches)

$ docker run --rm --entrypoint sh lit3808-full -c '
    OUT=$(find /app/.venv -type d -path "*/litellm/proxy/_experimental/out" | head -1)
    ls "$OUT/_next/static/" | grep -vE "chunks|css|media"   # build IDs
    grep -oE "<title>[^<]*</title>" "$OUT/index.html" | head -1
    find "$OUT" -type f | wc -l'
_vi7o2KVRtJ7cHYLhQV4i          # single build ID (fresh)
<title>LiteLLM Dashboard</title>
658                            # was 797 before clearing the stale bundle
# a chunk referenced by index.html resolves to a real file in the bundle (consistent)
```
