### PR TITLE
fix(websearch): update tool_choice when renaming web search tool (#30822)

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -294,15 +294,25 @@ class WebSearchInterceptionLogger(CustomLogger):
         if isinstance(tool_choice, dict):
             tc_type = tool_choice.get("type", "")
             tc_name = tool_choice.get("name", "")
-            if tc_type == "tool" and is_web_search_tool({"name": tc_name, "type": "function"}):
-                kwargs["tool_choice"] = {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
+            if tc_type == "tool" and is_web_search_tool(
+                {"name": tc_name, "type": "function"}
+            ):
+                kwargs["tool_choice"] = {
+                    **tool_choice,
+                    "name": LITELLM_WEB_SEARCH_TOOL_NAME,
+                }
                 verbose_logger.debug(
                     f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
                 )
             elif tc_type == "function" and "function" in tool_choice:
                 fn = tool_choice["function"]
-                if isinstance(fn, dict) and is_web_search_tool({"type": "function", "function": fn}):
-                    kwargs["tool_choice"] = {**tool_choice, "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME}}
+                if isinstance(fn, dict) and is_web_search_tool(
+                    {"type": "function", "function": fn}
+                ):
+                    kwargs["tool_choice"] = {
+                        **tool_choice,
+                        "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME},
+                    }
                     verbose_logger.debug(
                         f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
                     )
@@ -443,15 +453,25 @@ class WebSearchInterceptionLogger(CustomLogger):
         if isinstance(tool_choice, dict):
             tc_type = tool_choice.get("type", "")
             tc_name = tool_choice.get("name", "")
-            if tc_type == "tool" and is_web_search_tool({"name": tc_name, "type": "function"}):
-                kwargs["tool_choice"] = {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
+            if tc_type == "tool" and is_web_search_tool(
+                {"name": tc_name, "type": "function"}
+            ):
+                kwargs["tool_choice"] = {
+                    **tool_choice,
+                    "name": LITELLM_WEB_SEARCH_TOOL_NAME,
+                }
                 verbose_logger.debug(
                     f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
                 )
             elif tc_type == "function" and "function" in tool_choice:
                 fn = tool_choice["function"]
-                if isinstance(fn, dict) and is_web_search_tool({"type": "function", "function": fn}):
-                    kwargs["tool_choice"] = {**tool_choice, "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME}}
+                if isinstance(fn, dict) and is_web_search_tool(
+                    {"type": "function", "function": fn}
+                ):
+                    kwargs["tool_choice"] = {
+                        **tool_choice,
+                        "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME},
+                    }
                     verbose_logger.debug(
                         f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
                     )

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -290,32 +290,10 @@ class WebSearchInterceptionLogger(CustomLogger):
 
         kwargs["tools"] = converted_tools
 
-        tool_choice = kwargs.get("tool_choice")
-        if isinstance(tool_choice, dict):
-            tc_type = tool_choice.get("type", "")
-            tc_name = tool_choice.get("name", "")
-            if tc_type == "tool" and is_web_search_tool(
-                {"name": tc_name, "type": "function"}
-            ):
-                kwargs["tool_choice"] = {
-                    **tool_choice,
-                    "name": LITELLM_WEB_SEARCH_TOOL_NAME,
-                }
-                verbose_logger.debug(
-                    f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
-                )
-            elif tc_type == "function" and "function" in tool_choice:
-                fn = tool_choice["function"]
-                if isinstance(fn, dict) and is_web_search_tool(
-                    {"type": "function", "function": fn}
-                ):
-                    kwargs["tool_choice"] = {
-                        **tool_choice,
-                        "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME},
-                    }
-                    verbose_logger.debug(
-                        f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
-                    )
+        if "tool_choice" in kwargs:
+            kwargs["tool_choice"] = cls._sync_forced_tool_choice(
+                kwargs.get("tool_choice"), converted_tools
+            )
 
         if kwargs.get("stream"):
             verbose_logger.debug(
@@ -325,6 +303,34 @@ class WebSearchInterceptionLogger(CustomLogger):
             kwargs["_websearch_interception_converted_stream"] = True
 
         return kwargs
+
+    @staticmethod
+    def _tool_name(tool: dict[str, Any]) -> Optional[str]:
+        """Effective tool name, handling OpenAI ``function`` wrapper shape."""
+        fn = tool.get("function")
+        if tool.get("type") == "function" and isinstance(fn, dict):
+            return fn.get("name")
+        return tool.get("name")
+
+    @classmethod
+    def _sync_forced_tool_choice(
+        cls, tool_choice: Any, converted_tools: list[dict[str, Any]]
+    ) -> Any:
+        """Repoint a forced ``tool_choice`` at ``litellm_web_search`` when it
+        names a web-search tool that was just converted away.
+
+        Native clients (e.g. Claude Code) force the search tool via
+        ``tool_choice={"type": "tool", "name": "web_search"}``. Since the tool
+        definition gets renamed to ``litellm_web_search``, an unrewritten
+        ``tool_choice`` points at a tool that no longer exists, which Anthropic
+        rejects with "Tool 'web_search' not found in provided tools".
+        """
+        if not isinstance(tool_choice, dict) or tool_choice.get("type") != "tool":
+            return tool_choice
+        converted_names = {cls._tool_name(t) for t in converted_tools}
+        if tool_choice.get("name") in converted_names:
+            return tool_choice
+        return {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
 
     @classmethod
     def from_config_yaml(
@@ -449,32 +455,10 @@ class WebSearchInterceptionLogger(CustomLogger):
             f"WebSearchInterception: Tools after conversion: {[t.get('name') for t in converted_tools]}"
         )
 
-        tool_choice = kwargs.get("tool_choice")
-        if isinstance(tool_choice, dict):
-            tc_type = tool_choice.get("type", "")
-            tc_name = tool_choice.get("name", "")
-            if tc_type == "tool" and is_web_search_tool(
-                {"name": tc_name, "type": "function"}
-            ):
-                kwargs["tool_choice"] = {
-                    **tool_choice,
-                    "name": LITELLM_WEB_SEARCH_TOOL_NAME,
-                }
-                verbose_logger.debug(
-                    f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
-                )
-            elif tc_type == "function" and "function" in tool_choice:
-                fn = tool_choice["function"]
-                if isinstance(fn, dict) and is_web_search_tool(
-                    {"type": "function", "function": fn}
-                ):
-                    kwargs["tool_choice"] = {
-                        **tool_choice,
-                        "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME},
-                    }
-                    verbose_logger.debug(
-                        f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
-                    )
+        if "tool_choice" in kwargs:
+            kwargs["tool_choice"] = self._sync_forced_tool_choice(
+                kwargs.get("tool_choice"), converted_tools
+            )
 
         # Also convert here for direct callers that bypass the deployment hook.
         if kwargs.get("stream"):

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -290,6 +290,23 @@ class WebSearchInterceptionLogger(CustomLogger):
 
         kwargs["tools"] = converted_tools
 
+        tool_choice = kwargs.get("tool_choice")
+        if isinstance(tool_choice, dict):
+            tc_type = tool_choice.get("type", "")
+            tc_name = tool_choice.get("name", "")
+            if tc_type == "tool" and is_web_search_tool({"name": tc_name, "type": "function"}):
+                kwargs["tool_choice"] = {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
+                verbose_logger.debug(
+                    f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
+                )
+            elif tc_type == "function" and "function" in tool_choice:
+                fn = tool_choice["function"]
+                if isinstance(fn, dict) and is_web_search_tool({"type": "function", "function": fn}):
+                    kwargs["tool_choice"] = {**tool_choice, "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME}}
+                    verbose_logger.debug(
+                        f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
+                    )
+
         if kwargs.get("stream"):
             verbose_logger.debug(
                 "WebSearchInterception: deployment hook converting stream=True to stream=False"
@@ -344,34 +361,6 @@ class WebSearchInterceptionLogger(CustomLogger):
             enabled_providers=enabled_providers,
             search_tool_name=search_tool_name,
         )
-
-    @staticmethod
-    def _tool_name(tool: dict[str, Any]) -> Optional[str]:
-        """Effective tool name, handling OpenAI ``function`` wrapper shape."""
-        fn = tool.get("function")
-        if tool.get("type") == "function" and isinstance(fn, dict):
-            return fn.get("name")
-        return tool.get("name")
-
-    @classmethod
-    def _sync_forced_tool_choice(
-        cls, tool_choice: Any, converted_tools: list[dict[str, Any]]
-    ) -> Any:
-        """Repoint a forced ``tool_choice`` at ``litellm_web_search`` when it
-        names a web-search tool that was just converted away.
-
-        Native clients (e.g. Claude Code) force the search tool via
-        ``tool_choice={"type": "tool", "name": "web_search"}``. Since the tool
-        definition gets renamed to ``litellm_web_search``, an unrewritten
-        ``tool_choice`` points at a tool that no longer exists, which Anthropic
-        rejects with "Tool 'web_search' not found in provided tools".
-        """
-        if not isinstance(tool_choice, dict) or tool_choice.get("type") != "tool":
-            return tool_choice
-        converted_names = {cls._tool_name(t) for t in converted_tools}
-        if tool_choice.get("name") in converted_names:
-            return tool_choice
-        return {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
 
     async def async_pre_request_hook(
         self, model: str, messages: List[Dict], kwargs: Dict
@@ -450,10 +439,22 @@ class WebSearchInterceptionLogger(CustomLogger):
             f"WebSearchInterception: Tools after conversion: {[t.get('name') for t in converted_tools]}"
         )
 
-        if "tool_choice" in kwargs:
-            kwargs["tool_choice"] = self._sync_forced_tool_choice(
-                kwargs.get("tool_choice"), converted_tools
-            )
+        tool_choice = kwargs.get("tool_choice")
+        if isinstance(tool_choice, dict):
+            tc_type = tool_choice.get("type", "")
+            tc_name = tool_choice.get("name", "")
+            if tc_type == "tool" and is_web_search_tool({"name": tc_name, "type": "function"}):
+                kwargs["tool_choice"] = {**tool_choice, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
+                verbose_logger.debug(
+                    f"WebSearchInterception: Converted tool_choice.name from '{tc_name}' to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
+                )
+            elif tc_type == "function" and "function" in tool_choice:
+                fn = tool_choice["function"]
+                if isinstance(fn, dict) and is_web_search_tool({"type": "function", "function": fn}):
+                    kwargs["tool_choice"] = {**tool_choice, "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME}}
+                    verbose_logger.debug(
+                        f"WebSearchInterception: Converted tool_choice.function.name to '{LITELLM_WEB_SEARCH_TOOL_NAME}'"
+                    )
 
         # Also convert here for direct callers that bypass the deployment hook.
         if kwargs.get("stream"):

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_tool_choice.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_tool_choice.py
@@ -1,0 +1,155 @@
+"""
+Tests for tool_choice conversion when websearch interception renames tools.
+
+Regression test for https://github.com/BerriAI/litellm/issues/30822:
+websearch_interception doesn't convert tool_choice, so forced web_search
+fails on Bedrock (400 "Tool 'web_search' not found").
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from litellm.constants import LITELLM_WEB_SEARCH_TOOL_NAME
+from litellm.integrations.websearch_interception.handler import (
+    WebSearchInterceptionLogger,
+)
+
+
+def _anthropic_web_search_tool():
+    return {"type": "web_search_20250305", "name": "web_search"}
+
+
+class TestToolChoiceConversionDeploymentHook:
+    """async_pre_call_deployment_hook should rewrite tool_choice when it references a web search tool."""
+
+    @pytest.mark.asyncio
+    async def test_anthropic_tool_choice_type_tool(self):
+        """tool_choice: {type: 'tool', name: 'web_search'} -> name becomes litellm_web_search."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "model": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "tools": [_anthropic_web_search_tool()],
+            "tool_choice": {"type": "tool", "name": "web_search"},
+            "custom_llm_provider": "bedrock",
+        }
+
+        result = await logger.async_pre_call_deployment_hook(kwargs, None)
+
+        assert result is not None
+        assert result["tool_choice"]["name"] == LITELLM_WEB_SEARCH_TOOL_NAME
+        assert result["tool_choice"]["type"] == "tool"
+
+    @pytest.mark.asyncio
+    async def test_non_web_tool_choice_unchanged(self):
+        """tool_choice referencing a non-web-search tool should not be modified."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "model": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "tools": [
+                _anthropic_web_search_tool(),
+                {"name": "calculator", "input_schema": {"type": "object"}},
+            ],
+            "tool_choice": {"type": "tool", "name": "calculator"},
+            "custom_llm_provider": "bedrock",
+        }
+
+        result = await logger.async_pre_call_deployment_hook(kwargs, None)
+
+        assert result is not None
+        assert result["tool_choice"]["name"] == "calculator"
+
+    @pytest.mark.asyncio
+    async def test_string_tool_choice_unchanged(self):
+        """tool_choice as a string (e.g. 'auto', 'any') should not be modified."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "model": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "tools": [_anthropic_web_search_tool()],
+            "tool_choice": "auto",
+            "custom_llm_provider": "bedrock",
+        }
+
+        result = await logger.async_pre_call_deployment_hook(kwargs, None)
+
+        assert result is not None
+        assert result["tool_choice"] == "auto"
+
+    @pytest.mark.asyncio
+    async def test_no_tool_choice_unchanged(self):
+        """When no tool_choice is set, the hook should not add one."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "model": "bedrock/anthropic.claude-haiku-4-5-20251001-v1:0",
+            "tools": [_anthropic_web_search_tool()],
+            "custom_llm_provider": "bedrock",
+        }
+
+        result = await logger.async_pre_call_deployment_hook(kwargs, None)
+
+        assert result is not None
+        assert "tool_choice" not in result
+
+
+class TestToolChoiceConversionPreRequestHook:
+    """async_pre_request_hook should also rewrite tool_choice."""
+
+    @pytest.mark.asyncio
+    async def test_anthropic_tool_choice_rewritten(self):
+        """Pre-request hook converts tool_choice.name for Anthropic-style requests."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "tools": [_anthropic_web_search_tool()],
+            "tool_choice": {"type": "tool", "name": "web_search"},
+            "litellm_params": {"custom_llm_provider": "bedrock"},
+        }
+
+        result = await logger.async_pre_request_hook(
+            model="bedrock/claude-haiku-4-5",
+            messages=[{"role": "user", "content": "test"}],
+            kwargs=kwargs,
+        )
+
+        assert result is not None
+        assert result["tool_choice"]["name"] == LITELLM_WEB_SEARCH_TOOL_NAME
+
+    @pytest.mark.asyncio
+    async def test_pre_request_non_web_tool_choice_unchanged(self):
+        """Pre-request hook leaves non-web tool_choice alone."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "tools": [
+                _anthropic_web_search_tool(),
+                {"name": "calculator", "input_schema": {"type": "object"}},
+            ],
+            "tool_choice": {"type": "tool", "name": "calculator"},
+            "litellm_params": {"custom_llm_provider": "bedrock"},
+        }
+
+        result = await logger.async_pre_request_hook(
+            model="bedrock/claude-haiku-4-5",
+            messages=[{"role": "user", "content": "test"}],
+            kwargs=kwargs,
+        )
+
+        assert result is not None
+        assert result["tool_choice"]["name"] == "calculator"
+
+    @pytest.mark.asyncio
+    async def test_pre_request_string_tool_choice_unchanged(self):
+        """Pre-request hook leaves string tool_choice alone."""
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        kwargs: Dict[str, Any] = {
+            "tools": [_anthropic_web_search_tool()],
+            "tool_choice": "auto",
+            "litellm_params": {"custom_llm_provider": "bedrock"},
+        }
+
+        result = await logger.async_pre_request_hook(
+            model="bedrock/claude-haiku-4-5",
+            messages=[{"role": "user", "content": "test"}],
+            kwargs=kwargs,
+        )
+
+        assert result is not None
+        assert result["tool_choice"] == "auto"


### PR DESCRIPTION
## Relevant issues

Fixes #30822

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## What changed

When `websearch_interception` converts native web search tools (e.g. `web_search_20250305`) to the LiteLLM standard tool (`litellm_web_search`), it now also rewrites `tool_choice` if it references the old tool name. Without this, a request that forces the web search tool via `tool_choice` produces a 400 from Bedrock ("Tool 'web_search' not found in provided tools").

**Root cause:** Both `async_pre_call_deployment_hook` and `async_pre_request_hook` rename the tool in the `tools` array but leave `tool_choice` pointing at the original name. The provider then rejects the request because it can't find a tool matching `tool_choice.name`.

**Fix:** After converting tools, check `tool_choice` for a reference to a web search tool and rewrite it to `LITELLM_WEB_SEARCH_TOOL_NAME`. Handles both Anthropic format (`{type: "tool", name: "web_search"}`) and OpenAI format (`{type: "function", function: {name: "web_search"}}`).

## How to test

```bash
# Run the focused regression tests
python -m pytest tests/test_litellm/integrations/websearch_interception/test_websearch_tool_choice.py -v
```

The test covers:
- Anthropic `tool_choice` with `type: "tool"` gets rewritten
- Non-web-search `tool_choice` is left unchanged
- String `tool_choice` (e.g. "auto") is left unchanged
- No `tool_choice` does not add one
- Both deployment hook and pre-request hook paths

## Limitations

The OpenAI Chat Completions function-style `tool_choice` path (`{type: "function", function: {name: "web_search"}}`) is handled in the code but the existing `is_web_search_tool` does not match bare `web_search` in function format (only `litellm_web_search`). This is correct because the Chat Completions path uses the deployment hook with OpenAI-format tools, and the actual bug report is about the Anthropic Messages API path (`/v1/messages`) where `tool_choice` is `{type: "tool", name: "web_search"}`.