### PR TITLE
fix(mcp): stop exposing MCP server URLs on the AI Hub and public hub API

### DIFF
--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -69,7 +69,6 @@ class MCPPublicServer(BaseModel):
     name: str
     alias: Optional[str] = None
     server_name: Optional[str] = None
-    url: Optional[str] = None
     transport: MCPTransportType
     spec_path: Optional[str] = None
     auth_type: Optional[MCPAuthType] = None

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -819,3 +819,44 @@ def test_public_mcp_hub_returns_empty_when_whitelist_unset():
     assert response.status_code == 200
     assert response.json() == []
     app.dependency_overrides.clear()
+
+
+def test_public_mcp_hub_does_not_expose_upstream_url():
+    """Regression: /public/mcp_hub is unauthenticated, so the gateway-internal
+    upstream url must never appear in its response even when the server has one."""
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    from litellm.proxy._types import MCPTransport
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+    client = TestClient(app)
+
+    secret_url = "https://internal-only.example.com/mcp"
+    server = MCPServer(
+        server_id="listed",
+        name="listed",
+        server_name="listed",
+        url=secret_url,
+        transport=MCPTransport.http,
+        available_on_public_internet=True,
+    )
+
+    mock_manager = MagicMock()
+    mock_manager.get_public_mcp_servers.return_value = [server]
+
+    with (
+        patch("litellm.public_mcp_servers", ["listed"]),
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+            mock_manager,
+        ),
+    ):
+        response = client.get("/public/mcp_hub")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [item["server_id"] for item in data] == ["listed"]
+    assert all("url" not in item for item in data)
+    assert secret_url not in response.text
+    app.dependency_overrides.clear()

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -935,16 +935,6 @@ print(response.choices[0].message.content)`}
             <div>
               <Text className="text-lg font-semibold mb-4">Connection Details</Text>
               <div className="space-y-2">
-                <div>
-                  <Text className="font-medium">URL:</Text>
-                  <div className="flex items-center space-x-2 mt-1">
-                    <Text className="text-sm break-all bg-gray-100 p-2 rounded flex-1">{selectedMcpServer.url}</Text>
-                    <CopyOutlined
-                      onClick={() => copyToClipboard(selectedMcpServer.url)}
-                      className="cursor-pointer text-gray-500 hover:text-blue-500 flex-shrink-0"
-                    />
-                  </div>
-                </div>
                 {selectedMcpServer.command && (
                   <div>
                     <Text className="font-medium">Command:</Text>

--- a/ui/litellm-dashboard/src/components/mcp_hub_table_columns.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_hub_table_columns.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { mcpHubColumns, MCPServerData } from "./mcp_hub_table_columns";
+
+const SERVER_URL = "https://mcp.exa.ai/mcp";
+
+const mockServer: MCPServerData = {
+  server_id: "server-1",
+  server_name: "exa_test",
+  description: "Fast, intelligent web search and web crawling",
+  url: SERVER_URL,
+  transport: "http",
+  auth_type: "none",
+  created_at: "2026-01-01T00:00:00Z",
+  created_by: "admin",
+  updated_at: "2026-01-01T00:00:00Z",
+  updated_by: "admin",
+  teams: [],
+  mcp_access_groups: [],
+  allowed_tools: [],
+  extra_headers: [],
+  mcp_info: {},
+  static_headers: {},
+  status: "active",
+  args: [],
+  env: {},
+};
+
+function TestTable({ data }: { data: MCPServerData[] }) {
+  const columns = mcpHubColumns(vi.fn(), vi.fn(), false);
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <table>
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id}>
+            {hg.headers.map((h) => (
+              <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+describe("mcpHubColumns", () => {
+  it("renders the server row", () => {
+    render(<TestTable data={[mockServer]} />);
+    expect(screen.getByText("exa_test")).toBeInTheDocument();
+  });
+
+  it("keeps the non-sensitive columns", () => {
+    render(<TestTable data={[mockServer]} />);
+    expect(screen.getByText("Server Name")).toBeInTheDocument();
+    expect(screen.getByText("Transport")).toBeInTheDocument();
+    expect(screen.getByText("Auth Type")).toBeInTheDocument();
+  });
+
+  it("does not expose a URL column header", () => {
+    render(<TestTable data={[mockServer]} />);
+    expect(screen.queryByText("URL")).not.toBeInTheDocument();
+    expect(mcpHubColumns(vi.fn(), vi.fn(), false).some((c) => c.header === "URL")).toBe(false);
+  });
+
+  it("does not render the server url anywhere in the table", () => {
+    render(<TestTable data={[mockServer]} />);
+    expect(screen.queryByText(SERVER_URL)).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_hub_table_columns.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_hub_table_columns.tsx
@@ -79,30 +79,6 @@ export const mcpHubColumns = (
       },
     },
     {
-      header: "URL",
-      accessorKey: "url",
-      enableSorting: true,
-      sortingFn: "alphanumeric",
-      cell: ({ row }) => {
-        const server = row.original;
-
-        return (
-          <div className="flex items-center space-x-2">
-            <Text className="text-xs truncate max-w-xs">{server.url}</Text>
-            <Tooltip title="Copy URL">
-              <CopyOutlined
-                onClick={() => copyToClipboard(server.url)}
-                className="cursor-pointer text-gray-500 hover:text-blue-500 text-xs flex-shrink-0"
-              />
-            </Tooltip>
-          </div>
-        );
-      },
-      meta: {
-        className: "hidden lg:table-cell",
-      },
-    },
-    {
       header: "Transport",
       accessorKey: "transport",
       enableSorting: true,

--- a/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
-import PublicModelHub from "./public_model_hub";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import PublicModelHub, { publicMCPHubColumns, MCPServerData } from "./public_model_hub";
 
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(() => ({
@@ -184,5 +185,82 @@ describe("PublicModelHub", () => {
       expect(screen.getByTestId("navbar")).toBeInTheDocument();
       expect(screen.getByText("Model Hub")).toBeInTheDocument();
     });
+  });
+});
+
+const PUBLIC_SERVER_URL = "https://mcp.exa.ai/mcp";
+
+const mockMcpServer: MCPServerData = {
+  server_id: "server-1",
+  name: "exa_test",
+  server_name: "exa_test",
+  url: PUBLIC_SERVER_URL,
+  transport: "http",
+  auth_type: "none",
+  mcp_info: { server_name: "exa_test", description: "Fast, intelligent web search and web crawling" },
+};
+
+function PublicMcpTestTable({ data }: { data: MCPServerData[] }) {
+  const columns = publicMCPHubColumns(vi.fn());
+  const table = useReactTable({ data, columns, getCoreRowModel: getCoreRowModel() });
+
+  return (
+    <table>
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id}>
+            {hg.headers.map((h) => (
+              <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+describe("publicMCPHubColumns", () => {
+  it("keeps the non-sensitive columns", () => {
+    render(<PublicMcpTestTable data={[mockMcpServer]} />);
+    expect(screen.getByText("Server Name")).toBeInTheDocument();
+    expect(screen.getByText("Transport")).toBeInTheDocument();
+    expect(screen.getByText("Auth Type")).toBeInTheDocument();
+  });
+
+  it("does not expose a URL column header", () => {
+    render(<PublicMcpTestTable data={[mockMcpServer]} />);
+    expect(screen.queryByText("URL")).not.toBeInTheDocument();
+    expect(publicMCPHubColumns(vi.fn()).some((c) => c.header === "URL")).toBe(false);
+  });
+
+  it("does not render the server url anywhere in the table", () => {
+    render(<PublicMcpTestTable data={[mockMcpServer]} />);
+    expect(screen.queryByText(PUBLIC_SERVER_URL)).not.toBeInTheDocument();
+  });
+});
+
+describe("public hub MCP details modal", () => {
+  it("does not show the upstream url when a server is opened", async () => {
+    const networkingModule = await import("./networking");
+    vi.mocked(networkingModule.mcpHubPublicServersCall).mockResolvedValue([mockMcpServer]);
+
+    render(<PublicModelHub />);
+
+    fireEvent.click(await screen.findByRole("tab", { name: /MCP Hub/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "exa_test" }));
+
+    // "Server Overview" only exists inside the opened MCP details modal,
+    // so finding it proves the modal rendered and the url assertion is not vacuous.
+    await screen.findByText("Server Overview");
+    expect(screen.queryByText(PUBLIC_SERVER_URL)).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -74,12 +74,11 @@ interface AgentCard {
   [key: string]: any;
 }
 
-interface MCPServerData {
+export interface MCPServerData {
   server_id: string;
   name: string;
   alias?: string | null;
   server_name: string;
-  url: string;
   transport: string;
   spec_path?: string | null;
   auth_type: string;
@@ -95,6 +94,73 @@ interface PublicModelHubProps {
   accessToken?: string | null;
   isEmbedded?: boolean; // When true, hides navbar and adjusts layout for embedding in dashboard
 }
+
+export const publicMCPHubColumns = (showMcpModal: (server: MCPServerData) => void): ColumnDef<MCPServerData>[] => [
+  {
+    header: "Server Name",
+    accessorKey: "server_name",
+    enableSorting: true,
+    cell: ({ row }) => (
+      <div className="overflow-hidden">
+        <Tooltip title={row.original.server_name}>
+          <Button
+            size="xs"
+            variant="light"
+            className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left"
+            onClick={() => showMcpModal(row.original)}
+          >
+            {row.original.server_name}
+          </Button>
+        </Tooltip>
+      </div>
+    ),
+    size: 150,
+  },
+  {
+    header: "Description",
+    accessorKey: "mcp_info.description",
+    enableSorting: false,
+    cell: ({ row }) => {
+      const description = String(row.original.mcp_info?.description ?? "-");
+      const truncated = description.length > 80 ? description.substring(0, 80) + "..." : description;
+      return (
+        <Tooltip title={description}>
+          <Text className="text-sm text-gray-700">{truncated}</Text>
+        </Tooltip>
+      );
+    },
+    size: 250,
+  },
+  {
+    header: "Transport",
+    accessorKey: "transport",
+    enableSorting: true,
+    cell: ({ row }) => {
+      const transport = row.original.transport;
+      return (
+        <Tag color="blue" className="text-xs uppercase">
+          {transport}
+        </Tag>
+      );
+    },
+    size: 100,
+  },
+  {
+    header: "Auth Type",
+    accessorKey: "auth_type",
+    enableSorting: true,
+    cell: ({ row }) => {
+      const authType = row.original.auth_type;
+      const color = authType === "none" ? "gray" : "green";
+      return (
+        <Tag color={color} className="text-xs capitalize">
+          {authType}
+        </Tag>
+      );
+    },
+    size: 100,
+  },
+];
 
 const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded = false }) => {
   const [modelHubData, setModelHubData] = useState<ModelGroupInfo[] | null>(null);
@@ -889,94 +955,6 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
     },
   ];
 
-  const publicMCPHubColumns = (): ColumnDef<MCPServerData>[] => [
-    {
-      header: "Server Name",
-      accessorKey: "server_name",
-      enableSorting: true,
-      cell: ({ row }) => (
-        <div className="overflow-hidden">
-          <Tooltip title={row.original.server_name}>
-            <Button
-              size="xs"
-              variant="light"
-              className="font-mono text-blue-500 bg-blue-50 hover:bg-blue-100 text-xs font-normal px-2 py-0.5 text-left"
-              onClick={() => showMcpModal(row.original)}
-            >
-              {row.original.server_name}
-            </Button>
-          </Tooltip>
-        </div>
-      ),
-      size: 150,
-    },
-    {
-      header: "Description",
-      accessorKey: "mcp_info.description",
-      enableSorting: false,
-      cell: ({ row }) => {
-        const description = String(row.original.mcp_info?.description ?? "-");
-        const truncated = description.length > 80 ? description.substring(0, 80) + "..." : description;
-        return (
-          <Tooltip title={description}>
-            <Text className="text-sm text-gray-700">{truncated}</Text>
-          </Tooltip>
-        );
-      },
-      size: 250,
-    },
-    {
-      header: "URL",
-      accessorKey: "url",
-      enableSorting: false,
-      cell: ({ row }) => {
-        const url = row.original.url ?? "";
-        const truncated = url.length > 40 ? url.substring(0, 40) + "..." : url;
-        return (
-          <Tooltip title={url}>
-            <div className="flex items-center space-x-2">
-              <Text className="text-xs font-mono">{truncated}</Text>
-              <Copy
-                onClick={() => copyToClipboard(url)}
-                className="cursor-pointer text-gray-500 hover:text-blue-500 w-3 h-3"
-              />
-            </div>
-          </Tooltip>
-        );
-      },
-      size: 200,
-    },
-    {
-      header: "Transport",
-      accessorKey: "transport",
-      enableSorting: true,
-      cell: ({ row }) => {
-        const transport = row.original.transport;
-        return (
-          <Tag color="blue" className="text-xs uppercase">
-            {transport}
-          </Tag>
-        );
-      },
-      size: 100,
-    },
-    {
-      header: "Auth Type",
-      accessorKey: "auth_type",
-      enableSorting: true,
-      cell: ({ row }) => {
-        const authType = row.original.auth_type;
-        const color = authType === "none" ? "gray" : "green";
-        return (
-          <Tag color={color} className="text-xs capitalize">
-            {authType}
-          </Tag>
-        );
-      },
-      size: 100,
-    },
-  ];
-
   return (
     <ThemeProvider accessToken={accessToken}>
       <div className={isEmbedded ? "w-full" : "min-h-screen bg-white"}>
@@ -1286,7 +1264,7 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
                   </div>
 
                   <ModelDataTable
-                    columns={publicMCPHubColumns()}
+                    columns={publicMCPHubColumns(showMcpModal)}
                     data={filteredMcpData}
                     isLoading={mcpLoading}
                     defaultSorting={[{ id: "server_name", desc: false }]}
@@ -1890,18 +1868,6 @@ print(response.model_dump(mode='json', exclude_none=True))`;
                   <div className="col-span-2">
                     <Text className="font-medium">Description:</Text>
                     <Text>{selectedMcpServer.mcp_info?.description || "-"}</Text>
