### PR TITLE
fix(proxy): use e.request_data for logging_obj in ModifyResponseException streaming passthrough

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8959,7 +8959,7 @@ async def chat_completion(
                 completion_stream=_iterator,
                 model=e.model,
                 custom_llm_provider="cached_response",
-                logging_obj=data.get("litellm_logging_obj", None),
+                logging_obj=_data.get("litellm_logging_obj", None),
             )
             selected_data_generator = select_data_generator(
                 response=_streaming_response,
@@ -8994,7 +8994,7 @@ async def chat_completion(
                 completion_stream=_iterator,
                 model=data.get("model", ""),
                 custom_llm_provider="cached_response",
-                logging_obj=data.get("litellm_logging_obj", None),
+                logging_obj=_data.get("litellm_logging_obj", None),
             )
             selected_data_generator = select_data_generator(
                 response=_streaming_response,

--- a/tests/test_litellm/proxy/test_modify_response_streaming_passthrough.py
+++ b/tests/test_litellm/proxy/test_modify_response_streaming_passthrough.py
@@ -19,34 +19,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import Request, Response
 
+from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.proxy_server import chat_completion
 
 
-@pytest.mark.asyncio
-async def test_streaming_modify_response_uses_request_data_logging_obj():
+async def _run_streaming_block_and_get_wrapper(exception):
+    """Drive chat_completion's streaming guardrail-passthrough handler for the
+    given pre-call block exception and return the patched CustomStreamWrapper.
+
+    The outer request body (what _read_request_body returns) is a streaming
+    request that does NOT carry litellm_logging_obj -- mirroring production,
+    where the outer body diverges from the processor's data at function_setup.
+    Only the processor copy (exposed as exception.request_data) carries it.
+    """
     request = MagicMock(spec=Request)
     fastapi_response = MagicMock(spec=Response)
     user_api_key_dict = UserAPIKeyAuth()
-
-    # The outer request body (what _read_request_body returns) is a streaming
-    # request that does NOT carry litellm_logging_obj.
     outer_body = {"model": "gpt-4o", "messages": [], "stream": True}
-
-    # The exception carries the processor's data, which DOES carry the logging
-    # object (litellm attaches it after function_setup).
-    sentinel_logging_obj = MagicMock(name="litellm_logging_obj")
-    exception = ModifyResponseException(
-        message="blocked by guardrail",
-        model="gpt-4o",
-        request_data={
-            "model": "gpt-4o",
-            "stream": True,
-            "litellm_logging_obj": sentinel_logging_obj,
-        },
-        guardrail_name="test-guardrail",
-    )
 
     with patch(
         "litellm.proxy.proxy_server._read_request_body",
@@ -72,7 +63,48 @@ async def test_streaming_modify_response_uses_request_data_logging_obj():
             user_api_key_dict=user_api_key_dict,
         )
 
+    return mock_csw
+
+
+@pytest.mark.asyncio
+async def test_streaming_modify_response_uses_request_data_logging_obj():
+    sentinel_logging_obj = MagicMock(name="litellm_logging_obj")
+    exception = ModifyResponseException(
+        message="blocked by guardrail",
+        model="gpt-4o",
+        request_data={
+            "model": "gpt-4o",
+            "stream": True,
+            "litellm_logging_obj": sentinel_logging_obj,
+        },
+        guardrail_name="test-guardrail",
+    )
+
+    mock_csw = await _run_streaming_block_and_get_wrapper(exception)
+
     # The wrapper must be built with the logging object from e.request_data,
     # NOT None (which is what the outer body would have yielded).
+    mock_csw.assert_called_once()
+    assert mock_csw.call_args.kwargs["logging_obj"] is sentinel_logging_obj
+
+
+@pytest.mark.asyncio
+async def test_streaming_rejected_request_uses_request_data_logging_obj():
+    # RejectedRequestError gets the identical fix in its own streaming
+    # passthrough handler, so it needs the same regression guard.
+    sentinel_logging_obj = MagicMock(name="litellm_logging_obj")
+    exception = RejectedRequestError(
+        message="rejected by guardrail",
+        model="gpt-4o",
+        llm_provider="openai",
+        request_data={
+            "model": "gpt-4o",
+            "stream": True,
+            "litellm_logging_obj": sentinel_logging_obj,
+        },
+    )
+
+    mock_csw = await _run_streaming_block_and_get_wrapper(exception)
+
     mock_csw.assert_called_once()
     assert mock_csw.call_args.kwargs["logging_obj"] is sentinel_logging_obj

--- a/tests/test_litellm/proxy/test_modify_response_streaming_passthrough.py
+++ b/tests/test_litellm/proxy/test_modify_response_streaming_passthrough.py
@@ -1,0 +1,78 @@
+"""Regression test for the ModifyResponseException streaming passthrough.
+
+When a guardrail blocks a *streaming* request pre-call by raising
+``ModifyResponseException``, the chat-completion route streams the violation
+message back as a 200 by building a ``CustomStreamWrapper``. The logging object
+must be read from ``e.request_data`` (the processor's data, which carries
+``litellm_logging_obj``) and NOT from the outer request body returned by
+``_read_request_body`` -- the two diverge at ``function_setup`` and only the
+processor copy gets ``litellm_logging_obj`` attached.
+
+Reading it from the outer body passed ``logging_obj=None`` to
+``CustomStreamWrapper.__init__``, which dereferences
+``logging_obj.model_call_details`` and 500s with
+``AttributeError: 'NoneType' object has no attribute 'model_call_details'``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import Request, Response
+
+from litellm.integrations.custom_guardrail import ModifyResponseException
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.proxy_server import chat_completion
+
+
+@pytest.mark.asyncio
+async def test_streaming_modify_response_uses_request_data_logging_obj():
+    request = MagicMock(spec=Request)
+    fastapi_response = MagicMock(spec=Response)
+    user_api_key_dict = UserAPIKeyAuth()
+
+    # The outer request body (what _read_request_body returns) is a streaming
+    # request that does NOT carry litellm_logging_obj.
+    outer_body = {"model": "gpt-4o", "messages": [], "stream": True}
+
+    # The exception carries the processor's data, which DOES carry the logging
+    # object (litellm attaches it after function_setup).
+    sentinel_logging_obj = MagicMock(name="litellm_logging_obj")
+    exception = ModifyResponseException(
+        message="blocked by guardrail",
+        model="gpt-4o",
+        request_data={
+            "model": "gpt-4o",
+            "stream": True,
+            "litellm_logging_obj": sentinel_logging_obj,
+        },
+        guardrail_name="test-guardrail",
+    )
+
+    with patch(
+        "litellm.proxy.proxy_server._read_request_body",
+        new_callable=AsyncMock,
+        return_value=outer_body,
+    ), patch(
+        "litellm.proxy.proxy_server.ProxyBaseLLMRequestProcessing.base_process_llm_request",
+        new_callable=AsyncMock,
+        side_effect=exception,
+    ), patch(
+        "litellm.proxy.proxy_server.proxy_logging_obj"
+    ) as mock_proxy_logging, patch(
+        "litellm.proxy.proxy_server.select_data_generator",
+        return_value=iter([]),
+    ), patch(
+        "litellm.CustomStreamWrapper"
+    ) as mock_csw:
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+
+        await chat_completion(
+            request=request,
+            fastapi_response=fastapi_response,
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    # The wrapper must be built with the logging object from e.request_data,
+    # NOT None (which is what the outer body would have yielded).
+    mock_csw.assert_called_once()
+    assert mock_csw.call_args.kwargs["logging_obj"] is sentinel_logging_obj


### PR DESCRIPTION
## Relevant issues

Internal copy of #30701 by @seph-barker (Joseph Barker) so we can run it through CircleCI. Full credit for the fix and tests goes to the original author; the two commits here are cherry-picked from that PR with authorship preserved.

A guardrail that blocks a **streaming** request pre-call (by raising `ModifyResponseException` or `RejectedRequestError`) 500s the request instead of streaming the violation message back as a 200.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### The bug

When a guardrail blocks a streaming request pre-call, `chat_completion`'s `except ModifyResponseException` / `except RejectedRequestError` handlers stream the violation message back as a 200 by building a `CustomStreamWrapper`:

```python
except ModifyResponseException as e:
    _data = e.request_data
    ...
    _streaming_response = litellm.CustomStreamWrapper(
        completion_stream=_iterator,
        model=e.model,
        custom_llm_provider="cached_response",
        logging_obj=data.get("litellm_logging_obj", None),   # <-- outer body
    )
```

`data` here is the outer request body returned by `_read_request_body`. It never carries `litellm_logging_obj`: the processor's data dict diverges from the outer body at `function_setup` (which returns a fresh kwargs dict), and `litellm_logging_obj` is attached only to that processor copy. So `data.get("litellm_logging_obj")` is `None`, and `CustomStreamWrapper.__init__` immediately dereferences it:

```python
litellm_params: GenericLiteLLMParams = GenericLiteLLMParams(
    **self.logging_obj.model_call_details.get("litellm_params", {})
)
```

```
AttributeError: 'NoneType' object has no attribute 'model_call_details'
```

The non-streaming path is unaffected (it returns a `ModelResponse` directly), and the anthropic / responses-API passthrough paths are unaffected (they stream via a plain SSE generator, not `CustomStreamWrapper`). Only **streaming + pre-call block** hits this.

### The fix

`_data = e.request_data` is already bound two lines above and is the processor's data dict, which **does** carry `litellm_logging_obj`. Read `logging_obj` from `_data` in both streaming passthrough handlers (`ModifyResponseException` and `RejectedRequestError`).

Added a regression test (`tests/test_litellm/proxy/test_modify_response_streaming_passthrough.py`) that drives `chat_completion`'s `ModifyResponseException` streaming branch with an outer body lacking `litellm_logging_obj` and asserts the `CustomStreamWrapper` receives the logging object from `e.request_data` (it would be `None` without the fix).


---
_Generated by [Claude Code](https://claude.ai/code/session_018DV7pvcAYDEVF357aVfsic)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in guardrail streaming error handlers with targeted regression tests; no auth or data-model changes.
> 
> **Overview**
> Fixes **500 errors** when a guardrail blocks a **streaming** chat completion pre-call via `ModifyResponseException` or `RejectedRequestError`, where the intended behavior is to stream the violation as a **200** through `CustomStreamWrapper`.
> 
> In both streaming passthrough branches in `chat_completion`, `logging_obj` is now taken from **`_data` (`e.request_data`)** instead of the outer **`data`** from `_read_request_body`. Only the processor copy carries `litellm_logging_obj`; using the outer body left `logging_obj` as `None` and triggered `AttributeError` inside `CustomStreamWrapper`.
> 
> Adds regression tests that assert `CustomStreamWrapper` receives the logging object from the exception’s `request_data` when the outer body lacks it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7db9a3a8d0e027119105e17f21e38a0047737c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->