### PR TITLE
feat(proxy): add budget_exceeded_models_policy for model discovery behavior

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2396,15 +2396,17 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         ),
     )
 
-    budget_exceeded_models_policy: Optional[Literal["blocked", "all", "free_only"]] = Field(
-        "blocked",
-        description=(
-            "Controls model-list behavior when a team/user/key budget is exceeded. "
-            "'blocked' (default) returns 429 as before. "
-            "'all' returns the full model list regardless of budget. "
-            "'free_only' returns only zero-cost models. "
-            "Inference calls always enforce the budget regardless of this setting."
-        ),
+    budget_exceeded_models_policy: Optional[Literal["blocked", "all", "free_only"]] = (
+        Field(
+            "blocked",
+            description=(
+                "Controls model-list behavior when a team/user/key budget is exceeded. "
+                "'blocked' (default) returns 429 as before. "
+                "'all' returns the full model list regardless of budget. "
+                "'free_only' returns only zero-cost models. "
+                "Inference calls always enforce the budget regardless of this setting."
+            ),
+        )
     )
 
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2398,13 +2398,14 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
 
     budget_exceeded_models_policy: Optional[Literal["blocked", "all", "free_only"]] = (
         Field(
-            "blocked",
+            "all",
             description=(
-                "Controls model-list behavior when a team/user/key budget is exceeded. "
-                "'blocked' (default) returns 429 as before. "
-                "'all' returns the full model list regardless of budget. "
-                "'free_only' returns only zero-cost models. "
-                "Inference calls always enforce the budget regardless of this setting."
+                "Controls model-discovery behavior (/v1/models, /model/info) when a "
+                "key/team/user budget is exceeded. 'all' (default) returns the full "
+                "model list, preserving the existing behavior where discovery routes "
+                "are exempt from budget enforcement. 'blocked' returns a 429. "
+                "'free_only' returns only zero-cost models. Inference calls always "
+                "enforce the budget regardless of this setting."
             ),
         )
     )

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2396,6 +2396,17 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         ),
     )
 
