### PR TITLE
fix: accept MCP security on_violation actions

### DIFF
--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -700,9 +700,14 @@ class BaseLitellmParams(
         default=None,
         description="For /v1/realtime sessions: automatically close the session after this many guardrail violations.",
     )
-    on_violation: Optional[Literal["warn", "end_session"]] = Field(
+    on_violation: Optional[Literal["warn", "end_session", "block", "alert"]] = Field(
         default=None,
-        description="For /v1/realtime sessions: 'warn' speaks the violation message and continues; 'end_session' speaks the message and closes the connection.",
+        description=(
+            "For /v1/realtime sessions: 'warn' speaks the violation message and "
+            "continues; 'end_session' speaks the message and closes the connection. "
+            "For MCP security guardrails: 'block' rejects the request; 'alert' "
+            "logs the violation and allows the request."
+        ),
     )
     realtime_violation_message: Optional[str] = Field(
         default=None,
@@ -800,6 +805,7 @@ class LitellmParams(
         "mode",
         "default_action",
         "on_disallowed_action",
+        "on_violation",
         "unreachable_fallback",
         mode="before",
         check_fields=False,

--- a/tests/test_litellm/types/test_guardrails_case_normalization.py
+++ b/tests/test_litellm/types/test_guardrails_case_normalization.py
@@ -89,3 +89,15 @@ class TestLitellmParamsCaseNormalization:
             )
             assert params.on_disallowed_action in ["block", "rewrite"]
             assert params.on_disallowed_action.islower()
+
+    @pytest.mark.parametrize("on_violation", ["block", "alert", "Block", "ALERT"])
+    def test_mcp_security_on_violation_allows_block_and_alert(self, on_violation):
+        """MCP security policy templates use block/alert violation actions."""
+        params = LitellmParams(
+            guardrail="mcp_security",
+            mode="pre_call",
+            default_on=True,
+            on_violation=on_violation,
+        )
+        assert params.on_violation in ["block", "alert"]
+        assert params.on_violation.islower()


### PR DESCRIPTION
## Summary

Fixes #30953.

Allows the MCP Security policy template to create its `mcp_security` guardrail by accepting the `on_violation` actions that the MCP security initializer already supports (`block` and `alert`). The value is also normalized through the existing lowercase validator so dashboard/template input such as `Block` is handled consistently.

## Root cause

The "MCP Security: Block Unregistered Servers" template sends `litellm_params.on_violation: "block"` to `/guardrails`. `LitellmParams` previously modeled `on_violation` only as the realtime actions `warn | end_session`, so Pydantic rejected the request with a 422 before the guardrail could be created. The MCP security initializer already reads `on_violation` as `block | alert`.

## Duplicate check

I checked open PRs for:

- `30953 mcp-security-unregistered-server-block mcp_security on_violation block alert`
- `mcp-block guardrail template policy template`

I did not find an open PR for this issue.

## Validation

- `uv run pytest tests/test_litellm/types/test_guardrails_case_normalization.py -q`
  - `19 passed in 0.10s`
- `uv run ruff check litellm/types/guardrails.py tests/test_litellm/types/test_guardrails_case_normalization.py`
  - `All checks passed!`
- Reproduced the template payload by loading `mcp-security-unregistered-server-block` from `litellm/policy_templates_backup.json` and constructing `LitellmParams(**guardrail["litellm_params"])`
  - `mcp-security-block mcp_security block`
- `LITELLM_PYTHON='uv run --no-sync python' npm run gen:api` with local proxy env unset
  - completed; no relevant API type update was needed

## AI assistance

AI assistance was used to inspect the issue, trace the template payload to the Pydantic model, make this focused change, and run the validation above. I reviewed the final diff and test output.
