### PR TITLE
fix(websearch_interception): retarget tool_choice when renaming web_search tool

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -49,6 +49,56 @@ WEBSEARCH_EMIT_NATIVE_BLOCKS_KEY = "_websearch_interception_emit_native_blocks"
 WEBSEARCH_NATIVE_BLOCKS_METADATA_KEY = "websearch_native_blocks"
 
 
+def _referenceable_tool_names(tool: Dict[str, Any]) -> set:
+    """Names a ``tool_choice`` could use to force ``tool``.
+
+    A forced ``tool_choice`` references a tool by its ``name`` (Anthropic
+    format) or ``function.name`` (OpenAI format). We collect both so the
+    caller can tell whether a forced choice pointed at this specific tool.
+    """
+    names = set()
+    name = tool.get("name")
+    if isinstance(name, str):
+        names.add(name)
+    fn = tool.get("function")
+    if isinstance(fn, dict):
+        fn_name = fn.get("name")
+        if isinstance(fn_name, str):
+            names.add(fn_name)
+    return names
+
+
+def _retarget_tool_choice(
+    tool_choice: Any, renamed_tool_names: set
+) -> Any:
+    """Point a forced ``tool_choice`` at the renamed web-search tool.
+
+    When web-search tools are renamed to ``litellm_web_search``, a
+    ``tool_choice`` that forced one of them by its original name would
+    otherwise dangle and the backend rejects the request with
+    "Tool '<name>' not found in provided tools".
+
+    Only a forced choice whose name is in ``renamed_tool_names`` is
+    retargeted; choices for other tools (e.g. a forced ``calculator`` in a
+    request that also happens to include web search) are left untouched.
+    Handles both Anthropic ``{"type":"tool","name":...}`` and OpenAI
+    ``{"type":"function","function":{"name":...}}`` shapes.
+    """
+    if not isinstance(tool_choice, dict) or not renamed_tool_names:
+        return tool_choice
+
+    result = tool_choice
+    if result.get("name") in renamed_tool_names:
+        result = {**result, "name": LITELLM_WEB_SEARCH_TOOL_NAME}
+    fn = result.get("function")
+    if isinstance(fn, dict) and fn.get("name") in renamed_tool_names:
+        result = {
+            **result,
+            "function": {**fn, "name": LITELLM_WEB_SEARCH_TOOL_NAME},
+        }
+    return result
+
+
 class WebSearchInterceptionLogger(CustomLogger):
     """
     CustomLogger that intercepts WebSearch tool calls for models that don't
@@ -275,8 +325,13 @@ class WebSearchInterceptionLogger(CustomLogger):
 
         # Convert native/custom web_search tools to LiteLLM standard
         converted_tools = []
+        renamed_tool_names = set()
         for tool in tools:
             if is_web_search_tool(tool):
+                # Record the original name(s) this tool was referenceable by, so
+                # a forced tool_choice pointing at it can be retargeted below
+                # without affecting unrelated tools (e.g. a forced "calculator").
+                renamed_tool_names.update(_referenceable_tool_names(tool))
                 # Convert to LiteLLM standard web search tool
                 converted_tool = get_litellm_web_search_tool_openai()
                 converted_tools.append(converted_tool)
@@ -289,6 +344,15 @@ class WebSearchInterceptionLogger(CustomLogger):
                 converted_tools.append(tool)
 
         kwargs["tools"] = converted_tools
+
+        # Retarget a forced tool_choice (e.g. Claude Code's dedicated search
+        # sub-request sends tool_choice={"type":"tool","name":"web_search"}) to
+        # the renamed tool, else the backend rejects with "Tool 'web_search'
+        # not found in provided tools". Only retarget when the forced name was
+        # one of the web-search tools we just renamed — never a different tool.
+        kwargs["tool_choice"] = _retarget_tool_choice(
+            kwargs.get("tool_choice"), renamed_tool_names
+        )
 
         if kwargs.get("stream"):
             verbose_logger.debug(
@@ -406,8 +470,10 @@ class WebSearchInterceptionLogger(CustomLogger):
 
         # Convert native web search tools to LiteLLM standard
         converted_tools = []
+        renamed_tool_names = set()
         for tool in tools:
             if is_web_search_tool(tool):
+                renamed_tool_names.update(_referenceable_tool_names(tool))
                 standard_tool = get_litellm_web_search_tool()
                 converted_tools.append(standard_tool)
                 verbose_logger.debug(
@@ -420,6 +486,15 @@ class WebSearchInterceptionLogger(CustomLogger):
         kwargs["tools"] = converted_tools
         verbose_logger.debug(
             f"WebSearchInterception: Tools after conversion: {[t.get('name') for t in converted_tools]}"
+        )
+
+        # Retarget a forced tool_choice (e.g. Claude Code's dedicated search
+        # sub-request sends tool_choice={"type":"tool","name":"web_search"}) to
+        # the renamed tool, else the backend rejects with "Tool 'web_search'
+        # not found in provided tools". Only retarget when the forced name was
+        # one of the web-search tools we just renamed — never a different tool.
+        kwargs["tool_choice"] = _retarget_tool_choice(
+            kwargs.get("tool_choice"), renamed_tool_names
         )
 
         # Also convert here for direct callers that bypass the deployment hook.

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py
@@ -380,3 +380,170 @@ async def test_deployment_hook_converts_stream_and_logging_obj_syncs():
         logging_obj.stream = _hook_stream
 
     assert logging_obj.stream is False
+
+
+@pytest.mark.asyncio
+async def test_deployment_hook_retargets_anthropic_forced_tool_choice():
+    """Regression test: when the native web_search tool is renamed to
+    litellm_web_search, an Anthropic-format forced tool_choice
+    ({"type":"tool","name":"web_search"}) must be retargeted to the renamed
+    tool. Otherwise the backend rejects with "Tool 'web_search' not found in
+    provided tools" (e.g. Claude Code's dedicated web-search sub-request via
+    Bedrock).
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    kwargs = {
+        "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "messages": [{"role": "user", "content": "Search the web for LiteLLM"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+        ],
+        "tool_choice": {"type": "tool", "name": "web_search"},
+        "custom_llm_provider": "bedrock",
+        "api_key": "fake-key",
+    }
+
+    result = await logger.async_pre_call_deployment_hook(kwargs=kwargs, call_type=None)
+
+    assert result is not None
+    assert result["tool_choice"] == {"type": "tool", "name": "litellm_web_search"}
+
+
+@pytest.mark.asyncio
+async def test_deployment_hook_retargets_openai_forced_tool_choice():
+    """Regression test: OpenAI-format forced tool_choice
+    ({"type":"function","function":{"name":"web_search"}}) must also be
+    retargeted to the renamed tool.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["openai"])
+
+    kwargs = {
+        "model": "gpt-4o",
+        "messages": [{"role": "user", "content": "Search the web for LiteLLM"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"},
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "web_search"}},
+        "custom_llm_provider": "openai",
+        "api_key": "fake-key",
+    }
+
+    result = await logger.async_pre_call_deployment_hook(kwargs=kwargs, call_type=None)
+
+    assert result is not None
+    assert result["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "litellm_web_search"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_deployment_hook_leaves_non_forced_tool_choice_untouched():
+    """A string tool_choice ("auto"/"required") or one not naming the
+    web_search tool must be left untouched.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    kwargs = {
+        "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "messages": [{"role": "user", "content": "Search the web for LiteLLM"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"},
+        ],
+        "tool_choice": "auto",
+        "custom_llm_provider": "bedrock",
+    }
+
+    result = await logger.async_pre_call_deployment_hook(kwargs=kwargs, call_type=None)
+
+    assert result is not None
+    assert result["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_pre_request_hook_retargets_anthropic_forced_tool_choice():
+    """Regression test for the anthropic-format pre-request hook: a forced
+    tool_choice naming the original web_search tool must be retargeted to the
+    renamed litellm_web_search tool.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    kwargs = {
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
+        ],
+        "tool_choice": {"type": "tool", "name": "web_search"},
+        "litellm_params": {"custom_llm_provider": "bedrock"},
+    }
+
+    result = await logger.async_pre_request_hook(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=[{"role": "user", "content": "Search the web for LiteLLM"}],
+        kwargs=kwargs,
+    )
+
+    assert result is not None
+    assert result["tool_choice"] == {"type": "tool", "name": "litellm_web_search"}
+
+
+@pytest.mark.asyncio
+async def test_deployment_hook_preserves_forced_non_web_search_tool_choice():
+    """A request that mixes a web_search tool with another tool and forces
+    tool_choice to that *other* tool must NOT have its choice rewritten to
+    litellm_web_search — only the web_search tool is renamed.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    kwargs = {
+        "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"},
+            {
+                "type": "function",
+                "function": {"name": "calculator", "parameters": {}},
+            },
+        ],
+        "tool_choice": {"type": "tool", "name": "calculator"},
+        "custom_llm_provider": "bedrock",
+    }
+
+    result = await logger.async_pre_call_deployment_hook(kwargs=kwargs, call_type=None)
+
+    assert result is not None
+    # The forced calculator choice must be preserved untouched.
+    assert result["tool_choice"] == {"type": "tool", "name": "calculator"}
+
+
+@pytest.mark.asyncio
+async def test_pre_request_hook_preserves_forced_non_web_search_tool_choice():
+    """Same guard for the anthropic-format pre-request hook: forcing a
+    non-web-search tool in a request that also includes web search must be
+    left untouched.
+    """
+    logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+
+    kwargs = {
+        "tools": [
+            {"type": "web_search_20250305", "name": "web_search"},
+            {
+                "type": "function",
+                "function": {"name": "calculator", "parameters": {}},
+            },
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "calculator"}},
+        "litellm_params": {"custom_llm_provider": "bedrock"},
+    }
+
+    result = await logger.async_pre_request_hook(
+        model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        messages=[{"role": "user", "content": "What is 2 + 2?"}],
+        kwargs=kwargs,
+    )
+
+    assert result is not None
+    assert result["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "calculator"},
+    }