+    budget_exceeded_models_policy: Optional[Literal["blocked", "all", "free_only"]] = Field(
+        "blocked",
+        description=(
+            "Controls model-list behavior when a team/user/key budget is exceeded. "
+            "'blocked' (default) returns 429 as before. "
+            "'all' returns the full model list regardless of budget. "
+            "'free_only' returns only zero-cost models. "
+            "Inference calls always enforce the budget regardless of this setting."
+        ),
+    )
+
 
 class ConfigYAML(LiteLLMPydanticObjectBase):
     """

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8667,6 +8667,84 @@ class ProxyStartupEvent:
             )
 
 
+def _apply_budget_exceeded_models_policy(
+    user_api_key_dict: Optional[UserAPIKeyAuth],
+    all_models: list,
+) -> list:
+    """
+    Applies the budget_exceeded_models_policy general setting to model listings.
+    Supports list of strings or list of model dictionaries.
+    """
+    global general_settings, llm_router
+    if general_settings is None or llm_router is None or not user_api_key_dict:
+        return all_models
+
+    settings = cast(dict[str, object], general_settings)
+    policy = settings.get("budget_exceeded_models_policy", "blocked")
+
+    # If policy is not free_only or blocked, we just return all_models (the "all" behavior)
+    if policy not in ("free_only", "blocked"):
+        return all_models
+
+    # Determine if any budget is exceeded
+    budget_exceeded = False
+    current_cost = 0.0
+    max_budget = 0.0
+
+    if (
+        user_api_key_dict.max_budget is not None
+        and (user_api_key_dict.spend or 0) >= user_api_key_dict.max_budget
+    ):
+        budget_exceeded = True
+        current_cost = user_api_key_dict.spend or 0.0
+        max_budget = user_api_key_dict.max_budget
+    elif (
+        user_api_key_dict.team_max_budget is not None
+        and (user_api_key_dict.team_spend or 0) >= user_api_key_dict.team_max_budget
+    ):
+        budget_exceeded = True
+        current_cost = user_api_key_dict.team_spend or 0.0
+        max_budget = user_api_key_dict.team_max_budget
+    elif (
+        user_api_key_dict.user_max_budget is not None
+        and (user_api_key_dict.user_spend or 0) >= user_api_key_dict.user_max_budget
+    ):
+        budget_exceeded = True
+        current_cost = user_api_key_dict.user_spend or 0.0
+        max_budget = user_api_key_dict.user_max_budget
+
+    if not budget_exceeded:
+        return all_models
+
+    # If policy is "blocked" and budget is exceeded, raise BudgetExceededError (429)
+    if policy == "blocked":
+        import litellm
+        raise litellm.BudgetExceededError(
+            current_cost=current_cost,
+            max_budget=max_budget,
+        )
+
+    # If policy is "free_only" and budget is exceeded, filter to zero-cost models
+    if policy == "free_only":
+        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+
+        filtered_models = []
+        for m in all_models:
+            if isinstance(m, str):
+                model_name = m
+            elif isinstance(m, dict):
+                model_name = m.get("model_name") or m.get("model") or m.get("litellm_params", {}).get("model")
+            else:
+                model_name = getattr(m, "model_name", None) or getattr(m, "model", None)
+
+            if model_name and _is_model_cost_zero(model_name, llm_router):
+                filtered_models.append(m)
+
+        return filtered_models
+
+    return all_models
+
+
 #### API ENDPOINTS ####
 @router.get(
     "/v1/models", dependencies=[Depends(user_api_key_auth)], tags=["model management"]
@@ -8832,12 +8910,8 @@ async def model_list(
     if hidden_names:
         all_models = [m for m in all_models if m not in hidden_names]
 
-    # Budget-exceeded models policy: when "free_only", return only zero-cost models
-    policy = settings.get("budget_exceeded_models_policy", "blocked")
-    if policy == "free_only":
-        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
-
-        all_models = [m for m in all_models if _is_model_cost_zero(m, llm_router)]
+    # Budget-exceeded models policy
+    all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
 
     # Surface the public team name by default; legacy internal keys via flag.
     # The internal routing key drives the metadata/fallback lookup, while the
@@ -12562,6 +12636,10 @@ async def model_info_v2(
     # Translate `model_name` to the public name for team-scoped rows.
     all_models = [_translate_model_name_for_response(m) for m in all_models]
 
+    # Budget-exceeded models policy
+    all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+    search_total_count = len(all_models)
+
     return _paginate_models_response(
         all_models=all_models,
         page=page,
@@ -13335,6 +13413,9 @@ async def model_info_v1(
             llm_router=llm_router,
             user_api_key_dict=user_api_key_dict,
         )
+
+    # Budget-exceeded models policy
+    all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
 
     verbose_proxy_logger.debug("all_models: %s", all_models)
     return {"data": all_models}

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8680,7 +8680,7 @@ def _apply_budget_exceeded_models_policy(
         return all_models
 
     settings = cast(dict[str, object], general_settings)
-    policy = settings.get("budget_exceeded_models_policy", "blocked")
+    policy = settings.get("budget_exceeded_models_policy", "all")
 
     # If policy is not free_only or blocked, we just return all_models (the "all" behavior)
     if policy not in ("free_only", "blocked"):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8873,6 +8873,8 @@ async def model_list(
         if hidden_names:
             all_models = [m for m in all_models if m not in hidden_names]
 
+        all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+
         # Surface the public team name by default; legacy internal keys via flag.
         # The internal routing key drives the metadata/fallback lookup, while the
         # public name is what the client sees as the model id.
@@ -12638,11 +12640,12 @@ async def model_info_v2(
     # Update total count to include agents
     search_total_count = len(all_models)
 
+    # Budget-exceeded models policy runs before name translation so free_only
+    # filtering matches on internal model names rather than public aliases.
+    all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+
     # Translate `model_name` to the public name for team-scoped rows.
     all_models = [_translate_model_name_for_response(m) for m in all_models]
-
-    # Budget-exceeded models policy
-    all_models = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
     search_total_count = len(all_models)
 
     return _paginate_models_response(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8832,6 +8832,13 @@ async def model_list(
     if hidden_names:
         all_models = [m for m in all_models if m not in hidden_names]
 
+    # Budget-exceeded models policy: when "free_only", return only zero-cost models
+    policy = settings.get("budget_exceeded_models_policy", "blocked")
+    if policy == "free_only":
+        from litellm.proxy.auth.auth_checks import _is_model_cost_zero
+
+        all_models = [m for m in all_models if _is_model_cost_zero(m, llm_router)]
+
     # Surface the public team name by default; legacy internal keys via flag.
     # The internal routing key drives the metadata/fallback lookup, while the
     # public name is what the client sees as the model id.

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8719,6 +8719,7 @@ def _apply_budget_exceeded_models_policy(
     # If policy is "blocked" and budget is exceeded, raise BudgetExceededError (429)
     if policy == "blocked":
         import litellm
+
         raise litellm.BudgetExceededError(
             current_cost=current_cost,
             max_budget=max_budget,
@@ -8733,7 +8734,11 @@ def _apply_budget_exceeded_models_policy(
             if isinstance(m, str):
                 model_name = m
             elif isinstance(m, dict):
-                model_name = m.get("model_name") or m.get("model") or m.get("litellm_params", {}).get("model")
+                model_name = (
+                    m.get("model_name")
+                    or m.get("model")
+                    or m.get("litellm_params", {}).get("model")
+                )
             else:
                 model_name = getattr(m, "model_name", None) or getattr(m, "model", None)
 

--- a/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
+++ b/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import litellm
+from unittest.mock import MagicMock, patch
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.proxy_server import _apply_budget_exceeded_models_policy
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_all():
+    """
+    When policy is "all", the full model list is returned regardless of budget.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        max_budget=10.0,
+        spend=15.0,  # Over budget
+    )
+    
+    all_models = ["gpt-4", "gpt-3.5-turbo"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "all"}
+    mock_router = MagicMock()
+    
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router):
+        
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == all_models
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_blocked():
+    """
+    When policy is "blocked" and budget is exceeded, BudgetExceededError is raised.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        max_budget=10.0,
+        spend=15.0,  # Over budget
+    )
+    
+    all_models = ["gpt-4", "gpt-3.5-turbo"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "blocked"}
+    mock_router = MagicMock()
+    
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router):
+        
+        with pytest.raises(litellm.BudgetExceededError):
+            _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_free_only():
+    """
+    When policy is "free_only" and budget is exceeded, only zero-cost models are returned.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        max_budget=10.0,
+        spend=15.0,  # Over budget
+    )
+    
+    all_models = ["gpt-4", "free-model"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "free_only"}
+    mock_router = MagicMock()
+    
+    def mock_is_model_cost_zero(model, router):
+        return model == "free-model"
+        
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
+         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
+        
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == ["free-model"]
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_under_budget():
+    """
+    When the caller is under budget, all models are returned regardless of policy.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        max_budget=10.0,
+        spend=5.0,  # Under budget
+    )
+    
+    all_models = ["gpt-4", "free-model"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "free_only"}
+    mock_router = MagicMock()
+    
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router):
+        
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == all_models
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_team_budget_exceeded():
+    """
+    Tests that team budget exceedance is also honored.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        team_max_budget=100.0,
+        team_spend=120.0,  # Over budget
+    )
+    
+    all_models = ["gpt-4", "free-model"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "free_only"}
+    mock_router = MagicMock()
+    
+    def mock_is_model_cost_zero(model, router):
+        return model == "free-model"
+        
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
+         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
+        
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == ["free-model"]
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_user_budget_exceeded():
+    """
+    Tests that user budget exceedance is also honored.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        user_max_budget=50.0,
+        user_spend=60.0,  # Over budget
+    )
+    
+    all_models = ["gpt-4", "free-model"]
+    
+    mock_settings = {"budget_exceeded_models_policy": "free_only"}
+    mock_router = MagicMock()
+    
+    def mock_is_model_cost_zero(model, router):
+        return model == "free-model"
+        
+    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
+         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
+         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
+        
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == ["free-model"]

--- a/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
+++ b/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
@@ -1,6 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 import pytest
 import litellm
 from unittest.mock import MagicMock, patch

--- a/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
+++ b/tests/test_litellm/proxy/test_budget_exceeded_models_policy.py
@@ -18,15 +18,44 @@ async def test_apply_budget_exceeded_models_policy_all():
         max_budget=10.0,
         spend=15.0,  # Over budget
     )
-    
+
     all_models = ["gpt-4", "gpt-3.5-turbo"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "all"}
     mock_router = MagicMock()
-    
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+
+        result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
+        assert result == all_models
+
+
+@pytest.mark.asyncio
+async def test_apply_budget_exceeded_models_policy_default_is_all():
+    """
+    When no policy is configured, an over-budget caller still gets the full model
+    list. Model-discovery routes are exempt from budget enforcement by default
+    (MODEL_DISCOVERY_ROUTES / skip_budget_checks), so the default must not raise.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="sk-123",
+        max_budget=10.0,
+        spend=15.0,  # Over budget
+    )
+
+    all_models = ["gpt-4", "gpt-3.5-turbo"]
+
+    mock_settings = {}  # policy not set -> default behavior
+    mock_router = MagicMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+
         result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
         assert result == all_models
 
