### PR TITLE
feat: add lint-gate target and truncation-proof summary to the strict ruff gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,11 @@ lint-black: format-check
 lint-ruff-budget: install-dev
 	$(UV_RUN) python scripts/ruff_strict_gate.py
 
-# CI-parity strict gate: fetch the target branch fresh and count against a
-# throwaway merge into HEAD, so a local pass means the CI check will pass too.
+# Strict gate, invoked the same way CI does in test-linting.yml so a local pass
+# means the CI check will pass too.
 lint-gate: install-dev
 	git fetch origin litellm_internal_staging
-	$(UV_RUN) python scripts/ruff_strict_gate.py --ci-parity --base origin/litellm_internal_staging
+	$(UV_RUN) python scripts/ruff_strict_gate.py --base origin/litellm_internal_staging
 
 lint-ruff-budget-update: install-dev
 	$(UV_RUN) python scripts/ruff_strict_gate.py --update

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	test-proxy-unit-a test-proxy-unit-b test-integration test-unit-helm \
 	info lint lint-dev format \
 	lint-basedpyright lint-basedpyright-budget-update \
-	lint-ruff-budget lint-ruff-budget-update lint-budget-update \
+	lint-ruff-budget lint-ruff-budget-update lint-budget-update lint-gate \
 	install-dev install-proxy-dev install-test-deps install-hooks \
 	install-helm-unittest check-circular-imports check-import-safety
 
@@ -28,6 +28,7 @@ help:
 	@echo "  make lint-basedpyright-budget-update - Re-capture the basedpyright per-rule budget (ratchet)"
 	@echo "  make lint-black         - Check Black formatting (matches CI)"
 	@echo "  make lint-ruff-budget - Gate the codebase total of each strict ruff rule against its ceiling"
+	@echo "  make lint-gate        - Strict ruff gate in CI-parity mode (fetches staging, simulates the merge)"
 	@echo "  make lint-ruff-budget-update - Re-capture per-rule baselines in ruff-strict-budget.json (ratchet)"
 	@echo "  make lint-budget-update - Re-capture all ratchet budgets (ruff + basedpyright)"
 	@echo "  make check-circular-imports - Check for circular imports"
@@ -133,6 +134,12 @@ lint-black: format-check
 
 lint-ruff-budget: install-dev
 	$(UV_RUN) python scripts/ruff_strict_gate.py
+
+# CI-parity strict gate: fetch the target branch fresh and count against a
+# throwaway merge into HEAD, so a local pass means the CI check will pass too.
+lint-gate: install-dev
+	git fetch origin litellm_internal_staging
+	$(UV_RUN) python scripts/ruff_strict_gate.py --ci-parity --base origin/litellm_internal_staging
 
 lint-ruff-budget-update: install-dev
 	$(UV_RUN) python scripts/ruff_strict_gate.py --update

