### PR TITLE
fix(cloudflare): read OpenAI-style choices + usage for reasoning models

### DIFF
--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -264,7 +264,7 @@ class CloudflareChatResponseIterator(BaseModelResponseIterator):
             # ModelResponseStream so reasoning lands on the redaction-covered
             # delta.reasoning_content. (A nested provider_specific_fields entry
             # is NOT scrubbed by message-log redaction, so it must not be used.)
-            streaming_choices: List[StreamingChoices] = []
+            streaming_choices: list[StreamingChoices] = []
             for choice in chunk.get("choices") or []:
                 if not isinstance(choice, dict):
                     continue

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -148,22 +148,50 @@ class CloudflareChatConfig(BaseConfig):
         json_mode: Optional[bool] = None,
     ) -> ModelResponse:
         completion_response = raw_response.json()
+        result = completion_response.get("result", {})
 
-        # Support both "response" and "response_text" keys (newer models like Nemotron use "response_text")
-        result = completion_response["result"]
-        model_response.choices[0].message.content = result.get("response") if result.get("response") is not None else result.get("response_text", "")  # type: ignore
+        # Reasoning-capable Workers AI models (e.g. @cf/google/gemma-4-26b-a4b-it)
+        # return an OpenAI-style choices block and leave the flat "response" field
+        # empty, putting chain-of-thought in choices[0].message.reasoning. Read the
+        # choices block first, then fall back to legacy "response"/"response_text"
+        # (newer models like Nemotron use "response_text").
+        message = {}
+        choices = result.get("choices") or []
+        if choices and isinstance(choices[0], dict):
+            message = choices[0].get("message") or {}
 
-        prompt_tokens = litellm.utils.get_token_count(messages=messages, model=model)
-        completion_tokens = len(
-            encoding.encode(model_response["choices"][0]["message"].get("content", ""))
-        )
+        content = message.get("content")
+        if not content:
+            content = result.get("response")
+        if not content:
+            content = result.get("response_text", "")
+        model_response.choices[0].message.content = content  # type: ignore
+
+        reasoning = message.get("reasoning") or message.get("reasoning_content")
+        if reasoning:
+            model_response.choices[0].message.reasoning_content = reasoning  # type: ignore
 
         model_response.created = int(time.time())
         model_response.model = "cloudflare/" + model
+
+        # Prefer Cloudflare's own usage; estimate any field it omits so we never
+        # silently report zero tokens. Reasoning models always return usage; the
+        # legacy text shape may not.
+        usage_block = result.get("usage") or {}
+        prompt_tokens = usage_block.get("prompt_tokens")
+        if not prompt_tokens:
+            prompt_tokens = litellm.utils.get_token_count(messages=messages, model=model)
+        completion_tokens = usage_block.get("completion_tokens")
+        if not completion_tokens:
+            completion_tokens = len(encoding.encode(content or ""))
+        total_tokens = usage_block.get("total_tokens") or (
+            prompt_tokens + completion_tokens
+        )
+
         usage = Usage(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
-            total_tokens=prompt_tokens + completion_tokens,
+            total_tokens=total_tokens,
         )
         setattr(model_response, "usage", usage)
         return model_response
@@ -205,6 +233,32 @@ class CloudflareChatResponseIterator(BaseModelResponseIterator):
                 text = chunk["response"]
             elif "response_text" in chunk and chunk["response_text"] is not None:
                 text = chunk["response_text"]
