### PR TITLE
feat(mcp/v2): egress transport chokepoint (v2-owned connection) [WIP]

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/exceptions.py
+++ b/litellm/proxy/_experimental/mcp_server/exceptions.py
@@ -79,3 +79,25 @@ class MCPUpstreamAuthError(Exception):
             detail=detail,
             headers={"www-authenticate": challenge} if challenge else None,
         )
+
+
+class MCPUpstreamError(Exception):
+    """Raised when an egress call to an upstream MCP server fails for a non-auth reason: the upstream
+    is unreachable, or the server's credential config is invalid/unsupported.
+
+    Single-result routes (``call_tool``, ``read_resource``, ``get_prompt``) raise this since there is
+    no list to degrade to; auth failures use :class:`MCPUpstreamAuthError` instead so clients can
+    trigger re-auth. Carries a ``status_code`` so the gateway returns a semantically correct response
+    (e.g. 502 unreachable, 428 precondition, 500 misconfigured) rather than a blanket 500. Unlike the
+    auth error there is no ``WWW-Authenticate`` challenge to fabricate, so it converts to an
+    ``HTTPException`` with no request context.
+    """
+
+    def __init__(self, status_code: int, server_name: str, detail: str) -> None:
+        self.status_code = status_code
+        self.server_name = server_name
+        self.detail = detail
+        super().__init__(f"Upstream MCP server {server_name!r}: {detail}")
+
+    def to_http_exception(self) -> HTTPException:
+        return HTTPException(status_code=self.status_code, detail=self.detail)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4513,4 +4513,19 @@ class MCPServerManager:
         return [server for server in results if server is not None]
 
 
-global_mcp_server_manager: MCPServerManager = MCPServerManager()
+def _make_global_mcp_server_manager() -> MCPServerManager:
+    """Pick the egress manager: v2 (UpstreamConnection-backed) when LITELLM_USE_V2_MCP_EGRESS is
+    set, else v1. The v2 import is lazy so it can subclass MCPServerManager without an import
+    cycle, and flag-off never touches the v2 module."""
+    from litellm.proxy._experimental.mcp_server.v2_egress import v2_egress_enabled
+
+    if v2_egress_enabled():
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
+            MCPServerManagerV2,
+        )
+
+        return MCPServerManagerV2()
+    return MCPServerManager()
+
+
+global_mcp_server_manager: MCPServerManager = _make_global_mcp_server_manager()

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4514,18 +4514,13 @@ class MCPServerManager:
 
 
 def _make_global_mcp_server_manager() -> MCPServerManager:
-    """Pick the egress manager: v2 (UpstreamConnection-backed) when LITELLM_USE_V2_MCP_EGRESS is
-    set, else v1. The v2 import is lazy so it can subclass MCPServerManager without an import
-    cycle, and flag-off never touches the v2 module."""
-    from litellm.proxy._experimental.mcp_server.v2_egress import v2_egress_enabled
+    """Construct the v2 egress manager (UpstreamConnection-backed). The import is lazy so the v2
+    manager can subclass MCPServerManager without an import cycle."""
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
+        MCPServerManagerV2,
+    )
 
-    if v2_egress_enabled():
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
-            MCPServerManagerV2,
-        )
-
-        return MCPServerManagerV2()
-    return MCPServerManager()
+    return MCPServerManagerV2()
 
 
 global_mcp_server_manager: MCPServerManager = _make_global_mcp_server_manager()

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -13,7 +13,19 @@ import json
 import os
 import re
 import time
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 import anyio
@@ -4523,4 +4535,20 @@ def _make_global_mcp_server_manager() -> MCPServerManager:
     return MCPServerManagerV2()
 
 
-global_mcp_server_manager: MCPServerManager = _make_global_mcp_server_manager()
+_global_mcp_server_manager: Optional[MCPServerManager] = None
+
+if TYPE_CHECKING:
+    global_mcp_server_manager: MCPServerManager
+
+
+def __getattr__(name: str) -> MCPServerManager:
+    # PEP 562 lazy singleton: instantiating at import time would import the v2 subclass while this
+    # module is still loading (a v1<->v2 cycle, import-order dependent), so the manager is built on
+    # first access instead. Tests that reassign global_mcp_server_manager set a real attribute that
+    # shadows this.
+    if name == "global_mcp_server_manager":
+        global _global_mcp_server_manager
+        if _global_mcp_server_manager is None:
+            _global_mcp_server_manager = _make_global_mcp_server_manager()
+        return _global_mcp_server_manager
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -214,7 +214,7 @@ def _should_strip_caller_authorization(
     )
 
 
-def _extract_upstream_auth_failure(
+def extract_upstream_auth_failure(
     exc: BaseException,
 ) -> Optional[Tuple[int, Optional[str]]]:
     """Walk the exception tree looking for an HTTP 401/403 response from the
@@ -2847,7 +2847,7 @@ class MCPServerManager:
             return []
         except Exception as e:
             if should_surface_upstream_auth:
-                auth_info = _extract_upstream_auth_failure(e)
+                auth_info = extract_upstream_auth_failure(e)
                 if auth_info is not None:
                     status_code, www_authenticate = auth_info
                     verbose_logger.info(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3426,6 +3426,77 @@ class MCPServerManager:
             GuardrailRaisedException: If guardrails block the call
             HTTPException: If an HTTP error occurs
         """
+        tasks.append(
+            asyncio.create_task(
+                self._open_and_call_tool(
+                    mcp_server,
+                    original_tool_name,
+                    arguments,
+                    mcp_auth_header=mcp_auth_header,
+                    mcp_server_auth_headers=mcp_server_auth_headers,
+                    oauth2_headers=oauth2_headers,
+                    raw_headers=raw_headers,
+                    hook_extra_headers=hook_extra_headers,
+                    host_progress_callback=host_progress_callback,
+                    user_api_key_auth=user_api_key_auth,
+                )
+            )
+        )
+
+        _timeout = (
+            mcp_server.timeout if mcp_server.timeout is not None else MCP_CLIENT_TIMEOUT
+        )
+        try:
+            mcp_responses = await asyncio.wait_for(
+                asyncio.gather(*tasks), timeout=_timeout
+            )
+        except asyncio.TimeoutError:
+            raise HTTPException(
+                status_code=504,
+                detail={
+                    "error": "timeout",
+                    "message": f"MCP tool call timed out after {_timeout}s",
+                },
+            )
+        except (
+            BlockedPiiEntityError,
+            GuardrailRaisedException,
+            HTTPException,
+        ) as e:
+            verbose_logger.error(
+                f"Guardrail blocked MCP tool call during result check: {str(e)}"
+            )
+            raise e
+
+        # If proxy_logging_obj is None, the tool call result is at index 0
+        # If proxy_logging_obj is not None, the tool call result is at index 1 (after the during hook task)
+        result_index = 1 if proxy_logging_obj else 0
+        result = mcp_responses[result_index]
+
+        return cast(CallToolResult, result)
+
+    async def _open_and_call_tool(
+        self,
+        mcp_server: MCPServer,
+        original_tool_name: str,
+        arguments: Dict[str, Any],
+        *,
+        mcp_auth_header: Optional[str],
+        mcp_server_auth_headers: Optional[Dict[str, Dict[str, str]]],
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+        hook_extra_headers: Optional[Dict[str, str]],
+        host_progress_callback: Optional["ProgressFnT"],
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+    ) -> CallToolResult:
+        """Open the upstream connection and invoke one tool, returning its result.
+
+        The transport seam factored out of _call_regular_mcp_tool so v2 can override only the
+        connect-and-call step (resolve() + UpstreamConnection) while inheriting the
+        guardrail/hook, gather, timeout, and result-extraction tail. This v1 implementation
+        builds the outbound headers, creates the MCPClient, calls the tool, and caches the
+        upstream's initialize instructions.
+        """
         # Get server-specific auth header if available (case-insensitive)
         # FIX: Added case-insensitive matching to handle auth header keys that may not match
         # the exact case of server alias/name (e.g., '1litellmagcgateway' vs '1LiteLLMAGCGateway')
@@ -3538,44 +3609,9 @@ class MCPServerManager:
             arguments=arguments,
         )
 
-        async def _call_tool_via_client(client, params):
-            return await client.call_tool(
-                params, host_progress_callback=host_progress_callback
-            )
-
-        tasks.append(
-            asyncio.create_task(_call_tool_via_client(client, call_tool_params))
+        result = await client.call_tool(
+            call_tool_params, host_progress_callback=host_progress_callback
         )
-
-        _timeout = (
-            mcp_server.timeout if mcp_server.timeout is not None else MCP_CLIENT_TIMEOUT
-        )
-        try:
-            mcp_responses = await asyncio.wait_for(
-                asyncio.gather(*tasks), timeout=_timeout
-            )
-        except asyncio.TimeoutError:
-            raise HTTPException(
-                status_code=504,
-                detail={
-                    "error": "timeout",
-                    "message": f"MCP tool call timed out after {_timeout}s",
-                },
-            )
-        except (
-            BlockedPiiEntityError,
-            GuardrailRaisedException,
-            HTTPException,
-        ) as e:
-            verbose_logger.error(
-                f"Guardrail blocked MCP tool call during result check: {str(e)}"
-            )
-            raise e
-
-        # If proxy_logging_obj is None, the tool call result is at index 0
-        # If proxy_logging_obj is not None, the tool call result is at index 1 (after the during hook task)
-        result_index = 1 if proxy_logging_obj else 0
-        result = mcp_responses[result_index]
         self._remember_upstream_initialize_instructions(mcp_server, client)
 
         return cast(CallToolResult, result)
@@ -4538,6 +4574,8 @@ def _make_global_mcp_server_manager() -> MCPServerManager:
 _global_mcp_server_manager: Optional[MCPServerManager] = None
 
 if TYPE_CHECKING:
+    from mcp.shared.session import ProgressFnT
+
     global_mcp_server_manager: MCPServerManager
 
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -1,22 +1,130 @@
 """v2-owned MCP egress manager (the cutover seam).
 
-``MCPServerManagerV2`` subclasses v1's ``MCPServerManager`` and, in later steps, overrides the
-per-server egress methods (``_get_tools_from_server``, ``call_tool``, the prompt/resource ops) to
-route through the v2 ``UpstreamConnection`` + ``resolve()`` instead of ``_create_mcp_client``.
-Registry, RBAC, cross-server aggregation, namespacing, and static-header resolution are inherited
-from v1 unchanged. It is the egress manager, constructed at the composition root (see
+``MCPServerManagerV2`` subclasses v1's ``MCPServerManager`` and overrides the per-server egress
+methods to route through the v2 ``UpstreamConnection`` + ``resolve()`` instead of
+``_create_mcp_client``. Registry, RBAC, cross-server aggregation, namespacing
+(``_create_prefixed_tools``), and static-header resolution are inherited from v1 unchanged. It is
+the egress manager, constructed at the composition root (see
 ``mcp_server_manager._make_global_mcp_server_manager``); there is no opt-in flag (v2 is the egress
-implementation). v1's per-server methods remain reachable via ``super()`` for modes not yet
-overridden, so the migration is the override progression, not a runtime toggle.
+implementation).
 
-Step 6a lands the skeleton only: no overrides, so behavior is identical to v1. The egress overrides
-land in 6b/6c.
+Migration is the override progression: each egress mode is wired through ``resolve()`` +
+``UpstreamConnection``, live-validated, and committed one at a time. Modes that are not yet wired
+(passthrough / token_exchange, which need the caller's inbound token) simply fail closed until their
+commit. ``super()`` is reserved for non-egress concerns that migrate as their own subsystems:
+OpenAPI tools (registry, S1.8), the per-request ``mcp_auth_header`` override/inbound-token path, and
+the JWT-signer guardrail.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+from litellm.proxy._types import MCPTransport
+
+if TYPE_CHECKING:
+    from mcp.types import Tool as MCPTool
+
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import CredError
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    from .v2_egress import ConnError
 
 
 class MCPServerManagerV2(MCPServerManager):
-    """v2 egress manager; see the module docstring. No overrides yet (step 6a)."""
+    """v2 egress manager; see the module docstring."""
+
+    @staticmethod
+    def _jwt_signer_configured() -> bool:
+        from litellm.proxy.guardrails.guardrail_hooks.mcp_jwt_signer.mcp_jwt_signer import (
+            get_mcp_jwt_signer,
+        )
+
+        return get_mcp_jwt_signer() is not None
+
+    async def _get_tools_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[MCPTool]:
+        from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+        from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+            provider,
+            to_server_spec,
+            to_subject,
+        )
+        from litellm.proxy.gateway.mcp.result import Error
+
+        spec = to_server_spec(server)
+        # Stay on v1 for what hasn't migrated to the egress transport: unmapped/not-yet-wired modes
+        # (spec is None, e.g. aws_sigv4), OpenAPI tools (registry, S1.8), the per-request
+        # mcp_auth_header override/inbound-token path (migrated with passthrough/token_exchange), and
+        # the JWT-signer guardrail.
+        if (
+            spec is None
+            or server.spec_path
+            or mcp_auth_header
+            or self._jwt_signer_configured()
+        ):
+            return await super()._get_tools_from_server(
+                server,
+                mcp_auth_header,
+                extra_headers,
+                add_prefix,
+                raw_headers,
+                user_api_key_auth,
+            )
+
+        auth = await provider().resolve(to_subject(user_api_key_auth, None), spec)
+        if isinstance(auth, Error):
+            return self._egress_list_failure(server, auth.error)
+
+        resolved_static = await self._resolve_static_headers_with_env_vars(
+            server, user_api_key_auth, raise_on_missing=False
+        )
+        headers = {**(extra_headers or {}), **(resolved_static or {})} or None
+        is_stdio = server.transport == MCPTransport.stdio
+
+        result = await UpstreamConnection(
+            server.url,
+            transport=server.transport,
+            auth=auth.ok,
+            extra_headers=headers,
+            command=server.command,
+            args=server.args,
+            env=self._build_stdio_env(server, raw_headers) if is_stdio else None,
+        ).list_tools()
+        if isinstance(result, Error):
+            return self._egress_list_failure(server, result.error)
+        return self._create_prefixed_tools(result.ok, server, add_prefix=add_prefix)
+
+    def _egress_list_failure(
+        self, server: MCPServer, error: "CredError | ConnError"
+    ) -> List[MCPTool]:
+        # List path: an upstream 401/403 (or a per-user mode with no usable credential) surfaces as
+        # MCPUpstreamAuthError so the client gets a 401 + WWW-Authenticate and starts the OAuth flow
+        # (this is the LIT-3795 behavior for non-delegated interactive oauth2). Any other failure
+        # degrades to an empty tool list (logged), so one bad server never collapses the federated
+        # catalog. The typed partial-failure marker is a later, separate surface.
+        if error.tag == "unauthorized":
+            from litellm.proxy._experimental.mcp_server.exceptions import (
+                MCPUpstreamAuthError,
+            )
+
+            raise MCPUpstreamAuthError(
+                status_code=401, www_authenticate=None, server_name=server.name
+            )
+        verbose_logger.warning(
+            "v2 egress: tools unavailable for %s (%s): %s",
+            server.name,
+            server.server_id,
+            error.summary,
+        )
+        return []

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -8,12 +8,12 @@ the egress manager, constructed at the composition root (see
 ``mcp_server_manager._make_global_mcp_server_manager``); there is no opt-in flag (v2 is the egress
 implementation).
 
-Migration is the override progression: each egress mode is wired through ``resolve()`` +
-``UpstreamConnection``, live-validated, and committed one at a time. Modes that are not yet wired
-(passthrough / token_exchange, which need the caller's inbound token) simply fail closed until their
-commit. ``super()`` is reserved for non-egress concerns that migrate as their own subsystems:
-OpenAPI tools (registry, S1.8), the per-request ``mcp_auth_header`` override/inbound-token path, and
-the JWT-signer guardrail.
+Every per-server op method shares two seams: ``_should_defer`` (the v1-vs-v2 gate, temporary
+strangler scaffolding that shrinks to zero as modes migrate, then is deleted with
+``_create_mcp_client``) and ``_v2_connection`` (the permanent resolve()+build seam that returns a
+configured ``UpstreamConnection``). ``super()`` is reserved for what v2 does not own yet:
+unmapped/misconfigured modes, OpenAPI tools (registry, S1.8), the per-request ``mcp_auth_header``
+override/inbound-token path, and the JWT-signer guardrail.
 """
 
 from __future__ import annotations
@@ -29,9 +29,10 @@ if TYPE_CHECKING:
 
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.gateway.mcp.outbound_credentials.types import CredError
+    from litellm.proxy.gateway.mcp.result import Result
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
-    from .v2_egress import ConnError
+    from .v2_egress import ConnError, UpstreamConnection
 
 
 class MCPServerManagerV2(MCPServerManager):
@@ -45,6 +46,79 @@ class MCPServerManagerV2(MCPServerManager):
 
         return get_mcp_jwt_signer() is not None
 
+    def _should_defer(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]],
+    ) -> bool:
+        """Whether this request falls back to v1 (super()) instead of the v2 egress path.
+
+        True for what v2 does not own yet: unmapped/misconfigured modes (to_server_spec is None,
+        e.g. bearer_token), OpenAPI servers (registry, not a connection), the per-request
+        mcp_auth_header override/inbound-token path, and the JWT-signer guardrail. Temporary
+        strangler scaffolding: returns True for fewer cases as modes migrate, then is deleted
+        (with _create_mcp_client) once nothing is left on v1.
+        """
+        from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+            to_server_spec,
+        )
+
+        return (
+            to_server_spec(server) is None
+            or bool(server.spec_path)
+            or bool(mcp_auth_header)
+            or self._jwt_signer_configured()
+        )
+
+    async def _v2_connection(
+        self,
+        server: MCPServer,
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+        *,
+        raw_headers: Optional[Dict[str, str]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        subject_token: Optional[str] = None,
+    ) -> Result[UpstreamConnection, CredError]:
+        """The shared egress seam: resolve auth via resolve() and build the UpstreamConnection.
+
+        Maps the v1 MCPServer to a v2 ServerSpec, resolves the credential for the Subject, merges
+        static/env-var headers, and constructs the (not-yet-opened) connection. Returns the
+        connection or the CredError from resolve(). Every per-server op method goes through here, so
+        a mode migration or header change is a one-place change that lights up all ops. Callers must
+        gate with _should_defer first (so to_server_spec is not None here).
+        """
+        from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+        from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+            provider,
+            to_server_spec,
+            to_subject,
+        )
+        from litellm.proxy.gateway.mcp.result import Error, Ok
+
+        spec = to_server_spec(server)
+        assert spec is not None  # guaranteed by _should_defer (spec is None -> v1)
+        auth = await provider().resolve(
+            to_subject(user_api_key_auth, subject_token), spec
+        )
+        if isinstance(auth, Error):
+            return Error(auth.error)
+        resolved_static = await self._resolve_static_headers_with_env_vars(
+            server, user_api_key_auth, raise_on_missing=False
+        )
+        headers = {**(extra_headers or {}), **(resolved_static or {})} or None
+        is_stdio = server.transport == MCPTransport.stdio
+        return Ok(
+            UpstreamConnection(
+                server.url,
+                transport=server.transport,
+                auth=auth.ok,
+                extra_headers=headers,
+                command=server.command,
+                args=server.args,
+                env=self._build_stdio_env(server, raw_headers) if is_stdio else None,
+            )
+        )
+
     async def _get_tools_from_server(
         self,
         server: MCPServer,
@@ -54,25 +128,9 @@ class MCPServerManagerV2(MCPServerManager):
         raw_headers: Optional[Dict[str, str]] = None,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
     ) -> List[MCPTool]:
