### PR TITLE
fix(ui): keep team Organization optional for proxy admins in single-org setups

### DIFF
--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -1097,3 +1097,52 @@ describe("OldTeams - delete team warning copy", () => {
     );
   });
 });
+
+describe("OldTeams - LIT-2530 organization stays optional for proxy admin with a single org", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTeamInfoView.mockClear();
+    vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue(["gpt-4"]);
+    vi.mocked(fetchMCPAccessGroups).mockResolvedValue([]);
+    vi.mocked(getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    vi.mocked(teamListCall).mockResolvedValue({ teams: [], total: 0, page: 1, page_size: 100, total_pages: 1 });
+    vi.mocked(teamCreateCall).mockResolvedValue({
+      team_id: "new-team-1",
+      team_alias: "No Org Team",
+      models: ["gpt-4"],
+      organization_id: null,
+      keys: [],
+      members_with_roles: [],
+      spend: 0,
+    });
+    mockUseOrganizations.mockReturnValue({
+      data: [{ organization_id: "org-1", organization_alias: "Org 1", models: [], members: [] }],
+    });
+  });
+
+  it("creates a team with no organization when exactly one organization exists", async () => {
+    renderWithQueryClient(<OldTeams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    const createButton = screen.getAllByRole("button", { name: /create team/i })[0];
+    act(() => {
+      fireEvent.click(createButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/team name/i)).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText(/team name/i), { target: { value: "No Org Team" } });
+    fireEvent.change(screen.getByTestId("create-team-models-select"), { target: { value: "gpt-4" } });
+
+    const submitButtons = screen.getAllByRole("button", { name: /create team/i });
+    fireEvent.click(submitButtons[submitButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(teamCreateCall).toHaveBeenCalledWith(
+        "test-token",
+        expect.objectContaining({ team_alias: "No Org Team", organization_id: null }),
+      );
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/components/OldTeams.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.tsx
@@ -262,14 +262,15 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   useEffect(() => {
     if (isTeamModalVisible) {
       const adminOrgs = getAdminOrganizations(userRole, userID, organizations);
+      const isOrgAdmin = userRole !== "Admin";
 
-      // If there's exactly one organization the user is admin for, preselect it
-      if (adminOrgs.length === 1) {
+      // Org admins must scope a team to an org, so with exactly one we preselect it.
+      // Proxy admins can create org-less teams, so the field stays optional regardless of org count.
+      if (isOrgAdmin && adminOrgs.length === 1) {
         const org = adminOrgs[0];
         form.setFieldValue("organization_id", org.organization_id);
         setCurrentOrgForCreateTeam(org);
       } else {
-        // Reset the organization selection for multiple orgs
         form.setFieldValue("organization_id", currentOrg?.organization_id || null);
         setCurrentOrgForCreateTeam(currentOrg);
       }
@@ -1132,7 +1133,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                           : []
                       }
                       help={
-                        isSingleOrg
+                        isOrgAdmin && isSingleOrg
                           ? "You can only create teams within this organization"
                           : isOrgAdmin
                             ? "required"
@@ -1142,7 +1143,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
                       <Select
                         showSearch
                         allowClear={!isOrgAdmin}
-                        disabled={isSingleOrg}
+                        disabled={isOrgAdmin && isSingleOrg}
                         placeholder={hasNoOrgs ? "No organizations available" : "Search or select an Organization"}
                         onChange={(value) => {
                           form.setFieldValue("organization_id", value);


### PR DESCRIPTION
## Relevant issues

Fixes LIT-2530

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-2530/team-creation-requires-org-in-single-org-setups

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

This is a UI-only fix. The `/team/new` endpoint already accepts a null organization no matter how many organizations exist, so nothing changed on the backend. Verified against a local proxy backed by a fresh Postgres seeded with exactly one organization:

```
### 1) Create exactly ONE organization
$ curl -sS $BASE/organization/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"organization_alias":"acme"}'
organization_id = ec1d2fe4-bde1-4523-856d-546287effe04

### 2) Confirm there is exactly ONE org
$ curl -sS $BASE/organization/list -H "Authorization: Bearer sk-1234"
org count = 1

### 3) Create a team with NO organization (the case the UI used to block)
$ curl -sS $BASE/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias":"standalone-team"}'
{
  "team_id": "4c8d7a0d-52ea-4b04-b762-1835a93a2a5a",
  "team_alias": "standalone-team",
  "organization_id": null
}

### 4) Org-scoped creation still works
$ curl -sS $BASE/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"team_alias":"acme-team","organization_id":"ec1d2fe4-bde1-4523-856d-546287effe04"}'
{
  "team_id": "1ce8fd59-d207-49b7-b1a0-b72578e34e04",
  "team_alias": "acme-team",
  "organization_id": "ec1d2fe4-bde1-4523-856d-546287effe04"
}
```

UI repro (needs a deployment with exactly one organization, signed in as a Proxy Admin):

1. go to the Teams page, e.g. http://localhost:4000/ui/?page=teams
2. click Create Team
3. the Organization field is now empty, enabled, and clearable; before this change it was auto-filled with the only org and greyed out, with the note "You can only create teams within this organization"
4. enter a Team Name, leave Organization empty, click Create Team
5. the team is created with no organization

<img width="787" height="445" alt="image" src="https://github.com/user-attachments/assets/e563a425-655c-4e8d-9fa2-6f0595e83603" />

<img width="1055" height="268" alt="image" src="https://github.com/user-attachments/assets/5c2a4640-49c6-49a1-aef6-a0336dfeb287" />

<img width="993" height="86" alt="image" src="https://github.com/user-attachments/assets/378c2386-eb95-4f84-968b-39878ead335c" />

<img width="1900" height="169" alt="image" src="https://github.com/user-attachments/assets/c58ca925-14c3-47a5-9e09-67ec79e6581b" />

<img width="1891" height="342" alt="image" src="https://github.com/user-attachments/assets/1a261932-75da-4fe0-86f7-a5d009479c9d" />


## Type

🐛 Bug Fix

## Changes

The Create Team form gated three behaviors on "exactly one organization exists" without considering the caller's role: a `useEffect` preselected the org, the Organization `Select` was disabled, and the help text read "You can only create teams within this organization". For a Proxy Admin the organization is optional, so a single-org deployment could not create a standalone team even though the field is presented as optional. Org Admins, by contrast, genuinely require an org.

The fix gates those three behaviors on the org-admin role so they apply only to Org Admins, who must scope a team to their organization. Proxy Admins now get an optional, clearable, empty Organization field regardless of org count, which matches the existing multi-org behavior the bug report calls correct. Org Admin behavior is unchanged: a single admin org is still preselected and locked, and multiple admin orgs still force a choice.

Added a regression test in `OldTeams.test.tsx` that, as a Proxy Admin with exactly one organization, creates a team without selecting an org and asserts the create call sends `organization_id: null`. It fails on the pre-fix code (the call sends the auto-selected org id) and passes after the fix
