### PR TITLE
fix: route reused Responses API containers

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -196,7 +196,7 @@ def _collect_response_file_search_vector_store_ids(data: Dict[str, Any]) -> set[
     return vector_store_ids
 
 
-def _collect_response_code_interpreter_container_ids(data: Dict[str, Any]) -> set[str]:
+def _collect_response_code_interpreter_container_ids(data: dict[str, Any]) -> set[str]:
     container_ids: set[str] = set()
     tools = data.get("tools")
     if not isinstance(tools, list):
@@ -232,7 +232,7 @@ async def _authorize_response_file_search_vector_stores(
 
 
 async def _authorize_response_code_interpreter_containers(
-    data: Dict[str, Any],
+    data: dict[str, Any],
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     container_ids = _collect_response_code_interpreter_container_ids(data)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -196,6 +196,22 @@ def _collect_response_file_search_vector_store_ids(data: Dict[str, Any]) -> set[
     return vector_store_ids
 
 
+def _collect_response_code_interpreter_container_ids(data: Dict[str, Any]) -> set[str]:
+    container_ids: set[str] = set()
+    tools = data.get("tools")
+    if not isinstance(tools, list):
+        return container_ids
+
+    for tool in tools:
+        if not isinstance(tool, dict) or tool.get("type") != "code_interpreter":
+            continue
+        container_id = tool.get("container")
+        if isinstance(container_id, str) and container_id:
+            container_ids.add(container_id)
+
+    return container_ids
+
+
 async def _authorize_response_file_search_vector_stores(
     data: Dict[str, Any],
     user_api_key_dict: UserAPIKeyAuth,
@@ -212,6 +228,30 @@ async def _authorize_response_file_search_vector_stores(
         await assert_user_can_access_vector_store_id(
             vector_store_id=vector_store_id,
             user_api_key_dict=user_api_key_dict,
+        )
+
+
+async def _authorize_response_code_interpreter_containers(
+    data: Dict[str, Any],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    container_ids = _collect_response_code_interpreter_container_ids(data)
+    if not container_ids:
+        return
+
+    from litellm.proxy.container_endpoints.ownership import (
+        assert_user_can_access_container,
+    )
+
+    custom_llm_provider = data.get("custom_llm_provider")
+    if not isinstance(custom_llm_provider, str) or not custom_llm_provider:
+        custom_llm_provider = "openai"
+
+    for container_id in sorted(container_ids):
+        await assert_user_can_access_container(
+            container_id=container_id,
+            user_api_key_dict=user_api_key_dict,
+            custom_llm_provider=custom_llm_provider,
         )
 
 
@@ -1059,6 +1099,10 @@ class ProxyBaseLLMRequestProcessing:
             self.data.pop("include_fallback_errors", None)
         if route_type in {"aresponses", "_aresponses_websocket"}:
             await _authorize_response_file_search_vector_stores(
+                data=self.data,
+                user_api_key_dict=user_api_key_dict,
+            )
+            await _authorize_response_code_interpreter_containers(
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
             )

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -586,6 +586,42 @@ class ResponsesAPIRequestUtils:
         return decoded.get("response_id", container_id)
 
     @staticmethod
+    def decode_container_ids_in_tools_for_request(
+        tools: Optional[Iterable[Any]],
+    ) -> Optional[Iterable[Any]]:
+        """Decode LiteLLM-managed Responses API tool container IDs.
+
+        Returns the possibly updated tools with LiteLLM-managed container IDs
+        replaced by the original provider-issued container IDs.
+        """
+        if tools is None:
+            return tools
+
+        updated_tools: List[Any] = []
+        changed = False
+
+        for tool in tools:
+            updated_tool = tool.copy() if isinstance(tool, dict) else tool
+            if isinstance(updated_tool, dict):
+                container_id = updated_tool.get("container")
+                if isinstance(container_id, str):
+                    decoded = ResponsesAPIRequestUtils._decode_container_id(
+                        container_id
+                    )
+                    original_id = decoded.get("response_id", container_id)
+                    if original_id != container_id:
+                        updated_tool["container"] = original_id
+                        changed = True
+            updated_tools.append(updated_tool)
+
+        if not changed:
+            if isinstance(tools, list):
+                return tools
+            return updated_tools
+
+        return updated_tools
+
+    @staticmethod
     def _encode_container_ids_in_annotations(
         annotations: Any,
         custom_llm_provider: Optional[str],

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import re
 from typing import (
     Any,
@@ -586,6 +587,55 @@ class ResponsesAPIRequestUtils:
         return decoded.get("response_id", container_id)
 
     @staticmethod
+    def _get_tool_value(tool: Any, key: str) -> Any:
+        if isinstance(tool, dict):
+            return tool.get(key)
+        return getattr(tool, key, None)
+
+    @staticmethod
+    def _set_tool_value(tool: Any, key: str, value: Any) -> None:
+        if isinstance(tool, dict):
+            tool[key] = value
+            return
+        setattr(tool, key, value)
+
+    @staticmethod
+    def get_decoded_container_payload_from_tool(
+        tool: Any, require_code_interpreter: bool = False
+    ) -> Optional[DecodedResponseId]:
+        if require_code_interpreter and ResponsesAPIRequestUtils._get_tool_value(tool, "type") != "code_interpreter":
+            return None
+
+        container_id = ResponsesAPIRequestUtils._get_tool_value(tool, "container")
+        if not isinstance(container_id, str):
+            return None
+
+        decoded = ResponsesAPIRequestUtils._decode_container_id(container_id)
+        original_id = decoded.get("response_id", container_id)
+        if original_id == container_id:
+            return None
+        return decoded
+
+    @staticmethod
+    def get_decoded_container_payload_from_tools(
+        tools: Any,
+    ) -> Optional[DecodedResponseId]:
+        if not isinstance(tools, list):
+            return None
+        for tool in tools:
+            decoded = ResponsesAPIRequestUtils.get_decoded_container_payload_from_tool(
+                tool, require_code_interpreter=True
+            )
+            if decoded is not None:
+                return decoded
+        return None
+
+    @staticmethod
+    def set_custom_llm_provider_if_missing(kwargs: dict[str, Any], custom_llm_provider: Optional[str]) -> None:
+        if custom_llm_provider and "custom_llm_provider" not in kwargs:
+            kwargs["custom_llm_provider"] = custom_llm_provider
+
+    @staticmethod
     def decode_container_ids_in_tools_for_request(
         tools: Optional[Iterable[Any]],
     ) -> Optional[Iterable[Any]]:
@@ -597,21 +647,16 @@ class ResponsesAPIRequestUtils:
         if tools is None:
             return tools
 
-        updated_tools: List[Any] = []
+        updated_tools: list[Any] = []
         changed = False
 
         for tool in tools:
-            updated_tool = tool.copy() if isinstance(tool, dict) else tool
-            if isinstance(updated_tool, dict):
-                container_id = updated_tool.get("container")
-                if isinstance(container_id, str):
-                    decoded = ResponsesAPIRequestUtils._decode_container_id(
-                        container_id
-                    )
-                    original_id = decoded.get("response_id", container_id)
-                    if original_id != container_id:
-                        updated_tool["container"] = original_id
-                        changed = True
+            updated_tool = tool
+            decoded = ResponsesAPIRequestUtils.get_decoded_container_payload_from_tool(tool)
+            if decoded is not None:
+                updated_tool = tool.copy() if isinstance(tool, dict) else copy.copy(tool)
+                ResponsesAPIRequestUtils._set_tool_value(updated_tool, "container", decoded["response_id"])
+                changed = True
             updated_tools.append(updated_tool)
 
         if not changed:

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4445,6 +4445,8 @@ class Router:
 
         from litellm.litellm_core_utils.core_helpers import safe_deep_copy
 
+        self._decode_responses_api_tool_container_ids(kwargs)
+
         # Snapshot the request kwargs before _ageneric_api_call_with_fallbacks
         # mutates them. A shallow copy alone is not enough: the primary
         # attempt mutates nested dicts in place — notably `litellm_metadata`,
@@ -4475,6 +4477,19 @@ class Router:
                 initial_kwargs=fallback_kwargs,
             )
         return response
+
+    @staticmethod
+    def _decode_responses_api_tool_container_ids(kwargs: Dict[str, Any]) -> None:
+        from litellm.responses.utils import ResponsesAPIRequestUtils
+
+        # Keep authorization and deployment selection anchored to the requested
+        # model. Managed container IDs are supplied by the client, so only the
+        # provider-issued container ID is safe to recover from them here.
+        tools = ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
+            kwargs.get("tools")
+        )
+        if tools is not kwargs.get("tools"):
+            kwargs["tools"] = tools
 
     def _generic_api_call_with_fallbacks(self, model: str, original_function: Callable, **kwargs):
         """
@@ -5514,6 +5529,8 @@ class Router:
                 client: Optional[Any] = None,
                 **kwargs,
             ):
+                if call_type == "responses":
+                    self._decode_responses_api_tool_container_ids(kwargs)
                 return self._generic_api_call_with_fallbacks(original_function=original_function, **kwargs)
 
             return sync_wrapper
@@ -5617,6 +5634,8 @@ class Router:
                     **kwargs,
                 )
             elif call_type == "aresponses":
+                if custom_llm_provider and "custom_llm_provider" not in kwargs:
+                    kwargs["custom_llm_provider"] = custom_llm_provider
                 return await self._aresponses_with_streaming_fallbacks(
                     original_function=original_function,
                     **kwargs,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4482,14 +4482,35 @@ class Router:
     def _decode_responses_api_tool_container_ids(kwargs: Dict[str, Any]) -> None:
         from litellm.responses.utils import ResponsesAPIRequestUtils
 
-        # Keep authorization and deployment selection anchored to the requested
-        # model. Managed container IDs are supplied by the client, so only the
-        # provider-issued container ID is safe to recover from them here.
+        decoded_container_payload = None
+        request_tools = kwargs.get("tools")
+        if isinstance(request_tools, list):
+            for tool in request_tools:
+                if not isinstance(tool, dict) or tool.get("type") != "code_interpreter":
+                    continue
+                container_id = tool.get("container")
+                if not isinstance(container_id, str):
+                    continue
+                decoded = ResponsesAPIRequestUtils._decode_container_id(container_id)
+                original_id = decoded.get("response_id", container_id)
+                if original_id != container_id:
+                    decoded_container_payload = decoded
+                    break
+
         tools = ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
-            kwargs.get("tools")
+            request_tools
         )
-        if tools is not kwargs.get("tools"):
+        if tools is not request_tools:
             kwargs["tools"] = tools
+        if decoded_container_payload is None:
+            return
+
+        model_id = decoded_container_payload.get("model_id")
+        if model_id:
+            kwargs["model"] = model_id
+        decoded_provider = decoded_container_payload.get("custom_llm_provider")
+        if decoded_provider and kwargs.get("custom_llm_provider") == "openai":
+            kwargs["custom_llm_provider"] = decoded_provider
 
     def _generic_api_call_with_fallbacks(self, model: str, original_function: Callable, **kwargs):
         """

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5530,6 +5530,8 @@ class Router:
                 **kwargs,
             ):
                 if call_type == "responses":
+                    if custom_llm_provider and "custom_llm_provider" not in kwargs:
+                        kwargs["custom_llm_provider"] = custom_llm_provider
                     self._decode_responses_api_tool_container_ids(kwargs)
                 return self._generic_api_call_with_fallbacks(original_function=original_function, **kwargs)
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4479,27 +4479,15 @@ class Router:
         return response
 
     @staticmethod
-    def _decode_responses_api_tool_container_ids(kwargs: Dict[str, Any]) -> None:
+    def _decode_responses_api_tool_container_ids(
+        kwargs: dict[str, Any], custom_llm_provider: Optional[str] = None
+    ) -> None:
         from litellm.responses.utils import ResponsesAPIRequestUtils
 
-        decoded_container_payload = None
+        ResponsesAPIRequestUtils.set_custom_llm_provider_if_missing(kwargs, custom_llm_provider)
         request_tools = kwargs.get("tools")
-        if isinstance(request_tools, list):
-            for tool in request_tools:
-                if not isinstance(tool, dict) or tool.get("type") != "code_interpreter":
-                    continue
-                container_id = tool.get("container")
-                if not isinstance(container_id, str):
-                    continue
-                decoded = ResponsesAPIRequestUtils._decode_container_id(container_id)
-                original_id = decoded.get("response_id", container_id)
-                if original_id != container_id:
-                    decoded_container_payload = decoded
-                    break
-
-        tools = ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
-            request_tools
-        )
+        decoded_container_payload = ResponsesAPIRequestUtils.get_decoded_container_payload_from_tools(request_tools)
+        tools = ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(request_tools)
         if tools is not request_tools:
             kwargs["tools"] = tools
         if decoded_container_payload is None:
@@ -5551,9 +5539,7 @@ class Router:
                 **kwargs,
             ):
                 if call_type == "responses":
-                    if custom_llm_provider and "custom_llm_provider" not in kwargs:
-                        kwargs["custom_llm_provider"] = custom_llm_provider
-                    self._decode_responses_api_tool_container_ids(kwargs)
+                    self._decode_responses_api_tool_container_ids(kwargs, custom_llm_provider)
                 return self._generic_api_call_with_fallbacks(original_function=original_function, **kwargs)
 
             return sync_wrapper
@@ -5657,8 +5643,7 @@ class Router:
                     **kwargs,
                 )
             elif call_type == "aresponses":
-                if custom_llm_provider and "custom_llm_provider" not in kwargs:
-                    kwargs["custom_llm_provider"] = custom_llm_provider
+                self._decode_responses_api_tool_container_ids(kwargs, custom_llm_provider)
                 return await self._aresponses_with_streaming_fallbacks(
                     original_function=original_function,
                     **kwargs,

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -805,6 +805,34 @@ async def test_router_aresponses_decodes_managed_tool_container_id_without_routi
     assert kwargs["tools"][0]["container"] == "cntr_native_123"
 
 
+def test_router_responses_preserves_custom_provider_when_decoding_managed_tool_container_id():
+    from litellm.responses.utils import ResponsesAPIRequestUtils
+
+    router = Router(model_list=[])
+    router._generic_api_call_with_fallbacks = MagicMock(return_value={"id": "resp_1"})
+
+    encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+        custom_llm_provider="azure",
+        model_id="azure-deployment-id",
+        container_id="cntr_native_123",
+    )
+    tools = [{"type": "code_interpreter", "container": encoded_container_id}]
+
+    response = router.responses(
+        model="logical-model",
+        input="hello",
+        tools=tools,
+        custom_llm_provider="openai",
+    )
+
+    call_kwargs = router._generic_api_call_with_fallbacks.call_args.kwargs
+    assert response == {"id": "resp_1"}
+    assert call_kwargs["model"] == "logical-model"
+    assert call_kwargs["custom_llm_provider"] == "openai"
+    assert call_kwargs["tools"][0]["container"] == "cntr_native_123"
+    assert tools[0]["container"] == encoded_container_id
+
+
 @pytest.mark.asyncio
 async def test_init_vector_store_api_endpoints():
     """

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -768,6 +768,44 @@ async def test_init_responses_api_endpoints():
 
 
 @pytest.mark.asyncio
+async def test_router_aresponses_decodes_managed_tool_container_id_without_routing_override():
+    from litellm.responses.utils import ResponsesAPIRequestUtils
+
+    router = Router(model_list=[])
+    router._ageneric_api_call_with_fallbacks = AsyncMock(return_value={"id": "resp_1"})
+
+    encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+        custom_llm_provider="azure",
+        model_id="azure-deployment-id",
+        container_id="cntr_native_123",
+    )
+    tools = [{"type": "code_interpreter", "container": encoded_container_id}]
+
+    await router.aresponses(
+        model="logical-model",
+        input="hello",
+        tools=tools,
+        custom_llm_provider="openai",
+    )
+
+    call_kwargs = router._ageneric_api_call_with_fallbacks.call_args.kwargs
+    assert call_kwargs["model"] == "logical-model"
+    assert call_kwargs["custom_llm_provider"] == "openai"
+    assert call_kwargs["tools"][0]["container"] == "cntr_native_123"
+    assert tools[0]["container"] == encoded_container_id
+
+    kwargs = {
+        "model": "logical-model",
+        "custom_llm_provider": "openai",
+        "tools": [{"type": "code_interpreter", "container": encoded_container_id}],
+    }
+    router._decode_responses_api_tool_container_ids(kwargs)
+    assert kwargs["model"] == "logical-model"
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["tools"][0]["container"] == "cntr_native_123"
+
+
+@pytest.mark.asyncio
 async def test_init_vector_store_api_endpoints():
     """
     Test that _init_vector_store_api_endpoints correctly passes custom_llm_provider to kwargs

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -2,6 +2,7 @@ import sys
 import os
 import json
 import traceback
+from types import SimpleNamespace
 from typing import Optional
 from dotenv import load_dotenv
 from fastapi import Request
@@ -831,6 +832,30 @@ def test_router_responses_routes_managed_tool_container_id_to_owner_deployment()
     assert call_kwargs["custom_llm_provider"] == "azure"
     assert call_kwargs["tools"][0]["container"] == "cntr_native_123"
     assert tools[0]["container"] == encoded_container_id
+
+
+def test_router_responses_routes_managed_tool_object_container_id_to_owner_deployment():
+    from litellm.responses.utils import ResponsesAPIRequestUtils
+
+    router = Router(model_list=[])
+    encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+        custom_llm_provider="azure",
+        model_id="azure-deployment-id",
+        container_id="cntr_native_123",
+    )
+    tool = SimpleNamespace(type="code_interpreter", container=encoded_container_id)
+    kwargs = {
+        "model": "logical-model",
+        "custom_llm_provider": "openai",
+        "tools": [tool],
+    }
+
+    router._decode_responses_api_tool_container_ids(kwargs)
+
+    assert kwargs["model"] == "azure-deployment-id"
+    assert kwargs["custom_llm_provider"] == "azure"
+    assert kwargs["tools"][0].container == "cntr_native_123"
+    assert tool.container == encoded_container_id
 
 
 @pytest.mark.asyncio

--- a/tests/router_unit_tests/test_router_endpoints.py
+++ b/tests/router_unit_tests/test_router_endpoints.py
@@ -768,7 +768,7 @@ async def test_init_responses_api_endpoints():
 
 
 @pytest.mark.asyncio
-async def test_router_aresponses_decodes_managed_tool_container_id_without_routing_override():
+async def test_router_aresponses_routes_managed_tool_container_id_to_owner_deployment():
     from litellm.responses.utils import ResponsesAPIRequestUtils
 
     router = Router(model_list=[])
@@ -789,8 +789,8 @@ async def test_router_aresponses_decodes_managed_tool_container_id_without_routi
     )
 
     call_kwargs = router._ageneric_api_call_with_fallbacks.call_args.kwargs
-    assert call_kwargs["model"] == "logical-model"
-    assert call_kwargs["custom_llm_provider"] == "openai"
+    assert call_kwargs["model"] == "azure-deployment-id"
+    assert call_kwargs["custom_llm_provider"] == "azure"
     assert call_kwargs["tools"][0]["container"] == "cntr_native_123"
     assert tools[0]["container"] == encoded_container_id
 
@@ -800,12 +800,12 @@ async def test_router_aresponses_decodes_managed_tool_container_id_without_routi
         "tools": [{"type": "code_interpreter", "container": encoded_container_id}],
     }
     router._decode_responses_api_tool_container_ids(kwargs)