+            else:
+                # OpenAI-style stream (reasoning + newer models): text and
+                # chain-of-thought arrive on choices[0].delta.
+                choices = chunk.get("choices") or []
+                if choices and isinstance(choices[0], dict):
+                    index = int(choices[0].get("index", index))
+                    delta = choices[0].get("delta") or {}
+                    text = delta.get("content") or ""
+                    reasoning = delta.get("reasoning") or delta.get(
+                        "reasoning_content"
+                    )
+                    if reasoning:
+                        provider_specific_fields = {"reasoning_content": reasoning}
+                    finish_reason = choices[0].get("finish_reason") or ""
+                    is_finished = bool(finish_reason)
+
+            usage_block = chunk.get("usage")
+            if usage_block:
+                prompt_tokens = usage_block.get("prompt_tokens", 0)
+                completion_tokens = usage_block.get("completion_tokens", 0)
+                usage = ChatCompletionUsageBlock(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=usage_block.get("total_tokens")
+                    or (prompt_tokens + completion_tokens),
+                )
 
             returned_chunk = GenericStreamingChunk(
                 text=text,

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -15,10 +15,12 @@ from litellm.llms.base_llm.chat.transformation import (
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import (
-    ChatCompletionToolCallChunk,
     ChatCompletionUsageBlock,
+    Delta,
     GenericStreamingChunk,
     ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
     Usage,
 )
 
@@ -224,57 +226,78 @@ class CloudflareChatConfig(BaseConfig):
 
 
 class CloudflareChatResponseIterator(BaseModelResponseIterator):
-    def chunk_parser(self, chunk: dict) -> GenericStreamingChunk:
+    def chunk_parser(
+        self, chunk: dict
+    ) -> Union[GenericStreamingChunk, ModelResponseStream]:
         try:
-            text = ""
-            tool_use: Optional[ChatCompletionToolCallChunk] = None
-            is_finished = False
-            finish_reason = ""
-            usage: Optional[ChatCompletionUsageBlock] = None
-            provider_specific_fields = None
-
-            index = int(chunk.get("index", 0))
-
-            if "response" in chunk and chunk["response"] is not None:
-                text = chunk["response"]
-            elif "response_text" in chunk and chunk["response_text"] is not None:
-                text = chunk["response_text"]
-            else:
-                # OpenAI-style stream (reasoning + newer models): text and
-                # chain-of-thought arrive on choices[0].delta.
-                choices = chunk.get("choices") or []
-                if choices and isinstance(choices[0], dict):
-                    index = int(choices[0].get("index", index))
-                    delta = choices[0].get("delta") or {}
-                    text = delta.get("content") or ""
-                    reasoning = delta.get("reasoning") or delta.get("reasoning_content")
-                    if reasoning:
-                        provider_specific_fields = {"reasoning_content": reasoning}
-                    finish_reason = choices[0].get("finish_reason") or ""
-                    is_finished = bool(finish_reason)
-
-            usage_block = chunk.get("usage")
-            if usage_block:
-                prompt_tokens = usage_block.get("prompt_tokens", 0)
-                completion_tokens = usage_block.get("completion_tokens", 0)
-                usage = ChatCompletionUsageBlock(
-                    prompt_tokens=prompt_tokens,
-                    completion_tokens=completion_tokens,
-                    total_tokens=usage_block.get("total_tokens")
-                    or (prompt_tokens + completion_tokens),
+            # Legacy plain-model stream: text arrives on the flat "response" /
+            # "response_text" field (no OpenAI-style choices, no reasoning).
+            if (
+                chunk.get("response") is not None
+                or chunk.get("response_text") is not None
+            ):
+                text = chunk.get("response")
+                if text is None:
+                    text = chunk.get("response_text") or ""
+                usage: Optional[ChatCompletionUsageBlock] = None
+                usage_block = chunk.get("usage")
+                if usage_block:
+                    prompt_tokens = usage_block.get("prompt_tokens", 0)
+                    completion_tokens = usage_block.get("completion_tokens", 0)
+                    usage = ChatCompletionUsageBlock(
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        total_tokens=usage_block.get("total_tokens")
+                        or (prompt_tokens + completion_tokens),
+                    )
+                return GenericStreamingChunk(
+                    text=text,
+                    tool_use=None,
+                    is_finished=False,
+                    finish_reason="",
+                    usage=usage,
+                    index=int(chunk.get("index", 0)),
+                    provider_specific_fields=None,
                 )
 
-            returned_chunk = GenericStreamingChunk(
-                text=text,
-                tool_use=tool_use,
-                is_finished=is_finished,
-                finish_reason=finish_reason,
-                usage=usage,
-                index=index,
-                provider_specific_fields=provider_specific_fields,
-            )
+            # OpenAI-style stream (reasoning + newer models): emit a
+            # ModelResponseStream so reasoning lands on the redaction-covered
+            # delta.reasoning_content. (A nested provider_specific_fields entry
+            # is NOT scrubbed by message-log redaction, so it must not be used.)
+            streaming_choices: List[StreamingChoices] = []
+            for choice in chunk.get("choices") or []:
+                if not isinstance(choice, dict):
+                    continue
+                delta = choice.get("delta") or {}
+                reasoning = delta.get("reasoning") or delta.get("reasoning_content")
+                streaming_choices.append(
+                    StreamingChoices(
+                        index=int(choice.get("index", 0)),
+                        delta=Delta(
+                            content=delta.get("content"),
+                            role=delta.get("role") or "assistant",
+                            reasoning_content=reasoning,
+                        ),
+                        finish_reason=choice.get("finish_reason"),
+                    )
+                )
 
-            return returned_chunk
+            usage_payload = chunk.get("usage")
+            if usage_payload is not None and usage_payload.get("total_tokens") is None:
+                usage_payload = {
+                    **usage_payload,
+                    "total_tokens": (usage_payload.get("prompt_tokens") or 0)
+                    + (usage_payload.get("completion_tokens") or 0),
+                }
+
+            return ModelResponseStream(
+                id=chunk.get("id"),
+                created=chunk.get("created"),
+                model=chunk.get("model"),
+                object="chat.completion.chunk",
+                choices=streaming_choices,
+                usage=usage_payload,
+            )
 
         except json.JSONDecodeError:
             raise ValueError(f"Failed to decode JSON from chunk: {chunk}")

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -180,7 +180,9 @@ class CloudflareChatConfig(BaseConfig):
         usage_block = result.get("usage") or {}
         prompt_tokens = usage_block.get("prompt_tokens")
         if not prompt_tokens:
-            prompt_tokens = litellm.utils.get_token_count(messages=messages, model=model)
+            prompt_tokens = litellm.utils.get_token_count(
+                messages=messages, model=model
+            )
         completion_tokens = usage_block.get("completion_tokens")
         if not completion_tokens:
             completion_tokens = len(encoding.encode(content or ""))
@@ -241,9 +243,7 @@ class CloudflareChatResponseIterator(BaseModelResponseIterator):
                     index = int(choices[0].get("index", index))
                     delta = choices[0].get("delta") or {}
                     text = delta.get("content") or ""
-                    reasoning = delta.get("reasoning") or delta.get(
-                        "reasoning_content"
-                    )
+                    reasoning = delta.get("reasoning") or delta.get("reasoning_content")
                     if reasoning:
                         provider_specific_fields = {"reasoning_content": reasoning}
                     finish_reason = choices[0].get("finish_reason") or ""

--- a/litellm/llms/cloudflare/chat/transformation.py
+++ b/litellm/llms/cloudflare/chat/transformation.py
@@ -176,19 +176,23 @@ class CloudflareChatConfig(BaseConfig):
 
         # Prefer Cloudflare's own usage; estimate any field it omits so we never
         # silently report zero tokens. Reasoning models always return usage; the
-        # legacy text shape may not.
+        # legacy text shape may not. Use ``is None`` so a genuine provider 0 is
+        # respected, and drop the provider total whenever we estimate a field so
+        # ``prompt + completion == total`` stays consistent.
         usage_block = result.get("usage") or {}
         prompt_tokens = usage_block.get("prompt_tokens")
-        if not prompt_tokens:
+        completion_tokens = usage_block.get("completion_tokens")
+        total_tokens = usage_block.get("total_tokens")
+        if prompt_tokens is None:
             prompt_tokens = litellm.utils.get_token_count(
                 messages=messages, model=model
             )
-        completion_tokens = usage_block.get("completion_tokens")
-        if not completion_tokens:
+            total_tokens = None
+        if completion_tokens is None:
             completion_tokens = len(encoding.encode(content or ""))
-        total_tokens = usage_block.get("total_tokens") or (
-            prompt_tokens + completion_tokens
-        )
+            total_tokens = None
+        if total_tokens is None:
+            total_tokens = prompt_tokens + completion_tokens
 
         usage = Usage(
             prompt_tokens=prompt_tokens,

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -98,7 +98,11 @@ def test_transform_response_missing_usage_is_estimated_not_zero():
     # No usage block: the content must survive and tokens must be estimated
     # (non-zero), not reported as 0.
     resp = _transform(
-        {"result": {"choices": [{"message": {"content": "The capital of France is Paris."}}]}}
+        {
+            "result": {
+                "choices": [{"message": {"content": "The capital of France is Paris."}}]
+            }
+        }
     )
     assert resp.choices[0].message.content == "The capital of France is Paris."
     assert resp.usage.completion_tokens > 0

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -112,6 +112,26 @@ def test_transform_response_missing_usage_is_estimated_not_zero():
     )
 
 
+def test_transform_response_respects_provider_zero_completion_tokens():
+    # A genuine 0 from the provider must be kept (not re-estimated), and the
+    # provider total must stay consistent with prompt + completion.
+    resp = _transform(
+        {
+            "result": {
+                "choices": [{"message": {"content": ""}}],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 0,
+                    "total_tokens": 20,
+                },
+            }
+        }
+    )
+    assert resp.usage.prompt_tokens == 20
+    assert resp.usage.completion_tokens == 0
+    assert resp.usage.total_tokens == 20
+
+
 def test_chunk_parser_openai_style_delta_and_total_default():
     it = CloudflareChatResponseIterator(streaming_response=iter([]), sync_stream=True)
 

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -1,6 +1,12 @@
+import httpx
 import pytest
 
-from litellm.llms.cloudflare.chat.transformation import CloudflareChatConfig
+import litellm
+from litellm.llms.cloudflare.chat.transformation import (
+    CloudflareChatConfig,
+    CloudflareChatResponseIterator,
+)
+from litellm.types.utils import ModelResponse
 
 
 def test_get_complete_url_encodes_model_path_segment():
@@ -25,3 +31,106 @@ def test_get_complete_url_encodes_model_path_segment():
             optional_params={},
             litellm_params={},
         )
+
+
+def _transform(payload):
+    return CloudflareChatConfig().transform_response(
+        model="@cf/google/gemma-4-26b-a4b-it",
+        raw_response=httpx.Response(200, json=payload),
+        model_response=ModelResponse(),
+        logging_obj=None,
+        request_data={},
+        messages=[{"role": "user", "content": "Capital of France?"}],
+        optional_params={},
+        litellm_params={},
+        encoding=litellm.encoding,
+    )
+
+
+def test_transform_response_reasoning_model_reads_choices_and_usage():
+    # Reasoning models leave result.response empty and return the answer in
+    # choices[].message.content, with chain-of-thought in message.reasoning.
+    resp = _transform(
+        {
+            "result": {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "The capital of France is Paris.",
+                            "reasoning": "The user asks for the capital of France.",
+                        }
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 43,
+                    "total_tokens": 63,
+                },
+            }
+        }
+    )
+    message = resp.choices[0].message
+    assert message.content == "The capital of France is Paris."
+    assert message.reasoning_content == "The user asks for the capital of France."
+    assert resp.usage.prompt_tokens == 20
+    assert resp.usage.completion_tokens == 43
+    assert resp.usage.total_tokens == 63
+
+
+def test_transform_response_legacy_response_field_still_works():
+    resp = _transform(
+        {
+            "result": {
+                "response": "The capital of France is Paris.",
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 8,
+                    "total_tokens": 28,
+                },
+            }
+        }
+    )
+    assert resp.choices[0].message.content == "The capital of France is Paris."
+    assert resp.usage.completion_tokens == 8
+
+
+def test_transform_response_missing_usage_is_estimated_not_zero():
+    # No usage block: the content must survive and tokens must be estimated
+    # (non-zero), not reported as 0.
+    resp = _transform(
+        {"result": {"choices": [{"message": {"content": "The capital of France is Paris."}}]}}
+    )
+    assert resp.choices[0].message.content == "The capital of France is Paris."
+    assert resp.usage.completion_tokens > 0
+    assert (
+        resp.usage.total_tokens
+        == resp.usage.prompt_tokens + resp.usage.completion_tokens
+    )
+
+
+def test_chunk_parser_openai_style_delta_and_total_default():
+    it = CloudflareChatResponseIterator(streaming_response=iter([]), sync_stream=True)
+
+    content_chunk = it.chunk_parser(
+        {
+            "choices": [{"delta": {"content": " Paris"}, "index": 0}],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 30},
+        }
+    )
+    assert content_chunk["text"] == " Paris"
+    # total_tokens defaults to prompt + completion when the provider omits it.
+    assert content_chunk["usage"]["total_tokens"] == 50
+
+    reasoning_chunk = it.chunk_parser(
+        {"choices": [{"delta": {"reasoning": "Thinking"}, "index": 0}]}
+    )
+    assert reasoning_chunk["text"] == ""
+    assert reasoning_chunk["provider_specific_fields"] == {
+        "reasoning_content": "Thinking"
+    }
+
+
+def test_chunk_parser_legacy_response_field_still_works():
+    it = CloudflareChatResponseIterator(streaming_response=iter([]), sync_stream=True)
+    chunk = it.chunk_parser({"response": "Paris", "index": 0})
+    assert chunk["text"] == "Paris"

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -94,6 +94,26 @@ def test_transform_response_legacy_response_field_still_works():
     assert resp.usage.completion_tokens == 8
 
 