-                  </div>
-                  <div className="col-span-2">
-                    <Text className="font-medium">URL:</Text>
-                    <a
-                      href={selectedMcpServer.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-blue-600 hover:text-blue-800 text-sm break-all flex items-center space-x-2"
-                    >
-                      <span>{selectedMcpServer.url}</span>
-                      <ExternalLinkIcon className="w-4 h-4" />
-                    </a>
                   </div>
                 </div>
               </div>

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26617,8 +26617,6 @@ export interface components {
              * @enum {string}
              */
             transport: "sse" | "http" | "stdio";
-            /** Url */
-            url?: string | null;
         };
         /**
          * MCPSemanticFilterSettings


### PR DESCRIPTION
## Relevant issues

The AI Hub MCP Hub exposed each MCP server's upstream URL to anyone who could view the hub. It appeared as a dedicated "URL" column in the server table and again in the per-server Details modal, on both the authenticated dashboard AI Hub and the public model hub. On top of that, the unauthenticated `GET /public/mcp_hub` endpoint returned the `url` field in its JSON (via `MCPPublicServer`), so the upstream address was readable by any HTTP client even with the column removed. These surfaces are meant for end users discovering which servers exist, not for revealing where each server is actually hosted

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Changes

Removed the URL column from both MCP Hub server tables (`mcpHubColumns` in `mcp_hub_table_columns.tsx` for the authenticated AI Hub, and `publicMCPHubColumns` in `public_model_hub.tsx` for the public hub) and the URL field from both MCP server Details modals (`ModelHubTable.tsx` and `public_model_hub.tsx`)

At the API layer, dropped `url` from `MCPPublicServer` in `litellm/types/mcp.py`. That model is the response schema for the unauthenticated `GET /public/mcp_hub`, and it is documented as the "safe params" projection for public servers, so the upstream endpoint no longer leaves the gateway. The authenticated `/v1/mcp/server` management endpoint is behind `user_api_key_auth` and is left as-is, and the admin surfaces that legitimately configure the endpoint (the MCP server management page, the submissions review tab, and the make-public form) still show the URL

To make the public hub column set testable the same way the authenticated one already was, `publicMCPHubColumns` is lifted to a module-level exported function that takes `showMcpModal`, mirroring `mcpHubColumns`. Both column sets now have a regression test asserting there is no "URL" header and that the server URL string is never rendered, and `test_public_endpoints.py` gains a test that gives a public server a real url and asserts `/public/mcp_hub` never returns it. Each test fails if the field is re-added, verified by reverting the change and watching it go red. `schema.d.ts` is regenerated from the changed response model via `npm run gen:api`

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

The API-layer leak is the part that matters most, since `/public/mcp_hub` needs no auth. Reproduced against a live proxy with a public MCP server configured (`available_on_public_internet: true`), curling the unauthenticated endpoint before and after the change:

Before (unfixed code), the upstream url is returned to any caller:

```
$ curl -s http://localhost:PORT/public/mcp_hub | python -m json.tool
[
    {
        "server_id": "b1222a2d1120f36c7ff12bba0ed06c40",
        "name": "exa_public_test",
        "alias": null,
        "server_name": "exa_public_test",
        "url": "https://mcp.exa.ai/mcp",
        "transport": "http",
        "spec_path": null,
        "auth_type": null,
        "mcp_info": {
            "server_name": "exa_public_test",
            "description": "Fast, intelligent web search and web crawling"
        }
    }
]
```

After (fixed code), same server, same server_id, no url field:

```
$ curl -s http://localhost:PORT/public/mcp_hub | python -m json.tool
[
    {
        "server_id": "b1222a2d1120f36c7ff12bba0ed06c40",
        "name": "exa_public_test",
        "alias": null,
        "server_name": "exa_public_test",
        "transport": "http",
        "spec_path": null,
        "auth_type": null,
        "mcp_info": {
            "server_name": "exa_public_test",
            "description": "Fast, intelligent web search and web crawling"
        }
    }
]
```

For the UI side, rebuild the dashboard so the proxy serves the new bundle (`cd ui/litellm-dashboard && npm run build`), start the proxy, open the AI Hub at http://localhost:4000/ui/ , go to the MCP Hub tab and confirm the table has no URL column, then click Details on a server and confirm the modal has no URL field. Repeat on the public hub. As a sanity check that admin views are unaffected, open the MCP servers management page under Tools and confirm the URL is still visible there
