### PR TITLE
fix(ui): stop per-model usage export from duplicating user spend across models

### DIFF
--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
@@ -1036,6 +1036,18 @@ describe("EntityUsageExport utils", () => {
                   failed_requests: 2,
                   total_tokens: 500,
                 },
+                api_key_breakdown: {
+                  key1: {
+                    metrics: {
+                      spend: 5.0,
+                      api_requests: 50,
+                      successful_requests: 48,
+                      failed_requests: 2,
+                      total_tokens: 500,
+                    },
+                    metadata: { team_id: "team-1" },
+                  },
+                },
               },
               "gpt-3.5-turbo": {
                 metrics: {
@@ -1044,6 +1056,18 @@ describe("EntityUsageExport utils", () => {
                   successful_requests: 47,
                   failed_requests: 3,
                   total_tokens: 500,
+                },
+                api_key_breakdown: {
+                  key2: {
+                    metrics: {
+                      spend: 5.5,
+                      api_requests: 50,
+                      successful_requests: 47,
+                      failed_requests: 3,
+                      total_tokens: 500,
+                    },
+                    metadata: { team_id: "team-1" },
+                  },
                 },
               },
             },
@@ -1118,6 +1142,18 @@ describe("EntityUsageExport utils", () => {
                     failed_requests: 5,
                     total_tokens: 1000,
                   },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 10.5,
+                        api_requests: 100,
+                        successful_requests: 95,
+                        failed_requests: 5,
+                        total_tokens: 1000,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
                 },
               },
             },
@@ -1134,12 +1170,229 @@ describe("EntityUsageExport utils", () => {
       );
     });
 