+def test_transform_response_response_text_field_still_works():
+    # Newer Workers AI models (e.g. Nemotron) return the answer under
+    # "response_text" rather than the legacy "response" key, and without an
+    # OpenAI-style choices block. Content must fall through to "response_text".
+    resp = _transform(
+        {
+            "result": {
+                "response_text": "The capital of France is Paris.",
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 8,
+                    "total_tokens": 28,
+                },
+            }
+        }
+    )
+    assert resp.choices[0].message.content == "The capital of France is Paris."
+    assert resp.usage.completion_tokens == 8
+
+
 def test_transform_response_missing_usage_is_estimated_not_zero():
     # No usage block: the content must survive and tokens must be estimated
     # (non-zero), not reported as 0.

--- a/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
+++ b/tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 import litellm
+from litellm.litellm_core_utils.redact_messages import _redact_choice_content
 from litellm.llms.cloudflare.chat.transformation import (
     CloudflareChatConfig,
     CloudflareChatResponseIterator,
@@ -152,7 +153,7 @@ def test_transform_response_respects_provider_zero_completion_tokens():
     assert resp.usage.total_tokens == 20
 
 
-def test_chunk_parser_openai_style_delta_and_total_default():
+def test_chunk_parser_openai_style_delta_reasoning_and_total_default():
     it = CloudflareChatResponseIterator(streaming_response=iter([]), sync_stream=True)
 
     content_chunk = it.chunk_parser(
@@ -161,17 +162,31 @@ def test_chunk_parser_openai_style_delta_and_total_default():
             "usage": {"prompt_tokens": 20, "completion_tokens": 30},
         }
     )
