### PR TITLE
fix: propagate ssl_verify in AsyncHTTPHandler retry paths and BaseLLMAIOHTTPHandler

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -63,7 +63,9 @@ class BaseLLMAIOHTTPHandler:
 
         # Create a transport using AsyncHTTPHandler's logic
         try:
-            self.transport = AsyncHTTPHandler._create_aiohttp_transport(ssl_verify=self.ssl_verify)
+            self.transport = AsyncHTTPHandler._create_aiohttp_transport(
+                ssl_verify=self.ssl_verify
+            )
             self._owns_transport = True
             return self.transport
         except Exception:

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Tuple, Union, cast
 
 import aiohttp
 import httpx  # type: ignore
+import ssl
 from aiohttp import ClientSession, FormData
 
 import litellm
@@ -16,6 +17,7 @@ from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     HTTPHandler,
     _get_httpx_client,
+    get_ssl_configuration,
 )
 from litellm.llms.custom_httpx.aiohttp_transport import LiteLLMAiohttpTransport
 from litellm.types.llms.openai import FileTypes
@@ -61,10 +63,16 @@ class BaseLLMAIOHTTPHandler:
         if self.transport:
             return self.transport
 
-        # Create a transport using AsyncHTTPHandler's logic
+        # Create a transport using AsyncHTTPHandler's logic.
+        # Convert ssl_verify (which may be a CA-bundle path string) to the correct
+        # type before calling _create_aiohttp_transport, which only accepts bool or
+        # ssl.SSLContext.  This mirrors what AsyncHTTPHandler.create_client() does.
         try:
+            import ssl as _ssl
+            ssl_config = get_ssl_configuration(self.ssl_verify)
             self.transport = AsyncHTTPHandler._create_aiohttp_transport(
-                ssl_verify=self.ssl_verify
+                ssl_context=ssl_config if isinstance(ssl_config, _ssl.SSLContext) else None,
+                ssl_verify=ssl_config if isinstance(ssl_config, bool) else None,
             )
             self._owns_transport = True
             return self.transport

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -38,8 +38,10 @@ class BaseLLMAIOHTTPHandler:
         client_session: Optional[aiohttp.ClientSession] = None,
         transport: Optional[LiteLLMAiohttpTransport] = None,
         connector: Optional[aiohttp.BaseConnector] = None,
+        ssl_verify: Optional[Union[bool, str]] = None,
     ):
         self.client_session = client_session
+        self.ssl_verify = ssl_verify
         self._owns_session = (
             client_session is None
         )  # Track if we own the session for cleanup
@@ -61,7 +63,7 @@ class BaseLLMAIOHTTPHandler:
 
         # Create a transport using AsyncHTTPHandler's logic
         try:
