### PR TITLE
fix(test): drop references to removed Agent Shin workflows

### DIFF
--- a/tests/test_litellm/test_github_triage_workflows.py
+++ b/tests/test_litellm/test_github_triage_workflows.py
@@ -46,19 +46,12 @@ WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 # (rather than scraping every workflow file) means a new workflow file
 # that bypasses the dry-run gating doesn't silently slip past this test.
 DESTRUCTIVE_GATE_ENV: dict[str, str] = {
-    "triage_pr_with_llm.yml": "DISPATCH_CLOSE",
     "triage_issue_with_llm.yml": "DISPATCH_CLOSE",
     "close_low_quality_prs.yml": "CLOSE_FLAG",
     # The reconsider workflow has no per-run "really do it?" knob — its
     # only kill switch is `AGENT_SHIN_ENABLED`, which already serves as
     # both the destructive gate and the global enablement gate.
     "triage_reconsider.yml": "AGENT_SHIN_ENABLED",
-    # The review gate can add/remove labels, post comments, and close PRs.
-    # Its per-run knob is `CLOSE_FLAG` (from the workflow_dispatch input),
-    # gated by an outer `AGENT_SHIN_ENABLED = "true"` check. Listing it
-    # here ensures the same fail-safe `= "true"` and kill-switch invariants
-    # we enforce on every other destructive workflow are enforced here too.
-    "review_gate.yml": "CLOSE_FLAG",
 }
 
 
@@ -67,9 +60,7 @@ DESTRUCTIVE_GATE_ENV: dict[str, str] = {
 # release would otherwise execute in that context. A new workflow that
 # installs the client must be added here and use the same pinned file.
 LLM_CLIENT_INSTALLER_WORKFLOWS = (
-    "triage_pr_with_llm.yml",
     "triage_issue_with_llm.yml",
-    "review_gate.yml",
     "triage_reconsider.yml",
     "triage_rollout_heads_up.yml",
 )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before, on `litellm_internal_staging`, six cases failed because the two workflow files they parametrize over no longer exist:

```
$ .venv/bin/python -m pytest tests/test_litellm/test_github_triage_workflows.py -q
FAILED ...::test_llm_client_install_is_hash_pinned[review_gate.yml] - FileNotFoundError: .../.github/workflows/review_gate.yml
FAILED ...::test_llm_client_install_is_hash_pinned[triage_pr_with_llm.yml] - FileNotFoundError: .../.github/workflows/triage_pr_with_llm.yml
FAILED ...::test_should_require_agent_shin_enabled_for_close[review_gate.yml] - FileNotFoundError: ...
FAILED ...::test_should_require_agent_shin_enabled_for_close[triage_pr_with_llm.yml] - FileNotFoundError: ...
FAILED ...::test_should_use_failsafe_equals_true_comparison[review_gate.yml-CLOSE_FLAG] - FileNotFoundError: ...
FAILED ...::test_should_use_failsafe_equals_true_comparison[triage_pr_with_llm.yml-DISPATCH_CLOSE] - FileNotFoundError: ...
```

After:

```
$ .venv/bin/python -m pytest tests/test_litellm/test_github_triage_workflows.py -q
..............                                                           [100%]
14 passed in 0.23s
```

## Type

✅ Test

## Changes

[#30784](https://github.com/BerriAI/litellm/pull/30784) removed the `pull_request_target` Agent Shin workflows, deleting `.github/workflows/review_gate.yml` and `.github/workflows/triage_pr_with_llm.yml`. `tests/test_litellm/test_github_triage_workflows.py` still named both files in `DESTRUCTIVE_GATE_ENV` and `LLM_CLIENT_INSTALLER_WORKFLOWS`, and `_load_workflow` reads each file with no existence guard, so every parametrized case for the two deleted workflows raised `FileNotFoundError`.

This drops the two stale entries from both tables. The four workflows that still exist (`triage_issue_with_llm.yml`, `close_low_quality_prs.yml`, `triage_reconsider.yml`, `triage_rollout_heads_up.yml`) keep their guardrail coverage unchanged
