### PR TITLE
feat(ui): surface team budget on key overview when key has no own budget

### DIFF
--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -467,10 +467,15 @@ export function VirtualKeysTable({ teams, organizations, onSortChange, currentSo
         enableSorting: true,
         cell: (info) => {
           const maxBudget = info.getValue() as number | null;
-          if (maxBudget === null) {
-            return "Unlimited";
+          if (maxBudget !== null) {
+            return `$${formatNumberWithCommas(maxBudget)}`;
           }
-          return `$${formatNumberWithCommas(maxBudget)}`;
+          const teamId = info.row.original.team_id;
+          const team = teams?.find((t) => t.team_id === teamId);
+          if (team?.max_budget != null) {
+            return `$${formatNumberWithCommas(team.max_budget)} (Team)`;
+          }
+          return "Unlimited";
         },
       },
       {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
@@ -1,7 +1,7 @@
 import { renderWithProviders } from "../../../tests/test-utils";
 import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { KeyResponse } from "../key_team_helpers/key_list";
+import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "./key_info_view";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
@@ -107,6 +107,22 @@ const baseAuthorized = {
   isAuthorized: true,
 };
 
+const makeTeam = (overrides: Partial<Team>): Team => ({
+  team_id: "team-default",
+  team_alias: "Default Team",
+  models: [],
+  max_budget: null,
+  budget_duration: null,
+  tpm_limit: null,
+  rpm_limit: null,
+  organization_id: "",
+  created_at: "2026-01-01T00:00:00Z",
+  keys: [],
+  members_with_roles: [],
+  spend: 0,
+  ...overrides,
+});
+
 describe("KeyInfoView overview budget display (LIT-2845)", () => {
   beforeEach(() => {
     vi.mocked(useTeams).mockReturnValue({ teams: [], setTeams: vi.fn() });
@@ -153,10 +169,10 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
   it("renders 'Unlimited' when max_budget is null", async () => {
     renderWithProviders(
       <KeyInfoView
-        keyData={{ ...MOCK_KEY_DATA, max_budget: null } as any}
-        onClose={() => { }}
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null } as unknown as KeyResponse}
+        onClose={() => {}}
         keyId={"test-key-id"}
-        onKeyDataUpdate={() => { }}
+        onKeyDataUpdate={() => {}}
         teams={[]}
       />,
     );
@@ -167,15 +183,15 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
 
   it("renders team budget with alias and duration when key has no own budget but team has one", async () => {
     vi.mocked(useTeams).mockReturnValue({
-      teams: [{ team_id: "team-123", team_alias: "Test Budget", max_budget: 1200, budget_duration: "30d" }] as any,
+      teams: [makeTeam({ team_id: "team-123", team_alias: "Test Budget", max_budget: 1200, budget_duration: "30d" })],
       setTeams: vi.fn(),
     });
     renderWithProviders(
       <KeyInfoView
-        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-123" } as any}
-        onClose={() => { }}
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-123" } as unknown as KeyResponse}
+        onClose={() => {}}
         keyId={"test-key-id"}
-        onKeyDataUpdate={() => { }}
+        onKeyDataUpdate={() => {}}
         teams={[]}
       />,
     );
@@ -186,15 +202,15 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
 
   it("renders team budget without duration when team has no budget_duration", async () => {
     vi.mocked(useTeams).mockReturnValue({
-      teams: [{ team_id: "team-456", team_alias: "No Duration Team", max_budget: 500, budget_duration: null }] as any,
+      teams: [makeTeam({ team_id: "team-456", team_alias: "No Duration Team", max_budget: 500 })],
       setTeams: vi.fn(),
     });
     renderWithProviders(
       <KeyInfoView
-        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-456" } as any}
-        onClose={() => { }}
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-456" } as unknown as KeyResponse}
+        onClose={() => {}}
         keyId={"test-key-id"}
-        onKeyDataUpdate={() => { }}
+        onKeyDataUpdate={() => {}}
         teams={[]}
       />,
     );
@@ -205,15 +221,15 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
 
   it("renders 'Unlimited' when key has no budget and team also has no budget", async () => {
     vi.mocked(useTeams).mockReturnValue({
-      teams: [{ team_id: "team-789", team_alias: "Free Team", max_budget: null, budget_duration: null }] as any,
+      teams: [makeTeam({ team_id: "team-789", team_alias: "Free Team" })],
       setTeams: vi.fn(),
     });
     renderWithProviders(
       <KeyInfoView
-        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-789" } as any}
-        onClose={() => { }}
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-789" } as unknown as KeyResponse}
+        onClose={() => {}}
         keyId={"test-key-id"}
-        onKeyDataUpdate={() => { }}
+        onKeyDataUpdate={() => {}}
         teams={[]}
       />,
     );
@@ -222,4 +238,3 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
     });
   });
 });
-

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.budget_display.test.tsx
@@ -103,6 +103,8 @@ const baseAuthorized = {
   userEmail: null,
   disabledPersonalKeyCreation: null,
   showSSOBanner: false,
+  isLoading: false,
+  isAuthorized: true,
 };
 
 describe("KeyInfoView overview budget display (LIT-2845)", () => {
@@ -151,10 +153,67 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
   it("renders 'Unlimited' when max_budget is null", async () => {
     renderWithProviders(
       <KeyInfoView
-        keyData={{ ...MOCK_KEY_DATA, max_budget: null }}
-        onClose={() => {}}
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null } as any}
+        onClose={() => { }}
         keyId={"test-key-id"}
-        onKeyDataUpdate={() => {}}
+        onKeyDataUpdate={() => { }}
+        teams={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/of Unlimited/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders team budget with alias and duration when key has no own budget but team has one", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [{ team_id: "team-123", team_alias: "Test Budget", max_budget: 1200, budget_duration: "30d" }] as any,
+      setTeams: vi.fn(),
+    });
+    renderWithProviders(
+      <KeyInfoView
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-123" } as any}
+        onClose={() => { }}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => { }}
+        teams={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/of \$1,200\.00 \(Team: Test Budget \/ 30d\)/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders team budget without duration when team has no budget_duration", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [{ team_id: "team-456", team_alias: "No Duration Team", max_budget: 500, budget_duration: null }] as any,
+      setTeams: vi.fn(),
+    });
+    renderWithProviders(
+      <KeyInfoView
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-456" } as any}
+        onClose={() => { }}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => { }}
+        teams={[]}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/of \$500\.00 \(Team: No Duration Team\)/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders 'Unlimited' when key has no budget and team also has no budget", async () => {
+    vi.mocked(useTeams).mockReturnValue({
+      teams: [{ team_id: "team-789", team_alias: "Free Team", max_budget: null, budget_duration: null }] as any,
+      setTeams: vi.fn(),
+    });
+    renderWithProviders(
+      <KeyInfoView
+        keyData={{ ...MOCK_KEY_DATA, max_budget: null, team_id: "team-789" } as any}
+        onClose={() => { }}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => { }}
         teams={[]}
       />,
     );
@@ -163,3 +222,4 @@ describe("KeyInfoView overview budget display (LIT-2845)", () => {
     });
   });
 });
+

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -411,6 +411,15 @@ export default function KeyInfoView({
     });
   };
 
+  const parentTeam = currentKeyData.team_id ? teamsData?.find((team) => team.team_id === currentKeyData.team_id) : null;
+
+  const budgetDisplay =
+    currentKeyData.max_budget !== null
+      ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}`
+      : parentTeam?.max_budget != null
+        ? `$${formatNumberWithCommas(parentTeam.max_budget, 2)} (Team: ${parentTeam.team_alias || parentTeam.team_id}${parentTeam.budget_duration ? ` / ${parentTeam.budget_duration}` : ""})`
+        : "Unlimited";
+
   return (
     <div className="w-full h-full overflow-y-auto p-4">
       <KeyInfoHeader
@@ -520,19 +529,7 @@ export default function KeyInfoView({
                 <Text>Spend</Text>
                 <div className="mt-2">
                   <Title>${formatNumberWithCommas(currentKeyData.spend, 4)}</Title>
-                  <Text>
-                    of{" "}
-                    {currentKeyData.max_budget !== null
-                      ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}`
-                      : (() => {
-                        const keyTeam = currentKeyData.team_id
-                          ? teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0]
-                          : null;
-                        return keyTeam?.max_budget != null
-                          ? `$${formatNumberWithCommas(keyTeam.max_budget, 2)} (Team: ${keyTeam.team_alias || keyTeam.team_id}${keyTeam.budget_duration ? ` / ${keyTeam.budget_duration}` : ""})`
-                          : "Unlimited";
-                      })()}
-                  </Text>
+                  <Text>of {budgetDisplay}</Text>
                 </div>
               </Card>
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -524,7 +524,14 @@ export default function KeyInfoView({
                     of{" "}
                     {currentKeyData.max_budget !== null
                       ? `$${formatNumberWithCommas(currentKeyData.max_budget, 2)}`
-                      : "Unlimited"}
+                      : (() => {
+                        const keyTeam = currentKeyData.team_id
+                          ? teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0]
+                          : null;
+                        return keyTeam?.max_budget != null
+                          ? `$${formatNumberWithCommas(keyTeam.max_budget, 2)} (Team: ${keyTeam.team_alias || keyTeam.team_id}${keyTeam.budget_duration ? ` / ${keyTeam.budget_duration}` : ""})`
+                          : "Unlimited";
+                      })()}
                   </Text>
                 </div>
               </Card>