@@ -41,15 +70,17 @@ async def test_apply_budget_exceeded_models_policy_blocked():
         max_budget=10.0,
         spend=15.0,  # Over budget
     )
-    
+
     all_models = ["gpt-4", "gpt-3.5-turbo"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "blocked"}
     mock_router = MagicMock()
-    
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+
         with pytest.raises(litellm.BudgetExceededError):
             _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
 
@@ -64,19 +95,24 @@ async def test_apply_budget_exceeded_models_policy_free_only():
         max_budget=10.0,
         spend=15.0,  # Over budget
     )
-    
+
     all_models = ["gpt-4", "free-model"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "free_only"}
     mock_router = MagicMock()
-    
+
     def mock_is_model_cost_zero(model, router):
         return model == "free-model"
-        
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
-         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch(
+            "litellm.proxy.auth.auth_checks._is_model_cost_zero",
+            side_effect=mock_is_model_cost_zero,
+        ),
+    ):
+
         result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
         assert result == ["free-model"]
 
@@ -91,15 +127,17 @@ async def test_apply_budget_exceeded_models_policy_under_budget():
         max_budget=10.0,
         spend=5.0,  # Under budget
     )
-    
+
     all_models = ["gpt-4", "free-model"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "free_only"}
     mock_router = MagicMock()
