### PR TITLE
fix(ui): source api-keys identity from useAuthorized to stop "User ID is not set"

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/api-keys/ApiKeysDashboard.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-keys/ApiKeysDashboard.test.tsx
@@ -1,0 +1,63 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+const { userDashboardSpy } = vi.hoisted(() => ({
+  userDashboardSpy: vi.fn((_props: Record<string, unknown>) => null),
+}));
+
+vi.mock("@/components/user_dashboard", () => ({
+  default: (props: Record<string, unknown>) => userDashboardSpy(props),
+}));
+
+// AuthContext is still hydrating: userID has not been populated yet (the regression).
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({
+    userID: null,
+    userRole: "",
+    userEmail: null,
+    accessToken: null,
+    premiumUser: false,
+    setUserRole: vi.fn(),
+    setUserEmail: vi.fn(),
+  }),
+}));
+
+// useAuthorized decodes the cookie synchronously, so identity is already available.
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({
+    isLoading: false,
+    isAuthorized: true,
+    token: "jwt",
+    accessToken: "sk-access",
+    userId: "u-123",
+    userEmail: "admin@example.com",
+    userRole: "Admin",
+    premiumUser: false,
+    disabledPersonalKeyCreation: false,
+    showSSOBanner: false,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
+  teamListCall: vi.fn(() => new Promise(() => {})),
+}));
+
+vi.mock("@/components/organizations", () => ({
+  fetchOrganizations: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+import ApiKeysDashboard from "./ApiKeysDashboard";
+
+describe("ApiKeysDashboard identity source", () => {
+  it("passes the useAuthorized userID through even while AuthContext.userID is still null", () => {
+    render(<ApiKeysDashboard />);
+
+    expect(userDashboardSpy).toHaveBeenCalled();
+    const props = userDashboardSpy.mock.calls[0][0];
+    expect(props.userID).toBe("u-123");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-keys/ApiKeysDashboard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-keys/ApiKeysDashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { KeyResponse, Team } from "@/components/key_team_helpers/key_list";
 import { Organization } from "@/components/networking";
 import { CreateKeyPrefillData } from "@/components/organisms/create_key_button";
@@ -11,7 +12,10 @@ import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 export default function ApiKeysDashboard() {
-  const { userID, userRole, userEmail, accessToken, premiumUser, setUserRole, setUserEmail } = useAuth();
+  // Identity comes from useAuthorized (synchronous cookie decode) so userID is set whenever the
+  // route is authorized; useAuth only supplies the backfill setters UserDashboard still expects.
+  const { userId: userID, userRole, userEmail, accessToken, premiumUser } = useAuthorized();
+  const { setUserRole, setUserEmail } = useAuth();
   const searchParams = useSearchParams()!;
 
   const [teams, setTeams] = useState<Team[] | null>(null);
@@ -82,7 +86,7 @@ export default function ApiKeysDashboard() {
     <UserDashboard
       userID={userID}
       userRole={userRole}
-      premiumUser={premiumUser}
+      premiumUser={premiumUser ?? false}
       teams={teams}
       keys={keys}
       setUserRole={setUserRole}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Refs LIT-3687

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Testers on the new App Router build saw "User ID is not set" on the Virtual Keys page when landing on it directly (deep link or hard refresh). Reproduce and verify against a live proxy:

1. Log in to the UI as normal
2. Before the fix (current build): navigate straight to `http://localhost:4000/ui/api-keys/` (or press the browser refresh while on Virtual Keys). The content area shows "User ID is not set" while the sidebar renders normally
3. With this fix: the same deep link / hard refresh renders the Virtual Keys dashboard (key table, Create Key, teams). Refresh several times to confirm there is no flash of "User ID is not set"
4. Click "Virtual Keys" in the sidebar from another page and confirm it still renders correctly

Why it happened: the migrated `/ui/api-keys` route gates rendering on `useAuthorized()` (a synchronous cookie decode), but the dashboard read `userID` from the React `AuthContext`, which hydrates through async effects. The route could render `UserDashboard` before `AuthContext` had set `userID`, tripping `UserDashboard`'s `userID == null` guard. The fix reads identity from `useAuthorized`, the same source the route already uses to authorize, so the two can no longer disagree.

## Type

🐛 Bug Fix

## Changes

`ApiKeysDashboard` now sources `userID`, `userRole`, `userEmail`, `accessToken`, and `premiumUser` from `useAuthorized()` instead of `useAuth()`. `useAuthorized` decodes the auth cookie synchronously, so identity is available on the first render whenever the route is authorized, which removes the race against `AuthContext`'s asynchronous hydration. `useAuth` is retained only for the `setUserRole` / `setUserEmail` backfill setters that `UserDashboard` still expects; those go away with the planned `AuthContext` consolidation.

The regression test mocks the exact failure condition (`useAuth().userID` still `null` while `useAuthorized().userId` is populated) and asserts that `UserDashboard` receives the populated id. It fails when identity is read from `useAuth` and passes when read from `useAuthorized`, so it pins the regression.