### PR DESCRIPTION
## Relevant issues

 None | proactive UX improvement 

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

**Before:** A virtual key belonging to a team with a configured budget displayed "Unlimited" in both the key Overview tab and the Virtual Keys table, even though the key was budget-constrained at the team level.
<img width="1876" height="882" alt="Screenshot 2026-06-18 204625" src="https://github.com/user-attachments/assets/b1a15a5d-045b-4a17-854f-e13599561308" />

<img width="1868" height="875" alt="Screenshot 2026-06-18 205113" src="https://github.com/user-attachments/assets/ee1510ab-16c5-4958-8533-76b246d831a5" />

**After:**
- Key Overview tab now shows: `$0.0000 of $x amount (Team: {team name} / x days)`
- Virtual Keys table Budget (USD) column now shows: `$x amount (Team)`
- Keys without a team were untouched

<img width="1632" height="560" alt="Screenshot 2026-06-18 220616" src="https://github.com/user-attachments/assets/23ec9b6a-753e-41b4-ac0d-cabd305f7357" />


<img width="1618" height="597" alt="Screenshot 2026-06-18 210320" src="https://github.com/user-attachments/assets/a4447b12-cd74-4c00-acfd-044afd1f827e" />


## Type

🐛 Bug Fix


## Changes

- `key_info_view.tsx`: Spend card falls back to team budget (with team alias and duration) when key has no own `max_budget`
- `VirtualKeysTable.tsx`: Budget (USD) column falls back to team budget when key has no own `max_budget`
- `key_info_view.budget_display.test.tsx`: Added 3 test cases covering team budget fallback scenarios
- Also fixed a pre-existing type error in `baseAuthorized` mock. `isLoading` and `isAuthorized` fields were missing after the `useAuthorized` hook signature was updated.