-    assert kwargs["model"] == "logical-model"
-    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["model"] == "azure-deployment-id"
+    assert kwargs["custom_llm_provider"] == "azure"
     assert kwargs["tools"][0]["container"] == "cntr_native_123"
 
 
-def test_router_responses_preserves_custom_provider_when_decoding_managed_tool_container_id():
+def test_router_responses_routes_managed_tool_container_id_to_owner_deployment():
     from litellm.responses.utils import ResponsesAPIRequestUtils
 
     router = Router(model_list=[])
@@ -827,8 +827,8 @@ def test_router_responses_preserves_custom_provider_when_decoding_managed_tool_c
 
     call_kwargs = router._generic_api_call_with_fallbacks.call_args.kwargs
     assert response == {"id": "resp_1"}
-    assert call_kwargs["model"] == "logical-model"
-    assert call_kwargs["custom_llm_provider"] == "openai"
+    assert call_kwargs["model"] == "azure-deployment-id"
+    assert call_kwargs["custom_llm_provider"] == "azure"
     assert call_kwargs["tools"][0]["container"] == "cntr_native_123"
     assert tools[0]["container"] == encoded_container_id
 

--- a/tests/test_litellm/containers/test_container_api.py
+++ b/tests/test_litellm/containers/test_container_api.py
@@ -310,6 +310,74 @@ class TestContainerAPI:
         assert decoded.get("model_id") == "router-gpt"
 
     @pytest.mark.asyncio
