### PR TITLE
test(ui): isolate OldTeams delete-warning tests from leaked mock

### DIFF
--- a/ui/litellm-dashboard/src/components/OldTeams.test.tsx
+++ b/ui/litellm-dashboard/src/components/OldTeams.test.tsx
@@ -1046,17 +1046,14 @@ describe("OldTeams - delete team warning copy", () => {
   });
 
   const openDeleteModal = async (team: any) => {
-    renderWithQueryClient(
-      <OldTeams
-        teams={[team]}
-        searchParams={{}}
-        accessToken="test-token"
-        setTeams={vi.fn()}
-        userID="user-123"
-        userRole="Admin"
-        organizations={[]}
-      />,
-    );
+    vi.mocked(teamListCall).mockResolvedValue({
+      teams: [team],
+      total: 1,
+      page: 1,
+      page_size: 100,
+      total_pages: 1,
+    });
+    renderWithQueryClient(<OldTeams accessToken="test-token" userID="user-123" userRole="Admin" />);
     await waitFor(() => {
       expect(screen.getByTestId("delete-team-button")).toBeInTheDocument();
     });
@@ -1081,9 +1078,9 @@ describe("OldTeams - delete team warning copy", () => {
   };
 
   it("warns that the team's models are deleted when the team has keys", async () => {
-    await openDeleteModal({ ...baseTeam, keys: [], keys_count: 2 });
+    await openDeleteModal({ ...baseTeam, keys: [], keys_count: 5 });
 
-    expect(screen.getByText(/Warning: This team has 2 keys associated with it/i)).toHaveTextContent(
+    expect(screen.getByText(/Warning: This team has 5 keys associated with it/i)).toHaveTextContent(
       /along with any models created for this team/i,
     );
     expect(screen.getByText(/Are you sure you want to delete this team/i)).toHaveTextContent(


### PR DESCRIPTION
## Relevant issues

`ui_unit_tests` is red on `litellm_internal_staging` because of one deterministic failure in `OldTeams.test.tsx` ("still warns about model deletion in the confirmation message when the team has no keys"). This fixes that

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile returned 5/5, safe to merge)

## Root cause

The deprecated `OldTeams` component accepts only `accessToken`, `userID`, `userRole` and `premiumUser`. It ignores the `teams` prop that the delete-warning tests were passing and instead populates its table from the mocked `teamListCall`. That block never set `teamListCall`, and `vi.clearAllMocks()` clears call history but not implementations, so the table rendered the "Legacy Team" (`keys.length` 2) left behind by the previous block's last test ("falls back to keys.length when keys_count is absent").

Both delete tests therefore ran against that leaked team. The keys-present case passed only because the leaked count happened to be 2, and the no-keys case rendered the very "Warning: This team has 2 keys" message it asserted should be absent, so it failed

## Fix

Seed the team through the channel the component actually reads (`teamListCall`) and drop the props it never consumes, so each test renders exactly the team it declares. The keys-present case now uses a distinctive count (5) so it can no longer pass on a coincidental leak

## Screenshots / Proof of Fix

This is a frontend test-isolation fix, so the meaningful proof is the suite going from red to green on the clean `litellm_internal_staging` base, run from `ui/litellm-dashboard`:

```
# Before (pristine staging HEAD)
$ npx vitest run src/components/OldTeams.test.tsx
   × OldTeams - delete team warning copy > still warns about model deletion in the confirmation message when the team has no keys
 Tests  1 failed | 33 passed (34)

# After (this branch)
$ npx vitest run src/components/OldTeams.test.tsx
 Tests  34 passed (34)
```

Mutation checks confirming the tests still bite: forcing the component to always render the warning makes the no-keys test fail, and reverting the harness seeding (while keeping count 5) makes both delete tests fail because they render the leaked count-2 team

## Type

✅ Test

## Changes

`ui/litellm-dashboard/src/components/OldTeams.test.tsx`: drive the team data via the `teamListCall` mock that `OldTeams` reads, stop passing props the component ignores, and use a distinctive key count in the keys-present case

---
_Generated by [Claude Code](https://claude.ai/code/session_01SrgUxRtj3GxVZ8xLSrG7Cc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in OldTeams.test.tsx with no production code impact.
> 
> **Overview**
> Fixes flaky/failing **OldTeams** delete-modal tests by seeding team data through the **`teamListCall`** mock the component actually uses, instead of a **`teams`** prop it ignores.
> 
> The **`openDeleteModal`** helper now mocks **`teamListCall`** per test and renders **`OldTeams`** with only **`accessToken`**, **`userID`**, and **`userRole`**. The keys-present case asserts **`keys_count: 5`** so a leaked “2 keys” team from an earlier test can’t make the assertion pass by accident.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 245660d564e30e4aa02241faed6daa0d3e2a8bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->