### PR TITLE
fix(mcp): don't block key MCP grants when team has no allow-list

### DIFF
--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -469,11 +469,12 @@ async def validate_key_mcp_servers_against_team(
     Validate that MCP servers requested on a key are within the allowed scope.
 
     Rules:
-    - If key is in a team: key's mcp_servers must be a subset of
-      (team's allowed servers + allow_all_keys servers)
+    - If the team declares an MCP server allow-list: key's mcp_servers must be a
+      subset of (team's allowed servers + allow_all_keys servers)
+    - If the team declares no MCP allow-list: no team-level restriction applies
+      and the key may be granted any server (matches the runtime resolver)
     - If key is NOT in a team: key's mcp_servers must only contain
       allow_all_keys servers
-    - If team has no MCP config: key can only use allow_all_keys servers
 
     Raises HTTPException(403) if validation fails.
     """
@@ -494,6 +495,12 @@ async def validate_key_mcp_servers_against_team(
 
     # Combined allowed set = team servers + allow_all_keys servers
     all_allowed_servers = team_allowed_servers | allow_all_keys_servers
+
+    # A team that declares no MCP server allow-list imposes no team-level
+    # restriction on its keys (same semantics as the runtime resolver and the
+    # toolset check below). Only a team with an explicit list narrows what its
+    # keys may use; standalone keys (no team) stay limited to allow_all_keys.
+    enforce_server_scope = team_obj is None or bool(team_allowed_servers)
 
     # Validate requested server IDs
     if requested_servers:
@@ -522,7 +529,7 @@ async def validate_key_mcp_servers_against_team(
         )
 
         disallowed_servers = active_requested_servers - all_allowed_servers
-        if disallowed_servers:
+        if enforce_server_scope and disallowed_servers:
             if team_obj is not None:
                 team_id = team_obj.team_id
                 detail = (

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -339,17 +339,46 @@ async def test_validate_no_team_non_global_server_raises(
     new_callable=AsyncMock,
     return_value=[],
 )
-async def test_validate_team_no_mcp_config_blocks_all(
+async def test_validate_team_no_mcp_config_imposes_no_restriction(
     mock_access_groups, mock_allow_all
 ):
-    """Team with no object_permission — key can't use any non-global MCP servers."""
+    """Team with no object_permission declares no MCP allow-list, so it imposes no
+    team-level restriction: a key under it can be granted any server (1.82 behavior).
+
+    Regression for the post-1.82 'MCP not allowed by team. Team allows: []' 403 that
+    blocked every key MCP grant under teams with default config."""
     team_obj = _make_team_obj()  # No object_permission
-    with pytest.raises(HTTPException) as exc_info:
-        await validate_key_mcp_servers_against_team(
-            object_permission={"mcp_servers": ["some-server"]},
-            team_obj=team_obj,
-        )
-    assert exc_info.value.status_code == 403
+    result = await validate_key_mcp_servers_against_team(
+        object_permission={"mcp_servers": ["some-server"]},
+        team_obj=team_obj,
+    )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+    new=_make_mock_mcp_manager("some-server"),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_team_empty_mcp_list_imposes_no_restriction(
+    mock_access_groups, mock_allow_all
+):
+    """Team whose object_permission has an explicit empty mcp_servers list also
+    imposes no restriction (empty == no allow-list, same as the runtime resolver)."""
+    team_obj = _make_team_obj(mcp_servers=[])
+    await validate_key_mcp_servers_against_team(
+        object_permission={"mcp_servers": ["some-server"]},
+        team_obj=team_obj,
+    )
 
 
 @pytest.mark.asyncio
@@ -570,7 +599,7 @@ async def test_validate_db_mcp_server_alias_outside_team_scope_raises_when_regis
         return_value=[mock_db_server]
     )
 
-    team_obj = _make_team_obj(mcp_servers=[])
+    team_obj = _make_team_obj(mcp_servers=["team-allowed-server"])
     with pytest.raises(HTTPException) as exc_info:
         await validate_key_mcp_servers_against_team(
             object_permission={"mcp_servers": ["private-alias"]},


### PR DESCRIPTION
## Summary

A team with no MCP server allow-list (default config) used to accept MCP server grants on its keys. After #23323 added team-scoped MCP filtering, `validate_key_mcp_servers_against_team` began treating "no allow-list" as "allows zero servers", so creating or updating a key with any `mcp_servers` under such a team failed with a 403 ("Team allows: []"). This restores the pre-1.82 behavior; a team that declares no MCP allow-list imposes no restriction, while teams that do declare one still gate their keys

## Relevant issues

Regression introduced by #23323 ("MCP Server Team-Scoped Filtering for Key Creation"). Surfaced upgrading 1.82 -> 1.86.3

## Type

Bug Fix

## Changes

`validate_key_mcp_servers_against_team` now only enforces the team server ceiling when the team actually declares an allow-list (`enforce_server_scope = team_obj is None or bool(team_allowed_servers)`). An empty or unset team MCP list imposes no restriction, matching the toolset branch in the same function and the runtime resolver. Standalone keys with no team stay limited to `allow_all_keys` servers

## Proof of Fix

Live proxy on `localhost:4000`. Two MCP servers registered (`allow_all_keys=false`), one team with default config, one team scoped to S1 only:

```
### 1. FIX  default-config team (no MCP allow-list), grant S1 to a key
  POST /key/generate {team_id:<default>, mcp_servers:[S1]}  ->  HTTP 200
      (on 1.86.3 this returned 403 "Team allows: []"; with the fix it is 200)

### 2. GUARDRAIL  team scoped to [S1], grant S2 (out of scope)
  {"error": "Key requests MCP servers not allowed by team '...': ['<S2>']. Team allows: ['<S1>']..."}
  POST /key/generate {team_id:<scoped to S1>, mcp_servers:[S2]}  ->  HTTP 403

### 3. SANITY  scoped team grant its allowed S1
  POST /key/generate {team_id:<scoped to S1>, mcp_servers:[S1]}  ->  HTTP 200
```

## Pre-Submission checklist

- [x] Added meaningful regression tests in `tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py`: flipped the old `..._blocks_all` case to `..._imposes_no_restriction`, added `test_validate_team_empty_mcp_list_imposes_no_restriction`, and kept the out-of-scope-raises guardrail test green (32 passed)
- [x] PR scope isolated to the write-time validation; one function changed