### PR TITLE
fix: accept integer MCP progress tokens

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -249,6 +249,37 @@ if MCP_AVAILABLE:
         stateless=True,
     )
 
+    def _build_host_progress_callback(
+        host_ctx: Any,
+    ) -> Optional[Callable[[float, Optional[float]], Any]]:
+        """Build a progress forwarder for the host MCP request context."""
+        if not host_ctx or not getattr(host_ctx, "meta", None):
+            return None
+
+        host_token = getattr(host_ctx.meta, "progressToken", None)
+        host_session = getattr(host_ctx, "session", None)
+        if host_token is None or host_session is None:
+            return None
+
+        async def forward_progress(progress: float, total: Optional[float]):
+            """Forward progress notifications from external MCP to Host"""
+            try:
+                await host_session.send_progress_notification(
+                    progress_token=host_token,
+                    progress=progress,
+                    total=total,
+                )
+                verbose_logger.debug(
+                    f"Forwarded progress {progress}/{total} to Host"
+                )
+            except Exception as e:
+                verbose_logger.error(f"Failed to forward progress to Host: {e}")
+
+        verbose_logger.debug(
+            f"Host progressToken captured: {str(host_token)[:8]}..."
+        )
+        return forward_progress
+
     # Create SSE session manager
     sse_session_manager = StreamableHTTPSessionManager(
         app=server,
@@ -403,32 +434,9 @@ if MCP_AVAILABLE:
         )
         host_progress_callback = None
         try:
-            host_ctx = server.request_context
-            if host_ctx and hasattr(host_ctx, "meta") and host_ctx.meta:
-                host_token = getattr(host_ctx.meta, "progressToken", None)
-                if host_token and hasattr(host_ctx, "session") and host_ctx.session:
-                    host_session = host_ctx.session
-
-                    async def forward_progress(progress: float, total: float | None):
-                        """Forward progress notifications from external MCP to Host"""
-                        try:
-                            await host_session.send_progress_notification(
-                                progress_token=host_token,
-                                progress=progress,
-                                total=total,
-                            )
-                            verbose_logger.debug(
-                                f"Forwarded progress {progress}/{total} to Host"
-                            )
-                        except Exception as e:
-                            verbose_logger.error(
-                                f"Failed to forward progress to Host: {e}"
-                            )
-
-                    host_progress_callback = forward_progress
-                    verbose_logger.debug(
-                        f"Host progressToken captured: {host_token[:8]}..."
-                    )
+            host_progress_callback = _build_host_progress_callback(
+                server.request_context
+            )
         except Exception as e:
             verbose_logger.warning(f"Could not capture host progress context: {e}")
         try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 from datetime import datetime
+from types import SimpleNamespace
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2653,6 +2654,35 @@ class TestMCPServerManager:
 
         # Verify the MCP client call was awaited exactly once
         assert mock_client.call_tool.await_count == 1
+
+    @pytest.mark.parametrize("progress_token", [123, 0, "token-123456"])
+    @pytest.mark.asyncio
+    async def test_host_progress_callback_accepts_spec_progress_tokens(
+        self, progress_token
+    ):
+        """
+        MCP progressToken may be string or integer, including zero.
+        """
+        from litellm.proxy._experimental.mcp_server.server import (
+            _build_host_progress_callback,
+        )
+
+        session = MagicMock()
+        session.send_progress_notification = AsyncMock()
+        host_ctx = SimpleNamespace(
+            meta=SimpleNamespace(progressToken=progress_token),
+            session=session,
+        )
+
+        callback = _build_host_progress_callback(host_ctx)
+
+        assert callback is not None
+        await callback(progress=0.5, total=1.0)
+        session.send_progress_notification.assert_awaited_once_with(
+            progress_token=progress_token,
+            progress=0.5,
+            total=1.0,
+        )
 
     @pytest.mark.asyncio
     async def test_get_allowed_mcp_servers_with_user_api_key_auth(self):


### PR DESCRIPTION
## What

Fixes #30976. The MCP gateway now accepts spec-compliant integer `progressToken` values when capturing host progress context.

## Why

The previous debug log sliced `host_token[:8]`, which assumes the token is a string. MCP allows `progressToken` to be `string | integer`, so integer tokens raised `TypeError` before the surrounding try/except converted that into noisy warnings.

This also treats `0` as a valid token by checking `is not None` instead of token truthiness.

## Test

```bash
env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy \
  uv run --extra proxy pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py -q \
  -k "host_progress_callback_accepts_spec_progress_tokens or call_tool_without_broken_pipe_error"

uv run ruff check --extend-ignore T201 \
  litellm/proxy/_experimental/mcp_server/server.py \
  tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
```

Note: `T201` is ignored only for this targeted lint command because this existing test file already contains an unrelated `print`.
