### PR TITLE
fix(openrouter): force store false for Responses API

### DIFF
--- a/litellm/llms/openrouter/responses/transformation.py
+++ b/litellm/llms/openrouter/responses/transformation.py
@@ -13,6 +13,7 @@ from typing import Optional
 import litellm
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.llms.openai import ResponseInputParam
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
@@ -75,6 +76,23 @@ class OpenRouterResponsesAPIConfig(OpenAIResponsesAPIConfig):
         api_base = api_base.rstrip("/")
 
         return f"{api_base}/responses"
+
+    def transform_responses_api_request(
+        self,
+        model: str,
+        input: str | ResponseInputParam,
+        response_api_optional_request_params: dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> dict:
+        response_api_optional_request_params["store"] = False
+        return super().transform_responses_api_request(
+            model=model,
+            input=input,
+            response_api_optional_request_params=response_api_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def supports_native_websocket(self) -> bool:
         """OpenRouter does not support native WebSocket for Responses API"""

--- a/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
+++ b/tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py
@@ -13,6 +13,7 @@ import litellm
 from litellm.llms.openrouter.responses.transformation import (
     OpenRouterResponsesAPIConfig,
 )
+from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager
 
@@ -63,7 +64,6 @@ class TestOpenRouterResponsesAPIConfig:
     def test_validate_environment_raises_without_key(self, monkeypatch):
         """validate_environment should raise when no API key is available."""
         config = OpenRouterResponsesAPIConfig()
-        from litellm.types.router import GenericLiteLLMParams
 
         # Clear any globally set API keys so the validation correctly raises
         monkeypatch.setattr(litellm, "api_key", None)
@@ -79,6 +79,36 @@ class TestOpenRouterResponsesAPIConfig:
             assert False, "Should have raised ValueError"
         except ValueError as e:
             assert "OpenRouter API key is required" in str(e)
+
+    def test_transform_responses_api_request_forces_store_false_when_true(self):
+        """OpenRouter only accepts store=false for Responses API requests."""
+        config = OpenRouterResponsesAPIConfig()
+        request_params = {"store": True, "temperature": 0.2}
+
+        transformed = config.transform_responses_api_request(
+            model="openai/o4-mini",
+            input="hello",
+            response_api_optional_request_params=request_params,
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert transformed["store"] is False
+        assert transformed["temperature"] == 0.2
+
+    def test_transform_responses_api_request_forces_store_false_when_omitted(self):
+        """Omitted store should be sent as false instead of null/true."""
+        config = OpenRouterResponsesAPIConfig()
+
+        transformed = config.transform_responses_api_request(
+            model="openai/o4-mini",
+            input="hello",
+            response_api_optional_request_params={},
+            litellm_params=GenericLiteLLMParams(),
+            headers={},
+        )
+
+        assert transformed["store"] is False
 
 
 class TestOpenRouterResponsesAPIRegistration:


### PR DESCRIPTION
## Summary
- Force `store` to `false` for OpenRouter Responses API requests before applying the OpenAI-compatible transform
- Preserve other optional Responses API parameters unchanged
- Add regression coverage for both explicit `store: true` and omitted `store` request paths

## Why
OpenRouter validates the Responses API `store` field as false-or-absent. LiteLLM currently inherits the OpenAI Responses API parameter support, which can forward `store: true` or `store: null` from clients and cause OpenRouter to reject otherwise valid requests. Forcing `store: false` matches OpenRouter's schema and follows the existing LiteLLM pattern used by providers that require non-stored Responses API calls.

Fixes #30851

## Tests
- `python3 -m pytest tests/test_litellm/llms/openrouter/responses/test_openrouter_responses_transformation.py -q`
- `git diff --check`