### PR TITLE
fix(proxy): use user max_budget for SSO session tokens when set

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2391,11 +2391,16 @@ class ExperimentalUIJWTToken:
         # Format the expiration time as ISO 8601 string
         expires = expiration_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+00:00"
 
+        session_max_budget = (
+            user_info.max_budget
+            if user_info.max_budget is not None
+            else litellm.max_ui_session_budget
+        )
         valid_token = UserAPIKeyAuth(
             token="ui-token",
             key_name="ui-token",
             key_alias="ui-token",
-            max_budget=litellm.max_ui_session_budget,
+            max_budget=session_max_budget,
             rpm_limit=100,  # allow user to have a conversation on test key pane of UI
             expires=expires,
             user_id=user_info.user_id,
@@ -2448,11 +2453,16 @@ class ExperimentalUIJWTToken:
             # Use first team if user has teams
             _team_id = user_info.teams[0] if len(user_info.teams) > 0 else None
 
+        session_max_budget = (
+            user_info.max_budget
+            if user_info.max_budget is not None
+            else litellm.max_ui_session_budget
+        )
         valid_token = UserAPIKeyAuth(
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
-            max_budget=litellm.max_ui_session_budget,
+            max_budget=session_max_budget,
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -67,6 +67,9 @@ from litellm.proxy.common_utils.http_parsing_utils import (
     _safe_get_request_headers,
     _safe_get_request_query_params,
 )
+from litellm.proxy.common_utils.ui_session_budget_utils import (
+    resolve_ui_session_max_budget,
+)
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
 from litellm.proxy.guardrails.tool_name_extraction import (
@@ -2391,16 +2394,11 @@ class ExperimentalUIJWTToken:
         # Format the expiration time as ISO 8601 string
         expires = expiration_time.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+00:00"
 
-        session_max_budget = (
-            user_info.max_budget
-            if user_info.max_budget is not None
-            else litellm.max_ui_session_budget
-        )
         valid_token = UserAPIKeyAuth(
             token="ui-token",
             key_name="ui-token",
             key_alias="ui-token",
-            max_budget=session_max_budget,
+            max_budget=resolve_ui_session_max_budget(user_info.max_budget),
             rpm_limit=100,  # allow user to have a conversation on test key pane of UI
             expires=expires,
             user_id=user_info.user_id,
@@ -2453,16 +2451,11 @@ class ExperimentalUIJWTToken:
             # Use first team if user has teams
             _team_id = user_info.teams[0] if len(user_info.teams) > 0 else None
 
-        session_max_budget = (
-            user_info.max_budget
-            if user_info.max_budget is not None
-            else litellm.max_ui_session_budget
-        )
         valid_token = UserAPIKeyAuth(
             token=CLI_JWT_TOKEN_NAME,
             key_name=CLI_JWT_TOKEN_NAME,
             key_alias=CLI_JWT_TOKEN_NAME,
-            max_budget=session_max_budget,
+            max_budget=resolve_ui_session_max_budget(user_info.max_budget),
             expires=expires,
             user_id=user_info.user_id,
             team_id=_team_id,

--- a/litellm/proxy/common_utils/ui_session_budget_utils.py
+++ b/litellm/proxy/common_utils/ui_session_budget_utils.py
@@ -1,0 +1,9 @@
+from typing import Optional
+
+import litellm
+
+
+def resolve_ui_session_max_budget(user_max_budget: Optional[float]) -> Optional[float]:
+    if user_max_budget is not None:
+        return user_max_budget
+    return litellm.max_ui_session_budget

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -91,6 +91,9 @@ from litellm.proxy.common_utils.html_forms.jwt_display_template import (
     jwt_display_template,
 )
 from litellm.proxy.common_utils.html_forms.ui_login import build_ui_login_form
+from litellm.proxy.common_utils.ui_session_budget_utils import (
+    resolve_ui_session_max_budget,
+)
 from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
 from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
 from litellm.proxy.management_endpoints.sso import CustomMicrosoftSSO
@@ -166,16 +169,6 @@ _CLI_SSO_SECRET_KEY_FRAGMENTS = frozenset(
 
 def _hash_cli_sso_secret(secret: str) -> str:
     return hashlib.sha256(secret.encode("utf-8")).hexdigest()
-
-
-def _resolve_ui_session_max_budget(user_max_budget: Optional[float]) -> Optional[float]:
-    """
-    Session credentials use the user's configured max_budget when set;
-    otherwise fall back to the default UI/CLI session cap.
-    """
-    if user_max_budget is not None:
-        return user_max_budget
-    return litellm.max_ui_session_budget
 
 
 def _normalize_cli_sso_user_code(user_code: str) -> str:
@@ -2336,7 +2329,7 @@ async def cli_poll_key(
                 user_id=user_id,
                 user_role=session_data["user_role"],
                 models=session_data.get("models", []),
-                max_budget=_resolve_ui_session_max_budget(
+                max_budget=resolve_ui_session_max_budget(
                     session_data.get("max_budget")
                 ),
             )
@@ -3358,7 +3351,7 @@ class SSOAuthenticationHandler:
         )
 
         default_ui_key_values.update(user_defined_values)
-        default_ui_key_values["key_max_budget"] = _resolve_ui_session_max_budget(
+        default_ui_key_values["key_max_budget"] = resolve_ui_session_max_budget(
             user_info.max_budget if user_info is not None else None
         )
         default_ui_key_values["request_type"] = "key"
@@ -3411,7 +3404,7 @@ class SSOAuthenticationHandler:
                     user_id=user_defined_values["user_id"],
                     user_role=user_defined_values["user_role"] or user_role,
                     models=[],
-                    max_budget=_resolve_ui_session_max_budget(
+                    max_budget=resolve_ui_session_max_budget(
                         user_info.max_budget if user_info is not None else None
                     ),
                 )

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -168,6 +168,16 @@ def _hash_cli_sso_secret(secret: str) -> str:
     return hashlib.sha256(secret.encode("utf-8")).hexdigest()
 
 
+def _resolve_ui_session_max_budget(user_max_budget: Optional[float]) -> Optional[float]:
+    """
+    Session credentials use the user's configured max_budget when set;
+    otherwise fall back to the default UI/CLI session cap.
+    """
+    if user_max_budget is not None:
+        return user_max_budget
+    return litellm.max_ui_session_budget
+
+
 def _normalize_cli_sso_user_code(user_code: str) -> str:
     return "".join(ch for ch in user_code.upper() if ch.isalnum())
 
@@ -2124,6 +2134,7 @@ async def _complete_cli_sso_callback_session(
         "user_id": cast(str, user_info.user_id),
         "user_role": user_info.user_role,
         "models": user_info.models if hasattr(user_info, "models") else [],
+        "max_budget": user_info.max_budget,
         "user_email": user_email,
         "teams": teams,
         "team_details": team_details,
@@ -2325,7 +2336,9 @@ async def cli_poll_key(
                 user_id=user_id,
                 user_role=session_data["user_role"],
                 models=session_data.get("models", []),
-                max_budget=litellm.max_ui_session_budget,
+                max_budget=_resolve_ui_session_max_budget(
+                    session_data.get("max_budget")
+                ),
             )
 
             # Generate CLI JWT on-demand (expiration configurable via LITELLM_CLI_JWT_EXPIRATION_HOURS)
@@ -3345,6 +3358,9 @@ class SSOAuthenticationHandler:
         )
 
         default_ui_key_values.update(user_defined_values)
+        default_ui_key_values["key_max_budget"] = _resolve_ui_session_max_budget(
+            user_info.max_budget if user_info is not None else None
+        )
         default_ui_key_values["request_type"] = "key"
         response = await generate_key_helper_fn(
             **default_ui_key_values,  # type: ignore
@@ -3395,7 +3411,9 @@ class SSOAuthenticationHandler:
                     user_id=user_defined_values["user_id"],
                     user_role=user_defined_values["user_role"] or user_role,
                     models=[],
-                    max_budget=litellm.max_ui_session_budget,
+                    max_budget=_resolve_ui_session_max_budget(
+                        user_info.max_budget if user_info is not None else None
+                    ),
                 )
             if _user_info is None:
                 raise HTTPException(

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -127,6 +127,24 @@ def test_get_experimental_ui_login_jwt_auth_token_valid(valid_sso_user_defined_v
     assert expires <= now + timedelta(minutes=10, seconds=2)
 
 
+def test_get_experimental_ui_login_jwt_auth_token_falls_back_to_session_cap_without_user_budget(
+    valid_sso_user_defined_values,
+):
+    user_without_budget = valid_sso_user_defined_values.model_copy(
+        update={"max_budget": None}
+    )
+    token = ExperimentalUIJWTToken.get_experimental_ui_login_jwt_auth_token(
+        user_without_budget
+    )
+
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    assert token_data["max_budget"] == litellm.max_ui_session_budget
+
+
 def test_get_cli_jwt_auth_token_includes_team_alias(valid_sso_user_defined_values):
     token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(
         valid_sso_user_defined_values,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -116,7 +116,7 @@ def test_get_experimental_ui_login_jwt_auth_token_valid(valid_sso_user_defined_v
     assert token_data["user_id"] == "test_user"
     assert token_data["user_role"] == LitellmUserRoles.PROXY_ADMIN.value
     assert token_data["models"] == ["gpt-3.5-turbo"]
-    assert token_data["max_budget"] == litellm.max_ui_session_budget
+    assert token_data["max_budget"] == valid_sso_user_defined_values.max_budget
 
     # Verify expiration time is set and valid (Experimental UI uses fixed 10-min expiry)
     assert "expires" in token_data
@@ -215,7 +215,7 @@ def test_get_key_object_from_ui_hash_key_valid(
     assert key_object.user_id == "test_user"
     assert key_object.user_role == LitellmUserRoles.PROXY_ADMIN
     assert key_object.models == ["gpt-3.5-turbo"]
-    assert key_object.max_budget == litellm.max_ui_session_budget
+    assert key_object.max_budget == valid_sso_user_defined_values.max_budget
 
 
 def test_get_key_object_from_ui_hash_key_invalid():
@@ -422,7 +422,7 @@ def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values
     assert token_data["user_id"] == "test_user"
     assert token_data["user_role"] == LitellmUserRoles.PROXY_ADMIN.value
     assert token_data["models"] == ["gpt-3.5-turbo"]
-    assert token_data["max_budget"] == litellm.max_ui_session_budget
+    assert token_data["max_budget"] == valid_sso_user_defined_values.max_budget
 
     # Verify expiration time is set to 24 hours (default)
     assert "expires" in token_data
@@ -430,6 +430,22 @@ def test_get_cli_jwt_auth_token_default_expiration(valid_sso_user_defined_values
     assert expires > get_utc_datetime()
     assert expires <= get_utc_datetime() + timedelta(hours=24, minutes=1)
     assert expires >= get_utc_datetime() + timedelta(hours=23, minutes=59)
+
+
+def test_get_cli_jwt_auth_token_falls_back_to_session_cap_without_user_budget(
+    valid_sso_user_defined_values,
+):
+    user_without_budget = valid_sso_user_defined_values.model_copy(
+        update={"max_budget": None}
+    )
+    token = ExperimentalUIJWTToken.get_cli_jwt_auth_token(user_without_budget)
+
+    decrypted_token = decrypt_value_helper(
+        token, key="ui_hash_key", exception_type="debug"
+    )
+    assert decrypted_token is not None
+    token_data = json.loads(decrypted_token)
+    assert token_data["max_budget"] == litellm.max_ui_session_budget
 
 
 def test_get_cli_jwt_auth_token_custom_expiration(

--- a/tests/test_litellm/proxy/common_utils/test_ui_session_budget_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_ui_session_budget_utils.py
@@ -1,0 +1,12 @@
+import litellm
+from litellm.proxy.common_utils.ui_session_budget_utils import (
+    resolve_ui_session_max_budget,
+)
+
+
+def test_resolve_ui_session_max_budget_prefers_user_budget():
+    assert resolve_ui_session_max_budget(500.0) == 500.0
+
+
+def test_resolve_ui_session_max_budget_falls_back_to_session_cap():
+    assert resolve_ui_session_max_budget(None) == litellm.max_ui_session_budget

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1445,6 +1445,21 @@ class TestCLISSOCallbackFunction:
 class TestCLIPollingFunction:
     """Test the cli_poll_key function specifically"""
 
+    def test_resolve_ui_session_max_budget_prefers_user_budget(self):
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _resolve_ui_session_max_budget,
+        )
+
+        assert _resolve_ui_session_max_budget(500.0) == 500.0
+
+    def test_resolve_ui_session_max_budget_falls_back_to_session_cap(self):
+        import litellm
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _resolve_ui_session_max_budget,
+        )
+
+        assert _resolve_ui_session_max_budget(None) == litellm.max_ui_session_budget
+
     def test_cli_poll_key_validation_invalid_format(self):
         """Test CLI polling key format validation"""
         # Test key format validation logic
@@ -2900,9 +2915,54 @@ class TestCLIKeyRegenerationFlow:
             jwt_call_args = mock_get_jwt.call_args
             assert jwt_call_args.kwargs["team_id"] == selected_team
             assert jwt_call_args.kwargs["team_alias"] == "Team B"
+            assert (
+                jwt_call_args.kwargs["user_info"].max_budget
+                == litellm.max_ui_session_budget
+            )
 
             # Verify session was deleted after JWT generation
             mock_cache.delete_cache.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cli_poll_key_uses_user_max_budget_for_jwt(self):
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _hash_cli_sso_secret,
+            cli_poll_key,
+        )
+
+        session_key = "cli-session-user-budget"
+        session_data = {
+            "user_id": "test-user-budget",
+            "user_role": "internal_user",
+            "teams": ["team-a"],
+            "team_details": [{"team_id": "team-a", "team_alias": "Team A"}],
+            "models": ["gpt-4"],
+            "max_budget": 500.0,
+            "user_email": "budget@example.com",
+        }
+
+        mock_cache = MagicMock()
+        mock_cache.get_cache.return_value = {
+            "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
+            "sso_complete": True,
+            "user_code_verified": True,
+            "session_data": session_data,
+        }
+
+        with (
+            patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+            patch(
+                "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+                return_value="jwt-token",
+            ) as mock_get_jwt,
+        ):
+            await cli_poll_key(
+                key_id=session_key,
+                team_id="team-a",
+                x_litellm_cli_poll_secret="poll-secret",
+            )
+
+            assert mock_get_jwt.call_args.kwargs["user_info"].max_budget == 500.0
 
 
 class TestGetAppRolesFromIdToken:

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -1445,21 +1445,6 @@ class TestCLISSOCallbackFunction:
 class TestCLIPollingFunction:
     """Test the cli_poll_key function specifically"""
 
-    def test_resolve_ui_session_max_budget_prefers_user_budget(self):
-        from litellm.proxy.management_endpoints.ui_sso import (
-            _resolve_ui_session_max_budget,
-        )
-
-        assert _resolve_ui_session_max_budget(500.0) == 500.0
-
-    def test_resolve_ui_session_max_budget_falls_back_to_session_cap(self):
-        import litellm
-        from litellm.proxy.management_endpoints.ui_sso import (
-            _resolve_ui_session_max_budget,
-        )
-
-        assert _resolve_ui_session_max_budget(None) == litellm.max_ui_session_budget
-
     def test_cli_poll_key_validation_invalid_format(self):
         """Test CLI polling key format validation"""
         # Test key format validation logic


### PR DESCRIPTION
## Summary
- SSO and CLI session tokens (`cli-jwt-token`, browser UI session keys) now inherit the user's configured `max_budget` when one is set on their LiteLLM user record
- When no user budget is configured, behavior is unchanged and sessions still fall back to `max_ui_session_budget` ($0.25)

<img width="402" height="433" alt="image" src="https://github.com/user-attachments/assets/b3d892df-b2b4-4df8-9bcc-a936d8f454cb" />