+    async def test_router_aresponses_routes_managed_tool_container_id_to_owner_deployment(
+        self,
+    ):
+        router = Router(model_list=[])
+        router._ageneric_api_call_with_fallbacks = AsyncMock(
+            return_value={"id": "resp_1"}
+        )
+
+        encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+            custom_llm_provider="azure",
+            model_id="azure-deployment-id",
+            container_id="cntr_native_123",
+        )
+        tools = [
+            "not-a-dict",
+            {"type": "file_search", "container": "cntr_ignored"},
+            {"type": "code_interpreter", "container": {"type": "auto"}},
+            {"type": "code_interpreter", "container": encoded_container_id},
+        ]
+
+        await router.aresponses(
+            model="logical-model",
+            input="hello",
+            tools=tools,
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = router._ageneric_api_call_with_fallbacks.call_args.kwargs
+        assert call_kwargs["model"] == "azure-deployment-id"
+        assert call_kwargs["custom_llm_provider"] == "azure"
+        assert call_kwargs["tools"][3]["container"] == "cntr_native_123"
+        assert tools[3]["container"] == encoded_container_id
+
+    def test_router_responses_routes_managed_tool_container_id_to_owner_deployment(
+        self,
+    ):
+        router = Router(model_list=[])
+        router._generic_api_call_with_fallbacks = MagicMock(
+            return_value={"id": "resp_1"}
+        )
+
+        encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+            custom_llm_provider="azure",
+            model_id="azure-deployment-id",
+            container_id="cntr_native_123",
+        )
+        tools = [
+            "not-a-dict",
+            {"type": "file_search", "container": "cntr_ignored"},
+            {"type": "code_interpreter", "container": {"type": "auto"}},
+            {"type": "code_interpreter", "container": encoded_container_id},
+        ]
+
+        response = router.responses(
+            model="logical-model",
+            input="hello",
+            tools=tools,
+            custom_llm_provider="openai",
+        )
+
+        call_kwargs = router._generic_api_call_with_fallbacks.call_args.kwargs
+        assert response == {"id": "resp_1"}
+        assert call_kwargs["model"] == "azure-deployment-id"
+        assert call_kwargs["custom_llm_provider"] == "azure"
+        assert call_kwargs["tools"][3]["container"] == "cntr_native_123"
+        assert tools[3]["container"] == encoded_container_id
+
+    @pytest.mark.asyncio
     async def test_aretrieve_container_basic(self):
         """Test basic async container retrieval functionality."""
         container_id = "cntr_async_retrieve"

