### PR TITLE
fix(proxy): attribute org spend via team when key has no org_id

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -205,7 +205,10 @@ class _ProxyDBLogger(CustomLogger):
             )
             user_id = cast(Optional[str], metadata.get("user_api_key_user_id", None))
             team_id = cast(Optional[str], metadata.get("user_api_key_team_id", None))
-            org_id = cast(Optional[str], metadata.get("user_api_key_org_id", None))
+            org_id = await self._resolve_spend_tracking_org_id(
+                org_id=cast(Optional[str], metadata.get("user_api_key_org_id", None)),
+                team_id=team_id,
+            )
             key_alias = cast(Optional[str], metadata.get("user_api_key_alias", None))
             end_user_max_budget = metadata.get("user_api_end_user_max_budget", None)
             sl_object: Optional[StandardLoggingPayload] = kwargs.get(
@@ -332,6 +335,49 @@ class _ProxyDBLogger(CustomLogger):
             )
 
             spend_log_error("Error in tracking cost callback - %s", str(e), exc=e)
+
+    @staticmethod
+    async def _resolve_spend_tracking_org_id(
+        org_id: Optional[str], team_id: Optional[str]
+    ) -> Optional[str]:
+        """Resolve the organization a request's spend rolls up to.
+
+        A key created under a team that belongs to an organization carries no
+        organization_id of its own, so without this fallback its spend never
+        reaches the org's spend column or daily org aggregate. Org budgets then
+        fail to enforce once the in-memory reservation counter expires or across
+        workers that don't share it, because the persisted floor stays at zero.
+        This mirrors the auth-time fallback in
+        auth_checks._organization_max_budget_check so spend attribution and
+        budget enforcement agree on the same org.
+        """
+        if org_id is not None or team_id is None:
+            return org_id
+
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
+
+        if prisma_client is None:
+            return org_id
+
+        try:
+            team_object = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception:
+            verbose_proxy_logger.debug(
+                "Failed to resolve org_id from team_id=%s for spend tracking",
+                team_id,
+            )
+            return org_id
+
+        return team_object.organization_id
 
     @staticmethod
     async def _enrich_failure_metadata_with_key_info(metadata: dict) -> dict:

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -370,10 +370,12 @@ class _ProxyDBLogger(CustomLogger):
                 user_api_key_cache=user_api_key_cache,
                 proxy_logging_obj=proxy_logging_obj,
             )
-        except Exception:
-            verbose_proxy_logger.debug(
-                "Failed to resolve org_id from team_id=%s for spend tracking",
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                "Failed to resolve org_id from team_id=%s for spend tracking; "
+                "org spend for this request will be unattributed: %s",
                 team_id,
+                e,
             )
             return org_id
 

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1099,6 +1099,47 @@ async def test_resolve_spend_tracking_org_id_no_team_returns_none():
 
 
 @pytest.mark.asyncio
+async def test_resolve_spend_tracking_org_id_skips_lookup_without_db():
+    """With no DB client we cannot resolve the team's org, so return the original
+    org_id without attempting a lookup rather than crashing cost tracking."""
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch(
+            "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+            new_callable=AsyncMock,
+        ) as mock_get_team,
+    ):
+        resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
+            org_id=None, team_id="team-123"
+        )
+
+    assert resolved is None
+    mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_spend_tracking_org_id_swallows_team_lookup_failure():
+    """A failing team lookup must not break cost tracking; fall back to the
+    original org_id instead of letting the exception propagate."""
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+            new_callable=AsyncMock,
+            side_effect=Exception("team not found"),
+        ) as mock_get_team,
+    ):
+        resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
+            org_id=None, team_id="team-123"
+        )
+
+    assert resolved is None
+    mock_get_team.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_track_cost_callback_attributes_org_spend_via_team():
     """End-to-end through the cost callback: a team key with no org_id of its own
     must still record spend against the team's organization. Before the fallback,

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1120,7 +1120,9 @@ async def test_resolve_spend_tracking_org_id_skips_lookup_without_db():
 @pytest.mark.asyncio
 async def test_resolve_spend_tracking_org_id_swallows_team_lookup_failure():
     """A failing team lookup must not break cost tracking; fall back to the