### PR DESCRIPTION
## Relevant issues

Fixes #30822

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## The bug

The WebSearch interception feature (`litellm/integrations/websearch_interception/handler.py`) intercepts a client's native `web_search` tool and renames it to `litellm_web_search` before forwarding to the backend LLM. However, it does not update the request's `tool_choice` when the client forces a specific tool by name.

Claude Code's dedicated web-search sub-request sends:

```json
{
  "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 8}],
  "tool_choice": {"type": "tool", "name": "web_search"}
}
```

The interception renames the tool in `tools` to `litellm_web_search` but leaves `tool_choice.name == "web_search"`. A backend that validates `tool_choice` (e.g. Bedrock) then rejects the request:

```
Tool 'web_search' not found in provided tools
```

This breaks Claude Code WebSearch (and any client that forces `tool_choice` on a web_search tool) when routed through litellm against a non-native-websearch backend.

## The fix

Both hooks that rename the tool (`async_pre_call_deployment_hook`, OpenAI-format path; and `async_pre_request_hook`, Anthropic-format path) now also retarget a forced `tool_choice` to the renamed tool name (`LITELLM_WEB_SEARCH_TOOL_NAME`). It handles both:

- Anthropic-format forced choice: `{"type": "tool", "name": "web_search"}`
- OpenAI-format forced choice: `{"type": "function", "function": {"name": "web_search"}}`

Retargeting only happens when the name is a non-None, non-`litellm_web_search` value (i.e. it was the original web_search tool being forced). All other keys in the `tool_choice` dict are preserved.

## Tests

Added regression tests in `tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py` covering: Anthropic-format retarget (deployment + pre-request hooks), OpenAI-format function retarget, and that a non-forced `tool_choice` (e.g. `"auto"`) is left untouched.

```
$ python -m pytest tests/test_litellm/integrations/websearch_interception/test_websearch_interception_handler.py -q
17 passed
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- `litellm/integrations/websearch_interception/handler.py`: retarget forced `tool_choice` to the renamed tool in both interception hooks (Anthropic + OpenAI formats).
- `tests/.../test_websearch_interception_handler.py`: add regression tests.