--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -14,6 +14,7 @@ of the base into HEAD.
 """
 
 import argparse
+import contextlib
 import json
 import re
 import shutil
@@ -21,6 +22,7 @@ import subprocess
 import sys
 import tempfile
 from collections import Counter
+from collections.abc import Iterator
 from pathlib import Path
 from typing import NamedTuple
 
@@ -47,9 +49,9 @@ class Breach(NamedTuple):
 
 
 class GateInputs(NamedTuple):
-    head: list
-    base: dict
-    changed: dict
+    head: list[Violation]
+    base: dict[str, int]
+    changed: dict[str, set[int]]
 
 
 def _run(cmd: list, cwd: Path = REPO_ROOT) -> str:
@@ -86,18 +88,29 @@ def count_by_rule(violations: list) -> dict:
     return dict(Counter(v.code for v in violations))
 
 
-def base_counts(ref: str) -> dict:
-    parent = Path(tempfile.mkdtemp(prefix="ruff_base_"))
+@contextlib.contextmanager
+def _temp_worktree(ref: str) -> Iterator[Path]:
+    parent = Path(tempfile.mkdtemp(prefix="ruff_wt_"))
     worktree = parent / "wt"
+    _run(["git", "worktree", "add", "--detach", str(worktree), ref])
     try:
-        _run(["git", "worktree", "add", "--detach", str(worktree), ref])
+        yield worktree
+    finally:
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(worktree)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        shutil.rmtree(parent, ignore_errors=True)
+
+
+def base_counts(ref: str) -> dict:
+    with _temp_worktree(ref) as worktree:
         shutil.copy(STRICT_CONFIG, worktree / "ruff-strict.toml")
         return count_by_rule(
             collect_violations(worktree, worktree / "ruff-strict.toml")
         )
-    finally:
-        _run(["git", "worktree", "remove", "--force", str(worktree)])
-        shutil.rmtree(parent, ignore_errors=True)
 
 
 def parse_changed_lines(diff_text: str) -> dict:
@@ -138,10 +151,7 @@ def gather_fast(base: str) -> GateInputs:
 
 
 def gather_ci_parity(base: str) -> GateInputs:
-    parent = Path(tempfile.mkdtemp(prefix="ruff_merge_"))
-    worktree = parent / "wt"
-    try:
-        _run(["git", "worktree", "add", "--detach", str(worktree), "HEAD"])
+    with _temp_worktree("HEAD") as worktree:
         merge = subprocess.run(
             ["git", "merge", "--no-commit", "--no-ff", base],
             cwd=worktree,
@@ -149,7 +159,12 @@ def gather_ci_parity(base: str) -> GateInputs:
             text=True,
         )
         if merge.returncode != 0:
-            _run(["git", "merge", "--abort"], cwd=worktree)
+            subprocess.run(
+                ["git", "merge", "--abort"],
+                cwd=worktree,
+                capture_output=True,
+                text=True,
+            )
             raise SystemExit(
                 f"ci-parity: merging {base} into HEAD conflicts; rebase your branch first"
             )
@@ -160,9 +175,6 @@ def gather_ci_parity(base: str) -> GateInputs:
             cwd=worktree,
         )
         return GateInputs(head, base_counts(base), parse_changed_lines(diff))
-    finally:
-        _run(["git", "worktree", "remove", "--force", str(worktree)])
-        shutil.rmtree(parent, ignore_errors=True)
 
 
 def report(breaches: list, new: list, base: str) -> None:

--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -5,6 +5,12 @@ Each rule has a hard ceiling (baseline + slack) in ruff-strict-budget.json. The
 gate counts each rule across the whole tree and fails when a rule is both over
 its ceiling and higher than the base it merges into, so a change is blamed for
 the violations it adds, never for drift that already exists in the base.
+
+By default the base is the merge-base of the current branch, which is fast but
+diverges from CI: CI runs against the synthetic merge ref, so its base is the
+*current* tip of the target branch plus whatever drift landed since you forked.
+Pass --ci-parity to reproduce CI exactly by counting against a throwaway merge
+of the base into HEAD.
 """
 
 import argparse
@@ -40,6 +46,12 @@ class Breach(NamedTuple):
     added: int
 
 
+class GateInputs(NamedTuple):
+    head: list
+    base: dict
+    changed: dict
+
+
 def _run(cmd: list, cwd: Path = REPO_ROOT) -> str:
     proc = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
     if proc.returncode not in (0, 1):
@@ -56,14 +68,14 @@ def _ruff_json(cwd: Path, config: Path) -> list:
     return json.loads(raw or "[]")
 
 
-def head_violations() -> list:
+def collect_violations(root: Path, config: Path) -> list:
     out = []
-    for item in _ruff_json(REPO_ROOT, STRICT_CONFIG):
+    for item in _ruff_json(root, config):
         name = Path(item["filename"])
         rel = (
-            (name if name.is_absolute() else REPO_ROOT / name)
+            (name if name.is_absolute() else root / name)
             .resolve()
-            .relative_to(REPO_ROOT)
+            .relative_to(root)
             .as_posix()
         )
         out.append(Violation(rel, item["location"]["row"], item["code"]))
@@ -80,21 +92,12 @@ def base_counts(ref: str) -> dict:
     try:
         _run(["git", "worktree", "add", "--detach", str(worktree), ref])
         shutil.copy(STRICT_CONFIG, worktree / "ruff-strict.toml")
-        items = _ruff_json(worktree, worktree / "ruff-strict.toml")
-        return dict(Counter(item["code"] for item in items))
+        return count_by_rule(
+            collect_violations(worktree, worktree / "ruff-strict.toml")
+        )
     finally:
         _run(["git", "worktree", "remove", "--force", str(worktree)])
         shutil.rmtree(parent, ignore_errors=True)
