### PR TITLE
feat(scim): ingest enterprise extension attributes into user metadata

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -57,6 +57,9 @@ from litellm.repositories.verification_token_repository import (
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
+from litellm.types.proxy.management_endpoints.scim_v2 import (
+    SCIM_ENTERPRISE_METADATA_KEY,
+)
 from litellm.types.proxy.management_endpoints.internal_user_endpoints import (
     BulkUpdateUserRequest,
     BulkUpdateUserResponse,
@@ -719,6 +722,17 @@ async def _get_user_info_teams(
     return team_list, teams_1
 
 
+def _redact_scim_enterprise_metadata(
+    metadata: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """SCIM enterprise attributes are persisted in user metadata so reporting can
+    group on them, but they are directory-only fields that generic user-info
+    endpoints must not surface; SCIM clients read them through the SCIM endpoints."""
+    if not isinstance(metadata, dict) or SCIM_ENTERPRISE_METADATA_KEY not in metadata:
+        return metadata
+    return {k: v for k, v in metadata.items() if k != SCIM_ENTERPRISE_METADATA_KEY}
+
+
 def _build_user_info_response(
     user_id: Optional[str],
     user_info: Optional[Any],
@@ -739,6 +753,9 @@ def _build_user_info_response(
     )
     if isinstance(_user_info, dict):
         _user_info.pop("password", None)
+        _user_info["metadata"] = _redact_scim_enterprise_metadata(
+            _user_info.get("metadata")
+        )
 
     return UserInfoResponse(
         user_id=user_id,
@@ -983,7 +1000,7 @@ async def user_info_v2(
             models=user_data.get("models") or [],
             budget_duration=user_data.get("budget_duration"),
             budget_reset_at=user_data.get("budget_reset_at"),
-            metadata=user_data.get("metadata"),
+            metadata=_redact_scim_enterprise_metadata(user_data.get("metadata")),
             created_at=user_data.get("created_at"),
             updated_at=user_data.get("updated_at"),
             sso_user_id=user_data.get("sso_user_id"),
@@ -2098,9 +2115,13 @@ async def get_users(
     user_list: List[LiteLLM_UserTableWithKeyCount] = []
     if users is not None:
         for user in users:
+            user_dump = user.model_dump()
+            user_dump["metadata"] = _redact_scim_enterprise_metadata(
+                user_dump.get("metadata")
+            )
             user_list.append(
                 LiteLLM_UserTableWithKeyCount(
-                    **user.model_dump(), key_count=user_key_counts.get(user.user_id, 0)
+                    **user_dump, key_count=user_key_counts.get(user.user_id, 0)
                 )
             )
     else:

--- a/litellm/proxy/management_endpoints/scim/scim_transformations.py
+++ b/litellm/proxy/management_endpoints/scim/scim_transformations.py
@@ -50,8 +50,16 @@ class ScimTransformations:
         scim_active = metadata.get("scim_active")
         active = True if scim_active is None else bool(scim_active)
 
+        schemas = ["urn:ietf:params:scim:schemas:core:2.0:User"]
+        enterprise_user = None
+        if metadata.get(SCIM_ENTERPRISE_METADATA_KEY):
+            enterprise_user = SCIMEnterpriseUser.model_validate(
+                metadata[SCIM_ENTERPRISE_METADATA_KEY]
+            )
+            schemas.append(SCIM_ENTERPRISE_USER_SCHEMA)
+
         return SCIMUser(
-            schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+            schemas=schemas,
             id=user.user_id,
             userName=ScimTransformations._get_scim_user_name(user),
             displayName=ScimTransformations._get_scim_user_name(user),
@@ -62,6 +70,7 @@ class ScimTransformations:
             emails=emails,
             groups=groups,
             active=active,
+            enterprise_user=enterprise_user,
             meta={
                 "resourceType": "User",
                 "created": user_created_at,

--- a/litellm/proxy/management_endpoints/scim/scim_v2.py
+++ b/litellm/proxy/management_endpoints/scim/scim_v2.py
@@ -118,6 +118,7 @@ class ScimUserData(TypedDict):
     given_name: Optional[str]
     family_name: Optional[str]
     active: Optional[bool]
+    enterprise: Optional[SCIMEnterpriseUser]
 
 
 class GroupMemberExtractionResult(BaseModel):
@@ -199,11 +200,15 @@ def _extract_scim_user_data(user: SCIMUser) -> ScimUserData:
         "given_name": user.name.givenName if user.name else None,
         "family_name": user.name.familyName if user.name else None,
         "active": user.active,
+        "enterprise": user.enterprise_user,
     }
 
 
 def _build_scim_metadata(
-    given_name: Optional[str], family_name: Optional[str], active: Optional[bool] = None
+    given_name: Optional[str],
+    family_name: Optional[str],
+    active: Optional[bool] = None,
+    enterprise: Optional[SCIMEnterpriseUser] = None,
 ) -> Dict[str, Any]:
     """Build metadata dictionary with SCIM data."""
     metadata: Dict[str, Any] = {
@@ -215,6 +220,11 @@ def _build_scim_metadata(
 
     if active is not None:
         metadata["scim_active"] = active
+
+    if enterprise is not None:
+        metadata[SCIM_ENTERPRISE_METADATA_KEY] = enterprise.model_dump(
+            by_alias=True, exclude_none=True
+        )
 
     return metadata
 
@@ -999,7 +1009,9 @@ async def create_user(
         # Create user in database
         user_id = user.userName or str(uuid.uuid4())
         metadata = _build_scim_metadata(
-            user_data["given_name"], user_data["family_name"]
+            user_data["given_name"],
+            user_data["family_name"],
+            enterprise=user_data["enterprise"],
         )
 
         default_role: Optional[
@@ -1088,6 +1100,7 @@ async def update_user(
             user_data["given_name"],
             user_data["family_name"],
             scim_active_for_metadata,
+            enterprise=user_data["enterprise"],
         )
 
         await _handle_team_membership_changes(

--- a/litellm/types/proxy/management_endpoints/scim_v2.py
+++ b/litellm/types/proxy/management_endpoints/scim_v2.py
@@ -1,7 +1,20 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from fastapi import HTTPException
-from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    field_validator,
+    model_serializer,
+)
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
+
+SCIM_ENTERPRISE_USER_SCHEMA = (
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+)
+SCIM_ENTERPRISE_METADATA_KEY = "scim_enterprise"
 
 
 class LiteLLM_UserScimMetadata(BaseModel):
@@ -42,13 +55,49 @@ class SCIMUserGroup(BaseModel):
     type: Optional[str] = "direct"  # direct or indirect
 
 
+class SCIMUserManager(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    value: Optional[str] = None
+    displayName: Optional[str] = None
+    ref: Optional[str] = Field(default=None, alias="$ref")
+
+
+class SCIMEnterpriseUser(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    employeeNumber: Optional[str] = None
+    costCenter: Optional[str] = None
+    organization: Optional[str] = None
+    division: Optional[str] = None
+    department: Optional[str] = None
+    manager: Optional[SCIMUserManager] = None
+
+
 class SCIMUser(SCIMResource):
+    model_config = ConfigDict(populate_by_name=True)
+
     userName: Optional[str] = None
     name: Optional[SCIMUserName] = None
     displayName: Optional[str] = None
     active: bool = True
     emails: Optional[List[SCIMUserEmail]] = None
     groups: Optional[List[SCIMUserGroup]] = None
+    enterprise_user: Optional[SCIMEnterpriseUser] = Field(
+        default=None,
+        alias=SCIM_ENTERPRISE_USER_SCHEMA,
+        serialization_alias=SCIM_ENTERPRISE_USER_SCHEMA,
+    )
+
+    @model_serializer(mode="wrap")
+    def _omit_absent_enterprise(
+        self, handler: SerializerFunctionWrapHandler
+    ) -> Dict[str, Any]:
+        dumped = handler(self)
+        if self.enterprise_user is None:
+            dumped.pop(SCIM_ENTERPRISE_USER_SCHEMA, None)
+            dumped.pop("enterprise_user", None)
+        return dumped
 
 
 class SCIMMember(BaseModel):

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_transformations.py
@@ -13,7 +13,10 @@ from litellm.proxy.management_endpoints.scim.scim_transformations import (
     ScimTransformations,
 )
 from litellm.types.proxy.management_endpoints.scim_v2 import (
+    SCIM_ENTERPRISE_USER_SCHEMA,
+    SCIMEnterpriseUser,
     SCIMPatchOperation,
+    SCIMUser,
 )
 
 
@@ -148,6 +151,77 @@ class TestScimTransformations:
 
             assert scim_user.name.givenName == "Test"
             assert scim_user.name.familyName == "User"
+
+    @pytest.mark.asyncio
+    async def test_transform_user_with_enterprise_metadata(self, mock_prisma_client):
+        mock_client, mock_find_unique = mock_prisma_client
+        mock_find_unique.return_value = None
+
+        user = LiteLLM_UserTable(
+            user_id="user-ent",
+            user_email="ent@example.com",
+            user_alias=None,
+            teams=[],
+            created_at=None,
+            updated_at=None,
+            metadata={
+                "scim_enterprise": {"costCenter": "CC-42", "department": "Platform"}
+            },
+        )
+
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_client):
+            scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(
+                user
+            )
+
+            assert scim_user.enterprise_user is not None
+            assert scim_user.enterprise_user.costCenter == "CC-42"
+            assert scim_user.enterprise_user.department == "Platform"
+            assert SCIM_ENTERPRISE_USER_SCHEMA in scim_user.schemas
+
+    @pytest.mark.asyncio
+    async def test_transform_user_without_enterprise_metadata_omits_schema(
+        self, mock_user, mock_prisma_client
+    ):
+        mock_client, mock_find_unique = mock_prisma_client
+        team1 = LiteLLM_TeamTable(
+            team_id="team-1", team_alias="Team One", members_with_roles=[]
+        )
+        team2 = LiteLLM_TeamTable(
+            team_id="team-2", team_alias="Team Two", members_with_roles=[]
+        )
+        mock_find_unique.side_effect = [team1, team2]
+
+        with patch("litellm.proxy.proxy_server.prisma_client", mock_client):
+            scim_user = await ScimTransformations.transform_litellm_user_to_scim_user(
+                mock_user
+            )
+
+            assert scim_user.enterprise_user is None
+            assert SCIM_ENTERPRISE_USER_SCHEMA not in scim_user.schemas
+
+    def test_scim_user_serialization_omits_absent_enterprise_urn(self):
+        without_enterprise = SCIMUser(
+            schemas=["urn:ietf:params:scim:schemas:core:2.0:User"],
+            id="user-1",
+            userName="user@example.com",
+        )
+        dumped = without_enterprise.model_dump(by_alias=True)
+        assert SCIM_ENTERPRISE_USER_SCHEMA not in dumped
+        assert "enterprise_user" not in dumped
+        assert SCIM_ENTERPRISE_USER_SCHEMA not in dumped["schemas"]
+
+        with_enterprise = SCIMUser(
+            schemas=[
+                "urn:ietf:params:scim:schemas:core:2.0:User",
+                SCIM_ENTERPRISE_USER_SCHEMA,
+            ],
+            id="user-2",
+            userName="ent@example.com",
+            enterprise_user=SCIMEnterpriseUser(costCenter="CC-42"),
+        )
+        dumped_ent = with_enterprise.model_dump(by_alias=True)
+        assert dumped_ent[SCIM_ENTERPRISE_USER_SCHEMA]["costCenter"] == "CC-42"
 
     @pytest.mark.asyncio
     async def test_transform_litellm_team_to_scim_group(

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -24,6 +24,7 @@ from litellm.proxy.management_endpoints.scim.scim_v2 import (
     update_user,
 )
 from litellm.types.proxy.management_endpoints.scim_v2 import (
+    SCIM_ENTERPRISE_USER_SCHEMA,
     SCIMGroup,
     SCIMMember,
     SCIMPatchOp,
@@ -113,6 +114,59 @@ async def test_create_user_defaults_to_viewer(mocker, monkeypatch):
 
     called_args = new_user_mock.call_args.kwargs["data"]
     assert called_args.user_role == LitellmUserRoles.INTERNAL_USER_VIEW_ONLY
+
+
+@pytest.mark.asyncio
+async def test_create_user_ingests_enterprise_extension(mocker, monkeypatch):
+    """A SCIM create payload carrying the enterprise extension block should land
+    in the created user's metadata under scim_enterprise"""
+
+    scim_user = SCIMUser.model_validate(
+        {
+            "schemas": [
+                "urn:ietf:params:scim:schemas:core:2.0:User",
+                SCIM_ENTERPRISE_USER_SCHEMA,
+            ],
+            "userName": "ent-user",
+            "name": {"familyName": "User", "givenName": "Ent"},
+            "emails": [{"value": "ent@example.com"}],
+            SCIM_ENTERPRISE_USER_SCHEMA: {
+                "costCenter": "CC-42",
+                "department": "Platform",
+            },
+        }
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+    mock_prisma_client.db.litellm_usertable.find_first = AsyncMock(return_value=None)
+
+    monkeypatch.setattr("litellm.default_internal_user_params", None, raising=False)
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2._get_prisma_client_or_raise_exception",
+        AsyncMock(return_value=mock_prisma_client),
+    )
+
+    new_user_mock = mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.new_user",
+        AsyncMock(return_value=NewUserRequest(user_id="ent-user")),
+    )
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.scim.scim_v2.ScimTransformations.transform_litellm_user_to_scim_user",
+        AsyncMock(return_value=scim_user),
+    )
+
+    await create_user(user=scim_user)
+
+    created_metadata = new_user_mock.call_args.kwargs["data"].metadata
+    assert created_metadata["scim_enterprise"] == {
+        "costCenter": "CC-42",
+        "department": "Platform",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -657,6 +657,56 @@ async def test_get_users_includes_timestamps(mocker):
     assert user_response.key_count == 0
 
 
+@pytest.mark.asyncio
+async def test_get_users_redacts_scim_enterprise_metadata(mocker):
+    """
+    /user/list must strip scim_enterprise from each user's metadata while leaving
+    the rest of the metadata intact, matching the user-info endpoints.
+    """
+    mock_prisma_client = mocker.MagicMock()
+
+    mock_user_row = mocker.MagicMock()
+    mock_user_row.user_id = "listed-user"
+    mock_user_row.model_dump.return_value = {
+        "user_id": "listed-user",
+        "user_email": "listed@example.com",
+        "user_role": "internal_user",
+        "metadata": {
+            "scim_metadata": {"givenName": "Jane", "familyName": "Doe"},
+            "scim_enterprise": {"costCenter": "CC-42", "department": "Platform"},
+        },
+    }
+
+    async def mock_find_many(*args, **kwargs):
+        return [mock_user_row]
+
+    async def mock_count(*args, **kwargs):
+        return 1
+
+    mock_prisma_client.db.litellm_usertable.find_many = mock_find_many
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    async def mock_get_user_key_counts(*args, **kwargs):
+        return {"listed-user": 0}
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_user_key_counts",
+        mock_get_user_key_counts,
+    )
+
+    admin_key = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+    response = await get_users(
+        page=1, page_size=1, user_api_key_dict=admin_key, organization_ids=None
+    )
+
+    listed = response["users"][0]
+    assert listed.metadata == {
+        "scim_metadata": {"givenName": "Jane", "familyName": "Doe"}
+    }
+    assert "scim_enterprise" not in (listed.metadata or {})
+
+
 def test_validate_sort_params():
     """
     Test that validate_sort_params returns None if sort_by is None
@@ -2165,6 +2215,94 @@ async def test_user_info_v2_proxy_admin_can_query_any_user(mocker):
     assert response.teams == ["team-1", "team-2"]
     assert response.sso_user_id == "sso-abc"
     assert response.metadata == {"team": "engineering"}
+
+
+@pytest.mark.asyncio
+async def test_user_info_v2_redacts_scim_enterprise_metadata(mocker):
+    """
+    SCIM enterprise attributes are persisted in metadata for reporting, but
+    /v2/user/info must not surface them; the rest of metadata is preserved.
+    """
+    from fastapi import Request
+
+    from litellm.proxy._types import UserInfoV2Response
+    from litellm.proxy.management_endpoints.internal_user_endpoints import user_info_v2
+
+    mock_prisma_client = mocker.MagicMock()
+
+    mock_user_row = mocker.MagicMock()
+    mock_user_row.model_dump.return_value = {
+        "user_id": "target-user-123",
+        "user_email": "target@example.com",
+        "metadata": {
+            "scim_metadata": {"givenName": "Jane", "familyName": "Doe"},
+            "scim_enterprise": {
+                "costCenter": "CC-42",
+                "department": "Platform",
+                "employeeNumber": "E-1001",
+            },
+        },
+        "teams": ["team-1"],
+    }
+
+    async def mock_find_unique(*args, **kwargs):
+        if kwargs.get("where", {}).get("user_id") == "target-user-123":
+            return mock_user_row
+        return None
+
+    mock_prisma_client.db.litellm_usertable.find_unique = mocker.AsyncMock(
+        side_effect=mock_find_unique
+    )
+
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    mock_request = mocker.MagicMock(spec=Request)
+
+    admin_key = UserAPIKeyAuth(
+        user_id="admin-user", user_role=LitellmUserRoles.PROXY_ADMIN
+    )
+
+    response = await user_info_v2(
+        request=mock_request,
+        user_id="target-user-123",
+        user_api_key_dict=admin_key,
+    )
+
+    assert isinstance(response, UserInfoV2Response)
+    assert response.metadata == {
+        "scim_metadata": {"givenName": "Jane", "familyName": "Doe"}
+    }
+    assert "scim_enterprise" not in (response.metadata or {})
+
+
+def test_build_user_info_response_redacts_scim_enterprise_metadata():
+    """
+    The shared /user/info builder strips scim_enterprise from the returned user row
+    while leaving every other metadata key intact.
+    """
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _build_user_info_response,
+    )
+
+    user_row = {
+        "user_id": "target-user-123",
+        "metadata": {
+            "scim_metadata": {"givenName": "Jane"},
+            "scim_enterprise": {"costCenter": "CC-42"},
+        },
+    }
+
+    response = _build_user_info_response(
+        user_id="target-user-123",
+        user_info=user_row,
+        keys=None,
+        team_list=[],
+        teams_1=None,
+    )
+
+    assert response.user_info is not None
+    assert response.user_info["metadata"] == {"scim_metadata": {"givenName": "Jane"}}
+    assert "scim_enterprise" not in response.user_info["metadata"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-3617

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

SCIM `SCIMUser` only modeled the core schema, so the enterprise extension block keyed `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User` (employeeNumber, costCenter, organization, division, department, manager) was silently dropped by Pydantic and never reached `LiteLLM_UserTable.metadata`. Financial reporting had no way to group spend by fields like cost center and department

This adds `SCIMEnterpriseUser` and `SCIMUserManager` types plus an `enterprise_user` field on `SCIMUser` aliased to the enterprise URN, so FastAPI reads and serializes the URN key correctly. On create and PUT the extension is stored in metadata under `scim_enterprise`, and `transform_litellm_user_to_scim_user` round-trips it back out, appending the enterprise URN to the response `schemas` only when enterprise data is present

The enterprise block carries directory-only HR attributes, so it is scoped to the SCIM channel and to reporting rather than the generic user management surface. `/user/info`, `/v2/user/info`, and `/user/list` now drop `scim_enterprise` from the metadata they return, so non-proxy-admin callers such as team and org admins cannot read it for other users; the data still persists in `LiteLLM_UserTable.metadata` for reporting and still round-trips through the SCIM read endpoints, which build their response from the user row directly. The metadata key is now a shared `SCIM_ENTERPRISE_METADATA_KEY` constant used by the write, read, and redaction paths

Scope is deliberately limited to standard SCIM enterprise attributes on the create and PUT round-trip; PATCH keeps its existing generic-metadata behavior and arbitrary custom schemas are not supported

Tests extend the mapped files: `test_scim_transformations.py` covers round-trip out (enterprise metadata maps to `enterprise_user` and the schema list, and is omitted when absent), `test_scim_v2_endpoints.py` covers ingestion (a create payload with the enterprise block lands in the created user's metadata under `scim_enterprise`), and `test_internal_user_endpoints.py` covers the redaction (`/v2/user/info`, the shared `/user/info` builder, and `/user/list` each strip `scim_enterprise` while leaving the rest of metadata intact)

## Screenshots / Proof of Fix

Verified against a live proxy with a real Postgres and a valid enterprise license. SCIM provisioning is a management flow with no LLM call, so the meaningful proof is that the enterprise attributes survive create, persist into `LiteLLM_UserTable.metadata` for reporting, round-trip back out on the SCIM read endpoints, and stay out of the generic user-info responses. The same `jane.doe@acme.example` user is posted once, then read on `litellm_internal_staging` (before) and on this branch (after)

Payload posted (Okta-style enterprise extension):

```json
{
  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
  "userName": "jane.doe@acme.example",
  "name": {"givenName": "Jane", "familyName": "Doe"},
  "emails": [{"value": "jane.doe@acme.example", "primary": true}],
  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
    "costCenter": "CC-42", "department": "Platform", "division": "Engineering",
    "organization": "Acme", "employeeNumber": "E-1001",
    "manager": {"value": "mgr-1", "displayName": "Manager One"}
  }
}
```

The attributes land in `LiteLLM_UserTable.metadata` under `scim_enterprise`, which is what reporting groups on:

```
$ psql -c "SELECT jsonb_pretty(metadata::jsonb) FROM \"LiteLLM_UserTable\" WHERE user_id='jane.doe@acme.example';"
{
    "scim_metadata": {"givenName": "Jane", "familyName": "Doe"},
    "scim_enterprise": {
        "manager": {"value": "mgr-1", "displayName": "Manager One"},
        "division": "Engineering", "costCenter": "CC-42",
        "department": "Platform", "organization": "Acme",
        "employeeNumber": "E-1001"
    }
}
```

The SCIM read endpoint round-trips the enterprise block back out, with the enterprise URN listed in `schemas`:

```
$ curl -s http://127.0.0.1:4000/scim/v2/Users/jane.doe@acme.example -H "Authorization: Bearer $KEY"
{
  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"],
  "id": "jane.doe@acme.example",
  ...
  "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User": {
    "employeeNumber": "E-1001", "costCenter": "CC-42", "organization": "Acme",
    "division": "Engineering", "department": "Platform",
    "manager": {"value": "mgr-1", "displayName": "Manager One", "$ref": null}
  }
}
```

Generic user-info, before on `litellm_internal_staging`, returns the enterprise block in metadata:

```
$ curl -s "http://127.0.0.1:4000/v2/user/info?user_id=jane.doe@acme.example" -H "Authorization: Bearer $KEY"
{
  "user_id": "jane.doe@acme.example",
  ...
  "metadata": {
    "scim_metadata": {"givenName": "Jane", "familyName": "Doe"},
    "scim_enterprise": {
      "manager": {"value": "mgr-1", "displayName": "Manager One"},
      "division": "Engineering", "costCenter": "CC-42", "department": "Platform",
      "organization": "Acme", "employeeNumber": "E-1001"
    }
  }
}
```

After, on this branch, the same call returns metadata without `scim_enterprise`, while `scim_metadata` and everything else is preserved:

```
$ curl -s "http://127.0.0.1:4000/v2/user/info?user_id=jane.doe@acme.example" -H "Authorization: Bearer $KEY"
{
  "user_id": "jane.doe@acme.example",
  ...
  "metadata": {
    "scim_metadata": {"givenName": "Jane", "familyName": "Doe"}
  }
}
```

Mutation check on the redaction: stubbing `_redact_scim_enterprise_metadata` to return its input unchanged makes both `test_user_info_v2_redacts_scim_enterprise_metadata` and `test_build_user_info_response_redacts_scim_enterprise_metadata` fail (the returned metadata still carries `scim_enterprise`); restoring the helper returns the SCIM and user-info suites to green (112 passed)
