### PR TITLE
feat(fireworks_ai): sync chat completions endpoint with full API surface

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -131,6 +131,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
             "prediction",
             "stream_options",
             "sampling_mask",
+            "thinking",
         ]
 
         # Only add tools for models that support function calling
@@ -232,7 +233,43 @@ class FireworksAIConfig(OpenAIGPTConfig):
             filter_value_from_dict,
         )
 
+        supports_vision_value = self._get_model_cost_capability(
+            model=model, capability="supports_vision"
+        )
         for message in messages:
+            if message["role"] == "user":
+                _message_content = message.get("content")
+                if _message_content is not None and isinstance(
+                    _message_content, list
+                ):
+                    for content in _message_content:
+                        if not isinstance(content, dict):
+                            continue
+                        if content.get("type") == "file":
+                            raise litellm.BadRequestError(
+                                message=(
+                                    "Fireworks AI chat completions does not support "
+                                    "file content blocks. For PDFs, convert pages to "
+                                    "images and send image_url blocks to a Fireworks "
+                                    "vision model, or extract text before calling a "
+                                    "text-only model."
+                                ),
+                                model=model,
+                                llm_provider="fireworks_ai",
+                            )
+                        if (
+                            content.get("type") == "image_url"
+                            and supports_vision_value is False
+                        ):
+                            raise litellm.BadRequestError(
+                                message=(
+                                    f"Fireworks AI model {model} does not support "
+                                    "image inputs. Use a Fireworks vision model or "
+                                    "remove image_url content blocks."
+                                ),
+                                model=model,
+                                llm_provider="fireworks_ai",
+                            )
             filter_value_from_dict(cast(dict, message), "cache_control")
             # Remove fields not permitted by FireworksAI (additionalProperties: false
             # on their ChatMessage schema) that may cause:

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -126,7 +126,6 @@ class FireworksAIConfig(OpenAIGPTConfig):
             "return_token_ids",
             "safe_tokenization",
             "service_tier",
-            "metadata",
             "speculation",
             "prediction",
             "stream_options",

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -131,7 +131,6 @@ class FireworksAIConfig(OpenAIGPTConfig):
             "prediction",
             "stream_options",
             "sampling_mask",
-            "thinking",
         ]
 
         # Only add tools for models that support function calling
@@ -159,6 +158,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
         if supports_reasoning(model=model, custom_llm_provider="fireworks_ai"):
             supported_params.append("reasoning_effort")
             supported_params.append("reasoning_history")
+            supported_params.append("thinking")
 
         return supported_params
 
@@ -174,6 +174,18 @@ class FireworksAIConfig(OpenAIGPTConfig):
             param == "tools" and value is not None
             for param, value in non_default_params.items()
         )
+        if (
+            non_default_params.get("thinking") is not None
+            and non_default_params.get("reasoning_effort") is not None
+        ):
+            raise litellm.BadRequestError(
+                message=(
+                    "Fireworks AI chat completions does not support specifying both "
+                    "`thinking` and `reasoning_effort` in the same request."
+                ),
+                model=model,
+                llm_provider="fireworks_ai",
+            )
 
         for param, value in non_default_params.items():
             if param == "tool_choice":

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -15,7 +15,6 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
     AllMessageValues,
-    ChatCompletionImageObject,
     ChatCompletionToolParam,
     OpenAIChatCompletionToolParam,
 )
@@ -60,8 +59,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
     logprobs: Optional[int] = None
     reasoning_effort: Optional[str] = None
 
-    # Non OpenAI parameters - Fireworks AI only params
-    prompt_truncate_length: Optional[int] = None
+    prompt_truncate_len: Optional[int] = None
     context_length_exceeded_behavior: Optional[Literal["error", "truncate"]] = None
 
     def __init__(
@@ -80,7 +78,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
         user: Optional[str] = None,
         logprobs: Optional[int] = None,
         reasoning_effort: Optional[str] = None,
-        prompt_truncate_length: Optional[int] = None,
+        prompt_truncate_len: Optional[int] = None,
         context_length_exceeded_behavior: Optional[Literal["error", "truncate"]] = None,
     ) -> None:
         locals_ = locals().copy()
@@ -108,8 +106,31 @@ class FireworksAIConfig(OpenAIGPTConfig):
             "response_format",
             "user",
             "logprobs",
-            "prompt_truncate_length",
+            "prompt_truncate_len",
             "context_length_exceeded_behavior",
+            "seed",
+            "top_logprobs",
+            "min_p",
+            "typical_p",
+            "repetition_penalty",
+            "mirostat_target",
+            "mirostat_lr",
+            "logit_bias",
+            "echo",
+            "echo_last",
+            "ignore_eos",
+            "prompt_cache_key",
+            "prompt_cache_isolation_key",
+            "raw_output",
+            "perf_metrics_in_response",
+            "return_token_ids",
+            "safe_tokenization",
+            "service_tier",
+            "metadata",
+            "speculation",
+            "prediction",
+            "stream_options",
+            "sampling_mask",
         ]
 
         # Only add tools for models that support function calling
@@ -133,9 +154,10 @@ class FireworksAIConfig(OpenAIGPTConfig):
         if supports_tool_choice(model=model, custom_llm_provider="fireworks_ai"):
             supported_params.append("tool_choice")
 
-        # Only add reasoning_effort for models that support it
+        # Only add reasoning params for models that support it
         if supports_reasoning(model=model, custom_llm_provider="fireworks_ai"):
             supported_params.append("reasoning_effort")
+            supported_params.append("reasoning_history")
 
         return supported_params
 
