### PR TITLE
fix(oci): report finish_reason="tool_calls" when the response carries tool calls

### DIFF
--- a/litellm/llms/oci/chat/cohere.py
+++ b/litellm/llms/oci/chat/cohere.py
@@ -375,6 +375,13 @@ def handle_cohere_stream_chunk(
         ]
 
     finish_reason = _normalize_oci_finish_reason(typed_chunk.finishReason)
+    # OpenAI semantics: the terminal chunk must report finish_reason="tool_calls"
+    # when tool calls were emitted — on this chunk or earlier in the stream. OCI
+    # Cohere's terminal finishReason is "COMPLETE" (normalized to "stop"), and the
+    # terminal chunk suppresses already-emitted tool calls, so rely on
+    # prior_tool_calls_emitted as well.
+    if finish_reason is not None and (tool_calls or prior_tool_calls_emitted):
+        finish_reason = "tool_calls"
 
     return ModelResponseStream(
         choices=[

--- a/litellm/llms/oci/chat/cohere.py
+++ b/litellm/llms/oci/chat/cohere.py
@@ -247,6 +247,13 @@ def handle_cohere_response(
             for i, tc in enumerate(cohere_response.chatResponse.toolCalls)
         ]
 
+    # Per OpenAI semantics a response carrying tool calls must report
+    # finish_reason="tool_calls". OCI's Cohere protocol has no TOOL_CALLS
+    # finishReason value (it returns "COMPLETE"), so _normalize_oci_finish_reason
+    # yields "stop"; override it when tool calls are present.
+    if tool_calls:
+        finish_reason = "tool_calls"
+
     content: Optional[str] = response_text if response_text else None
 
     # Only include ``tool_calls`` in the message dict when actually present.

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -377,6 +377,10 @@ def handle_generic_response(
     model_response.choices[0].finish_reason = _normalize_oci_finish_reason(  # type: ignore[union-attr,assignment]
         response_choice.finishReason
     )
+    # OpenAI semantics: a response carrying tool calls reports
+    # finish_reason="tool_calls" regardless of the provider's raw stop reason.
+    if message.tool_calls:
+        model_response.choices[0].finish_reason = "tool_calls"  # type: ignore[union-attr]
 
     oci_usage = completion_response.chatResponse.usage
     reasoning_tokens: Optional[int] = None

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -463,6 +463,9 @@ def handle_generic_stream_chunk(dict_chunk: dict) -> ModelResponseStream:
     finish_reason: Optional[str] = _normalize_oci_finish_reason(
         typed_chunk.finishReason
     )
+    # OpenAI semantics: a chunk carrying tool calls reports finish_reason="tool_calls".
+    if tool_calls:
+        finish_reason = "tool_calls"
 
     return ModelResponseStream(
         choices=[

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -463,8 +463,12 @@ def handle_generic_stream_chunk(dict_chunk: dict) -> ModelResponseStream:
     finish_reason: Optional[str] = _normalize_oci_finish_reason(
         typed_chunk.finishReason
     )
-    # OpenAI semantics: a chunk carrying tool calls reports finish_reason="tool_calls".
-    if tool_calls:
+    # OpenAI semantics: the terminal chunk reports finish_reason="tool_calls" when
+    # tool calls are present. Guard with `finish_reason is not None` so intermediate
+    # chunks (OCI streams tool calls progressively, with finishReason=null and
+    # toolCalls populated) keep finish_reason=None — a non-null value on a
+    # non-terminal chunk would signal premature stream termination to callers.
+    if finish_reason is not None and tool_calls:
         finish_reason = "tool_calls"
 
     return ModelResponseStream(

--- a/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_chat_transformation.py
@@ -700,7 +700,10 @@ class TestOCIChatConfig:
 
         choice = result.choices[0]
         assert isinstance(choice, litellm.Choices)
-        assert choice.finish_reason == "stop"
+        # The response carries tool calls, so finish_reason is normalized to
+        # "tool_calls" (OpenAI semantics) regardless of OCI's raw "stop" — matching
+        # the Cohere path (test_cohere_response_finish_reason_tool_call).
+        assert choice.finish_reason == "tool_calls"
 
         # Message and tool_calls assertions
         message = choice.message

--- a/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
@@ -145,3 +145,26 @@ def test_generic_stream_chunk_with_tool_calls_reports_tool_calls():
     }
     result = handle_generic_stream_chunk(chunk)
     assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_generic_stream_intermediate_chunk_keeps_finish_reason_none():
+    # OCI streams tool calls progressively: an intermediate chunk carries
+    # toolCalls but finishReason=null. finish_reason must stay None on a
+    # non-terminal chunk — emitting "tool_calls" here would signal premature
+    # stream termination to callers that stop on finish_reason is not None.
+    chunk = {
+        "finishReason": None,
+        "message": {
+            "toolCalls": [
+                {
+                    "id": "call_0",
+                    "type": "FUNCTION",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                }
+            ]
+        },
+        "index": 0,
+    }
+    result = handle_generic_stream_chunk(chunk)
+    assert result.choices[0].finish_reason is None

--- a/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
@@ -1,0 +1,96 @@
+import datetime
+
+import httpx
+
+from litellm import ModelResponse
+from litellm.llms.oci.chat.transformation import OCIChatConfig
+
+
+def _transform(model: str, body: dict) -> ModelResponse:
+    response = httpx.Response(
+        status_code=200, json=body, headers={"Content-Type": "application/json"}
+    )
+    return OCIChatConfig().transform_response(
+        model=model,
+        raw_response=response,
+        model_response=ModelResponse(),
+        logging_obj={},  # type: ignore
+        request_data={},
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        encoding={},
+    )
+
+
+def _cohere_body(with_tool_calls: bool) -> dict:
+    chat_response: dict = {
+        "apiFormat": "COHERE",
+        "text": "I will look up the weather in Tokyo.",
+        "finishReason": "COMPLETE",
+        "usage": {"promptTokens": 26, "completionTokens": 22, "totalTokens": 48},
+    }
+    if with_tool_calls:
+        chat_response["toolCalls"] = [
+            {"name": "get_weather", "parameters": {"location": "Tokyo"}}
+        ]
+    return {
+        "modelId": "cohere.command-latest",
+        "modelVersion": "1.0",
+        "chatResponse": chat_response,
+    }
+
+
+def _generic_body_with_tool_calls() -> dict:
+    created = (
+        datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+    return {
+        "modelId": "meta.llama-3.3-70b-instruct",
+        "modelVersion": "1.0",
+        "chatResponse": {
+            "apiFormat": "GENERIC",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "ASSISTANT",
+                        "content": [{"type": "TEXT", "text": "Calling a tool."}],
+                        "toolCalls": [
+                            {
+                                "id": "call_0",
+                                "type": "FUNCTION",
+                                "name": "get_weather",
+                                "arguments": '{"location": "Tokyo"}',
+                            }
+                        ],
+                    },
+                    # OCI GENERIC may report STOP even when tool calls are present.
+                    "finishReason": "STOP",
+                }
+            ],
+            "timeCreated": created,
+            "usage": {"promptTokens": 5, "completionTokens": 10, "totalTokens": 15},
+        },
+    }
+
+
+def test_cohere_tool_calls_report_finish_reason_tool_calls():
+    # OCI Cohere returns finishReason="COMPLETE" for tool calls; finish_reason
+    # must still be "tool_calls" when the message carries them.
+    result = _transform("cohere.command-latest", _cohere_body(with_tool_calls=True))
+    assert result.choices[0].message.tool_calls is not None
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_cohere_without_tool_calls_finish_reason_stop():
+    # Sanity: a plain COMPLETE response still maps to "stop".
+    result = _transform("cohere.command-latest", _cohere_body(with_tool_calls=False))
+    assert result.choices[0].message.tool_calls is None
+    assert result.choices[0].finish_reason == "stop"
+
+
+def test_generic_tool_calls_report_finish_reason_tool_calls():
+    result = _transform("meta.llama-3.3-70b-instruct", _generic_body_with_tool_calls())
+    assert result.choices[0].message.tool_calls is not None
+    assert result.choices[0].finish_reason == "tool_calls"

--- a/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
+++ b/tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py
@@ -3,6 +3,8 @@ import datetime
 import httpx
 
 from litellm import ModelResponse
+from litellm.llms.oci.chat.cohere import handle_cohere_stream_chunk
+from litellm.llms.oci.chat.generic import handle_generic_stream_chunk
 from litellm.llms.oci.chat.transformation import OCIChatConfig
 
 
@@ -93,4 +95,53 @@ def test_cohere_without_tool_calls_finish_reason_stop():
 def test_generic_tool_calls_report_finish_reason_tool_calls():
     result = _transform("meta.llama-3.3-70b-instruct", _generic_body_with_tool_calls())
     assert result.choices[0].message.tool_calls is not None
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+# --- streaming handlers (terminal chunk finish_reason) ---
+
+
+def _cohere_terminal_chunk() -> dict:
+    return {
+        "apiFormat": "COHERE",
+        "text": "All done.",
+        "finishReason": "COMPLETE",
+        "chatHistory": [{"role": "CHATBOT", "message": "All done."}],
+        "index": 0,
+    }
+
+
+def test_cohere_stream_terminal_chunk_reports_tool_calls_when_emitted():
+    # On the terminal chunk, OCI Cohere reports finishReason="COMPLETE" and
+    # suppresses already-streamed tool calls; finish_reason must still be
+    # "tool_calls" when tool calls were emitted earlier in the stream.
+    result = handle_cohere_stream_chunk(
+        _cohere_terminal_chunk(), prior_tool_calls_emitted=True
+    )
+    assert result.choices[0].finish_reason == "tool_calls"
+
+
+def test_cohere_stream_terminal_chunk_reports_stop_without_tool_calls():
+    result = handle_cohere_stream_chunk(
+        _cohere_terminal_chunk(), prior_tool_calls_emitted=False
+    )
+    assert result.choices[0].finish_reason == "stop"
+
+
+def test_generic_stream_chunk_with_tool_calls_reports_tool_calls():
+    chunk = {
+        "finishReason": "STOP",
+        "message": {
+            "toolCalls": [
+                {
+                    "id": "call_0",
+                    "type": "FUNCTION",
+                    "name": "get_weather",
+                    "arguments": "{}",
+                }
+            ]
+        },
+        "index": 0,
+    }
+    result = handle_generic_stream_chunk(chunk)
     assert result.choices[0].finish_reason == "tool_calls"


### PR DESCRIPTION
## Relevant issues

None — found while reviewing OCI response handling.

## What this fixes

OCI non-streaming responses derived `finish_reason` solely from the provider's raw stop reason via `_normalize_oci_finish_reason`. The OCI **Cohere** protocol has no `TOOL_CALLS` finishReason — a tool-calling response comes back as `"COMPLETE"`, which normalizes to `"stop"`. So `handle_cohere_response` returned `finish_reason="stop"` while `message.tool_calls` was populated, violating OpenAI semantics (`finish_reason` must be `"tool_calls"` when the assistant message contains tool calls).

Fix: override `finish_reason` to `"tool_calls"` whenever tool calls are present, in both the Cohere and GENERIC response handlers (the GENERIC override is defensive — a no-op when OCI already reports a TOOL_CALLS reason).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit` (added `tests/test_litellm/llms/oci/chat/test_oci_finish_reason.py`; the 3 new tests pass and `ruff` is clean on changed files — full local suite not run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Proof of fix

New tests fail on `main` (Cohere/GENERIC tool-call responses report `finish_reason="stop"`) and pass with this change (`finish_reason="tool_calls"`), with a sanity test confirming a plain `COMPLETE` response still maps to `"stop"`.