### PR TITLE
fix(proxy): derive generic passthrough model from URL path

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -91,6 +91,12 @@ def get_response_body(response: httpx.Response) -> Optional[dict]:
         return None
 
 
+def _get_passthrough_model_from_url(url: Optional[httpx.URL]) -> str:
+    if url is None:
+        return "unknown"
+    return url.path.strip("/") or "unknown"
+
+
 async def set_env_variables_in_header(custom_headers: Optional[dict]) -> Optional[dict]:
     """
     checks if any headers on config.yaml are defined as os.environ/COHERE_API_KEY etc
@@ -880,7 +886,9 @@ async def pass_through_request(
         ## LOGGING OBJECT ## - initialize before pre_call_hook so guardrails can access it
         # Surface the requested model (when the body carries one) so logging/spans
         # read e.g. ``chat gpt-4o`` instead of ``chat unknown``.
-        passthrough_model = (_parsed_body.get("model") if isinstance(_parsed_body, dict) else None) or "unknown"
+        passthrough_model = (
+            _parsed_body.get("model") if isinstance(_parsed_body, dict) else None
+        ) or _get_passthrough_model_from_url(url)
         start_time = datetime.now()
         logging_obj = Logging(
             model=passthrough_model,

--- a/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
+++ b/tests/pass_through_unit_tests/test_pass_through_unit_tests.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -31,6 +32,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
 from fastapi import Request
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+    _get_passthrough_model_from_url,
     _update_metadata_with_tags_in_header,
     HttpPassThroughEndpointHelpers,
 )
@@ -279,6 +281,21 @@ athropic_request_body = {
 }
 
 
+@pytest.mark.parametrize(
+    ("url", "expected_model"),
+    [
+        ("https://fal.run/fal-ai/flux/schnell", "fal-ai/flux/schnell"),
+        ("https://fal.run/fal-ai/flux/", "fal-ai/flux"),
+        ("https://fal.run/", "unknown"),
+        ("https://fal.run", "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_get_passthrough_model_from_url(url, expected_model):
+    parsed_url = httpx.URL(url) if url is not None else None
+    assert _get_passthrough_model_from_url(parsed_url) == expected_model
+
+
 @pytest.mark.asyncio
 async def test_pass_through_request_logging_failure(
     mock_request, mock_user_api_key_dict
@@ -335,6 +352,58 @@ async def test_pass_through_request_logging_failure(
         # Verify we got the mock response content
         # For FastAPI Response objects, content is accessed via the body attribute
         assert response.body == b'{"mock": "response"}'
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_uses_url_path_as_model_fallback(
+    mock_request, mock_user_api_key_dict
+):
+    logged_models = []
+    logging_tasks: list[asyncio.Task[None]] = []
+
+    async def capture_success_logging(*args, **kwargs):
+        logged_models.append(kwargs["logging_obj"].model_call_details["model"])
+
+    def run_success_logging(*, async_coroutine):
+        logging_tasks.append(asyncio.create_task(async_coroutine))
+
+    mock_response = httpx.Response(
+        200,
+        json={"mock": "response"},
+        request=httpx.Request("POST", "https://fal.run/fal-ai/flux/schnell"),
+    )
+
+    with (
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.PassThroughEndpointLogging.pass_through_async_success_handler",
+            new=capture_success_logging,
+        ),
+        patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue",
+            side_effect=run_success_logging,
+        ),
+        patch(
+            "httpx.AsyncClient.send",
+            return_value=mock_response,
+        ),
+        patch(
+            "httpx.AsyncClient.request",
+            return_value=mock_response,
+        ),
+    ):
+        request = mock_request(
+            headers={}, method="POST", request_body={"prompt": "test"}
+        )
+        response = await pass_through_request(
+            request=request,
+            target="https://fal.run/fal-ai/flux/schnell",
+            custom_headers={},
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+        await asyncio.gather(*logging_tasks)
+
+    assert response.status_code == 200
+    assert logged_models == ["fal-ai/flux/schnell"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Fixes #30932

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a confidence score of at least 4/5 on the current head before requesting a maintainer review

## Delays in PR merge?

The branch is refreshed on current `litellm_internal_staging` and validated from my side, but GitHub does not allow this fork author to change the PR from draft to ready

## CI (LiteLLM team)

- [ ] Branch creation CI run
- [x] CI run for the last commit
- [ ] Merge / cherry-pick CI run

## Screenshots / Proof of Fix

Before the fix, generic passthrough logging used `model="unknown"` for `https://fal.run/fal-ai/flux/schnell` when the request body had no `model` field

After the fix, the same request records `model="fal-ai/flux/schnell"` on the passthrough logging object. Requests with an explicit body model keep the existing behavior

The original branch had fallen 656 commits behind staging. Commit `1084dd03` reapplies the two-file change on current staging `bf02a4a4` and updates the integration test for the current `AsyncClient.send()` request path and queued logging worker

A Greptile 4/5 review on the first refreshed head identified trailing-slash normalization and the optional URL type boundary. The current head strips surrounding slashes and explicitly maps a missing URL to `unknown`, with regression cases for both

Validation:

```text
env -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY -u all_proxy -u http_proxy -u https_proxy \
  uv run --extra proxy pytest tests/pass_through_unit_tests/test_pass_through_unit_tests.py -q
18 passed, 2 existing warnings

uv run ruff check litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
All checks passed

uv run ruff check --ignore F401,T201,RUF100 \
  tests/pass_through_unit_tests/test_pass_through_unit_tests.py
All checks passed

uvx --from black==25.1.0 black --check \
  tests/pass_through_unit_tests/test_pass_through_unit_tests.py
1 file left unchanged

git diff --check bf02a4a4...1084dd03
passed
```

The two warnings come from the pre-existing streaming logging test and are outside the refreshed test

## Type

Bug Fix

Test

## Changes

Generic passthrough endpoints now use the normalized target URL path as the logged model fallback when the request body does not include a model field

The tests cover URL parsing boundaries, including empty and trailing-slash paths, and the current end-to-end success logging path through the background logging queue