-            self.transport = AsyncHTTPHandler._create_aiohttp_transport()
+            self.transport = AsyncHTTPHandler._create_aiohttp_transport(ssl_verify=self.ssl_verify)
             self._owns_transport = True
             return self.transport
         except Exception:

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -650,7 +650,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
+                
             )
             try:
                 return await self.single_connection_post_request(
@@ -713,7 +713,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
+                
             )
             try:
                 return await self.single_connection_post_request(
@@ -774,7 +774,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
+                
             )
             try:
                 return await self.single_connection_post_request(
@@ -835,7 +835,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
+                
             )
             try:
                 return await self.single_connection_post_request(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -62,7 +62,7 @@ except Exception:
 
 
 # aiohttp 3.10+ exposes a `socket_factory` kwarg on TCPConnector. Older
-# versions don't — detect once and skip the keep-alive wiring there.
+# versions don't â detect once and skip the keep-alive wiring there.
 # https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.TCPConnector
 _AIOHTTP_SUPPORTS_SOCKET_FACTORY = (
     "socket_factory" in inspect.signature(TCPConnector.__init__).parameters
@@ -470,7 +470,7 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
         # Mask the original exception message too (it contains the full URL)
         masked_original_message = mask_sensitive_info(str(original_error))
 
-        # Safely access response content — decompression can fail (e.g. zlib error).
+        # Safely access response content â decompression can fail (e.g. zlib error).
         # `.content` returns already-decoded bytes, so we must strip transport
         # encoding headers before rebuilding the Response (otherwise httpx will
         # try to decode the bytes a second time and raise DecodingError).
@@ -500,7 +500,7 @@ class MaskedHTTPStatusError(httpx.HTTPStatusError):
         super().__init__(
             message=masked_original_message,
             request=masked_request,
-            # Attach the masked request so `response.request` is set — otherwise
+            # Attach the masked request so `response.request` is set â otherwise
             # downstream code that inspects err.response.request (e.g.
             # exception_mapping_utils) hits `RuntimeError: .request not set`.
             response=httpx.Response(
@@ -649,7 +649,11 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.            )
+            new_client = self.create_client(
+                timeout=timeout,
+                event_hooks=self.event_hooks,
+                ssl_verify=self.ssl_verify,
+            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -710,7 +714,11 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.            )
+            new_client = self.create_client(
+                timeout=timeout,
+                event_hooks=self.event_hooks,
+                ssl_verify=self.ssl_verify,
+            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -769,7 +777,11 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.            )
+            new_client = self.create_client(
+                timeout=timeout,
+                event_hooks=self.event_hooks,
+                ssl_verify=self.ssl_verify,
+            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -828,7 +840,11 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.            )
+            new_client = self.create_client(
+                timeout=timeout,
+                event_hooks=self.event_hooks,
+                ssl_verify=self.ssl_verify,
+            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -1037,7 +1053,7 @@ class AsyncHTTPHandler:
                 AIOHTTP_CONNECTOR_LIMIT_PER_HOST
             )
         # Returns None when SO_KEEPALIVE is disabled or aiohttp is too old to
-        # accept socket_factory — version detection lives inside the builder.
+        # accept socket_factory â version detection lives inside the builder.
         socket_factory = _build_aiohttp_keepalive_socket_factory()
         if socket_factory is not None:
             transport_connector_kwargs["socket_factory"] = socket_factory
@@ -1135,7 +1151,7 @@ class HTTPHandler:
     @staticmethod
     def extract_query_params(url: str) -> Dict[str, str]:
         """
-        Parse a URL’s query-string into a dict.
+        Parse a URLâs query-string into a dict.
 
         :param url: full URL, e.g. "https://.../path?foo=1&bar=2"
         :return: {"foo": "1", "bar": "2"}

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -527,6 +527,7 @@ class AsyncHTTPHandler:
     ):
         self.timeout = timeout
         self.event_hooks = event_hooks
+        self.ssl_verify = ssl_verify
         self.client = self.create_client(
             timeout=timeout,
             event_hooks=event_hooks,
@@ -649,7 +650,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks
+                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
             )
             try:
                 return await self.single_connection_post_request(
@@ -712,7 +713,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks
+                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
             )
             try:
                 return await self.single_connection_post_request(
@@ -773,7 +774,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks
+                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
             )
             try:
                 return await self.single_connection_post_request(
@@ -834,7 +835,7 @@ class AsyncHTTPHandler:
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
             new_client = self.create_client(
-                timeout=timeout, event_hooks=self.event_hooks
+                timeout=timeout, event_hooks=self.event_hooks, ssl_verify=self.ssl_verify
             )
             try:
                 return await self.single_connection_post_request(

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -649,9 +649,7 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.create_client(
-                
-            )
+            new_client = self.            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -712,9 +710,7 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.create_client(
-                
-            )
+            new_client = self.            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -773,9 +769,7 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.create_client(
-                
-            )
+            new_client = self.            )
             try:
                 return await self.single_connection_post_request(
                     url=url,
@@ -834,9 +828,7 @@ class AsyncHTTPHandler:
             return response
         except (httpx.RemoteProtocolError, httpx.ConnectError):
             # Retry the request with a new session if there is a connection error
-            new_client = self.create_client(
-                
-            )
+            new_client = self.            )
             try:
                 return await self.single_connection_post_request(
                     url=url,


### PR DESCRIPTION
## Problem

Fixes #30778

`ssl_verify` is silently dropped in two places:

1. **`AsyncHTTPHandler` retry paths** — `post()`, `put()`, `patch()`, and `delete()` all catch `httpx.RemoteProtocolError` / `httpx.ConnectError` and recreate the client via `self.create_client()`, but none passed `ssl_verify`. This means any retry after a connection error ignores the user's SSL setting.

2. **`BaseLLMAIOHTTPHandler`** — `__init__` had no `ssl_verify` parameter, so `_get_or_create_transport()` called `AsyncHTTPHandler._create_aiohttp_transport()` without any SSL args.

## Fix

**`http_handler.py`**
- Store `ssl_verify` on the instance as `self.ssl_verify` in `AsyncHTTPHandler.__init__`
- Pass `ssl_verify=self.ssl_verify` in all four retry `create_client()` calls

**`aiohttp_handler.py`**
- Add `ssl_verify: Optional[Union[bool, str]] = None` parameter to `BaseLLMAIOHTTPHandler.__init__`
- Store it as `self.ssl_verify`
- Forward it to `AsyncHTTPHandler._create_aiohttp_transport(ssl_verify=self.ssl_verify)`

## Testing

Both files already have `ssl_verify` wired through `create_client()` / `_create_aiohttp_transport()` for the normal (non-retry) path — this PR makes retries consistent with that existing behaviour.