-        from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
-        from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-            provider,
-            to_server_spec,
-            to_subject,
-        )
         from litellm.proxy.gateway.mcp.result import Error
 
-        spec = to_server_spec(server)
-        # Stay on v1 for what hasn't migrated to the egress transport: unmapped/not-yet-wired modes
-        # (spec is None, e.g. aws_sigv4), OpenAPI tools (registry, S1.8), the per-request
-        # mcp_auth_header override/inbound-token path (migrated with passthrough/token_exchange), and
-        # the JWT-signer guardrail.
-        if (
-            spec is None
-            or server.spec_path
-            or mcp_auth_header
-            or self._jwt_signer_configured()
-        ):
+        if self._should_defer(server, mcp_auth_header):
             return await super()._get_tools_from_server(
                 server,
                 mcp_auth_header,
@@ -81,26 +139,15 @@ class MCPServerManagerV2(MCPServerManager):
                 raw_headers,
                 user_api_key_auth,
             )
-
-        auth = await provider().resolve(to_subject(user_api_key_auth, None), spec)
-        if isinstance(auth, Error):
-            return self._egress_list_failure(server, auth.error)
-
-        resolved_static = await self._resolve_static_headers_with_env_vars(
-            server, user_api_key_auth, raise_on_missing=False
+        conn = await self._v2_connection(
+            server,
+            user_api_key_auth,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
         )
-        headers = {**(extra_headers or {}), **(resolved_static or {})} or None
-        is_stdio = server.transport == MCPTransport.stdio
-
-        result = await UpstreamConnection(
-            server.url,
-            transport=server.transport,
-            auth=auth.ok,
-            extra_headers=headers,
-            command=server.command,
-            args=server.args,
-            env=self._build_stdio_env(server, raw_headers) if is_stdio else None,
-        ).list_tools()
+        if isinstance(conn, Error):
+            return self._egress_list_failure(server, conn.error)
+        result = await conn.ok.list_tools()
         if isinstance(result, Error):
             return self._egress_list_failure(server, result.error)
         return self._create_prefixed_tools(result.ok, server, add_prefix=add_prefix)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -1,0 +1,20 @@
+"""v2-owned MCP egress manager (the cutover seam).
+
+``MCPServerManagerV2`` subclasses v1's ``MCPServerManager`` and, in later steps, overrides the
+per-server egress methods (``_get_tools_from_server``, ``call_tool``, the prompt/resource ops) to
+route through the v2 ``UpstreamConnection`` + ``resolve()`` instead of ``_create_mcp_client``.
+Registry, RBAC, cross-server aggregation, namespacing, and static-header resolution are inherited
+from v1 unchanged. It is injected at the composition root when ``LITELLM_USE_V2_MCP_EGRESS`` is set
+(see ``mcp_server_manager._make_global_mcp_server_manager``); flag-off keeps v1 exactly.
+
+Step 6a lands the skeleton only: no overrides, so behavior is identical to v1. The egress overrides
+land in 6b/6c.
+"""
+
+from __future__ import annotations
+
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+
+
+class MCPServerManagerV2(MCPServerManager):
+    """v2 egress manager; see the module docstring. No overrides yet (step 6a)."""

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -27,7 +27,14 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerM
 from litellm.proxy._types import MCPTransport
 
 if TYPE_CHECKING:
-    from mcp.types import GetPromptResult, Prompt, ReadResourceResult, Resource
+    from mcp.shared.session import ProgressFnT
+    from mcp.types import (
+        CallToolResult,
+        GetPromptResult,
+        Prompt,
+        ReadResourceResult,
+        Resource,
+    )
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
 
@@ -82,6 +89,8 @@ class MCPServerManagerV2(MCPServerManager):
         raw_headers: Optional[Dict[str, str]] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         subject_token: Optional[str] = None,
+        forward_caller_headers: bool = False,
+        raise_on_missing_env: bool = False,
     ) -> Result[UpstreamConnection, CredError]:
         """The shared egress seam: resolve auth via resolve() and build the UpstreamConnection.
 
@@ -106,10 +115,14 @@ class MCPServerManagerV2(MCPServerManager):
         )
         if isinstance(auth, Error):
             return Error(auth.error)
-        resolved_static = await self._resolve_static_headers_with_env_vars(
-            server, user_api_key_auth, raise_on_missing=False
+        egress = await self._build_egress_headers(
+            server,
+            user_api_key_auth,
+            raw_headers,
+            forward_caller_headers=forward_caller_headers,
+            raise_on_missing_env=raise_on_missing_env,
         )
-        headers = {**(extra_headers or {}), **(resolved_static or {})} or None
+        headers = {**(extra_headers or {}), **egress} or None
         is_stdio = server.transport == MCPTransport.stdio
         return Ok(
             UpstreamConnection(
@@ -122,6 +135,53 @@ class MCPServerManagerV2(MCPServerManager):
                 env=self._build_stdio_env(server, raw_headers) if is_stdio else None,
             )
         )
+
+    async def _build_egress_headers(
+        self,
+        server: MCPServer,
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+        raw_headers: Optional[Dict[str, str]],
+        *,
+        forward_caller_headers: bool,
+        raise_on_missing_env: bool,
+    ) -> Dict[str, str]:
+        """The non-credential egress headers: configured static headers (with per-user env-var
+        interpolation) plus, on the call path, the caller headers the server forwards upstream.
+
+        The credential (Authorization) is resolve()'s, never this dict. raise_on_missing_env
+        propagates MCPMissingUserEnvVarsError (412 + setup URL) on the call path; list ops degrade.
+        forward_caller_headers gates caller-header forwarding (call only; list/prompts/resources do
+        not forward, matching v1).
+        """
+        static = await self._resolve_static_headers_with_env_vars(
+            server, user_api_key_auth, raise_on_missing=raise_on_missing_env
+        )
+        forwarded = (
+            self._forwarded_request_headers(server, raw_headers)
+            if forward_caller_headers
+            else {}
+        )
+        return {**forwarded, **(static or {})}
+
+    @staticmethod
+    def _forwarded_request_headers(
+        server: MCPServer,
+        raw_headers: Optional[Dict[str, str]],
+    ) -> Dict[str, str]:
+        """Caller request headers the server is configured to forward (server.extra_headers pulled
+        from raw_headers). Authorization is always stripped: the upstream credential is resolve()'s,
+        so the forwarder never ships inbound auth upstream (the credential-isolation invariant; the
+        passthrough/override paths that would forward an inbound token defer to v1).
+        """
+        if not server.extra_headers or not raw_headers:
+            return {}
+        normalized = {k.lower(): v for k, v in raw_headers.items()}
+        return {
+            header: normalized[header.lower()]
+            for header in server.extra_headers
+            if header.lower() != "authorization"
+            and normalized.get(header.lower()) is not None
+        }
 
     async def _get_tools_from_server(
         self,
@@ -264,6 +324,69 @@ class MCPServerManagerV2(MCPServerManager):
         result = await conn.ok.get_prompt(prompt_name, str_args)
         if isinstance(result, Error):
             self._egress_item_failure(server, result.error)
+        return result.ok
+
+    async def _open_and_call_tool(
+        self,
+        mcp_server: MCPServer,
+        original_tool_name: str,
+        arguments: Dict[str, object],
+        *,
+        mcp_auth_header: Optional[str],
+        mcp_server_auth_headers: Optional[Dict[str, Dict[str, str]]],
+        oauth2_headers: Optional[Dict[str, str]],
+        raw_headers: Optional[Dict[str, str]],
+        hook_extra_headers: Optional[Dict[str, str]],
+        host_progress_callback: Optional[ProgressFnT],
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+    ) -> CallToolResult:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        # The effective inbound credential is the per-server header if present, else the deprecated
+        # mcp_auth_header (matches v1); an override here means the request defers to v1.
+        server_auth_header: Optional[Union[str, Dict[str, str]]] = mcp_auth_header
+        if mcp_server_auth_headers:
+            from litellm.proxy._experimental.mcp_server.utils import (
+                lookup_mcp_server_auth_in_headers,
+            )
+
+            found = lookup_mcp_server_auth_in_headers(
+                mcp_server_auth_headers,
+                alias=mcp_server.alias,
+                server_name=mcp_server.server_name,
+            )
+            if found is not None:
+                server_auth_header = found
+
+        # Defer to v1 for guardrail-injected headers (JWT signer etc.), which the v2 path does not
+        # apply, in addition to the usual _should_defer cases (unmapped mode, OpenAPI, override).
+        if hook_extra_headers or self._should_defer(mcp_server, server_auth_header):
+            return await super()._open_and_call_tool(
+                mcp_server,
+                original_tool_name,
+                arguments,
+                mcp_auth_header=mcp_auth_header,
+                mcp_server_auth_headers=mcp_server_auth_headers,
+                oauth2_headers=oauth2_headers,
+                raw_headers=raw_headers,
+                hook_extra_headers=hook_extra_headers,
+                host_progress_callback=host_progress_callback,
+                user_api_key_auth=user_api_key_auth,
+            )
+        conn = await self._v2_connection(
+            mcp_server,
+            user_api_key_auth,
+            raw_headers=raw_headers,
+            forward_caller_headers=True,
+            raise_on_missing_env=True,
+        )
+        if isinstance(conn, Error):
+            self._egress_item_failure(mcp_server, conn.error)
+        result = await conn.ok.call_tool(
+            original_tool_name, arguments, host_progress_callback
+        )
+        if isinstance(result, Error):
+            self._egress_item_failure(mcp_server, result.error)
         return result.ok
 
     def _egress_list_failure(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -13,7 +13,7 @@ strangler scaffolding that shrinks to zero as modes migrate, then is deleted wit
 ``_create_mcp_client``) and ``_v2_connection`` (the permanent resolve()+build seam that returns a
 configured ``UpstreamConnection``). ``super()`` is reserved for what v2 does not own yet:
 unmapped/misconfigured modes, OpenAPI tools (registry, S1.8), the per-request ``mcp_auth_header``
-override/inbound-token path, and the JWT-signer guardrail.
+override path, and the JWT-signer guardrail.
 """
 
 from __future__ import annotations
@@ -66,8 +66,8 @@ class MCPServerManagerV2(MCPServerManager):
         """Whether this request falls back to v1 (super()) instead of the v2 egress path.
 
         True for what v2 does not own yet: unmapped/misconfigured modes (to_server_spec is None,
-        e.g. bearer_token), OpenAPI servers (registry, not a connection), the per-request
-        mcp_auth_header override/inbound-token path, and the JWT-signer guardrail. Temporary
+        e.g. basic/token), OpenAPI servers (registry, not a connection), the per-request
+        mcp_auth_header override path, and the JWT-signer guardrail. Temporary
         strangler scaffolding: returns True for fewer cases as modes migrate, then is deleted
         (with _create_mcp_client) once nothing is left on v1.
         """
@@ -209,6 +209,7 @@ class MCPServerManagerV2(MCPServerManager):
             user_api_key_auth,
             raw_headers=raw_headers,
             extra_headers=extra_headers,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_list_failure(server, conn.error)