@@ -174,39 +196,18 @@ class FireworksAIConfig(OpenAIGPTConfig):
                     optional_params["response_format"] = value
             elif param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
+            elif param == "reasoning_effort":
+                if value is True:
+                    optional_params["reasoning_effort"] = "medium"
+                elif value is False:
+                    optional_params["reasoning_effort"] = "none"
+                else:
+                    optional_params["reasoning_effort"] = value
             elif param in supported_openai_params:
                 if value is not None:
                     optional_params[param] = value
 
         return optional_params
-
-    def _add_transform_inline_image_block(
-        self,
-        content: ChatCompletionImageObject,
-        model: str,
-        disable_add_transform_inline_image_block: Optional[bool],
-    ) -> ChatCompletionImageObject:
-        """
-        Add transform_inline to the image_url (allows non-vision models to parse documents/images/etc.)
-        - ignore if model is a vision model
-        - ignore if user has disabled this feature
-        """
-        if (
-            "vision" in model or disable_add_transform_inline_image_block
-        ):  # allow user to toggle this feature.
-            return content
-        if isinstance(content["image_url"], str):
-            # Skip base64 data URLs — appending #transform=inline corrupts the
-            # base64 payload and causes an "Incorrect padding" decode error on
-            # the Fireworks side.  Data URLs are already inlined by definition.
-            # Lower-case before checking: URI schemes are case-insensitive (RFC 3986).
-            if not content["image_url"].lower().startswith("data:"):
-                content["image_url"] = f"{content['image_url']}#transform=inline"
-        elif isinstance(content["image_url"], dict):
-            url = content["image_url"]["url"]
-            if not url.lower().startswith("data:"):
-                content["image_url"]["url"] = f"{url}#transform=inline"
-        return content
 
     def _transform_tools(
         self, tools: List[OpenAIChatCompletionToolParam]
@@ -225,37 +226,13 @@ class FireworksAIConfig(OpenAIGPTConfig):
         self, messages: List[AllMessageValues], model: str, litellm_params: dict
     ) -> List[AllMessageValues]:
         """
-        Add 'transform=inline' to the url of the image_url
+        Strip fields not permitted by FireworksAI from messages.
         """
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             filter_value_from_dict,
-            migrate_file_to_image_url,
         )
 
-        disable_add_transform_inline_image_block = cast(
-            Optional[bool],
-            litellm_params.get("disable_add_transform_inline_image_block")
-            or litellm.disable_add_transform_inline_image_block,
-        )
-        ## For any 'file' message type with pdf content, move to 'image_url' message type
         for message in messages:
-            if message["role"] == "user":
-                _message_content = message.get("content")
-                if _message_content is not None and isinstance(_message_content, list):
-                    for idx, content in enumerate(_message_content):
-                        if content["type"] == "file":
-                            _message_content[idx] = migrate_file_to_image_url(content)
-        for message in messages:
-            if message["role"] == "user":
-                _message_content = message.get("content")
-                if _message_content is not None and isinstance(_message_content, list):
-                    for content in _message_content:
-                        if content["type"] == "image_url":
-                            content = self._add_transform_inline_image_block(
-                                content=content,
-                                model=model,
-                                disable_add_transform_inline_image_block=disable_add_transform_inline_image_block,
-                            )
             filter_value_from_dict(cast(dict, message), "cache_control")
             # Remove fields not permitted by FireworksAI (additionalProperties: false
             # on their ChatMessage schema) that may cause:
@@ -362,12 +339,16 @@ class FireworksAIConfig(OpenAIGPTConfig):
         supports_reasoning_value = self._get_model_cost_capability(
             model=model, capability="supports_reasoning"
         )
+        supports_vision_value = self._get_model_cost_capability(
+            model=model, capability="supports_vision"
+        )
+        supports_pdf_input_value = self._get_model_cost_capability(
+            model=model, capability="supports_pdf_input"
+        )
 
         provider_specific_model_info: ProviderSpecificModelInfo = {
             "supports_function_calling": True,
             "supports_prompt_caching": True,  # https://docs.fireworks.ai/guides/prompt-caching
-            "supports_pdf_input": True,  # via document inlining
-            "supports_vision": True,  # via document inlining
         }
 
         if supports_function_calling_value is not None:
@@ -379,6 +360,14 @@ class FireworksAIConfig(OpenAIGPTConfig):
         if supports_reasoning_value:
             provider_specific_model_info["supports_reasoning"] = (
                 supports_reasoning_value
+            )
+
+        if supports_vision_value is not None:
+            provider_specific_model_info["supports_vision"] = supports_vision_value
+
+        if supports_pdf_input_value is not None:
+            provider_specific_model_info["supports_pdf_input"] = (
+                supports_pdf_input_value
             )
 
         return provider_specific_model_info
@@ -402,6 +391,15 @@ class FireworksAIConfig(OpenAIGPTConfig):
         if "tools" in optional_params and optional_params["tools"] is not None:
             tools = self._transform_tools(tools=optional_params["tools"])
             optional_params["tools"] = tools
+        if optional_params.get("stream"):
+            stream_options = optional_params.get("stream_options")
+            if stream_options is None:
+                optional_params["stream_options"] = {"include_usage": True}
+            elif stream_options.get("include_usage") is not False:
+                optional_params["stream_options"] = {
+                    **stream_options,
+                    "include_usage": True,
+                }
         return super().transform_request(
             model=model,
             messages=messages,
@@ -494,7 +492,35 @@ class FireworksAIConfig(OpenAIGPTConfig):
                 )
             )
 
