### PR TITLE
fix: eliminate mutable default argument bugs (B006) across litellm

### DIFF
--- a/litellm/batch_completion/main.py
+++ b/litellm/batch_completion/main.py
@@ -11,7 +11,7 @@ from ..llms.vllm.completion import handler as vllm_handler
 def batch_completion(
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
-    messages: List = [],
+    messages: Optional[List] = None,
     functions: Optional[List] = None,
     function_call: Optional[str] = None,
     temperature: Optional[float] = None,
@@ -56,6 +56,8 @@ def batch_completion(
     Returns:
         list: A list of completion results.
     """
+    if messages is None:
+        messages = []
     args = locals()
 
     batch_messages = messages

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -67,20 +67,7 @@ class Cache:
         default_in_memory_ttl: Optional[float] = None,
         default_in_redis_ttl: Optional[float] = None,
         similarity_threshold: Optional[float] = None,
-        supported_call_types: Optional[List[CachingSupportedCallTypes]] = [
-            "completion",
-            "acompletion",
-            "embedding",
-            "aembedding",
-            "atranscription",
-            "transcription",
-            "atext_completion",
-            "text_completion",
-            "arerank",
-            "rerank",
-            "responses",
-            "aresponses",
-        ],
+        supported_call_types: Optional[List[CachingSupportedCallTypes]] = None,
         # s3 Bucket, boto3 configuration
         azure_account_url: Optional[str] = None,
         azure_blob_container: Optional[str] = None,
@@ -165,6 +152,21 @@ class Cache:
         Returns:
             None. Cache is set as a litellm param
         """
+        if supported_call_types is None:
+            supported_call_types = [
+                "completion",
+                "acompletion",
+                "embedding",
+                "aembedding",
+                "atranscription",
+                "transcription",
+                "atext_completion",
+                "text_completion",
+                "arerank",
+                "rerank",
+                "responses",
+                "aresponses",
+            ]
         if type == LiteLLMCacheType.REDIS:
             # Check REDIS_CLUSTER_NODES env var if no explicit startup nodes
             if not redis_startup_nodes:
@@ -858,20 +860,7 @@ def enable_cache(
     host: Optional[str] = None,
     port: Optional[str] = None,
     password: Optional[str] = None,
-    supported_call_types: Optional[List[CachingSupportedCallTypes]] = [
-        "completion",
-        "acompletion",
-        "embedding",
-        "aembedding",
-        "atranscription",
-        "transcription",
-        "atext_completion",
-        "text_completion",
-        "arerank",
-        "rerank",
-        "responses",
-        "aresponses",
-    ],
+    supported_call_types: Optional[List[CachingSupportedCallTypes]] = None,
     **kwargs,
 ):
     """
@@ -892,6 +881,21 @@ def enable_cache(
     Raises:
         None
     """
+    if supported_call_types is None:
+        supported_call_types = [
+            "completion",
+            "acompletion",
+            "embedding",
+            "aembedding",
+            "atranscription",
+            "transcription",
+            "atext_completion",
+            "text_completion",
+            "arerank",
+            "rerank",
+            "responses",
+            "aresponses",
+        ]
     print_verbose("LiteLLM: Enabling Cache")
     if "cache" not in litellm.input_callback:
         litellm.input_callback.append("cache")
@@ -918,20 +922,7 @@ def update_cache(
     host: Optional[str] = None,
     port: Optional[str] = None,
     password: Optional[str] = None,
-    supported_call_types: Optional[List[CachingSupportedCallTypes]] = [
-        "completion",
-        "acompletion",
-        "embedding",
-        "aembedding",
-        "atranscription",
-        "transcription",
-        "atext_completion",
-        "text_completion",
-        "arerank",
-        "rerank",
-        "responses",
-        "aresponses",
-    ],
+    supported_call_types: Optional[List[CachingSupportedCallTypes]] = None,
     **kwargs,
 ):
     """
@@ -950,6 +941,21 @@ def update_cache(
         None
 
     """
+    if supported_call_types is None:
+        supported_call_types = [
+            "completion",
+            "acompletion",
+            "embedding",
+            "aembedding",
+            "atranscription",
+            "transcription",
+            "atext_completion",
+            "text_completion",
+            "arerank",
+            "rerank",
+            "responses",
+            "aresponses",
+        ]
     print_verbose("LiteLLM: Updating Cache")
     litellm.cache = Cache(
         type=type,

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1094,7 +1094,7 @@ def completion_cost(  # noqa: PLR0915
     completion_response=None,
     model: Optional[str] = None,
     prompt="",
-    messages: List = [],
+    messages: Optional[List] = None,
     completion="",
     total_time: Optional[float] = 0.0,  # used for replicate, sagemaker
     call_type: Optional[CallTypesLiteral] = None,
@@ -1146,6 +1146,8 @@ def completion_cost(  # noqa: PLR0915
         - For certain models containing "togethercomputer" in the name, prices are based on the model size.
         - For un-mapped Replicate models, the cost is calculated based on the total time used for the request.
     """
+    if messages is None:
+        messages = []
     try:
         call_type = _infer_call_type(call_type, completion_response) or "completion"
 

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -76,7 +76,7 @@ def _prepare_azure_extra_body(
 async def acreate_fine_tuning_job(
     model: str,
     training_file: str,
-    hyperparameters: Optional[dict] = {},
+    hyperparameters: Optional[dict] = None,
     suffix: Optional[str] = None,
     validation_file: Optional[str] = None,
     integrations: Optional[List[str]] = None,
@@ -90,6 +90,8 @@ async def acreate_fine_tuning_job(
     Async: Creates and executes a batch from an uploaded file of request
 
     """
+    if hyperparameters is None:
+        hyperparameters = {}
     verbose_logger.debug(
         "inside acreate_fine_tuning_job model=%s and kwargs=%s", model, kwargs
     )
@@ -157,7 +159,7 @@ def _resolve_fine_tuning_timeout(
 def create_fine_tuning_job(
     model: str,
     training_file: str,
-    hyperparameters: Optional[dict] = {},
+    hyperparameters: Optional[dict] = None,
     suffix: Optional[str] = None,
     validation_file: Optional[str] = None,
     integrations: Optional[List[str]] = None,
@@ -173,6 +175,8 @@ def create_fine_tuning_job(
     Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete
 
     """
+    if hyperparameters is None:
+        hyperparameters = {}
     try:
         _is_async = kwargs.pop("acreate_fine_tuning_job", False) is True
         optional_params = GenericLiteLLMParams(**kwargs)

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -63,16 +63,20 @@ class SlackAlerting(CustomBatchLogger):
         alerting_threshold: Optional[
             float
         ] = None,  # threshold for slow / hanging llm responses (in seconds)
-        alerting: Optional[List] = [],
+        alerting: Optional[List] = None,
         alert_types: List[AlertType] = DEFAULT_ALERT_TYPES,
         alert_to_webhook_url: Optional[
             Dict[AlertType, Union[List[str], str]]
         ] = None,  # if user wants to separate alerts to diff channels
-        alerting_args={},
+        alerting_args=None,
         default_webhook_url: Optional[str] = None,
         alert_type_config: Optional[Dict[str, dict]] = None,
         **kwargs,
     ):
+        if alerting is None:
+            alerting = []
+        if alerting_args is None:
+            alerting_args = {}
         if alerting_threshold is None:
             alerting_threshold = 300
         self.alerting_threshold = alerting_threshold

--- a/litellm/integrations/gcs_bucket/gcs_bucket_base.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket_base.py
@@ -144,7 +144,7 @@ class GCSBucketBase(CustomBatchLogger):
         return bucket_name, object_name
 
     async def get_gcs_logging_config(
-        self, kwargs: Optional[Dict[str, Any]] = {}
+        self, kwargs: Optional[Dict[str, Any]] = None
     ) -> GCSLoggingConfig:
         """
         This function is used to get the GCS logging config for the GCS Bucket Logger.

--- a/litellm/integrations/lunary.py
+++ b/litellm/integrations/lunary.py
@@ -95,7 +95,7 @@ class LunaryLogger:
         run_id,
         model,
         print_verbose,
-        extra={},
+        extra=None,
         input=None,
         user_id=None,
         response_obj=None,
@@ -103,6 +103,8 @@ class LunaryLogger:
         end_time=datetime.now(timezone.utc),
         error=None,
     ):
+        if extra is None:
+            extra = {}
         try:
             print_verbose(f"Lunary Logging - Logging request for model {model}")
 

--- a/litellm/integrations/prometheus_services.py
+++ b/litellm/integrations/prometheus_services.py
@@ -190,8 +190,10 @@ class PrometheusServicesLogger:
         counter,
         labels: str,
         amount: float,
-        additional_labels: Optional[List[str]] = [],
+        additional_labels: Optional[List[str]] = None,
     ):
+        if additional_labels is None:
+            additional_labels = []
         assert isinstance(counter, self.Counter)
 
         if additional_labels:

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -237,10 +237,14 @@ def exception_type(  # type: ignore  # noqa: PLR0915
     model,
     original_exception,
     custom_llm_provider,
-    completion_kwargs={},
-    extra_kwargs={},
+    completion_kwargs=None,
+    extra_kwargs=None,
 ):
     """Maps an LLM Provider Exception to OpenAI Exception Format"""
+    if completion_kwargs is None:
+        completion_kwargs = {}
+    if extra_kwargs is None:
+        extra_kwargs = {}
     if any(
         isinstance(original_exception, exc_type)
         for exc_type in litellm.LITELLM_EXCEPTION_TYPES
@@ -2485,10 +2489,12 @@ def exception_type(  # type: ignore  # noqa: PLR0915
 
 
 def exception_logging(
-    additional_args={},
+    additional_args=None,
     logger_fn=None,
     exception=None,
 ):
+    if additional_args is None:
+        additional_args = {}
     try:
         model_call_details = {}
         if exception:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -964,10 +964,12 @@ class Logging(LiteLLMLoggingBaseClass):
             masked_api_base = api_base
         return str(masked_api_base)
 
-    def _pre_call(self, input, api_key, model=None, additional_args={}):
+    def _pre_call(self, input, api_key, model=None, additional_args=None):
         """
         Common helper function across the sync + async pre-call function
         """
+        if additional_args is None:
+            additional_args = {}
 
         self.model_call_details["input"] = input
         self.model_call_details["api_key"] = api_key
@@ -981,7 +983,11 @@ class Logging(LiteLLMLoggingBaseClass):
             self._get_masked_api_base(additional_args.get("api_base", ""))
         )
 
-    def pre_call(self, input, api_key, model=None, additional_args={}):  # noqa: PLR0915
+    def pre_call(
+        self, input, api_key, model=None, additional_args=None
+    ):  # noqa: PLR0915
+        if additional_args is None:
+            additional_args = {}
         # Log the exact input to the LLM API
         litellm.error_logs["PRE_CALL"] = locals()
         try:
@@ -1225,8 +1231,10 @@ class Logging(LiteLLMLoggingBaseClass):
         )
 
     def post_call(
-        self, original_response, input=None, api_key=None, additional_args={}
+        self, original_response, input=None, api_key=None, additional_args=None
     ):
+        if additional_args is None:
+            additional_args = {}
         # Log the exact result from the LLM API, for streaming - log the type of response received
         litellm.error_logs["POST_CALL"] = locals()
         if isinstance(original_response, dict):
@@ -3719,7 +3727,7 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
     llm_router: Optional[
         Any
     ],  # expect litellm.Router, but typing errors due to circular import
-    custom_logger_init_args: Optional[dict] = {},
+    custom_logger_init_args: Optional[dict] = None,
 ) -> Optional[CustomLogger]:
     """
     Initialize a custom logger compatible class

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -98,11 +98,13 @@ def handle_messages_with_content_list_to_str_conversion(
 
 
 def strip_name_from_message(
-    message: AllMessageValues, allowed_name_roles: List[str] = ["user"]
+    message: AllMessageValues, allowed_name_roles: Optional[List[str]] = None
 ) -> AllMessageValues:
     """
     Removes 'name' from message
     """
+    if allowed_name_roles is None:
+        allowed_name_roles = ["user"]
     msg_copy = message.copy()
     if msg_copy.get("role") not in allowed_name_roles:
         msg_copy.pop("name", None)  # type: ignore
@@ -110,11 +112,13 @@ def strip_name_from_message(
 
 
 def strip_name_from_messages(
-    messages: List[AllMessageValues], allowed_name_roles: List[str] = ["user"]
+    messages: List[AllMessageValues], allowed_name_roles: Optional[List[str]] = None
 ) -> List[AllMessageValues]:
     """
     Removes 'name' from messages
     """
+    if allowed_name_roles is None:
+        allowed_name_roles = ["user"]
     new_messages = []
     for message in messages:
         msg_role = message.get("role")

--- a/litellm/llms/a2a/common_utils.py
+++ b/litellm/llms/a2a/common_utils.py
@@ -2,7 +2,7 @@
 Common utilities for A2A (Agent-to-Agent) Protocol
 """
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
 
@@ -20,8 +20,10 @@ class A2AError(BaseLLMException):
         self,
         status_code: int,
         message: str,
-        headers: Dict[str, Any] = {},
+        headers: Optional[Dict[str, Any]] = None,
     ):
+        if headers is None:
+            headers = {}
         super().__init__(
             status_code=status_code,
             message=message,

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -224,8 +224,10 @@ class AnthropicChatCompletion(BaseLLM):
         optional_params=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
     ):
+        if headers is None:
+            headers = {}
         from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
 
         data["stream"] = True
@@ -276,9 +278,11 @@ class AnthropicChatCompletion(BaseLLM):
         litellm_params: dict,
         provider_config: "BaseConfig",
         logger_fn=None,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
     ) -> Union[ModelResponse, "CustomStreamWrapper"]:
+        if headers is None:
+            headers = {}
         async_handler = client or get_async_httpx_client(
             llm_provider=litellm.LlmProviders.ANTHROPIC
         )
@@ -344,9 +348,11 @@ class AnthropicChatCompletion(BaseLLM):
         litellm_params: dict,
         acompletion=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         client=None,
     ):
+        if headers is None:
+            headers = {}
         from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
         from litellm.utils import ProviderConfigManager
 

--- a/litellm/llms/aws_polly/text_to_speech/transformation.py
+++ b/litellm/llms/aws_polly/text_to_speech/transformation.py
@@ -147,11 +147,13 @@ class AWSPollyTextToSpeechConfig(BaseTextToSpeechConfig, BaseAWSLLM):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
-        kwargs: Dict = {},
+        kwargs: Optional[Dict] = None,
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI parameters to AWS Polly parameters
         """
+        if kwargs is None:
+            kwargs = {}
         mapped_params = {}
 
         # Map voice - support both native Polly voices and OpenAI voice mappings

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -402,8 +402,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         azure_ad_token_provider: Optional[Callable] = None,
         convert_tool_call_to_json_mode: Optional[bool] = None,
         client=None,  # this is the AsyncAzureOpenAI
-        litellm_params: Optional[dict] = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         response = None
         try:
             # setting Azure client
@@ -510,8 +512,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         azure_ad_token: Optional[str] = None,
         azure_ad_token_provider: Optional[Callable] = None,
         client=None,
-        litellm_params: Optional[dict] = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         # init AzureOpenAI Client
         azure_client_params = {
             "api_version": api_version,
@@ -588,8 +592,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         azure_ad_token: Optional[str] = None,
         azure_ad_token_provider: Optional[Callable] = None,
         client=None,
-        litellm_params: Optional[dict] = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         try:
             azure_client = self.get_azure_openai_client(
                 api_version=api_version,
@@ -668,8 +674,10 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         max_retries: Optional[int] = None,
         azure_ad_token: Optional[str] = None,
         azure_ad_token_provider: Optional[Callable] = None,
-        litellm_params: Optional[dict] = {},
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if litellm_params is None:
+            litellm_params = {}
         response = None
         try:
             openai_aclient = self.get_azure_openai_client(

--- a/litellm/llms/azure/chat/o_series_handler.py
+++ b/litellm/llms/azure/chat/o_series_handler.py
@@ -36,13 +36,15 @@ class AzureOpenAIO1ChatCompletion(BaseAzureLLM, OpenAIChatCompletion):
         acompletion: bool = False,
         logger_fn=None,
         headers: Optional[dict] = None,
-        custom_prompt_dict: dict = {},
+        custom_prompt_dict: Optional[dict] = None,
         client=None,
         organization: Optional[str] = None,
         custom_llm_provider: Optional[str] = None,
         drop_params: Optional[bool] = None,
         shared_session: Optional["ClientSession"] = None,
     ):
+        if custom_prompt_dict is None:
+            custom_prompt_dict = {}
         client = self.get_azure_openai_client(
             litellm_params=litellm_params,
             api_key=api_key,

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -207,8 +207,10 @@ class AzureTextCompletion(BaseAzureLLM):
         max_retries: int,
         azure_ad_token: Optional[str] = None,
         client=None,  # this is the AsyncAzureOpenAI
-        litellm_params: dict = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         response = None
         try:
             # init AzureOpenAI Client
@@ -270,8 +272,10 @@ class AzureTextCompletion(BaseAzureLLM):
         timeout: Any,
         azure_ad_token: Optional[str] = None,
         client=None,
-        litellm_params: dict = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         max_retries = data.pop("max_retries", 2)
         if not isinstance(max_retries, int):
             raise AzureOpenAIError(
@@ -327,8 +331,10 @@ class AzureTextCompletion(BaseAzureLLM):
         timeout: Any,
         azure_ad_token: Optional[str] = None,
         client=None,
-        litellm_params: dict = {},
+        litellm_params: Optional[dict] = None,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         try:
             # init AzureOpenAI Client
             azure_client = self.get_azure_openai_client(

--- a/litellm/llms/azure/text_to_speech/transformation.py
+++ b/litellm/llms/azure/text_to_speech/transformation.py
@@ -229,11 +229,13 @@ class AzureAVATextToSpeechConfig(BaseTextToSpeechConfig):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
-        kwargs: Dict = {},
+        kwargs: Optional[Dict] = None,
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI parameters to Azure AVA TTS parameters
         """
+        if kwargs is None:
+            kwargs = {}
         mapped_params = {}
         ##########################################################
         # Map voice

--- a/litellm/llms/azure_ai/anthropic/handler.py
+++ b/litellm/llms/azure_ai/anthropic/handler.py
@@ -48,13 +48,15 @@ class AzureAnthropicChatCompletion(AnthropicChatCompletion):
         litellm_params: dict,
         acompletion=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         client=None,
     ):
         """
         Completion method that uses Azure authentication instead of Anthropic's x-api-key.
         All other logic is the same as AnthropicChatCompletion.
         """
+        if headers is None:
+            headers = {}
 
         optional_params = copy.deepcopy(optional_params)
         stream = optional_params.pop("stream", None)

--- a/litellm/llms/azure_ai/rerank/transformation.py
+++ b/litellm/llms/azure_ai/rerank/transformation.py
@@ -95,10 +95,16 @@ class AzureAIRerankConfig(CohereRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         rerank_response = super().transform_rerank_response(
             model=model,
             raw_response=raw_response,

--- a/litellm/llms/base_llm/rerank/transformation.py
+++ b/litellm/llms/base_llm/rerank/transformation.py
@@ -45,10 +45,16 @@ class BaseRerankConfig(ABC):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         return model_response
 
     @abstractmethod

--- a/litellm/llms/base_llm/text_to_speech/transformation.py
+++ b/litellm/llms/base_llm/text_to_speech/transformation.py
@@ -71,11 +71,13 @@ class BaseTextToSpeechConfig(ABC):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
-        kwargs: Dict = {},
+        kwargs: Optional[Dict] = None,
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI TTS parameters to provider-specific parameters
         """
+        if kwargs is None:
+            kwargs = {}
         pass
 
     @abstractmethod

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -103,13 +103,15 @@ class BedrockConverseLLM(BaseAWSLLM):
         litellm_params: dict,
         credentials: Credentials,
         logger_fn=None,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
         fake_stream: bool = False,
         json_mode: Optional[bool] = False,
         api_key: Optional[str] = None,
         stream_chunk_size: int = 1024,
     ) -> CustomStreamWrapper:
+        if headers is None:
+            headers = {}
         request_data = await litellm.AmazonConverseConfig()._async_transform_request(
             model=model,
             messages=messages,
@@ -174,10 +176,12 @@ class BedrockConverseLLM(BaseAWSLLM):
         litellm_params: dict,
         credentials: Credentials,
         logger_fn=None,
-        headers: dict = {},
+        headers: Optional[dict] = None,
         client: Optional[AsyncHTTPHandler] = None,
         api_key: Optional[str] = None,
     ) -> Union[ModelResponse, CustomStreamWrapper]:
+        if headers is None:
+            headers = {}
         request_data = await litellm.AmazonConverseConfig()._async_transform_request(
             model=model,
             messages=messages,

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1290,9 +1290,11 @@ class BedrockLLM(BaseAWSLLM):
         optional_params: dict,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
     ) -> Union[ModelResponse, CustomStreamWrapper]:
+        if headers is None:
+            headers = {}
         if client is None:
             _params = {}
             if timeout is not None:
@@ -1348,10 +1350,12 @@ class BedrockLLM(BaseAWSLLM):
         optional_params: dict,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
         stream_chunk_size: int = 1024,
     ) -> CustomStreamWrapper:
+        if headers is None:
+            headers = {}
         # The call is not made here; instead, we prepare the necessary objects for the stream.
 
         streaming_response = CustomStreamWrapper(

--- a/litellm/llms/codestral/completion/handler.py
+++ b/litellm/llms/codestral/completion/handler.py
@@ -208,8 +208,10 @@ class CodestralTextCompletion:
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers: dict = {},
+        headers: Optional[dict] = None,
     ) -> Union[TextCompletionResponse, CustomStreamWrapper]:
+        if headers is None:
+            headers = {}
         headers = self._validate_environment(api_key, headers)
 
         if optional_params.pop("custom_endpoint", None) is True:
@@ -351,8 +353,10 @@ class CodestralTextCompletion:
         timeout: Union[float, httpx.Timeout],
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
     ) -> TextCompletionResponse:
+        if headers is None:
+            headers = {}
         async_handler = get_async_httpx_client(
             llm_provider=litellm.LlmProviders.TEXT_COMPLETION_CODESTRAL,
             params={"timeout": timeout},
@@ -400,8 +404,10 @@ class CodestralTextCompletion:
         optional_params=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
     ) -> CustomStreamWrapper:
+        if headers is None:
+            headers = {}
         data["stream"] = True
 
         streamwrapper = CustomStreamWrapper(

--- a/litellm/llms/cohere/rerank/transformation.py
+++ b/litellm/llms/cohere/rerank/transformation.py
@@ -135,15 +135,21 @@ class CohereRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform Cohere rerank response
 
         No transformation required, litellm follows cohere API response format
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -334,9 +334,11 @@ class BaseLLMAIOHTTPHandler:
         stream: Optional[bool] = False,
         fake_stream: bool = False,
         api_key: Optional[str] = None,
-        headers: Optional[dict] = {},
+        headers: Optional[dict] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler, ClientSession]] = None,
     ):
+        if headers is None:
+            headers = {}
         provider_config = ProviderConfigManager.get_provider_chat_config(
             model=model, provider=litellm.LlmProviders(custom_llm_provider)
         )

--- a/litellm/llms/custom_llm.py
+++ b/litellm/llms/custom_llm.py
@@ -63,10 +63,12 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[HTTPHandler] = None,
     ) -> Union[ModelResponse, "CustomStreamWrapper"]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     def streaming(
@@ -84,10 +86,12 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[HTTPHandler] = None,
     ) -> Iterator[GenericStreamingChunk]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     async def acompletion(
@@ -105,13 +109,15 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[AsyncHTTPHandler] = None,
     ) -> Union[
         Coroutine[Any, Any, Union[ModelResponse, "CustomStreamWrapper"]],
         Union[ModelResponse, "CustomStreamWrapper"],
     ]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     async def astreaming(
@@ -129,10 +135,12 @@ class CustomLLM(BaseLLM):
         acompletion=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         client: Optional[AsyncHTTPHandler] = None,
     ) -> AsyncIterator[GenericStreamingChunk]:
+        if headers is None:
+            headers = {}
         raise CustomLLMError(status_code=500, message="Not implemented yet!")
 
     def image_generation(

--- a/litellm/llms/deepinfra/rerank/transformation.py
+++ b/litellm/llms/deepinfra/rerank/transformation.py
@@ -146,10 +146,16 @@ class DeepinfraRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             response_json = raw_response.json()
             logging_obj.post_call(original_response=raw_response.text)

--- a/litellm/llms/fireworks_ai/rerank/transformation.py
+++ b/litellm/llms/fireworks_ai/rerank/transformation.py
@@ -176,13 +176,19 @@ class FireworksAIRerankConfig(FireworksAIMixin, BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform Fireworks AI rerank response to LiteLLM RerankResponse format
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception as e:

--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -145,13 +145,19 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Process response from Hosted VLLM rerank API
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/huggingface/embedding/handler.py
+++ b/litellm/llms/huggingface/embedding/handler.py
@@ -331,8 +331,10 @@ class HuggingFaceEmbedding(BaseLLM):
         timeout: Union[float, httpx.Timeout] = httpx.Timeout(None),
         aembedding: Optional[bool] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
-        headers={},
+        headers=None,
     ) -> EmbeddingResponse:
+        if headers is None:
+            headers = {}
         super().embedding()
         headers = config.validate_environment(
             api_key=api_key,

--- a/litellm/llms/huggingface/rerank/transformation.py
+++ b/litellm/llms/huggingface/rerank/transformation.py
@@ -173,10 +173,16 @@ class HuggingFaceRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LoggingClass,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json: HuggingFaceRerankResponseList = raw_response.json()
         except Exception:

--- a/litellm/llms/infinity/common_utils.py
+++ b/litellm/llms/infinity/common_utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 import httpx
 
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
@@ -6,8 +6,13 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 
 class InfinityError(BaseLLMException):
     def __init__(
-        self, status_code: int, message: str, headers: Union[dict, httpx.Headers] = {}
+        self,
+        status_code: int,
+        message: str,
+        headers: Optional[Union[dict, httpx.Headers]] = None,
     ):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(

--- a/litellm/llms/infinity/embedding/transformation.py
+++ b/litellm/llms/infinity/embedding/transformation.py
@@ -110,10 +110,16 @@ class InfinityEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/infinity/rerank/transformation.py
+++ b/litellm/llms/infinity/rerank/transformation.py
@@ -74,15 +74,21 @@ class InfinityRerankConfig(CohereRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform Infinity rerank response
 
         No transformation required, Infinity follows Cohere API response format
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/jina_ai/rerank/transformation.py
+++ b/litellm/llms/jina_ai/rerank/transformation.py
@@ -89,10 +89,16 @@ class JinaAIRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: Dict = {},
-        optional_params: Dict = {},
-        litellm_params: Dict = {},
+        request_data: Optional[Dict] = None,
+        optional_params: Optional[Dict] = None,
+        litellm_params: Optional[Dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         if raw_response.status_code != 200:
             raise Exception(raw_response.text)
 

--- a/litellm/llms/nlp_cloud/chat/handler.py
+++ b/litellm/llms/nlp_cloud/chat/handler.py
@@ -28,8 +28,10 @@ def completion(
     logger_fn=None,
     default_max_tokens_to_sample=None,
     client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
-    headers={},
+    headers=None,
 ):
+    if headers is None:
+        headers = {}
     headers = nlp_config.validate_environment(
         api_key=api_key,
         headers=headers,

--- a/litellm/llms/nvidia_nim/rerank/transformation.py
+++ b/litellm/llms/nvidia_nim/rerank/transformation.py
@@ -253,9 +253,9 @@ class NvidiaNimRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform Nvidia NIM rerank response to LiteLLM format.
@@ -281,6 +281,12 @@ class NvidiaNimRerankConfig(BaseRerankConfig):
             ]
         }
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/oci/embed/transformation.py
+++ b/litellm/llms/oci/embed/transformation.py
@@ -275,9 +275,9 @@ class OCIEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
         """
         Transform OCI embedding response to standard EmbeddingResponse format.
@@ -290,6 +290,12 @@ class OCIEmbeddingConfig(BaseEmbeddingConfig):
             "inputTextTokenCounts": [5, 4]
         }
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         if raw_response.status_code != 200:
             raise OCIError(
                 message=raw_response.text,

--- a/litellm/llms/oobabooga/chat/oobabooga.py
+++ b/litellm/llms/oobabooga/chat/oobabooga.py
@@ -22,10 +22,12 @@ def completion(
     logging_obj,
     optional_params: dict,
     litellm_params: dict,
-    custom_prompt_dict={},
+    custom_prompt_dict=None,
     logger_fn=None,
     default_max_tokens_to_sample=None,
 ):
+    if custom_prompt_dict is None:
+        custom_prompt_dict = {}
     headers = oobabooga_config.validate_environment(
         api_key=api_key,
         headers={},

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -626,13 +626,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         acompletion: bool = False,
         logger_fn=None,
         headers: Optional[dict] = None,
-        custom_prompt_dict: dict = {},
+        custom_prompt_dict: Optional[dict] = None,
         client=None,
         organization: Optional[str] = None,
         custom_llm_provider: Optional[str] = None,
         drop_params: Optional[bool] = None,
         shared_session: Optional["ClientSession"] = None,
     ):
+        if custom_prompt_dict is None:
+            custom_prompt_dict = {}
         super().completion(shared_session=shared_session)
         try:
             fake_stream: bool = False

--- a/litellm/llms/openai_like/chat/handler.py
+++ b/litellm/llms/openai_like/chat/handler.py
@@ -129,11 +129,13 @@ class OpenAILikeChatHandler(OpenAILikeBase):
         optional_params=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
         streaming_decoder: Optional[CustomStreamingDecoder] = None,
         fake_stream: bool = False,
     ) -> CustomStreamWrapper:
+        if headers is None:
+            headers = {}
         data["stream"] = True
         completion_stream = await make_call(
             client=client,
@@ -173,10 +175,12 @@ class OpenAILikeChatHandler(OpenAILikeBase):
         optional_params: dict,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
         json_mode: bool = False,
     ) -> ModelResponse:
+        if headers is None:
+            headers = {}
         if timeout is None:
             timeout = httpx.Timeout(timeout=600.0, connect=5.0)
 
@@ -230,7 +234,7 @@ class OpenAILikeChatHandler(OpenAILikeBase):
         logging_obj,
         optional_params: dict,
         acompletion=None,
-        litellm_params: dict = {},
+        litellm_params: Optional[dict] = None,
         logger_fn=None,
         headers: Optional[dict] = None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -241,6 +245,8 @@ class OpenAILikeChatHandler(OpenAILikeBase):
         ] = None,  # if openai-compatible api needs custom stream decoder - e.g. sagemaker
         fake_stream: bool = False,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         custom_endpoint = custom_endpoint or optional_params.pop(
             "custom_endpoint", None
         )

--- a/litellm/llms/perplexity/embedding/transformation.py
+++ b/litellm/llms/perplexity/embedding/transformation.py
@@ -30,8 +30,10 @@ class PerplexityEmbeddingError(BaseLLMException):
         self,
         status_code: int,
         message: str,
-        headers: Union[dict, httpx.Headers] = {},
+        headers: Optional[Union[dict, httpx.Headers]] = None,
     ):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(
@@ -145,10 +147,16 @@ class PerplexityEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/predibase/chat/handler.py
+++ b/litellm/llms/predibase/chat/handler.py
@@ -67,8 +67,10 @@ class PredibaseChatCompletion:
         timeout: Union[float, httpx.Timeout],
         acompletion=None,
         logger_fn=None,
-        headers: dict = {},
+        headers: Optional[dict] = None,
     ) -> Union[ModelResponse, CustomStreamWrapper]:
