### PR TITLE
fix(deepseek): drop non-function tools before chat completions call

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -146,6 +146,51 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             and (optional_params.get("thinking") or {}).get("type") == "enabled"
         )
 
+    @staticmethod
+    def _drop_unsupported_tools(optional_params: dict) -> dict:
+        """
+        DeepSeek's /chat/completions only accepts tools of type "function".
+
+        Requests bridged from /v1/responses can carry responses-API-native tool
+        types (e.g. a Codex CLI tool typed "namespace"); DeepSeek rejects the
+        whole request with `unknown variant '<type>', expected 'function'` (issue
+        #30722). Drop the unsupported entries so the function tools still go
+        through, and drop the now-dangling tool_choice/parallel_tool_calls when
+        nothing callable survives.
+        """
+        tools = optional_params.get("tools")
+        if not isinstance(tools, list) or not tools:
+            return optional_params
+
+        def _is_function_tool(tool: object) -> bool:
+            return isinstance(tool, dict) and tool.get("type") == "function"
+
+        function_tools = [tool for tool in tools if _is_function_tool(tool)]
+        if len(function_tools) == len(tools):
+            return optional_params
+
+        dropped_types = sorted(
+            {
+                str(tool.get("type")) if isinstance(tool, dict) else type(tool).__name__
+                for tool in tools
+                if not _is_function_tool(tool)
+            }
+        )
+        litellm.verbose_logger.warning(
+            "DeepSeek chat completions only supports function tools; dropping "
+            "unsupported tool type(s) %s before sending the request",
+            dropped_types,
+        )
+
+        cleaned = {k: v for k, v in optional_params.items() if k != "tools"}
+        if function_tools:
+            return {**cleaned, "tools": function_tools}
+        return {
+            k: v
+            for k, v in cleaned.items()
+            if k not in ("tool_choice", "parallel_tool_calls")
+        }
+
     def transform_request(
         self,
         model: str,
@@ -163,6 +208,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         (user explicitly enabled it), preventing spurious injection on models
         like deepseek-v3.2 that support thinking as opt-in but not always-on.
         """
+        optional_params = self._drop_unsupported_tools(optional_params)
         if self._thinking_mode_active(model=model, optional_params=optional_params):
             messages = self._fill_reasoning_content(messages)
         return super().transform_request(
@@ -185,6 +231,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         Async equivalent of transform_request — applies the same reasoning_content
         fix for multi-turn thinking-mode conversations.
         """
+        optional_params = self._drop_unsupported_tools(optional_params)
         if self._thinking_mode_active(model=model, optional_params=optional_params):
             messages = self._fill_reasoning_content(messages)
         return await super().async_transform_request(

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -157,6 +157,11 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         #30722). Drop the unsupported entries so the function tools still go
         through, and drop the now-dangling tool_choice/parallel_tool_calls when
         nothing callable survives.
+
+        Only non-`function` tools are ever dropped, so a `tool_choice` that names
+        a specific function still points at a surviving tool and is left intact;
+        `tool_choice`/`parallel_tool_calls` are cleared only when no function
+        tool remains.
         """
         tools = optional_params.get("tools")
         if not isinstance(tools, list) or not tools:

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -1,0 +1,83 @@
+from litellm.llms.deepseek.chat.transformation import DeepSeekChatConfig
+
+
+def _function_tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {"name": name, "parameters": {"type": "object"}},
+    }
+
+
+def test_drop_unsupported_tools_keeps_function_tools_only():
+    optional_params = {
+        "tools": [
+            _function_tool("shell"),
+            {"type": "namespace", "name": "container.exec"},
+            _function_tool("apply_patch"),
+        ],
+        "tool_choice": "auto",
+    }
+
+    result = DeepSeekChatConfig._drop_unsupported_tools(optional_params)
+
+    assert [tool["function"]["name"] for tool in result["tools"]] == [
+        "shell",
+        "apply_patch",
+    ]
+    assert all(tool["type"] == "function" for tool in result["tools"])
+    assert result["tool_choice"] == "auto"
+
+
+def test_drop_unsupported_tools_drops_dangling_tool_choice_when_none_survive():
+    optional_params = {
+        "tools": [{"type": "namespace", "name": "container.exec"}],
+        "tool_choice": "required",
+        "parallel_tool_calls": True,
+        "temperature": 0.2,
+    }
+
+    result = DeepSeekChatConfig._drop_unsupported_tools(optional_params)
+
+    assert "tools" not in result
+    assert "tool_choice" not in result
+    assert "parallel_tool_calls" not in result
+    assert result["temperature"] == 0.2
+
+
+def test_drop_unsupported_tools_is_noop_for_function_only():
+    optional_params = {
+        "tools": [_function_tool("shell")],
+        "tool_choice": "auto",
+    }
+
+    result = DeepSeekChatConfig._drop_unsupported_tools(optional_params)
+
+    assert result is optional_params
+
+
+def test_drop_unsupported_tools_is_noop_without_tools():
+    optional_params = {"temperature": 0.7}
+
+    result = DeepSeekChatConfig._drop_unsupported_tools(optional_params)
+
+    assert result is optional_params
+
+
+def test_transform_request_strips_unsupported_tools_from_body():
+    config = DeepSeekChatConfig()
+    body = config.transform_request(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "tools": [
+                _function_tool("shell"),
+                {"type": "namespace", "name": "container.exec"},
+            ],
+            "tool_choice": "auto",
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert [tool["type"] for tool in body["tools"]] == ["function"]
+    assert body["tools"][0]["function"]["name"] == "shell"

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -81,3 +81,23 @@ def test_transform_request_strips_unsupported_tools_from_body():
 
     assert [tool["type"] for tool in body["tools"]] == ["function"]
     assert body["tools"][0]["function"]["name"] == "shell"
+
+
+async def test_async_transform_request_strips_unsupported_tools_from_body():
+    config = DeepSeekChatConfig()
+    body = await config.async_transform_request(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "tools": [
+                _function_tool("shell"),
+                {"type": "namespace", "name": "container.exec"},
+            ],
+            "tool_choice": "auto",
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert [tool["type"] for tool in body["tools"]] == ["function"]
+    assert body["tools"][0]["function"]["name"] == "shell"


### PR DESCRIPTION
## Relevant issues

Fixes #30722

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

DeepSeek's chat completions endpoint only accepts tools of type `function`. When a `/v1/responses` request is bridged to chat completions for DeepSeek, responses-API-native tool types pass through unchanged and DeepSeek rejects the whole request. A Codex CLI client triggers this with a tool typed `namespace`.

Reproduced against a live proxy with `deepseek-v4 -> deepseek/deepseek-chat`.

Request:

```bash
curl http://localhost:4000/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "deepseek-v4",
  "input": "What is 2+2? Answer in one word.",
  "tools": [
    {"type": "function", "name": "get_weather", "description": "get weather", "parameters": {"type":"object","properties":{"city":{"type":"string"}}}},
    {"type": "namespace", "name": "container.exec"}
  ]
}'
```

Before the fix, DeepSeek returns 400:

```
{"error":{"message":"litellm.BadRequestError: DeepseekException - {\"error\":{\"message\":\"Failed to deserialize the JSON body into the target type: tools[1].type: unknown variant `namespace`, expected `function` at line 1 column 320\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"invalid_request_error\"}}. Received Model Group=deepseek-v4","code":"400"}}
```

After the fix the same request returns 200 and the unsupported tool is dropped (note `"tools":[]`):

```
{"id":"resp_...","model":"deepseek-v4","object":"response","output":[{"type":"message","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Four"}]}],"tools":[],"status":"completed","usage":{"input_tokens":275,"output_tokens":1,"total_tokens":276}}
```

## Type

🐛 Bug Fix

## Changes

`DeepSeekChatConfig` now filters tools down to type `function` in `transform_request` and `async_transform_request` before delegating to the OpenAI-compatible base. When no function tool survives the filter, the dangling `tool_choice` and `parallel_tool_calls` are dropped as well so the request does not fail validation a second time. The fix is scoped to the DeepSeek provider; the generic responses-to-chat bridge keeps passing other tool types through for providers that can use them.
