### PR TITLE
fix(mlflow): call model_dump() instead of passing method reference in _add_chunk_events

### DIFF
--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -157,7 +157,7 @@ class MlflowLogger(CustomLogger):
                     SpanEvent(
                         name="streaming_chunk",
                         attributes={
-                            "delta": json.dumps(choice.delta.model_dump, default=str)
+                            "delta": json.dumps(choice.delta.model_dump(), default=str)
                         },
                     )
                 )


### PR DESCRIPTION
## Problem

In `MlflowLogger._add_chunk_events`, `choice.delta.model_dump` (missing parentheses) passes the bound method object to `json.dumps` instead of calling it. This causes `_add_chunk_events` to always raise a `TypeError` silently, which prevents `_end_span_or_trace` from being called, so **zero MLflow traces are recorded for streaming responses**.

## Fix

Add `()` to call the method:

```python
# Before (bug)
"delta": json.dumps(choice.delta.model_dump, default=str)

# After (fix)
"delta": json.dumps(choice.delta.model_dump(), default=str)
```

## Impact

- Streaming responses with MLflow enabled produced no traces
- Non-streaming responses were unaffected (only `_add_chunk_events` was broken)

Note: Line 64 already calls `c.message.model_dump(exclude_none=True)` correctly — this is a one-off typo on line 160.