--- a/tests/test_litellm/containers/test_container_proxy_ownership.py
+++ b/tests/test_litellm/containers/test_container_proxy_ownership.py
@@ -215,6 +215,87 @@ async def test_should_deny_untracked_container_access_by_default(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_response_code_interpreter_container_requires_owner_access(monkeypatch):
+    from litellm.proxy.common_request_processing import (
+        _authorize_response_code_interpreter_containers,
+    )
+
+    table = AsyncMock()
+    table.find_first.return_value = SimpleNamespace(created_by="user-2")
+    prisma_client = SimpleNamespace(
+        db=SimpleNamespace(litellm_managedobjecttable=table)
+    )
+    monkeypatch.setattr(
+        ownership,
+        "_get_prisma_client",
+        AsyncMock(return_value=prisma_client),
+    )
+    encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+        custom_llm_provider="azure",
+        model_id="azure-deployment-id",
+        container_id="cntr_native_123",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await _authorize_response_code_interpreter_containers(
+            data={
+                "tools": [
+                    {
+                        "type": "code_interpreter",
+                        "container": encoded_container_id,
+                    }
+                ]
+            },
+            user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        )
+
+    assert exc.value.status_code == 403
+    table.find_first.assert_awaited_once_with(
+        where={
+            "model_object_id": "container:azure:cntr_native_123",
+            "file_purpose": ownership.CONTAINER_OBJECT_PURPOSE,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_code_interpreter_container_allows_owner(monkeypatch):
+    from litellm.proxy.common_request_processing import (
+        _authorize_response_code_interpreter_containers,
+    )
+
+    table = AsyncMock()
+    table.find_first.return_value = SimpleNamespace(created_by="user-1")
+    prisma_client = SimpleNamespace(
+        db=SimpleNamespace(litellm_managedobjecttable=table)
+    )
+    monkeypatch.setattr(
+        ownership,
+        "_get_prisma_client",
+        AsyncMock(return_value=prisma_client),
+    )
+    encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+        custom_llm_provider="azure",
+        model_id="azure-deployment-id",
+        container_id="cntr_native_123",
+    )
+
+    await _authorize_response_code_interpreter_containers(
+        data={
+            "tools": [
+                {
+                    "type": "code_interpreter",
+                    "container": encoded_container_id,
+                }
+            ]
+        },
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    table.find_first.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_should_not_reassign_existing_container_to_different_owner(monkeypatch):
     table = AsyncMock()
     table.find_unique.return_value = SimpleNamespace(

--- a/tests/test_litellm/containers/test_container_proxy_ownership.py
+++ b/tests/test_litellm/containers/test_container_proxy_ownership.py
@@ -38,6 +38,59 @@ def _container(container_id: str) -> ContainerObject:
     )
 
 
+def test_collect_response_code_interpreter_container_ids_filters_tools():
+    from litellm.proxy.common_request_processing import (
+        _collect_response_code_interpreter_container_ids,
+    )
+
+    assert _collect_response_code_interpreter_container_ids({"tools": None}) == set()
+    assert _collect_response_code_interpreter_container_ids(
+        {
+            "tools": [
+                "not-a-dict",
+                {"type": "file_search", "container": "cntr_ignored"},
+                {"type": "code_interpreter", "container": {"type": "auto"}},
+                {"type": "code_interpreter", "container": ""},
+                {"type": "code_interpreter", "container": "cntr_1"},
+            ]
+        }
+    ) == {"cntr_1"}
+
+
+@pytest.mark.asyncio
+async def test_response_code_interpreter_container_authorization_defaults_to_openai(
+    monkeypatch,
+):
+    from litellm.proxy.common_request_processing import (
+        _authorize_response_code_interpreter_containers,
+    )
+
+    mock_assert = AsyncMock()
+    monkeypatch.setattr(
+        ownership,
+        "assert_user_can_access_container",
+        mock_assert,
+    )
+
+    await _authorize_response_code_interpreter_containers(
+        data={
+            "tools": [
+                {
+                    "type": "code_interpreter",
+                    "container": "cntr_native_123",
+                }
+            ]
+        },
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    mock_assert.assert_awaited_once_with(
+        container_id="cntr_native_123",
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+        custom_llm_provider="openai",
+    )
+
+
 @pytest.mark.asyncio
 async def test_should_record_container_owner_with_original_provider_id(monkeypatch):
     table = AsyncMock()

--- a/tests/test_litellm/containers/test_container_proxy_ownership.py
+++ b/tests/test_litellm/containers/test_container_proxy_ownership.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
@@ -88,6 +88,80 @@ async def test_response_code_interpreter_container_authorization_defaults_to_ope
         container_id="cntr_native_123",
         user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
         custom_llm_provider="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_responses_pre_call_authorizes_vector_stores_and_code_containers(
+    monkeypatch,
+):
+    from litellm.proxy import common_request_processing
+    from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+
+    data = {
+        "model": "gpt-4.1",
+        "tools": [
+            {"type": "file_search", "vector_store_ids": ["vs_123"]},
+            {"type": "code_interpreter", "container": "cntr_native_123"},
+        ],
+    }
+    processor = ProxyBaseLLMRequestProcessing(data=data)
+    request = MagicMock()
+    request.headers = {}
+    request.url.path = "/v1/responses"
+    user_api_key_dict = UserAPIKeyAuth(user_id="user-1")
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.pre_call_hook = AsyncMock(
+        side_effect=lambda **kwargs: kwargs["data"]
+    )
+    logging_obj = MagicMock()
+
+    async def mock_add_litellm_data_to_request(**kwargs):
+        return kwargs["data"]
+
+    mock_authorize_vector_stores = AsyncMock()
+    mock_authorize_code_containers = AsyncMock()
+    monkeypatch.setattr(
+        common_request_processing,
+        "add_litellm_data_to_request",
+        mock_add_litellm_data_to_request,
+    )
+    monkeypatch.setattr(
+        common_request_processing,
+        "_authorize_response_file_search_vector_stores",
+        mock_authorize_vector_stores,
+    )
+    monkeypatch.setattr(
+        common_request_processing,
+        "_authorize_response_code_interpreter_containers",
+        mock_authorize_code_containers,
+    )
+    monkeypatch.setattr(
+        common_request_processing.litellm.utils,
+        "function_setup",
+        lambda **kwargs: (logging_obj, kwargs),
+    )
+
+    returned_data, returned_logging_obj = (
+        await processor.common_processing_pre_call_logic(
+            request=request,
+            general_settings={},
+            user_api_key_dict=user_api_key_dict,
+            proxy_logging_obj=proxy_logging_obj,
+            proxy_config=MagicMock(),
+            route_type="aresponses",
+        )
+    )
+
+    assert returned_data["tools"] == data["tools"]
+    assert returned_logging_obj is logging_obj
+    mock_authorize_vector_stores.assert_awaited_once_with(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+    )
+    mock_authorize_code_containers.assert_awaited_once_with(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
     )
 
 

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -163,6 +164,27 @@ class TestResponsesAPIRequestUtils:
             )
         )
         assert plain_tuple_result == list(plain_tuple)
+
+    def test_decode_container_ids_in_tool_objects_for_request(self):
+        encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+            custom_llm_provider="azure",
+            model_id="azure-deployment-id",
+            container_id="cntr_native_123",
+        )
+        tool = SimpleNamespace(
+            type="code_interpreter", container=encoded_container_id
+        )
+        tools = [tool]
+
+        updated_tools = (
+            ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(tools)
+        )
+
+        assert updated_tools is not tools
+        assert isinstance(updated_tools, list)
+        assert updated_tools[0] is not tool
+        assert updated_tools[0].container == "cntr_native_123"
+        assert tool.container == encoded_container_id
 
     def test_update_responses_api_response_id_with_model_id_handles_dict(self):
         """Ensure _update_responses_api_response_id_with_model_id works with dict input"""

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -123,6 +123,34 @@ class TestResponsesAPIRequestUtils:
         )
         assert result_plain == plain_id
 