-        response._hidden_params = {"additional_headers": additional_headers}
+        hidden_params: dict = {"additional_headers": additional_headers}
+
+        if "perf_metrics" in completion_response:
+            hidden_params["fireworks_perf_metrics"] = completion_response[
+                "perf_metrics"
+            ]
+        if "prompt_token_ids" in completion_response:
+            hidden_params["fireworks_prompt_token_ids"] = completion_response[
+                "prompt_token_ids"
+            ]
+
+        raw_choices = completion_response.get("choices") or []
+        fireworks_raw_outputs = [
+            choice["raw_output"]
+            for choice in raw_choices
+            if isinstance(choice, dict) and "raw_output" in choice
+        ]
+        if fireworks_raw_outputs:
+            hidden_params["fireworks_raw_outputs"] = fireworks_raw_outputs
+
+        fireworks_token_ids = [
+            choice["token_ids"]
+            for choice in raw_choices
+            if isinstance(choice, dict) and "token_ids" in choice
+        ]
+        if fireworks_token_ids:
+            hidden_params["fireworks_token_ids"] = fireworks_token_ids
+
+        response._hidden_params = hidden_params
 
         return response
 

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -251,9 +251,7 @@ class FireworksAIConfig(OpenAIGPTConfig):
         for message in messages:
             if message["role"] == "user":
                 _message_content = message.get("content")
-                if _message_content is not None and isinstance(
-                    _message_content, list
-                ):
+                if _message_content is not None and isinstance(_message_content, list):
                     for content in _message_content:
                         if not isinstance(content, dict):
                             continue

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -15011,7 +15011,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": true
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
         "input_cost_per_token": 1.2e-06,
@@ -15314,7 +15314,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": true
     },
     "fireworks_ai/qwen3p7-plus": {
         "cache_read_input_token_cost": 8e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -15019,7 +15019,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": true
     },
     "fireworks_ai/accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
         "input_cost_per_token": 1.2e-06,
@@ -15322,7 +15322,7 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": false
+        "supports_vision": true
     },
     "fireworks_ai/qwen3p7-plus": {
         "cache_read_input_token_cost": 8e-08,

--- a/tests/llm_translation/test_fireworks_ai_translation.py
+++ b/tests/llm_translation/test_fireworks_ai_translation.py
@@ -9,7 +9,6 @@ sys.path.insert(
 import litellm
 from litellm import transcription
 from litellm.llms.fireworks_ai.chat.transformation import FireworksAIConfig
-from base_llm_unit_tests import BaseLLMChatTest
 from base_audio_transcription_unit_tests import BaseLLMAudioTranscriptionTest
 
 fireworks = FireworksAIConfig()
@@ -146,11 +145,8 @@ class TestFireworksAIAudioTranscription(BaseLLMAudioTranscriptionTest):
 )
 def test_document_inlining_example(disable_add_transform_inline_image_block):
     """
-    Document inlining appends ``#transform=inline`` to image/PDF URLs in the
-    outgoing request unless explicitly disabled. Assert the transform on the
-    serialized payload rather than making a live Fireworks call — the live
-    call only proved the model responded and broke whenever Fireworks rotated
-    its serverless model catalog.
+    Fireworks document inlining has been removed from the platform. LiteLLM
+    must not append ``#transform=inline`` regardless of the legacy disable flag.
     """
     from unittest.mock import patch
 
@@ -182,89 +178,80 @@ def test_document_inlining_example(disable_add_transform_inline_image_block):
                 disable_add_transform_inline_image_block=disable_add_transform_inline_image_block,
                 client=client,
             )
-        except Exception as e:
-            print(e)
+        except Exception:
+            pass
 
         mock_post.assert_called_once()
         json_data = json.loads(mock_post.call_args.kwargs["data"])
         sent_url = json_data["messages"][0]["content"][0]["image_url"]["url"]
-        if disable_add_transform_inline_image_block is True:
-            assert sent_url == pdf_url
-            assert "#transform=inline" not in sent_url
-        else:
-            assert sent_url == pdf_url + "#transform=inline"
+        assert sent_url == pdf_url
+        assert "#transform=inline" not in sent_url
 
 
 @pytest.mark.parametrize(
-    "content, model, expected_url",
+    "content, expected_url",
     [
         (
             {"image_url": "http://example.com/image.png"},
-            "gpt-4",
-            "http://example.com/image.png#transform=inline",
+            "http://example.com/image.png",
         ),
         (
             {"image_url": {"url": "http://example.com/image.png"}},
-            "gpt-4",
-            {"url": "http://example.com/image.png#transform=inline"},
+            {"url": "http://example.com/image.png"},
         ),
-        (
-            {"image_url": "http://example.com/image.png"},
-            "vision-gpt",
-            "http://example.com/image.png",
-        ),
-        # data: URLs must never have #transform=inline appended — doing so
-        # corrupts the base64 payload (fixes #23583).
-        # URI schemes are case-insensitive (RFC 3986) so check all variants.
         (
             {"image_url": "data:image/png;base64,iVBORw0KGgo="},
-            "gpt-4",
             "data:image/png;base64,iVBORw0KGgo=",
         ),
         (
             {"image_url": {"url": "data:image/jpeg;base64,/9j/4AAQ=="}},
-            "gpt-4",
             {"url": "data:image/jpeg;base64,/9j/4AAQ=="},
         ),
         (
             {"image_url": "Data:image/png;base64,iVBORw0KGgo="},
-            "gpt-4",
             "Data:image/png;base64,iVBORw0KGgo=",
         ),
     ],
 )
-def test_transform_inline(content, model, expected_url):
+def test_transform_inline_no_longer_added(content, expected_url):
+    image_block = {"type": "image_url", **content}
+    messages = [{"role": "user", "content": [image_block]}]
 
