### PR TITLE
fix(gemini): ignore null text response parts

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1504,6 +1504,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             _content_str = ""
             if "text" in part:
                 text_content = part["text"]
+                if text_content is None:
+                    continue
                 # Check if text content is audio data URI - if so, exclude from text content
                 if text_content.startswith("data:audio") and ";base64," in text_content:
                     try:

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -441,6 +441,25 @@ def test_vertex_ai_empty_content():
     assert reasoning_content is None
 
 
+def test_vertex_ai_null_text_part_is_ignored():
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+    from litellm.types.llms.vertex_ai import HttpxPartType
+
+    v = VertexGeminiConfig()
+    parts = cast(
+        List[HttpxPartType],
+        [
+            {"text": None},
+            {"text": "Generated image"},
+        ],
+    )
+    content, reasoning_content = v.get_assistant_content_message(parts=parts)
+    assert content == "Generated image"
+    assert reasoning_content is None
+
+
 @pytest.mark.parametrize(
     "usage_metadata, inclusive, expected_usage",
     [


### PR DESCRIPTION
## Relevant issues

Fixes #24385

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, a Gemini response part shaped like `{"text": null}` raised `AttributeError: 'NoneType' object has no attribute 'startswith'` inside `VertexGeminiConfig.get_assistant_content_message`

After the fix, the same null text part is ignored and later text parts are still returned:

```bash
uv run python - <<'PY'
from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexGeminiConfig
from litellm.types.llms.vertex_ai import HttpxPartType

parts = [HttpxPartType(text=None), HttpxPartType(text='Generated image')]
print(VertexGeminiConfig().get_assistant_content_message(parts=parts))
PY
```

Output:

```text
('Generated image', None)
```

Targeted validation:

```bash
uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_vertex_ai_null_text_part_is_ignored tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_vertex_ai_empty_content tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_vertex_ai_thinking_output_part -q
```

```text
3 passed in 0.07s
```

```bash
uv run pytest tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py -q
```

```text
126 passed in 0.22s
```

```bash
uv run black --check litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
uv run ruff check litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
```

Both commands passed. A broader `ruff check` on the existing Gemini test file reports pre-existing lint violations unrelated to this diff, so I kept the lint gate scoped to the changed production file

## Type

Bug Fix
Test

## Changes

Gemini image generation responses can include a part with `text: null`. The current parser treats the presence of the `text` key as enough to call `.startswith()` and concatenate the value, which raises before LiteLLM can return the response

This change skips null text parts in `get_assistant_content_message`. Non-null text parts, reasoning parts, and the existing inline data handling continue to use the same path. The regression test covers a null text part followed by normal generated text, so the exact crash cannot come back without failing the provider test