@@ -234,7 +235,11 @@ class MCPServerManagerV2(MCPServerManager):
                 server, mcp_auth_header, extra_headers, add_prefix, raw_headers
             )
         conn = await self._v2_connection(
-            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+            server,
+            None,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_list_failure(server, conn.error)
@@ -260,7 +265,11 @@ class MCPServerManagerV2(MCPServerManager):
                 server, mcp_auth_header, extra_headers, add_prefix, raw_headers
             )
         conn = await self._v2_connection(
-            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+            server,
+            None,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_list_failure(server, conn.error)
@@ -286,7 +295,11 @@ class MCPServerManagerV2(MCPServerManager):
                 server, mcp_auth_header, extra_headers, add_prefix, raw_headers
             )
         conn = await self._v2_connection(
-            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+            server,
+            None,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_list_failure(server, conn.error)
@@ -319,6 +332,7 @@ class MCPServerManagerV2(MCPServerManager):
             raw_headers=raw_headers,
             extra_headers=extra_headers,
             raise_on_missing_env=True,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_item_failure(server, conn.error)
@@ -353,6 +367,7 @@ class MCPServerManagerV2(MCPServerManager):
             raw_headers=raw_headers,
             extra_headers=extra_headers,
             raise_on_missing_env=True,
+            subject_token=self._extract_bearer_token(None, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_item_failure(server, conn.error)
@@ -416,6 +431,7 @@ class MCPServerManagerV2(MCPServerManager):
             raw_headers=raw_headers,
             forward_caller_headers=True,
             raise_on_missing_env=True,
+            subject_token=self._extract_bearer_token(oauth2_headers, raw_headers),
         )
         if isinstance(conn, Error):
             self._egress_item_failure(mcp_server, conn.error)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -4,8 +4,10 @@
 per-server egress methods (``_get_tools_from_server``, ``call_tool``, the prompt/resource ops) to
 route through the v2 ``UpstreamConnection`` + ``resolve()`` instead of ``_create_mcp_client``.
 Registry, RBAC, cross-server aggregation, namespacing, and static-header resolution are inherited
-from v1 unchanged. It is injected at the composition root when ``LITELLM_USE_V2_MCP_EGRESS`` is set
-(see ``mcp_server_manager._make_global_mcp_server_manager``); flag-off keeps v1 exactly.
+from v1 unchanged. It is the egress manager, constructed at the composition root (see
+``mcp_server_manager._make_global_mcp_server_manager``); there is no opt-in flag (v2 is the egress
+implementation). v1's per-server methods remain reachable via ``super()`` for modes not yet
+overridden, so the migration is the override progression, not a runtime toggle.
 
 Step 6a lands the skeleton only: no overrides, so behavior is identical to v1. The egress overrides
 land in 6b/6c.

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -3,8 +3,8 @@
 ``MCPServerManagerV2`` subclasses v1's ``MCPServerManager`` and overrides the per-server egress
 methods to route through the v2 ``UpstreamConnection`` + ``resolve()`` instead of
 ``_create_mcp_client``. Registry, RBAC, cross-server aggregation, namespacing
-(``_create_prefixed_tools``), and static-header resolution are inherited from v1 unchanged. It is
-the egress manager, constructed at the composition root (see
+(``_create_prefixed_*``), and static-header resolution are inherited from v1 unchanged. It is the
+egress manager, constructed at the composition root (see
 ``mcp_server_manager._make_global_mcp_server_manager``); there is no opt-in flag (v2 is the egress
 implementation).
 
@@ -25,6 +25,7 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerM
 from litellm.proxy._types import MCPTransport
 
 if TYPE_CHECKING:
+    from mcp.types import Prompt, Resource
     from mcp.types import Tool as MCPTool
 
     from litellm.proxy._types import UserAPIKeyAuth
@@ -146,20 +147,74 @@ class MCPServerManagerV2(MCPServerManager):
             extra_headers=extra_headers,
         )
         if isinstance(conn, Error):
-            return self._egress_list_failure(server, conn.error)
+            self._egress_list_failure(server, conn.error)
+            return []
         result = await conn.ok.list_tools()
         if isinstance(result, Error):
-            return self._egress_list_failure(server, result.error)
+            self._egress_list_failure(server, result.error)
+            return []
         return self._create_prefixed_tools(result.ok, server, add_prefix=add_prefix)
+
+    async def get_prompts_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> List[Prompt]:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        if self._should_defer(server, mcp_auth_header):
+            return await super().get_prompts_from_server(
+                server, mcp_auth_header, extra_headers, add_prefix, raw_headers
+            )
+        conn = await self._v2_connection(
+            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+        )
+        if isinstance(conn, Error):
+            self._egress_list_failure(server, conn.error)
+            return []
+        result = await conn.ok.list_prompts()
+        if isinstance(result, Error):
+            self._egress_list_failure(server, result.error)
+            return []
+        return self._create_prefixed_prompts(result.ok, server, add_prefix=add_prefix)
+
+    async def get_resources_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> List[Resource]:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        if self._should_defer(server, mcp_auth_header):
+            return await super().get_resources_from_server(
+                server, mcp_auth_header, extra_headers, add_prefix, raw_headers
+            )
+        conn = await self._v2_connection(
+            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+        )
+        if isinstance(conn, Error):
+            self._egress_list_failure(server, conn.error)
+            return []
+        result = await conn.ok.list_resources()
+        if isinstance(result, Error):
+            self._egress_list_failure(server, result.error)
+            return []
+        return self._create_prefixed_resources(result.ok, server, add_prefix=add_prefix)
 
     def _egress_list_failure(
         self, server: MCPServer, error: "CredError | ConnError"
-    ) -> List[MCPTool]:
-        # List path: an upstream 401/403 (or a per-user mode with no usable credential) surfaces as
-        # MCPUpstreamAuthError so the client gets a 401 + WWW-Authenticate and starts the OAuth flow
-        # (this is the LIT-3795 behavior for non-delegated interactive oauth2). Any other failure
-        # degrades to an empty tool list (logged), so one bad server never collapses the federated
-        # catalog. The typed partial-failure marker is a later, separate surface.
+    ) -> None:
+        # List path (tools/prompts/resources): an upstream 401/403 (or a per-user mode with no usable
+        # credential) surfaces as MCPUpstreamAuthError so the client gets a 401 + WWW-Authenticate and
+        # starts the OAuth flow (the LIT-3795 behavior for non-delegated interactive oauth2). Any
+        # other failure is logged and the caller degrades to an empty list, so one bad server never
+        # collapses the federated catalog. The typed partial-failure marker is a later surface.
         if error.tag == "unauthorized":
             from litellm.proxy._experimental.mcp_server.exceptions import (
                 MCPUpstreamAuthError,
@@ -169,9 +224,8 @@ class MCPServerManagerV2(MCPServerManager):
                 status_code=401, www_authenticate=None, server_name=server.name
             )
         verbose_logger.warning(
-            "v2 egress: tools unavailable for %s (%s): %s",
+            "v2 egress: items unavailable for %s (%s): %s",
             server.name,
             server.server_id,
             error.summary,
         )
-        return []

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -285,7 +285,11 @@ class MCPServerManagerV2(MCPServerManager):
                 server, url, mcp_auth_header, extra_headers, raw_headers
             )
         conn = await self._v2_connection(
-            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+            server,
+            None,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
+            raise_on_missing_env=True,
         )
         if isinstance(conn, Error):
             self._egress_item_failure(server, conn.error)
@@ -315,7 +319,11 @@ class MCPServerManagerV2(MCPServerManager):
                 raw_headers,
             )
         conn = await self._v2_connection(
-            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+            server,
+            None,
+            raw_headers=raw_headers,
+            extra_headers=extra_headers,
+            raise_on_missing_env=True,
         )
         if isinstance(conn, Error):
             self._egress_item_failure(server, conn.error)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
         Prompt,
         ReadResourceResult,
         Resource,
+        ResourceTemplate,
     )
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
@@ -269,6 +270,34 @@ class MCPServerManagerV2(MCPServerManager):
             self._egress_list_failure(server, result.error)
             return []
         return self._create_prefixed_resources(result.ok, server, add_prefix=add_prefix)
+
+    async def get_resource_templates_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> List[ResourceTemplate]:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        if self._should_defer(server, mcp_auth_header):
+            return await super().get_resource_templates_from_server(
+                server, mcp_auth_header, extra_headers, add_prefix, raw_headers
+            )
+        conn = await self._v2_connection(
+            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+        )
+        if isinstance(conn, Error):
+            self._egress_list_failure(server, conn.error)
+            return []
+        result = await conn.ok.list_resource_templates()
+        if isinstance(result, Error):
+            self._egress_list_failure(server, result.error)
+            return []
+        return self._create_prefixed_resource_templates(
+            result.ok, server, add_prefix=add_prefix
+        )
 
     async def read_resource_from_server(
         self,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager_v2.py
@@ -18,15 +18,18 @@ override/inbound-token path, and the JWT-signer guardrail.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, NoReturn, Optional, Union
+
+from typing_extensions import assert_never
 
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
 from litellm.proxy._types import MCPTransport
 
 if TYPE_CHECKING:
-    from mcp.types import Prompt, Resource
+    from mcp.types import GetPromptResult, Prompt, ReadResourceResult, Resource
     from mcp.types import Tool as MCPTool
+    from pydantic import AnyUrl
 
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.proxy.gateway.mcp.outbound_credentials.types import CredError
@@ -207,6 +210,62 @@ class MCPServerManagerV2(MCPServerManager):
             return []
         return self._create_prefixed_resources(result.ok, server, add_prefix=add_prefix)
 
+    async def read_resource_from_server(
+        self,
+        server: MCPServer,
+        url: AnyUrl,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> ReadResourceResult:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        if self._should_defer(server, mcp_auth_header):
+            return await super().read_resource_from_server(
+                server, url, mcp_auth_header, extra_headers, raw_headers
+            )
+        conn = await self._v2_connection(
+            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+        )
+        if isinstance(conn, Error):
+            self._egress_item_failure(server, conn.error)
+        result = await conn.ok.read_resource(url)
+        if isinstance(result, Error):
+            self._egress_item_failure(server, result.error)
+        return result.ok
+
+    async def get_prompt_from_server(
+        self,
+        server: MCPServer,
+        prompt_name: str,
+        arguments: Optional[Dict[str, object]] = None,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> GetPromptResult:
+        from litellm.proxy.gateway.mcp.result import Error
+
+        if self._should_defer(server, mcp_auth_header):
+            return await super().get_prompt_from_server(
+                server,
+                prompt_name,
+                arguments,
+                mcp_auth_header,
+                extra_headers,
+                raw_headers,
+            )
+        conn = await self._v2_connection(
+            server, None, raw_headers=raw_headers, extra_headers=extra_headers
+        )
+        if isinstance(conn, Error):
+            self._egress_item_failure(server, conn.error)
+        # MCP prompt arguments are strings on the wire; coerce the loose dict to match the op's type.
+        str_args = {k: str(v) for k, v in arguments.items()} if arguments else None
+        result = await conn.ok.get_prompt(prompt_name, str_args)
+        if isinstance(result, Error):
+            self._egress_item_failure(server, result.error)
+        return result.ok
+
     def _egress_list_failure(
         self, server: MCPServer, error: "CredError | ConnError"
     ) -> None:
@@ -229,3 +288,28 @@ class MCPServerManagerV2(MCPServerManager):
             server.server_id,
             error.summary,
         )
+
+    def _egress_item_failure(
+        self, server: MCPServer, error: "CredError | ConnError"
+    ) -> NoReturn:
+        # Single-result path (call_tool / read_resource / get_prompt): no list to degrade to, so
+        # every failure raises. unauthorized -> MCPUpstreamAuthError (401 + re-auth); the rest map to
+        # a semantically correct MCPUpstreamError. assert_never keeps the map total -- a new error
+        # variant fails the build here until it is given a mapping.
+        from litellm.proxy._experimental.mcp_server.exceptions import (
+            MCPUpstreamAuthError,
+            MCPUpstreamError,
+        )
+
+        match error.tag:
+            case "unauthorized":
+                raise MCPUpstreamAuthError(
+                    status_code=401, www_authenticate=None, server_name=server.name
+                )
+            case "upstream_unavailable":
+                raise MCPUpstreamError(502, server.name, error.summary)
+            case "precondition_required":
+                raise MCPUpstreamError(428, server.name, error.summary)
+            case "misconfigured" | "unsupported_mode" | "not_implemented":
+                raise MCPUpstreamError(500, server.name, error.summary)
+        assert_never(error.tag)

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -18,7 +18,10 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 
 from litellm._logging import verbose_logger
-from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+from litellm.proxy._experimental.mcp_server.exceptions import (
+    MCPUpstreamAuthError,
+    MCPUpstreamError,
+)
 from litellm.proxy._experimental.mcp_server.ui_session_utils import (
     build_effective_auth_contexts,
 )
@@ -886,6 +889,10 @@ if MCP_AVAILABLE:
                     "setup_url": e.setup_url,
                 },
             )
+        except MCPUpstreamError as e:
+            # Non-auth upstream failure on the tool call; surface the semantic status
+            # (502 unreachable / 428 precondition / 500 misconfigured) instead of a blanket 500.
+            raise e.to_http_exception()
         except BlockedPiiEntityError as e:
             verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {str(e)}")
             raise HTTPException(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -40,7 +40,10 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
 )
-from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+from litellm.proxy._experimental.mcp_server.exceptions import (
+    MCPUpstreamAuthError,
+    MCPUpstreamError,
+)
 from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
     get_request_base_url,
 )
@@ -4003,6 +4006,10 @@ if MCP_AVAILABLE:
                 base_url=get_request_base_url(StarletteRequest(scope)),
                 request_path=scope.get("_original_path") or scope.get("path"),
             )
+        except MCPUpstreamError as e:
+            # Non-auth upstream failure on a single-result op; surface the semantic status
+            # (502 unreachable / 428 precondition / 500 misconfigured) instead of a blanket 500.
+            raise e.to_http_exception()
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
@@ -4119,6 +4126,10 @@ if MCP_AVAILABLE:
                 base_url=get_request_base_url(StarletteRequest(scope)),
                 request_path=scope.get("_original_path") or scope.get("path"),
             )
+        except MCPUpstreamError as e:
+            # Non-auth upstream failure on a single-result op; surface the semantic status
+            # (502 unreachable / 428 precondition / 500 misconfigured) instead of a blanket 500.
+            raise e.to_http_exception()
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             # (e.g. 401 + WWW-Authenticate challenges from OAuth pass-through).

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -123,12 +123,12 @@ class MCPEgressManager(Protocol):
 class ConnError(BaseModel):
     """A connection/transport failure to an upstream MCP server, modeled as a value.
 
-    Discriminated on ``tag`` so callers can route on it (a 401 is surfaced to the client to
-    trigger the upstream OAuth flow; transient/transport failures map to a 503).
+    Discriminated on ``tag``: an upstream 401/403 is surfaced to the client to trigger the
+    upstream OAuth flow; any other transport failure maps to a 503.
     """
 
     model_config = ConfigDict(frozen=True)
-    tag: Literal["unauthorized", "upstream_unavailable", "protocol_error"]
+    tag: Literal["unauthorized", "upstream_unavailable"]
     summary: str
 
     @classmethod
@@ -139,31 +139,19 @@ class ConnError(BaseModel):
     def of_upstream_unavailable(cls, summary: str) -> "ConnError":
         return cls(tag="upstream_unavailable", summary=summary)
 
-    @classmethod
-    def of_protocol_error(cls, summary: str) -> "ConnError":
-        return cls(tag="protocol_error", summary=summary)
-
-
-_TRANSIENT_ERROR_NAMES = (
-    "ConnectError",
-    "ConnectTimeout",
-    "ReadTimeout",
-    "WriteTimeout",
-    "PoolTimeout",
-    "TimeoutException",
-    "ConnectionError",
-    "RemoteProtocolError",
-)
-
 
 def _classify_conn_error(error: Exception) -> ConnError:
-    response = getattr(error, "response", None)
-    if getattr(response, "status_code", None) == 401:
-        return ConnError.of_unauthorized(f"upstream returned 401: {error}")
-    if type(error).__name__ == "McpError":
-        return ConnError.of_protocol_error(f"MCP protocol error: {error}")
-    if type(error).__name__ in _TRANSIENT_ERROR_NAMES:
-        return ConnError.of_upstream_unavailable(f"upstream unreachable: {error}")
+    # Reuse v1's exception-tree walk (it handles the SDK's anyio ExceptionGroup and the
+    # __cause__/__context__ chains portably) to spot an upstream 401/403; anything else is a
+    # transport failure. Imported lazily to avoid an import cycle at the manager swap.
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        extract_upstream_auth_failure,
+    )
+
+    auth_failure = extract_upstream_auth_failure(error)
+    if auth_failure is not None:
+        status_code, _ = auth_failure
+        return ConnError.of_unauthorized(f"upstream returned {status_code}")
     return ConnError.of_upstream_unavailable(f"upstream connection failed: {error}")
 
 

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     )
     from mcp import ReadResourceResult, Resource
     from mcp.shared.message import SessionMessage
+    from mcp.shared.session import ProgressFnT
     from mcp.types import CallToolResult, GetPromptResult, Prompt
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
@@ -193,10 +194,15 @@ class UpstreamConnection:
         return await self._run(op)
 
     async def call_tool(
-        self, name: str, arguments: Dict[str, object]
+        self,
+        name: str,
+        arguments: Dict[str, object],
+        progress_callback: Optional[ProgressFnT] = None,
     ) -> Result[CallToolResult, ConnError]:
         async def op(session: ClientSession) -> CallToolResult:
-            return await session.call_tool(name, arguments)
+            return await session.call_tool(
+                name, arguments, progress_callback=progress_callback
+            )
 
         return await self._run(op)
 

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -31,21 +31,36 @@ from typing import (
 )
 
 import httpx
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.sse import sse_client
+from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
 from pydantic import BaseModel, ConfigDict
 
 from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
+from litellm.proxy._types import MCPTransport
 from litellm.proxy.gateway.mcp.result import Error, Ok, Result
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from anyio.streams.memory import (
+        MemoryObjectReceiveStream,
+        MemoryObjectSendStream,
+    )
     from mcp import ReadResourceResult, Resource
+    from mcp.shared.message import SessionMessage
     from mcp.types import CallToolResult, GetPromptResult, Prompt
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
 
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    _Streams = tuple[
+        MemoryObjectReceiveStream[SessionMessage | Exception],
+        MemoryObjectSendStream[SessionMessage],
+    ]
 
 _T = TypeVar("_T")
 
@@ -160,29 +175,71 @@ class UpstreamConnection:
 
     The v2 egress transport: attaches ``resolve()``'s ``httpx.Auth`` (and any static/env-var
     headers) to the connection through litellm's httpx client (SSL/proxy config), opens a
