### PR TITLE
refactor(streaming): extract chunk_creator dispatch so basedpyright can analyze it

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -6,6 +6,7 @@ import logging
 import threading
 import time
 import traceback
+from dataclasses import dataclass
 from typing import (
     Any,
     AsyncIterator,
@@ -95,6 +96,19 @@ def print_verbose(print_statement):
             print(print_statement)  # noqa: T201
     except Exception:
         pass
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderChunkParsed:
+    response_obj: Dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _ProviderChunkEarlyReturn:
+    value: Any
+
+
+_ProviderChunkResult = Union[_ProviderChunkParsed, _ProviderChunkEarlyReturn]
 
 
 class CustomStreamWrapper:
@@ -1145,6 +1159,376 @@ class CustomStreamWrapper:
                 del model_response.choices[0].delta.reasoning_content
         return
 
+    def _dispatch_provider_chunk(
+        self,
+        chunk: Any,
+        model_response: ModelResponseStream,
+        completion_obj: Dict[str, Any],
+    ) -> _ProviderChunkResult:
+        response_obj: Dict[str, Any] = {}
+        if (
+            isinstance(chunk, ModelResponseStream)
+            and self.custom_llm_provider is not None
+            and self.custom_llm_provider in litellm._custom_providers
+        ):
+            _has_content = bool(
+                chunk.choices
+                and chunk.choices[0].delta is not None
+                and (
+                    chunk.choices[0].delta.content or chunk.choices[0].delta.tool_calls
+                )
+            )
+            if self.received_finish_reason is not None:
+                if not _has_content:
+                    raise StopIteration
+            if chunk.choices and chunk.choices[0].finish_reason:
+                self.received_finish_reason = chunk.choices[0].finish_reason
+                if not _has_content:
+                    return _ProviderChunkEarlyReturn(None)
+                # Strip finish_reason from the content chunk so it appears
+                # only on the trailing empty-delta chunk (OpenAI spec).
+                # finish_reason_handler() will emit the proper terminal chunk.
+                chunk.choices[0].finish_reason = None  # type: ignore[assignment]
+            return _ProviderChunkEarlyReturn(chunk)
+
+        if (
+            isinstance(chunk, dict)
+            and generic_chunk_has_all_required_fields(
+                chunk=chunk
+            )  # check if chunk is a generic streaming chunk
+        ) or (
+            self.custom_llm_provider
+            and self.custom_llm_provider in litellm._custom_providers
+        ):
+            if self.received_finish_reason is not None:
+                _chunk_has_content = isinstance(chunk, dict) and (
+                    bool(chunk.get("text", ""))
+                    or chunk.get("tool_use") is not None
+                    # Usage-only final chunks are valid and needed to surface
+                    # finish_reason/usage to downstream translators.
+                    or chunk.get("usage") is not None
+                )
+                if not _chunk_has_content and (
+                    not isinstance(chunk, dict)
+                    or "provider_specific_fields" not in chunk
+                ):
+                    raise StopIteration
+            anthropic_response_obj: GChunk = cast(GChunk, chunk)
+            completion_obj["content"] = anthropic_response_obj["text"]
+            if anthropic_response_obj["is_finished"]:
+                self.received_finish_reason = anthropic_response_obj["finish_reason"]
+
+            if anthropic_response_obj["finish_reason"]:
+                self.intermittent_finish_reason = anthropic_response_obj[
+                    "finish_reason"
+                ]
+
+            if anthropic_response_obj["usage"] is not None:
+                setattr(
+                    model_response,
+                    "usage",
+                    litellm.Usage(**anthropic_response_obj["usage"]),
+                )
+
+            if (
+                "tool_use" in anthropic_response_obj
+                and anthropic_response_obj["tool_use"] is not None
+            ):
+                completion_obj["tool_calls"] = [anthropic_response_obj["tool_use"]]
+
+            if (
+                "provider_specific_fields" in anthropic_response_obj
+                and anthropic_response_obj["provider_specific_fields"] is not None
+            ):
+                for key, value in anthropic_response_obj[
+                    "provider_specific_fields"
+                ].items():
+                    setattr(model_response, key, value)
+
+            response_obj = cast(Dict[str, Any], anthropic_response_obj)
+        elif self.model == "replicate" or self.custom_llm_provider == "replicate":
+            response_obj = self.handle_replicate_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider and self.custom_llm_provider == "predibase":
+            response_obj = self.handle_predibase_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif (
+            self.custom_llm_provider and self.custom_llm_provider == "baseten"
+        ):  # baseten doesn't provide streaming
+            completion_obj["content"] = self.handle_baseten_chunk(chunk)
+        elif (
+            self.custom_llm_provider and self.custom_llm_provider == "ai21"
+        ):  # ai21 doesn't provide streaming
+            response_obj = self.handle_ai21_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider and self.custom_llm_provider == "maritalk":
+            response_obj = self.handle_maritalk_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider and self.custom_llm_provider == "vllm":
+            completion_obj["content"] = chunk[0].outputs[0].text
+        elif (
+            self.custom_llm_provider and self.custom_llm_provider == "aleph_alpha"
+        ):  # aleph alpha doesn't provide streaming
+            response_obj = self.handle_aleph_alpha_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider == "nlp_cloud":
+            try:
+                response_obj = self.handle_nlp_cloud_chunk(chunk)
+                completion_obj["content"] = response_obj["text"]
+                if response_obj["is_finished"]:
+                    self.received_finish_reason = response_obj["finish_reason"]
+            except Exception as e:
+                if self.received_finish_reason:
+                    raise e
+                else:
+                    if self.sent_first_chunk is False:
+                        raise Exception("An unknown error occurred with the stream")
+                    self.received_finish_reason = "stop"
+        elif self.custom_llm_provider == "vertex_ai" and not isinstance(
+            chunk, ModelResponseStream
+        ):
+            chunk = cast(Any, chunk)
+            import proto  # type: ignore
+
+            if hasattr(chunk, "candidates") is True:
+                try:
+                    try:
+                        completion_obj["content"] = chunk.text  # type: ignore
+                    except Exception as e:
+                        original_exception = e
+                        if "Part has no text." in str(e):
+                            ## check for function calling
+                            function_call = (
+                                chunk.candidates[0].content.parts[0].function_call  # type: ignore
+                            )
+
+                            args_dict = {}
+
+                            # Check if it's a RepeatedComposite instance
+                            for key, val in function_call.args.items():
+                                if isinstance(
+                                    val,
+                                    proto.marshal.collections.repeated.RepeatedComposite,  # type: ignore
+                                ):
+                                    # If so, convert to list
+                                    args_dict[key] = [v for v in val]
+                                else:
+                                    args_dict[key] = val
+
+                            try:
+                                args_str = json.dumps(args_dict)
+                            except Exception as e:
+                                raise e
+                            _delta_obj = litellm.utils.Delta(
+                                content=None,
+                                tool_calls=[
+                                    {
+                                        "id": f"call_{str(uuid.uuid4())}",
+                                        "function": {
+                                            "arguments": args_str,
+                                            "name": function_call.name,
+                                        },
+                                        "type": "function",
+                                    }
+                                ],
+                            )
+                            _streaming_response = StreamingChoices(delta=_delta_obj)
+                            _model_response = ModelResponseStream()
+                            _model_response.choices = [_streaming_response]
+                            response_obj = {"original_chunk": _model_response}
+                        else:
+                            raise original_exception
+                    if (
+                        hasattr(chunk.candidates[0], "finish_reason")  # type: ignore
+                        and chunk.candidates[0].finish_reason.name  # type: ignore
+                        != "FINISH_REASON_UNSPECIFIED"
+                    ):  # every non-final chunk in vertex ai has this
+                        self.received_finish_reason = map_finish_reason(  # type: ignore
+                            chunk.candidates[0].finish_reason.name
+                        )
+                except Exception:
+                    if chunk.candidates[0].finish_reason.name == "SAFETY":  # type: ignore
+                        raise Exception(
+                            f"The response was blocked by VertexAI. {str(chunk)}"
+                        )
+            else:
+                completion_obj["content"] = str(chunk)
+        elif self.custom_llm_provider == "petals":
+            if self.completion_stream is None or len(self.completion_stream) == 0:
+                if self.received_finish_reason is not None:
+                    raise StopIteration
+                else:
+                    self.received_finish_reason = "stop"
+            chunk_size = 30
+            stream = cast(Any, self.completion_stream)
+            new_chunk = stream[:chunk_size]
+            completion_obj["content"] = new_chunk
+            self.completion_stream = stream[chunk_size:]
+        elif self.custom_llm_provider == "palm":
+            # fake streaming
+            response_obj = {}
+            if self.completion_stream is None or len(self.completion_stream) == 0:
+                if self.received_finish_reason is not None:
+                    raise StopIteration
+                else:
+                    self.received_finish_reason = "stop"
+            chunk_size = 30
+            stream = cast(Any, self.completion_stream)
+            new_chunk = stream[:chunk_size]
+            completion_obj["content"] = new_chunk
+            self.completion_stream = stream[chunk_size:]
+        elif self.custom_llm_provider == "triton":
+            response_obj = self.handle_triton_stream(chunk)
+            completion_obj["content"] = response_obj["text"]
+            print_verbose(f"completion obj content: {completion_obj['content']}")
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider == "text-completion-openai":
+            response_obj = self.handle_openai_text_completion_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            print_verbose(f"completion obj content: {completion_obj['content']}")
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+            if response_obj["usage"] is not None:
+                setattr(
+                    model_response,
+                    "usage",
+                    litellm.Usage(
+                        prompt_tokens=response_obj["usage"].prompt_tokens,
+                        completion_tokens=response_obj["usage"].completion_tokens,
+                        total_tokens=response_obj["usage"].total_tokens,
+                    ),
+                )
+        elif self.custom_llm_provider == "text-completion-codestral":
+            if not isinstance(chunk, str):
+                raise ValueError(f"chunk is not a string: {chunk}")
+            response_obj = cast(
+                Dict[str, Any],
+                litellm.CodestralTextCompletionConfig()._chunk_parser(chunk),
+            )
+            completion_obj["content"] = response_obj["text"]
+            print_verbose(f"completion obj content: {completion_obj['content']}")
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+            if "usage" in response_obj is not None:
+                setattr(
+                    model_response,
+                    "usage",
+                    litellm.Usage(
+                        prompt_tokens=response_obj["usage"].prompt_tokens,
+                        completion_tokens=response_obj["usage"].completion_tokens,
+                        total_tokens=response_obj["usage"].total_tokens,
+                    ),
+                )
+        elif self.custom_llm_provider == "azure_text":
+            response_obj = self.handle_azure_text_completion_chunk(chunk)
+            completion_obj["content"] = response_obj["text"]
+            print_verbose(f"completion obj content: {completion_obj['content']}")
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        elif self.custom_llm_provider == "cached_response":
+            chunk = cast(ModelResponseStream, chunk)
+            response_obj = {
+                "text": chunk.choices[0].delta.content,
+                "is_finished": True,
+                "finish_reason": chunk.choices[0].finish_reason,
+                "original_chunk": chunk,
+                "tool_calls": (
+                    chunk.choices[0].delta.tool_calls
+                    if hasattr(chunk.choices[0].delta, "tool_calls")
+                    else None
+                ),
+            }
+
+            completion_obj["content"] = response_obj["text"]
+            if response_obj["tool_calls"] is not None:
+                completion_obj["tool_calls"] = response_obj["tool_calls"]
+            print_verbose(f"completion obj content: {completion_obj['content']}")
+            if hasattr(chunk, "id"):
+                model_response.id = chunk.id
+                self.response_id = chunk.id
+            if hasattr(chunk, "system_fingerprint"):
+                self.system_fingerprint = chunk.system_fingerprint
+            if response_obj["is_finished"]:
+                self.received_finish_reason = response_obj["finish_reason"]
+        else:  # openai / azure chat model
+            if self.custom_llm_provider in [
+                LlmProviders.AZURE.value,
+                LlmProviders.AZURE_AI.value,
+            ]:
+                if isinstance(chunk, BaseModel) and hasattr(chunk, "model"):
+                    # for azure, we need to pass the model from the original chunk
+                    self.model = getattr(chunk, "model", self.model)
+            response_obj = self.handle_openai_chat_completion_chunk(chunk)
+            if response_obj is None:
+                return _ProviderChunkEarlyReturn(None)
+            completion_obj["content"] = response_obj["text"]
+            self.intermittent_finish_reason = response_obj.get("finish_reason", None)
+            if response_obj["is_finished"]:
+                if response_obj["finish_reason"] == "error":
+                    raise Exception(
+                        "{} raised a streaming error - finish_reason: error, no content string given. Received Chunk={}".format(
+                            self.custom_llm_provider, response_obj
+                        )
+                    )
+                self.received_finish_reason = response_obj["finish_reason"]
+            if response_obj.get("original_chunk", None) is not None:
+                if hasattr(response_obj["original_chunk"], "id"):
+                    model_response = self.set_model_id(
+                        response_obj["original_chunk"].id, model_response
+                    )
+                if hasattr(response_obj["original_chunk"], "system_fingerprint"):
+                    model_response.system_fingerprint = response_obj[
+                        "original_chunk"
+                    ].system_fingerprint
+                    self.system_fingerprint = response_obj[
+                        "original_chunk"
+                    ].system_fingerprint
+            if response_obj["logprobs"] is not None:
+                model_response.choices[0].logprobs = response_obj["logprobs"]
+
+            if response_obj["usage"] is not None:
+                if isinstance(response_obj["usage"], dict):
+                    setattr(
+                        model_response,
+                        "usage",
+                        litellm.Usage(
+                            prompt_tokens=response_obj["usage"].get(
+                                "prompt_tokens", None
+                            )
+                            or None,
+                            completion_tokens=response_obj["usage"].get(
+                                "completion_tokens", None
+                            )
+                            or None,
+                            total_tokens=response_obj["usage"].get("total_tokens", None)
+                            or None,
+                        ),
+                    )
+                elif isinstance(response_obj["usage"], Usage):
+                    setattr(
+                        model_response,
+                        "usage",
+                        response_obj["usage"],
+                    )
+                elif isinstance(response_obj["usage"], BaseModel):
+                    setattr(
+                        model_response,
+                        "usage",
+                        litellm.Usage(**response_obj["usage"].model_dump()),
+                    )
+        return _ProviderChunkParsed(response_obj)
+
     def chunk_creator(self, chunk: Any):  # type: ignore
         if hasattr(chunk, "id"):
             self.response_id = chunk.id
@@ -1153,373 +1537,14 @@ class CustomStreamWrapper:
         try:
             # return this for all models
             completion_obj: Dict[str, Any] = {"content": ""}
-            from litellm.types.utils import GenericStreamingChunk as GChunk
-
-            if (
-                isinstance(chunk, ModelResponseStream)
-                and self.custom_llm_provider is not None
-                and self.custom_llm_provider in litellm._custom_providers
-            ):
-                _has_content = bool(
-                    chunk.choices
-                    and chunk.choices[0].delta is not None
-                    and (
-                        chunk.choices[0].delta.content
-                        or chunk.choices[0].delta.tool_calls
-                    )
-                )
-                if self.received_finish_reason is not None:
-                    if not _has_content:
-                        raise StopIteration
-                if chunk.choices and chunk.choices[0].finish_reason:
-                    self.received_finish_reason = chunk.choices[0].finish_reason
-                    if not _has_content:
-                        return None
-                    # Strip finish_reason from the content chunk so it appears
-                    # only on the trailing empty-delta chunk (OpenAI spec).
-                    # finish_reason_handler() will emit the proper terminal chunk.
-                    chunk.choices[0].finish_reason = None  # type: ignore[assignment]
-                return chunk
-
-            if (
-                isinstance(chunk, dict)
-                and generic_chunk_has_all_required_fields(
-                    chunk=chunk
-                )  # check if chunk is a generic streaming chunk
-            ) or (
-                self.custom_llm_provider
-                and self.custom_llm_provider in litellm._custom_providers
-            ):
-                if self.received_finish_reason is not None:
-                    _chunk_has_content = isinstance(chunk, dict) and (
-                        bool(chunk.get("text", ""))
-                        or chunk.get("tool_use") is not None
-                        # Usage-only final chunks are valid and needed to surface
-                        # finish_reason/usage to downstream translators.
-                        or chunk.get("usage") is not None
-                    )
-                    if not _chunk_has_content and (
-                        not isinstance(chunk, dict)
-                        or "provider_specific_fields" not in chunk
-                    ):
-                        raise StopIteration
-                anthropic_response_obj: GChunk = cast(GChunk, chunk)
-                completion_obj["content"] = anthropic_response_obj["text"]
-                if anthropic_response_obj["is_finished"]:
-                    self.received_finish_reason = anthropic_response_obj[
-                        "finish_reason"
-                    ]
-
-                if anthropic_response_obj["finish_reason"]:
-                    self.intermittent_finish_reason = anthropic_response_obj[
-                        "finish_reason"
-                    ]
-
-                if anthropic_response_obj["usage"] is not None:
-                    setattr(
-                        model_response,
-                        "usage",
-                        litellm.Usage(**anthropic_response_obj["usage"]),
-                    )
-
-                if (
-                    "tool_use" in anthropic_response_obj
-                    and anthropic_response_obj["tool_use"] is not None
-                ):
-                    completion_obj["tool_calls"] = [anthropic_response_obj["tool_use"]]
-
-                if (
-                    "provider_specific_fields" in anthropic_response_obj
-                    and anthropic_response_obj["provider_specific_fields"] is not None
-                ):
-                    for key, value in anthropic_response_obj[
-                        "provider_specific_fields"
-                    ].items():
-                        setattr(model_response, key, value)
-
-                response_obj = cast(Dict[str, Any], anthropic_response_obj)
-            elif self.model == "replicate" or self.custom_llm_provider == "replicate":
-                response_obj = self.handle_replicate_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider and self.custom_llm_provider == "predibase":
-                response_obj = self.handle_predibase_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif (
-                self.custom_llm_provider and self.custom_llm_provider == "baseten"
-            ):  # baseten doesn't provide streaming
-                completion_obj["content"] = self.handle_baseten_chunk(chunk)
-            elif (
-                self.custom_llm_provider and self.custom_llm_provider == "ai21"
-            ):  # ai21 doesn't provide streaming
-                response_obj = self.handle_ai21_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider and self.custom_llm_provider == "maritalk":
-                response_obj = self.handle_maritalk_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider and self.custom_llm_provider == "vllm":
-                completion_obj["content"] = chunk[0].outputs[0].text
-            elif (
-                self.custom_llm_provider and self.custom_llm_provider == "aleph_alpha"
-            ):  # aleph alpha doesn't provide streaming
-                response_obj = self.handle_aleph_alpha_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider == "nlp_cloud":
-                try:
-                    response_obj = self.handle_nlp_cloud_chunk(chunk)
-                    completion_obj["content"] = response_obj["text"]
-                    if response_obj["is_finished"]:
-                        self.received_finish_reason = response_obj["finish_reason"]
-                except Exception as e:
-                    if self.received_finish_reason:
-                        raise e
-                    else:
-                        if self.sent_first_chunk is False:
-                            raise Exception("An unknown error occurred with the stream")
-                        self.received_finish_reason = "stop"
-            elif self.custom_llm_provider == "vertex_ai" and not isinstance(
-                chunk, ModelResponseStream
-            ):
-                import proto  # type: ignore
-
-                if hasattr(chunk, "candidates") is True:
-                    try:
-                        try:
-                            completion_obj["content"] = chunk.text  # type: ignore
-                        except Exception as e:
-                            original_exception = e
-                            if "Part has no text." in str(e):
-                                ## check for function calling
-                                function_call = (
-                                    chunk.candidates[0].content.parts[0].function_call  # type: ignore
-                                )
-
-                                args_dict = {}
-
-                                # Check if it's a RepeatedComposite instance
-                                for key, val in function_call.args.items():
-                                    if isinstance(
-                                        val,
-                                        proto.marshal.collections.repeated.RepeatedComposite,  # type: ignore
-                                    ):
-                                        # If so, convert to list
-                                        args_dict[key] = [v for v in val]
-                                    else:
-                                        args_dict[key] = val
-
-                                try:
-                                    args_str = json.dumps(args_dict)
-                                except Exception as e:
-                                    raise e
-                                _delta_obj = litellm.utils.Delta(
-                                    content=None,
-                                    tool_calls=[
-                                        {
-                                            "id": f"call_{str(uuid.uuid4())}",
-                                            "function": {
-                                                "arguments": args_str,
-                                                "name": function_call.name,
-                                            },
-                                            "type": "function",
-                                        }
-                                    ],
-                                )
-                                _streaming_response = StreamingChoices(delta=_delta_obj)
-                                _model_response = ModelResponseStream()
-                                _model_response.choices = [_streaming_response]
-                                response_obj = {"original_chunk": _model_response}
-                            else:
-                                raise original_exception
-                        if (
-                            hasattr(chunk.candidates[0], "finish_reason")  # type: ignore
-                            and chunk.candidates[0].finish_reason.name  # type: ignore
-                            != "FINISH_REASON_UNSPECIFIED"
-                        ):  # every non-final chunk in vertex ai has this
-                            self.received_finish_reason = map_finish_reason(  # type: ignore
-                                chunk.candidates[0].finish_reason.name
-                            )
-                    except Exception:
-                        if chunk.candidates[0].finish_reason.name == "SAFETY":  # type: ignore
-                            raise Exception(
-                                f"The response was blocked by VertexAI. {str(chunk)}"
-                            )
-                else:
-                    completion_obj["content"] = str(chunk)
-            elif self.custom_llm_provider == "petals":
-                if self.completion_stream is None or len(self.completion_stream) == 0:
-                    if self.received_finish_reason is not None:
-                        raise StopIteration
-                    else:
-                        self.received_finish_reason = "stop"
-                chunk_size = 30
-                new_chunk = self.completion_stream[:chunk_size]  # type: ignore[index]
-                completion_obj["content"] = new_chunk
-                self.completion_stream = self.completion_stream[chunk_size:]  # type: ignore[index]
-            elif self.custom_llm_provider == "palm":
-                # fake streaming
-                response_obj = {}
-                if self.completion_stream is None or len(self.completion_stream) == 0:
-                    if self.received_finish_reason is not None:
-                        raise StopIteration
-                    else:
-                        self.received_finish_reason = "stop"
-                chunk_size = 30
-                new_chunk = self.completion_stream[:chunk_size]  # type: ignore[index]
-                completion_obj["content"] = new_chunk
-                self.completion_stream = self.completion_stream[chunk_size:]  # type: ignore[index]
-            elif self.custom_llm_provider == "triton":
-                response_obj = self.handle_triton_stream(chunk)
-                completion_obj["content"] = response_obj["text"]
-                print_verbose(f"completion obj content: {completion_obj['content']}")
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider == "text-completion-openai":
-                response_obj = self.handle_openai_text_completion_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                print_verbose(f"completion obj content: {completion_obj['content']}")
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-                if response_obj["usage"] is not None:
-                    setattr(
-                        model_response,
-                        "usage",
-                        litellm.Usage(
-                            prompt_tokens=response_obj["usage"].prompt_tokens,
-                            completion_tokens=response_obj["usage"].completion_tokens,
-                            total_tokens=response_obj["usage"].total_tokens,
-                        ),
-                    )
-            elif self.custom_llm_provider == "text-completion-codestral":
-                if not isinstance(chunk, str):
-                    raise ValueError(f"chunk is not a string: {chunk}")
-                response_obj = cast(
-                    Dict[str, Any],
-                    litellm.CodestralTextCompletionConfig()._chunk_parser(chunk),
-                )
-                completion_obj["content"] = response_obj["text"]
-                print_verbose(f"completion obj content: {completion_obj['content']}")
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-                if "usage" in response_obj is not None:
-                    setattr(
-                        model_response,
-                        "usage",
-                        litellm.Usage(
-                            prompt_tokens=response_obj["usage"].prompt_tokens,
-                            completion_tokens=response_obj["usage"].completion_tokens,
-                            total_tokens=response_obj["usage"].total_tokens,
-                        ),
-                    )
-            elif self.custom_llm_provider == "azure_text":
-                response_obj = self.handle_azure_text_completion_chunk(chunk)
-                completion_obj["content"] = response_obj["text"]
-                print_verbose(f"completion obj content: {completion_obj['content']}")
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            elif self.custom_llm_provider == "cached_response":
-                chunk = cast(ModelResponseStream, chunk)
-                response_obj = {
-                    "text": chunk.choices[0].delta.content,
-                    "is_finished": True,
-                    "finish_reason": chunk.choices[0].finish_reason,
-                    "original_chunk": chunk,
-                    "tool_calls": (
-                        chunk.choices[0].delta.tool_calls
-                        if hasattr(chunk.choices[0].delta, "tool_calls")
-                        else None
-                    ),
-                }
-
-                completion_obj["content"] = response_obj["text"]
-                if response_obj["tool_calls"] is not None:
-                    completion_obj["tool_calls"] = response_obj["tool_calls"]
-                print_verbose(f"completion obj content: {completion_obj['content']}")
-                if hasattr(chunk, "id"):
-                    model_response.id = chunk.id
-                    self.response_id = chunk.id
-                if hasattr(chunk, "system_fingerprint"):
-                    self.system_fingerprint = chunk.system_fingerprint
-                if response_obj["is_finished"]:
-                    self.received_finish_reason = response_obj["finish_reason"]
-            else:  # openai / azure chat model
-                if self.custom_llm_provider in [
-                    LlmProviders.AZURE.value,
-                    LlmProviders.AZURE_AI.value,
-                ]:
-                    if isinstance(chunk, BaseModel) and hasattr(chunk, "model"):
-                        # for azure, we need to pass the model from the original chunk
-                        self.model = getattr(chunk, "model", self.model)
-                response_obj = self.handle_openai_chat_completion_chunk(chunk)
-                if response_obj is None:
-                    return
-                completion_obj["content"] = response_obj["text"]
-                self.intermittent_finish_reason = response_obj.get(
-                    "finish_reason", None
-                )
-                if response_obj["is_finished"]:
-                    if response_obj["finish_reason"] == "error":
-                        raise Exception(
-                            "{} raised a streaming error - finish_reason: error, no content string given. Received Chunk={}".format(
-                                self.custom_llm_provider, response_obj
-                            )
-                        )
-                    self.received_finish_reason = response_obj["finish_reason"]
-                if response_obj.get("original_chunk", None) is not None:
-                    if hasattr(response_obj["original_chunk"], "id"):
-                        model_response = self.set_model_id(
-                            response_obj["original_chunk"].id, model_response
-                        )
-                    if hasattr(response_obj["original_chunk"], "system_fingerprint"):
-                        model_response.system_fingerprint = response_obj[
-                            "original_chunk"
-                        ].system_fingerprint
-                        self.system_fingerprint = response_obj[
-                            "original_chunk"
-                        ].system_fingerprint
-                if response_obj["logprobs"] is not None:
-                    model_response.choices[0].logprobs = response_obj["logprobs"]
-
-                if response_obj["usage"] is not None:
-                    if isinstance(response_obj["usage"], dict):
-                        setattr(
-                            model_response,
-                            "usage",
-                            litellm.Usage(
-                                prompt_tokens=response_obj["usage"].get(
-                                    "prompt_tokens", None
-                                )
-                                or None,
-                                completion_tokens=response_obj["usage"].get(
-                                    "completion_tokens", None
-                                )
-                                or None,
-                                total_tokens=response_obj["usage"].get(
-                                    "total_tokens", None
-                                )
-                                or None,
-                            ),
-                        )
-                    elif isinstance(response_obj["usage"], Usage):
-                        setattr(
-                            model_response,
-                            "usage",
-                            response_obj["usage"],
-                        )
-                    elif isinstance(response_obj["usage"], BaseModel):
-                        setattr(
-                            model_response,
-                            "usage",
-                            litellm.Usage(**response_obj["usage"].model_dump()),
-                        )
+            dispatch_result = self._dispatch_provider_chunk(
+                chunk=chunk,
+                model_response=model_response,
+                completion_obj=completion_obj,
+            )
+            if isinstance(dispatch_result, _ProviderChunkEarlyReturn):
+                return dispatch_result.value
+            response_obj = dispatch_result.response_obj
 
             model_response.model = self.model
             ## FUNCTION CALL PARSING

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -100,7 +100,7 @@ def print_verbose(print_statement):
 
 @dataclass(frozen=True, slots=True)
 class _ProviderChunkParsed:
-    response_obj: Dict[str, Any]
+    response_obj: dict[str, Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -1163,9 +1163,9 @@ class CustomStreamWrapper:
         self,
         chunk: Any,
         model_response: ModelResponseStream,
-        completion_obj: Dict[str, Any],
+        completion_obj: dict[str, Any],
     ) -> _ProviderChunkResult:
-        response_obj: Dict[str, Any] = {}
+        response_obj: dict[str, Any] = {}
         if (
             isinstance(chunk, ModelResponseStream)
             and self.custom_llm_provider is not None
@@ -1245,7 +1245,7 @@ class CustomStreamWrapper:
                 ].items():
                     setattr(model_response, key, value)
 
-            response_obj = cast(Dict[str, Any], anthropic_response_obj)
+            response_obj = cast(dict[str, Any], anthropic_response_obj)
         elif self.model == "replicate" or self.custom_llm_provider == "replicate":
             response_obj = self.handle_replicate_chunk(chunk)
             completion_obj["content"] = response_obj["text"]
@@ -1413,7 +1413,7 @@ class CustomStreamWrapper:
             if not isinstance(chunk, str):
                 raise ValueError(f"chunk is not a string: {chunk}")
             response_obj = cast(
-                Dict[str, Any],
+                dict[str, Any],
                 litellm.CodestralTextCompletionConfig()._chunk_parser(chunk),
             )
             completion_obj["content"] = response_obj["text"]
@@ -1533,10 +1533,10 @@ class CustomStreamWrapper:
         if hasattr(chunk, "id"):
             self.response_id = chunk.id
         model_response = self.model_response_creator()
-        response_obj: Dict[str, Any] = {}
+        response_obj: dict[str, Any] = {}
         try:
             # return this for all models
-            completion_obj: Dict[str, Any] = {"content": ""}
+            completion_obj: dict[str, Any] = {"content": ""}
             dispatch_result = self._dispatch_provider_chunk(
                 chunk=chunk,
                 model_response=model_response,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -18,6 +18,8 @@ from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.streaming_handler import (
     AUDIO_ATTRIBUTE,
     CustomStreamWrapper,
+    _ProviderChunkEarlyReturn,
+    _ProviderChunkParsed,
 )
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
@@ -1799,6 +1801,344 @@ def test_usage_only_chunk_not_dropped_when_finish_reason_already_set(
     assert result is not None, "usage-only chunk should not be dropped"
     assert result.choices[0].finish_reason == "content_filter"
     assert result.usage is not None
+
+
+def _run_dispatch(wrapper: CustomStreamWrapper, chunk):
+    model_response = wrapper.model_response_creator()
+    completion_obj = {"content": ""}
+    result = wrapper._dispatch_provider_chunk(
+        chunk=chunk,
+        model_response=model_response,
+        completion_obj=completion_obj,
+    )
+    return result, model_response, completion_obj
+
+
+def test_dispatch_vllm_extracts_output_text(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """vllm chunks expose text at chunk[0].outputs[0].text; the dispatch must
+    surface that as the content and report a parsed result."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "vllm"
+
+    class _Output:
+        text = "hello from vllm"
+
+    class _VLLMChunk:
+        outputs = [_Output()]
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, [_VLLMChunk()]
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "hello from vllm"
+
+
+def test_dispatch_petals_slices_completion_stream(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """petals fakes streaming by slicing 30 chars off the buffered completion
+    stream each call, leaving the remainder for the next chunk."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "petals"
+    initialized_custom_stream_wrapper.completion_stream = "A" * 50
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, chunk=None
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "A" * 30
+    assert initialized_custom_stream_wrapper.completion_stream == "A" * 20
+    assert initialized_custom_stream_wrapper.received_finish_reason is None
+
+
+def test_dispatch_petals_empty_stream_sets_stop(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """An exhausted petals stream marks the turn finished with a stop reason."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "petals"
+    initialized_custom_stream_wrapper.completion_stream = ""
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, chunk=None
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == ""
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_petals_empty_stream_after_finish_raises(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """Once petals has already finished, an empty stream signals end-of-iteration."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "petals"
+    initialized_custom_stream_wrapper.completion_stream = ""
+    initialized_custom_stream_wrapper.received_finish_reason = "stop"
+
+    with pytest.raises(StopIteration):
+        _run_dispatch(initialized_custom_stream_wrapper, chunk=None)
+
+
+def test_dispatch_palm_slices_completion_stream(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """palm uses the same fake-streaming slice strategy as petals."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "palm"
+    initialized_custom_stream_wrapper.completion_stream = "B" * 40
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, chunk=None
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "B" * 30
+    assert initialized_custom_stream_wrapper.completion_stream == "B" * 10
+
+
+def test_dispatch_cached_response_extracts_delta(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """cached_response replays a stored ModelResponseStream; the dispatch lifts
+    its delta content, finish_reason and id back onto the live response."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "cached_response"
+    chunk = ModelResponseStream(
+        id="chatcmpl-cache-1",
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(content="cached text"),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+    result, model_response, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, chunk
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "cached text"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+    assert model_response.id == "chatcmpl-cache-1"
+    assert initialized_custom_stream_wrapper.response_id == "chatcmpl-cache-1"
+
+
+def test_dispatch_vertex_ai_legacy_text_and_finish_reason(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """Legacy vertex_ai chunks (non-ModelResponseStream) expose .text and a
+    candidate finish_reason enum that must be normalised to an OpenAI reason."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "vertex_ai"
+
+    class _FinishReason:
+        name = "STOP"
+
+    class _Candidate:
+        finish_reason = _FinishReason()
+
+    class _VertexChunk:
+        candidates = [_Candidate()]
+        text = "vertex content"
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, _VertexChunk()
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "vertex content"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_vertex_ai_legacy_without_candidates_stringifies_chunk(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """A legacy vertex_ai chunk with no candidates falls back to str(chunk)."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "vertex_ai"
+
+    class _RawChunk:
+        def __str__(self) -> str:
+            return "raw vertex blob"
+
+    result, _, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, _RawChunk()
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "raw vertex blob"
+
+
+def test_dispatch_vertex_ai_legacy_function_call(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """A legacy vertex_ai chunk whose part has no text but carries a
+    function_call is converted into an OpenAI tool-call delta."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "vertex_ai"
+
+    class _FunctionCall:
+        name = "get_weather"
+        args = {"location": "SF"}
+
+    class _Part:
+        function_call = _FunctionCall()
+
+    class _Content:
+        parts = [_Part()]
+
+    class _FinishReason:
+        name = "STOP"
+
+    class _Candidate:
+        content = _Content()
+        finish_reason = _FinishReason()
+
+    class _VertexFunctionChunk:
+        candidates = [_Candidate()]
+
+        @property
+        def text(self):
+            raise RuntimeError("Part has no text.")
+
+    result, _, _ = _run_dispatch(
+        initialized_custom_stream_wrapper, _VertexFunctionChunk()
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    tool_calls = result.response_obj["original_chunk"].choices[0].delta.tool_calls
+    assert tool_calls[0].function.name == "get_weather"
+    assert json.loads(tool_calls[0].function.arguments) == {"location": "SF"}
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_custom_provider_returns_chunk_early(
+    monkeypatch: pytest.MonkeyPatch,
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """A registered custom provider passes its already-OpenAI-shaped chunk
+    straight through as an early return rather than re-parsing it."""
+    monkeypatch.setattr(litellm, "_custom_providers", ["my-custom-llm"])
+    initialized_custom_stream_wrapper.custom_llm_provider = "my-custom-llm"
+    chunk = ModelResponseStream(
+        choices=[
+            StreamingChoices(index=0, delta=Delta(content="hi"), finish_reason=None)
+        ]
+    )
+
+    result, _, _ = _run_dispatch(initialized_custom_stream_wrapper, chunk)
+
+    assert isinstance(result, _ProviderChunkEarlyReturn)
+    assert result.value is chunk
+
+
+def test_dispatch_custom_provider_finish_only_returns_none_early(
+    monkeypatch: pytest.MonkeyPatch,
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """A custom-provider chunk that carries only a finish_reason (no content)
+    records the reason and returns None so no empty delta is emitted."""
+    monkeypatch.setattr(litellm, "_custom_providers", ["my-custom-llm"])
+    initialized_custom_stream_wrapper.custom_llm_provider = "my-custom-llm"
+    chunk = ModelResponseStream(
+        choices=[
+            StreamingChoices(index=0, delta=Delta(content=None), finish_reason="stop")
+        ]
+    )
+
+    result, _, _ = _run_dispatch(initialized_custom_stream_wrapper, chunk)
+
+    assert isinstance(result, _ProviderChunkEarlyReturn)
+    assert result.value is None
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_text_completion_codestral_parses_chunk(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """text-completion-codestral streams raw SSE JSON strings that the dispatch
+    routes through CodestralTextCompletionConfig to extract content/finish."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "text-completion-codestral"
+    chunk = json.dumps(
+        {"choices": [{"delta": {"content": "codestral text"}, "finish_reason": "stop"}]}
+    )
+
+    result, _, completion_obj = _run_dispatch(initialized_custom_stream_wrapper, chunk)
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "codestral text"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_text_completion_codestral_requires_string(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """The codestral branch only knows how to parse raw strings; anything else
+    is a programming error and must surface loudly."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "text-completion-codestral"
+
+    with pytest.raises(ValueError):
+        _run_dispatch(initialized_custom_stream_wrapper, {"not": "a string"})
+
+
+def test_dispatch_triton_stream(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """triton stream chunks arrive as dicts keyed by text_output/stop_reason."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "triton"
+    chunk = {"text_output": "triton text", "is_finished": True, "stop_reason": "stop"}
+
+    result, _, completion_obj = _run_dispatch(initialized_custom_stream_wrapper, chunk)
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "triton text"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_ai21_decodes_completion(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """ai21 does fake streaming over a single byte-encoded JSON completion."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "ai21"
+    chunk = json.dumps({"completions": [{"data": {"text": "ai21 text"}}]}).encode(
+        "utf-8"
+    )
+
+    result, _, completion_obj = _run_dispatch(initialized_custom_stream_wrapper, chunk)
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "ai21 text"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+
+
+def test_dispatch_text_completion_openai_with_usage(
+    initialized_custom_stream_wrapper: CustomStreamWrapper,
+):
+    """text-completion-openai chunks expose choices[].text and an optional usage
+    block that the dispatch lifts onto the model response."""
+    initialized_custom_stream_wrapper.custom_llm_provider = "text-completion-openai"
+
+    class _Choice:
+        text = "oai text"
+        finish_reason = "stop"
+
+    class _Usage:
+        prompt_tokens = 5
+        completion_tokens = 3
+        total_tokens = 8
+
+    class _TextChunk:
+        choices = [_Choice()]
+        usage = _Usage()
+
+    result, model_response, completion_obj = _run_dispatch(
+        initialized_custom_stream_wrapper, _TextChunk()
+    )
+
+    assert isinstance(result, _ProviderChunkParsed)
+    assert completion_obj["content"] == "oai text"
+    assert initialized_custom_stream_wrapper.received_finish_reason == "stop"
+    assert model_response.usage.prompt_tokens == 5
+    assert model_response.usage.total_tokens == 8
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Part of an effort to make basedpyright actually analyze the codebase's hottest functions. Across `litellm/`, basedpyright bails out with "Code is too complex to analyze" on exactly three functions, leaving their entire bodies unchecked: `completion` (litellm/main.py, ~3,500 lines), `exception_type` (exception_mapping_utils.py, ~2,275 lines), and `CustomStreamWrapper.chunk_creator` (this PR). This is the first of three, scoped on its own.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests: a new block in `tests/test_litellm/litellm_core_utils/test_streaming_handler.py` drives the extracted `_dispatch_provider_chunk` directly across the legacy provider branches (vllm, petals, palm, cached_response, legacy vertex_ai, registered custom providers and text-completion-codestral) and asserts the tagged-union contract plus the content, finish_reason and fake-stream slicing side effects, on top of the existing mapped suite that already exercises `chunk_creator` across providers
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only touches `chunk_creator` and its new helper in one file
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5 (5/5)

## What and why

`CustomStreamWrapper.chunk_creator` packed a ~20-branch provider `if/elif` dispatch plus heavy post-processing into a single body, which pushed it past basedpyright's code-flow complexity ceiling. basedpyright responded with "Code is too complex to analyze" and skipped the whole function, so every type error in one of the hottest streaming paths was invisible and unguarded.

This extracts the provider dispatch into `_dispatch_provider_chunk`, which returns a tagged union (`_ProviderChunkParsed | _ProviderChunkEarlyReturn`) so the original early-return and `StopIteration` semantics are preserved exactly. `chunk_creator` now sits well under the ceiling and basedpyright type-checks both functions.

Restoring analysis surfaced pre-existing latent type noise in two legacy branches: dynamic `proto` attribute access in the `vertex_ai` path, and `Optional` subscripting of `completion_stream` in the `petals`/`palm` fake-streaming paths. Both are cast to `Any` at the point of dynamic access, matching the intent of the dead `# type: ignore` comments they already carried, so no basedpyright budget ceiling moves and no unrelated drift is absorbed.

## Screenshots / Proof of Fix

Before, on `litellm_internal_staging`, basedpyright refuses to analyze the function:

```
$ uv run basedpyright litellm/litellm_core_utils/streaming_handler.py 2>&1 | grep "too complex"
  litellm/litellm_core_utils/streaming_handler.py:1148:9 - error: Code is too complex to analyze; reduce complexity by refactoring into subroutines or reducing conditional code paths (reportGeneralTypeIssues)
```

After this PR, the bailout is gone and the per-rule budget gate passes on the unchanged budget (no ceilings moved):

```
$ uv run basedpyright litellm/litellm_core_utils/streaming_handler.py 2>&1 | grep -c "too complex"
0

$ make lint-basedpyright
OK: every rule is within its basedpyright ceiling (150422 errors total)

$ git diff --stat basedpyright-code-budget.json
(no changes)
```

Behavioral proof that streaming is unchanged, run against a live proxy hitting real provider APIs and spending real money. The refactored dispatch routes by provider, so this streams through three distinct branches (native Anthropic, Azure AI, OpenAI) and checks each one returns incremental `delta.content`, a terminal `finish_reason`, a usage chunk, then `data: [DONE]`.

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Stream through the native Anthropic branch

```
curl -sN http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"anthropic-haiku-4-5","stream":true,"stream_options":{"include_usage":true},
       "messages":[{"role":"user","content":"Count from 1 to 8, one number per line."}]}'
```

```
data: {"id":"chatcmpl-eddf671e...","object":"chat.completion.chunk","model":"anthropic-haiku-4-5","choices":[{"index":0,"delta":{"role":"assistant","content":"1\n2\n3\n4"}}]}
data: {"id":"chatcmpl-eddf671e...","object":"chat.completion.chunk","model":"anthropic-haiku-4-5","choices":[{"index":0,"delta":{"content":"\n5\n6\n7\n8"}}]}
data: {"id":"chatcmpl-eddf671e...","object":"chat.completion.chunk","model":"anthropic-haiku-4-5","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
data: {"id":"chatcmpl-eddf671e...","object":"chat.completion.chunk","model":"anthropic-haiku-4-5","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":19,"prompt_tokens":21,"total_tokens":40}}
data: [DONE]
```

3. Repeat through the Azure AI and OpenAI branches (same request shape, `model` set to `azure-haiku-4-5` then `gpt-5.5`). Both return the same incremental-delta then `finish_reason` then usage then `[DONE]` structure.

4. The proxy computes a real, non-zero cost for each stream and writes spend to the DB, which is what proves real money was billed (from `litellm.log`):

```
model_group=anthropic-haiku-4-5  provider=anthropic  prompt=21 completion=19  spend=$0.000116
model_group=azure-haiku-4-5      provider=azure_ai   prompt=15 completion=7   spend=$0.00005
model_group=gpt-5.5              provider=openai     prompt=14 completion=18  spend=$0.00061
```

## Type

🧹 Refactoring

## Changes

Extracts the provider dispatch out of `CustomStreamWrapper.chunk_creator` into a new typed helper `_dispatch_provider_chunk` returning a tagged union, restoring basedpyright analysis of both functions, and casts two dynamic legacy branches to `Any` so the newly-visible errors do not move any budget ceiling. No behavior change.

A follow-up commit adds the test coverage described above and switches the seven `Dict[str, Any]` annotations the refactor introduced to the builtin `dict[str, Any]` generics, which keeps the `UP006` strict-rule budget within its ceiling without moving any baseline

Note: two pre-existing tests in the mapped file (`test_gemini_legacy_vertex_stop_finish_reason_normalised`, `test_gemini_legacy_vertex_tool_calls_finish_reason_with_stop_enum`) fail in deterministic order on `litellm_internal_staging` as well; they depend on `proto` being present in `sys.modules` from an earlier test. They are unrelated to this change and left for a separate fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming dispatch for many LLM providers; behavior is intended to be identical but regressions would affect all streamed completions. Risk is mitigated by broad new unit tests and an explicit no-behavior-change refactor.
> 
> **Overview**
> Pulls the large provider-specific `if/elif` chain out of **`CustomStreamWrapper.chunk_creator`** into **`_dispatch_provider_chunk`**, so basedpyright can type-check the hot streaming path instead of bailing with “too complex to analyze.”
> 
> The helper returns a small tagged union (**`_ProviderChunkParsed`** vs **`_ProviderChunkEarlyReturn`**) so existing behaviors stay the same: pass-through chunks for registered custom providers, **`None`** when only a finish reason arrives, and **`StopIteration`** after the stream has finished.
> 
> **`chunk_creator`** now only runs dispatch and keeps the shared post-processing (tool calls, **`return_processed_chunk_logic`**, etc.). **`cast(Any, …)`** on legacy **vertex_ai** and **petals**/**palm** dynamic access addresses type noise the refactor surfaced, without changing runtime logic.
> 
> Tests drive **`_dispatch_provider_chunk`** directly across vllm, fake-stream providers, cached_response, legacy vertex, codestral, triton, ai21, and custom-provider early-return cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6958e1acabb6facf4e65d0a82311d28b9ddf0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->