### PR TITLE
fix(bedrock): detect Nova 2 models on all cross-region inference profiles

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -77,6 +77,7 @@ from ..common_utils import (
     BedrockError,
     BedrockModelInfo,
     get_anthropic_beta_from_headers,
+    get_bedrock_cross_region_inference_regions,
     get_bedrock_tool_name,
     is_claude_4_5_on_bedrock,
     normalize_bedrock_opus_output_config_effort,
@@ -321,10 +322,10 @@ class AmazonConverseConfig(BaseConfig):
                 model_without_region = model_without_region[len(routing_prefix) :]
                 break
 
-        # Remove regional prefix if present (us., eu., apac.)
-        for prefix in ["us.", "eu.", "apac."]:
-            if model_without_region.startswith(prefix):
-                model_without_region = model_without_region[len(prefix) :]
+        # Remove cross-region inference prefix if present (us., eu., apac., global., jp., ...)
+        for region in get_bedrock_cross_region_inference_regions():
+            if model_without_region.startswith(f"{region}."):
+                model_without_region = model_without_region[len(region) + 1 :]
                 break
 
         # Check if the model is a Nova 2 model (matches nova-2-lite, nova-2-pro, etc.)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation_nova_2.py
@@ -222,6 +222,24 @@ class TestNova2ParameterMapping:
         assert result["reasoningConfig"]["type"] == "enabled"
         assert result["reasoningConfig"]["maxReasoningEffort"] == "high"
 
+    @pytest.mark.parametrize("region", ["global", "jp", "au", "us-gov"])
+    def test_nova_2_cross_region_variant_mapping(self, region):
+        """Cross-region inference profiles beyond us/eu/apac must still map reasoning_effort to reasoningConfig."""
+        config = AmazonConverseConfig()
+
+        model = f"{region}.amazon.nova-2-lite-v1:0"
+        result = config.map_openai_params(
+            non_default_params={"reasoning_effort": "high"},
+            optional_params={},
+            model=model,
+            drop_params=False,
+        )
+
+        assert "reasoningConfig" in result
+        assert result["reasoningConfig"]["type"] == "enabled"
+        assert result["reasoningConfig"]["maxReasoningEffort"] == "high"
+        assert "thinking" not in result
+
     def test_nova_2_with_other_params(self):
         """Test that Nova 2 reasoning works alongside other parameters."""
         config = AmazonConverseConfig()
@@ -306,6 +324,17 @@ class TestNova15SupportedParameters:
         assert "reasoning_effort" in supported_params
 
         # Verify thinking is NOT in supported params
+        assert "thinking" not in supported_params
+
+    @pytest.mark.parametrize("region", ["global", "jp", "au", "us-gov"])
+    def test_nova_2_cross_region_variant_supported_params(self, region):
+        """Cross-region inference profiles beyond us/eu/apac must still report reasoning_effort, not thinking."""
+        config = AmazonConverseConfig()
+
+        model = f"{region}.amazon.nova-2-lite-v1:0"
+        supported_params = config.get_supported_openai_params(model)
+
+        assert "reasoning_effort" in supported_params
         assert "thinking" not in supported_params
 
     def test_nova_2_has_standard_params(self):


### PR DESCRIPTION
## Relevant issues

Related to the cross-region inference profile handling discussed in #30768 and #30725; this fixes a separate Nova 2 detection gap on those same prefixes.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## What's the bug

`AmazonConverseConfig._is_nova_2_model` strips the cross-region inference prefix from the model id before checking for the `amazon.nova-2-` family, but it only stripped `us.`, `eu.`, and `apac.`. AWS Bedrock cross-region inference profiles also include `global.`, `jp.`, `au.`, and `us-gov.`, and the rest of the Bedrock code already knows about them through `get_bedrock_cross_region_inference_regions`.

Because of the missing prefixes, a Nova 2 model invoked through, say, a `global.` profile was not recognized as Nova 2. Three things then went wrong for that request: `reasoning_effort` was mapped to Anthropic's `thinking` block instead of Nova's `reasoningConfig`, `reasoning_effort` handling diverged in the supported-params path, and the wrong token-budgeting branch ran.

## The fix

Strip the prefix using `get_bedrock_cross_region_inference_regions`, the single source of truth the rest of the Bedrock provider already uses, so detection stays correct for every cross-region profile and keeps working as AWS adds regions.

## Screenshots / Proof of Fix

This is a request-transformation bug, so the faithful artifact is the Bedrock request body LiteLLM builds. The environment here has no Bedrock credentials for a global/jp/au Nova 2 deployment, so the proof below drives the converse transformation directly for `global.amazon.nova-2-lite-v1:0` with `reasoning_effort: high`; the mapped params are exactly what gets sent to Bedrock.

Before (on `litellm_internal_staging`):

```
model: global.amazon.nova-2-lite-v1:0
is_nova_2: False
mapped params: {'thinking': {'type': 'enabled', 'budget_tokens': 4096}, 'maxTokens': 8192}
```

The `thinking` block is Anthropic-shaped and is not valid for Nova; Bedrock either rejects it or silently drops the reasoning request.

After (this branch):

```
model: global.amazon.nova-2-lite-v1:0
is_nova_2: True
mapped params: {'reasoningConfig': {'type': 'enabled', 'maxReasoningEffort': 'high'}}
```

For anyone with a Nova 2 cross-region deployment, the same can be observed end to end by pointing a model at `bedrock/global.amazon.nova-2-lite-v1:0`, sending a request with `reasoning_effort`, and confirming the outgoing Bedrock body carries `reasoningConfig` rather than `thinking`:

```bash
curl -s -X POST "http://localhost:4000/v1/chat/completions" \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/global.amazon.nova-2-lite-v1:0",
    "messages": [{"role": "user", "content": "Give me 5 k8s image security best practices"}],
    "reasoning_effort": "high"
  }'
```

The new tests in `test_converse_transformation_nova_2.py` cover `global`, `jp`, `au`, and `us-gov` for both the parameter mapping and the supported-params paths; they fail on `litellm_internal_staging` and pass here.

## Type

🐛 Bug Fix

## Changes

`_is_nova_2_model` now derives the cross-region prefixes from `get_bedrock_cross_region_inference_regions` instead of a hardcoded `us./eu./apac.` list, and parametrized regression tests cover the previously-missing profiles
