### PR TITLE
fix(watsonx): wrap string embedding input in array for WatsonX API

### DIFF
--- a/litellm/llms/watsonx/embed/transformation.py
+++ b/litellm/llms/watsonx/embed/transformation.py
@@ -2,7 +2,7 @@
 Translates from OpenAI's `/v1/embeddings` to IBM's `/text/embeddings` route.
 """
 
-from typing import Optional
+from typing import List, Optional, cast
 
 import httpx
 
@@ -43,8 +43,13 @@ class IBMWatsonXEmbeddingConfig(IBMWatsonXMixin, BaseEmbeddingConfig):
             api_params=watsonx_api_params,
         )
 
+        if isinstance(input, list) and (len(input) > 0 and (isinstance(input[0], list) or isinstance(input[0], int))):
+            raise ValueError("WatsonX embeddings require a string or list of strings")
+
+        inputs: List[str] = cast(List[str], input) if isinstance(input, list) else [input]
+
         return {
-            "inputs": input,
+            "inputs": inputs,
             "parameters": optional_params,
             **watsonx_auth_payload,
         }
@@ -66,9 +71,7 @@ class IBMWatsonXEmbeddingConfig(IBMWatsonXMixin, BaseEmbeddingConfig):
         url = url.rstrip("/") + endpoint
 
         ## add api version
-        url = self._add_api_version_to_url(
-            url=url, api_version=optional_params.pop("api_version", None)
-        )
+        url = self._add_api_version_to_url(url=url, api_version=optional_params.pop("api_version", None))
         return url
 
     def transform_embedding_response(

--- a/litellm/llms/watsonx/embed/transformation.py
+++ b/litellm/llms/watsonx/embed/transformation.py
@@ -2,7 +2,7 @@
 Translates from OpenAI's `/v1/embeddings` to IBM's `/text/embeddings` route.
 """
 
-from typing import List, Optional, cast
+from typing import Optional
 
 import httpx
 
@@ -43,14 +43,16 @@ class IBMWatsonXEmbeddingConfig(IBMWatsonXMixin, BaseEmbeddingConfig):
             api_params=watsonx_api_params,
         )
 
-        if isinstance(input, list) and (
-            len(input) > 0 and (isinstance(input[0], list) or isinstance(input[0], int))
-        ):
-            raise ValueError("WatsonX embeddings require a string or list of strings")
-
-        inputs: List[str] = (
-            cast(List[str], input) if isinstance(input, list) else [input]
-        )
+        if isinstance(input, str):
+            inputs: list[str] = [input]
+        elif isinstance(input, list):
+            if len(input) > 0 and isinstance(input[0], (list, int)):
+                raise ValueError(
+                    "WatsonX embeddings require a string or list of strings"
+                )
+            inputs = input
+        else:
+            inputs = [input]
 
         return {
             "inputs": inputs,

--- a/litellm/llms/watsonx/embed/transformation.py
+++ b/litellm/llms/watsonx/embed/transformation.py
@@ -43,10 +43,14 @@ class IBMWatsonXEmbeddingConfig(IBMWatsonXMixin, BaseEmbeddingConfig):
             api_params=watsonx_api_params,
         )
 
-        if isinstance(input, list) and (len(input) > 0 and (isinstance(input[0], list) or isinstance(input[0], int))):
+        if isinstance(input, list) and (
+            len(input) > 0 and (isinstance(input[0], list) or isinstance(input[0], int))
+        ):
             raise ValueError("WatsonX embeddings require a string or list of strings")
 
