### PR TITLE
fix(snowflake): add streaming chunk parser to handle tool_calls in streaming responses (closes #30762)

### DIFF
--- a/litellm/llms/snowflake/common_utils.py
+++ b/litellm/llms/snowflake/common_utils.py
@@ -1,7 +1,8 @@
-from typing import Optional
+from typing import Optional, Iterator, Dict, Any
+from litellm.llms.base_llm.chat.transformation import BaseConfig
 
 
-class SnowflakeBase:
+class SnowflakeBase(BaseConfig):
     def validate_environment(
         self,
         headers: dict,
@@ -32,3 +33,32 @@ class SnowflakeBase:
             }
         )
         return headers
+
+    def chunk_parser(self, chunk: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
+        """Parse Snowflake streaming chunks to emit OpenAI-style delta."""
+        # Snowflake streaming returns events with data: {"type": "delta", ...}
+        # or {"type": "tool_use", ...}
+        if "type" not in chunk:
+            return
+        if chunk["type"] == "delta":
+            yield {"choices": [{"delta": {"content": chunk.get("delta", "")}}]}
+        elif chunk["type"] == "tool_use":
+            # Snowflake tool_use format: {"type": "tool_use", "name": ..., "input": ...}
+            yield {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": None,
+                                    "function": {
+                                        "name": chunk.get("name", ""),
+                                        "arguments": chunk.get("input", ""),
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }


### PR DESCRIPTION
## What

When using Snowflake Cortex models in streaming mode, tool calls (tool_use deltas) were silently dropped because the provider lacked a custom chunk parser. The generic SSE parser did not understand Snowflake's streaming tool call format.

## Fix

Added a `chunk_parser` method to `SnowflakeBase` (now inheriting from `BaseConfig`) that:
- Handles `type: "delta"` events for text content.
- Handles `type: "tool_use"` events and maps them to the OpenAI-compatible `tool_calls` delta structure.

This ensures that streaming tool calls are no longer dropped and work similarly to the non-streaming path.

Closes #30762