+    def test_decode_container_ids_in_tools_for_request(self):
+        encoded_container_id = ResponsesAPIRequestUtils._build_container_id(
+            custom_llm_provider="azure",
+            model_id="azure-deployment-id",
+            container_id="cntr_native_123",
+        )
+        tools = [
+            {"type": "code_interpreter", "container": encoded_container_id},
+            {"type": "file_search", "vector_store_ids": ["vs_123"]},
+        ]
+
+        updated_tools = (
+            ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(tools)
+        )
+
+        assert updated_tools is not tools
+        assert isinstance(updated_tools, list)
+        assert updated_tools[0]["container"] == "cntr_native_123"
+        assert tools[0]["container"] == encoded_container_id
+
+        plain_tools = [{"type": "file_search", "vector_store_ids": ["vs_123"]}]
+        plain_result = (
+            ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
+                plain_tools
+            )
+        )
+        assert plain_result is plain_tools
+
     def test_update_responses_api_response_id_with_model_id_handles_dict(self):
         """Ensure _update_responses_api_response_id_with_model_id works with dict input"""
         responses_api_response = {"id": "resp_abc123"}

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -143,6 +143,11 @@ class TestResponsesAPIRequestUtils:
         assert updated_tools[0]["container"] == "cntr_native_123"
         assert tools[0]["container"] == encoded_container_id
 
