### PR TITLE
fix(mistral): drop output-only reasoning fields from input messages

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -247,6 +247,8 @@ class MistralConfig(OpenAIGPTConfig):
         The above statement is not valid now. Need to plan to remove all the #1,2,3
         Mistral API supports content as a list.
         """
+        messages = [self._strip_output_only_fields(m) for m in messages]
+
         ## 1. If 'image_url' or 'file' in content, then transform with base class and mistral-specific handling
         for m in messages:
             _content_block = m.get("content")
@@ -408,6 +410,25 @@ class MistralConfig(OpenAIGPTConfig):
         )
 
         return cleaned_tools
+
+    @classmethod
+    def _strip_output_only_fields(cls, message: AllMessageValues) -> AllMessageValues:
+        """
+        ``reasoning_content`` and ``thinking_blocks`` are output-only fields that
+        LiteLLM attaches to assistant responses. Mistral's input schema forbids
+        unknown fields, so replaying them verbatim in a follow-up turn triggers a
+        422 ``extra_forbidden``. Drop them before the request is sent.
+        """
+        if message["role"] != "assistant":
+            return message
+        return cast(
+            AllMessageValues,
+            {
+                k: v
+                for k, v in message.items()
+                if k not in ("reasoning_content", "thinking_blocks")
+            },
+        )
 
     @classmethod
     def _handle_name_in_message(cls, message: AllMessageValues) -> AllMessageValues:

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -719,3 +719,93 @@ class TestMistralFileHandling:
         # Check that file_ids are modified to match Mistral's expected format
         assert result[0]["content"][1]["file_id"] == "file-12345"  # type: ignore
         assert result[0]["content"][2]["file_id"] == "file-67890"  # type: ignore
+
+
+class TestMistralStripsOutputOnlyFields:
+    """Mistral rejects unknown input fields with a 422 ``extra_forbidden``.
+
+    LiteLLM attaches ``reasoning_content`` / ``thinking_blocks`` to assistant
+    responses, so replaying an assistant turn verbatim must not forward them.
+    Regression for https://github.com/BerriAI/litellm/issues/30835.
+    """
+
+    def test_assistant_reasoning_content_is_dropped(self):
+        messages = cast(
+            List[AllMessageValues],
+            [
+                {"role": "user", "content": "Question?"},
+                {
+                    "role": "assistant",
+                    "content": "Follow-up",
+                    "reasoning_content": "Some internal reasoning text.",
+                    "thinking_blocks": [
+                        {"type": "thinking", "thinking": "step", "signature": "mistral"}
+                    ],
+                },
+            ],
+        )
+
+        result = cast(
+            List[AllMessageValues],
+            MistralConfig()._transform_messages(
+                messages=messages, model="mistral-medium-3-5"
+            ),
+        )
+
+        assistant_message = result[-1]
+        assert "reasoning_content" not in assistant_message
+        assert "thinking_blocks" not in assistant_message
+        assert assistant_message["content"] == "Follow-up"
+        assert assistant_message["role"] == "assistant"
+
+    def test_non_assistant_messages_are_untouched(self):
+        messages = cast(
+            List[AllMessageValues],
+            [{"role": "user", "content": "Question?", "reasoning_content": "noise"}],
+        )
+
+        result = cast(
+            List[AllMessageValues],
+            MistralConfig()._transform_messages(
+                messages=messages, model="mistral-medium-3-5"
+            ),
+        )
+
+        assert result[0].get("reasoning_content") == "noise"
+
+    def test_reasoning_content_dropped_when_image_present(self):
+        """The image branch returns early, so stripping must run before it."""
+        messages = cast(
+            List[AllMessageValues],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/cat.png"},
+                        },
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "A cat.",
+                    "reasoning_content": "leaked reasoning",
+                },
+            ],
+        )
+
+        with patch.object(
+            MistralConfig,
+            "_transform_messages_sync",
+            side_effect=lambda transformed, model: transformed,
+        ):
+            result = cast(
+                List[AllMessageValues],
+                MistralConfig()._transform_messages(
+                    messages=messages, model="mistral-medium-3-5", is_async=False
+                ),
+            )
+
+        assert "reasoning_content" not in result[-1]


### PR DESCRIPTION
## Relevant issues

Fixes #30835

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

LiteLLM attaches `reasoning_content` (and `thinking_blocks` for magistral) to assistant responses. When a client keeps the full conversation and replays a prior assistant turn, those fields go back out on the next request. Mistral's input schema forbids unknown keys, so the upstream rejects the whole call with a `422 extra_forbidden`:

```
litellm.BadRequestError: MistralException - {"detail":[{"type":"extra_forbidden","loc":["body","messages",2,"assistant","reasoning_content"],"msg":"Extra inputs are not permitted",...}]}
```

The net effect is that any multi-turn conversation through a reasoning-capable Mistral model breaks the moment a reasoning assistant turn is fed back in.

The fix strips both output-only fields from assistant messages in `MistralConfig._transform_messages`, before the image/file branch returns early, so every code path is covered. Non-assistant messages are left untouched, and assistant `content`, `tool_calls`, and the rest pass through unchanged.

### Tests

Added `TestMistralStripsOutputOnlyFields` to the mapped test file `tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py`, covering the plain text path, the image path (which returns early), and a guard that user/tool messages are not modified. The two assistant-path tests fail on `main` (the fields survive the transform) and pass with this change.

## Screenshots / Proof of Fix

Reproduction against a local proxy pointed at Mistral. Before this change the second call (replaying an assistant turn with `reasoning_content`) returns a 422; after, it succeeds.

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-medium-3-5",
    "messages": [
      {"role": "user", "content": "Question?"},
      {"role": "assistant", "content": "Follow-up", "reasoning_content": "Some internal reasoning text."},
      {"role": "user", "content": "Continue"}
    ]
  }'
```