-    
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+    ):
+
         result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
         assert result == all_models
 
@@ -114,19 +152,24 @@ async def test_apply_budget_exceeded_models_policy_team_budget_exceeded():
         team_max_budget=100.0,
         team_spend=120.0,  # Over budget
     )
-    
+
     all_models = ["gpt-4", "free-model"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "free_only"}
     mock_router = MagicMock()
-    
+
     def mock_is_model_cost_zero(model, router):
         return model == "free-model"
-        
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
-         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch(
+            "litellm.proxy.auth.auth_checks._is_model_cost_zero",
+            side_effect=mock_is_model_cost_zero,
+        ),
+    ):
+
         result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
         assert result == ["free-model"]
 
@@ -141,18 +184,23 @@ async def test_apply_budget_exceeded_models_policy_user_budget_exceeded():
         user_max_budget=50.0,
         user_spend=60.0,  # Over budget
     )
-    
+
     all_models = ["gpt-4", "free-model"]
-    
+
     mock_settings = {"budget_exceeded_models_policy": "free_only"}
     mock_router = MagicMock()
-    
+
     def mock_is_model_cost_zero(model, router):
         return model == "free-model"
-        
-    with patch("litellm.proxy.proxy_server.general_settings", mock_settings), \
-         patch("litellm.proxy.proxy_server.llm_router", mock_router), \
-         patch("litellm.proxy.auth.auth_checks._is_model_cost_zero", side_effect=mock_is_model_cost_zero):
-        
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", mock_settings),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch(
+            "litellm.proxy.auth.auth_checks._is_model_cost_zero",
+            side_effect=mock_is_model_cost_zero,
+        ),
+    ):
+
         result = _apply_budget_exceeded_models_policy(user_api_key_dict, all_models)
         assert result == ["free-model"]

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -3826,6 +3826,9 @@ async def test_model_info_v1_oci_secrets_not_leaked():
     mock_user_api_key_dict.api_key = "test-key"
     mock_user_api_key_dict.team_models = []
     mock_user_api_key_dict.models = ["oci-grok-test"]
