### PR TITLE
fix(responses): route and translate managed code_interpreter container ids on /v1/responses

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -655,6 +655,42 @@ def _decode_vector_store_ids_in_tools(
     return updated_tools
 
 
+def _decode_container_ids_in_tools(
+    tools: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Decode managed code_interpreter container ids to their native provider ids.
+
+    A LiteLLM-managed container id (``cntr_...``) encodes provider/model_id/native-id
+    so it can round-trip through the proxy for routing. Before the request reaches the
+    upstream provider the managed id must be translated back to the native id, otherwise
+    the provider rejects it (e.g. Azure caps ``tools[].container`` at 64 chars and 400s
+    on the ~237-char managed id). Routing to the owning deployment is handled separately
+    by DeploymentAffinityCheck; this only rewrites the wire value.
+
+    No-ops on the object container form (provision-new) and on non-managed strings:
+    ``decode_container_id_to_original`` returns the input unchanged when it isn't managed.
+    """
+    from litellm.responses.utils import ResponsesAPIRequestUtils
+
+    updated_tools: List[Dict[str, Any]] = []
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "code_interpreter":
+            updated_tools.append(tool)
+            continue
+        container = tool.get("container")
+        if not isinstance(container, str):
+            updated_tools.append(tool)
+            continue
+        native_id = ResponsesAPIRequestUtils.decode_container_id_to_original(container)
+        if native_id != container:
+            updated_tool = tool.copy()
+            updated_tool["container"] = native_id
+            updated_tools.append(updated_tool)
+        else:
+            updated_tools.append(tool)
+    return updated_tools
+
+
 def update_responses_tools_with_model_file_ids(
     tools: Optional[List[Dict[str, Any]]],
     model_id: Optional[str] = None,
@@ -677,6 +713,9 @@ def update_responses_tools_with_model_file_ids(
 
     # Pass 1: decode unified vector_store_ids (no mapping needed)
     tools = _decode_vector_store_ids_in_tools(tools) or tools
+    # Pass 1b: decode managed code_interpreter container ids to native provider ids
+    # (no mapping needed; must run before the Pass 2 mapping gate returns early)
+    tools = _decode_container_ids_in_tools(tools) or tools
 
     # Pass 2: map code_interpreter file IDs (requires mapping)
     if not model_file_id_mapping or not model_id:

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -656,8 +656,8 @@ def _decode_vector_store_ids_in_tools(
 
 
 def _decode_container_ids_in_tools(
-    tools: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
+    tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     """Decode managed code_interpreter container ids to their native provider ids.
 
     A LiteLLM-managed container id (``cntr_...``) encodes provider/model_id/native-id
@@ -672,7 +672,7 @@ def _decode_container_ids_in_tools(
     """
     from litellm.responses.utils import ResponsesAPIRequestUtils
 
-    updated_tools: List[Dict[str, Any]] = []
+    updated_tools: list[dict[str, Any]] = []
     for tool in tools:
         if not isinstance(tool, dict) or tool.get("type") != "code_interpreter":
             updated_tools.append(tool)

--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -298,6 +298,47 @@ class DeploymentAffinityCheck(CustomLogger):
                 return deployment
         return None
 
+    def _find_deployment_by_container_id(
+        self,
+        request_kwargs: dict,
+        healthy_deployments: List[dict],
+    ) -> Optional[List[dict]]:
+        """Pin to the deployment that owns a managed code_interpreter container.
+
+        A LiteLLM-managed container id (cntr_...) in tools[].container encodes the
+        owning deployment's model_id. Returns [deployment] so the follow-up
+        /v1/responses call routes to it instead of load-balancing by model name
+        (Azure containers are region-local). Returns None when no managed container
+        id is present. Non-str container values (e.g. {"type": "auto"}) carry no
+        model_id and are skipped.
+        """
+        tools = request_kwargs.get("tools")
+        if not isinstance(tools, list):
+            return None
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            if tool.get("type") != "code_interpreter":
+                continue
+            container = tool.get("container")
+            if not isinstance(container, str):
+                continue
+            decoded = ResponsesAPIRequestUtils._decode_container_id(container)
+            container_model_id = decoded.get("model_id")
+            if container_model_id is None:
+                continue
+            deployment = self._find_deployment_by_model_id(
+                healthy_deployments=healthy_deployments,
+                model_id=container_model_id,
+            )
+            if deployment is not None:
+                verbose_router_logger.debug(
+                    "DeploymentAffinityCheck: code_interpreter container pinning -> deployment=%s",
+                    container_model_id,
+                )
+                return [deployment]
+        return None
+
     async def async_filter_deployments(
         self,
         model: str,
@@ -341,44 +382,18 @@ class DeploymentAffinityCheck(CustomLogger):
                         )
                         return [deployment]
             # 1b) code_interpreter container affinity (Responses API create calls).
-            # A LiteLLM-managed container id (cntr_...) encodes the owning
-            # deployment's model_id. Reusing it in tools[].container must pin
-            # routing to that deployment, otherwise the call load-balances by
-            # model name and lands on a deployment that doesn't own the
-            # container (Azure containers are region-local -> 404). Lower
-            # priority than previous_response_id, which stays authoritative
-            # while its owning deployment is healthy.
-            # Reached when previous_response_id is absent, or when its owning
-            # deployment is unhealthy and the branch above fell through. Pinning
-            # to the container's deployment here is intentional -- the next-best
-            # routing signal, better than routing blindly by model name.
-            tools = request_kwargs.get("tools")
-            if isinstance(tools, list):
-                for tool in tools:
-                    if not isinstance(tool, dict):
-                        continue
-                    if tool.get("type") != "code_interpreter":
-                        continue
-                    # container is either a managed id string (cntr_...) or an
-                    # object for provisioning a new container ({"type": "auto"}),
-                    # which carries no model_id to pin -> skip non-str values.
-                    container = tool.get("container")
-                    if not isinstance(container, str):
-                        continue
-                    decoded = ResponsesAPIRequestUtils._decode_container_id(container)
-                    container_model_id = decoded.get("model_id")
-                    if container_model_id is None:
-                        continue
-                    deployment = self._find_deployment_by_model_id(
-                        healthy_deployments=typed_healthy_deployments,
-                        model_id=container_model_id,
-                    )
-                    if deployment is not None:
-                        verbose_router_logger.debug(
-                            "DeploymentAffinityCheck: code_interpreter container pinning -> deployment=%s",
-                            container_model_id,
-                        )
-                        return [deployment]
+            # A managed container id in tools[].container encodes the owning
+            # deployment's model_id; pin to it. Reached when previous_response_id
+            # is absent, or when its deployment is unhealthy and the branch above
+            # fell through -- the container id is the next-best routing signal,
+            # better than load-balancing by model name. Lower priority than
+            # previous_response_id, which stays authoritative while healthy.
+            container_pin = self._find_deployment_by_container_id(
+                request_kwargs=request_kwargs,
+                healthy_deployments=typed_healthy_deployments,
+            )
+            if container_pin is not None:
+                return container_pin
 
         stable_model_map_key = self._get_stable_model_map_key_from_deployments(
             healthy_deployments=typed_healthy_deployments

--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -340,6 +340,40 @@ class DeploymentAffinityCheck(CustomLogger):
                             responses_model_id,
                         )
                         return [deployment]
+            # 1b) code_interpreter container affinity (Responses API create calls).
+            # A LiteLLM-managed container id (cntr_...) encodes the owning
+            # deployment's model_id. Reusing it in tools[].container must pin
+            # routing to that deployment, otherwise the call load-balances by
+            # model name and lands on a deployment that doesn't own the
+            # container (Azure containers are region-local -> 404). Lower
+            # priority than previous_response_id, which stays authoritative.
+            tools = request_kwargs.get("tools")
+            if isinstance(tools, list):
+                for tool in tools:
+                    if not isinstance(tool, dict):
+                        continue
+                    if tool.get("type") != "code_interpreter":
+                        continue
+                    # container is either a managed id string (cntr_...) or an
+                    # object for provisioning a new container ({"type": "auto"}),
+                    # which carries no model_id to pin -> skip non-str values.
+                    container = tool.get("container")
+                    if not isinstance(container, str):
+                        continue
+                    decoded = ResponsesAPIRequestUtils._decode_container_id(container)
+                    container_model_id = decoded.get("model_id")
+                    if container_model_id is None:
+                        continue
+                    deployment = self._find_deployment_by_model_id(
+                        healthy_deployments=typed_healthy_deployments,
+                        model_id=container_model_id,
+                    )
+                    if deployment is not None:
+                        verbose_router_logger.debug(
+                            "DeploymentAffinityCheck: code_interpreter container pinning -> deployment=%s",
+                            container_model_id,
+                        )
+                        return [deployment]
 
         stable_model_map_key = self._get_stable_model_map_key_from_deployments(
             healthy_deployments=typed_healthy_deployments

--- a/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
+++ b/litellm/router_utils/pre_call_checks/deployment_affinity_check.py
@@ -346,7 +346,12 @@ class DeploymentAffinityCheck(CustomLogger):
             # routing to that deployment, otherwise the call load-balances by
             # model name and lands on a deployment that doesn't own the
             # container (Azure containers are region-local -> 404). Lower
-            # priority than previous_response_id, which stays authoritative.
+            # priority than previous_response_id, which stays authoritative
+            # while its owning deployment is healthy.
+            # Reached when previous_response_id is absent, or when its owning
+            # deployment is unhealthy and the branch above fell through. Pinning
+            # to the container's deployment here is intentional -- the next-best
+            # routing signal, better than routing blindly by model name.
             tools = request_kwargs.get("tools")
             if isinstance(tools, list):
                 for tool in tools:

--- a/tests/test_litellm/llms/test_file_search_responses.py
+++ b/tests/test_litellm/llms/test_file_search_responses.py
@@ -162,6 +162,48 @@ class TestUpdateResponsesToolsWithModelFileIds:
         assert result[0]["vector_store_ids"] == ["vs_decoded"]
         assert result[1]["container"]["file_ids"] == ["provider_file_xyz"]
 
+    def test_B4_managed_container_string_decoded_to_native(self):
+        """Pass 1b: a managed cntr_ string is rewritten to the native id (no mapping needed)."""
+        from litellm.responses.utils import ResponsesAPIRequestUtils
+
+        native = "cntr_nativehex0123456789abcdef0123456789abcdef"
+        composite = ResponsesAPIRequestUtils._build_container_id(
+            custom_llm_provider="azure",
+            model_id="dep-42",
+            container_id=native,
+        )
+        assert composite != native  # managed form is longer / encoded
+        tools = [{"type": "code_interpreter", "container": composite}]
+        result = update_responses_tools_with_model_file_ids(
+            tools=tools,
+            model_id=None,
+            model_file_id_mapping=None,
+        )
+        assert result is not None
+        assert result[0]["container"] == native
+
+    def test_B5_container_object_form_untouched(self):
+        """The provision-new object container ({'type': 'auto'}) carries no id and is left as-is."""
+        tools = [{"type": "code_interpreter", "container": {"type": "auto"}}]
+        result = update_responses_tools_with_model_file_ids(
+            tools=tools,
+            model_id=None,
+            model_file_id_mapping=None,
+        )
+        assert result is not None
+        assert result[0]["container"] == {"type": "auto"}
+
+    def test_B6_non_managed_container_string_passes_through(self):
+        """A bare native id (not LiteLLM-managed) is forwarded unchanged."""
+        tools = [{"type": "code_interpreter", "container": "cntr_plainnative"}]
+        result = update_responses_tools_with_model_file_ids(
+            tools=tools,
+            model_id=None,
+            model_file_id_mapping=None,
+        )
+        assert result is not None
+        assert result[0]["container"] == "cntr_plainnative"
+
 
 # ---------------------------------------------------------------------------
 # C/D-series: supports_native_file_search

--- a/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
@@ -11,6 +11,7 @@ import json
 
 import litellm
 from litellm.caching.dual_cache import DualCache
+from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
     DeploymentAffinityCheck,
 )
@@ -967,3 +968,136 @@ async def test_model_group_affinity_config_overrides_global():
     )
     # All deployments returned (user-key affinity disabled for this group)
     assert len(filtered) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_code_interpreter_container_pins_to_owning_deployment():
+    """
+    Reusing a LiteLLM-issued code_interpreter container id in tools[].container
+    on a follow-up /v1/responses call must pin routing to the deployment that
+    owns the container, overriding user-key affinity -- mirroring
+    previous_response_id pinning. Regression test for #30781.
+    """
+    mock_response_data = {
+        "id": "resp_mock-resp-789",
+        "object": "response",
+        "created_at": 1741476542,
+        "status": "completed",
+        "model": "azure/computer-use-preview",
+        "output": [
+            {
+                "type": "code_interpreter_call",
+                "id": "ci_123",
+                "status": "completed",
+                "container_id": "cntr_rawnativeid123456789",
+                "code": "print('hi')",
+            }
+        ],
+        "parallel_tool_calls": True,
+        "usage": {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "total_tokens": 30,
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+        "text": {"format": {"type": "text"}},
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "metadata": {},
+        "temperature": 1.0,
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": 1.0,
+        "max_output_tokens": None,
+        "previous_response_id": None,
+        "reasoning": {"effort": None, "summary": None},
+        "truncation": "disabled",
+        "user": None,
+    }
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "azure-computer-use-preview",
+                "litellm_params": {
+                    "model": "azure/computer-use-preview-1",
+                    "api_key": "mock-api-key-1",
+                    "api_version": "mock-api-version",
+                    "api_base": "https://mock-endpoint-1.openai.azure.com",
+                },
+                "model_info": {"base_model": "computer-use-preview"},
+            },
+            {
+                "model_name": "azure-computer-use-preview",
+                "litellm_params": {
+                    "model": "azure/computer-use-preview-2",
+                    "api_key": "mock-api-key-2",
+                    "api_version": "mock-api-version-2",
+                    "api_base": "https://mock-endpoint-2.openai.azure.com",
+                },
+                "model_info": {"base_model": "computer-use-preview"},
+            },
+        ],
+        optional_pre_call_checks=[
+            "deployment_affinity",
+            "responses_api_deployment_check",
+        ],
+    )
+
+    model_group = "azure-computer-use-preview"
+    user_api_key_hash = "test-user-key-1"
+
+    with (
+        patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post,
+        patch(
+            "litellm.router_strategy.simple_shuffle.random.choice",
+            side_effect=lambda seq: seq[0],
+        ),
+    ):
+        mock_post.return_value = MockResponse(mock_response_data, 200)
+
+        first_response = await router.aresponses(
+            model=model_group,
+            input="Run some code.",
+            truncation="auto",
+            tools=[{"type": "code_interpreter", "container": {"type": "auto"}}],
+            litellm_metadata={"user_api_key_hash": user_api_key_hash},
+        )
+        first_model_id = first_response._hidden_params["model_id"]
+
+        encoded_container_ids = (
+            ResponsesAPIRequestUtils.collect_container_ids_from_responses_response(
+                first_response
+            )
+        )
+        assert len(encoded_container_ids) == 1
+        encoded_container_id = encoded_container_ids[0]
+        # the managed id must encode routing payload (not the raw native id)
+        assert encoded_container_id != "cntr_rawnativeid123456789"
+
+        all_model_ids = router.get_model_ids(model_name=model_group)
+        other_model_id = next(mid for mid in all_model_ids if mid != first_model_id)
+
+        # Force user-key affinity to point to the OTHER deployment.
+        affinity_cache_key = DeploymentAffinityCheck.get_affinity_cache_key(
+            model_group=model_group,
+            user_key=user_api_key_hash,
+        )
+        await router.cache.async_set_cache(
+            affinity_cache_key, {"model_id": other_model_id}, ttl=3600
+        )
+
+        # Reusing the container id must pin back to the owning deployment,
+        # overriding user-key affinity.
+        follow_up = await router.aresponses(
+            model=model_group,
+            input="Run more code.",
+            truncation="auto",
+            tools=[{"type": "code_interpreter", "container": encoded_container_id}],
+            litellm_metadata={"user_api_key_hash": user_api_key_hash},
+        )
+        assert follow_up._hidden_params["model_id"] == first_model_id

--- a/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_deployment_affinity_check.py
@@ -1068,14 +1068,29 @@ async def test_async_code_interpreter_container_pins_to_owning_deployment():
             litellm_metadata={"user_api_key_hash": user_api_key_hash},
         )
         first_model_id = first_response._hidden_params["model_id"]
-
-        encoded_container_ids = (
-            ResponsesAPIRequestUtils.collect_container_ids_from_responses_response(
-                first_response
-            )
+        # Extract the encoded container id from the first response's output.
+        # (collect_container_ids_from_responses_response postdates this base
+        # branch, so read the code_interpreter_call item directly.)
+        output = (
+            first_response.output
+            if not isinstance(first_response, dict)
+            else first_response.get("output", [])
         )
-        assert len(encoded_container_ids) == 1
-        encoded_container_id = encoded_container_ids[0]
+        encoded_container_id = None
+        for item in output or []:
+            item_type = (
+                item.get("type")
+                if isinstance(item, dict)
+                else getattr(item, "type", None)
+            )
+            if item_type == "code_interpreter_call":
+                encoded_container_id = (
+                    item.get("container_id")
+                    if isinstance(item, dict)
+                    else getattr(item, "container_id", None)
+                )
+                break
+        assert encoded_container_id is not None
         # the managed id must encode routing payload (not the raw native id)
         assert encoded_container_id != "cntr_rawnativeid123456789"
 


### PR DESCRIPTION
Supersedes #30936 — recreated on `litellm_oss_branch` to drop unrelated base-branch merge noise. Same change, 4 files.

## What
Reusing a LiteLLM-issued `code_interpreter` container id in `tools[].container` on a follow-up `/v1/responses` call currently fails two ways:

1. **400 `string_above_max_length`**. The composite managed id (`cntr_` + base64 payload, ~237 chars) is forwarded to the provider verbatim. Azure caps `tools[].container` at 64 chars and rejects it.
2. **404 `Container not found`**. If the caller strips it to the native id to dodge (1), the id carries no routing payload, so the call load-balances by model name and lands on a deployment that doesn't own the container (Azure containers are region-local).

So a container LiteLLM hands back from one `/v1/responses` call can't be reliably reused on the next.

Fixes #30781.

## Why this shape
The managed-id decode plus model_id routing already exists for container ids in the URL path (`/v1/containers/{id}/...`, added in #27921 via `_init_containers_api_endpoints`). It was never applied to a container id embedded in a `/v1/responses` request body. This PR extends the same pattern to the body case, split across the two layers where each concern already lives:

- **Routing (404):** `DeploymentAffinityCheck.async_filter_deployments` adds a branch that decodes the container id in `tools[].container` and pins to the encoded deployment, mirroring the existing `previous_response_id` affinity. Lower priority than `previous_response_id`, which stays authoritative while its deployment is healthy.
- **Translation (400):** `update_responses_tools_with_model_file_ids` decodes managed container strings to the native provider id. Placed in the always-runs pass, before the file-mapping gate returns early, so it fires even without a file mapping. No-ops on the object container form (`{"type": "auto"}`) and on non-managed strings.

## Tests
- `test_async_code_interpreter_container_pins_to_owning_deployment`. End-to-end through the Router: provisions a container, forces user-key affinity to the other deployment, asserts the follow-up pins back to the owning deployment via the container id.
- `test_B4/B5/B6` in `test_file_search_responses.py`. Translation through the public entry point: managed id to native, object form passthrough, non-managed passthrough.

## Known limitation
The routing half is verified with a mocked Router (no live Azure). I don't have a multi-deployment Azure setup to run the original repro end to end against a real provider, so the live round-trip is covered by the mocked test rather than an integration test.