-
-
-def evaluate(head: dict, base: dict, budget: dict) -> list:
-    breaches = []
-    for rule, spec in budget.items():
-        cap = spec["baseline"] + spec["slack"]
-        total = head.get(rule, 0)
-        if total > cap and total > base.get(rule, 0):
-            breaches.append(Breach(rule, total, cap, total - base.get(rule, 0)))
-    return sorted(breaches)
 
 
 def parse_changed_lines(diff_text: str) -> dict:
@@ -110,24 +113,59 @@ def parse_changed_lines(diff_text: str) -> dict:
     return changed
 
 
+def evaluate(head: dict, base: dict, budget: dict) -> list:
+    breaches = []
+    for rule, spec in budget.items():
+        cap = spec["baseline"] + spec["slack"]
+        total = head.get(rule, 0)
+        if total > cap and total > base.get(rule, 0):
+            breaches.append(Breach(rule, total, cap, total - base.get(rule, 0)))
+    return sorted(breaches)
+
+
 def introduced(violations: list, changed: dict) -> list:
     return [v for v in violations if v.line in changed.get(v.file, set())]
 
 
-def cmd_check(base: str) -> None:
-    budget = json.loads(BUDGET_PATH.read_text())
-    head = head_violations()
+def gather_fast(base: str) -> GateInputs:
     base_point = _run(["git", "merge-base", base, "HEAD"]).strip() or base
