### PR TITLE
fix(ollama): don't crash ollama_pt on an assistant tool call with empty arguments

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -251,7 +251,15 @@ def ollama_pt(
                 for call in tool_calls:
                     call_id: str = call["id"]
                     function_name: str = call["function"]["name"]
-                    arguments = json.loads(call["function"]["arguments"])
+                    # Use the shared safe parser (mirrors the other tool-call
+                    # sites in this module): a no-argument function call carries
+                    # arguments="" / None, on which a bare json.loads raises
+                    # JSONDecodeError and aborts the whole request during prompt
+                    # construction. parse_tool_call_arguments returns {} for
+                    # empty/None and repairs truncated JSON.
+                    arguments = parse_tool_call_arguments(
+                        call["function"]["arguments"], tool_name=function_name
+                    )
 
                     ollama_tool_calls.append(
                         {

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -51,6 +51,33 @@ def test_ollama_pt_simple_messages():
     assert result["images"] == []
 
 
+def test_ollama_pt_assistant_tool_call_with_empty_arguments():
+    """A prior assistant tool call for a no-argument function carries
+    arguments="" (or None). ollama_pt must not abort the request with a
+    JSONDecodeError while rebuilding the prompt; empty arguments parse to {}."""
+    messages = [
+        {"role": "user", "content": "What time is it?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_current_time", "arguments": ""},
+                }
+            ],
+        },
+        {"role": "tool", "content": "12:00", "tool_call_id": "call_1"},
+    ]
+
+    result = ollama_pt(model="llama2", messages=messages)  # must not raise
+
+    assert isinstance(result, dict)
+    assert "get_current_time" in result["prompt"]
+    assert '"arguments": {}' in result["prompt"]
+
+
 def test_ollama_pt_consecutive_user_messages():
     """Test handling consecutive user messages"""
     messages = [


### PR DESCRIPTION
## Relevant issues

None — found while reviewing ollama prompt construction.

## What this fixes

`ollama_pt` rebuilt prior assistant tool calls with a bare `json.loads(call["function"]["arguments"])`. A no-argument function call carries `arguments=""` (or `None`), so `json.loads("")` raises `JSONDecodeError` and **aborts the whole completion during prompt construction — before any network call** — for any multi-turn `ollama/*` conversation whose history includes such a tool call.

Fix: use the shared `parse_tool_call_arguments` helper (already imported and used by the other tool-call sites in this module), which returns `{}` for empty/`None` and repairs truncated JSON.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit` (added `test_ollama_pt_assistant_tool_call_with_empty_arguments`; it + the existing `ollama_pt` tests pass, and `ruff check` is clean on the changed `litellm/` source — full local suite not run)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Proof of fix

The new test fails on `main` with `JSONDecodeError` and passes with this change (empty arguments render as `{}` in the prompt).