-    original org_id instead of letting the exception propagate."""
+    original org_id instead of letting the exception propagate. The failure is
+    a silent org-attribution gap in production, so it must surface at warning
+    level (not debug) for operators to notice."""
     with (
         patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
         patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
@@ -1130,6 +1132,9 @@ async def test_resolve_spend_tracking_org_id_swallows_team_lookup_failure():
             new_callable=AsyncMock,
             side_effect=Exception("team not found"),
         ) as mock_get_team,
+        patch(
+            "litellm.proxy.hooks.proxy_track_cost_callback.verbose_proxy_logger.warning"
+        ) as mock_warning,
     ):
         resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
             org_id=None, team_id="team-123"
@@ -1137,6 +1142,8 @@ async def test_resolve_spend_tracking_org_id_swallows_team_lookup_failure():
 
     assert resolved is None
     mock_get_team.assert_awaited_once()
+    mock_warning.assert_called_once()
+    assert "team-123" in mock_warning.call_args.args
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -1043,6 +1043,130 @@ async def test_failure_hook_keeps_error_information_traceback_by_default(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_resolve_spend_tracking_org_id_falls_back_to_team_org():
+    """A key with no org_id of its own must attribute spend to its team's org,
+    so org spend/budget tracking sees the usage. Mirrors the auth-time fallback
+    in auth_checks._organization_max_budget_check."""
+    mock_team_obj = MagicMock()
+    mock_team_obj.organization_id = "org-from-team"
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch(
+            "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team_obj,
+        ) as mock_get_team,
+    ):
+        resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
+            org_id=None, team_id="team-123"
+        )
+
+    assert resolved == "org-from-team"
+    mock_get_team.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_spend_tracking_org_id_prefers_explicit_org_id():
+    """When the key already carries an org_id, keep it and skip the team lookup."""
+    with patch(
+        "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+        new_callable=AsyncMock,
+    ) as mock_get_team:
+        resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
+            org_id="explicit-org", team_id="team-123"
+        )
+
+    assert resolved == "explicit-org"
+    mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_resolve_spend_tracking_org_id_no_team_returns_none():
+    """No org_id and no team_id means there is nothing to attribute org spend to."""
+    with patch(
+        "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+        new_callable=AsyncMock,
+    ) as mock_get_team:
+        resolved = await _ProxyDBLogger._resolve_spend_tracking_org_id(
+            org_id=None, team_id=None
+        )
+
+    assert resolved is None
+    mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_track_cost_callback_attributes_org_spend_via_team():
+    """End-to-end through the cost callback: a team key with no org_id of its own
+    must still record spend against the team's organization. Before the fallback,
+    org_id stayed None and org spend/budget were never tracked."""
+    logger = _ProxyDBLogger()
+
+    mock_team_obj = MagicMock()
+    mock_team_obj.organization_id = "org-from-team"
+
+    kwargs = {
+        "model": "gpt-4",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": "hashed_key",
+                "user_api_key_user_id": "user-1",
+                "user_api_key_team_id": "team-123",
+                # no user_api_key_org_id - the key inherits org via its team
+            },
+        },
+        "standard_logging_object": {
+            "response_cost": 0.5,
+            "request_tags": None,
+        },
+        "stream": False,
+    }
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.db_spend_update_writer.update_database = AsyncMock()
+    mock_proxy_logging.slack_alerting_instance.customer_spend_alert = AsyncMock()
+    mock_increment_spend_counters = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging),
+        patch(
+            "litellm.proxy.proxy_server.increment_spend_counters",
+            mock_increment_spend_counters,
+        ),
+        patch(
+            "litellm.proxy.proxy_server.update_cache",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.hooks.proxy_track_cost_callback.get_team_object",
+            new_callable=AsyncMock,
+            return_value=mock_team_obj,
+        ),
+    ):
+        await logger._PROXY_track_cost_callback(
+            kwargs=kwargs,
+            completion_response=None,
+            start_time=datetime.now(),
+            end_time=datetime.now(),
+        )
+
+    mock_proxy_logging.db_spend_update_writer.update_database.assert_awaited_once()
+    assert (
+        mock_proxy_logging.db_spend_update_writer.update_database.call_args.kwargs[
+            "org_id"
+        ]
+        == "org-from-team"
+    )
+    mock_increment_spend_counters.assert_awaited_once()
+    assert mock_increment_spend_counters.call_args.kwargs["org_id"] == "org-from-team"
+
+
+@pytest.mark.asyncio
 async def test_failure_hook_drops_error_information_traceback_when_env_set(
     monkeypatch,
 ):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

