### PR TITLE
refactor(ui): point invitation links at the dedicated /onboarding route

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -912,9 +912,9 @@ class BaseEmailLogger(CustomLogger):
         """
         Construct invitation link for the user
 
-        # http://localhost:4000/ui?invitation_id=7a096b3a-37c6-440f-9dd1-ba22e8043f6b
+        # http://localhost:4000/ui/onboarding?invitation_id=7a096b3a-37c6-440f-9dd1-ba22e8043f6b
         """
-        return f"{base_url}/ui?invitation_id={invitation_id}"
+        return f"{base_url}/ui/onboarding?invitation_id={invitation_id}"
 
     async def send_email(
         self,

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
@@ -346,7 +346,9 @@ async def test_get_invitation_link(base_email_logger):
         result = await base_email_logger._get_invitation_link(
             user_id="test-user", base_url="http://test.com"
         )
-        assert result == "http://test.com/ui?invitation_id=test-invitation-id"
+        assert (
+            result == "http://test.com/ui/onboarding?invitation_id=test-invitation-id"
+        )
 
         # Test with None user_id
         result = await base_email_logger._get_invitation_link(
@@ -370,7 +372,7 @@ def test_construct_invitation_link(base_email_logger):
     result = base_email_logger._construct_invitation_link(
         invitation_id="test-id-123", base_url="http://test.com"
     )
-    assert result == "http://test.com/ui?invitation_id=test-id-123"
+    assert result == "http://test.com/ui/onboarding?invitation_id=test-id-123"
 
 
 @pytest.mark.asyncio
@@ -406,7 +408,10 @@ async def test_get_invitation_link_creates_new_when_none_exist(base_email_logger
             assert call_args["user_api_key_dict"].user_id == "test-user"
 
             # Verify the returned link uses the new invitation ID
-            assert result == "http://test.com/ui?invitation_id=new-invitation-id"
+            assert (
+                result
+                == "http://test.com/ui/onboarding?invitation_id=new-invitation-id"
+            )
 
 
 @pytest.mark.asyncio
@@ -437,7 +442,10 @@ async def test_get_invitation_link_uses_existing_when_available(base_email_logge
             mock_create_invitation.assert_not_called()
 
             # Verify the returned link uses the existing invitation ID
-            assert result == "http://test.com/ui?invitation_id=existing-invitation-id"
+            assert (
+                result
+                == "http://test.com/ui/onboarding?invitation_id=existing-invitation-id"
+            )
 
 
 @pytest.mark.asyncio
@@ -473,7 +481,10 @@ async def test_get_invitation_link_creates_new_when_list_is_none(base_email_logg
             assert call_args["user_api_key_dict"].user_id == "test-user"
 
             # Verify the returned link uses the new invitation ID
-            assert result == "http://test.com/ui?invitation_id=new-invitation-from-none"
+            assert (
+                result
+                == "http://test.com/ui/onboarding?invitation_id=new-invitation-from-none"
+            )
 
 
 @pytest.mark.asyncio
@@ -493,7 +504,7 @@ async def test_get_email_params_user_invitation(
         with mock.patch.object(
             base_email_logger,
             "_get_invitation_link",
-            return_value="http://test.com/ui?invitation_id=test-id",
+            return_value="http://test.com/ui/onboarding?invitation_id=test-id",
         ):
             # Test with user invitation event
             result = await base_email_logger._get_email_params(
@@ -507,7 +518,9 @@ async def test_get_email_params_user_invitation(
                 == "https://litellm-listing.s3.amazonaws.com/litellm_logo.png"
             )
             assert result.support_contact == "support@berri.ai"
-            assert result.base_url == "http://test.com/ui?invitation_id=test-id"
+            assert (
+                result.base_url == "http://test.com/ui/onboarding?invitation_id=test-id"
+            )
             assert result.recipient_email == "test@example.com"
 
 

--- a/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
+++ b/ui/litellm-dashboard/src/components/bulk_create_users_button.tsx
@@ -364,7 +364,7 @@ const BulkCreateUsersButton: React.FC<BulkCreateUsersProps> = ({
             if (!uiSettings?.SSO_ENABLED) {
               // Regular invitation flow
               const invitationData = await invitationCreateCall(accessToken, user_id);
-              const invitationUrl = new URL(`/ui?invitation_id=${invitationData.id}`, baseUrl).toString();
+              const invitationUrl = new URL(`/ui/onboarding?invitation_id=${invitationData.id}`, baseUrl).toString();
 
               setParsedData((current) =>
                 current.map((u, i) =>

--- a/ui/litellm-dashboard/src/components/onboarding_link.test.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.test.tsx
@@ -56,4 +56,15 @@ describe("buildOnboardingUrl", () => {
       }),
     ).toBe("");
   });
+
+  it("returns an empty string rather than an invitation_id=undefined link when the id is not ready", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "http://localhost:4000/",
+        invitationId: undefined,
+        hasUserSetupSso: false,
+        resetPassword: false,
+      }),
+    ).toBe("");
+  });
 });

--- a/ui/litellm-dashboard/src/components/onboarding_link.test.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { buildOnboardingUrl } from "./onboarding_link";
+
+describe("buildOnboardingUrl", () => {
+  it("points the invitation link at the dedicated /ui/onboarding route", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "http://localhost:4000/",
+        invitationId: "inv-123",
+        hasUserSetupSso: false,
+        resetPassword: false,
+      }),
+    ).toBe("http://localhost:4000/ui/onboarding?invitation_id=inv-123");
+  });
+
+  it("preserves a server_root_path prefix before /ui/onboarding", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "https://proxy.example.com/litellm",
+        invitationId: "inv-123",
+        hasUserSetupSso: false,
+        resetPassword: false,
+      }),
+    ).toBe("https://proxy.example.com/litellm/ui/onboarding?invitation_id=inv-123");
+  });
+
+  it("appends action=reset_password for the reset-password flow", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "http://localhost:4000/",
+        invitationId: "inv-123",
+        hasUserSetupSso: false,
+        resetPassword: true,
+      }),
+    ).toBe("http://localhost:4000/ui/onboarding?invitation_id=inv-123&action=reset_password");
+  });
+
+  it("sends SSO users to the dashboard root, not the onboarding form", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "http://localhost:4000/",
+        invitationId: "inv-123",
+        hasUserSetupSso: true,
+        resetPassword: false,
+      }),
+    ).toBe("http://localhost:4000/ui");
+  });
+
+  it("returns an empty string when no base URL is known yet", () => {
+    expect(
+      buildOnboardingUrl({
+        baseUrl: "",
+        invitationId: "inv-123",
+        hasUserSetupSso: false,
+        resetPassword: false,
+      }),
+    ).toBe("");
+  });
+});