-    streamable-http ``ClientSession`` per request, and returns typed results (errors-as-values).
-    Replaces v1's ``MCPClient`` for the modes routed through the v2 manager. (sse/stdio transports
-    and the prompt/resource ops land in later steps.)
+    ``ClientSession`` per request over the server's transport (streamable-http, sse, or stdio),
+    and returns typed results (errors-as-values). Replaces v1's ``MCPClient`` for the modes routed
+    through the v2 manager.
     """
 
     def __init__(
         self,
-        server_url: str,
+        server_url: Optional[str] = None,
         *,
+        transport: MCPTransport = MCPTransport.http,
         auth: Optional[httpx.Auth] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         timeout: float = 60.0,
+        command: Optional[str] = None,
+        args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
     ) -> None:
         self._server_url = server_url
+        self._transport = transport
         self._auth = auth
         self._extra_headers = extra_headers
         self._timeout = timeout
+        self._command = command
+        self._args = args
+        self._env = env
 
-    async def _run(
-        self, operation: Callable[[ClientSession], Awaitable[_T]]
-    ) -> Result[_T, ConnError]:
-        # The resolved auth (and any static/env-var headers) ride on the httpx client; SSL/proxy
-        # config comes from litellm's get_ssl_configuration, matching v1's connection behavior.
+    def _http_client_factory(self) -> Callable[..., httpx.AsyncClient]:
+        def factory(
+            *,
+            headers: Optional[Dict[str, str]] = None,
+            timeout: Optional[httpx.Timeout] = None,
+            auth: Optional[httpx.Auth] = None,
+        ) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                headers=headers,
+                timeout=timeout,
+                auth=auth,
+                verify=get_ssl_configuration(None),
+                follow_redirects=True,
+            )
+
+        return factory
+
+    @contextlib.asynccontextmanager
+    async def _session_streams(self) -> AsyncGenerator[_Streams, None]:
+        # The resolved auth and static/env-var headers ride on the httpx client (SDK 1.26: not the
+        # transport kwargs); SSL/proxy config comes from litellm's get_ssl_configuration. Normalizes
+        # all three transports to a (read, write) stream pair (streamable-http yields a third value).
+        if self._transport == MCPTransport.stdio:
+            params = StdioServerParameters(
+                command=self._command or "", args=self._args or [], env=self._env
+            )
+            async with stdio_client(params) as (read_stream, write_stream, *_):
+                yield read_stream, write_stream
+            return
+        if self._transport == MCPTransport.sse:
+            async with sse_client(
+                url=self._server_url or "",
+                timeout=self._timeout,
+                headers=self._extra_headers,
+                auth=self._auth,
+                httpx_client_factory=self._http_client_factory(),
+            ) as (read_stream, write_stream, *_):
+                yield read_stream, write_stream
+            return
         http_client = httpx.AsyncClient(
             headers=self._extra_headers,
             timeout=httpx.Timeout(self._timeout),
@@ -192,17 +249,24 @@ class UpstreamConnection:
         )
         try:
             async with streamable_http_client(
-                url=self._server_url, http_client=http_client
-            ) as (read_stream, write_stream, _):
+                url=self._server_url or "", http_client=http_client
+            ) as (read_stream, write_stream, *_):
+                yield read_stream, write_stream
+        finally:
+            with contextlib.suppress(Exception):
+                await http_client.aclose()
+
+    async def _run(
+        self, operation: Callable[[ClientSession], Awaitable[_T]]
+    ) -> Result[_T, ConnError]:
+        try:
+            async with self._session_streams() as (read_stream, write_stream):
                 async with ClientSession(read_stream, write_stream) as session:
                     await session.initialize()
                     result = await operation(session)
             return Ok(result)
         except Exception as e:  # transport / protocol failures -> ConnError
             return Error(_classify_conn_error(e))
-        finally:
-            with contextlib.suppress(Exception):
-                await http_client.aclose()
 
     async def list_tools(self) -> Result[List[MCPTool], ConnError]:
         async def op(session: ClientSession) -> List[MCPTool]:

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -1,0 +1,98 @@
+"""v2 MCP egress transport (the chokepoint): scaffolding.
+
+This phase makes v2 own the upstream MCP connection. When ``LITELLM_USE_V2_MCP_EGRESS`` is enabled,
+a v2 manager (built in later steps) implements the handler-facing egress surface via an
+``UpstreamConnection`` that attaches ``resolve()``'s ``httpx.Auth`` plus resolved static/env-var
+headers directly to the SDK client, replacing v1's ``_create_mcp_client`` and the
+``resolve_mcp_auth`` header graft.
+
+Step 1 lands only the flag and the egress contract (``MCPEgressManager``). The implementation
+(``UpstreamConnection``, the static-headers resolver, the per-user token bridges,
+``MCPServerManagerV2``) arrives in later steps; the contract grows with the surface as it is
+implemented (call_tool/dispatch and the reused registry/RBAC lookups are added when the v2 manager
+is assembled). The CLI flag wiring lands at the cutover step.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union
+
+if TYPE_CHECKING:
+    from mcp import ReadResourceResult, Resource
+    from mcp.types import GetPromptResult, Prompt
+    from mcp.types import Tool as MCPTool
+    from pydantic import AnyUrl
+
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+_V2_EGRESS_ENV_FLAG = "LITELLM_USE_V2_MCP_EGRESS"
+
+
+def v2_egress_enabled() -> bool:
+    """True when v2 owns the MCP egress transport (set via the env flag)."""
+    return os.getenv(_V2_EGRESS_ENV_FLAG, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+class MCPEgressManager(Protocol):
+    """The per-server egress operations the inbound handler invokes on the manager.
+
+    v1's ``MCPServerManager`` satisfies this today; ``MCPServerManagerV2`` (later steps) will
+    implement it via the ``UpstreamConnection``. Registry/RBAC lookups
+    (``get_allowed_mcp_servers``, ``get_registry``, ...) are reused from v1 and are intentionally
+    not part of this egress contract; ``call_tool``/dispatch is added when the v2 manager is
+    assembled.
+    """
+
+    async def _get_tools_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+    ) -> List[MCPTool]: ...
+
+    async def get_prompts_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> List[Prompt]: ...
+
+    async def get_resources_from_server(
+        self,
+        server: MCPServer,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        add_prefix: bool = True,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> List[Resource]: ...
+
+    async def read_resource_from_server(
+        self,
+        server: MCPServer,
+        url: AnyUrl,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> ReadResourceResult: ...
+
+    async def get_prompt_from_server(
+        self,
+        server: MCPServer,
+        prompt_name: str,
+        arguments: Optional[Dict[str, object]] = None,
+        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        raw_headers: Optional[Dict[str, str]] = None,
+    ) -> GetPromptResult: ...

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -217,3 +217,29 @@ class UpstreamConnection:
             return await session.call_tool(name, arguments)
 
         return await self._run(op)
+
+    async def list_prompts(self) -> Result[List[Prompt], ConnError]:
+        async def op(session: ClientSession) -> List[Prompt]:
+            return (await session.list_prompts()).prompts
+
+        return await self._run(op)
+
+    async def get_prompt(
+        self, name: str, arguments: Optional[Dict[str, str]] = None
+    ) -> Result[GetPromptResult, ConnError]:
+        async def op(session: ClientSession) -> GetPromptResult:
+            return await session.get_prompt(name, arguments)
+
+        return await self._run(op)
+
+    async def list_resources(self) -> Result[List[Resource], ConnError]:
+        async def op(session: ClientSession) -> List[Resource]:
+            return (await session.list_resources()).resources
+
+        return await self._run(op)
+
+    async def read_resource(self, uri: AnyUrl) -> Result[ReadResourceResult, ConnError]:
+        async def op(session: ClientSession) -> ReadResourceResult:
+            return await session.read_resource(uri)
+
+        return await self._run(op)

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -1,22 +1,15 @@
-"""v2 MCP egress transport (the chokepoint): scaffolding.
+"""v2 MCP egress transport: v2 owns the upstream MCP connection.
 
-This phase makes v2 own the upstream MCP connection. When ``LITELLM_USE_V2_MCP_EGRESS`` is enabled,
-a v2 manager (built in later steps) implements the handler-facing egress surface via an
-``UpstreamConnection`` that attaches ``resolve()``'s ``httpx.Auth`` plus resolved static/env-var
-headers directly to the SDK client, replacing v1's ``_create_mcp_client`` and the
-``resolve_mcp_auth`` header graft.
-
-Step 1 lands only the flag and the egress contract (``MCPEgressManager``). The implementation
-(``UpstreamConnection``, the static-headers resolver, the per-user token bridges,
-``MCPServerManagerV2``) arrives in later steps; the contract grows with the surface as it is
-implemented (call_tool/dispatch and the reused registry/RBAC lookups are added when the v2 manager
-is assembled). The CLI flag wiring lands at the cutover step.
+``UpstreamConnection`` opens the SDK client over the server's transport (streamable-http, sse, or
+stdio), attaches ``resolve()``'s ``httpx.Auth`` plus resolved static/env-var headers on the httpx
+client, runs an operation, and returns typed results (errors-as-values via ``ConnError``). It
+replaces v1's ``_create_mcp_client`` and the ``resolve_mcp_auth`` header graft;
+``MCPServerManagerV2`` (in ``mcp_server_manager_v2``) is the manager that drives it.
 """
 
 from __future__ import annotations
 
 import contextlib
-import os
 from typing import (
     TYPE_CHECKING,
     Awaitable,
@@ -25,9 +18,7 @@ from typing import (
     List,
     Literal,
     Optional,
-    Protocol,
     TypeVar,
-    Union,
 )
 
 import httpx
@@ -54,85 +45,12 @@ if TYPE_CHECKING:
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
 
-    from litellm.proxy._types import UserAPIKeyAuth
-    from litellm.types.mcp_server.mcp_server_manager import MCPServer
-
     _Streams = tuple[
         MemoryObjectReceiveStream[SessionMessage | Exception],
         MemoryObjectSendStream[SessionMessage],
     ]
 
 _T = TypeVar("_T")
-
-_V2_EGRESS_ENV_FLAG = "LITELLM_USE_V2_MCP_EGRESS"
-
-
-def v2_egress_enabled() -> bool:
-    """True when v2 owns the MCP egress transport (set via the env flag)."""
-    return os.getenv(_V2_EGRESS_ENV_FLAG, "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
-
-
-class MCPEgressManager(Protocol):
-    """The per-server egress operations the inbound handler invokes on the manager.
-
-    v1's ``MCPServerManager`` satisfies this today; ``MCPServerManagerV2`` (later steps) will
-    implement it via the ``UpstreamConnection``. Registry/RBAC lookups
-    (``get_allowed_mcp_servers``, ``get_registry``, ...) are reused from v1 and are intentionally
-    not part of this egress contract; ``call_tool``/dispatch is added when the v2 manager is
-    assembled.
-    """
-
-    async def _get_tools_from_server(
-        self,
-        server: MCPServer,
-        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        add_prefix: bool = True,
-        raw_headers: Optional[Dict[str, str]] = None,
-        user_api_key_auth: Optional[UserAPIKeyAuth] = None,
-    ) -> List[MCPTool]: ...
-
-    async def get_prompts_from_server(
-        self,
-        server: MCPServer,
-        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        add_prefix: bool = True,
-        raw_headers: Optional[Dict[str, str]] = None,
-    ) -> List[Prompt]: ...
-
-    async def get_resources_from_server(
-        self,
-        server: MCPServer,
-        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        add_prefix: bool = True,
-        raw_headers: Optional[Dict[str, str]] = None,
-    ) -> List[Resource]: ...
-
-    async def read_resource_from_server(
-        self,
-        server: MCPServer,
-        url: AnyUrl,
-        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        raw_headers: Optional[Dict[str, str]] = None,
-    ) -> ReadResourceResult: ...
-
-    async def get_prompt_from_server(
-        self,
-        server: MCPServer,
-        prompt_name: str,
-        arguments: Optional[Dict[str, object]] = None,
-        mcp_auth_header: Optional[Union[str, Dict[str, str]]] = None,
-        extra_headers: Optional[Dict[str, str]] = None,
-        raw_headers: Optional[Dict[str, str]] = None,
-    ) -> GetPromptResult: ...
 
 
 class ConnError(BaseModel):

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -15,17 +15,39 @@ is assembled). The CLI flag wiring lands at the cutover step.
 
 from __future__ import annotations
 
+import contextlib
 import os
-from typing import TYPE_CHECKING, Dict, List, Optional, Protocol, Union
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+)
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from pydantic import BaseModel, ConfigDict
+
+from litellm.llms.custom_httpx.http_handler import get_ssl_configuration
+from litellm.proxy.gateway.mcp.result import Error, Ok, Result
 
 if TYPE_CHECKING:
     from mcp import ReadResourceResult, Resource
-    from mcp.types import GetPromptResult, Prompt
+    from mcp.types import CallToolResult, GetPromptResult, Prompt
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
 
     from litellm.proxy._types import UserAPIKeyAuth
     from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+_T = TypeVar("_T")
 
 _V2_EGRESS_ENV_FLAG = "LITELLM_USE_V2_MCP_EGRESS"
 
@@ -96,3 +118,114 @@ class MCPEgressManager(Protocol):
         extra_headers: Optional[Dict[str, str]] = None,
         raw_headers: Optional[Dict[str, str]] = None,
     ) -> GetPromptResult: ...
+
+
+class ConnError(BaseModel):
+    """A connection/transport failure to an upstream MCP server, modeled as a value.
+
+    Discriminated on ``tag`` so callers can route on it (a 401 is surfaced to the client to
+    trigger the upstream OAuth flow; transient/transport failures map to a 503).
+    """
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["unauthorized", "upstream_unavailable", "protocol_error"]
+    summary: str
+
+    @classmethod
+    def of_unauthorized(cls, summary: str) -> "ConnError":
+        return cls(tag="unauthorized", summary=summary)
+
+    @classmethod
+    def of_upstream_unavailable(cls, summary: str) -> "ConnError":
+        return cls(tag="upstream_unavailable", summary=summary)
+
+    @classmethod
+    def of_protocol_error(cls, summary: str) -> "ConnError":
+        return cls(tag="protocol_error", summary=summary)
+
+
+_TRANSIENT_ERROR_NAMES = (
+    "ConnectError",
+    "ConnectTimeout",
+    "ReadTimeout",
+    "WriteTimeout",
+    "PoolTimeout",
+    "TimeoutException",
+    "ConnectionError",
+    "RemoteProtocolError",
+)
+
+
+def _classify_conn_error(error: Exception) -> ConnError:
+    response = getattr(error, "response", None)
+    if getattr(response, "status_code", None) == 401:
+        return ConnError.of_unauthorized(f"upstream returned 401: {error}")
+    if type(error).__name__ == "McpError":
+        return ConnError.of_protocol_error(f"MCP protocol error: {error}")
+    if type(error).__name__ in _TRANSIENT_ERROR_NAMES:
+        return ConnError.of_upstream_unavailable(f"upstream unreachable: {error}")
+    return ConnError.of_upstream_unavailable(f"upstream connection failed: {error}")
+
+
+class UpstreamConnection:
+    """Opens the SDK client connection to one upstream MCP server and runs an operation.
+
+    The v2 egress transport: attaches ``resolve()``'s ``httpx.Auth`` (and any static/env-var
+    headers) to the connection through litellm's httpx client (SSL/proxy config), opens a
+    streamable-http ``ClientSession`` per request, and returns typed results (errors-as-values).
+    Replaces v1's ``MCPClient`` for the modes routed through the v2 manager. (sse/stdio transports
+    and the prompt/resource ops land in later steps.)
+    """
+
+    def __init__(
+        self,
+        server_url: str,
+        *,
+        auth: Optional[httpx.Auth] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+        timeout: float = 60.0,
+    ) -> None:
+        self._server_url = server_url
+        self._auth = auth
+        self._extra_headers = extra_headers
+        self._timeout = timeout
+
+    async def _run(
+        self, operation: Callable[[ClientSession], Awaitable[_T]]
+    ) -> Result[_T, ConnError]:
+        # The resolved auth (and any static/env-var headers) ride on the httpx client; SSL/proxy
+        # config comes from litellm's get_ssl_configuration, matching v1's connection behavior.
+        http_client = httpx.AsyncClient(
+            headers=self._extra_headers,
+            timeout=httpx.Timeout(self._timeout),
+            auth=self._auth,
+            verify=get_ssl_configuration(None),
+            follow_redirects=True,
+        )
+        try:
+            async with streamable_http_client(
+                url=self._server_url, http_client=http_client
+            ) as (read_stream, write_stream, _):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    result = await operation(session)
+            return Ok(result)
+        except Exception as e:  # transport / protocol failures -> ConnError
+            return Error(_classify_conn_error(e))
+        finally:
+            with contextlib.suppress(Exception):
+                await http_client.aclose()
+
+    async def list_tools(self) -> Result[List[MCPTool], ConnError]:
+        async def op(session: ClientSession) -> List[MCPTool]:
+            return (await session.list_tools()).tools
+
+        return await self._run(op)
+
+    async def call_tool(
+        self, name: str, arguments: Dict[str, object]
+    ) -> Result[CallToolResult, ConnError]:
+        async def op(session: ClientSession) -> CallToolResult:
+            return await session.call_tool(name, arguments)
+
+        return await self._run(op)

--- a/litellm/proxy/_experimental/mcp_server/v2_egress.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_egress.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from mcp import ReadResourceResult, Resource
     from mcp.shared.message import SessionMessage
     from mcp.shared.session import ProgressFnT
-    from mcp.types import CallToolResult, GetPromptResult, Prompt
+    from mcp.types import CallToolResult, GetPromptResult, Prompt, ResourceTemplate
     from mcp.types import Tool as MCPTool
     from pydantic import AnyUrl
 
@@ -229,5 +229,13 @@ class UpstreamConnection:
     async def read_resource(self, uri: AnyUrl) -> Result[ReadResourceResult, ConnError]:
         async def op(session: ClientSession) -> ReadResourceResult:
             return await session.read_resource(uri)
+
+        return await self._run(op)
+
+    async def list_resource_templates(
+        self,
+    ) -> Result[List[ResourceTemplate], ConnError]:
+        async def op(session: ClientSession) -> List[ResourceTemplate]:
+            return (await session.list_resource_templates()).resourceTemplates
 
         return await self._run(op)

--- a/litellm/proxy/_experimental/mcp_server/v2_port_bodies.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_port_bodies.py
@@ -113,6 +113,16 @@ class HttpxClientCredentialsFetcher:
     async def fetch(
         self, config: ClientCredentialsConfig
     ) -> Result[StoredToken, CredError]:
+        if (
+            config.client_id is None
+            or config.client_secret is None
+            or config.token_url is None
+        ):
+            return Error(
+                CredError.of_misconfigured(
+                    "client_credentials requires client_id, client_secret, and token_url"
+                )
+            )
         data = {
             "grant_type": "client_credentials",
             "client_id": config.client_id,

--- a/litellm/proxy/_experimental/mcp_server/v2_port_bodies.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_port_bodies.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Mapping, Optional
 
 import httpx
 from pydantic import BaseModel, ConfigDict, SecretStr, ValidationError
@@ -20,7 +20,10 @@ from litellm.proxy.gateway.mcp.outbound_credentials.clock import Clock, SystemCl
 from litellm.proxy.gateway.mcp.outbound_credentials.credential_store import (
     CredentialKey,
 )
-from litellm.proxy.gateway.mcp.outbound_credentials.token_store import StoredToken
+from litellm.proxy.gateway.mcp.outbound_credentials.token_store import (
+    StoredToken,
+    TokenKey,
+)
 from litellm.proxy.gateway.mcp.outbound_credentials.types import (
     AssumeRole,
     AwsSigV4Config,
@@ -256,3 +259,91 @@ def _classify_sigv4_error(error: Exception) -> CredError:
     return CredError.of_misconfigured(
         f"aws_sigv4 credentials could not be resolved: {error}"
     )
+
+
+# v1 refreshes the per-user token on every read, so the token this store returns is always
+# currently valid; expiry is set beyond the resolver's refresh buffer to keep v2's proactive
+# refresh inert (the OAuth dance and refresh stay on v1 until it retires).
+_BRIDGE_TOKEN_TTL = timedelta(hours=1)
+
+
+class _OAuthPayload(BaseModel):
+    """The slice of v1's stored OAuth2 payload we consume; extra fields are ignored."""
+
+    model_config = ConfigDict(extra="ignore")
+    access_token: str
+
+
+async def _read_valid_user_oauth_token(
+    subject_id: str, server_id: str
+) -> Optional[Mapping[str, object]]:
+    from litellm.proxy._experimental.mcp_server.db import (
+        get_user_oauth_credential,
+        resolve_valid_user_oauth_token,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        raise RuntimeError("no DB client available for OAuth token lookup")
+    server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+    if server is None:
+        return None
+    cred = await get_user_oauth_credential(prisma_client, subject_id, server_id)
+    return await resolve_valid_user_oauth_token(subject_id, server, cred, prisma_client)
+
+
+class V1OAuthTokenStore:
+    """Per-user authorization_code TokenStore backed by v1's stored OAuth tokens.
+
+    Read-path graft: ``get`` returns the user's currently-valid upstream token, reusing v1's
+    ``resolve_valid_user_oauth_token`` (which reads the stored credential and refreshes it via the
+    server's token_url when near expiry). Because v1 refreshes on every read, the returned token is
+    always currently valid, so ``expires_at`` is set beyond the resolver's refresh buffer to keep
+    v2's proactive-refresh path inert; the dance and refresh stay on v1 until it retires, at which
+    point a v2-owned store returns real expiry and the resolver owns refresh. A missing/invalid
+    token is ``Ok(None)`` (the arm turns that into a 401 that starts the OAuth flow); a DB outage is
+    ``upstream_unavailable``. The reader is injected so the arm stays unit-testable without a DB.
+    """
+
+    def __init__(
+        self,
+        reader: Callable[
+            [str, str], Awaitable[Optional[Mapping[str, object]]]
+        ] = _read_valid_user_oauth_token,
+        clock: Optional[Clock] = None,
+    ) -> None:
+        self._reader = reader
+        self._clock: Clock = clock or SystemClock()
+
+    async def get(self, key: TokenKey) -> Result[Optional[StoredToken], CredError]:
+        if not key.subject_id:
+            # No authenticated identity -> no per-user token; never share one slot.
+            return Ok(None)
+        try:
+            payload = await self._reader(key.subject_id, key.server_id)
+        except Exception as e:
+            return Error(
+                CredError.of_upstream_unavailable(f"OAuth token lookup failed: {e}")
+            )
+        if payload is None:
+            return Ok(None)
+        try:
+            parsed = _OAuthPayload.model_validate(payload)
+        except ValidationError:
+            return Ok(None)  # no usable access_token -> drives the OAuth dance
+        return Ok(
+            StoredToken(
+                access_token=SecretStr(parsed.access_token),
+                expires_at=self._clock.now() + _BRIDGE_TOKEN_TTL,
+                refresh_token=None,
+            )
+        )
+
+    async def put(self, key: TokenKey, token: StoredToken) -> Result[None, CredError]:
+        # Unreached during the bridge: get returns non-near-expiry tokens, so the resolver never
+        # refreshes/persists through this port; v1 persists inside resolve_valid_user_oauth_token.
+        _ = (key, token)
+        return Ok(None)

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -146,6 +146,15 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
                 key_source=SharedKey(value=SecretStr(token)),
             ),
         )