-    it("should aggregate model metrics from api key breakdown", () => {
+    it("should attribute each model only its own per-key spend", () => {
       const result = generateDailyWithModelsData(mockSpendDataWithModels, "Team");
 
       const gpt4Entry = result.find((r) => r.Model === "gpt-4");
-      expect(gpt4Entry).toBeDefined();
-      expect(gpt4Entry?.Requests).toBeGreaterThan(0);
+      const gpt35Entry = result.find((r) => r.Model === "gpt-3.5-turbo");
+
+      expect(gpt4Entry?.["Spend ($)"]).toBe("5.0000");
+      expect(gpt4Entry?.Requests).toBe(50);
+      expect(gpt4Entry?.["Total Tokens"]).toBe(500);
+
+      expect(gpt35Entry?.["Spend ($)"]).toBe("5.5000");
+      expect(gpt35Entry?.Requests).toBe(50);
+      expect(gpt35Entry?.["Total Tokens"]).toBe(500);
+    });
+
+    it("should not duplicate a user's spend across every model (regression for LIT overcount)", () => {
+      // One user, one key, that key used two models. The entity-level api_key_breakdown
+      // carries the key's total (8.0) across both models; each model's api_key_breakdown
+      // carries only that model's share (3.0 + 5.0). The per-model rows must sum back to
+      // the user-day total, not repeat the total once per model.
+      const data: EntitySpendData = {
+        results: [
+          {
+            date: "2025-02-14",
+            breakdown: {
+              entities: {
+                user1: {
+                  metrics: {
+                    spend: 8.0,
+                    api_requests: 80,
+                    successful_requests: 78,
+                    failed_requests: 2,
+                    total_tokens: 800,
+                    prompt_tokens: 500,
+                    completion_tokens: 300,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 8.0,
+                        api_requests: 80,
+                        successful_requests: 78,
+                        failed_requests: 2,
+                        total_tokens: 800,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+              },
+              models: {
+                "claude-3-haiku": {
+                  metrics: {
+                    spend: 3.0,
+                    api_requests: 30,
+                    successful_requests: 29,
+                    failed_requests: 1,
+                    total_tokens: 300,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 3.0,
+                        api_requests: 30,
+                        successful_requests: 29,
+                        failed_requests: 1,
+                        total_tokens: 300,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+                "claude-sonnet-4-5": {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 50,
+                    successful_requests: 49,
+                    failed_requests: 1,
+                    total_tokens: 500,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 5.0,
+                        api_requests: 50,
+                        successful_requests: 49,
+                        failed_requests: 1,
+                        total_tokens: 500,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        metadata: {
+          total_spend: 8.0,
+          total_api_requests: 80,
+          total_successful_requests: 78,
+          total_failed_requests: 2,
+          total_tokens: 800,
+        },
+      };
+
+      const result = generateDailyWithModelsData(data, "User");
+
+      expect(result).toHaveLength(2);
+
+      const haiku = result.find((r) => r.Model === "claude-3-haiku");
+      const sonnet = result.find((r) => r.Model === "claude-sonnet-4-5");
+
+      expect(haiku?.["Spend ($)"]).toBe("3.0000");
+      expect(sonnet?.["Spend ($)"]).toBe("5.0000");
+
+      const totalSpend = result.reduce((sum, r) => sum + parseFloat(r["Spend ($)"].replace(/,/g, "")), 0);
+      const totalRequests = result.reduce((sum, r) => sum + r.Requests, 0);
+      const totalTokens = result.reduce((sum, r) => sum + r["Total Tokens"], 0);
+
+      expect(totalSpend).toBeCloseTo(8.0, 4);
+      expect(totalRequests).toBe(80);
+      expect(totalTokens).toBe(800);
+    });
+
+    it("should omit models the user never called instead of fanning out", () => {
+      // A second key (key2) belongs to a different user and is the only caller of
+      // gpt-3.5-turbo. user1 only used key1 -> gpt-4. user1 must get exactly one row.
+      const data: EntitySpendData = {
+        results: [
+          {
+            date: "2025-02-14",
+            breakdown: {
+              entities: {
+                user1: {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 50,
+                    successful_requests: 48,
+                    failed_requests: 2,
+                    total_tokens: 500,
+                    prompt_tokens: 300,
+                    completion_tokens: 200,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 5.0,
+                        api_requests: 50,
+                        successful_requests: 48,
+                        failed_requests: 2,
+                        total_tokens: 500,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+              },
+              models: {
+                "gpt-4": {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 50,
+                    successful_requests: 48,
+                    failed_requests: 2,
+                    total_tokens: 500,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 5.0,
+                        api_requests: 50,
+                        successful_requests: 48,
+                        failed_requests: 2,
+                        total_tokens: 500,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+                "gpt-3.5-turbo": {
+                  metrics: {
+                    spend: 9.0,
+                    api_requests: 90,
+                    successful_requests: 90,
+                    failed_requests: 0,
+                    total_tokens: 900,
+                  },
+                  api_key_breakdown: {
+                    key2: {
+                      metrics: {
+                        spend: 9.0,
+                        api_requests: 90,
+                        successful_requests: 90,
+                        failed_requests: 0,
+                        total_tokens: 900,
+                      },
+                      metadata: { team_id: "team-2" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        metadata: {
+          total_spend: 14.0,
+          total_api_requests: 140,
+          total_successful_requests: 138,
+          total_failed_requests: 2,
+          total_tokens: 1400,
+        },
+      };
+
+      const result = generateDailyWithModelsData(data, "User");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].Model).toBe("gpt-4");
+      expect(result[0]["Spend ($)"]).toBe("5.0000");
     });
 
     it("should use team alias when available", () => {
@@ -1311,6 +1564,18 @@ describe("EntityUsageExport utils", () => {
                     successful_requests: 95,
                     failed_requests: 5,
                     total_tokens: 1000,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 10.5,
+                        api_requests: 100,
+                        successful_requests: 95,
+                        failed_requests: 5,
+                        total_tokens: 1000,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
                   },
                 },
               },
@@ -1595,7 +1860,43 @@ describe("EntityUsageExport utils", () => {
               metadata: { team_id: "team-1", key_alias: "staging-key" },
             },
           },
-          models: { "gpt-4": { metrics: { spend: 35, api_requests: 350, total_tokens: 3500 } } },
+          models: {
+            "gpt-4": {
+              metrics: { spend: 35.8, api_requests: 350, total_tokens: 3500 },
+              api_key_breakdown: {
+                key1: {
+                  metrics: {
+                    spend: 10.5,
+                    api_requests: 100,
+                    successful_requests: 95,
+                    failed_requests: 5,
+                    total_tokens: 1000,
+                  },
+                  metadata: { team_id: "team-1" },
+                },
+                key1b: {
+                  metrics: {
+                    spend: 5,
+                    api_requests: 50,
+                    successful_requests: 48,
+                    failed_requests: 2,
+                    total_tokens: 500,
+                  },
+                  metadata: { team_id: "team-1" },
+                },
+                key2: {
+                  metrics: {
+                    spend: 20.3,
+                    api_requests: 200,
+                    successful_requests: 195,
+                    failed_requests: 5,
+                    total_tokens: 2000,
+                  },
+                  metadata: { team_id: "team-2" },
+                },
+              },
+            },
+          },
         },
       })),
     };
@@ -1699,6 +2000,13 @@ describe("EntityUsageExport utils", () => {
         const result = generateDailyWithModelsData(aggregatedSpendData, "Team");
         expect(result.length).toBeGreaterThan(0);
         expect(result[0]).toHaveProperty("Model");
+
+        // team-1 = key1 (10.5) + key1b (5) on gpt-4; team-2 = key2 (20.3) on gpt-4.
+        // Spend must aggregate per team-key, not repeat the model total per team.
+        const team1 = result.find((r) => r["Team ID"] === "team-1");
+        const team2 = result.find((r) => r["Team ID"] === "team-2");
+        expect(team1?.["Spend ($)"]).toBe("15.5000");
+        expect(team2?.["Spend ($)"]).toBe("20.3000");
       });
     });
   });

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -237,9 +237,13 @@ export const generateDailyWithModelsData = (
       }
 
       Object.entries(day.breakdown.models || {}).forEach(([model, modelData]: [string, any]) => {
-        const apiKeyBreakdown = entityData.api_key_breakdown || {};
+        const entityApiKeys = entityData.api_key_breakdown || {};
+        const modelApiKeys = modelData.api_key_breakdown || {};
 
-        Object.entries(apiKeyBreakdown).forEach(([apiKey, apiKeyData]: [string, any]) => {
+        Object.keys(entityApiKeys).forEach((apiKey) => {
+          const keyMetrics = modelApiKeys[apiKey]?.metrics;
+          if (!keyMetrics) return;
+
           if (!dailyEntityModels[entity][model]) {
             dailyEntityModels[entity][model] = {
               spend: 0,
@@ -249,11 +253,11 @@ export const generateDailyWithModelsData = (
               tokens: 0,
             };
           }
-          dailyEntityModels[entity][model].spend += apiKeyData.metrics.spend || 0;
-          dailyEntityModels[entity][model].requests += apiKeyData.metrics.api_requests || 0;
-          dailyEntityModels[entity][model].successful += apiKeyData.metrics.successful_requests || 0;
-          dailyEntityModels[entity][model].failed += apiKeyData.metrics.failed_requests || 0;
-          dailyEntityModels[entity][model].tokens += apiKeyData.metrics.total_tokens || 0;
+          dailyEntityModels[entity][model].spend += keyMetrics.spend || 0;
+          dailyEntityModels[entity][model].requests += keyMetrics.api_requests || 0;
+          dailyEntityModels[entity][model].successful += keyMetrics.successful_requests || 0;
+          dailyEntityModels[entity][model].failed += keyMetrics.failed_requests || 0;
+          dailyEntityModels[entity][model].tokens += keyMetrics.total_tokens || 0;
         });
       });
     });


### PR DESCRIPTION
## Relevant issues

Reported in the proxy usage export: the "day-by-day by user and model" export overcounts spend

## Linear ticket

Resolves LIT-3866

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of 5/5**

## What was wrong

The Usage page has three export variants. "by user" and "by user and key" tie to the dashboard; "by user and model" overcounts. The export is built client side in `ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts`, and the per-model variant was fabricating its rows.

`generateDailyWithModelsData` iterated `day.breakdown.models` crossed with the entity's own `api_key_breakdown`, and for every model it added the api key's full daily spend. The per-model object (`modelData`) was destructured but never used, and the api key was never matched to the model. So every model row for a given user-day received that user's entire day total, and a user who called N models produced N identical rows. Summing the spend column multiplied the real spend by the model count. One reported export totaled $167,953 against a true $21,353 (about 7.87x), and across that report 440 of 441 multi-model user-day groups had identical spend on every row.

## The fix

Attribute each model only the spend of the keys that actually used it, by intersecting the entity's api keys with `modelData.api_key_breakdown` (both are populated by the backend in `litellm/proxy/management_endpoints/common_daily_activity.py` and keyed by the same api key). Per-model rows now sum back to the user-day total, and models a user never called no longer appear. This mirrors the pattern already used correctly by the on-screen charts in `activity_metrics.tsx`, which is why the dashboard always tied out while only the export drifted.

## Screenshots / Proof of Fix

Live proxy with real Anthropic calls. One user, one key, three models, so the fan-out condition exists.

1. Create the user and a key, then make real calls across three models

```bash
curl -s -X POST http://localhost:4000/user/new -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"user_id":"lit3866_repro_user","user_email":"lit3866@example.com"}'

curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"user_id":"lit3866_repro_user","key_alias":"lit3866-repro-key"}'
# -> sk-YFDoisKGjzs4rj9t5xgsow

for MODEL in anthropic-haiku-4-5 anthropic-sonnet-4-5 anthropic-opus-4-5; do
  for i in 1 2; do
    curl -s -X POST http://localhost:4000/v1/chat/completions \
      -H "Authorization: Bearer sk-YFDoisKGjzs4rj9t5xgsow" -H "Content-Type: application/json" \
      -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly one word: hello\"}],\"max_tokens\":10}"
  done
done
```

2. The real per-(user, model) spend the backend recorded

```text
    date    |      user_id       |            model            |  spend
------------+--------------------+-----------------------------+----------
 2026-06-22 | lit3866_repro_user | anthropic/claude-haiku-4-5  |  0.000068
 2026-06-22 | lit3866_repro_user | anthropic/claude-opus-4-5   |  0.000340
 2026-06-22 | lit3866_repro_user | anthropic/claude-sonnet-4-5 |  0.000204
```

True user-day total: 0.000612

3. The real payload that feeds the export

```bash
curl -s "http://localhost:4000/user/daily/activity?start_date=2026-06-22&end_date=2026-06-22&page_size=1000" \
  -H "Authorization: Bearer sk-1234"
```

The user entity carries spend 0.000612 with one api key, and each of the three models carries an `api_key_breakdown` keyed by that same api key with its own per-model spend.

4. Running the shipped per-model export transform over that exact payload

Before the fix, every model row repeats the full user total and the column sums to 3x (one factor per model called):

```text
  2026-06-22  anthropic/claude-sonnet-4-5  spend=0.0006  requests=6
  2026-06-22  anthropic/claude-opus-4-5    spend=0.0006  requests=6
  2026-06-22  anthropic/claude-haiku-4-5   spend=0.0006  requests=6
  sum of per-model Spend ($): 0.0018   overcount: 2.94x
```

After the fix, each model carries only its own spend and the column ties to the user-day total (the small residual is 4-decimal display rounding of sub-cent values):

```text
  2026-06-22  anthropic/claude-sonnet-4-5  spend=0.0002  requests=2
  2026-06-22  anthropic/claude-opus-4-5    spend=0.0003  requests=2
  2026-06-22  anthropic/claude-haiku-4-5   spend=0.0001  requests=2
  sum of per-model Spend ($): 0.0006   ties to by-user total
```

The 3x here matches the three models called; the reported 6x matched six models. The factor is the model count, which is the fan-out signature.

## Type

🐛 Bug Fix

## Changes

`ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts`: `generateDailyWithModelsData` now intersects the entity's api keys with each model's `api_key_breakdown` and attributes per-model spend from the model-key metrics, instead of adding the entity-key total to every model.

`ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts`: mocks now carry `models[*].api_key_breakdown` to match the real `/user/daily/activity` payload, and new tests assert that per-model spend sums to the user-day total and that uncalled models are omitted. Both fail on the old code and pass on the fix.
