### PR TITLE
fix(ui): repoint dead usage guide link to cost tracking docs

### DIFF
--- a/ui/litellm-dashboard/src/components/usage.tsx
+++ b/ui/litellm-dashboard/src/components/usage.tsx
@@ -547,7 +547,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ accessToken, token, userRole, use
             Please follow our guide to view usage when SpendLogs has more than 1M rows.
           </Text>
           <Button className="mt-4">
-            <a href="https://docs.litellm.ai/docs/proxy/spending_monitoring" target="_blank">
+            <a href="https://docs.litellm.ai/docs/proxy/cost_tracking" target="_blank">
               View Usage Guide
             </a>
           </Button>


### PR DESCRIPTION
## Relevant issues

Reported by a customer: the "View Usage Guide" button on the Usage page opens https://docs.litellm.ai/docs/proxy/spending_monitoring, which returns a 404.

## Linear ticket

fixes LIT-2724

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The docs page `proxy/spending_monitoring` was deleted upstream and never relocated, so the old link 404s. `proxy/cost_tracking` ("Spend Tracking") is the live, on-topic replacement.

```
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://docs.litellm.ai/docs/proxy/spending_monitoring
404
$ curl -s -o /dev/null -w "%{http_code}\n" -L https://docs.litellm.ai/docs/proxy/cost_tracking
200
```

To reproduce in the UI, on a proxy where the spend logs table has crossed ~1M rows (so `DISABLE_EXPENSIVE_DB_QUERIES` is set), go to http://localhost:4000/ui/?page=usage. The "Database Query Limit Reached" card shows a "View Usage Guide" button. Before this change it opened a 404; after, it opens the Spend Tracking docs page

## Type

🐛 Bug Fix

## Changes

The "View Usage Guide" button on the legacy Usage page ([usage.tsx](https://github.com/BerriAI/litellm/blob/main/ui/litellm-dashboard/src/components/usage.tsx)) linked to `docs/proxy/spending_monitoring`, which was removed from the docs and now 404s. It is only rendered inside the "Database Query Limit Reached" card, which appears when `DISABLE_EXPENSIVE_DB_QUERIES` is set (SpendLogs has 1M+ rows). The link is unchanged from the customer's v1.83.7 through the latest 1.89.x, and lives only on the legacy "Old Usage" page; the current Usage page does not carry it

This repoints the button to `docs/proxy/cost_tracking`, which is live and on-topic. I did not add a unit test: the only thing a unit test could assert here is that the href string equals `cost_tracking`, which would not catch the actual failure mode (the destination not existing). The meaningful regression guard is that the URL resolves, shown by the HTTP status check above

One thing worth flagging for a follow-up: `cost_tracking` does not carry the at-scale guidance the deleted page had (exporting logs to S3/GCS, analyzing in Redash/Snowflake, disabling spend logs past 1M rows), while the card's text still says "follow our guide to view usage when SpendLogs has more than 1M rows". Recreating that content in litellm-docs and pointing here would fully close the gap; this PR just removes the 404