-    result = litellm.FireworksAIConfig()._add_transform_inline_image_block(
-        content=content, model=model, disable_add_transform_inline_image_block=False
+    result = litellm.FireworksAIConfig()._transform_messages_helper(
+        messages=messages,
+        model="accounts/fireworks/models/minimax-m3",
+        litellm_params={},
     )
+    result_image_block = result[0]["content"][0]
     if isinstance(expected_url, str):
-        assert result["image_url"] == expected_url
+        assert result_image_block["image_url"] == expected_url
     else:
-        assert result["image_url"]["url"] == expected_url["url"]
+        assert result_image_block["image_url"]["url"] == expected_url["url"]
 
 
 @pytest.mark.parametrize(
-    "model, is_disabled, expected_url",
-    [
-        ("gpt-4", True, "http://example.com/image.png"),
-        ("vision-gpt", False, "http://example.com/image.png"),
-        ("gpt-4", False, "http://example.com/image.png#transform=inline"),
-    ],
+    "is_disabled",
+    [True, False],
 )
-def test_global_disable_flag(model, is_disabled, expected_url):
-    content = {"image_url": "http://example.com/image.png"}
-    result = litellm.FireworksAIConfig()._add_transform_inline_image_block(
-        content=content,
-        model=model,
-        disable_add_transform_inline_image_block=is_disabled,
+def test_global_disable_flag_no_longer_adds_transform_inline(is_disabled):
+    url = "http://example.com/image.png"
+    litellm.disable_add_transform_inline_image_block = is_disabled
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": url}],
+        }
+    ]
+    result = litellm.FireworksAIConfig()._transform_messages_helper(
+        messages=messages,
+        model="accounts/fireworks/models/minimax-m3",
+        litellm_params={},
     )
-    assert result["image_url"] == expected_url
+    assert result[0]["content"][0]["image_url"] == url
     litellm.disable_add_transform_inline_image_block = False  # Reset for other tests
 
 
 def test_global_disable_flag_with_transform_messages_helper(monkeypatch):
-    from openai import OpenAI
     from unittest.mock import patch
     from litellm import completion
     from litellm.llms.custom_httpx.http_handler import HTTPHandler
@@ -296,11 +283,10 @@ def test_global_disable_flag_with_transform_messages_helper(monkeypatch):
                 ],
                 client=client,
             )
-        except Exception as e:
-            print(e)
+        except Exception:
+            pass
 
         mock_post.assert_called_once()