-    assert content_chunk["text"] == " Paris"
+    assert content_chunk.choices[0].delta.content == " Paris"
     # total_tokens defaults to prompt + completion when the provider omits it.
-    assert content_chunk["usage"]["total_tokens"] == 50
+    assert content_chunk.usage.total_tokens == 50
 
     reasoning_chunk = it.chunk_parser(
         {"choices": [{"delta": {"reasoning": "Thinking"}, "index": 0}]}
     )
-    assert reasoning_chunk["text"] == ""
-    assert reasoning_chunk["provider_specific_fields"] == {
-        "reasoning_content": "Thinking"
-    }
+    delta = reasoning_chunk.choices[0].delta
+    assert delta.content is None
+    # Reasoning is surfaced on the redaction-covered reasoning_content field,
+    # not a nested provider_specific_fields entry.
+    assert delta.reasoning_content == "Thinking"
+    assert getattr(delta, "provider_specific_fields", None) is None
+
+
+def test_chunk_parser_streaming_reasoning_is_redactable():
+    # turn_off_message_logging scrubs delta.reasoning_content; streamed Cloudflare
+    # reasoning must land there so it is redacted, rather than leaking via a nested
+    # provider_specific_fields entry the redactor does not touch.
+    it = CloudflareChatResponseIterator(streaming_response=iter([]), sync_stream=True)
+    chunk = it.chunk_parser(
+        {"choices": [{"delta": {"reasoning": "secret chain of thought"}, "index": 0}]}
+    )
+    _redact_choice_content(chunk.choices[0])
+    assert chunk.choices[0].delta.reasoning_content == "redacted-by-litellm"
 
 
 def test_chunk_parser_legacy_response_field_still_works():


