### PR TITLE
fix(ui): make key detail panel scroll so the edit form Save button stays reachable

### DIFF
--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -163,6 +163,24 @@ describe("KeyInfoView", () => {
     });
   });
 
+  it("bounds the detail panel scroll container to the viewport so edit form actions stay reachable", async () => {
+    vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
+
+    const { container } = renderWithProviders(
+      <KeyInfoView
+        keyData={MOCK_KEY_DATA}
+        onClose={() => {}}
+        keyId={"test-key-id"}
+        onKeyDataUpdate={() => {}}
+        teams={[]}
+      />,
+    );
+
+    const scrollContainer = container.querySelector(".overflow-y-auto");
+    expect(scrollContainer).not.toBeNull();
+    expect(scrollContainer!.className).toContain("max-h-[85vh]");
+  });
+
   it("should not render tags in metadata textarea", async () => {
     vi.mocked(useAuthorized).mockReturnValue(baseUseAuthorizedMock);
 

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -176,9 +176,10 @@ describe("KeyInfoView", () => {
       />,
     );
 
-    const scrollContainer = container.querySelector(".overflow-y-auto");
-    expect(scrollContainer).not.toBeNull();
-    expect(scrollContainer!.className).toContain("max-h-[85vh]");
+    const boundedScrollContainers = Array.from(container.querySelectorAll(".overflow-y-auto")).filter((el) =>
+      el.classList.contains("max-h-[85vh]"),
+    );
+    expect(boundedScrollContainers).toHaveLength(1);
   });
 
   it("should not render tags in metadata textarea", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -412,7 +412,7 @@ export default function KeyInfoView({
   };
 
   return (
-    <div className="w-full h-full overflow-y-auto p-4">
+    <div className="w-full h-full max-h-[85vh] overflow-y-auto p-4">
       <KeyInfoHeader
         data={{
           keyName: currentKeyData.key_alias || "Virtual Key",


### PR DESCRIPTION
## Relevant issues

Editing a key from the UI is impossible when the form is long; the "Save Changes" button sits below the fold and cannot be scrolled into view, so users have to fall back to the update endpoint

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Local proof needs a live proxy serving the UI. Steps once it's running: open a key with many fields populated, go to the Settings tab, click Edit Settings, then scroll the panel and confirm Save Changes is reachable and saves

Mechanism was verified in a headless browser by reproducing the exact wrapper chain (navbar -> flex shell -> `h-[75vh]` -> Grid -> Col -> `overflow-hidden` -> the panel). With the current code the panel's `h-full` collapses to `auto` (clientHeight == scrollHeight), the panel is not scrollable, and in a shell where the window can't scroll the Save button is unreachable. With `max-h-[85vh]` the panel becomes a real scroll container (clientHeight clamps to 85vh, content scrolls) and Save is reachable

## Type

🐛 Bug Fix

## Changes

The key detail/edit panel wraps its content in a div meant to be the internal scroll container (`overflow-y-auto`) but sizes it with `h-full`. `h-full` is `height: 100%`, which only resolves when every ancestor has a definite height. The chain breaks: a Tremor `Grid` and `Col` with no height sit between this div and the only fixed height in the tree (`h-[75vh]` in `user_dashboard.tsx`), so `h-full` collapses to `auto`. The panel grows to fit its content and never scrolls internally, and reaching Save then depends on the whole window scrolling. In a constrained-height shell that window scroll isn't available, so a long edit form's footer is cut off

The fix adds `max-h-[85vh]` to the container in `key_info_view.tsx`. A viewport-relative max-height always resolves regardless of ancestor heights, so the panel becomes a bounded scroll container and Save is always reachable. It lives on the `KeyInfoView` component, so it covers every caller (keys page, team keys, usage, logs) without touching the shared dashboard layout or the table view

The regression test in `key_info_view.test.tsx` asserts the panel keeps a viewport-bounded `max-h-[85vh]`; it fails when the class is removed and passes with it