--- a/ui/litellm-dashboard/src/components/onboarding_link.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.tsx
@@ -44,6 +44,9 @@ export function buildOnboardingUrl({
   if (hasUserSetupSso) {
     return new URL(uiPath, baseUrl).toString();
   }
+  if (!invitationId) {
+    return "";
+  }
   const action = resetPassword ? "&action=reset_password" : "";
   return new URL(`${uiPath}/onboarding?invitation_id=${invitationId}${action}`, baseUrl).toString();
 }

--- a/ui/litellm-dashboard/src/components/onboarding_link.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.tsx
@@ -25,6 +25,29 @@ interface OnboardingProps {
   modalType?: "invitation" | "resetPassword";
 }
 
+export function buildOnboardingUrl({
+  baseUrl,
+  invitationId,
+  hasUserSetupSso,
+  resetPassword,
+}: {
+  baseUrl: string;
+  invitationId: string | undefined;
+  hasUserSetupSso: boolean;
+  resetPassword: boolean;
+}): string {
+  if (!baseUrl) {
+    return "";
+  }
+  const basePath = new URL(baseUrl).pathname;
+  const uiPath = basePath && basePath !== "/" ? `${basePath}/ui` : "ui";
+  if (hasUserSetupSso) {
+    return new URL(uiPath, baseUrl).toString();
+  }
+  const action = resetPassword ? "&action=reset_password" : "";
+  return new URL(`${uiPath}/onboarding?invitation_id=${invitationId}${action}`, baseUrl).toString();
+}
+
 export default function OnboardingModal({
   isInvitationLinkModalVisible,
   setIsInvitationLinkModalVisible,
@@ -41,24 +64,13 @@ export default function OnboardingModal({
     setIsInvitationLinkModalVisible(false);
   };
 
-  const getInvitationUrl = () => {
-    if (!baseUrl) {
-      return "";
-    }
-    const baseUrlObj = new URL(baseUrl);
-    const basePath = baseUrlObj.pathname; // This will be "/litellm" or ""
-    const path = basePath && basePath !== "/" ? `${basePath}/ui` : "ui";
-    // Get the path from the base URL
-    if (invitationLinkData?.has_user_setup_sso) {
-      return new URL(path, baseUrl).toString();
-    }
-    let urlPath = `${path}?invitation_id=${invitationLinkData?.id}`;
-    if (modalType === "resetPassword") {
-      urlPath += "&action=reset_password";
-    }
-    const url = new URL(urlPath, baseUrl).toString();
-    return url;
-  };
+  const getInvitationUrl = () =>
+    buildOnboardingUrl({
+      baseUrl,
+      invitationId: invitationLinkData?.id,
+      hasUserSetupSso: invitationLinkData?.has_user_setup_sso ?? false,
+      resetPassword: modalType === "resetPassword",
+    });
 
   return (
     <Modal


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

This is a UI routing change with no LLM calls, so the proof is the onboarding flow itself against a live proxy. Run the proxy, then walk the suite below. Steps that need a raw `invitation_id` can mint one with curl; the rest are UI clicks. Use an Incognito window for every "open the link" step, because an authenticated session masks the login gate that the invitation flow is supposed to bypass.

Setup:

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
MASTER_KEY="<your master key from .env>"
```

Mint a user + invitation when a step needs a raw id:

```
USER_ID=$(curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"user_email":"invitee-local@example.com","user_role":"internal_user"}' | jq -r .user_id)
INVITE_ID=$(curl -s -X POST http://localhost:4000/invitation/new \
  -H "Authorization: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -d "{\"user_id\":\"$USER_ID\"}" | jq -r .id)
echo "new format : http://localhost:4000/ui/onboarding?invitation_id=$INVITE_ID"
echo "old format : http://localhost:4000/ui/?invitation_id=$INVITE_ID"
```

A. New invitation link uses the dedicated route (UI)
1. Go to http://localhost:4000/ui/?page=users (Internal Users) with SSO disabled, click **+ Invite User**, submit. The invitation modal link must read `.../ui/onboarding?invitation_id=...` and no longer `.../ui?invitation_id=...`
2. Repeat via **Bulk Create**; confirm the generated `invitation_link` in the results table is also the `/ui/onboarding` form

B. New link works end to end (Incognito)
3. Open the `new format` URL printed above. Expect: the set-password form renders, no sidebar/navbar, and no redirect to `/ui/login`
4. Set a password and submit. Expect a redirect to `.../ui/?login=success`
5. Log in as `invitee-local@example.com` with that password; you should land in the dashboard

C. Reset-password variant
6. For an existing user, generate a reset-password link (Internal Users -> the user -> reset password). Confirm the link is `.../ui/onboarding?invitation_id=...&action=reset_password`
7. Open it in Incognito; the form header should read "Reset Password" (the reset variant), not "Sign Up"

D. Backward compatibility for already-sent emails
8. Open the `old format` URL (`/ui/?invitation_id=...`) in Incognito. It must still render the onboarding form inline with no login bounce, so links already delivered to users keep working

E. SSO and server_root_path (optional)
9. With an SSO-enabled user, the invitation modal link should point at `/ui` (the SSO login entry), not `/ui/onboarding`
10. If you run the proxy under `SERVER_ROOT_PATH=/litellm`, the modal link should preserve the prefix: `.../litellm/ui/onboarding?invitation_id=...`

Negative control: open `http://localhost:4000/ui/` in Incognito with no `invitation_id` and no cookie; it should bounce to login, confirming the gate only opens for invitations.

## Type

🧹 Refactoring

## Changes

Invitation and reset-password links were generated as `/ui?invitation_id=...`, which lands on the dashboard index (`(dashboard)/page.tsx`) and renders the onboarding form inline through `UserDashboard`. This points all three generators at the standalone `/ui/onboarding` route that already serves that same form, so the index no longer has to special-case `invitation_id`. It is the first step of the App Router migration closeout (decoupling onboarding from the index); the index keeps rendering onboarding inline for old `?invitation_id` links, so nothing already delivered to a user breaks. Removing that inline branch and adding a forwarding redirect is a later closeout step.

Generators updated: the enterprise email builder (`base_email.py:_construct_invitation_link`), bulk user create (`bulk_create_users_button.tsx`), and the invitation/reset-password modal (`onboarding_link.tsx`). The modal's URL building is extracted into a pure `buildOnboardingUrl` so the server_root_path prefix, the `reset_password` action, and the SSO branch are covered by a focused unit test. The seven backend assertions that pinned the old `/ui?invitation_id=` string are updated to the new format, locking it in as a regression anchor.
