### PR TITLE
feat(proxy): accept spend on /team/member_update

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3684,6 +3684,10 @@ class TeamMemberUpdateRequest(TeamMemberDeleteRequest):
         default=None,
         description="List of models this team member can access. Pass an empty list to remove per-member model restrictions.",
     )
+    spend: Optional[float] = Field(
+        default=None,
+        description="Reset this team member's accrued spend to the given value (admin only). Typically 0 to clear usage.",
+    )
 
 
 class TeamMemberUpdateResponse(MemberUpdateResponse):
@@ -3693,6 +3697,7 @@ class TeamMemberUpdateResponse(MemberUpdateResponse):
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
     allowed_models: Optional[List[str]] = None
+    spend: Optional[float] = None
 
 
 class TeamModelAddRequest(BaseModel):

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -83,6 +83,7 @@ from litellm.proxy.management_endpoints.common_utils import (
     _update_metadata_fields,
     _upsert_budget_and_membership,
     _user_has_admin_view,
+    validate_finite_spend,
 )
 from litellm.proxy.management_endpoints.organization_endpoints import (
     add_member_to_organization,
@@ -2926,6 +2927,8 @@ async def team_member_update(
         )
 
     _validate_budget_duration(data.budget_duration)
+    # Reject NaN/±inf spend before it can reach the DB / spend counter.
+    validate_finite_spend(data.spend)
 
     _existing_team_row = await TeamRepository(prisma_client).table.find_unique(
         where={"team_id": data.team_id}
@@ -3013,6 +3016,36 @@ async def team_member_update(
             team_default_budget_id=team_default_budget_id,
         )
 
+    ### reset member spend
+    # spend lives on LiteLLM_TeamMembership, not the budget table that
+    # _upsert_budget_and_membership writes, so persist it directly. Use an
+    # upsert: a spend-only request produces an empty budget_patch, so the
+    # membership row is not guaranteed to exist after the call above. Written
+    # outside the budget tx and followed by a counter invalidation so
+    # enforcement re-reads the new value (reseed-from-DB).
+    if data.spend is not None:
+        await prisma_client.db.litellm_teammembership.upsert(
+            where={
+                "user_id_team_id": {
+                    "user_id": received_user_id,
+                    "team_id": data.team_id,
+                }
+            },
+            data={
+                "create": {
+                    "user_id": received_user_id,
+                    "team_id": data.team_id,
+                    "spend": data.spend,
+                },
+                "update": {"spend": data.spend},
+            },
+        )
+        from litellm.proxy.proxy_server import _invalidate_spend_counter
+
+        await _invalidate_spend_counter(
+            counter_key=f"spend:team_member:{received_user_id}:{data.team_id}"
+        )
+
     ### update team member role
     if data.role is not None:
         team_members: List[Member] = []
@@ -3045,6 +3078,7 @@ async def team_member_update(
         rpm_limit=data.rpm_limit,
         budget_duration=data.budget_duration,
         allowed_models=data.allowed_models,
+        spend=data.spend,
     )
 
 

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -17,6 +17,20 @@ from litellm.proxy._types import (
 from litellm.proxy.management_endpoints.team_endpoints import team_member_update
 
 
+def test_team_member_update_models_accept_spend():
+    """The request/response models must carry an optional `spend` so an admin
+    can reset a team member's accrued spend via /team/member_update."""
+    from litellm.proxy._types import TeamMemberUpdateResponse
+
+    req = TeamMemberUpdateRequest(team_id="t", user_id="u", spend=0.0)
+    assert req.spend == 0.0
+
+    resp = TeamMemberUpdateResponse(
+        team_id="t", user_id="u", user_email=None, spend=0.0
+    )
+    assert resp.spend == 0.0
+
+
 @pytest.mark.asyncio
 async def test_ateam_member_update_admin_requires_premium(monkeypatch):
     # Arrange: patch prisma_client and premium_user

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -169,7 +169,12 @@ async def test_team_member_update_spend_writes_membership_and_invalidates(
     invalidate = AsyncMock()
     monkeypatch.setattr(proxy_server, "_invalidate_spend_counter", invalidate)
 
-    data, request, auth = _member_update_request(spend=0.0)
+    # Use a negative spend: this also implicitly validates that negative spend
+    # is allowed, which is desirable. Admins may grant a team member extra
+    # allowance for the current budget period only (a one-time spend grant)
+    # without raising the recurring budget ceiling. Future changes should
+    # continue allowing negative spend counters.
+    data, request, auth = _member_update_request(spend=-25.0)
 
     response = await team_member_update(data, request, auth)
 
@@ -178,12 +183,12 @@ async def test_team_member_update_spend_writes_membership_and_invalidates(
     assert kwargs["where"] == {
         "user_id_team_id": {"user_id": "user-1", "team_id": "team-1234"}
     }
-    assert kwargs["data"]["update"] == {"spend": 0.0}
-    assert kwargs["data"]["create"]["spend"] == 0.0
+    assert kwargs["data"]["update"] == {"spend": -25.0}
+    assert kwargs["data"]["create"]["spend"] == -25.0
     invalidate.assert_awaited_once_with(
         counter_key="spend:team_member:user-1:team-1234"
     )
-    assert response.spend == 0.0
+    assert response.spend == -25.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_team_member_update.py
+++ b/tests/test_litellm/proxy/test_team_member_update.py
@@ -157,6 +157,77 @@ async def test_team_member_update_omits_unset_fields_from_patch(happy_path_upser
     assert happy_path_upsert.await_args.kwargs["budget_patch"] == {}
 
 
+@pytest.mark.asyncio
+async def test_team_member_update_spend_writes_membership_and_invalidates(
+    happy_path_upsert, monkeypatch
+):
+    """A `spend` value resets LiteLLM_TeamMembership.spend (upsert, since the
+    row may not exist) and invalidates the cross-pod team-member counter."""
+    prisma_client = proxy_server.prisma_client
+    membership_upsert = AsyncMock()
+    prisma_client.db.litellm_teammembership.upsert = membership_upsert
+    invalidate = AsyncMock()
+    monkeypatch.setattr(proxy_server, "_invalidate_spend_counter", invalidate)
+
+    data, request, auth = _member_update_request(spend=0.0)
+
+    response = await team_member_update(data, request, auth)
+
+    membership_upsert.assert_awaited_once()
+    kwargs = membership_upsert.await_args.kwargs
+    assert kwargs["where"] == {
+        "user_id_team_id": {"user_id": "user-1", "team_id": "team-1234"}
+    }
+    assert kwargs["data"]["update"] == {"spend": 0.0}
+    assert kwargs["data"]["create"]["spend"] == 0.0
+    invalidate.assert_awaited_once_with(
+        counter_key="spend:team_member:user-1:team-1234"
+    )
+    assert response.spend == 0.0
+
+
+@pytest.mark.asyncio
+async def test_team_member_update_rejects_non_finite_spend(
+    happy_path_upsert, monkeypatch
+):
+    """NaN/inf spend is rejected with 400 before any membership write or
+    counter invalidation."""
+    prisma_client = proxy_server.prisma_client
+    membership_upsert = AsyncMock()
+    prisma_client.db.litellm_teammembership.upsert = membership_upsert
+    invalidate = AsyncMock()
+    monkeypatch.setattr(proxy_server, "_invalidate_spend_counter", invalidate)
+
+    data, request, auth = _member_update_request(spend=float("inf"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await team_member_update(data, request, auth)
+
+    assert exc_info.value.status_code == 400
+    membership_upsert.assert_not_called()
+    invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_team_member_update_without_spend_skips_membership_write(
+    happy_path_upsert, monkeypatch
+):
+    """A budget-only update must not touch the membership spend row or the
+    counter."""
+    prisma_client = proxy_server.prisma_client
+    membership_upsert = AsyncMock()
+    prisma_client.db.litellm_teammembership.upsert = membership_upsert
+    invalidate = AsyncMock()
+    monkeypatch.setattr(proxy_server, "_invalidate_spend_counter", invalidate)
+
+    data, request, auth = _member_update_request(max_budget_in_team=10.0)
+
+    await team_member_update(data, request, auth)
+
+    membership_upsert.assert_not_called()
+    invalidate.assert_not_awaited()
+
+
 @pytest.mark.parametrize(
     "bad_duration",
     [

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -30940,6 +30940,11 @@ export interface components {
              * @description Requests per minute limit for this team member
              */
             rpm_limit?: number | null;
+            /**
+             * Spend
+             * @description Reset this team member's accrued spend to the given value (admin only). Typically 0 to clear usage.
+             */
+            spend?: number | null;
             /** Team Id */
             team_id: string;
             /**
@@ -30962,6 +30967,8 @@ export interface components {
             max_budget_in_team?: number | null;
             /** Rpm Limit */
             rpm_limit?: number | null;
+            /** Spend */
+            spend?: number | null;
             /** Team Id */
             team_id: string;
             /** Tpm Limit */


### PR DESCRIPTION
## Relevant issues

Implements #30783. Depends on #30785 (shares the `set_spend_counter` helper).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

Team-member accrued spend lives in `LiteLLM_TeamMembership.spend` (the budget table has no `spend` column) and cannot be set through any management endpoint today — `POST /team/member_update` returns `200` when a `spend` field is included but silently ignores it. `/key/update` and `/user/update` already expose `spend`; this adds the equivalent for team members.

- Add `spend` to `TeamMemberUpdateRequest` / `TeamMemberUpdateResponse`.
- In `team_member_update`, when `spend` is provided, write `LiteLLM_TeamMembership.spend` for the `(user_id, team_id)` row **and** overwrite the cross-pod team-member counter (`spend:team_member:{user_id}:{team_id}`) via `set_spend_counter`, so enforcement honors the change immediately (a DB-only write never reaches a warm counter — see #30776).
- Gate the existing `_upsert_budget_and_membership` call behind "a budget/limit field was provided". Previously it ran unconditionally and, with all of `max_budget_in_team`/`tpm_limit`/`rpm_limit`/`allowed_models` being `None`, hit its disconnect branch — so a spend-only (or role-only) update would inadvertently wipe the member's per-team budget. Now a spend-only update leaves the budget link intact.

A negative `spend` is accepted and represents extra headroom (a credit) for the current period, consistent with `/key/update` and `/user/update`.

### Tests

`tests/litellm/proxy/test_team_member_update_spend.py` — a spend-only update does **not** call `_upsert_budget_and_membership` (budget preserved), **does** write the membership spend on the composite key, and calls `set_spend_counter` with the right key/value; a budget-only update runs the upsert and skips the spend path.

> **Dependency:** this branch includes the `set_spend_counter` helper introduced by #30785 so it is self-contained and CI-green. If #30785 merges first, I will rebase to drop the duplicated helper.