### PR TITLE
fix: emit native web_search blocks on the websearch_interception short-circuit path

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -92,6 +92,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         messages: List[Dict],
         tools: Optional[List[Dict]],
         custom_llm_provider: Optional[str],
+        emit_native_blocks: bool = False,
     ) -> Optional[Dict[str, Any]]:
         """
         Short-circuit web-search-only requests by executing the search directly.
@@ -108,6 +109,9 @@ class WebSearchInterceptionLogger(CustomLogger):
             messages: Messages list from the request
             tools: Tools list from the request
             custom_llm_provider: Provider name
+            emit_native_blocks: True when the client sent an Anthropic-native
+                web_search_* tool (computed before the pre-request hook
+                rewrote it into the litellm_web_search standard form).
 
         Returns:
             An AnthropicMessagesResponse dict if short-circuited, or None to
@@ -174,6 +178,7 @@ class WebSearchInterceptionLogger(CustomLogger):
             (t for t in tools if is_anthropic_native_web_search_tool(t)),
             None,
         )
+        is_native = emit_native_blocks or native_tool is not None
 
         # Execute search — keep the structured SearchResponse so the native
         # block can carry per-result url/title/page_age.
@@ -186,9 +191,9 @@ class WebSearchInterceptionLogger(CustomLogger):
             search_result_text, structured = f"Search failed: {e}", None
 
         content: List[Dict[str, Any]] = []
-        if native_tool is not None:
+        if is_native:
             tool_use_id = f"srvtoolu_{uuid.uuid4().hex}"
-            tool_name = native_tool.get("name") or "web_search"
+            tool_name = (native_tool or {}).get("name") or "web_search"
             content.append(
                 {
                     "type": "server_tool_use",
@@ -221,7 +226,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         verbose_logger.debug(
             "WebSearchInterception: Short-circuit search completed, "
             f"returning synthetic response ({len(search_result_text)} chars, "
-            f"native_blocks={native_tool is not None})"
+            f"native_blocks={is_native})"
         )
         return response
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -136,6 +136,7 @@ async def _try_websearch_short_circuit(
     tools: Optional[List[Dict]],
     custom_llm_provider: Optional[str],
     stream: Optional[bool],
+    emit_native_blocks: bool = False,
 ) -> Optional[Union[AnthropicMessagesResponse, AsyncIterator]]:
     """
     Attempt to short-circuit a web-search-only request.
@@ -165,6 +166,7 @@ async def _try_websearch_short_circuit(
             messages=messages,
             tools=tools,
             custom_llm_provider=custom_llm_provider,
+            emit_native_blocks=emit_native_blocks,
         )
         if response is not None:
             anthropic_response = cast(AnthropicMessagesResponse, response)
@@ -271,6 +273,9 @@ async def anthropic_messages(
         tools=tools,
         custom_llm_provider=custom_llm_provider,
         stream=original_stream,
+        emit_native_blocks=bool(
+            kwargs.get("_websearch_interception_emit_native_blocks")
+        ),
     )
     if short_circuit_response is not None:
         return short_circuit_response

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
@@ -61,6 +61,70 @@ class TestTryShortCircuitSearch:
         mock_search.assert_called_once_with("Search for Claude Code releases")
 
     @pytest.mark.asyncio
