### PR TITLE
fix: clarify temperature=None behavior in completion() docstrings

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -455,7 +455,7 @@ async def acompletion(
         OPTIONAL PARAMS
         functions (List, optional): A list of functions to apply to the conversation messages (default is an empty list).
         function_call (str, optional): The name of the function to call within the conversation (default is an empty string).
-        temperature (float, optional): The temperature parameter for controlling the randomness of the output (default is 1.0).
+        temperature (float, optional): The sampling temperature, between 0 and 2. When None (default), the parameter is omitted from the request and the provider applies its own default.
         top_p (float, optional): The top-p parameter for nucleus sampling (default is 1.0).
         n (int, optional): The number of completions to generate (default is 1).
         stream (bool, optional): If True, return a streaming response (default is False).
@@ -1149,7 +1149,7 @@ def completion(  # type: ignore
         OPTIONAL PARAMS
         functions (List, optional): A list of functions to apply to the conversation messages (default is an empty list).
         function_call (str, optional): The name of the function to call within the conversation (default is an empty string).
-        temperature (float, optional): The temperature parameter for controlling the randomness of the output (default is 1.0).
+        temperature (float, optional): The sampling temperature, between 0 and 2. When None (default), the parameter is omitted from the request and the provider applies its own default.
         top_p (float, optional): The top-p parameter for nucleus sampling (default is 1.0).
         n (int, optional): The number of completions to generate (default is 1).
         stream (bool, optional): If True, return a streaming response (default is False).


### PR DESCRIPTION
Fixes #30520 (docstring claims temperature defaults to 1.0)

## Problem

The docstrings for `completion()` and `acompletion()` both state:

> temperature (float, optional): ... (default is 1.0)

The function signatures use `temperature: Optional[float] = None`. When
`temperature=None`, `_get_non_default_params()` does not forward the
parameter to the provider. The provider applies its own default, which
may or may not be 1.0.

The "default is 1.0" claim is incorrect and causes confusion about whether
callers need to explicitly pass `temperature=1.0` to get neutral behavior.

## Change

Updated both docstrings to reflect the actual behavior:

- Removed the incorrect `(default is 1.0)`
- Noted that `None` omits the parameter from the request
- Added the valid range (0–2) to match the online docs

No behavior change. Docstring only.