+        assert (
+            ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(None)
+            is None
+        )
+
         plain_tools = [{"type": "file_search", "vector_store_ids": ["vs_123"]}]
         plain_result = (
             ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
@@ -150,6 +155,14 @@ class TestResponsesAPIRequestUtils:
             )
         )
         assert plain_result is plain_tools
+
+        plain_tuple = ({"type": "file_search", "vector_store_ids": ["vs_123"]},)
+        plain_tuple_result = (
+            ResponsesAPIRequestUtils.decode_container_ids_in_tools_for_request(
+                plain_tuple
+            )
+        )
+        assert plain_tuple_result == list(plain_tuple)
 
     def test_update_responses_api_response_id_with_model_id_handles_dict(self):
         """Ensure _update_responses_api_response_id_with_model_id works with dict input"""


### PR DESCRIPTION
## Summary
- Decode LiteLLM-managed Responses API tool container IDs before router deployment selection.
- Route reused code_interpreter containers through the embedded model_id while forwarding the provider-native container ID upstream.
- Cover the request helper and public router.aresponses path with focused regressions.

## Root cause
Responses output already wraps provider container IDs with LiteLLM provider/model metadata, but follow-up /v1/responses create calls only decoded response_id fields. When clients reused the returned code_interpreter tool container ID, the router kept the logical model group and forwarded the managed container ID to the provider. For Azure, that can both exceed the native container ID length limit and miss the deployment that owns the container.