+        if headers is None:
+            headers = {}
         predibase_config = litellm.PredibaseConfig()
         headers = predibase_config.validate_environment(
             api_key=api_key,
@@ -206,9 +208,11 @@ class PredibaseChatCompletion:
         timeout: Union[float, httpx.Timeout],
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
         predibase_config=None,
     ) -> ModelResponse:
+        if headers is None:
+            headers = {}
         if predibase_config is None:
             predibase_config = litellm.PredibaseConfig()
         async_handler = get_async_httpx_client(
@@ -261,8 +265,10 @@ class PredibaseChatCompletion:
         optional_params=None,
         litellm_params=None,
         logger_fn=None,
-        headers={},
+        headers=None,
     ) -> CustomStreamWrapper:
+        if headers is None:
+            headers = {}
         data["stream"] = True
 
         streamwrapper = CustomStreamWrapper(

--- a/litellm/llms/replicate/chat/handler.py
+++ b/litellm/llms/replicate/chat/handler.py
@@ -140,11 +140,15 @@ def completion(
     logging_obj,
     api_key,
     encoding,
-    custom_prompt_dict={},
+    custom_prompt_dict=None,
     logger_fn=None,
     acompletion=None,
-    headers={},
+    headers=None,
 ) -> Union[ModelResponse, CustomStreamWrapper]:
+    if custom_prompt_dict is None:
+        custom_prompt_dict = {}
+    if headers is None:
+        headers = {}
     headers = replicate_config.validate_environment(
         api_key=api_key,
         headers=headers,

--- a/litellm/llms/runwayml/text_to_speech/transformation.py
+++ b/litellm/llms/runwayml/text_to_speech/transformation.py
@@ -145,7 +145,7 @@ class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
-        kwargs: Dict = {},
+        kwargs: Optional[Dict] = None,
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI parameters to RunwayML TTS parameters
@@ -156,6 +156,8 @@ class RunwayMLTextToSpeechConfig(BaseTextToSpeechConfig):
         Note: Since RunwayML requires voice as a dict, we store it in
         mapped_params["runwayml_voice"] and return None for the voice string.
         """
+        if kwargs is None:
+            kwargs = {}
         mapped_params = {}
 
         # Map voice parameter to RunwayML format dict

--- a/litellm/llms/sagemaker/chat/handler.py
+++ b/litellm/llms/sagemaker/chat/handler.py
@@ -121,12 +121,16 @@ class SagemakerChatHandler(BaseAWSLLM):
         optional_params: dict,
         litellm_params: dict,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        custom_prompt_dict={},
+        custom_prompt_dict=None,
         logger_fn=None,
         acompletion: bool = False,
-        headers: dict = {},
+        headers: Optional[dict] = None,
         client: Optional[Union[HTTPHandler, AsyncHTTPHandler]] = None,
     ):
+        if custom_prompt_dict is None:
+            custom_prompt_dict = {}
+        if headers is None:
+            headers = {}
         # pop streaming if it's in the optional params as 'stream' raises an error with sagemaker
         credentials, aws_region_name = self._load_credentials(optional_params)
         inference_params = deepcopy(optional_params)

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -149,12 +149,16 @@ class SagemakerLLM(BaseAWSLLM):
         optional_params: dict,
         litellm_params: dict,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
-        custom_prompt_dict={},
+        custom_prompt_dict=None,
         hf_model_name=None,
         logger_fn=None,
         acompletion: bool = False,
-        headers: dict = {},
+        headers: Optional[dict] = None,
     ):
+        if custom_prompt_dict is None:
+            custom_prompt_dict = {}
+        if headers is None:
+            headers = {}
         # pop streaming if it's in the optional params as 'stream' raises an error with sagemaker
         credentials, aws_region_name = self._load_credentials(optional_params)
         inference_params = deepcopy(optional_params)
@@ -573,13 +577,15 @@ class SagemakerLLM(BaseAWSLLM):
         encoding,
         logging_obj,
         optional_params: dict,
-        custom_prompt_dict={},
+        custom_prompt_dict=None,
         litellm_params=None,
         logger_fn=None,
     ):
         """
         Supports Hugging Face (TGI), Voyage, and Cohere embedding endpoints
         """
+        if custom_prompt_dict is None:
+            custom_prompt_dict = {}
         ### BOTO3 INIT
         import boto3
 

--- a/litellm/llms/sagemaker/embedding/cohere_transformation.py
+++ b/litellm/llms/sagemaker/embedding/cohere_transformation.py
@@ -96,9 +96,9 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         model_response: "EmbeddingResponse",
         logging_obj: Any,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> "EmbeddingResponse":
         """
         Transform embedding response for Cohere models on SageMaker.
@@ -108,6 +108,12 @@ class SagemakerCohereEmbeddingConfig(BaseEmbeddingConfig):
         — the SageMaker embedding handler already logs `post_call` before
         invoking this transform.
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         input_value = (
             logging_obj.model_call_details.get("input")
             or request_data.get("texts")

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -90,13 +90,19 @@ class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
         model_response: "EmbeddingResponse",
         logging_obj: Any,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> "EmbeddingResponse":
         """
         Transform embedding response for Hugging Face models on SageMaker
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             response_data = raw_response.json()
         except Exception as e:

--- a/litellm/llms/triton/embedding/transformation.py
+++ b/litellm/llms/triton/embedding/transformation.py
@@ -74,10 +74,16 @@ class TritonEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/vertex_ai/fine_tuning/handler.py
+++ b/litellm/llms/vertex_ai/fine_tuning/handler.py
@@ -51,7 +51,7 @@ class VertexFineTuningAPI(VertexLLM):
     def convert_openai_request_to_vertex(
         self,
         create_fine_tuning_job_data: FineTuningJobCreate,
-        original_hyperparameters: dict = {},
+        original_hyperparameters: Optional[dict] = None,
         kwargs: Optional[dict] = None,
     ) -> FineTuneJobCreate:
         """
@@ -59,6 +59,8 @@ class VertexFineTuningAPI(VertexLLM):
         https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/tuning
         supervised_tuning_spec = FineTunesupervisedTuningSpec(
         """
+        if original_hyperparameters is None:
+            original_hyperparameters = {}
 
         supervised_tuning_spec = FineTunesupervisedTuningSpec(
             training_dataset_uri=create_fine_tuning_job_data.training_file,
@@ -91,9 +93,11 @@ class VertexFineTuningAPI(VertexLLM):
     def _transform_openai_hyperparameters_to_vertex_hyperparameters(
         self,
         create_fine_tuning_job_data: FineTuningJobCreate,
-        original_hyperparameters: dict = {},
+        original_hyperparameters: Optional[dict] = None,
         kwargs: Optional[dict] = None,
     ) -> FineTuneHyperparameters:
+        if original_hyperparameters is None:
+            original_hyperparameters = {}
         _oai_hyperparameters = create_fine_tuning_job_data.hyperparameters
         _vertex_hyperparameters = FineTuneHyperparameters()
         if _oai_hyperparameters:
@@ -228,8 +232,10 @@ class VertexFineTuningAPI(VertexLLM):
         api_base: Optional[str],
         timeout: Union[float, httpx.Timeout],
         kwargs: Optional[dict] = None,
-        original_hyperparameters: Optional[dict] = {},
+        original_hyperparameters: Optional[dict] = None,
     ) -> Union[LiteLLMFineTuningJob, Coroutine[Any, Any, LiteLLMFineTuningJob]]:
+        if original_hyperparameters is None:
+            original_hyperparameters = {}
         verbose_logger.debug(
             "creating fine tuning job, args= %s", create_fine_tuning_job_data
         )

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -654,12 +654,14 @@ def _get_equivalent_key(key: str, available_keys: set) -> Optional[str]:
 
 
 def check_if_part_exists_in_parts(
-    parts: List[PartType], part: PartType, excluded_keys: List[str] = []
+    parts: List[PartType], part: PartType, excluded_keys: Optional[List[str]] = None
 ) -> bool:
     """
     Check if a part exists in a list of parts
     Handles both camelCase and snake_case key variations (e.g., function_call vs functionCall)
     """
+    if excluded_keys is None:
+        excluded_keys = []
     keys_to_compare = set(part.keys()) - set(excluded_keys)
     for p in parts:
         p_keys = set(p.keys())

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
@@ -293,13 +293,15 @@ class GoogleBatchEmbeddings(VertexLLM):
         model_response: EmbeddingResponse,
         input: GeminiEmbeddingInput,
         timeout: Optional[Union[float, httpx.Timeout]],
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
         use_embed_content: bool = False,
         api_key: Optional[str] = None,
         optional_params: Optional[dict] = None,
         logging_obj: Optional[Any] = None,
     ) -> EmbeddingResponse:
+        if headers is None:
+            headers = {}
         if client is None:
             _params = {}
             if timeout is not None:

--- a/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
@@ -41,7 +41,7 @@ class VertexMultimodalEmbedding(VertexLLM):
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
-        headers: dict = {},
+        headers: Optional[dict] = None,
         encoding=None,
         vertex_project=None,
         vertex_location=None,
@@ -50,6 +50,8 @@ class VertexMultimodalEmbedding(VertexLLM):
         timeout=300,
         client=None,
     ) -> EmbeddingResponse:
+        if headers is None:
+            headers = {}
         _auth_header, vertex_project = self._ensure_access_token(
             credentials=vertex_credentials,
             project_id=vertex_project,
@@ -150,10 +152,12 @@ class VertexMultimodalEmbedding(VertexLLM):
         model_response: EmbeddingResponse,
         timeout: Optional[Union[float, httpx.Timeout]],
         logging_obj: LiteLLMLoggingObj,
-        headers={},
+        headers=None,
         client: Optional[AsyncHTTPHandler] = None,
         api_key: Optional[str] = None,
     ) -> EmbeddingResponse:
+        if headers is None:
+            headers = {}
         if client is None:
             _params = {}
             if timeout is not None:

--- a/litellm/llms/vertex_ai/rerank/transformation.py
+++ b/litellm/llms/vertex_ai/rerank/transformation.py
@@ -162,13 +162,19 @@ class VertexAIRerankConfig(BaseRerankConfig, VertexBase):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform Vertex AI Discovery Engine response to Cohere format
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception as e:

--- a/litellm/llms/vertex_ai/text_to_speech/transformation.py
+++ b/litellm/llms/vertex_ai/text_to_speech/transformation.py
@@ -206,7 +206,7 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         optional_params: Dict,
         voice: Optional[Union[str, Dict]] = None,
         drop_params: bool = False,
-        kwargs: Dict = {},
+        kwargs: Optional[Dict] = None,
     ) -> Tuple[Optional[str], Dict]:
         """
         Map OpenAI parameters to Vertex AI TTS parameters
@@ -222,6 +222,8 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         Returns:
             Tuple of (mapped_voice_str, mapped_params)
         """
+        if kwargs is None:
+            kwargs = {}
         mapped_params: Dict[str, Any] = {}
 
         ##########################################################

--- a/litellm/llms/vllm/completion/handler.py
+++ b/litellm/llms/vllm/completion/handler.py
@@ -44,10 +44,12 @@ def completion(
     encoding,
     logging_obj,
     optional_params: dict,
-    custom_prompt_dict={},
+    custom_prompt_dict=None,
     litellm_params=None,
     logger_fn=None,
 ):
+    if custom_prompt_dict is None:
+        custom_prompt_dict = {}
     global llm
     try:
         llm, SamplingParams = validate_environment(model=model)
@@ -111,7 +113,7 @@ def completion(
 
 
 def batch_completions(
-    model: str, messages: list, optional_params=None, custom_prompt_dict={}
+    model: str, messages: list, optional_params=None, custom_prompt_dict=None
 ):
     """
     Example usage:
@@ -138,6 +140,8 @@ def batch_completions(
         ]
     )
     """
+    if custom_prompt_dict is None:
+        custom_prompt_dict = {}
     try:
         llm, SamplingParams = validate_environment(model=model)
     except Exception as e:

--- a/litellm/llms/voyage/embedding/transformation.py
+++ b/litellm/llms/voyage/embedding/transformation.py
@@ -15,8 +15,10 @@ class VoyageError(BaseLLMException):
         self,
         status_code: int,
         message: str,
-        headers: Union[dict, httpx.Headers] = {},
+        headers: Optional[Union[dict, httpx.Headers]] = None,
     ):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(
@@ -117,10 +119,16 @@ class VoyageEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/voyage/embedding/transformation_contextual.py
+++ b/litellm/llms/voyage/embedding/transformation_contextual.py
@@ -20,8 +20,10 @@ class VoyageError(BaseLLMException):
         self,
         status_code: int,
         message: str,
-        headers: Union[dict, httpx.Headers] = {},
+        headers: Optional[Union[dict, httpx.Headers]] = None,
     ):
+        if headers is None:
+            headers = {}
         self.status_code = status_code
         self.message = message
         self.request = httpx.Request(
@@ -119,10 +121,16 @@ class VoyageContextualEmbeddingConfig(BaseEmbeddingConfig):
         model_response: EmbeddingResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> EmbeddingResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/litellm/llms/voyage/rerank/transformation.py
+++ b/litellm/llms/voyage/rerank/transformation.py
@@ -82,10 +82,16 @@ class VoyageRerankConfig(BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: Dict = {},
-        optional_params: Dict = {},
-        litellm_params: Dict = {},
+        request_data: Optional[Dict] = None,
+        optional_params: Optional[Dict] = None,
+        litellm_params: Optional[Dict] = None,
     ) -> RerankResponse:
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         if raw_response.status_code != 200:
             raise VoyageError(
                 message=raw_response.text, status_code=raw_response.status_code

--- a/litellm/llms/watsonx/chat/handler.py
+++ b/litellm/llms/watsonx/chat/handler.py
@@ -31,7 +31,7 @@ class WatsonXChatHandler(OpenAILikeChatHandler):
         logging_obj,
         optional_params: dict,
         acompletion=None,
-        litellm_params: dict = {},
+        litellm_params: Optional[dict] = None,
         headers: Optional[dict] = None,
         logger_fn=None,
         timeout: Optional[Union[float, httpx.Timeout]] = None,
@@ -40,6 +40,8 @@ class WatsonXChatHandler(OpenAILikeChatHandler):
         streaming_decoder: Optional[CustomStreamingDecoder] = None,
         fake_stream: bool = False,
     ):
+        if litellm_params is None:
+            litellm_params = {}
         api_params = _get_api_params(params=optional_params, model=model)
 
         ## UPDATE HEADERS

--- a/litellm/llms/watsonx/rerank/transformation.py
+++ b/litellm/llms/watsonx/rerank/transformation.py
@@ -163,13 +163,19 @@ class IBMWatsonXRerankConfig(IBMWatsonXMixin, BaseRerankConfig):
         model_response: RerankResponse,
         logging_obj: LiteLLMLoggingObj,
         api_key: Optional[str] = None,
-        request_data: dict = {},
-        optional_params: dict = {},
-        litellm_params: dict = {},
+        request_data: Optional[dict] = None,
+        optional_params: Optional[dict] = None,
+        litellm_params: Optional[dict] = None,
     ) -> RerankResponse:
         """
         Transform IBM watsonx.ai rerank response to LiteLLM RerankResponse format
         """
+        if request_data is None:
+            request_data = {}
+        if optional_params is None:
+            optional_params = {}
+        if litellm_params is None:
+            litellm_params = {}
         try:
             raw_response_json = raw_response.json()
         except Exception as e:

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -394,7 +394,7 @@ class AsyncCompletions:
 async def acompletion(  # noqa: PLR0915
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
-    messages: List = [],
+    messages: Optional[List] = None,
     functions: Optional[List] = None,
     function_call: Optional[str] = None,
     timeout: Optional[Union[float, int]] = None,
@@ -486,6 +486,8 @@ async def acompletion(  # noqa: PLR0915
         - The `completion` function is called using `run_in_executor` to execute synchronously in the event loop.
         - If `stream` is True, the function returns an async generator that yields completion lines.
     """
+    if messages is None:
+        messages = []
     fallbacks = kwargs.get("fallbacks", None)
     mock_timeout = kwargs.get("mock_timeout", None)
 
@@ -1085,7 +1087,7 @@ def _build_custom_pricing_entry(
 def completion(  # type: ignore # noqa: PLR0915
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
-    messages: List = [],
+    messages: Optional[List] = None,
     timeout: Optional[Union[float, str, httpx.Timeout]] = None,
     temperature: Optional[float] = None,
     top_p: Optional[float] = None,
@@ -1180,6 +1182,8 @@ def completion(  # type: ignore # noqa: PLR0915
         - It supports various optional parameters for customizing the completion behavior.
         - If 'mock_response' is provided, a mock completion response is returned for testing or debugging.
     """
+    if messages is None:
+        messages = []
     ### VALIDATE Request ###
     if model is None:
         raise ValueError("model param not passed in.")
@@ -4717,7 +4721,7 @@ async def aembedding(*args, **kwargs) -> EmbeddingResponse:
 @overload
 def embedding(
     model,
-    input=[],
+    input=None,
     # Optional params
     dimensions: Optional[int] = None,
     encoding_format: Optional[str] = None,
@@ -4735,7 +4739,7 @@ def embedding(
     *,
     aembedding: Literal[True],
     **kwargs,
-) -> Coroutine[Any, Any, EmbeddingResponse]: 
+) -> Coroutine[Any, Any, EmbeddingResponse]:
     ...
 
 
@@ -4743,7 +4747,7 @@ def embedding(
 @overload
 def embedding(
     model,
-    input=[],
+    input=None,
     # Optional params
     dimensions: Optional[int] = None,
     encoding_format: Optional[str] = None,
@@ -4770,7 +4774,7 @@ def embedding(
 @client
 def embedding(  # noqa: PLR0915
     model,
-    input=[],
+    input=None,
     # Optional params
     dimensions: Optional[int] = None,
     encoding_format: Optional[str] = None,
@@ -4812,6 +4816,8 @@ def embedding(  # noqa: PLR0915
     Raises:
     - exception_type: If an exception occurs during the API call.
     """
+    if input is None:
+        input = []
     azure = kwargs.get("azure", None)
     client = kwargs.pop("client", None)
     shared_session = kwargs.get("shared_session", None)

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -178,7 +178,7 @@ def get_complete_model_list(
     infer_model_from_keys: Optional[bool],
     return_wildcard_routes: Optional[bool] = False,
     llm_router: Optional[Router] = None,
-    model_access_groups: Dict[str, List[str]] = {},
+    model_access_groups: Optional[Dict[str, List[str]]] = None,
     include_model_access_groups: Optional[bool] = False,
     only_model_access_groups: Optional[bool] = False,
     team_id: Optional[str] = None,
@@ -191,6 +191,8 @@ def get_complete_model_list(
 
     If list contains wildcard -> return known provider models
     """
+    if model_access_groups is None:
+        model_access_groups = {}
 
     unique_models = []
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -552,11 +552,13 @@ class ProxyBaseLLMRequestProcessing:
         response_cost: Optional[Union[float, str]] = None,
         hidden_params: Optional[dict] = None,
         fastest_response_batch_completion: Optional[bool] = None,
-        request_data: Optional[dict] = {},
+        request_data: Optional[dict] = None,
         timeout: Optional[Union[float, int, httpx.Timeout]] = None,
         litellm_logging_obj: Optional[LiteLLMLoggingObj] = None,
         **kwargs,
     ) -> dict:
+        if request_data is None:
+            request_data = {}
         exclude_values = {"", None, "None"}
         hidden_params = hidden_params or {}
 

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -25,8 +25,10 @@ def initialize_callbacks_on_proxy(  # noqa: PLR0915
     premium_user: bool,
     config_file_path: str,
     litellm_settings: dict,
-    callback_specific_params: dict = {},
+    callback_specific_params: Optional[dict] = None,
 ):
+    if callback_specific_params is None:
+        callback_specific_params = {}
     from litellm.integrations.custom_logger import CustomLogger
     from litellm.litellm_core_utils.logging_callback_manager import (
         LoggingCallbackManager,

--- a/litellm/proxy/guardrails/guardrail_hooks/dynamoai/dynamoai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/dynamoai/dynamoai.py
@@ -45,9 +45,11 @@ class DynamoAIGuardrails(CustomGuardrail):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         model_id: str = "",
-        policy_ids: List[str] = [],
+        policy_ids: Optional[List[str]] = None,
         **kwargs,
     ):
+        if policy_ids is None:
+            policy_ids = []
         self.async_handler = get_async_httpx_client(
             llm_provider=httpxSpecialProvider.GuardrailCallback
         )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3336,9 +3336,9 @@ async def generate_key_helper_fn(  # noqa: PLR0915
         "user", "key"
     ],  # identifies if this request is from /user/new or /key/generate
     duration: Optional[str] = None,
-    models: list = [],
-    aliases: dict = {},
-    config: dict = {},
+    models: Optional[list] = None,
+    aliases: Optional[dict] = None,
+    config: Optional[dict] = None,
     spend: float = 0.0,
     key_max_budget: Optional[float] = None,  # key_max_budget is used to Budget Per key
     key_budget_duration: Optional[str] = None,
@@ -3360,15 +3360,15 @@ async def generate_key_helper_fn(  # noqa: PLR0915
     user_email: Optional[str] = None,
     user_role: Optional[str] = None,
     max_parallel_requests: Optional[int] = None,
-    metadata: Optional[dict] = {},
+    metadata: Optional[dict] = None,
     tpm_limit: Optional[int] = None,
     rpm_limit: Optional[int] = None,
     query_type: Literal["insert_data", "update_data"] = "insert_data",
     update_key_values: Optional[dict] = None,
     key_alias: Optional[str] = None,
-    allowed_cache_controls: Optional[list] = [],
-    permissions: Optional[dict] = {},
-    model_max_budget: Optional[dict] = {},
+    allowed_cache_controls: Optional[list] = None,
+    permissions: Optional[dict] = None,
+    model_max_budget: Optional[dict] = None,
     model_rpm_limit: Optional[dict] = None,
     model_tpm_limit: Optional[dict] = None,
     guardrails: Optional[list] = None,
@@ -3393,6 +3393,20 @@ async def generate_key_helper_fn(  # noqa: PLR0915
     access_group_ids: Optional[list] = None,
     budget_limits: Optional[list] = None,  # multiple concurrent budget windows
 ):
+    if models is None:
+        models = []
+    if aliases is None:
+        aliases = {}
+    if config is None:
+        config = {}
+    if metadata is None:
+        metadata = {}
+    if allowed_cache_controls is None:
+        allowed_cache_controls = []
+    if permissions is None:
+        permissions = {}
+    if model_max_budget is None:
+        model_max_budget = {}
     from litellm.proxy.proxy_server import premium_user, prisma_client
 
     if prisma_client is None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7016,7 +7016,9 @@ def select_data_generator(
     )
 
 
-def get_litellm_model_info(model: dict = {}):
+def get_litellm_model_info(model: Optional[dict] = None):
+    if model is None:
+        model = {}
     model_info = model.get("model_info", {})
     model_to_lookup = model.get("litellm_params", {}).get("model", None)
     try:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3744,7 +3744,7 @@ class PrismaClient:
     async def update_data(  # noqa: PLR0915
         self,
         token: Optional[str] = None,
-        data: dict = {},
+        data: Optional[dict] = None,
         data_list: Optional[List] = None,
         user_id: Optional[str] = None,
         team_id: Optional[str] = None,
@@ -3758,6 +3758,8 @@ class PrismaClient:
         """
         Update existing data
         """
+        if data is None:
+            data = {}
         verbose_proxy_logger.debug(
             f"PrismaClient: update_data, table_name: {table_name}"
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -259,7 +259,9 @@ class Router:
         redis_password: Optional[str] = None,
         redis_db: Optional[int] = None,
         cache_responses: Optional[bool] = False,
-        cache_kwargs: dict = {},  # additional kwargs to pass to RedisCache (see caching.py)
+        cache_kwargs: Optional[
+            dict
+        ] = None,  # additional kwargs to pass to RedisCache (see caching.py)
         caching_groups: Optional[
             List[tuple]
         ] = None,  # if you want to cache across model groups
@@ -283,12 +285,12 @@ class Router:
         default_fallbacks: Optional[
             List[str]
         ] = None,  # generic fallbacks, works across all deployments
-        fallbacks: List = [],
-        context_window_fallbacks: List = [],
-        content_policy_fallbacks: List = [],
+        fallbacks: Optional[List] = None,
+        context_window_fallbacks: Optional[List] = None,
+        content_policy_fallbacks: Optional[List] = None,
         model_group_alias: Optional[
             Dict[str, Union[str, RouterModelGroupAliasItem]]
-        ] = {},
+        ] = None,
         enable_pre_call_checks: bool = False,
         enable_tag_filtering: bool = False,
         tag_filtering_match_any: bool = True,
@@ -296,9 +298,9 @@ class Router:
         retry_policy: Optional[
             Union[RetryPolicy, dict]
         ] = None,  # set custom retries for different exceptions
-        model_group_retry_policy: Dict[
-            str, RetryPolicy
-        ] = {},  # set custom retry policies based on model group
+        model_group_retry_policy: Optional[
+            Dict[str, RetryPolicy]
+        ] = None,  # set custom retry policies based on model group
         allowed_fails: Optional[
             int
         ] = None,  # Number of times a deployment can failbefore being added to cooldown
@@ -318,7 +320,7 @@ class Router:
             "usage-based-routing-v2",
         ] = "simple-shuffle",
         optional_pre_call_checks: Optional[OptionalPreCallChecks] = None,
-        routing_strategy_args: dict = {},  # just for latency-based
+        routing_strategy_args: Optional[dict] = None,  # just for latency-based
         routing_groups: Optional[List[Union[RoutingGroup, dict]]] = None,
         provider_budget_config: Optional[GenericBudgetConfigType] = None,
         alerting_config: Optional[AlertingConfig] = None,
@@ -404,6 +406,20 @@ class Router:
         router = Router(model_list=model_list, fallbacks=[{"azure-gpt-3.5-turbo": "openai-gpt-3.5-turbo"}])
         ```
         """
+        if cache_kwargs is None:
+            cache_kwargs = {}
+        if fallbacks is None:
+            fallbacks = []
+        if context_window_fallbacks is None:
+            context_window_fallbacks = []
+        if content_policy_fallbacks is None:
+            content_policy_fallbacks = []
+        if model_group_alias is None:
+            model_group_alias = {}
+        if model_group_retry_policy is None:
+            model_group_retry_policy = {}
+        if routing_strategy_args is None:
+            routing_strategy_args = {}
 
         self.set_verbose = set_verbose
         self.ignore_invalid_deployments = ignore_invalid_deployments

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -15,7 +15,9 @@ class LowestCostLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
+        if routing_args is None:
+            routing_args = {}
         self.router_cache = router_cache
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -31,7 +31,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
     logged_success: int = 0
     logged_failure: int = 0
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
+        if routing_args is None:
+            routing_args = {}
         self.router_cache = router_cache
         self.routing_args = RoutingArgs(**routing_args)
 

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -22,7 +22,9 @@ class LowestTPMLoggingHandler(CustomLogger):
     logged_failure: int = 0
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
+        if routing_args is None:
+            routing_args = {}
         self.router_cache = router_cache
         self.routing_args = RoutingArgs(**routing_args)
 

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -47,7 +47,9 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
     logged_failure: int = 0
     default_cache_time_seconds: int = 1 * 60 * 60  # 1 hour
 
-    def __init__(self, router_cache: DualCache, routing_args: dict = {}):
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
+        if routing_args is None:
+            routing_args = {}
         self.router_cache = router_cache
         self.routing_args = RoutingArgs(**routing_args)
         BaseRoutingStrategy.__init__(

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2248,7 +2248,7 @@ def encode(model="", text="", custom_tokenizer: Optional[dict] = None):
 
 def decode(
     model="",
-    tokens: List[int] = [],
+    tokens: Optional[List[int]] = None,
     custom_tokenizer: Optional[dict] = None,
     skip_special_tokens: bool = True,
 ):
@@ -2260,6 +2260,8 @@ def decode(
             LiteLLM round-trip behavior by omitting special tokens by default.
             Set to False to inspect decoded BOS/EOS tokens.
     """
+    if tokens is None:
+        tokens = []
     tokenizer_json = custom_tokenizer or _select_tokenizer(model=model)
     if tokenizer_json["type"] == "huggingface_tokenizer":
         if skip_special_tokens:
@@ -6933,10 +6935,10 @@ def _calculate_retry_after(
 # custom prompt helper function
 def register_prompt_template(
     model: str,
-    roles: dict = {},
+    roles: Optional[dict] = None,
     initial_prompt_value: str = "",
     final_prompt_value: str = "",
-    tokenizer_config: dict = {},
+    tokenizer_config: Optional[dict] = None,
 ):
     """
     Register a prompt template to follow your custom format for a given model
@@ -6973,6 +6975,10 @@ def register_prompt_template(
     )
     ```
     """
+    if roles is None:
+        roles = {}
+    if tokenizer_config is None:
+        tokenizer_config = {}
     complete_model = model
     potential_models = [complete_model]
     try:

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -22,8 +22,11 @@ else:
 
 class VectorStoreIndexRegistry:
     def __init__(
-        self, vector_store_indexes: List[LiteLLM_ManagedVectorStoreIndex] = []
+        self,
+        vector_store_indexes: Optional[List[LiteLLM_ManagedVectorStoreIndex]] = None,
     ):
+        if vector_store_indexes is None:
+            vector_store_indexes = []
         self.vector_store_indexes: List[LiteLLM_ManagedVectorStoreIndex] = (
             vector_store_indexes
         )
@@ -106,7 +109,11 @@ class VectorStoreIndexRegistry:
 
 
 class VectorStoreRegistry:
-    def __init__(self, vector_stores: List[LiteLLM_ManagedVectorStore] = []):
+    def __init__(
+        self, vector_stores: Optional[List[LiteLLM_ManagedVectorStore]] = None
+    ):
+        if vector_stores is None:
+            vector_stores = []
         self.vector_stores: List[LiteLLM_ManagedVectorStore] = vector_stores
         self.vector_store_ids_to_vector_store_map: Dict[
             str, LiteLLM_ManagedVectorStore
@@ -421,11 +428,15 @@ class VectorStoreRegistry:
         return vector_stores_to_run
 
     def _get_vector_store_ids_from_tool_calls(
-        self, tools: Optional[List[Dict]] = None, vector_store_ids: List[str] = []
+        self,
+        tools: Optional[List[Dict]] = None,
+        vector_store_ids: Optional[List[str]] = None,
     ) -> List[str]:
         """
         Returns the vector store ids from the tool calls
         """
+        if vector_store_ids is None:
+            vector_store_ids = []
         if tools:
             for tool in tools:
                 if "vector_store_ids" in tool:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 lint.ignore = ["F405", "E402", "E501", "F403"]
-lint.extend-select = ["E501", "PLR0915", "T20"]
+lint.extend-select = ["B006", "E501", "PLR0915", "T20"]
 line-length = 120
 exclude = ["litellm/types/*", "litellm/__init__.py", "litellm/proxy/example_config_yaml/*", "tests/*"]
 

--- a/tests/test_litellm/vector_stores/test_vector_store_registry.py
+++ b/tests/test_litellm/vector_stores/test_vector_store_registry.py
@@ -18,7 +18,10 @@ from unittest.mock import MagicMock, patch
 import litellm
 from litellm.types.vector_stores import LiteLLM_ManagedVectorStore
 from litellm.vector_stores.main import search
-from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
+from litellm.vector_stores.vector_store_registry import (
+    VectorStoreIndexRegistry,
+    VectorStoreRegistry,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -187,3 +190,37 @@ def test_search_uses_registry_credentials():
             assert getattr(called_params, "aws_region_name") == "us-east-1"
     finally:
         litellm.vector_store_registry = original_registry
+
+
+def test_registries_do_not_share_mutable_default_state():
+    """Regression test for the mutable-default-argument (B006) shared-state bug.
+
+    ``VectorStoreIndexRegistry`` and ``VectorStoreRegistry`` used a mutable list
+    literal as a constructor default (``= []``), so every instance created
+    without an explicit list shared the *same* list object. Mutating one
+    default-constructed registry therefore leaked into all the others. Each
+    instance must now own a fresh, independent list.
+    """
+    # VectorStoreIndexRegistry: default-constructed instances must not share a list.
+    idx_reg_1 = VectorStoreIndexRegistry()
+    idx_reg_2 = VectorStoreIndexRegistry()
+    assert idx_reg_1.vector_store_indexes is not idx_reg_2.vector_store_indexes
+    assert idx_reg_1.vector_store_indexes == []
+    assert idx_reg_2.vector_store_indexes == []
+
+    # VectorStoreRegistry: adding to one default-constructed registry must not
+    # affect another (it would, with a shared default list, before the fix).
+    reg_1 = VectorStoreRegistry()
+    reg_2 = VectorStoreRegistry()
+    assert reg_1.vector_stores is not reg_2.vector_stores
+
+    store = LiteLLM_ManagedVectorStore(
+        vector_store_id="vs_isolation_1",
+        custom_llm_provider="openai",
+        vector_store_name="isolation_store",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    reg_1.add_vector_store_to_registry(store)
+    assert len(reg_1.vector_stores) == 1
+    assert reg_2.vector_stores == []


### PR DESCRIPTION
## Relevant issues

No existing issue — found while auditing for the mutable-default-argument footgun. Targeting `litellm_oss_branch` per the external-contributor policy.

## What this does

Enables flake8-bugbear **B006** in `ruff.toml` and fixes all **180** violations across the package.

A mutable literal bound as a parameter default (`def f(x={})` / `x: List = []`) is created **once** at definition time and shared by every call that omits the argument. Any code path that stores that default on `self` or mutates it in place therefore leaks state **across calls and instances**. `B006` was not in this repo's `ruff.toml`, so these accumulated over time, largely via copy-paste across the provider adapters (e.g. the `transform_rerank_response` signature cloned into several rerank adapters).

### Demonstrable active bug (covered by a test)

`VectorStoreIndexRegistry` and `VectorStoreRegistry` assigned the shared default list straight to `self`:

```python
def __init__(self, vector_store_indexes: List[...] = []):
    self.vector_store_indexes = vector_store_indexes   # shared default!
```

So two default-constructed registries shared **one** underlying list, and mutating one (`upsert_vector_store_index` / `add_vector_store_to_registry`) corrupted the other:

```python
r1 = VectorStoreIndexRegistry(); r2 = VectorStoreIndexRegistry()
r1.vector_store_indexes is r2.vector_store_indexes   # True (before)  -> False (after)
```

The new regression test `tests/test_litellm/vector_stores/test_vector_store_registry.py::test_registries_do_not_share_mutable_default_state` fails before this change and passes after.

### How each site is fixed

Mechanically: the default becomes `None` and a guard at the top of the body restores the original value:

```python
def f(x: Optional[dict] = None):
    if x is None:
        x = {}
    ...
```

This is **behavior-preserving** at every call site (each call gets a fresh object, the intended semantics) and removes the shared-state footgun. Most of the 180 sites are latent (the default is read-only today) — preventive hygiene there — but the registry sites above are an active cross-instance bug. **B006 is now enabled** so new occurrences fail CI.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the touched unit tests locally
- [x] My PR's scope is as isolated as possible; it solves exactly one problem (the B006 mutable-default class), purely mechanical + lint-enforced
- [ ] I have requested a Greptile review

## Notes

- 79 source files changed; every change is the same `None`-guard transform. `black --check` (26.3.1) and `ruff check .` are clean with B006 enabled; `import litellm` and the touched unit tests pass.