### PR TITLE
feat(provider): add LibertAI GLM-5.2 models

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -41481,6 +41481,35 @@
         "supports_reasoning": true,
         "source": "https://docs.libertai.io/apis/text/"
     },
+    "libertai/glm-5.2": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "libertai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true,
+        "supports_vision": false,
+        "source": "https://docs.libertai.io/apis/text/"
+    },
+    "libertai/glm-5.2-thinking": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "libertai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true,
+        "supports_vision": false,
+        "supports_reasoning": true,
+        "source": "https://docs.libertai.io/apis/text/"
+    },
     "libertai/bge-m3": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -41691,6 +41691,35 @@
         "supports_reasoning": true,
         "source": "https://docs.libertai.io/apis/text/"
     },
+    "libertai/glm-5.2": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "libertai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true,
+        "supports_vision": false,
+        "source": "https://docs.libertai.io/apis/text/"
+    },
+    "libertai/glm-5.2-thinking": {
+        "max_tokens": 262144,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "libertai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true,
+        "supports_vision": false,
+        "supports_reasoning": true,
+        "source": "https://docs.libertai.io/apis/text/"
+    },
     "libertai/bge-m3": {
         "max_tokens": 8192,
         "max_input_tokens": 8192,

--- a/tests/test_litellm/llms/openai_like/test_libertai_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_libertai_provider.py
@@ -70,9 +70,23 @@ class TestLibertAIProviderConfig:
         assert info["max_input_tokens"] == 262144
         assert info["max_output_tokens"] == 262144
 
+        assert "libertai/glm-5.2" in model_cost
+        glm = model_cost["libertai/glm-5.2"]
+        assert glm["litellm_provider"] == "libertai"
+        assert glm["mode"] == "chat"
+        assert glm["max_input_tokens"] == 262144
+        assert glm["max_output_tokens"] == 262144
+        assert glm["input_cost_per_token"] == 1.4e-06
+        assert glm["output_cost_per_token"] == 4.4e-06
+        assert glm["supports_vision"] is False
+
         # thinking variants are marked as reasoning models
         assert (
             model_cost["libertai/qwen3.6-27b-thinking"].get("supports_reasoning")
+            is True
+        )
+        assert (
+            model_cost["libertai/glm-5.2-thinking"].get("supports_reasoning")
             is True
         )
 


### PR DESCRIPTION
Adds the new LibertAI GLM-5.2 model IDs to the LiteLLM model cost map after the initial LibertAI provider PR (#30203) was merged.

Models added:
- `libertai/glm-5.2`
- `libertai/glm-5.2-thinking`

Both entries use 262144 input/output tokens and live pricing from LibertAI: $1.40/M input, $4.40/M output. The thinking variant is marked with `supports_reasoning: true`.

Validation run locally:
- `jq empty model_prices_and_context_window.json litellm/model_prices_and_context_window_backup.json`
- `git diff --check`
- Python JSON assertion for both GLM entries in root + backup cost maps

Could not run pytest in this fresh clone because `pytest` is not installed and the repo requires `uv >=0.10.9` while this environment has `uv 0.9.28`.