Fixes #30781

## Tests
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --no-sync pytest tests/test_litellm/responses/test_responses_utils.py::TestResponsesAPIRequestUtils::test_decode_container_ids_in_tools_for_request tests/test_litellm/responses/test_responses_utils.py::TestResponsesAPIRequestUtils::test_decode_container_ids_in_tool_objects_for_request tests/router_unit_tests/test_router_endpoints.py::test_router_aresponses_routes_managed_tool_container_id_to_owner_deployment tests/router_unit_tests/test_router_endpoints.py::test_router_responses_routes_managed_tool_container_id_to_owner_deployment tests/router_unit_tests/test_router_endpoints.py::test_router_responses_routes_managed_tool_object_container_id_to_owner_deployment -q` -> 5 passed
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --no-sync pytest tests/test_litellm/containers/test_container_api.py::TestContainerAPI::test_retrieve_container_reencodes_short_managed_id_for_routing tests/test_litellm/containers/test_container_api.py::TestContainerAPI::test_delete_container_reencodes_short_managed_id_for_routing tests/test_litellm/containers/test_container_proxy_ownership.py::test_response_code_interpreter_container_requires_owner_access tests/test_litellm/containers/test_container_proxy_ownership.py::test_response_code_interpreter_container_allows_owner -q` -> 4 passed
- `uv run --no-sync ruff check litellm/responses/utils.py litellm/router.py litellm/proxy/common_request_processing.py` -> All checks passed
- `uv run --no-sync python -m py_compile litellm/responses/utils.py litellm/router.py litellm/proxy/common_request_processing.py tests/test_litellm/responses/test_responses_utils.py tests/router_unit_tests/test_router_endpoints.py tests/test_litellm/containers/test_container_api.py tests/test_litellm/containers/test_container_proxy_ownership.py` -> passed
- `git diff --check origin/litellm_internal_staging...HEAD` -> passed