### PR TITLE
fix(prometheus): allow litellm_total_users and litellm_teams_count in metrics config

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -224,6 +224,9 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_remaining_user_budget_metric",
     "litellm_user_max_budget_metric",
     "litellm_user_budget_remaining_hours_metric",
+    # User and team count metrics
+    "litellm_total_users",
+    "litellm_teams_count",
     "litellm_deployment_state",
     "litellm_deployment_failure_responses",
     "litellm_deployment_total_requests",

--- a/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_user_team_metrics.py
@@ -927,3 +927,28 @@ def test_custom_latency_buckets():
                 REGISTRY.unregister(collector)
             except Exception:
                 pass
+
+
+def test_user_team_count_metrics_pass_config_validation(monkeypatch):
+    """litellm_total_users and litellm_teams_count must be configurable via
+    prometheus_metrics_config without raising a validation error.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/30839
+    """
+    import litellm
+
+    monkeypatch.setattr(
+        litellm,
+        "prometheus_metrics_config",
+        [
+            {
+                "group": "my_metrics",
+                "metrics": ["litellm_total_users", "litellm_teams_count"],
+            }
+        ],
+    )
+
+    logger = PrometheusLogger()
+
+    assert "litellm_total_users" in logger.enabled_metrics
+    assert "litellm_teams_count" in logger.enabled_metrics


### PR DESCRIPTION
## Relevant issues

Fixes #30839

## Type

🐛 Bug Fix

## Changes

`litellm_total_users` and `litellm_teams_count` are registered as gauge metrics, but they were missing from `DEFINED_PROMETHEUS_METRICS`. Since `prometheus_metrics_config` validation rejects any metric name that is not in that set, listing either metric raised a "Configuration validation failed" error at startup, so operators had no way to opt into them when using explicit metric config.

This adds both names to the allowed set so they can be configured like any other metric.

To reproduce on the current code:

```yaml
litellm_settings:
  prometheus_metrics_config:
    - group: my_metrics
      metrics:
        - litellm_total_users
        - litellm_teams_count
```

Before this change, startup fails validation and lists `litellm_total_users` and `litellm_teams_count` as invalid metric names. After it, the proxy starts and both gauges are enabled and exposed.

A regression test configures both metrics and asserts that `PrometheusLogger` initializes and enables them without raising; it fails on the current code and passes with this change