### PR DESCRIPTION
## Title
fix(cloudflare): read OpenAI-style choices + usage for reasoning models

## What / Why

Cloudflare Workers AI's `ai/run` endpoint returns chat output in two shapes:

- legacy flat field `result.response` (string), and
- OpenAI-style `result.choices[0].message.content` + `result.usage`.

Plain instruct models populate **both**. Reasoning-capable models (e.g. `@cf/google/gemma-4-26b-a4b-it`, Kimi K2.x, GLM) populate **only** the OpenAI-style block — they put chain-of-thought in `result.choices[0].message.reasoning` and leave `result.response` empty/absent.

`CloudflareChatConfig.transform_response` read **only** `result.response`, then computed `completion_tokens` by re-encoding that (empty) string. So reasoning models returned `content=""` and `completion_tokens=0` despite Cloudflare producing — and billing — real output. The streaming `chunk_parser` had the same flaw: it read only `response`/`response_text`, while reasoning chunks carry `choices[0].delta.content` / `delta.reasoning`.

Related: #24065 (Cloudflare `KeyError: 'response'` / empty content on newer models), #20246 (streaming iterator ignores the `reasoning` key).

### Raw Cloudflare `/run` response (gemma-4, reasoning) vs llama (legacy)

| | `result.response` | `choices[0].message.content` | `usage.completion_tokens` |
|---|---|---|---|
| `@cf/google/gemma-4-26b-a4b-it` | `null` | `"The capital of France is **Paris**."` | 43 |
| `@cf/meta/llama-3.2-3b-instruct` | `"...Paris."` | `"...Paris."` | 8 |