+    async def test_emit_native_blocks_flag_drives_native_output(self):
+        """emit_native_blocks=True yields native blocks even when the tool has
+        already been rewritten to litellm_web_search.
+
+        In the real request path the pre-request hook converts the native
+        web_search_* tool into the litellm_web_search standard form before the
+        short-circuit runs, so inspecting ``tools`` here no longer detects a
+        native client. The flag carries that signal across the conversion.
+        """
+        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+
+        with patch.object(
+            logger, "_execute_search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ("results", None)
+
+            result = await logger.try_short_circuit_search(
+                model="github_copilot/claude-sonnet-4",
+                messages=[{"role": "user", "content": "search query"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "litellm_web_search"},
+                    }
+                ],
+                custom_llm_provider="github_copilot",
+                emit_native_blocks=True,
+            )
+
+        block_types = [b["type"] for b in result["content"]]
+        assert "server_tool_use" in block_types
+        assert "web_search_tool_result" in block_types
+
+    @pytest.mark.asyncio
+    async def test_converted_tool_without_flag_stays_text_only(self):
+        """Converted tool + emit_native_blocks=False → text-only, no native blocks.
+
+        Non-native callers (those that sent the litellm_web_search standard tool)
+        must keep the original text-only payload.
+        """
+        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+
+        with patch.object(
+            logger, "_execute_search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ("results", None)
+
+            result = await logger.try_short_circuit_search(
+                model="github_copilot/claude-sonnet-4",
+                messages=[{"role": "user", "content": "search query"}],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {"name": "litellm_web_search"},
+                    }
+                ],
+                custom_llm_provider="github_copilot",
+                emit_native_blocks=False,
+            )
+
+        block_types = [b["type"] for b in result["content"]]
+        assert block_types == ["text"]
+
+    @pytest.mark.asyncio
     async def test_does_not_short_circuit_mixed_tools(self):
         """Mix of web_search and other tools → NOT short-circuited"""
         logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])


### PR DESCRIPTION
## Relevant issues

Web search returns no results / empty citation panel for **native** `web_search_*` clients (e.g. Claude Code) on the short-circuit path of `websearch_interception`.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

### Problem

When `websearch_interception` short-circuits a web-search-only `/v1/messages` request for a provider without native web search (e.g. `github_copilot`), it is supposed to emit `server_tool_use` + `web_search_tool_result` content blocks for clients that sent an **Anthropic-native** `web_search_*` tool, so citation panels can render. Instead, native clients receive only a `text` block — the citation UI shows nothing (Claude Code reports "Did 0 searches").

### Root cause

The native-client signal is lost by the time the short-circuit runs:

1. `async_pre_call_deployment_hook` rewrites the native `{"type": "web_search_20250305", ...}` tool into the `litellm_web_search` standard form **before** `anthropic_messages()` runs. It correctly sets the `_websearch_interception_emit_native_blocks` flag at that point.
2. `try_short_circuit_search` then re-derives "is this native?" by inspecting `tools` with `is_anthropic_native_web_search_tool(...)` — but `tools` has already been converted, so it never matches.
3. Result: `native_blocks=False`, text-only output.

The existing unit test passes the native tool **directly** to `try_short_circuit_search` (pre-conversion), so it doesn't exercise the real request path where conversion happens first.

### Fix

Thread the existing `_websearch_interception_emit_native_blocks` flag (already computed pre-conversion) into `try_short_circuit_search`, and use it as the native signal — falling back to tool inspection so callers that don't pass the flag are unaffected.

- `anthropic_messages()` reads the flag from `kwargs` and passes it to `_try_websearch_short_circuit`.
- `_try_websearch_short_circuit` forwards it to `try_short_circuit_search`.
- `try_short_circuit_search` uses `emit_native_blocks or native_tool is not None`.

No behavior change for non-native clients (they get text-only as before) or for providers that use the agentic loop (bedrock/vertex_ai/anthropic — they don't short-circuit).

### Tests

Added two tests to `test_websearch_short_circuit.py`:
- `test_emit_native_blocks_flag_drives_native_output` — converted `litellm_web_search` tool + `emit_native_blocks=True` → native blocks present (the real-path scenario).
- `test_converted_tool_without_flag_stays_text_only` — converted tool + `emit_native_blocks=False` → text-only (backward compat).

Full `tests/test_litellm/integrations/websearch_interception/` suite: 82 passed, 2 skipped.

### Proof

Before (native `web_search_20250305` via proxy → github_copilot): `content` block types `['text']`.
After: `['server_tool_use', 'web_search_tool_result', 'text']`.
