### PR TITLE
fix(sambanova): return embeddings supported params instead of dropping them

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -191,7 +191,9 @@ def get_supported_openai_params(
         )
     elif custom_llm_provider == "sambanova":
         if request_type == "embeddings":
-            litellm.SambaNovaEmbeddingConfig().get_supported_openai_params(model=model)
+            return litellm.SambaNovaEmbeddingConfig().get_supported_openai_params(
+                model=model
+            )
         else:
             return litellm.SambanovaConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "nebius":

--- a/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
@@ -132,3 +132,17 @@ def test_azure_base_model_detection_preserved():
     assert params is not None
     assert "reasoning_effort" in params
     assert "tools" in params
+
+
+def test_sambanova_embeddings_request_returns_list_not_none():
+    """The sambanova embeddings branch resolved the config but dropped the result,
+    so embedding requests got ``None`` instead of the supported-params list while the
+    chat branch returned correctly. A list (the sambanova embeddings config exposes no
+    extra params, hence ``[]``) must reach the caller."""
+    embedding_params = get_supported_openai_params(
+        model="E5-Mistral-7B-Instruct",
+        custom_llm_provider="sambanova",
+        request_type="embeddings",
+    )
+
+    assert embedding_params == []


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`get_supported_openai_params` resolved the SambaNova embeddings config but never returned its result, so calling it with `custom_llm_provider="sambanova"` and `request_type="embeddings"` returned `None` instead of the supported-params list. Every sibling branch in this dispatcher, including SambaNova's own chat-completion branch directly below it, returns the config result; this branch simply omitted the `return`.

This adds the missing `return` so the embeddings supported-params list reaches the caller. It now returns `[]` (the SambaNova embeddings config exposes no extra params) instead of `None`.

Added a regression test (`test_sambanova_embeddings_request_returns_list_not_none`) in `tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py` that asserts the embeddings request returns the list rather than `None`. Verified red/green: the test fails against the previous behavior (`assert None == []`) and passes with the fix. `black --check` and `ruff check` are clean on the changed source.