Surfaced by the new every-12h e2e suite in #30790 (`tests/e2e_tests/budgets/test_budget_enforcement_e2e.py::test_organization_budget_blocks`), which is the "org level budget gap" flagged in #eng.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review (5/5)

## Changes

Org budget enforcement and org spend tracking disagreed on how they resolve a request's organization. Enforcement (`auth_checks._organization_max_budget_check` and `budget_reservation._get_org_budget_counter`) falls back to the team's `organization_id` when the key itself has no `org_id`, but spend tracking did not: in `proxy_track_cost_callback._PROXY_track_cost_callback` the org came straight from `metadata["user_api_key_org_id"]` (i.e. `valid_token.org_id`), which is null for a key created under a team that belongs to an org. Keys generated with only a `team_id` do not inherit the team's org onto the key row, so that value is null in the common case.

The result is that for a key whose org comes from its team, `_update_org_db`, the daily org transaction, and the unreserved `spend:org:{org_id}` counter were all skipped (org_id None). The org's `LiteLLM_OrganizationTable.spend` column, which is the persisted floor that read-time enforcement reads back through `get_current_spend(..., fallback_spend=org_table.spend)`, therefore stayed at zero. Org budgets then fail to enforce whenever the in-memory reservation counter isn't the source of truth: across workers that don't share it (the e2e proxy runs with `--workers`), after the counter's TTL, or when reservation is disabled / the model is unpriced.

The fix resolves the spend-tracking org the same way enforcement already does: when the request has no `org_id` but does have a `team_id`, look up the (cached) team and use its `organization_id`. This is confined to the spend-tracking path and deliberately does not mutate `valid_token.org_id`, so org-scoped access control (resource ownership, MCP, rate limiting) is untouched.

A team-lookup failure during this resolution is swallowed so cost tracking keeps working, but it now logs at `warning` (not `debug`) with the attribution impact; at debug level that gap would be invisible in production and an unenforced org budget would have no signal to investigate. Follow-up commits also add regression coverage for the no-DB-client and lookup-failure branches so the patch is fully exercised.

## Where the gap is documented

The PR #30790 budget matrices describe the org row as enforcing off real-time reservation counters; they do not call out that the persisted org floor is never written for team-inherited orgs. The closest existing pointer is the unit suite `tests/test_litellm/proxy/auth/test_organization_budget_enforcement.py`, which only passes because it injects org `spend` directly and mocks `get_org_object`, so it never exercises the team->org spend write path that the live e2e test does. There is no public docs page describing this gap; it lives in those test matrices plus the live suite.

## Screenshots / Proof of Fix

Unit + regression (the two new behavioral tests fail before the fix with `org_id == None`, pass after):

```
$ uv run pytest tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py \
                tests/test_litellm/proxy/auth/test_organization_budget_enforcement.py -q
35 passed
```

Mateo: to reproduce the original gap on a live proxy without waiting 12h, run the proxy with `--workers 2` (no shared redis) and the budget suite's org case against a real model; pre-fix the org never blocks because `organization.spend` stays 0, post-fix it blocks once accumulated org spend crosses `max_budget`. I did not run the full live suite here since it needs the multi-worker proxy + real provider keys; happy to attach run logs if you want them before the deploy.

## Type

🐛 Bug Fix

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1781831545149239?thread_ts=1781831545.149239&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-411863cc-03e3-5206-a4ac-403b68e749f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-411863cc-03e3-5206-a4ac-403b68e749f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