-    breaches = evaluate(count_by_rule(head), base_counts(base_point), budget)
-    if not breaches:
-        print(f"OK: every strict rule is within its codebase ceiling (base {base})")
-        return
-    new = introduced(
-        head,
-        parse_changed_lines(
-            _run(["git", "diff", base_point, "--unified=0", "--no-color", "--", TARGET])
-        ),
+    diff = _run(["git", "diff", base_point, "--unified=0", "--no-color", "--", TARGET])
+    return GateInputs(
+        collect_violations(REPO_ROOT, STRICT_CONFIG),
+        base_counts(base_point),
+        parse_changed_lines(diff),
     )
+
+
+def gather_ci_parity(base: str) -> GateInputs:
+    parent = Path(tempfile.mkdtemp(prefix="ruff_merge_"))
+    worktree = parent / "wt"
+    try:
+        _run(["git", "worktree", "add", "--detach", str(worktree), "HEAD"])
+        merge = subprocess.run(
+            ["git", "merge", "--no-commit", "--no-ff", base],
+            cwd=worktree,
+            capture_output=True,
+            text=True,
+        )
+        if merge.returncode != 0:
+            _run(["git", "merge", "--abort"], cwd=worktree)
+            raise SystemExit(
+                f"ci-parity: merging {base} into HEAD conflicts; rebase your branch first"
+            )
+        shutil.copy(STRICT_CONFIG, worktree / "ruff-strict.toml")
+        head = collect_violations(worktree, worktree / "ruff-strict.toml")
+        diff = _run(
+            ["git", "diff", base, "--unified=0", "--no-color", "--", TARGET],
+            cwd=worktree,
+        )
+        return GateInputs(head, base_counts(base), parse_changed_lines(diff))
+    finally:
+        _run(["git", "worktree", "remove", "--force", str(worktree)])
+        shutil.rmtree(parent, ignore_errors=True)
+
+
+def report(breaches: list, new: list, base: str) -> None:
     print(f"FAIL: strict-rule totals exceed their ceiling (base {base}):")
     for breach in breaches:
         print(
@@ -138,12 +176,24 @@ def cmd_check(base: str) -> None:
     print(
         "Reduce the new violations or remove an equal number elsewhere; the ceiling is baseline + slack in ruff-strict-budget.json."
     )
+    summary = "; ".join(f"{b.rule} {b.total}/{b.cap} (+{b.added})" for b in breaches)
+    print(f"BREACHED RULES: {summary}")
+
+
+def cmd_check(base: str, ci_parity: bool) -> None:
+    budget = json.loads(BUDGET_PATH.read_text())
+    inputs = gather_ci_parity(base) if ci_parity else gather_fast(base)
+    breaches = evaluate(count_by_rule(inputs.head), inputs.base, budget)
+    if not breaches:
+        print(f"OK: every strict rule is within its codebase ceiling (base {base})")
+        return
+    report(breaches, introduced(inputs.head, inputs.changed), base)
     raise SystemExit(1)
 
 
 def cmd_update() -> None:
     budget = json.loads(BUDGET_PATH.read_text())
-    head = count_by_rule(head_violations())
+    head = count_by_rule(collect_violations(REPO_ROOT, STRICT_CONFIG))
     for rule in budget:
         budget[rule]["baseline"] = head.get(rule, 0)
     BUDGET_PATH.write_text(json.dumps(budget, indent=2, sort_keys=True) + "\n")
@@ -154,8 +204,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument("--update", action="store_true")
+    parser.add_argument(
+        "--ci-parity",
+        action="store_true",
+        help="count against a throwaway merge of --base into HEAD, matching CI",
+    )
     args = parser.parse_args()
-    cmd_update() if args.update else cmd_check(args.base)
+    cmd_update() if args.update else cmd_check(args.base, args.ci_parity)
 
 
 if __name__ == "__main__":

--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -6,11 +6,8 @@ gate counts each rule across the whole tree and fails when a rule is both over
 its ceiling and higher than the base it merges into, so a change is blamed for
 the violations it adds, never for drift that already exists in the base.
 
-By default the base is the merge-base of the current branch, which is fast but
-diverges from CI: CI runs against the synthetic merge ref, so its base is the
-*current* tip of the target branch plus whatever drift landed since you forked.
-Pass --ci-parity to reproduce CI exactly by counting against a throwaway merge
-of the base into HEAD.
+The base is the merge-base of the current branch with --base; this matches CI,
+which checks out the PR head sha and runs the gate against the PR's base sha.
 """
 
 import argparse
@@ -140,7 +137,7 @@ def introduced(violations: list, changed: dict) -> list:
     return [v for v in violations if v.line in changed.get(v.file, set())]
 
 
-def gather_fast(base: str) -> GateInputs:
+def gather(base: str) -> GateInputs:
     base_point = _run(["git", "merge-base", base, "HEAD"]).strip() or base
     diff = _run(["git", "diff", base_point, "--unified=0", "--no-color", "--", TARGET])
     return GateInputs(
@@ -148,33 +145,6 @@ def gather_fast(base: str) -> GateInputs:
         base_counts(base_point),
         parse_changed_lines(diff),
     )
-
-
-def gather_ci_parity(base: str) -> GateInputs:
-    with _temp_worktree("HEAD") as worktree:
-        merge = subprocess.run(
-            ["git", "merge", "--no-commit", "--no-ff", base],
-            cwd=worktree,
-            capture_output=True,
-            text=True,
-        )
-        if merge.returncode != 0:
-            subprocess.run(
-                ["git", "merge", "--abort"],
-                cwd=worktree,
-                capture_output=True,
-                text=True,
-            )
-            raise SystemExit(
-                f"ci-parity: merging {base} into HEAD conflicts; rebase your branch first"
-            )
-        shutil.copy(STRICT_CONFIG, worktree / "ruff-strict.toml")
-        head = collect_violations(worktree, worktree / "ruff-strict.toml")
-        diff = _run(
-            ["git", "diff", base, "--unified=0", "--no-color", "--", TARGET],
-            cwd=worktree,
-        )
-        return GateInputs(head, base_counts(base), parse_changed_lines(diff))
 
 
 def report(breaches: list, new: list, base: str) -> None:
@@ -192,9 +162,9 @@ def report(breaches: list, new: list, base: str) -> None:
     print(f"BREACHED RULES: {summary}")
 
 
-def cmd_check(base: str, ci_parity: bool) -> None:
+def cmd_check(base: str) -> None:
     budget = json.loads(BUDGET_PATH.read_text())
-    inputs = gather_ci_parity(base) if ci_parity else gather_fast(base)
+    inputs = gather(base)
     breaches = evaluate(count_by_rule(inputs.head), inputs.base, budget)
     if not breaches:
         print(f"OK: every strict rule is within its codebase ceiling (base {base})")
@@ -216,13 +186,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base", default=DEFAULT_BASE)
     parser.add_argument("--update", action="store_true")
-    parser.add_argument(
-        "--ci-parity",
-        action="store_true",
-        help="count against a throwaway merge of --base into HEAD, matching CI",
-    )
     args = parser.parse_args()
-    cmd_update() if args.update else cmd_check(args.base, args.ci_parity)
+    cmd_update() if args.update else cmd_check(args.base)
 
 
 if __name__ == "__main__":

--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -92,8 +92,8 @@ def count_by_rule(violations: list) -> dict:
 def _temp_worktree(ref: str) -> Iterator[Path]:
     parent = Path(tempfile.mkdtemp(prefix="ruff_wt_"))
     worktree = parent / "wt"
-    _run(["git", "worktree", "add", "--detach", str(worktree), ref])
     try:
+        _run(["git", "worktree", "add", "--detach", str(worktree), ref])
         yield worktree
     finally:
         subprocess.run(

--- a/tests/test_litellm/test_ruff_strict_gate.py
+++ b/tests/test_litellm/test_ruff_strict_gate.py
@@ -82,3 +82,13 @@ def test_introduced_keeps_only_violations_on_changed_lines():
 @pytest.mark.parametrize("hunk", ["@@ -1 +1 @@", "@@ -1,0 +1,2 @@"])
 def test_parse_changed_lines_handles_single_and_ranged_hunks(hunk):
     assert gate.parse_changed_lines(f"+++ b/litellm/a.py\n{hunk}\n")["litellm/a.py"]
+
+
+def test_report_emits_breached_rules_as_final_line(capsys):
+    # CI surfaces only the tail of the log, so the breached-rule summary (rule,
+    # total/cap, added) must be the last line or it gets truncated away.
+    breaches = sorted([gate.Breach("UP045", 530, 529, 1), gate.Breach("ANN401", 12, 10, 2)])
+    new = [gate.Violation("litellm/types/llms/bedrock.py", 16, "UP045")]
+    gate.report(breaches, new, "origin/litellm_internal_staging")
+    last = capsys.readouterr().out.strip().splitlines()[-1]
+    assert last == "BREACHED RULES: ANN401 12/10 (+2); UP045 530/529 (+1)"


### PR DESCRIPTION
## Relevant issues

None; this is developer-experience cleanup for the strict ruff gate that came out of fighting it on a recent PR.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

Two pain points with the strict ruff gate and how to see the fix locally.

First, the truncation-proof summary. CI only surfaces the tail of the job log, and the gate printed each breached rule's header before its (potentially long) list of offending files, so on a real failure the rule name and counts scrolled off the top of the captured tail and you could not tell which rule blew the budget. The gate now also prints a single `BREACHED RULES: ...` line as the very last line, which survives tail truncation. Covered by `test_report_emits_breached_rules_as_final_line`.

Second, a local entry point that predicts CI. `make lint-gate` fetches `origin/litellm_internal_staging` fresh and then runs the gate the same way the lint check does in `test-linting.yml` (the CI job checks out the PR head sha and counts against the merge-base with the base branch), so a clean local run predicts the CI verdict before you push.

```bash
# matches what the lint CI check will conclude, before you push
make lint-gate
```

Default behavior and the existing `make lint-ruff-budget` target are unchanged.

## Type

🚄 Infrastructure

## Changes

`scripts/ruff_strict_gate.py` always emits a final one-line `BREACHED RULES` summary so the verdict survives log truncation, and the shared violation-collection logic is factored into `collect_violations(root, config)` with worktree handling consolidated behind a `_temp_worktree` context manager that cleans up its temp dir even when `git worktree add` fails. `make lint-gate` is a new local entry point that fetches staging fresh and runs the gate exactly as CI does. Tests extend `tests/test_litellm/test_ruff_strict_gate.py` with a regression for the trailing summary line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Makefile targets, the ruff strict gate script, and unit tests—no runtime or proxy behavior.
> 
> **Overview**
> Improves **strict ruff budget gate** developer experience: failures now end with a single **`BREACHED RULES:`** line (rule, total/cap, added) so CI log tails still show which rules failed.
> 
> Adds **`make lint-gate`**, which fetches `origin/litellm_internal_staging` and runs `ruff_strict_gate.py --base` the same way contributors expect before push; **`make lint-ruff-budget`** is unchanged.
> 
> **`scripts/ruff_strict_gate.py`** is refactored: shared **`collect_violations`**, **`gather`**, and a **`_temp_worktree`** context manager for base-branch counts; docs note merge-base behavior aligns with CI. A unit test locks in the trailing summary line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497447aa8e15e6a0724f2b48a109e036f022ec2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->