-        print(mock_post.call_args.kwargs)
         json_data = json.loads(mock_post.call_args.kwargs["data"])
         assert (
             "#transform=inline"

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -624,7 +624,6 @@ def test_get_supported_openai_params_includes_all_fireworks_params():
         "return_token_ids",
         "safe_tokenization",
         "service_tier",
-        "metadata",
         "speculation",
         "prediction",
         "stream_options",

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1,9 +1,8 @@
 import json
 import os
 import sys
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 import litellm
@@ -14,8 +13,12 @@ sys.path.insert(
 
 from litellm import get_model_info, supports_reasoning
 from litellm.llms.fireworks_ai.chat.transformation import FireworksAIConfig
-from litellm.types.llms.openai import ChatCompletionToolCallFunctionChunk
-from litellm.types.utils import ChatCompletionMessageToolCall, Function, Message
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Function,
+    Message,
+    ModelResponse,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -98,12 +101,12 @@ def test_supports_reasoning_effort():
 
     for model in supported_models:
         assert (
-            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") == True
+            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is True
         ), f"{model} should support reasoning_effort"
 
     for model in unsupported_models:
         assert (
-            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") == False
+            supports_reasoning(model=model, custom_llm_provider="fireworks_ai") is False
         ), f"{model} should not support reasoning_effort"
 
 
@@ -179,41 +182,6 @@ def test_get_provider_info_omits_false_supports_reasoning(monkeypatch):
     info = config.get_provider_info(model)
 
     assert "supports_reasoning" not in info
-
-
-def test_add_transform_inline_image_block_skips_data_urls():
-    """
-    data: URLs must not have #transform=inline appended — doing so corrupts the
-    base64 payload and raises binascii.Error: Incorrect padding on the Fireworks side.
-    Regression test for https://github.com/BerriAI/litellm/issues/23583
-    """
-    config = FireworksAIConfig()
-    data_url = "data:image/jpeg;base64,/9j/4AAQSkZJRgAB"
-
-    # str branch
-    str_content = {"type": "image_url", "image_url": data_url}
-    result = config._add_transform_inline_image_block(
-        str_content, model="gpt-4", disable_add_transform_inline_image_block=False
-    )
-    assert result["image_url"] == data_url, "data URL must not be modified (str branch)"
-
-    # dict branch
-    dict_content = {"type": "image_url", "image_url": {"url": data_url}}
-    result = config._add_transform_inline_image_block(
-        dict_content, model="gpt-4", disable_add_transform_inline_image_block=False
-    )
-    assert (
-        result["image_url"]["url"] == data_url
-    ), "data URL must not be modified (dict branch)"
-
-    # regular https URL should still get the suffix
-    https_content = {"type": "image_url", "image_url": "https://example.com/image.jpg"}
-    result = config._add_transform_inline_image_block(
-        https_content, model="gpt-4", disable_add_transform_inline_image_block=False
-    )
-    assert result["image_url"].endswith(
-        "#transform=inline"
-    ), "https URL should get #transform=inline"
 
 
 @pytest.mark.parametrize(
@@ -582,3 +550,301 @@ def test_transform_request_routes_short_form_model_to_models_path():
         headers={},
     )
     assert result["model"] == "accounts/fireworks/models/glm-5p2"
+
+
+def _make_fireworks_raw_response(body: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.return_value = body
+    mock.text = json.dumps(body)
+    mock.headers = {}
+    return mock
+
+
+_BASE_CHAT_COMPLETION_RESPONSE: dict = {
+    "id": "resp-test",
+    "object": "chat.completion",
+    "created": 1234567890,
+    "model": "glm-5p1",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hello"},
+            "finish_reason": "stop",
+        }
+    ],
+    "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+}
+
+
+def _run_transform_response(response_body: dict) -> ModelResponse:
+    config = FireworksAIConfig()
+    raw_response = _make_fireworks_raw_response(response_body)
+    logging_obj = MagicMock()
+    return config.transform_response(
+        model="accounts/fireworks/models/glm-5p1",
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=logging_obj,
+        request_data={},
+        messages=[{"role": "user", "content": "Hi"}],
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+        api_key="test-key",
+    )
+
+
+_REASONING_MODEL = "fireworks_ai/accounts/fireworks/models/glm-5p1"
+_NON_REASONING_MODEL = "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct"
+
+
+def test_get_supported_openai_params_includes_all_fireworks_params():
+    config = FireworksAIConfig()
+    params = config.get_supported_openai_params(_REASONING_MODEL)
+
+    required = [
+        "seed",
+        "top_logprobs",
+        "min_p",
+        "typical_p",
+        "repetition_penalty",
+        "mirostat_target",
+        "mirostat_lr",
+        "logit_bias",
+        "echo",
+        "echo_last",
+        "ignore_eos",
+        "prompt_cache_key",
+        "prompt_cache_isolation_key",
+        "raw_output",
+        "perf_metrics_in_response",
+        "return_token_ids",
+        "safe_tokenization",
+        "service_tier",
+        "metadata",
+        "speculation",
+        "prediction",
+        "stream_options",
+        "sampling_mask",
+        "reasoning_history",
+    ]
+    missing = [p for p in required if p not in params]
+    assert missing == [], f"Missing params: {missing}"
+    assert "thinking" not in params
+
+
+def test_prompt_truncate_len_correct_name():
+    config = FireworksAIConfig()
+    params = config.get_supported_openai_params(_REASONING_MODEL)
+    assert "prompt_truncate_len" in params
+    assert "prompt_truncate_length" not in params
+
+    result = config.map_openai_params(
+        {"prompt_truncate_len": 4096},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result == {"prompt_truncate_len": 4096}
+
+
+def test_stream_options_include_usage_auto_injected():
+    config = FireworksAIConfig()
+    result = config.transform_request(
+        model="accounts/fireworks/models/glm-5p1",
+        messages=[{"role": "user", "content": "Hi"}],
+        optional_params={"stream": True},
+        litellm_params={},
+        headers={},
+    )
+    assert result["stream_options"] == {"include_usage": True}
+
+
+def test_stream_options_not_injected_when_not_streaming():
+    config = FireworksAIConfig()
+    result = config.transform_request(
+        model="accounts/fireworks/models/glm-5p1",
+        messages=[{"role": "user", "content": "Hi"}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+    assert "stream_options" not in result
+
+
+def test_stream_options_preserves_user_override():
+    config = FireworksAIConfig()
+    result = config.transform_request(
+        model="accounts/fireworks/models/glm-5p1",
+        messages=[{"role": "user", "content": "Hi"}],
+        optional_params={"stream": True, "stream_options": {"include_usage": False}},
+        litellm_params={},
+        headers={},
+    )
+    assert result["stream_options"]["include_usage"] is False
+
+
+def test_reasoning_history_in_supported_params():
+    config = FireworksAIConfig()
+    reasoning_params = config.get_supported_openai_params(_REASONING_MODEL)
+    assert "reasoning_history" in reasoning_params
+
+    non_reasoning_params = config.get_supported_openai_params(_NON_REASONING_MODEL)
+    assert "reasoning_history" not in non_reasoning_params
+
+
+def test_transform_messages_helper_no_file_migration():
+    config = FireworksAIConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "file", "file_url": "https://example.com/doc.pdf"},
+                {"type": "text", "text": "Describe this"},
+            ],
+        }
+    ]
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+    )
+    content = out[0]["content"]
+    assert any(
+        isinstance(b, dict) and b.get("type") == "file" for b in content
+    ), "file block must remain as type=file"
+    assert not any(
+        isinstance(b, dict) and b.get("type") == "image_url" for b in content
+    ), "file block must not be migrated to image_url"
+
+
+def test_transform_messages_helper_no_transform_inline():
+    config = FireworksAIConfig()
+    url = "https://example.com/image.jpg"
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": url}],
+        }
+    ]
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+    )
+    block = out[0]["content"][0]
+    assert block["image_url"] == url
+    assert "#transform=inline" not in block["image_url"]
+
+
+def test_get_provider_info_vision_from_model_cost(monkeypatch):
+    config = FireworksAIConfig()
+
+    vision_model = "fireworks_ai/test-vision-from-cost"
+    monkeypatch.setitem(
+        litellm.model_cost,
+        vision_model,
+        {"supports_vision": True, "supports_pdf_input": True},
+    )
+    info = config.get_provider_info(vision_model)
+    assert info["supports_vision"] is True
+    assert info["supports_pdf_input"] is True
+
+    no_vision_model = "fireworks_ai/test-no-vision-from-cost"
+    monkeypatch.setitem(litellm.model_cost, no_vision_model, {})
+    info_no_vision = config.get_provider_info(no_vision_model)
+    assert info_no_vision.get("supports_vision") is not True
+    assert "supports_pdf_input" not in info_no_vision
+
+
+def test_reasoning_effort_boolean_true_to_medium():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": True},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "medium"
+
+
+def test_reasoning_effort_boolean_false_to_none():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": False},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "none"
+
+
+def test_reasoning_effort_string_passthrough():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": "high"},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "high"
+
+
+def test_reasoning_effort_integer_passthrough():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": 1000},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == 1000
+    assert isinstance(result["reasoning_effort"], int)
+
+
+def test_transform_response_captures_perf_metrics():
+    body = {
+        **_BASE_CHAT_COMPLETION_RESPONSE,
+        "perf_metrics": {"prompt-tokens": 10},
+    }
+    result = _run_transform_response(body)
+    assert result._hidden_params["fireworks_perf_metrics"] == {"prompt-tokens": 10}
+
+
+def test_transform_response_captures_prompt_token_ids():
+    body = {
+        **_BASE_CHAT_COMPLETION_RESPONSE,
+        "prompt_token_ids": [1, 2, 3],
+    }
+    result = _run_transform_response(body)
+    assert result._hidden_params["fireworks_prompt_token_ids"] == [1, 2, 3]
+
+
+def test_transform_response_captures_raw_output():
+    raw_output = {
+        "prompt_fragments": [],
+        "prompt_token_ids": [],
+        "completion": "test",
+    }
+    body = {
+        **_BASE_CHAT_COMPLETION_RESPONSE,
+        "choices": [
+            {
+                **_BASE_CHAT_COMPLETION_RESPONSE["choices"][0],
+                "raw_output": raw_output,
+            }
+        ],
+    }
+    result = _run_transform_response(body)
+    assert result._hidden_params["fireworks_raw_outputs"] == [raw_output]
+
+
+def test_transform_response_captures_token_ids():
+    body = {
+        **_BASE_CHAT_COMPLETION_RESPONSE,
+        "choices": [
+            {
+                **_BASE_CHAT_COMPLETION_RESPONSE["choices"][0],
+                "token_ids": [4, 5, 6],
+            }
+        ],
+    }
+    result = _run_transform_response(body)
+    assert result._hidden_params["fireworks_token_ids"] == [[4, 5, 6]]

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -809,6 +809,21 @@ def test_transform_messages_helper_allows_vision_image_inputs():
     assert out == messages
 
 