+    if server.auth_type == MCPAuth.aws_sigv4:
+        # Reuse the SigV4 config builder; the resolver's aws_sigv4 arm turns it into the botocore
+        # signer (an httpx.Auth) that signs each upstream request.
+        aws_config = _to_aws_sigv4_config(server)
+        if aws_config is None:
+            return None  # AssumeRole with explicit base keys: not representable yet, defer to v1
+        return ServerSpec(
+            server_id=server.server_id, resource=resource, config=aws_config
+        )
     if server.has_token_exchange_config:
         # token_exchange takes precedence over client_credentials (matches v1's cascade); the arm
         # binds the exchanged token to this resource (audience, RFC 8707).

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -12,6 +12,7 @@ This lives on the v1 side so the v2 core keeps its no-v1-imports invariant.
 
 from __future__ import annotations
 
+import base64
 import functools
 import os
 from typing import TYPE_CHECKING, Dict, Optional
@@ -146,17 +147,31 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
                 key_source=SharedKey(value=SecretStr(token)),
             ),
         )
-    if server.auth_type == MCPAuth.bearer_token:
+    # Static credential on the Authorization header; these differ only by scheme prefix (basic is
+    # base64(user:pass)). All reuse the api_key arm. authorization uses an empty prefix (verbatim),
+    # so test the prefix with `is not None`, not truthiness.
+    authorization_prefix = {
+        MCPAuth.bearer_token: "Bearer",
+        MCPAuth.token: "token",
+        MCPAuth.authorization: "",
+        MCPAuth.basic: "Basic",
+    }.get(server.auth_type)
+    if authorization_prefix is not None:
         token = server.authentication_token
         if not token:
-            return None  # bearer_token with no token: let v1 handle it (parity-safe)
+            return None  # static Authorization mode with no token: let v1 handle it (parity-safe)
+        value = (
+            base64.b64encode(token.encode("utf-8")).decode()
+            if server.auth_type == MCPAuth.basic
+            else token
+        )
         return ServerSpec(
             server_id=server.server_id,
             resource=resource,
             config=ApiKeyConfig(
                 header_name="Authorization",
-                value_prefix="Bearer",
-                key_source=SharedKey(value=SecretStr(token)),
+                value_prefix=authorization_prefix,
+                key_source=SharedKey(value=SecretStr(value)),
             ),
         )
     if server.auth_type == MCPAuth.aws_sigv4:

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -91,7 +91,7 @@ class _Unwired:
 
 
 @functools.lru_cache(maxsize=1)
-def _provider() -> UpstreamCredentialProvider:
+def provider() -> UpstreamCredentialProvider:
     # Real bodies are wired as their modes are grafted. token_refresher stays unwired: the bridge's
     # V1OAuthTokenStore returns currently-valid tokens (v1 refreshes on read), so the resolver's
     # proactive-refresh path is inert until v1 retires.
@@ -108,7 +108,7 @@ def _provider() -> UpstreamCredentialProvider:
     )
 
 
-def _to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
+def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
     resource = server.url or server.server_id
     if server.auth_type in (None, MCPAuth.none):
         # A none server opted into upstream OAuth passthrough forwards the caller's bearer; the
@@ -219,7 +219,7 @@ def _added_headers(auth: httpx.Auth) -> Dict[str, str]:
     }
 
 
-def _to_subject(
+def to_subject(
     user_api_key_auth: Optional[UserAPIKeyAuth], subject_token: Optional[str]
 ) -> Subject:
     """Map v1's authenticated principal onto the v2 Subject.
@@ -246,11 +246,11 @@ async def resolve_v2_auth_value(
     """Resolve `none`/`api_key` via the v2 resolver, or return None to defer to v1."""
     if not v2_resolver_enabled():
         return None
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     if spec is None:
         return None
-    result = await _provider().resolve(
-        _to_subject(user_api_key_auth, subject_token), spec
+    result = await provider().resolve(
+        to_subject(user_api_key_auth, subject_token), spec
     )
     if isinstance(result, Error):
         verbose_logger.warning(
@@ -315,7 +315,7 @@ async def resolve_v2_aws_auth(server: MCPServer) -> Optional[httpx.Auth]:
     config = _to_aws_sigv4_config(server)
     if config is None:
         return None
-    result = await _provider().resolve(
+    result = await provider().resolve(
         Subject(tenant_id="", subject_id="", inbound_token=None),
         ServerSpec(
             server_id=server.server_id,

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -200,18 +200,18 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
                 scopes=tuple(server.scopes or ()),
             ),
         )
-    if (
-        server.has_client_credentials
-        and server.client_id
-        and server.client_secret
-        and server.token_url
-    ):
+    if server.has_client_credentials:
+        # Mode selector only (oauth2_flow == client_credentials); completeness is no longer a guard.
+        # An incomplete M2M config still builds, and the _client_credentials arm raises misconfigured
+        # at resolve time instead of returning None and deferring to v1.
         return ServerSpec(
             server_id=server.server_id,
             resource=resource,
             config=ClientCredentialsConfig(
                 client_id=server.client_id,
-                client_secret=SecretStr(server.client_secret),
+                client_secret=(
+                    SecretStr(server.client_secret) if server.client_secret else None
+                ),
                 token_url=server.token_url,
                 scopes=tuple(server.scopes or ()),
             ),

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -47,6 +47,7 @@ from litellm.proxy.gateway.mcp.outbound_credentials.types import (
     ClientCredentialsConfig,
     CredError,
     NoneConfig,
+    PassthroughConfig,
     ServerSpec,
     SharedKey,
     StaticKeys,
@@ -111,6 +112,14 @@ def _provider() -> UpstreamCredentialProvider:
 def _to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
     resource = server.url or server.server_id
     if server.auth_type in (None, MCPAuth.none):
+        # A none server opted into upstream OAuth passthrough forwards the caller's bearer; the
+        # passthrough arm sends the inbound token. Otherwise no upstream credential.
+        if server.is_oauth_passthrough:
+            return ServerSpec(
+                server_id=server.server_id,
+                resource=resource,
+                config=PassthroughConfig(),
+            )
         return ServerSpec(
             server_id=server.server_id, resource=resource, config=NoneConfig()
         )
@@ -171,7 +180,31 @@ def _to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
                 scopes=tuple(server.scopes or ()),
             ),
         )
-    return None  # other modes are not grafted yet
+    if server.needs_user_oauth_token:
+        # Interactive oauth2 (3LO), not M2M/exchange (handled above). delegate_auth_to_upstream
+        # forwards the caller token (passthrough); otherwise the gateway holds a per-user token
+        # (authorization_code). This split is the LIT-3795 fix: a non-delegated interactive oauth2
+        # server must not forward the caller JWT upstream.
+        if server.delegate_auth_to_upstream:
+            return ServerSpec(
+                server_id=server.server_id,
+                resource=resource,
+                config=PassthroughConfig(),
+            )
+        return ServerSpec(
+            server_id=server.server_id,
+            resource=resource,
+            config=AuthorizationCodeConfig(
+                client_id=server.client_id,
+                client_secret=(
+                    SecretStr(server.client_secret) if server.client_secret else None
+                ),
+                authorization_url=server.authorization_url,
+                token_url=server.token_url,
+                scopes=tuple(server.scopes or ()),
+            ),
+        )
+    return None  # aws_sigv4 uses the aws_auth seam; misconfigured modes defer to v1
 
 
 def _added_headers(auth: httpx.Auth) -> Dict[str, str]:

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -25,6 +25,7 @@ from litellm.proxy._experimental.mcp_server.v2_port_bodies import (
     HttpxSigV4Signer,
     HttpxTokenExchanger,
     V1ByokCredentialStore,
+    V1OAuthTokenStore,
 )
 from litellm.proxy.gateway.mcp.outbound_credentials.clock import SystemClock
 from litellm.proxy.gateway.mcp.outbound_credentials.resolver import (
@@ -33,10 +34,7 @@ from litellm.proxy.gateway.mcp.outbound_credentials.resolver import (
 from litellm.proxy.gateway.mcp.outbound_credentials.service_token_store import (
     InMemoryServiceTokenStore,
 )
-from litellm.proxy.gateway.mcp.outbound_credentials.token_store import (
-    InMemoryTokenStore,
-    StoredToken,
-)
+from litellm.proxy.gateway.mcp.outbound_credentials.token_store import StoredToken
 from litellm.proxy.gateway.mcp.outbound_credentials.types import (
     Ambient,
     ApiKeyConfig,
@@ -94,12 +92,13 @@ class _Unwired:
 
 @functools.lru_cache(maxsize=1)
 def _provider() -> UpstreamCredentialProvider:
-    # none + api_key resolve from config alone, so the stores/ports below are inert placeholders;
-    # real bodies get wired in as their modes are grafted.
+    # Real bodies are wired as their modes are grafted. token_refresher stays unwired: the bridge's
+    # V1OAuthTokenStore returns currently-valid tokens (v1 refreshes on read), so the resolver's
+    # proactive-refresh path is inert until v1 retires.
     unwired = _Unwired()
     return UpstreamCredentialProvider(
         credential_store=V1ByokCredentialStore(),
-        token_store=InMemoryTokenStore(),
+        token_store=V1OAuthTokenStore(),
         token_refresher=unwired,
         clock=SystemClock(),
         service_token_store=InMemoryServiceTokenStore(),

--- a/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
+++ b/litellm/proxy/_experimental/mcp_server/v2_resolver_bridge.py
@@ -146,6 +146,19 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
                 key_source=SharedKey(value=SecretStr(token)),
             ),
         )
+    if server.auth_type == MCPAuth.bearer_token:
+        token = server.authentication_token
+        if not token:
+            return None  # bearer_token with no token: let v1 handle it (parity-safe)
+        return ServerSpec(
+            server_id=server.server_id,
+            resource=resource,
+            config=ApiKeyConfig(
+                header_name="Authorization",
+                value_prefix="Bearer",
+                key_source=SharedKey(value=SecretStr(token)),
+            ),
+        )
     if server.auth_type == MCPAuth.aws_sigv4:
         # Reuse the SigV4 config builder; the resolver's aws_sigv4 arm turns it into the botocore
         # signer (an httpx.Auth) that signs each upstream request.

--- a/litellm/proxy/gateway/mcp/outbound_credentials/resolver.py
+++ b/litellm/proxy/gateway/mcp/outbound_credentials/resolver.py
@@ -44,7 +44,6 @@ from .types import (
     CredError,
     NoneConfig,
     PassthroughConfig,
-    PerUserEnvVar,
     ServerSpec,
     SharedKey,
     Subject,
@@ -112,18 +111,6 @@ class UpstreamCredentialProvider:
                 # The shared key is read straight from ServerSpec.config, not the per-user
                 # store; it is the same credential for every caller.
                 return Ok(_api_key_auth(config, source.value.get_secret_value()))
-            case PerUserEnvVar():
-                fetched = await self._per_user_value(subject, server)
-                if isinstance(fetched, Error):
-                    return Error(fetched.error)  # store/DB down -> 503
-                value = fetched.ok
-                if value is None:
-                    return Error(
-                        CredError.of_precondition_required(
-                            "api_key: per-user env var not set for this subject"
-                        )
-                    )
-                return Ok(_api_key_auth(config, value))
             case Byok():
                 fetched = await self._per_user_value(subject, server)
                 if isinstance(fetched, Error):

--- a/litellm/proxy/gateway/mcp/outbound_credentials/types.py
+++ b/litellm/proxy/gateway/mcp/outbound_credentials/types.py
@@ -188,15 +188,6 @@ class SharedKey(BaseModel):
     value: SecretStr
 
 
-class PerUserEnvVar(BaseModel):
-    """A per-user value the admin templated as an env var; the user fills it in. Pulled from
-    the credential store at resolve time. Missing means the user has not completed setup, a
-    precondition (412) rather than an auth failure."""
-
-    model_config = ConfigDict(frozen=True)
-    source: Literal["per_user_env_var"] = "per_user_env_var"
-
-
 class Byok(BaseModel):
     """A key the user brings via the entry flow, stored per-user. Pulled from the credential
     store at resolve time. Missing means the user must provide it, a 401 + WWW-Authenticate
@@ -206,9 +197,7 @@ class Byok(BaseModel):
     source: Literal["byok"] = "byok"
 
 
-ApiKeySource = Annotated[
-    SharedKey | PerUserEnvVar | Byok, Field(discriminator="source")
-]
+ApiKeySource = Annotated[SharedKey | Byok, Field(discriminator="source")]
 
 
 class ApiKeyConfig(BaseModel):

--- a/litellm/proxy/gateway/mcp/outbound_credentials/types.py
+++ b/litellm/proxy/gateway/mcp/outbound_credentials/types.py
@@ -158,9 +158,12 @@ class ClientCredentialsConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
     kind: Literal[AuthSpecKind.client_credentials] = AuthSpecKind.client_credentials
-    client_id: str
-    client_secret: SecretStr
-    token_url: str
+    # Optional so the config can be built incomplete: the values may be supplied at runtime (token_url
+    # via RFC 8414 discovery, client_id/secret via DCR) and the _client_credentials arm raises
+    # CredError.misconfigured when a needed field is still absent at resolve time.
+    client_id: str | None = None
+    client_secret: SecretStr | None = None
+    token_url: str | None = None
     scopes: tuple[str, ...] = ()
 
 

--- a/tests/mcp_tests/gateway/test_resolver.py
+++ b/tests/mcp_tests/gateway/test_resolver.py
@@ -59,7 +59,6 @@ from litellm.proxy.gateway.mcp.outbound_credentials.types import (
     CredError,
     NoneConfig,
     PassthroughConfig,
-    PerUserEnvVar,
     ServerSpec,
     SharedKey,
     StaticKeys,
@@ -295,13 +294,12 @@ def test_secret_fields_are_masked_in_serialization():
     assert config.key_source.value.get_secret_value() == "SUPER-SECRET"
 
 
-@pytest.mark.parametrize("source", [Byok(), PerUserEnvVar()])
-async def test_api_key_per_user_pulls_the_subject_credential(source: object):
+async def test_api_key_byok_pulls_the_subject_credential():
     store = InMemoryCredentialStore(
         {CredentialKey(tenant_id="t1", subject_id="u1", server_id="s1"): "user-secret"}
     )
     provider = _provider(credential_store=store)
-    result = await provider.resolve(SUBJECT, _spec(ApiKeyConfig(key_source=source)))  # type: ignore[arg-type]
+    result = await provider.resolve(SUBJECT, _spec(ApiKeyConfig(key_source=Byok())))
     assert isinstance(result, Ok)
     assert _applied_headers(result.ok)["Authorization"] == "Bearer user-secret"
 
@@ -311,15 +309,6 @@ async def test_api_key_byok_missing_returns_unauthorized():
     result = await PROVIDER.resolve(SUBJECT, _spec(ApiKeyConfig(key_source=Byok())))
     assert isinstance(result, Error)
     assert result.error.tag == "unauthorized"
-
-
-async def test_api_key_env_var_missing_returns_precondition_required():
-    # Missing per-user env var -> 412 (a setup precondition), distinct from BYOK's 401.
-    result = await PROVIDER.resolve(
-        SUBJECT, _spec(ApiKeyConfig(key_source=PerUserEnvVar()))
-    )
-    assert isinstance(result, Error)
-    assert result.error.tag == "precondition_required"
 
 
 async def test_api_key_per_user_isolated_by_subject():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -11,7 +11,7 @@ sys.path.insert(0, "../../../../../")
 from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
-    _extract_upstream_auth_failure,
+    extract_upstream_auth_failure,
 )
 from litellm.proxy._types import MCPTransport
 from litellm.types.mcp import MCPAuth
@@ -26,7 +26,7 @@ def test_extract_upstream_auth_failure_finds_401_in_http_status_error():
     )
     exc = httpx.HTTPStatusError("401", request=response.request, response=response)
 