## Changes

`transform_response`:
- read `result.choices[0].message.content` first, fall back to legacy `result.response` / `result.response_text` (plain models unchanged);
- surface `message.reasoning` (or `reasoning_content`) on `message.reasoning_content`;
- take token counts from `result.usage`, estimating any field the provider omits (prompt via `get_token_count`, completion via the encoder) so usage is never silently `0`; `total_tokens` defaults to `prompt + completion`.

`chunk_parser`:
- legacy `response`/`response_text` chunks → `GenericStreamingChunk` (unchanged);
- OpenAI-style chunks → a `ModelResponseStream` with reasoning on `delta.reasoning_content` (mirrors the OpenRouter handler) so `turn_off_message_logging` redaction covers it — **not** a nested `provider_specific_fields` entry, which the redactor does not scrub;
- default streaming `total_tokens` to `prompt + completion`.

## Tests

Added to `tests/test_litellm/llms/cloudflare/test_cloudflare_transformation.py` (no network): reasoning-shape parsing (content + reasoning_content + usage), legacy-shape regression, missing-usage estimation (non-zero), OpenAI-style streaming delta + reasoning + total default, and legacy streaming. All pass.

## Notes

🔥 🔥 This fix has been running in production at **Eden AI** (which routes Cloudflare through litellm) to confirm the behavior against live reasoning and instruct models.