+def test_transform_messages_helper_skips_non_dict_content():
+    config = FireworksAIConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": ["just a string", {"type": "text", "text": "hello"}],
+        }
+    ]
+
+    out = config._transform_messages_helper(
+        messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
+    )
+    assert out == messages
+
+
 def test_transform_messages_helper_no_transform_inline():
     config = FireworksAIConfig()
     url = "https://example.com/image.jpg"

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -118,11 +118,13 @@ def test_get_supported_openai_params_reasoning_effort():
         "fireworks_ai/accounts/fireworks/models/glm-5p1"
     )
     assert "reasoning_effort" in supported_params
+    assert "thinking" in supported_params
 
     unsupported_params = config.get_supported_openai_params(
         "fireworks_ai/accounts/fireworks/models/llama-v3-70b-instruct"
     )
     assert "reasoning_effort" not in unsupported_params
+    assert "thinking" not in unsupported_params
 
 
 def test_get_supported_openai_params_parallel_tool_calls():
@@ -704,6 +706,23 @@ def test_thinking_param_passthrough():
         drop_params=False,
     )
     assert result == {"thinking": thinking}
+
+
+def test_thinking_and_reasoning_effort_conflict_rejected():
+    config = FireworksAIConfig()
+    with pytest.raises(
+        litellm.BadRequestError,
+        match="does not support specifying both `thinking` and `reasoning_effort`",
+    ):
+        config.map_openai_params(
+            {
+                "thinking": {"type": "enabled", "budget_tokens": 4096},
+                "reasoning_effort": "medium",
+            },
+            {},
+            _REASONING_MODEL,
+            drop_params=False,
+        )
 
 
 def test_minimax_m3_supports_vision_from_model_map():

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -11,7 +11,7 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
-from litellm import get_model_info, supports_reasoning
+from litellm import get_model_info, supports_reasoning, supports_vision
 from litellm.llms.fireworks_ai.chat.transformation import FireworksAIConfig
 from litellm.types.utils import (
     ChatCompletionMessageToolCall,
@@ -627,11 +627,11 @@ def test_get_supported_openai_params_includes_all_fireworks_params():
         "prediction",
         "stream_options",
         "sampling_mask",
+        "thinking",
         "reasoning_history",
     ]
     missing = [p for p in required if p not in params]
     assert missing == [], f"Missing params: {missing}"
-    assert "thinking" not in params
 
 
 def test_prompt_truncate_len_correct_name():
@@ -694,27 +694,100 @@ def test_reasoning_history_in_supported_params():
     assert "reasoning_history" not in non_reasoning_params
 
 
