### PR TITLE
feat(pricing): add xAI Grok 4.3 on AWS Bedrock

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37532,6 +37532,36 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "xai.grok-4.3": {
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
+    "us.xai.grok-4.3": {
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 2.5e-06,
+        "cache_read_input_token_cost": 2e-07,
+        "litellm_provider": "bedrock_converse",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "zai.glm-4.7": {
         "input_cost_per_token": 6e-07,
         "litellm_provider": "bedrock_converse",


### PR DESCRIPTION
## Summary

Adds missing Bedrock pricing for xAI Grok 4.3.

### New entries
| Key | Provider | Input/M | Output/M | Source |
|-----|----------|---------|----------|--------|
| `xai.grok-4.3` | bedrock_converse | $1.25 | $2.50 | [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/) |
| `us.xai.grok-4.3` | bedrock_converse | $1.25 | $2.50 | [AWS Bedrock Pricing](https://aws.amazon.com/bedrock/pricing/) |

### Verification
Scraped all 19 Bedrock provider tabs (AI21, Amazon, Anthropic, Cohere, DeepSeek, Google, Luma AI, Meta, MiniMax, Mistral, Moonshot, NVIDIA, OpenAI, Qwen, Stability AI, TwelveLabs, Writer, xAI, Z AI) + Azure OpenAI pricing page and compared against the full cost map.

- **0 pricing discrepancies** on existing entries
- Azure >272k context pricing already handled via `_above_272k_tokens` fields
- `azure/gpt-5-chat-latest` may need a price update ($1.25→$5.00 input, $10→$30 output) if the alias now points to GPT-5.5 — flagging for review

*Opened by Viktor AI*