### PR TITLE
fix: strip extra fields from messages for Mistral chat

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -287,7 +287,7 @@ class MistralConfig(OpenAIGPTConfig):
         # and then apply Mistral-specific handling for files
         messages = await super()._transform_messages(messages, model, True)
         messages = self._handle_message_with_file(messages)
-        return messages
+        return self._strip_extra_fields(messages)
 
     def _transform_messages_sync(self, messages: List[AllMessageValues], model: str) -> List[AllMessageValues]:
         """Handle modification of messages for Mistral API in a sync context."""
@@ -296,6 +296,16 @@ class MistralConfig(OpenAIGPTConfig):
         # This is the sync version of the async method above
         messages = super()._transform_messages(messages, model, False)
         messages = self._handle_message_with_file(messages)
+        return self._strip_extra_fields(messages)
+
+    @staticmethod
+    def _strip_extra_fields(messages: List[AllMessageValues]) -> List[AllMessageValues]:
+        for m in messages:
+            if isinstance(m, dict):
+                m.pop("metadata", None)
+                m.pop("provider_specific_fields", None)
+                m.pop("thinking_blocks", None)
+                m.pop("cache_control", None)
         return messages
 
     def _handle_message_with_file(self, messages: List[AllMessageValues]) -> List[AllMessageValues]:

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -265,6 +265,13 @@ class MistralConfig(OpenAIGPTConfig):
             if MistralConfig._is_empty_assistant_message(m):
                 continue
             m = strip_none_values_from_message(m)  # prevents 'extra_forbidden' error
+            # GH#30882: strip fields not permitted by Mistral
+            # (additionalProperties: false on their message schema)
+            if isinstance(m, dict):
+                m.pop("metadata", None)
+                m.pop("provider_specific_fields", None)
+                m.pop("thinking_blocks", None)
+                m.pop("cache_control", None)
             new_messages.append(m)
 
         if is_async:

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -272,6 +272,7 @@ class MistralConfig(OpenAIGPTConfig):
                 m.pop("provider_specific_fields", None)
                 m.pop("thinking_blocks", None)
                 m.pop("cache_control", None)
+                m.pop("reasoning_content", None)
             new_messages.append(m)
 
         if is_async:
@@ -306,6 +307,7 @@ class MistralConfig(OpenAIGPTConfig):
                 m.pop("provider_specific_fields", None)
                 m.pop("thinking_blocks", None)
                 m.pop("cache_control", None)
+                m.pop("reasoning_content", None)
         return messages
 
     def _handle_message_with_file(self, messages: List[AllMessageValues]) -> List[AllMessageValues]:

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -296,7 +296,7 @@ class MistralConfig(OpenAIGPTConfig):
     @staticmethod
     def _strip_extra_fields(messages: list[AllMessageValues]) -> list[AllMessageValues]:
         for m in messages:
-            if isinstance(m, dict):
+            if isinstance(m, dict) and m.get("role") == "assistant":
                 m.pop("metadata", None)
                 m.pop("provider_specific_fields", None)
                 m.pop("thinking_blocks", None)

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -265,15 +265,9 @@ class MistralConfig(OpenAIGPTConfig):
             if MistralConfig._is_empty_assistant_message(m):
                 continue
             m = strip_none_values_from_message(m)  # prevents 'extra_forbidden' error
-            # GH#30882: strip fields not permitted by Mistral
-            # (additionalProperties: false on their message schema)
-            if isinstance(m, dict):
-                m.pop("metadata", None)
-                m.pop("provider_specific_fields", None)
-                m.pop("thinking_blocks", None)
-                m.pop("cache_control", None)
-                m.pop("reasoning_content", None)
             new_messages.append(m)
+
+        new_messages = self._strip_extra_fields(new_messages)
 
         if is_async:
             return super()._transform_messages(new_messages, model, True)

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -300,7 +300,7 @@ class MistralConfig(OpenAIGPTConfig):
         return self._strip_extra_fields(messages)
 
     @staticmethod
-    def _strip_extra_fields(messages: List[AllMessageValues]) -> List[AllMessageValues]:
+    def _strip_extra_fields(messages: list[AllMessageValues]) -> list[AllMessageValues]:
         for m in messages:
             if isinstance(m, dict):
                 m.pop("metadata", None)

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -281,6 +281,21 @@ class TestMistralReasoningSupport:
         assert "cache_control" not in msg
         assert "reasoning_content" not in msg
 
+    def test_user_message_extra_fields_are_preserved(self):
+        """GH#30882: user messages should not be stripped of extra fields."""
+        mistral_config = MistralConfig()
+        messages: List[AllMessageValues] = [
+            cast(
+                AllMessageValues,
+                {"role": "user", "content": "Question?", "reasoning_content": "noise"},
+            )
+        ]
+        result = mistral_config._transform_messages(messages, "mistral/mistral-large-latest")
+        assert len(result) == 1
+        msg = cast(dict, result[0])
+        assert msg["role"] == "user"
+        assert msg["reasoning_content"] == "noise"
+
     def test_transform_request_magistral_with_reasoning(self):
         """Test transform_request method for magistral model with reasoning."""
         mistral_config = MistralConfig()

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -249,6 +249,36 @@ class TestMistralReasoningSupport:
         assert result == messages
         assert len(result) == 1
 
+    def test_transform_messages_strips_extra_fields(self):
+        """GH#30882: extra fields like metadata should be stripped
+        from messages before sending to Mistral API."""
+        mistral_config = MistralConfig()
+        messages: List[AllMessageValues] = [
+            cast(
+                AllMessageValues,
+                {
+                    "role": "assistant",
+                    "content": "hello",
+                    "metadata": {
+                        "tool_outputs_trimmed": True,
+                        "trimmed_by": "async_context_compression",
+                    },
+                    "provider_specific_fields": {"foo": "bar"},
+                    "thinking_blocks": [],
+                    "cache_control": {"type": "ephemeral"},
+                },
+            )
+        ]
+        result = mistral_config._transform_messages(messages, "mistral/mistral-large-latest")
+        assert len(result) == 1
+        msg = cast(dict, result[0])
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "hello"
+        assert "metadata" not in msg
+        assert "provider_specific_fields" not in msg
+        assert "thinking_blocks" not in msg
+        assert "cache_control" not in msg
+
     def test_transform_request_magistral_with_reasoning(self):
         """Test transform_request method for magistral model with reasoning."""
         mistral_config = MistralConfig()

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -266,6 +266,7 @@ class TestMistralReasoningSupport:
                     "provider_specific_fields": {"foo": "bar"},
                     "thinking_blocks": [],
                     "cache_control": {"type": "ephemeral"},
+                    "reasoning_content": "some thinking",
                 },
             )
         ]
@@ -278,6 +279,7 @@ class TestMistralReasoningSupport:
         assert "provider_specific_fields" not in msg
         assert "thinking_blocks" not in msg
         assert "cache_control" not in msg
+        assert "reasoning_content" not in msg
 
     def test_transform_request_magistral_with_reasoning(self):
         """Test transform_request method for magistral model with reasoning."""


### PR DESCRIPTION
Fixes #30882

Mistral API enforces additionalProperties: false on its message schema, rejecting extra fields like metadata, provider_specific_fields, thinking_blocks, and cache_control. Strip these before sending to prevent "Extra inputs are not permitted" errors when messages contain fields from other providers or plugins (e.g. async_context_compression adds metadata to assistant messages).