-        inputs: List[str] = cast(List[str], input) if isinstance(input, list) else [input]
+        inputs: List[str] = (
+            cast(List[str], input) if isinstance(input, list) else [input]
+        )
 
         return {
             "inputs": inputs,
@@ -71,7 +75,9 @@ class IBMWatsonXEmbeddingConfig(IBMWatsonXMixin, BaseEmbeddingConfig):
         url = url.rstrip("/") + endpoint
 
         ## add api version
-        url = self._add_api_version_to_url(url=url, api_version=optional_params.pop("api_version", None))
+        url = self._add_api_version_to_url(
+            url=url, api_version=optional_params.pop("api_version", None)
+        )
         return url
 
     def transform_embedding_response(

--- a/tests/test_litellm/llms/watsonx/embed/test_watsonx_embedding_transformation.py
+++ b/tests/test_litellm/llms/watsonx/embed/test_watsonx_embedding_transformation.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import pytest
+
+from litellm.llms.watsonx.embed.transformation import IBMWatsonXEmbeddingConfig
+
+
+class TestIBMWatsonXEmbeddingConfig:
+    def _config(self) -> IBMWatsonXEmbeddingConfig:
+        return IBMWatsonXEmbeddingConfig()
+
+    def test_transform_embedding_request_wraps_string_input(self):
+        cfg = self._config()
+        request = cfg.transform_embedding_request(
+            model="intfloat/multilingual-e5-large",
+            input="cdsc",
+            optional_params={"project_id": "test-project-id"},
+            headers={},
+        )
+
+        assert request["inputs"] == ["cdsc"]
+        assert request["project_id"] == "test-project-id"
+
+    def test_transform_embedding_request_preserves_list_input(self):
+        cfg = self._config()
+        request = cfg.transform_embedding_request(
+            model="intfloat/multilingual-e5-large",
+            input=["first", "second"],
+            optional_params={"project_id": "test-project-id"},
+            headers={},
+        )
+
+        assert request["inputs"] == ["first", "second"]
+
+    def test_transform_embedding_request_rejects_token_input(self):
+        cfg = self._config()
+
+        with pytest.raises(ValueError, match="string or list of strings"):
+            cfg.transform_embedding_request(
+                model="intfloat/multilingual-e5-large",
+                input=[[1, 2, 3]],
+                optional_params={"project_id": "test-project-id"},
+                headers={},
+            )


### PR DESCRIPTION
WatsonX embedding requests fail with 400 invalid_request_entity when input is sent as a single string (valid OpenAI format)

Issue
Calling /v1/embeddings on the proxy with a WatsonX model (e.g. multilingual-e5-large backed by watsonx/intfloat/multilingual-e5-large) and a string input returns:

WatsonxException - Failed to deserialize json: 'Mismatch type []string with value string'
The upstream payload shows "inputs":"cdsc" instead of "inputs":["cdsc"]. OpenAI clients and the LiteLLM UI commonly send "input": "cdsc" for single-text embeddings, so this breaks the normal embedding path for WatsonX.

Root cause
IBMWatsonXEmbeddingConfig.transform_embedding_request passed the OpenAI input value straight through as WatsonX inputs. OpenAI accepts both a string and a list of strings; WatsonX /ml/v1/text/embeddings always expects inputs to be []string. A string input was serialized as a JSON string, which WatsonX rejected.

Fix
Normalize input before building the WatsonX request body: wrap a single string in a one-element list, pass through an existing list of strings unchanged, and raise a clear error for token-array inputs (which WatsonX does not support).

Added regression tests in tests/test_litellm/llms/watsonx/embed/test_watsonx_embedding_transformation.py covering string input, list input, and token-array rejection.

Screenshots / Proof of Fix
Before (broken payload sent to WatsonX):

{"inputs":"cdsc","parameters":{...},"model_id":"intfloat/multilingual-e5-large","project_id":"..."}
After fix, unit test + mocked integration confirm the payload is:

{"inputs":["cdsc"],"parameters":{...},"model_id":"intfloat/multilingual-e5-large","project_id":"..."}
Live proxy repro (restart proxy after pulling this branch):

```
uv run litellm --config litellm/proxy/test.yaml --port 4000 --detailed_debug --reload
curl -s http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"multilingual-e5-large","input":"cdsc"}'
```
Type
Bug Fix

Changes
litellm/llms/watsonx/embed/transformation.py: wrap string input into inputs: [str] before calling WatsonX
tests/test_litellm/llms/watsonx/embed/test_watsonx_embedding_transformation.py: regression tests for string, list, and token-a