### PR TITLE
feat: add support for exa /search outputschema

### DIFF
--- a/litellm/llms/exa_ai/search/transformation.py
+++ b/litellm/llms/exa_ai/search/transformation.py
@@ -46,6 +46,7 @@ class ExaAISearchRequest(_ExaAISearchRequestRequired, total=False):
     context: Union[bool, dict]  # Optional - format results for LLMs
     moderation: bool  # Optional - enable content moderation, default false
     contents: dict  # Optional - content retrieval options
+    outputSchema: dict  # Optional - output schema definition
 
 
 class ExaAISearchConfig(BaseSearchConfig):
@@ -196,7 +197,10 @@ class ExaAISearchConfig(BaseSearchConfig):
             )
             results.append(search_result)
 
-        return SearchResponse(
+        search_response = SearchResponse(
             results=results,
             object="search",
         )
+        if "output" in response_json:
+            search_response.output = response_json["output"]
+        return search_response

--- a/litellm/llms/exa_ai/search/transformation.py
+++ b/litellm/llms/exa_ai/search/transformation.py
@@ -197,10 +197,12 @@ class ExaAISearchConfig(BaseSearchConfig):
             )
             results.append(search_result)
 
+        extra: dict = {}
+        if "output" in response_json:
+            extra["output"] = response_json["output"]
         search_response = SearchResponse(
             results=results,
             object="search",
+            **extra,
         )
-        if "output" in response_json:
-            search_response.output = response_json["output"]
         return search_response

--- a/tests/search_tests/test_exa_ai_search.py
+++ b/tests/search_tests/test_exa_ai_search.py
@@ -1,7 +1,9 @@
 import pytest
 import litellm
 from typing import List, Union
+from unittest.mock import Mock
 
+from litellm.llms.exa_ai.search.transformation import ExaAISearchConfig
 from tests.search_tests.base_search_unit_tests import BaseSearchTest
 
 
@@ -15,3 +17,68 @@ class TestExaAISearch(BaseSearchTest):
         Return search_provider for Exa AI Search.
         """
         return "exa_ai"
+
+
+class TestExaAISearchTransformation:
+    def test_should_include_output_when_exa_returns_output(self):
+        config = ExaAISearchConfig()
+        raw_response = Mock()
+        raw_response.json.return_value = {
+            "output": {
+                "content": "Nvidia announced the Vera Rubin platform.",
+                "grounding": [
+                    {
+                        "field": "content",
+                        "citations": [
+                            {
+                                "url": "https://nvidianews.nvidia.com/news/test",
+                                "title": "NVIDIA Newsroom",
+                            }
+                        ],
+                        "confidence": "high",
+                    }
+                ],
+            },
+            "results": [
+                {
+                    "title": "NVIDIA Newsroom",
+                    "url": "https://nvidianews.nvidia.com/news/test",
+                    "text": "NVIDIA announced Vera Rubin.",
+                    "publishedDate": "2026-06-22T00:00:00.000Z",
+                }
+            ],
+        }
+
+        response = config.transform_search_response(
+            raw_response=raw_response,
+            logging_obj=None,
+        )
+
+        assert response.output == raw_response.json.return_value["output"]
+        assert (
+            response.model_dump()["output"]
+            == raw_response.json.return_value["output"]
+        )
+        assert response.results[0].title == "NVIDIA Newsroom"
+
+    def test_should_not_require_output_when_exa_omits_output(self):
+        config = ExaAISearchConfig()
+        raw_response = Mock()
+        raw_response.json.return_value = {
+            "results": [
+                {
+                    "title": "NVIDIA Newsroom",
+                    "url": "https://nvidianews.nvidia.com/news/test",
+                    "text": "NVIDIA announced Vera Rubin.",
+                }
+            ],
+        }
+
+        response = config.transform_search_response(
+            raw_response=raw_response,
+            logging_obj=None,
+        )
+
+        assert "output" not in response.model_dump()
+        assert response.object == "search"
+        assert response.results[0].title == "NVIDIA Newsroom"


### PR DESCRIPTION
## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [X] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Request:
```
{
    "query": "what started ww2?",   
    "max_results": 1,
    "outputSchema": {
      "description": "a concise summarized answer, one sentence only",
      "type": "text"
    },
    "type": "auto"
}
```

Response:
```
{
  "results": [
    {
      "title": "How Europe ...",
      "url": "https://www....",
      "snippet": "How Europe Went ...",
      "date": null,
      "last_updated": null
    }
  ],
  "object": "search",
  "output": {
    "content": "World War II began when ...",
    "grounding": [
      {
        "field": "content",
        "citations": [
          {
            "url": "https://www.iwm.org....",
            "title": "How Europe ..."
          }
        ],
        "confidence": "high"
      }
    ]
  }
}
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
✅ Test

## Changes

- Adds support for `outputSchema` on exa `/search` and `output` response format