-    result = _extract_upstream_auth_failure(exc)
+    result = extract_upstream_auth_failure(exc)
     assert result == (401, 'Bearer resource_metadata="https://x"')
 
 
@@ -41,13 +41,13 @@ def test_extract_upstream_auth_failure_walks_exception_group():
     try:
         raise ExceptionGroup("wrapped", [inner])  # noqa: F821 (PEP 654, py3.11+)
     except Exception as group:
-        result = _extract_upstream_auth_failure(group)
+        result = extract_upstream_auth_failure(group)
 
     assert result == (401, "Bearer")
 
 
 def test_extract_upstream_auth_failure_returns_none_for_non_auth():
-    assert _extract_upstream_auth_failure(RuntimeError("boom")) is None
+    assert extract_upstream_auth_failure(RuntimeError("boom")) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -1,0 +1,27 @@
+"""Tests for the v2 egress manager factory + skeleton (step 6a)."""
+
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+    MCPServerManager,
+    _make_global_mcp_server_manager,
+)
+from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
+    MCPServerManagerV2,
+)
+
+FLAG = "LITELLM_USE_V2_MCP_EGRESS"
+
+
+def test_v2_is_a_manager_subclass():
+    assert issubclass(MCPServerManagerV2, MCPServerManager)
+
+
+def test_factory_returns_v2_when_egress_enabled(monkeypatch):
+    monkeypatch.setenv(FLAG, "true")
+    assert isinstance(_make_global_mcp_server_manager(), MCPServerManagerV2)
+
+
+def test_factory_returns_v1_when_egress_disabled(monkeypatch):
+    monkeypatch.delenv(FLAG, raising=False)
+    manager = _make_global_mcp_server_manager()
+    assert isinstance(manager, MCPServerManager)
+    assert not isinstance(manager, MCPServerManagerV2)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -159,3 +159,30 @@ async def test_v2_override_gets_prompt_via_upstream_connection(echo_server_url):
     )
     result = await manager.get_prompt_from_server(server, "greeting", {"name": "Tin"})
     assert result.messages
+
+
+@pytest.mark.asyncio
+async def test_v2_override_calls_tool_via_upstream_connection(echo_server_url):
+    # Tool-call path: the factored _open_and_call_tool seam routes through resolve() +
+    # UpstreamConnection.call_tool (v2) for the none mode, returning the upstream CallToolResult.
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    result = await manager._open_and_call_tool(
+        server,
+        "echo",
+        {"text": "hi"},
+        mcp_auth_header=None,
+        mcp_server_auth_headers=None,
+        oauth2_headers=None,
+        raw_headers=None,
+        hook_extra_headers=None,
+        host_progress_callback=None,
+        user_api_key_auth=None,
+    )
+    assert any("echo: hi" in getattr(c, "text", "") for c in result.content)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -41,6 +41,14 @@ def _serve_echo():
     def echo(text: str) -> str:
         return f"echo: {text}"
 
+    @mcp.prompt()
+    def greeting(name: str) -> str:
+        return f"Hello, {name}"
+
+    @mcp.resource("echo://info")
+    def info() -> str:
+        return "echo server info"
+
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
@@ -88,3 +96,34 @@ async def test_v2_override_lists_tools_via_upstream_connection(echo_server_url):
     )
     tools = await manager._get_tools_from_server(server, add_prefix=True)
     assert any(t.name.endswith("echo") for t in tools)
+
+
+@pytest.mark.asyncio
+async def test_v2_override_lists_prompts_via_upstream_connection(echo_server_url):
+    # The none-mode prompts path goes through resolve() + UpstreamConnection.list_prompts (v2),
+    # namespaced via the inherited _create_prefixed_prompts.
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    prompts = await manager.get_prompts_from_server(server, add_prefix=True)
+    assert any("greeting" in p.name for p in prompts)
+
+
+@pytest.mark.asyncio
+async def test_v2_override_lists_resources_via_upstream_connection(echo_server_url):
+    # The none-mode resources path goes through resolve() + UpstreamConnection.list_resources (v2).
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    resources = await manager.get_resources_from_server(server, add_prefix=True)
+    assert len(resources) >= 1

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -8,20 +8,11 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
     MCPServerManagerV2,
 )
 
-FLAG = "LITELLM_USE_V2_MCP_EGRESS"
-
 
 def test_v2_is_a_manager_subclass():
     assert issubclass(MCPServerManagerV2, MCPServerManager)
 
 
-def test_factory_returns_v2_when_egress_enabled(monkeypatch):
-    monkeypatch.setenv(FLAG, "true")
+def test_factory_constructs_the_v2_manager():
+    # v2 is the egress implementation; there is no opt-in flag.
     assert isinstance(_make_global_mcp_server_manager(), MCPServerManagerV2)
-
-
-def test_factory_returns_v1_when_egress_disabled(monkeypatch):
-    monkeypatch.delenv(FLAG, raising=False)
-    manager = _make_global_mcp_server_manager()
-    assert isinstance(manager, MCPServerManager)
-    assert not isinstance(manager, MCPServerManagerV2)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -1,5 +1,6 @@
 """Tests for the v2 egress manager: factory, skeleton, and the egress override (step 6)."""
 
+import base64
 import contextlib
 import socket
 import threading
@@ -267,3 +268,119 @@ async def test_v2_passthrough_without_token_fails_closed(echo_server_url):
             host_progress_callback=None,
             user_api_key_auth=None,
         )
+
+
+# --- _v2_connection header-assembly + isolation matrix ---
+# Run the full _v2_connection seam per mode and assert the EXACT upstream headers (resolve()'s auth
+# merged with the metadata headers), so a mode can never silently attach a wrong, missing, or extra
+# header, and the caller's credentials never leak where they shouldn't.
+
+
+def _egress_server(**kwargs):
+    return MCPServer(
+        server_id="s",
+        name="s",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        **kwargs,
+    )
+
+
+def _final_headers(conn_ok):
+    # Exact upstream headers = metadata headers + what resolve()'s Auth attaches (auth wins on conflict).
+    # White-box: read the connection's resolved auth + metadata headers directly.
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import _added_headers
+
+    return {**(conn_ok._extra_headers or {}), **_added_headers(conn_ok._auth)}
+
+
+async def _connect(server, **kwargs):
+    from litellm.proxy.gateway.mcp.result import Ok
+
+    manager = MCPServerManagerV2()
+    conn = await manager._v2_connection(
+        server, kwargs.pop("user_api_key_auth", None), **kwargs
+    )
+    assert isinstance(conn, Ok), f"_v2_connection returned {conn!r}"
+    return conn.ok
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"auth_type": MCPAuth.none}, {}),
+        (
+            {"auth_type": MCPAuth.api_key, "authentication_token": "k"},
+            {"X-API-Key": "k"},
+        ),
+        (
+            {"auth_type": MCPAuth.bearer_token, "authentication_token": "k"},
+            {"Authorization": "Bearer k"},
+        ),
+        (
+            {"auth_type": MCPAuth.authorization, "authentication_token": "Raw v"},
+            {"Authorization": "Raw v"},
+        ),
+        (
+            {"auth_type": MCPAuth.token, "authentication_token": "k"},
+            {"Authorization": "token k"},
+        ),
+        (
+            {"auth_type": MCPAuth.basic, "authentication_token": "u:p"},
+            {"Authorization": f"Basic {base64.b64encode(b'u:p').decode()}"},
+        ),
+    ],
+)
+async def test_v2_connection_builds_exact_headers_per_mode(kwargs, expected):
+    conn = await _connect(_egress_server(**kwargs))
+    assert _final_headers(conn) == expected  # exact match -> no missing/extra headers
+
+
+@pytest.mark.asyncio
+async def test_v2_connection_passthrough_forwards_only_the_inbound_token():
+    conn = await _connect(
+        _passthrough_server("https://up.example/mcp"), subject_token="caller-tok"
+    )
+    assert _final_headers(conn) == {"Authorization": "Bearer caller-tok"}
+
+
+@pytest.mark.asyncio
+async def test_v2_connection_merges_static_headers_without_extras():
+    conn = await _connect(
+        _egress_server(
+            auth_type=MCPAuth.api_key,
+            authentication_token="k",
+            static_headers={"X-Custom": "v"},
+        )
+    )
+    assert _final_headers(conn) == {"X-API-Key": "k", "X-Custom": "v"}
+
+
+@pytest.mark.asyncio
+async def test_v2_connection_strips_caller_authorization_but_forwards_configured_headers():
+    # The server forwards [Authorization, X-Tenant]; Authorization is the gateway credential and must
+    # be stripped, X-Tenant forwarded, and the upstream credential comes from resolve().
+    conn = await _connect(
+        _egress_server(
+            auth_type=MCPAuth.api_key,
+            authentication_token="k",
+            extra_headers=["Authorization", "X-Tenant"],
+        ),
+        raw_headers={"Authorization": "Bearer GATEWAY-CRED", "X-Tenant": "t1"},
+        forward_caller_headers=True,
+    )
+    assert _final_headers(conn) == {"X-API-Key": "k", "X-Tenant": "t1"}
+
+
+@pytest.mark.asyncio
+async def test_v2_connection_does_not_leak_inbound_token_into_non_obo_modes():
+    # The inbound token is always put on the Subject, but a non-OBO mode (api_key) ignores it: the
+    # headers carry only the configured credential, never the caller's token (credential isolation).
+    conn = await _connect(
+        _egress_server(auth_type=MCPAuth.api_key, authentication_token="k"),
+        subject_token="LEAK-ME",
+    )
+    headers = _final_headers(conn)
+    assert headers == {"X-API-Key": "k"}
+    assert "LEAK-ME" not in str(headers)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -127,3 +127,35 @@ async def test_v2_override_lists_resources_via_upstream_connection(echo_server_u
     )
     resources = await manager.get_resources_from_server(server, add_prefix=True)
     assert len(resources) >= 1
+
+
+@pytest.mark.asyncio
+async def test_v2_override_reads_resource_via_upstream_connection(echo_server_url):
+    # Single-result read path: resolve() + UpstreamConnection.read_resource (v2), raises on failure.
+    from pydantic import AnyUrl
+
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    result = await manager.read_resource_from_server(server, AnyUrl("echo://info"))
+    assert result.contents
+
+
+@pytest.mark.asyncio
+async def test_v2_override_gets_prompt_via_upstream_connection(echo_server_url):
+    # Single-result prompt path: resolve() + UpstreamConnection.get_prompt (v2), raises on failure.
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    result = await manager.get_prompt_from_server(server, "greeting", {"name": "Tin"})
+    assert result.messages

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -49,6 +49,10 @@ def _serve_echo():
     def info() -> str:
         return "echo server info"
 
+    @mcp.resource("echo://item/{item_id}")
+    def item(item_id: str) -> str:
+        return f"item {item_id}"
+
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
@@ -127,6 +131,26 @@ async def test_v2_override_lists_resources_via_upstream_connection(echo_server_u
     )
     resources = await manager.get_resources_from_server(server, add_prefix=True)
     assert len(resources) >= 1
+
+
+@pytest.mark.asyncio
+async def test_v2_override_lists_resource_templates_via_upstream_connection(
+    echo_server_url,
+):
+    # resources/templates/list path: resolve() + UpstreamConnection.list_resource_templates (v2),
+    # namespaced via the inherited _create_prefixed_resource_templates.
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    templates = await manager.get_resource_templates_from_server(
+        server, add_prefix=True
+    )
+    assert len(templates) >= 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -210,3 +210,60 @@ async def test_v2_override_calls_tool_via_upstream_connection(echo_server_url):
         user_api_key_auth=None,
     )
     assert any("echo: hi" in getattr(c, "text", "") for c in result.content)