+    mock_user_api_key_dict.max_budget = None
+    mock_user_api_key_dict.team_max_budget = None
+    mock_user_api_key_dict.user_max_budget = None
 
     # Mock model data with OCI sensitive information
     mock_model_data = {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22211,8 +22211,8 @@ export interface components {
             background_health_checks?: boolean | null;
             /**
              * Budget Exceeded Models Policy
-             * @description Controls model-list behavior when a team/user/key budget is exceeded. 'blocked' (default) returns 429 as before. 'all' returns the full model list regardless of budget. 'free_only' returns only zero-cost models. Inference calls always enforce the budget regardless of this setting.
-             * @default blocked
+             * @description Controls model-discovery behavior (/v1/models, /model/info) when a key/team/user budget is exceeded. 'all' (default) returns the full model list, preserving the existing behavior where discovery routes are exempt from budget enforcement. 'blocked' returns a 429. 'free_only' returns only zero-cost models. Inference calls always enforce the budget regardless of this setting.
+             * @default all
              */
             budget_exceeded_models_policy: ("blocked" | "all" | "free_only") | null;
             /**

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22210,6 +22210,12 @@ export interface components {
              */
             background_health_checks?: boolean | null;
             /**
+             * Budget Exceeded Models Policy
+             * @description Controls model-list behavior when a team/user/key budget is exceeded. 'blocked' (default) returns 429 as before. 'all' returns the full model list regardless of budget. 'free_only' returns only zero-cost models. Inference calls always enforce the budget regardless of this setting.
+             * @default blocked
+             */
+            budget_exceeded_models_policy: ("blocked" | "all" | "free_only") | null;
+            /**
              * Cancel On Disconnect
              * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
              */


### PR DESCRIPTION
## Relevant issues

Closes #27923

## Summary

Adds a `budget_exceeded_models_policy` general-setting option controlling model-discovery behavior (`/v1/models`, `/model/info`) when a key/team/user budget is exceeded. Three modes:

- `all` (default) — returns the full model list; preserves today's behavior since discovery routes are already exempt from budget enforcement via `MODEL_DISCOVERY_ROUTES` / `skip_budget_checks`
- `blocked` — returns a 429 `BudgetExceededError` on model-listing calls from over-budget callers
- `free_only` — returns only zero-cost models, letting the caller discover what they can still use

Inference calls always enforce the budget regardless of this setting.

## Type

🆕 New Feature

## Changes

- `litellm/proxy/_types.py`: add `budget_exceeded_models_policy` field to `ConfigGeneralSettings` with `Literal["all", "blocked", "free_only"]` and default `"all"`
- `litellm/proxy/proxy_server.py`: add `_apply_budget_exceeded_models_policy()` helper; wire it into `/v1/models`, `/v2/model/info`, and `/model/info`; apply it inside the `scope=expand` admin branch before early return; run it before `_translate_model_name_for_response` in `model_info_v2` so `free_only` filters on internal model names rather than translated aliases
- `ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated OpenAPI types
- `tests/test_litellm/proxy/test_budget_exceeded_models_policy.py`: 7 unit tests covering all policies and all budget entities (key, team, user)

## Screenshots / Proof of Fix

```bash
# Start proxy with a tiny-budget key and the policy configured
litellm --config config.yaml --port 4000 &

# default (policy unset / "all"): over-budget key still lists models
curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-overbudget" | jq '.data | length'

# budget_exceeded_models_policy: blocked -> 429
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/v1/models -H "Authorization: Bearer sk-overbudget"

# free_only -> only zero-cost models
curl -s http://localhost:4000/v1/models -H "Authorization: Bearer sk-overbudget" | jq '.data[].id'
```