### PR TITLE
ci(zizmor): gate PRs on medium+ findings and clear existing ones

### DIFF
--- a/.github/workflows/check-ui-api-types.yml
+++ b/.github/workflows/check-ui-api-types.yml
@@ -54,7 +54,7 @@ jobs:
         run: uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Set up Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,14 +43,14 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+        uses: github/codeql-action/init@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+        uses: github/codeql-action/analyze@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           category: "/language:${{ matrix.language }}"
           output: sarif-results
@@ -77,7 +77,7 @@ jobs:
           output: sarif-results/python.sarif
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3
+        uses: github/codeql-action/upload-sarif@ebcb5b36ded6beda4ceefea6a8bc4cc885255bb3 # v3.34.1
         with:
           sarif_file: sarif-results
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/test-litellm-ui-build.yml
+++ b/.github/workflows/test-litellm-ui-build.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: "npm"
@@ -77,7 +77,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changed.outputs.has_files == 'true'
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -11,8 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,6 +18,10 @@ concurrency:
 
 jobs:
   proxy-endpoints:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: ./.github/workflows/_test-unit-base.yml
     with:
       test-path: >-
@@ -52,6 +54,10 @@ jobs:
   # is independent and its coverage artifact is uploaded separately.
   # See: https://www.notion.so/36c43b8acdab81ee845fd5365128a2fc
   proxy-server:
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     uses: ./.github/workflows/_test-unit-base.yml
     with:
       test-path: tests/test_litellm/proxy/proxy_server

--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -32,17 +32,16 @@ jobs:
           df -h /
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build Docker image
-        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 #v6.14
+        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
         with:
           context: .
           file: ./docker/Dockerfile.non_root
           tags: litellm-test:${{ github.sha }}
           load: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          push: false
 
       - name: Start LiteLLM container with SERVER_ROOT_PATH
         run: |

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,9 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      security-events: write
       contents: read
-      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -28,4 +26,9 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: "1.24.1"
+          min-severity: medium
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

This PR changes GitHub Actions workflow configuration only, with no application code, so there are no unit tests to add and `make test-unit` is not the relevant check. Verification is the zizmor run shown below plus the branch CI run

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

The zizmor job today uploads findings to code scanning and always exits green, so it cannot block anything. This makes it gate instead, then clears the findings that were already open so the gate passes. Verified locally with the exact engine the action runs (zizmor 1.24.1, regular persona, medium threshold)

```
$ zizmor --persona regular --min-severity medium .github/workflows
No findings to report. Good job! (138 suppressed)
exit code: 0
```

The gate still blocks a fundamentally insecure trigger, so it keeps real signal:

```
$ zizmor --persona regular --min-severity medium <pull_request_target workflow>
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
4 findings (3 suppressed): 0 informational, 0 low, 0 medium, 1 high
exit code: 14
```

## Type

🚄 Infrastructure

## Changes

The zizmor check runs with `advanced-security: false`, `min-severity: medium` and `annotations: true`, so it fails on any finding at medium or above and surfaces them as inline PR annotations. The `security-events: write` and `actions: read` permissions are dropped since nothing is uploaded anymore, leaving only `contents: read`. Once this lands, the check can be promoted to a required check for merges into `litellm_internal_staging`

The engine is pinned to zizmor 1.24.1 through zizmor-action v0.5.6 (SHA pinned), so runs are deterministic rather than tracking whatever the action's bundled `latest` resolves to. 1.24.1 also scopes the `secrets-outside-env` audit to the auditor persona, so env-mapped secrets in the triage and helper workflows are no longer reported at the regular persona this check uses

To make the gate pass, the previously open findings are cleared. Mismatched action pin version comments are corrected to the exact tag each SHA resolves to (`# v3` to `# v3.34.1` for the CodeQL actions, `# v5.0` to `# v5.0.0` for setup-node, and the buildx and build-push comments in the server-root-path workflow). The proxy endpoints workflow no longer grants `id-token: write` and `pull-requests: write` at the workflow level; those move to the two jobs that actually call the reusable test workflow. The server-root-path docker build is marked `push: false` and no longer reads or writes the shared `type=gha` build cache, which removes the only writer of that cache from an untrusted pull_request context

No application code changes; this is workflow configuration only
