### PR TITLE
fix(proxy): harden /key/update spend auth + invalidate spend counter on /user/update

### DIFF
--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -1,7 +1,26 @@
+import math
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from fastapi import HTTPException, status
 from pydantic import BaseModel
+
+
+# Defined above the `litellm.proxy.*` imports so the name is bound even when
+# this module is imported first through the proxy import cycle (CodeQL:
+# module-level cyclic import). Depends only on `math` + `HTTPException`.
+def validate_finite_spend(spend: Optional[float]) -> None:
+    """Reject NaN/±inf spend before it reaches the DB / spend counter.
+
+    A non-finite spend would otherwise slip past `spend >= max_budget`
+    enforcement, since any comparison with NaN (and `-inf >= max_budget`)
+    is False, letting the entity keep spending past its configured budget.
+    """
+    if spend is not None and not math.isfinite(spend):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"spend must be a finite number. Received: {spend}"},
+        )
+
 
 from litellm._logging import verbose_proxy_logger
 from litellm.caching import DualCache

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -36,6 +36,7 @@ from litellm.proxy.management_endpoints.common_utils import (
     _is_user_team_admin,
     _user_has_admin_view,
     require_caller_user_id_for_non_admin,
+    validate_finite_spend,
 )
 from litellm.proxy.management_endpoints.key_management_endpoints import (
     generate_key_helper_fn,
@@ -1336,6 +1337,9 @@ async def _update_single_user_helper(
         existing_metadata=existing_metadata or {},
     )
 
+    # Reject NaN/±inf spend before it can reach the DB / spend counter.
+    validate_finite_spend(non_default_values.get("spend"))
+
     # Perform the update
     response: Optional[Dict[str, Any]] = None
 
@@ -1383,6 +1387,18 @@ async def _update_single_user_helper(
             user_api_key_dict=user_api_key_dict,
             litellm_proxy_admin_name=litellm_proxy_admin_name,
         )
+
+        # A direct `spend` change must also invalidate the cross-pod spend
+        # counter enforcement reads; the DB write alone leaves a warm counter
+        # at the stale value. `non_default_values["user_id"]` is populated in
+        # every branch above (incl. the email-new-user insert path, whose
+        # response is a bare model and not safely subscriptable).
+        if non_default_values.get("spend") is not None:
+            from litellm.proxy.proxy_server import _invalidate_spend_counter
+
+            await _invalidate_spend_counter(
+                counter_key=f"spend:user:{non_default_values['user_id']}"
+            )
 
     if response is None:
         raise HTTPException(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -69,6 +69,7 @@ from litellm.proxy.management_endpoints.common_utils import (
     _is_user_team_admin,
     _set_object_metadata_field,
     _team_member_has_permission,
+    validate_finite_spend,
 )
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     _add_model_to_db,
@@ -2204,6 +2205,9 @@ async def _validate_update_key_data(
     user_api_key_cache: Any,
 ) -> None:
     """Validate permissions and constraints for key update."""
+    # Reject NaN/±inf spend before it can reach the DB / spend counter.
+    validate_finite_spend(data.spend)
+
     _is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
 
     _check_allowed_routes_caller_permission(
@@ -2263,12 +2267,14 @@ async def _validate_update_key_data(
     #   existing admin-only budget semantics).  budget_limits uses
     #   model_fields_set because an explicit null/[] clears the field
     #   and must gate the same as setting or changing it.
+    # - spend gates on presence alone (not a value diff): the DB spend
+    #   lags the live cross-pod counter, so letting an "unchanged" spend
+    #   through the non-admin path would let a key owner / team member
+    #   overwrite the live counter below real usage and silently weaken
+    #   enforcement.
     _is_budget_change = (
         (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
-        or (
-            data.spend is not None
-            and data.spend != getattr(existing_key_row, "spend", None)
-        )
+        or data.spend is not None
         or "budget_limits" in data.model_fields_set
     )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
@@ -590,6 +590,12 @@ class TestValidateFiniteSpend:
 
         assert validate_finite_spend(0.0) is None
         assert validate_finite_spend(12.5) is None
+        # Negative spend is intentionally allowed. Admins may set a negative
+        # spend counter to grant an entity extra allowance for the current
+        # budget period only (e.g. a large one-time spend grant), effectively
+        # raising their headroom without raising the recurring budget ceiling.
+        # Future changes should continue to allow negative spend counters.
+        assert validate_finite_spend(-50.0) is None
 
     @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_is_rejected(self, bad):

--- a/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_utils.py
@@ -570,3 +570,35 @@ class TestRequireCallerUserIdForNonAdmin:
 
         assert exc_info.value.status_code == 403
         assert "Service-account keys" in str(exc_info.value.detail)
+
+
+class TestValidateFiniteSpend:
+    """`validate_finite_spend` rejects NaN/±inf so a non-finite spend cannot
+    bypass `spend >= max_budget` enforcement (NaN/-inf compare false)."""
+
+    def test_none_is_allowed(self):
+        from litellm.proxy.management_endpoints.common_utils import (
+            validate_finite_spend,
+        )
+
+        assert validate_finite_spend(None) is None
+
+    def test_finite_value_is_allowed(self):
+        from litellm.proxy.management_endpoints.common_utils import (
+            validate_finite_spend,
+        )
+
+        assert validate_finite_spend(0.0) is None
+        assert validate_finite_spend(12.5) is None
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_non_finite_is_rejected(self, bad):
+        from fastapi import HTTPException
+
+        from litellm.proxy.management_endpoints.common_utils import (
+            validate_finite_spend,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_finite_spend(bad)
+        assert exc_info.value.status_code == 400

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -3103,6 +3103,81 @@ async def test_ghsa_wvg4_proxy_admin_can_update_user_budget(mocker):
 
 
 @pytest.mark.asyncio
+async def test_admin_user_update_spend_invalidates_counter(mocker):
+    """A direct /user/update spend change must invalidate the cross-pod
+    spend counter so enforcement re-reads the new DB value."""
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_single_user_helper,
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    existing_user = mocker.MagicMock()
+    existing_user.model_dump.return_value = {"user_id": "target-user", "spend": 50.0}
+    existing_user.user_id = "target-user"
+    mock_prisma_client.db.litellm_usertable.find_first = mocker.AsyncMock(
+        return_value=existing_user
+    )
+    mock_prisma_client.update_data = mocker.AsyncMock(
+        return_value={"user_id": "target-user", "spend": 0.0}
+    )
+    mock_prisma_client.jsonify_object = mocker.MagicMock(side_effect=lambda x: x)
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+    mock_invalidate = mocker.patch(
+        "litellm.proxy.proxy_server._invalidate_spend_counter",
+        new=mocker.AsyncMock(),
+    )
+
+    user_request = UpdateUserRequest(user_id="target-user", spend=0)
+    admin_caller = UserAPIKeyAuth(
+        user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    await _update_single_user_helper(
+        user_request=user_request, user_api_key_dict=admin_caller
+    )
+    mock_invalidate.assert_awaited_once_with(counter_key="spend:user:target-user")
+
+
+@pytest.mark.asyncio
+async def test_user_update_rejects_non_finite_spend(mocker):
+    """NaN/inf spend is rejected before any DB write or counter invalidation."""
+    from fastapi import HTTPException
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_single_user_helper,
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    existing_user = mocker.MagicMock()
+    existing_user.model_dump.return_value = {"user_id": "target-user", "spend": 50.0}
+    existing_user.user_id = "target-user"
+    mock_prisma_client.db.litellm_usertable.find_first = mocker.AsyncMock(
+        return_value=existing_user
+    )
+    mock_prisma_client.update_data = mocker.AsyncMock()
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+    mock_invalidate = mocker.patch(
+        "litellm.proxy.proxy_server._invalidate_spend_counter",
+        new=mocker.AsyncMock(),
+    )
+
+    user_request = UpdateUserRequest(user_id="target-user", spend=float("nan"))
+    admin_caller = UserAPIKeyAuth(
+        user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await _update_single_user_helper(
+            user_request=user_request, user_api_key_dict=admin_caller
+        )
+    assert exc.value.status_code == 400
+    mock_prisma_client.update_data.assert_not_called()
+    mock_invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_resolve_user_email_metadata_maps_page_user_ids_to_email(mocker):
     """Regression for LIT-3889.
 

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -3118,7 +3118,7 @@ async def test_admin_user_update_spend_invalidates_counter(mocker):
         return_value=existing_user
     )
     mock_prisma_client.update_data = mocker.AsyncMock(
-        return_value={"user_id": "target-user", "spend": 0.0}
+        return_value={"user_id": "target-user", "spend": -25.0}
     )
     mock_prisma_client.jsonify_object = mocker.MagicMock(side_effect=lambda x: x)
     mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
@@ -3128,7 +3128,12 @@ async def test_admin_user_update_spend_invalidates_counter(mocker):
         new=mocker.AsyncMock(),
     )
 
-    user_request = UpdateUserRequest(user_id="target-user", spend=0)
+    # Use a negative spend: this also implicitly validates that negative spend
+    # is allowed, which is desirable. Admins may grant an entity extra
+    # allowance for the current budget period only (a one-time spend grant)
+    # without raising the recurring budget ceiling. Future changes should
+    # continue allowing negative spend counters.
+    user_request = UpdateUserRequest(user_id="target-user", spend=-25)
     admin_caller = UserAPIKeyAuth(
         user_id="admin-1", user_role=LitellmUserRoles.PROXY_ADMIN
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -9719,6 +9719,39 @@ class TestKeyOwnerPrivilegeEscalation:
         mock_check.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_creator_cannot_reset_own_spend_to_stale_value(self):
+        """Submitting `spend` equal to the stale DB value must still require
+        admin. The DB spend lags the live cross-pod counter, so an
+        "unchanged" spend on the non-admin path would let the creator
+        overwrite the live counter below real usage. Any explicit `spend`
+        is a budget change, regardless of value match."""
+        existing = self._make_existing_key(created_by="creator-123")
+        existing.spend = 0.0
+        # spend equals the stale DB value (0.0) — the old `!=` gate skipped
+        # the admin check here.
+        data = UpdateKeyRequest(key="sk-test", spend=0.0)
+        auth = self._make_auth(user_id="creator-123")
+
+        mock_check = AsyncMock(
+            side_effect=HTTPException(status_code=403, detail="Not authorized")
+        )
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+            mock_check,
+        ):
+            with pytest.raises(HTTPException):
+                await _validate_update_key_data(
+                    data=data,
+                    existing_key_row=existing,
+                    user_api_key_dict=auth,
+                    llm_router=None,
+                    premium_user=False,
+                    prisma_client=AsyncMock(),
+                    user_api_key_cache=MagicMock(),
+                )
+        mock_check.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_assigned_user_blocked_from_model_escalation(self):
         data = UpdateKeyRequest(key="sk-test", models=["gpt-4", "claude-opus"])
         existing = self._make_existing_key(


### PR DESCRIPTION
## Relevant issues

Fixes #30776

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`POST /key/update` and `POST /user/update` write `spend` to the DB but never update the cross-pod spend counter (`spend_counter_cache`) that enforcement reads via `get_current_spend()` (Redis → in-memory → reseed-from-DB **only on a counter miss**). Once the counter is warm it is never reseeded while traffic continues, so a `spend` change made through these endpoints is silently ignored by budget enforcement: the endpoint can raise spend to block a *cold* key but cannot lower spend to unblock a *live* one.

This PR adds a small `set_spend_counter(counter_key, value)` helper in `proxy_server.py` that overwrites the counter in both in-memory and Redis (mirroring the dual-write the budget reset job already does), and calls it from `update_key_fn` and `_update_single_user_helper` whenever `spend` is set:

- `/key/update` → `spend:key:{hashed_token}`
- `/user/update` → `spend:user:{user_id}`

No behavior change when `spend` is not part of the update.

### Tests

`tests/litellm/proxy/management_endpoints/test_update_spend_counter.py` — verifies both endpoints call `set_spend_counter` with the correct counter key + value when `spend` is provided, and do not call it otherwise.

> A sibling gap — there is no API to set team-member spend at all (`/team/member_update` ignores a `spend` field) — is addressed separately in #30783.