-def test_transform_messages_helper_no_file_migration():
+def test_thinking_param_passthrough():
+    config = FireworksAIConfig()
+    thinking = {"type": "disabled"}
+    result = config.map_openai_params(
+        {"thinking": thinking},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result == {"thinking": thinking}
+
+
+def test_minimax_m3_supports_vision_from_model_map():
+    config = FireworksAIConfig()
+
+    for model in [
+        "fireworks_ai/accounts/fireworks/models/minimax-m3",
+        "fireworks_ai/minimax-m3",
+    ]:
+        assert supports_vision(model=model, custom_llm_provider="fireworks_ai") is True
+        assert config.get_provider_info(model)["supports_vision"] is True
+
+
+def test_transform_messages_helper_rejects_file_blocks():
     config = FireworksAIConfig()
     messages = [
         {
             "role": "user",
             "content": [
-                {"type": "file", "file_url": "https://example.com/doc.pdf"},
+                {
+                    "type": "file",
+                    "file": {
+                        "file_data": "data:application/pdf;base64,JVBERi0xLjQKJSVFT0YK",
+                        "filename": "tiny.pdf",
+                    },
+                },
                 {"type": "text", "text": "Describe this"},
             ],
         }
     ]
+
+    with pytest.raises(
+        litellm.BadRequestError,
+        match="Fireworks AI chat completions does not support file content blocks",
+    ):
+        config._transform_messages_helper(
+            messages, model="accounts/fireworks/models/kimi-k2p6", litellm_params={}
+        )
+
+
+def test_transform_messages_helper_rejects_non_vision_image_inputs():
+    config = FireworksAIConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+                    },
+                },
+            ],
+        }
+    ]
+
+    with pytest.raises(litellm.BadRequestError, match="does not support image inputs"):
+        config._transform_messages_helper(
+            messages, model="accounts/fireworks/models/glm-5p2", litellm_params={}
+        )
+
+
+def test_transform_messages_helper_allows_vision_image_inputs():
+    config = FireworksAIConfig()
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAE="
+                    },
+                },
+            ],
+        }
+    ]
+
     out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
     )
-    content = out[0]["content"]
-    assert any(
-        isinstance(b, dict) and b.get("type") == "file" for b in content
-    ), "file block must remain as type=file"
-    assert not any(
-        isinstance(b, dict) and b.get("type") == "image_url" for b in content
-    ), "file block must not be migrated to image_url"
+    assert out == messages
 
 
 def test_transform_messages_helper_no_transform_inline():
@@ -727,7 +800,7 @@ def test_transform_messages_helper_no_transform_inline():
         }
     ]
     out = config._transform_messages_helper(
-        messages, model="accounts/fireworks/models/glm-5p1", litellm_params={}
+        messages, model="accounts/fireworks/models/minimax-m3", litellm_params={}
     )
     block = out[0]["content"][0]
     assert block["image_url"] == url

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4292,7 +4292,7 @@ _FIREWORKS_MODELS = [
         6e-08,
         512000,
         512000,
-        False,
+        True,
         True,
     ),
     (


### PR DESCRIPTION
## Relevant issues

Fixes #30842  

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Every missing parameter was verified individually against the live Fireworks API and accepted with HTTP 200. The fixes below were confirmed with live proxy and SDK calls

Start the proxy on localhost:4000 with a Fireworks model configured:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

Non-streaming completion, verify usage is present:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"What is 2+2?"}],
    "max_tokens": 50,
    "seed": 42,
    "prompt_cache_key": "test-key"
  }' | python -m json.tool
```
<img width="1920" height="482" alt="image" src="https://github.com/user-attachments/assets/b0d42a73-df89-44e4-bb40-8bb00b002a07" />

Streaming completion, verify usage appears in the final chunk (auto-injected `stream_options.include_usage`):

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"What is 2+2?"}],
    "max_tokens": 50,
    "stream": true
  }'
```
<img width="1920" height="272" alt="image" src="https://github.com/user-attachments/assets/899c6d38-c3c6-47c5-bbde-7aee171a1f32" />

The last SSE chunk should contain `"usage": {"prompt_tokens": ..., "completion_tokens": ..., "total_tokens": ...}` with `"choices": []`, matching the non-streaming behavior

Streaming with explicit `include_usage: false` override, verify usage is absent:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"What is 2+2?"}],
    "max_tokens": 50,
    "stream": true,
    "stream_options": {"include_usage": false}
  }'
```
<img width="1920" height="315" alt="image" src="https://github.com/user-attachments/assets/4c0d1475-7a9b-4654-a42d-21681f937187" />

Boolean `reasoning_effort` normalization, verify `true` maps to `"medium"` and the request succeeds:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"Explain recursion"}],
    "max_tokens": 100,
    "reasoning_effort": true
  }' | python -m json.tool
```
<img width="1920" height="502" alt="image" src="https://github.com/user-attachments/assets/fbfdb3a1-b8a1-4c05-b698-d65753e0290f" />

Response field capture with `perf_metrics_in_response` and `return_token_ids`, verify the data is accessible in `response._hidden_params`:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"Hello"}],
    "max_tokens": 10,
    "perf_metrics_in_response": true,
    "return_token_ids": true
  }' | python -m json.tool
```
<img width="613" height="879" alt="image" src="https://github.com/user-attachments/assets/627c59e4-f5c8-4bf5-aacd-86f9a2aa6def" />

Verify the correct parameter name `prompt_truncate_len` works:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-..." \
  -d '{
    "model": "fireworks_ai/accounts/fireworks/models/glm-5p2",
    "messages": [{"role":"user","content":"Hello"}],
    "max_tokens": 10,
    "extra_body": {"prompt_truncate_len": 1000}
  }' | python -m json.tool
```
<img width="814" height="467" alt="image" src="https://github.com/user-attachments/assets/a14ee076-b4ca-4d9c-8b92-2b919e17a002" />

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

This PR brings the Fireworks AI chat completions provider in sync with the full `/v1/chat/completions` API surface. All changes are confined to `litellm/llms/fireworks_ai/chat/transformation.py`, both model cost map JSON files, and the corresponding test files. No other provider is touched. All 60 unit tests pass, ruff is clean.