+
+
+def _passthrough_server(url):
+    return MCPServer(
+        server_id="pt",
+        name="pt",
+        transport=MCPTransport.http,
+        url=url,
+        auth_type=MCPAuth.oauth2,
+        delegate_auth_to_upstream=True,
+        client_id="cid",
+        authorization_url="https://idp/auth",
+        token_url="https://idp/token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_v2_passthrough_forwards_inbound_token(echo_server_url):
+    # Passthrough: the caller token is extracted and threaded as inbound_token, so the v2 call
+    # reaches the upstream (the no-auth echo server ignores the forwarded bearer and serves it).
+    manager = MCPServerManagerV2()
+    result = await manager._open_and_call_tool(
+        _passthrough_server(echo_server_url),
+        "echo",
+        {"text": "hi"},
+        mcp_auth_header=None,
+        mcp_server_auth_headers=None,
+        oauth2_headers={"Authorization": "Bearer caller-token"},
+        raw_headers=None,
+        hook_extra_headers=None,
+        host_progress_callback=None,
+        user_api_key_auth=None,
+    )
+    assert any("echo: hi" in getattr(c, "text", "") for c in result.content)
+
+
+@pytest.mark.asyncio
+async def test_v2_passthrough_without_token_fails_closed(echo_server_url):
+    # No caller token -> inbound_token is None -> the passthrough arm fails closed (401), surfaced
+    # as MCPUpstreamAuthError. Before the inbound-token plumbing, the token was never threaded
+    # through, so every passthrough call hit this path.
+    from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+
+    manager = MCPServerManagerV2()
+    with pytest.raises(MCPUpstreamAuthError):
+        await manager._open_and_call_tool(
+            _passthrough_server(echo_server_url),
+            "echo",
+            {"text": "hi"},
+            mcp_auth_header=None,
+            mcp_server_auth_headers=None,
+            oauth2_headers=None,
+            raw_headers=None,
+            hook_extra_headers=None,
+            host_progress_callback=None,
+            user_api_key_auth=None,
+        )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager_v2.py
@@ -1,4 +1,13 @@
-"""Tests for the v2 egress manager factory + skeleton (step 6a)."""
+"""Tests for the v2 egress manager: factory, skeleton, and the egress override (step 6)."""
+
+import contextlib
+import socket
+import threading
+import time
+
+import httpx
+import pytest
+import uvicorn
 
 from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
     MCPServerManager,
@@ -7,6 +16,9 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
 from litellm.proxy._experimental.mcp_server.mcp_server_manager_v2 import (
     MCPServerManagerV2,
 )
+from litellm.proxy._types import MCPTransport
+from litellm.types.mcp import MCPAuth
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
 
 def test_v2_is_a_manager_subclass():
@@ -16,3 +28,63 @@ def test_v2_is_a_manager_subclass():
 def test_factory_constructs_the_v2_manager():
     # v2 is the egress implementation; there is no opt-in flag.
     assert isinstance(_make_global_mcp_server_manager(), MCPServerManagerV2)
+
+
+@contextlib.contextmanager
+def _serve_echo():
+    """A no-auth streamable-http FastMCP server with one `echo` tool, in a background thread."""
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("mgr-echo-test", stateless_http=True)
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return f"echo: {text}"
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    url = f"http://127.0.0.1:{port}/mcp"
+    server = uvicorn.Server(
+        uvicorn.Config(
+            mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="error"
+        )
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(100):
+        try:
+            httpx.get(url, timeout=0.3)
+            break
+        except httpx.ConnectError:
+            time.sleep(0.05)
+        except Exception:
+            break
+    try:
+        yield url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+@pytest.fixture
+def echo_server_url():
+    with _serve_echo() as url:
+        yield url
+
+
+@pytest.mark.asyncio
+async def test_v2_override_lists_tools_via_upstream_connection(echo_server_url):
+    # The `none`-mode list path goes through resolve() + UpstreamConnection (v2), and the tools come
+    # back namespaced via the inherited _create_prefixed_tools.
+    manager = MCPServerManagerV2()
+    server = MCPServer(
+        server_id="echo1",
+        name="echo1",
+        transport=MCPTransport.http,
+        url=echo_server_url,
+        auth_type=MCPAuth.none,
+    )
+    tools = await manager._get_tools_from_server(server, add_prefix=True)
+    assert any(t.name.endswith("echo") for t in tools)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -1,5 +1,6 @@
 """Tests for the v2 MCP egress transport: the flag and the UpstreamConnection."""
 
+import contextlib
 import socket
 import threading
 import time
@@ -30,27 +31,16 @@ def test_egress_flag_falsey_values(monkeypatch, value):
     assert v2_egress_enabled() is False
 
 
-@pytest.fixture
-def echo_server_url():
-    """A no-auth streamable-http FastMCP server with one `echo` tool, in a background thread."""
-    from mcp.server.fastmcp import FastMCP
-
-    mcp = FastMCP("egress-echo-test", stateless_http=True)
-
-    @mcp.tool()
-    def echo(text: str) -> str:
-        return f"echo: {text}"
-
+@contextlib.contextmanager
+def _serve(app):
+    """Serve an ASGI app on a free port in a background thread; yield its /mcp url."""
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
     sock.close()
     url = f"http://127.0.0.1:{port}/mcp"
-
     server = uvicorn.Server(
-        uvicorn.Config(
-            mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="error"
-        )
+        uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
     )
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -67,6 +57,44 @@ def echo_server_url():
     finally:
         server.should_exit = True
         thread.join(timeout=5)
+
+
+def _echo_app(token=None):
+    """A stateless streamable-http FastMCP app with one `echo` tool, optionally Bearer-gated."""
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("egress-test", stateless_http=True)
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return f"echo: {text}"
+
+    app = mcp.streamable_http_app()
+    if token is not None:
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
+
+        class _BearerCheck(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                authorized = request.headers.get("authorization") == f"Bearer {token}"
+                if request.url.path.startswith("/mcp") and not authorized:
+                    return JSONResponse({"error": "unauthorized"}, status_code=401)
+                return await call_next(request)
+
+        app.add_middleware(_BearerCheck)
+    return app
+
+
+@pytest.fixture
+def echo_server_url():
+    with _serve(_echo_app()) as url:
+        yield url
+
+
+@pytest.fixture
+def protected_server_url():
+    with _serve(_echo_app(token="secret-token")) as url:
+        yield url, "secret-token"
 
 
 @pytest.mark.asyncio
@@ -95,3 +123,25 @@ async def test_upstream_connection_unreachable_is_upstream_unavailable():
     result = await conn.list_tools()
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_401_is_unauthorized(protected_server_url):
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy.gateway.mcp.outbound_credentials.httpx_auth import (
+        NoOpAuth,
+        StaticHeaderAuth,
+    )
+    from litellm.proxy.gateway.mcp.result import Error, Ok
+
+    url, token = protected_server_url
+
+    rejected = await UpstreamConnection(url, auth=NoOpAuth()).list_tools()
+    assert isinstance(rejected, Error)
+    assert rejected.error.tag == "unauthorized"
+
+    authed = await UpstreamConnection(
+        url, auth=StaticHeaderAuth(f"Bearer {token}")
+    ).list_tools()
+    assert isinstance(authed, Ok)
+    assert any(t.name == "echo" for t in authed.ok)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -1,4 +1,4 @@
-"""Tests for the v2 MCP egress transport: the flag and the UpstreamConnection."""
+"""Tests for the v2 MCP egress transport (UpstreamConnection)."""
 
 import contextlib
 import socket
@@ -9,27 +9,6 @@ import time
 import httpx
 import pytest
 import uvicorn
-
-from litellm.proxy._experimental.mcp_server.v2_egress import v2_egress_enabled
-
-FLAG = "LITELLM_USE_V2_MCP_EGRESS"
-
-
-def test_egress_flag_off_by_default(monkeypatch):
-    monkeypatch.delenv(FLAG, raising=False)
-    assert v2_egress_enabled() is False
-
-
-@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on"])
-def test_egress_flag_truthy_values(monkeypatch, value):
-    monkeypatch.setenv(FLAG, value)
-    assert v2_egress_enabled() is True
-
-
-@pytest.mark.parametrize("value", ["0", "false", "no", "", "  "])
-def test_egress_flag_falsey_values(monkeypatch, value):
-    monkeypatch.setenv(FLAG, value)
-    assert v2_egress_enabled() is False
 
 
 @contextlib.contextmanager

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import socket
+import sys
 import threading
 import time
 
@@ -32,13 +33,13 @@ def test_egress_flag_falsey_values(monkeypatch, value):
 
 
 @contextlib.contextmanager
-def _serve(app):
-    """Serve an ASGI app on a free port in a background thread; yield its /mcp url."""
+def _serve(app, path="/mcp"):
+    """Serve an ASGI app on a free port in a background thread; yield its endpoint url."""
     sock = socket.socket()
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
     sock.close()
-    url = f"http://127.0.0.1:{port}/mcp"
+    url = f"http://127.0.0.1:{port}{path}"
     server = uvicorn.Server(
         uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
     )
@@ -103,6 +104,20 @@ def echo_server_url():
 def protected_server_url():
     with _serve(_echo_app(token="secret-token")) as url:
         yield url, "secret-token"
+
+
+@pytest.fixture
+def sse_server_url():
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("egress-sse-test")
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return f"echo: {text}"
+
+    with _serve(mcp.sse_app(), path="/sse") as url:
+        yield url
 
 
 @pytest.mark.asyncio
@@ -178,3 +193,41 @@ async def test_upstream_connection_prompts_and_resources(echo_server_url):
     read = await conn.read_resource(target.uri)
     assert isinstance(read, Ok)
     assert read.ok.contents  # at least one content block
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_stdio(tmp_path):
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy._types import MCPTransport
+    from litellm.proxy.gateway.mcp.result import Ok
+
+    script = tmp_path / "stdio_server.py"
+    script.write_text(
+        "from mcp.server.fastmcp import FastMCP\n"
+        "mcp = FastMCP('stdio-test')\n"
+        "@mcp.tool()\n"
+        "def ping() -> str:\n"
+        "    return 'pong'\n"
+        "mcp.run(transport='stdio')\n"
+    )
+    conn = UpstreamConnection(
+        transport=MCPTransport.stdio, command=sys.executable, args=[str(script)]
+    )
+    tools = await conn.list_tools()
+    assert isinstance(tools, Ok)
+    assert any(t.name == "ping" for t in tools.ok)
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_sse(sse_server_url):
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy._types import MCPTransport
+    from litellm.proxy.gateway.mcp.outbound_credentials.httpx_auth import NoOpAuth
+    from litellm.proxy.gateway.mcp.result import Ok
+
+    conn = UpstreamConnection(
+        sse_server_url, transport=MCPTransport.sse, auth=NoOpAuth()
+    )
+    tools = await conn.list_tools()
+    assert isinstance(tools, Ok)
+    assert any(t.name == "echo" for t in tools.ok)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -1,0 +1,24 @@
+"""Tests for the v2 MCP egress transport scaffolding (the flag)."""
+
+import pytest
+
+from litellm.proxy._experimental.mcp_server.v2_egress import v2_egress_enabled
+
+FLAG = "LITELLM_USE_V2_MCP_EGRESS"
+
+
+def test_egress_flag_off_by_default(monkeypatch):
+    monkeypatch.delenv(FLAG, raising=False)
+    assert v2_egress_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on"])
+def test_egress_flag_truthy_values(monkeypatch, value):
+    monkeypatch.setenv(FLAG, value)
+    assert v2_egress_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "", "  "])
+def test_egress_flag_falsey_values(monkeypatch, value):
+    monkeypatch.setenv(FLAG, value)
+    assert v2_egress_enabled() is False

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -69,6 +69,14 @@ def _echo_app(token=None):
     def echo(text: str) -> str:
         return f"echo: {text}"
 
+    @mcp.prompt()
+    def greet(name: str) -> str:
+        return f"Hello {name}"
+
+    @mcp.resource("data://info")
+    def info() -> str:
+        return "resource-info"
+
     app = mcp.streamable_http_app()
     if token is not None:
         from starlette.middleware.base import BaseHTTPMiddleware
@@ -145,3 +153,28 @@ async def test_upstream_connection_401_is_unauthorized(protected_server_url):
     ).list_tools()
     assert isinstance(authed, Ok)
     assert any(t.name == "echo" for t in authed.ok)
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_prompts_and_resources(echo_server_url):
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy.gateway.mcp.outbound_credentials.httpx_auth import NoOpAuth
+    from litellm.proxy.gateway.mcp.result import Ok
+
+    conn = UpstreamConnection(echo_server_url, auth=NoOpAuth())
+
+    prompts = await conn.list_prompts()
+    assert isinstance(prompts, Ok)
+    assert any(p.name == "greet" for p in prompts.ok)
+
+    got = await conn.get_prompt("greet", {"name": "Ada"})
+    assert isinstance(got, Ok)
+    assert got.ok.messages  # the rendered prompt has at least one message
+
+    resources = await conn.list_resources()
+    assert isinstance(resources, Ok)
+    target = next(r for r in resources.ok if str(r.uri) == "data://info")
+
+    read = await conn.read_resource(target.uri)
+    assert isinstance(read, Ok)
+    assert read.ok.contents  # at least one content block

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_egress.py
@@ -1,6 +1,12 @@
-"""Tests for the v2 MCP egress transport scaffolding (the flag)."""
+"""Tests for the v2 MCP egress transport: the flag and the UpstreamConnection."""
 
+import socket
+import threading
+import time
+
+import httpx
 import pytest
+import uvicorn
 
 from litellm.proxy._experimental.mcp_server.v2_egress import v2_egress_enabled
 
@@ -22,3 +28,70 @@ def test_egress_flag_truthy_values(monkeypatch, value):
 def test_egress_flag_falsey_values(monkeypatch, value):
     monkeypatch.setenv(FLAG, value)
     assert v2_egress_enabled() is False
+
+
+@pytest.fixture
+def echo_server_url():
+    """A no-auth streamable-http FastMCP server with one `echo` tool, in a background thread."""
+    from mcp.server.fastmcp import FastMCP
+
+    mcp = FastMCP("egress-echo-test", stateless_http=True)
+
+    @mcp.tool()
+    def echo(text: str) -> str:
+        return f"echo: {text}"
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    server = uvicorn.Server(
+        uvicorn.Config(
+            mcp.streamable_http_app(), host="127.0.0.1", port=port, log_level="error"
+        )
+    )
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(100):  # wait until the app responds (any HTTP status means it is up)
+        try:
+            httpx.get(url, timeout=0.3)
+            break
+        except httpx.ConnectError:
+            time.sleep(0.05)
+        except Exception:
+            break
+    try:
+        yield url
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_lists_and_calls(echo_server_url):
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy.gateway.mcp.outbound_credentials.httpx_auth import NoOpAuth
+    from litellm.proxy.gateway.mcp.result import Ok
+
+    conn = UpstreamConnection(echo_server_url, auth=NoOpAuth())
+
+    tools = await conn.list_tools()
+    assert isinstance(tools, Ok)
+    assert any(t.name == "echo" for t in tools.ok)
+
+    called = await conn.call_tool("echo", {"text": "hi"})
+    assert isinstance(called, Ok)
+    assert called.ok.isError is False
+
+
+@pytest.mark.asyncio
+async def test_upstream_connection_unreachable_is_upstream_unavailable():
+    from litellm.proxy._experimental.mcp_server.v2_egress import UpstreamConnection
+    from litellm.proxy.gateway.mcp.result import Error
+
+    conn = UpstreamConnection("http://127.0.0.1:1/mcp", timeout=3.0)
+    result = await conn.list_tools()
+    assert isinstance(result, Error)
+    assert result.error.tag == "upstream_unavailable"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_port_bodies.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_port_bodies.py
@@ -13,11 +13,13 @@ from litellm.proxy._experimental.mcp_server.v2_port_bodies import (
     HttpxSigV4Signer,
     HttpxTokenExchanger,
     V1ByokCredentialStore,
+    V1OAuthTokenStore,
     _classify_sigv4_error,
 )
 from litellm.proxy.gateway.mcp.outbound_credentials.credential_store import (
     CredentialKey,
 )
