### PR TITLE
fix(ui): seed auth state synchronously so api-keys stops showing "User ID is not set"

### DIFF
--- a/ui/litellm-dashboard/src/contexts/AuthContext.test.tsx
+++ b/ui/litellm-dashboard/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,75 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider, useAuth } from "./AuthContext";
+
+// getUiConfig never resolves here on purpose: it lets the test prove that auth state is
+// available from the first render, independent of the config fetch. The bug was that userID
+// only became available inside an effect gated behind this await, so a consumer could render
+// with a valid token but a null userID ("User ID is not set").
+vi.mock("@/components/networking", () => ({
+  getUiConfig: vi.fn(() => new Promise<never>(() => {})),
+  setGlobalLitellmHeaderName: vi.fn(),
+}));
+
+const base64Url = (obj: Record<string, unknown>) =>
+  btoa(JSON.stringify(obj)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+
+const makeToken = (payload: Record<string, unknown>) =>
+  `${base64Url({ alg: "HS256", typ: "JWT" })}.${base64Url(payload)}.sig`;
+
+const setTokenCookie = (token: string) => {
+  document.cookie = `token=${token}; path=/`;
+};
+
+const inOneHour = () => Math.floor(Date.now() / 1000) + 3600;
+
+const wrapper = ({ children }: { children: React.ReactNode }) => <AuthProvider>{children}</AuthProvider>;
+
+describe("AuthProvider", () => {
+  afterEach(() => {
+    document.cookie = "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC";
+    vi.clearAllMocks();
+  });
+
+  it("exposes auth state from a valid cookie on first render, before getUiConfig resolves", () => {
+    setTokenCookie(
+      makeToken({
+        user_id: "default_user_id",
+        user_role: "proxy_admin",
+        key: "sk-test-key",
+        login_method: "username_password",
+        exp: inOneHour(),
+      }),
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.userID).toBe("default_user_id");
+    expect(result.current.accessToken).toBe("sk-test-key");
+    expect(result.current.userRole).toBe("Admin");
+  });
+
+  it("leaves userID null when no token cookie is present", () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.userID).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it("leaves userID null when the token cookie is expired", () => {
+    setTokenCookie(
+      makeToken({
+        user_id: "default_user_id",
+        user_role: "proxy_admin",
+        key: "sk-test-key",
+        exp: Math.floor(Date.now() / 1000) - 60,
+      }),
+    );
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.userID).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/contexts/AuthContext.tsx
+++ b/ui/litellm-dashboard/src/contexts/AuthContext.tsx
@@ -36,16 +36,78 @@ type AuthContextValue = {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+type DecodedAuthToken = {
+  key?: string;
+  user_id?: string;
+  user_role?: string;
+  user_email?: string;
+  login_method?: string;
+  premium_user?: boolean;
+  disabled_non_admin_personal_key_creation?: boolean;
+};
+
+type AuthSnapshot = {
+  token: string | null;
+  accessToken: string | null;
+  userID: string | null;
+  userRole: string;
+  userEmail: string | null;
+  premiumUser: boolean;
+  disabledPersonalKeyCreation: boolean;
+  showSSOBanner: boolean;
+};
+
+const EMPTY_AUTH_SNAPSHOT: AuthSnapshot = {
+  token: null,
+  accessToken: null,
+  userID: null,
+  userRole: "",
+  userEmail: null,
+  premiumUser: false,
+  disabledPersonalKeyCreation: false,
+  showSSOBanner: true,
+};
+
+// Derive auth state from the cookie synchronously on first render. The previous flow only
+// populated userID inside an effect gated behind an await getUiConfig() network call, so a
+// route whose own login gate didn't also wait on AuthContext could render with a valid token
+// but a still-null userID for a frame, which is what surfaced the "User ID is not set" screen.
+function readInitialAuthSnapshot(): AuthSnapshot {
+  const raw = getCookie("token");
+  if (!raw || isJwtExpired(raw)) {
+    return EMPTY_AUTH_SNAPSHOT;
+  }
+  let decoded: DecodedAuthToken;
+  try {
+    decoded = jwtDecode<DecodedAuthToken>(raw);
+  } catch {
+    return EMPTY_AUTH_SNAPSHOT;
+  }
+  return {
+    token: raw,
+    accessToken: decoded.key ?? null,
+    userID: decoded.user_id ?? null,
+    userRole: decoded.user_role ? formatUserRole(decoded.user_role) : "",
+    userEmail: decoded.user_email ?? null,
+    premiumUser: decoded.premium_user ?? false,
+    disabledPersonalKeyCreation: decoded.disabled_non_admin_personal_key_creation ?? false,
+    showSSOBanner: decoded.login_method ? decoded.login_method === "username_password" : true,
+  };
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [initialAuth] = useState(readInitialAuthSnapshot);
   const [authLoading, setAuthLoading] = useState(true);
-  const [token, setToken] = useState<string | null>(null);
-  const [userID, setUserID] = useState<string | null>(null);
-  const [userRole, setUserRole] = useState("");
-  const [userEmail, setUserEmail] = useState<string | null>(null);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
-  const [premiumUser, setPremiumUser] = useState(false);
-  const [disabledPersonalKeyCreation, setDisabledPersonalKeyCreation] = useState(false);
-  const [showSSOBanner, setShowSSOBanner] = useState(true);
+  const [token, setToken] = useState<string | null>(initialAuth.token);
+  const [userID, setUserID] = useState<string | null>(initialAuth.userID);
+  const [userRole, setUserRole] = useState(initialAuth.userRole);
+  const [userEmail, setUserEmail] = useState<string | null>(initialAuth.userEmail);
+  const [accessToken, setAccessToken] = useState<string | null>(initialAuth.accessToken);
+  const [premiumUser, setPremiumUser] = useState(initialAuth.premiumUser);
+  const [disabledPersonalKeyCreation, setDisabledPersonalKeyCreation] = useState(
+    initialAuth.disabledPersonalKeyCreation,
+  );
+  const [showSSOBanner, setShowSSOBanner] = useState(initialAuth.showSSOBanner);
 
   // Load runtime UI config (populates proxyBaseUrl etc.) before clearing
   // authLoading, so any consumer that builds proxy-rooted URLs from authLoading=false


### PR DESCRIPTION
## Relevant issues

Internal report: logging into the dashboard as the default admin (admin / master key) and landing on `/ui/api-keys/` intermittently rendered "User ID is not set" instead of the Virtual Keys page

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

This is a frontend render-timing race, so there is no proxy endpoint to curl; the human-visible check runs in the browser

1. Build the dashboard from this branch (`cd ui/litellm-dashboard && npm run build`) and serve the resulting `out/` through the proxy (the same artifacts CI commits under `litellm/proxy/_experimental/out/`)
2. Open DevTools -> Network and set throttling to "Slow 3G"; this widens the window the bug lived in, so on the old build it reproduces on almost every load
3. Go to http://localhost:4000/ui/api-keys/ and hard-refresh (Cmd+Shift+R) several times
4. Confirm the Virtual Keys table renders every time and "User ID is not set" never appears

Confirming it was never a bad token: on the broken build, running `JSON.parse(atob(document.cookie.split("token=")[1].split(";")[0].split(".")[1]))` in the console on the error page returns a valid `user_id` ("default_user_id") and `login_method: "username_password"`, while the page still shows the error. That is what pins it to render timing rather than auth data

## Type

Bug Fix

## Changes

Root cause: the `/ui/api-keys/` route added in the App Router migration gates login on `useAuthorized`, which reads the cookie synchronously, while `userID` was only populated inside an `AuthContext` effect that runs after an awaited `getUiConfig` network call. On some loads the dashboard mounted with a valid token but a still-null `userID`, and `UserDashboard` treats that as a hard error ("User ID is not set"). Since a valid session JWT always carries `user_id`, a null `userID` is always a not-yet-resolved state, never a real failure, so erroring on it is wrong. The pre-migration keys landing rendered through the index page's `authLoading` gate, which is coupled to `AuthContext`, so nothing exposed this until the new route existed

Fix: `AuthContext` now derives the token-based fields (token, accessToken, userID, userRole, userEmail, premiumUser, disabledPersonalKeyCreation, showSSOBanner) synchronously from the cookie on first render via `readInitialAuthSnapshot`, so no consumer observes the token-present-but-userID-null window. The `getUiConfig` effect still resolves the proxy base url and clears `authLoading`, and the existing token-change effect still handles login within an active session, so the login flow is unchanged

Tests: added `AuthContext.test.tsx`, which mocks `getUiConfig` to never resolve (forcing the old effect-gated path to stall) and asserts `userID` is still populated from a valid cookie. It fails against the previous code (`expected null to be 'default_user_id'`) and passes with this change