**Added 23 missing request parameters.** `get_supported_openai_params()` now lists `seed`, `top_logprobs`, `min_p`, `typical_p`, `repetition_penalty`, `mirostat_target`, `mirostat_lr`, `logit_bias`, `echo`, `echo_last`, `ignore_eos`, `prompt_cache_key`, `prompt_cache_isolation_key`, `raw_output`, `perf_metrics_in_response`, `return_token_ids`, `safe_tokenization`, `service_tier`, `metadata`, `speculation`, `prediction`, `stream_options`, and `sampling_mask` for all models. `reasoning_history` is added conditionally, gated on `supports_reasoning` in the model cost map, alongside the existing `reasoning_effort`. Each of these parameters was verified individually against the live Fireworks API and accepted with HTTP 200. Previously, these parameters were silently dropped from requests because they were not in the supported list, so users who passed them got no error and no effect.

**Added `thinking` parameter for reasoning models.** Fireworks accepts `thinking` with types `enabled`, `disabled`, and `adaptive` on the `/v1/chat/completions` endpoint (verified via live API). It is added to `get_supported_openai_params()` for reasoning-capable models only, alongside `reasoning_effort` and `reasoning_history`. A preflight check in `map_openai_params()` rejects requests that specify both `thinking` and `reasoning_effort`, since Fireworks returns HTTP 400 ("cannot specify both 'thinking' and 'reasoning_effort'") when both are present.

**Fixed `prompt_truncate_length` to `prompt_truncate_len`.** The Fireworks API expects `prompt_truncate_len`, but litellm used `prompt_truncate_length`, which meant the parameter was silently dropped even though litellm claimed to support it. The old name was never in `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`, so it always went to `extra_body` and was rejected by Fireworks; it never actually worked. The supported params list, class attribute, and `__init__` parameter now use the correct name. Users should pass `prompt_truncate_len` directly.

**Normalized `reasoning_effort` booleans.** The Fireworks OpenAPI schema documents that `reasoning_effort` accepts booleans and integers, but live testing confirms the server rejects non-string values with HTTP 400 (`"of type 'bool', expected 'string'"`). The schema describes the intended mapping: `True` becomes `"medium"` and `False` becomes `"none"`. `map_openai_params()` now performs this normalization client-side so users passing boolean values (which OpenAI itself uses for some models) get the documented behavior instead of an error. String values pass through unchanged. Integers are passed through as-is so the user gets a clear error from Fireworks rather than a silent drop; this can be revisited if Fireworks fixes integer support server-side.

**Auto-injected `stream_options.include_usage` when streaming.** When `stream=True` and the user has not set `stream_options`, litellm now injects `{"include_usage": True}` so that Fireworks returns usage data in a final SSE chunk with `choices: []`, matching the non-streaming behavior where usage is always present. If the user has set `stream_options` but did not explicitly set `include_usage` to `false`, `include_usage` is set to `True`. If the user explicitly sets `{"include_usage": false}`, that override is preserved and no usage data is sent. This fixes the inconsistency where streaming Fireworks responses through litellm had no usage data at all.

**Captured Fireworks-specific response fields.** When users enable `perf_metrics_in_response`, `return_token_ids`, or `raw_output` in the request, Fireworks returns `perf_metrics`, `prompt_token_ids`, `raw_output` (per choice), and `token_ids` (per choice) in the response body. Previously, `transform_response()` created a `ModelResponse` and silently dropped these fields. They are now captured into `response._hidden_params` under the keys `fireworks_perf_metrics`, `fireworks_prompt_token_ids`, `fireworks_raw_outputs`, and `fireworks_token_ids`, following the same pattern already used for `additional_headers`. This makes the data accessible to litellm logging, the proxy, and downstream consumers.

**Removed deprecated document inlining logic.** Fireworks deprecated document inlining on 2025-06-30 (https://docs.fireworks.ai/updates/changelog#-document-inlining-deprecation). The `_add_transform_inline_image_block()` method, the file-to-image_url migration loop, and the `disable_add_transform_inline_image_block` variable lookup have all been removed from `_transform_messages_helper()`. Current models that support image input (`kimi-k2p6`, `qwen3p7-plus`, `minimax-m3`) do so natively as vision-language models, not via inlining. The stripping of `cache_control`, `provider_specific_fields`, and `thinking_blocks` from messages is retained.

**Updated `get_provider_info()` to use model cost map for vision and PDF.** Previously, `get_provider_info()` hardcoded `supports_vision: True` and `supports_pdf_input: True` for every Fireworks model because document inlining allowed any model to "see" images and PDFs. With inlining deprecated, these capabilities are now looked up from the model cost map using `_get_model_cost_capability()`, the same pattern already used for `supports_function_calling` and `supports_reasoning`. `supports_vision` and `supports_pdf_input` are only included in the provider info if the cost map has a value for them. `supports_prompt_caching: True` is retained since prompt caching is still valid per https://docs.fireworks.ai/guides/prompt-caching.

**Fixed `supports_vision` for `minimax-m3` in both model cost maps.** It was marked `false` but the model accepts image inputs on the live API (verified with `image_url` content blocks returning vision descriptions). Both `model_prices_and_context_window.json` and `model_prices_and_context_window_backup.json` are updated.

**Reject invalid `file` and `image_url` content blocks.** `_transform_messages_helper()` now raises `BadRequestError` when a `file` content block is present (Fireworks rejects them) or when an `image_url` content block is sent to a model explicitly marked `supports_vision: false`. Models with no cost map entry (`None`) are allowed through to preserve the default-allow behavior for unknown models.

**Updated document-inlining tests.** The stale tests in `tests/llm_translation/test_fireworks_ai_translation.py` that asserted `#transform=inline` is appended now assert it is never appended, since the inlining code was removed and Fireworks deprecated the feature on 2025-06-30.