+from litellm.proxy.gateway.mcp.outbound_credentials.token_store import TokenKey
 from litellm.proxy.gateway.mcp.outbound_credentials.types import (
     AwsSigV4Config,
     ClientCredentialsConfig,
@@ -207,6 +209,64 @@ async def test_byok_store_db_error_is_upstream_unavailable():
         raise RuntimeError("db down")
 
     result = await V1ByokCredentialStore(reader=reader).get(_cred_key())
+    assert isinstance(result, Error)
+    assert result.error.tag == "upstream_unavailable"
+
+
+def _token_key(subject_id="u1", server_id="s1"):
+    return TokenKey(
+        tenant_id="org1",
+        subject_id=subject_id,
+        server_id=server_id,
+        resource="https://up.example/mcp",
+    )
+
+
+async def test_oauth_store_returns_valid_token():
+    async def reader(subject_id, server_id):
+        assert (subject_id, server_id) == ("u1", "s1")
+        return {"type": "oauth2", "access_token": "valid-access", "refresh_token": "r"}
+
+    result = await V1OAuthTokenStore(reader=reader).get(_token_key())
+    assert isinstance(result, Ok)
+    assert result.ok is not None
+    assert result.ok.access_token.get_secret_value() == "valid-access"
+    # v1 owns refresh, so v2's refresh path is kept inert: no refresh_token, expiry beyond the buffer
+    assert result.ok.refresh_token is None
+
+
+async def test_oauth_store_missing_token_is_ok_none():
+    async def reader(subject_id, server_id):
+        return None
+
+    result = await V1OAuthTokenStore(reader=reader).get(_token_key())
+    assert isinstance(result, Ok)
+    assert result.ok is None
+
+
+async def test_oauth_store_payload_without_access_token_is_ok_none():
+    async def reader(subject_id, server_id):
+        return {"type": "oauth2"}  # no access_token -> drives the OAuth dance
+
+    result = await V1OAuthTokenStore(reader=reader).get(_token_key())
+    assert isinstance(result, Ok)
+    assert result.ok is None
+
+
+async def test_oauth_store_empty_subject_skips_the_store():
+    async def reader(subject_id, server_id):
+        raise AssertionError("store must not be queried for an empty subject")
+
+    result = await V1OAuthTokenStore(reader=reader).get(_token_key(subject_id=""))
+    assert isinstance(result, Ok)
+    assert result.ok is None
+
+
+async def test_oauth_store_db_error_is_upstream_unavailable():
+    async def reader(subject_id, server_id):
+        raise RuntimeError("db down")
+
+    result = await V1OAuthTokenStore(reader=reader).get(_token_key())
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -150,6 +150,33 @@ async def test_client_credentials_maps_to_config():
     assert spec.config.scopes == ("a", "b")
 
 
+async def test_m2m_incomplete_creds_resolves_misconfigured():
+    # A client_credentials server missing client_id/secret now BUILDS a spec (the completeness
+    # pre-check was dropped) and resolve() raises misconfigured at the arm, instead of to_server_spec
+    # returning None and deferring to v1.
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+        provider,
+        to_server_spec,
+        to_subject,
+    )
+    from litellm.proxy.gateway.mcp.result import Error
+
+    server = MCPServer(
+        server_id="m2m-incomplete",
+        name="m2m-incomplete",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.oauth2,
+        oauth2_flow="client_credentials",
+        token_url="https://idp/token",
+    )  # has_client_credentials, but no client_id / client_secret
+    spec = to_server_spec(server)
+    assert spec is not None  # builds incomplete now (was None -> defer to v1 before)
+    result = await provider().resolve(to_subject(None, None), spec)
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+
+
 async def test_client_credentials_graft_end_to_end(v2_on, monkeypatch):
     # M2M flows through the real fetcher; mock the IdP token endpoint and assert the Bearer.
     from litellm.proxy._experimental.mcp_server import v2_port_bodies

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -413,3 +413,28 @@ async def test_none_without_passthrough_maps_to_none():
     spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, NoneConfig)
+
+
+async def test_aws_sigv4_server_maps_to_config():
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import to_server_spec
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import (
+        AwsSigV4Config,
+        StaticKeys,
+    )
+
+    server = MCPServer(
+        server_id="sig1",
+        name="sig1",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.aws_sigv4,
+        aws_access_key_id="AKIA",
+        aws_secret_access_key="secret",
+        aws_region_name="us-west-2",
+        aws_service_name="bedrock-agentcore",
+    )
+    spec = to_server_spec(server)
+    assert spec is not None
+    assert isinstance(spec.config, AwsSigV4Config)
+    assert isinstance(spec.config.credentials, StaticKeys)
+    assert spec.config.region == "us-west-2"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -5,6 +5,8 @@ headers must be byte-identical to what v1 produces, and every other mode (or any
 fall back to v1 unchanged.
 """
 
+import base64
+
 import httpx
 import pytest
 
@@ -71,20 +73,34 @@ async def test_none_attaches_no_auth(v2_on):
     assert _v1_headers(MCPAuth.none, None) == _v1_headers(MCPAuth.none, v2_value) == {}
 
 
-async def test_non_grafted_mode_defers_to_v1(v2_on):
-    # basic is not grafted yet -> v2 returns None so v1 handles it
-    assert await resolve_v2_auth_value(_server(MCPAuth.basic, "k")) is None
-
-
-async def test_bearer_token_parity(v2_on):
-    token = "up-secret"
-    server = _server(MCPAuth.bearer_token, token)
+@pytest.mark.parametrize(
+    "auth_type,token,expected",
+    [
+        (MCPAuth.bearer_token, "up-secret", {"Authorization": "Bearer up-secret"}),
+        (MCPAuth.token, "up-secret", {"Authorization": "token up-secret"}),
+        (
+            MCPAuth.authorization,
+            "Custom raw-value",
+            {"Authorization": "Custom raw-value"},
+        ),
+        (
+            MCPAuth.basic,
+            "user:pass",
+            {"Authorization": f"Basic {base64.b64encode(b'user:pass').decode()}"},
+        ),
+    ],
+)
+async def test_static_authorization_modes_parity(v2_on, auth_type, token, expected):
+    server = _server(auth_type, token)
     v2_value = await resolve_v2_auth_value(server)
-    assert v2_value == {"Authorization": f"Bearer {token}"}
+    assert v2_value == expected
     # byte-identical to v1's final upstream headers
-    assert _v1_headers(MCPAuth.bearer_token, token) == _v1_headers(
-        MCPAuth.bearer_token, v2_value
-    )
+    assert _v1_headers(auth_type, token) == _v1_headers(auth_type, v2_value) == expected
+
+
+async def test_static_auth_without_token_defers_to_v1(v2_on):
+    # A static Authorization mode with no configured token defers to v1 (parity-safe).
+    assert await resolve_v2_auth_value(_server(MCPAuth.bearer_token, None)) is None
 
 
 async def test_api_key_without_token_defers_to_v1(v2_on):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -324,3 +324,92 @@ async def test_token_exchange_server_maps_to_config():
     assert spec.config.client_secret.get_secret_value() == "csecret"
     assert spec.config.scopes == ("a", "b")
     assert spec.resource == "https://aud.example"  # audience preferred for the binding
+
+
+async def test_interactive_oauth2_no_delegate_maps_to_authorization_code():
+    # LIT-3795: a non-delegated interactive oauth2 server resolves to authorization_code
+    # (gateway-stored per-user token), so the caller JWT is never forwarded upstream.
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+        _to_server_spec,
+    )
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import (
+        AuthorizationCodeConfig,
+    )
+
+    server = MCPServer(
+        server_id="oa1",
+        name="oa1",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.oauth2,
+        oauth2_flow="authorization_code",
+        delegate_auth_to_upstream=False,
+        client_id="cid",
+        client_secret="csecret",
+        authorization_url="https://idp/authorize",
+        token_url="https://idp/token",
+        scopes=["openid"],
+    )
+    spec = _to_server_spec(server)
+    assert spec is not None
+    assert isinstance(spec.config, AuthorizationCodeConfig)
+    assert spec.config.token_url == "https://idp/token"
+    assert spec.config.client_id == "cid"
+
+
+async def test_interactive_oauth2_delegate_maps_to_passthrough():
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+        _to_server_spec,
+    )
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import PassthroughConfig
+
+    server = MCPServer(
+        server_id="oa2",
+        name="oa2",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.oauth2,
+        oauth2_flow="authorization_code",
+        delegate_auth_to_upstream=True,
+    )
+    spec = _to_server_spec(server)
+    assert spec is not None
+    assert isinstance(spec.config, PassthroughConfig)
+
+
+async def test_none_oauth_passthrough_maps_to_passthrough():
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+        _to_server_spec,
+    )
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import PassthroughConfig
+
+    server = MCPServer(
+        server_id="pt1",
+        name="pt1",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.none,
+        oauth_passthrough=True,
+        extra_headers=["Authorization"],
+    )
+    spec = _to_server_spec(server)
+    assert spec is not None
+    assert isinstance(spec.config, PassthroughConfig)
+
+
+async def test_none_without_passthrough_maps_to_none():
+    from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
+        _to_server_spec,
+    )
+    from litellm.proxy.gateway.mcp.outbound_credentials.types import NoneConfig
+
+    server = MCPServer(
+        server_id="n1",
+        name="n1",
+        transport=MCPTransport.http,
+        url="https://up.example/mcp",
+        auth_type=MCPAuth.none,
+    )
+    spec = _to_server_spec(server)
+    assert spec is not None
+    assert isinstance(spec.config, NoneConfig)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -11,7 +11,7 @@ import pytest
 from litellm.experimental_mcp_client.client import MCPClient
 from litellm.proxy._experimental.mcp_server.oauth2_token_cache import resolve_mcp_auth
 from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-    _to_subject,
+    to_subject,
     resolve_v2_auth_value,
     resolve_v2_aws_auth,
 )
@@ -108,13 +108,13 @@ def _m2m_server():
 
 async def test_client_credentials_maps_to_config():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import (
         ClientCredentialsConfig,
     )
 
-    spec = _to_server_spec(_m2m_server())
+    spec = to_server_spec(_m2m_server())
     assert spec is not None
     assert isinstance(spec.config, ClientCredentialsConfig)
     assert spec.config.client_id == "cid"
@@ -244,7 +244,7 @@ async def test_aws_sigv4_config_defaults_to_ambient(v2_on):
 
 async def test_to_subject_maps_v1_identity():
     auth = UserAPIKeyAuth(token="sk-test", user_id="u1", org_id="org1", team_id="t1")
-    subj = _to_subject(auth, "inbound-jwt")
+    subj = to_subject(auth, "inbound-jwt")
     assert subj.subject_id == "u1"
     assert subj.tenant_id == "org1"  # org preferred over team
     assert subj.inbound_token is not None
@@ -252,7 +252,7 @@ async def test_to_subject_maps_v1_identity():
 
 
 async def test_to_subject_anonymous_when_no_auth():
-    subj = _to_subject(None, None)
+    subj = to_subject(None, None)
     assert subj.subject_id == ""
     assert subj.tenant_id == ""
     assert subj.inbound_token is None
@@ -260,7 +260,7 @@ async def test_to_subject_anonymous_when_no_auth():
 
 async def test_to_subject_falls_back_to_team_and_blanks_missing_user():
     auth = UserAPIKeyAuth(token="sk-test", team_id="team-x")
-    subj = _to_subject(auth, None)
+    subj = to_subject(auth, None)
     assert subj.tenant_id == "team-x"  # no org -> team
     assert (
         subj.subject_id == ""
@@ -278,7 +278,7 @@ async def test_resolve_v2_auth_value_threads_identity_without_breaking_static(v2
 
 async def test_byok_server_maps_to_byok_key_source():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import ApiKeyConfig, Byok
 
@@ -290,7 +290,7 @@ async def test_byok_server_maps_to_byok_key_source():
         auth_type=MCPAuth.api_key,
         is_byok=True,
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, ApiKeyConfig)
     assert isinstance(spec.config.key_source, Byok)
@@ -299,7 +299,7 @@ async def test_byok_server_maps_to_byok_key_source():
 
 async def test_token_exchange_server_maps_to_config():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import TokenExchangeConfig
 
@@ -315,7 +315,7 @@ async def test_token_exchange_server_maps_to_config():
         audience="https://aud.example",
         scopes=["a", "b"],
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, TokenExchangeConfig)
     assert spec.config.token_exchange_endpoint == "https://idp/exchange"
@@ -330,7 +330,7 @@ async def test_interactive_oauth2_no_delegate_maps_to_authorization_code():
     # LIT-3795: a non-delegated interactive oauth2 server resolves to authorization_code
     # (gateway-stored per-user token), so the caller JWT is never forwarded upstream.
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import (
         AuthorizationCodeConfig,
@@ -350,7 +350,7 @@ async def test_interactive_oauth2_no_delegate_maps_to_authorization_code():
         token_url="https://idp/token",
         scopes=["openid"],
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, AuthorizationCodeConfig)
     assert spec.config.token_url == "https://idp/token"
@@ -359,7 +359,7 @@ async def test_interactive_oauth2_no_delegate_maps_to_authorization_code():
 
 async def test_interactive_oauth2_delegate_maps_to_passthrough():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import PassthroughConfig
 
@@ -372,14 +372,14 @@ async def test_interactive_oauth2_delegate_maps_to_passthrough():
         oauth2_flow="authorization_code",
         delegate_auth_to_upstream=True,
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, PassthroughConfig)
 
 
 async def test_none_oauth_passthrough_maps_to_passthrough():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import PassthroughConfig
 
@@ -392,14 +392,14 @@ async def test_none_oauth_passthrough_maps_to_passthrough():
         oauth_passthrough=True,
         extra_headers=["Authorization"],
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, PassthroughConfig)
 
 
 async def test_none_without_passthrough_maps_to_none():
     from litellm.proxy._experimental.mcp_server.v2_resolver_bridge import (
-        _to_server_spec,
+        to_server_spec,
     )
     from litellm.proxy.gateway.mcp.outbound_credentials.types import NoneConfig
 
@@ -410,6 +410,6 @@ async def test_none_without_passthrough_maps_to_none():
         url="https://up.example/mcp",
         auth_type=MCPAuth.none,
     )
-    spec = _to_server_spec(server)
+    spec = to_server_spec(server)
     assert spec is not None
     assert isinstance(spec.config, NoneConfig)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_v2_resolver_bridge.py
@@ -72,8 +72,19 @@ async def test_none_attaches_no_auth(v2_on):
 
 
 async def test_non_grafted_mode_defers_to_v1(v2_on):
-    # bearer_token is not grafted yet -> v2 returns None so v1 handles it
-    assert await resolve_v2_auth_value(_server(MCPAuth.bearer_token, "k")) is None
+    # basic is not grafted yet -> v2 returns None so v1 handles it
+    assert await resolve_v2_auth_value(_server(MCPAuth.basic, "k")) is None
+
+
+async def test_bearer_token_parity(v2_on):
+    token = "up-secret"
+    server = _server(MCPAuth.bearer_token, token)
+    v2_value = await resolve_v2_auth_value(server)
+    assert v2_value == {"Authorization": f"Bearer {token}"}
+    # byte-identical to v1's final upstream headers
+    assert _v1_headers(MCPAuth.bearer_token, token) == _v1_headers(
+        MCPAuth.bearer_token, v2_value
+    )
 
 
 async def test_api_key_without_token_defers_to_v1(v2_on):


### PR DESCRIPTION
## Relevant issues

Part of the MCP Gateway v2 migration. Builds the v2-owned egress transport (the chokepoint) on top of the credential resolver landed in #30698.

## Linear ticket

LIT-3851 (related; the explicit-auth-mode storage cleanup is tracked there separately)

## Pre-Submission checklist

- [ ] Meaningful tests (each step ships its own unit tests)

## Type

New Feature

## Changes

Stacked on #30698 (base `litellm_mcp_week1_stability`) so this PR's diff shows only the egress-transport work, not the credential resolver already under review.

This phase makes v2 own the upstream MCP connection: an `UpstreamConnection` opens the SDK client and attaches `resolve()`'s `httpx.Auth` plus resolved static/env-var headers directly, replacing v1's `_create_mcp_client` and the `resolve_mcp_auth` header graft. It reuses the v2 `resolve()` arms and port bodies from #30698; it does not undo them.

Build plan (incremental; additive until the cutover):

1. Flag + egress contract (this commit) - `LITELLM_USE_V2_MCP_EGRESS`, `MCPEgressManager` Protocol mirroring the existing per-server egress methods.
2. `UpstreamConnection` (http) attaching `resolve()` auth + list/call for one server.
3. `resolve_static_headers` (static + per-user env-var interpolation).
4. Per-user token bridges (authorization_code read-path + BYOK), wired.
5. Aggregation/namespacing + remaining ops + sse/stdio.
6. Cutover: `MCPServerManagerV2` + flag-gated injection; retire the `resolve_mcp_auth` header graft.
7. Request-level parity tests + DB-backed live e2e.
8. AS surface (S7) for the authorization_code dance (tail).

Steps 1-5 are additive (nothing wired live); step 6 is the single flag-gated cutover, revertible via the flag.
