### PR TITLE
fix(anthropic): add metadata param support to Anthropic messages pass-through

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -48,8 +48,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             "speed",
             "output_config",
             "reasoning_effort",
-            # TODO: Add Anthropic `metadata` support
-            # "metadata",
+            "metadata",
         ]
 
     def _remove_scope_from_cache_control(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_metadata_support.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_metadata_support.py
@@ -1,0 +1,44 @@
+"""Tests for `metadata` param support on the Anthropic /v1/messages pass-through route."""
+
+import pytest
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+@pytest.fixture
+def config():
+    return AnthropicMessagesConfig()
+
+def test_metadata_in_supported_params(config):
+    supported = config.get_supported_anthropic_messages_params(model="claude-3-5-sonnet-20241022")
+    assert "metadata" in supported
+
+def test_metadata_passes_through_transform_request(config):
+    from litellm.types.router import GenericLiteLLMParams
+    optional_params = {
+        "max_tokens": 100,
+        "metadata": {"user_id": "user-abc-123"},
+    }
+    result = config.transform_anthropic_messages_request(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert result.get("metadata") == {"user_id": "user-abc-123"}
+
+def test_metadata_without_user_id_passes_through(config):
+    from litellm.types.router import GenericLiteLLMParams
+    optional_params = {
+        "max_tokens": 50,
+        "metadata": {"user_id": "test-user"},
+    }
+    result = config.transform_anthropic_messages_request(
+        model="claude-haiku-4-5-20251001",
+        messages=[{"role": "user", "content": "Hi"}],
+        anthropic_messages_optional_request_params=optional_params,
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert "metadata" in result


### PR DESCRIPTION
## Problem
The `metadata` field (used to pass `user_id` to Anthropic for request 
tracing) was commented out with a TODO in `get_supported_anthropic_messages_params`, 
causing it to be silently dropped on the pass-through route.

## Fix
Uncomment `metadata` from the supported params list so it flows 
through to the Anthropic API correctly.

## Tests
Added 3 unit tests:
- metadata appears in supported params
- metadata.user_id passes through to the request body
- works across different claude models

## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem