### PR TITLE
fix(bedrock): surface modeled HTTP status for mid-stream error events so 5xx is retryable (#24608)

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -70,6 +70,7 @@ from ..base_aws_llm import BaseAWSLLM
 from ..common_utils import (
     BedrockError,
     ModelResponseIterator,
+    build_bedrock_stream_error,
     get_bedrock_response_stream_shape,
     get_bedrock_tool_name,
 )
@@ -1841,23 +1842,7 @@ class AWSEventStreamDecoder:
         parsed_response = self.parser.parse(response_dict, response_stream_shape)
 
         if response_dict["status_code"] != 200:
-            decoded_body = response_dict["body"].decode()
-            if isinstance(decoded_body, dict):
-                error_message = decoded_body.get("message")
-            elif isinstance(decoded_body, str):
-                error_message = decoded_body
-            else:
-                error_message = ""
-            exception_status = response_dict["headers"].get(":exception-type")
-            error_message = exception_status + " " + error_message
-            raise BedrockError(
-                status_code=response_dict["status_code"],
-                message=(
-                    json.dumps(error_message)
-                    if isinstance(error_message, dict)
-                    else error_message
-                ),
-            )
+            raise build_bedrock_stream_error(response_dict, response_stream_shape)
         if "chunk" in parsed_response:
             chunk = parsed_response.get("chunk")
             if not chunk:

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -1168,7 +1168,9 @@ def build_bedrock_stream_error(
     if exception_type is not None and response_stream_shape is not None:
         member = response_stream_shape.members.get(exception_type)
         if member is not None:
-            modeled_status = (member.metadata or {}).get("error", {}).get("httpStatusCode")
+            modeled_status = (
+                (member.metadata or {}).get("error", {}).get("httpStatusCode")
+            )
             if modeled_status is not None:
                 status_code = int(modeled_status)
 

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -7,9 +7,21 @@ Common utilities used across bedrock chat/embedding/image generation
 import functools
 import json
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    TypedDict,
+    Union,
+)
 
 if TYPE_CHECKING:
+    from botocore.model import Shape
+
     from litellm.types.llms.bedrock import BedrockCreateBatchRequest
 
 import httpx
@@ -1132,6 +1144,37 @@ def get_bedrock_response_stream_shape():
     return _load_bedrock_response_stream_shape()
 
 
+class BedrockEventStreamResponseDict(TypedDict):
+    status_code: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+def build_bedrock_stream_error(
+    response_dict: BedrockEventStreamResponseDict,
+    response_stream_shape: Shape | None,
+) -> BedrockError:
+    """Build a BedrockError for a non-200 event-stream error event.
+
+    botocore hard-codes HTTP 400 on every mid-stream error event, so the modeled
+    ResponseStream member's httpStatusCode is the real status. Resolve it from the
+    shape and fall back to the raw status when the type is not modeled.
+    """
+    exception_type = response_dict["headers"].get(":exception-type")
+    decoded_body = response_dict["body"].decode()
+    message = f"{exception_type} {decoded_body}" if exception_type else decoded_body
+
+    status_code = response_dict["status_code"]
+    if exception_type is not None and response_stream_shape is not None:
+        member = response_stream_shape.members.get(exception_type)
+        if member is not None:
+            modeled_status = (member.metadata or {}).get("error", {}).get("httpStatusCode")
+            if modeled_status is not None:
+                status_code = int(modeled_status)
+
+    return BedrockError(status_code=status_code, message=message)
+
+
 class BedrockEventStreamDecoderBase:
     """
     Base class for event stream decoding for Bedrock
@@ -1156,23 +1199,7 @@ class BedrockEventStreamDecoderBase:
         parsed_response = self.parser.parse(response_dict, response_stream_shape)
 
         if response_dict["status_code"] != 200:
-            decoded_body = response_dict["body"].decode()
-            if isinstance(decoded_body, dict):
-                error_message = decoded_body.get("message")
-            elif isinstance(decoded_body, str):
-                error_message = decoded_body
-            else:
-                error_message = ""
-            exception_status = response_dict["headers"].get(":exception-type")
-            error_message = exception_status + " " + error_message
-            raise BedrockError(
-                status_code=response_dict["status_code"],
-                message=(
-                    json.dumps(error_message)
-                    if isinstance(error_message, dict)
-                    else error_message
-                ),
-            )
+            raise build_bedrock_stream_error(response_dict, response_stream_shape)
         if "chunk" in parsed_response:
             chunk = parsed_response.get("chunk")
             if not chunk:

--- a/tests/llm_translation/test_bedrock_completion.py
+++ b/tests/llm_translation/test_bedrock_completion.py
@@ -2502,19 +2502,34 @@ async def test_bedrock_image_url_sync_client():
         mock_post.assert_called_once()
 
 
-def test_bedrock_error_handling_streaming():
+@pytest.mark.parametrize(
+    "exception_type, expected_status_code",
+    [
+        ("internalServerException", 500),
+        ("serviceUnavailableException", 503),
+        ("modelTimeoutException", 408),
+        ("modelStreamErrorException", 424),
+        ("validationException", 400),
+    ],
+)
+def test_bedrock_error_handling_streaming(exception_type, expected_status_code):
+    """Bedrock event-stream error events arrive with botocore's hard-coded
+    status_code=400; the decoder must surface the modeled HTTP status instead
+    (e.g. internalServerException -> 500). For 5xx this is what makes the error
+    retryable downstream; for all types it replaces the misleading 400 with the
+    true code. Regression for #24608."""
     from litellm.llms.bedrock.chat.invoke_handler import (
         AWSEventStreamDecoder,
         BedrockError,
     )
-    from unittest.mock import patch, Mock
+    from unittest.mock import Mock
 
     event = Mock()
     event.to_response_dict = Mock(
         return_value={
             "status_code": 400,
             "headers": {
-                ":exception-type": "serviceUnavailableException",
+                ":exception-type": exception_type,
                 ":content-type": "application/json",
                 ":message-type": "exception",
             },
@@ -2525,11 +2540,10 @@ def test_bedrock_error_handling_streaming():
     decoder = AWSEventStreamDecoder(
         model="bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
     )
-    with pytest.raises(Exception) as e:
+    with pytest.raises(BedrockError) as e:
         decoder._parse_message_from_event(event)
-    assert isinstance(e.value, BedrockError)
     assert "Bedrock is unable to process your request." in e.value.message
-    assert e.value.status_code == 400
+    assert e.value.status_code == expected_status_code
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -876,6 +876,114 @@ def test_sync_streaming_bad_request_not_midstream(logging_obj: Logging):
     assert "invalid maxOutputTokens" in str(excinfo.value)
 
 
+def _bedrock_error_event(exception_type: str):
+    """A mocked botocore event-stream error event: status_code is botocore's
+    hard-coded 400, with the real type in the :exception-type header."""
+    event = Mock()
+    event.to_response_dict = Mock(
+        return_value={
+            "status_code": 400,
+            "headers": {
+                ":exception-type": exception_type,
+                ":content-type": "application/json",
+                ":message-type": "exception",
+            },
+            "body": b'{"message":"Bedrock had an internal error."}',
+        }
+    )
+    return event
+
+
+@pytest.mark.asyncio
+async def test_bedrock_midstream_internal_server_error_wraps_for_fallback(
+    logging_obj: Logging,
+):
+    """End-to-end regression for https://github.com/BerriAI/litellm/issues/24608:
+    a Bedrock mid-stream internalServerException event (botocore stamps it 400)
+    must flow through the real decoder, gain its modeled 500 status, and wrap
+    into MidStreamFallbackError so the Router can run streaming fallback.
+
+    Calls the real AWSEventStreamDecoder, so reverting the decoder status fix
+    makes the decoder raise BedrockError(400) and the gate raises BadRequestError
+    directly -> this test fails without the fix."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
+
+    decoder = AWSEventStreamDecoder(model="anthropic.claude-3-sonnet-20240229-v1:0")
+
+    async def _bedrock_stream():
+        decoder._parse_message_from_event(
+            _bedrock_error_event("internalServerException")
+        )
+        yield  # unreachable; the line above raises
+
+    async def _make_call(**kwargs):
+        return _bedrock_stream()
+
+    response = CustomStreamWrapper(
+        completion_stream=None,
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        logging_obj=logging_obj,
+        custom_llm_provider="bedrock",
+        make_call=_make_call,
+    )
+
+    with pytest.raises(MidStreamFallbackError):
+        await response.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_5xx_wraps_for_midstream_fallback(logging_obj: Logging):
+    """Gate contract: a Bedrock 5xx (here 503 serviceUnavailableException) wraps
+    into MidStreamFallbackError so the Router can run streaming fallback."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.llms.bedrock.chat.invoke_handler import BedrockError
+
+    async def _raise_503(**kwargs):
+        raise BedrockError(
+            status_code=503,
+            message="serviceUnavailableException Bedrock is unavailable.",
+        )
+
+    response = CustomStreamWrapper(
+        completion_stream=None,
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        logging_obj=logging_obj,
+        custom_llm_provider="bedrock",
+        make_call=_raise_503,
+    )
+
+    with pytest.raises(MidStreamFallbackError):
+        await response.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_bedrock_validation_error_raises_directly(logging_obj: Logging):
+    """Gate contract: a Bedrock validationException (400) is a client error and
+    must surface directly, never wrapped into MidStreamFallbackError."""
+    from litellm.exceptions import MidStreamFallbackError
+    from litellm.llms.bedrock.chat.invoke_handler import BedrockError
+
+    async def _raise_400(**kwargs):
+        raise BedrockError(
+            status_code=400,
+            message="validationException malformed input.",
+        )
+
+    response = CustomStreamWrapper(
+        completion_stream=None,
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        logging_obj=logging_obj,
+        custom_llm_provider="bedrock",
+        make_call=_raise_400,
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        await response.__anext__()
+    assert not isinstance(excinfo.value, MidStreamFallbackError)
+    assert getattr(excinfo.value, "status_code", None) == 400
+
+
 @pytest.mark.asyncio
 async def test_async_streaming_read_timeout_triggers_midstream_fallback(
     logging_obj: Logging,


### PR DESCRIPTION
## Relevant issues

Fixes #24608

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Verified against real Bedrock (us-east-1, real tokens) on two proxies: one on the base commit (pre-fix, :4000) and one on this branch (post-fix, :4001), both pointed at the same config with a `bedrock-fault` model that falls back to a healthy `bedrock-healthy` model.

A genuine mid-stream `internalServerException` is not reproducible on real Bedrock on demand (it is a transient server-side fault), so the one error event AWS will not emit on cue was injected by a thin reverse proxy that otherwise relays real Bedrock stream frames. Everything else, including the fallback target's output, is real Bedrock.

Test 1 - PRE-FIX, mid-stream internalServerException -> non-retryable 400, fallback never fires, request dies:

<img width="1432" height="335" alt="Test1" src="https://github.com/user-attachments/assets/aaa4f171-3033-4c2e-9e72-50765aecf818" />

Test 2 - POST-FIX, identical request -> mapped to a retryable 503, the router falls back to the healthy model and the caller gets a real answer (HTTP 200):

<img width="1437" height="683" alt="Test2" src="https://github.com/user-attachments/assets/7db7d51b-9e3b-4d19-a360-f11629c2a962" />

Test 3 - POST-FIX, healthy model, no fault -> normal stream (HTTP 200), no regression:

<img width="1437" height="600" alt="Test3" src="https://github.com/user-attachments/assets/04e091a1-0846-42f5-9f00-81892e85e791" />

Test 4 - PRE-FIX, healthy model -> HTTP 200, confirming the 400 in Test 1 comes from the injected mid-stream error and not a broken setup:

<img width="1438" height="604" alt="Test4" src="https://github.com/user-attachments/assets/7cd90d66-99a7-47c4-a3ab-2c9dc9accff8" />

Log evidence E1 - the injector spliced the real mid-stream error event:

<img width="1436" height="267" alt="E1" src="https://github.com/user-attachments/assets/152d7b6d-9b78-4efa-9353-74ccdc0b35aa" />

Log evidence E2 - POST-FIX, the error became retryable and the router fell back: `MidStreamFallbackError` -> `ServiceUnavailableError`, then `Falling back to model_group = bedrock-healthy`, then `Successful fallback b/w models.`:

<img width="1435" height="665" alt="E2-1" src="https://github.com/user-attachments/assets/2b16b330-f76b-4c4f-b528-26ccafa990a3" />
<img width="1437" height="306" alt="E2-2" src="https://github.com/user-attachments/assets/c64290b0-8d3e-4ac7-92e7-8e2766126a1e" />


Log evidence E3 - PRE-FIX, the same event stayed a non-retryable 400 `BadRequestError` with no fallback:

<img width="1435" height="256" alt="E3" src="https://github.com/user-attachments/assets/38a1fd0f-88a5-43a7-acbb-d5f23215cbba" />

## Type

🐛 Bug Fix

## Changes

When AWS Bedrock returns an error mid-stream, botocore's event-stream protocol hard-codes HTTP 400 on the error event regardless of the real failure. LiteLLM's stream decoder then built its `BedrockError` from that 400, so a genuine `internalServerException` surfaced as a non-retryable `BadRequestError`. On the streaming path this is worse than a wrong label: `CustomStreamWrapper._handle_stream_fallback_error` inspects the original exception's status code and raises any non-429 4xx directly, so the router's streaming fallback never fired and the request hard-failed.

The fix resolves the real HTTP status at the decoder source. botocore's bundled `ResponseStream` shape already models each event-stream error member's status (`internalServerException` -> 500, `serviceUnavailableException` -> 503, `modelTimeoutException` -> 408, `modelStreamErrorException` -> 424, `validationException` -> 400), and the `:exception-type` header value is the member key, so the lookup is model-driven with no hard-coded table; it falls back to the raw status when a type is not modeled. With the corrected status, a 5xx mid-stream error is retryable, wraps into `MidStreamFallbackError`, and the router can fall back.

The status-building logic was duplicated byte-for-byte between the two streaming decoders this fix targets: `AWSEventStreamDecoder` in `invoke_handler.py` (chat invoke/converse) and `BedrockEventStreamDecoderBase` in `common_utils.py` (passthrough). They now share one helper, `build_bedrock_stream_error`, which also drops a pair of dead branches the old code carried (`response_dict["body"].decode()` always returns `str`, so the `isinstance(..., dict)` / `json.dumps` paths were unreachable) and removes a latent `TypeError` when the `:exception-type` header is absent.

The invoke-agent decoder carries a third copy of the same block, but its `_parse_message_from_event` wraps the body in a `try/except: return None` that swallows the raised error, so correcting the status there would not change that path's behavior. It is intentionally left untouched to keep this PR scoped to the streaming paths the issue is about.

Known limitation: `modelTimeoutException` (408) and `modelStreamErrorException` (424) now also carry their correct status, but they do not become retryable on the streaming path because the shared fallback gate treats every non-429 4xx as terminal. Changing that gate would affect every provider, not just Bedrock, so it is intentionally out of scope here. The reported error, `internalServerException` (500), is fully fixed.

Tests: a parametrized decoder unit test asserting the corrected per-type status (runs the real decoder, so it fails if the source fix is reverted), an end-to-end streaming test that feeds a status-400 `internalServerException` event through the real decoder and asserts the wrapper raises `MidStreamFallbackError` (also reverts-to-red), and two gate-contract guards pinning that a 5xx wraps for fallback while a 400 raises directly.

