### PR TITLE
fix(mistral): drop reasoning_content from assistant input messages

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -265,6 +265,7 @@ class MistralConfig(OpenAIGPTConfig):
         new_messages: List[AllMessageValues] = []
         for m in messages:
             m = MistralConfig._handle_name_in_message(m)
+            m = MistralConfig._handle_reasoning_content_in_message(m)
             m = MistralConfig._handle_tool_call_message(m)
             if MistralConfig._is_empty_assistant_message(m):
                 continue
@@ -408,6 +409,19 @@ class MistralConfig(OpenAIGPTConfig):
         )
 
         return cleaned_tools
+
+    @classmethod
+    def _handle_reasoning_content_in_message(
+        cls, message: AllMessageValues
+    ) -> AllMessageValues:
+        """
+        Mistral rejects `reasoning_content` on input assistant messages with a 422
+        `extra_forbidden` error. It is an output-only field, so drop it when a prior
+        assistant turn is replayed back as input.
+        """
+        if message["role"] == "assistant":
+            message.pop("reasoning_content", None)  # type: ignore
+        return message
 
     @classmethod
     def _handle_name_in_message(cls, message: AllMessageValues) -> AllMessageValues:

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -247,6 +247,12 @@ class MistralConfig(OpenAIGPTConfig):
         The above statement is not valid now. Need to plan to remove all the #1,2,3
         Mistral API supports content as a list.
         """
+        ## 0. reasoning_content is output-only; Mistral rejects it on input regardless of
+        ## which path below handles the message, so strip it up front (issue #30835)
+        messages = [
+            MistralConfig._handle_reasoning_content_in_message(m) for m in messages
+        ]
+
         ## 1. If 'image_url' or 'file' in content, then transform with base class and mistral-specific handling
         for m in messages:
             _content_block = m.get("content")
@@ -265,7 +271,6 @@ class MistralConfig(OpenAIGPTConfig):
         new_messages: List[AllMessageValues] = []
         for m in messages:
             m = MistralConfig._handle_name_in_message(m)
-            m = MistralConfig._handle_reasoning_content_in_message(m)
             m = MistralConfig._handle_tool_call_message(m)
             if MistralConfig._is_empty_assistant_message(m):
                 continue

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -41,6 +41,39 @@ async def test_mistral_chat_transformation():
     )
 
 
+def test_mistral_strips_reasoning_content_from_assistant_input():
+    """Regression for https://github.com/BerriAI/litellm/issues/30835
+
+    `reasoning_content` is an output-only field; replaying it back as input made
+    Mistral reject the request with a 422 `extra_forbidden` error. It must be dropped
+    from assistant input messages while being preserved on every other role.
+    """
+    mistral_config = MistralConfig()
+    messages: List[AllMessageValues] = [
+        {"role": "user", "content": "Hi"},
+        {
+            "role": "assistant",
+            "content": "Hello there",
+            "reasoning_content": "the user greeted me, so I greet back",  # type: ignore
+        },
+        {"role": "user", "content": "And again"},
+    ]
+
+    result = cast(
+        List[AllMessageValues],
+        mistral_config._transform_messages(
+            messages=messages, model="mistral-medium-3-5", is_async=False
+        ),
+    )
+
+    assistant_messages = [m for m in result if m["role"] == "assistant"]
+    assert assistant_messages, "assistant message should survive transformation"
+    assert all(
+        "reasoning_content" not in m for m in assistant_messages
+    ), "reasoning_content must be stripped from assistant input messages"
+    assert assistant_messages[0]["content"] == "Hello there"
+
+
 class TestMistralReasoningSupport:
     """Test suite for Mistral Magistral reasoning functionality."""
 

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -74,6 +74,45 @@ def test_mistral_strips_reasoning_content_from_assistant_input():
     assert assistant_messages[0]["content"] == "Hello there"
 
 
+def test_mistral_strips_reasoning_content_on_multimodal_path():
+    """reasoning_content must also be stripped when the conversation contains an
+    image/file content block, which takes the early-return multimodal path that
+    bypasses the per-message loop (issue #30835).
+    """
+    mistral_config = MistralConfig()
+    one_px_png = (
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1"
+        "HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
+    )
+    messages: List[AllMessageValues] = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is this?"},
+                {"type": "image_url", "image_url": {"url": one_px_png}},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": "A single pixel",
+            "reasoning_content": "the image is 1x1",  # type: ignore
+        },
+    ]
+
+    result = cast(
+        List[AllMessageValues],
+        mistral_config._transform_messages(
+            messages=messages, model="pixtral-12b-latest", is_async=False
+        ),
+    )
+
+    assistant_messages = [m for m in result if m["role"] == "assistant"]
+    assert assistant_messages, "assistant message should survive transformation"
+    assert all(
+        "reasoning_content" not in m for m in assistant_messages
+    ), "reasoning_content must be stripped even on the multimodal path"
+
+
 class TestMistralReasoningSupport:
     """Test suite for Mistral Magistral reasoning functionality."""
 


### PR DESCRIPTION
## Relevant issues

Fixes #30835

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review and received a Confidence Score of 5/5

## Type

🐛 Bug Fix

## Changes

When an assistant message in the request payload carries a `reasoning_content` field, the Mistral backend rejects the whole request with `422 Unprocessable Entity` (`extra_forbidden`). `reasoning_content` is a model output field and Mistral's input schema forbids it as an extra field, but conversation histories that replay a prior assistant turn forward it verbatim.

The existing transform already strips `None`-valued extras via `strip_none_values_from_message` to avoid this same class of error, but `reasoning_content` carries a real value so it slips through. This adds `_handle_reasoning_content_in_message`, which drops `reasoning_content` from assistant messages.

The stripping runs up front in `_transform_messages`, before the `image_url`/`file` early-return branch that delegates to `_transform_messages_sync` / `_transform_messages_async`. This way multimodal conversations (an image attachment plus a replayed assistant turn carrying `reasoning_content`) are covered too, not just the text-only path.

Two regression tests are added: one for the text-only path and one for the multimodal path. Both fail before the fix and pass after.