### PR TITLE
fix: prevent key-level metadata.tags from leaking into Bedrock passthrough body

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -699,6 +699,12 @@ async def common_checks(
         if valid_token is not None:
             from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
+            # GH#30629: pre-seed litellm_metadata for bedrock routes so
+            # apply_key_tags_pre_auth writes tags there instead of
+            # leaking them into the provider-facing metadata field
+            if "bedrock" in route:
+                request_body.setdefault("litellm_metadata", {})
+
             LiteLLMProxyRequestSetup.apply_key_tags_pre_auth(
                 request_data=request_body,
                 user_api_key_dict=valid_token,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -697,20 +697,12 @@ async def common_checks(
             )
 
         if valid_token is not None:
-            from litellm.proxy.litellm_pre_call_utils import (
-                LITELLM_METADATA_ROUTES,
-                LiteLLMProxyRequestSetup,
-            )
+            from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 
-            # GH#30629: routes in LITELLM_METADATA_ROUTES track tags in
-            # litellm_metadata, but that field isn't seeded until the pre-call
-            # phase runs after auth. Pre-seed it here so apply_key_tags_pre_auth
-            # writes tags into litellm_metadata instead of leaking them into the
-            # provider-facing metadata field
-            if any(
-                metadata_route in route for metadata_route in LITELLM_METADATA_ROUTES
-            ):
-                request_body.setdefault("litellm_metadata", {})
+            LiteLLMProxyRequestSetup.pre_seed_litellm_metadata_for_route(
+                request_data=request_body,
+                route=route,
+            )
 
             LiteLLMProxyRequestSetup.apply_key_tags_pre_auth(
                 request_data=request_body,

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -697,12 +697,19 @@ async def common_checks(
             )
 
         if valid_token is not None:
-            from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
+            from litellm.proxy.litellm_pre_call_utils import (
+                LITELLM_METADATA_ROUTES,
+                LiteLLMProxyRequestSetup,
+            )
 
-            # GH#30629: pre-seed litellm_metadata for bedrock routes so
-            # apply_key_tags_pre_auth writes tags there instead of
-            # leaking them into the provider-facing metadata field
-            if "bedrock" in route:
+            # GH#30629: routes in LITELLM_METADATA_ROUTES track tags in
+            # litellm_metadata, but that field isn't seeded until the pre-call
+            # phase runs after auth. Pre-seed it here so apply_key_tags_pre_auth
+            # writes tags into litellm_metadata instead of leaking them into the
+            # provider-facing metadata field
+            if any(
+                metadata_route in route for metadata_route in LITELLM_METADATA_ROUTES
+            ):
                 request_body.setdefault("litellm_metadata", {})
 
             LiteLLMProxyRequestSetup.apply_key_tags_pre_auth(

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2396,6 +2396,17 @@ async def _run_centralized_common_checks(
         llm_router=llm_router,
     )
 
+    # Pin the metadata variable name (litellm_metadata vs metadata) before
+    # any tag merge runs. Without this, header tags from
+    # apply_client_tag_policy_pre_auth would land in `metadata` while the
+    # later seed in common_checks pushes key tags and the
+    # _tag_max_budget_check read into `litellm_metadata`, hiding header
+    # tags from per-tag budget enforcement on LITELLM_METADATA_ROUTES.
+    LiteLLMProxyRequestSetup.pre_seed_litellm_metadata_for_route(
+        request_data=request_data,
+        route=route,
+    )
+
     # Merge x-litellm-tags into request_data BEFORE common_checks runs.
     # _tag_max_budget_check inside common_checks only inspects request_data;
     # without this pre-merge, header-supplied tags bypass tag-budget

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1239,6 +1239,27 @@ class LiteLLMProxyRequestSetup:
         return tags
 
     @staticmethod
+    def pre_seed_litellm_metadata_for_route(
+        request_data: dict,
+        route: str,
+    ) -> None:
+        """Pre-seed ``litellm_metadata`` for routes that track tags there.
+
+        Routes in ``LITELLM_METADATA_ROUTES`` (e.g. Bedrock, ``/v1/messages``,
+        responses, batches, files) store request-scoped tag metadata in
+        ``litellm_metadata`` rather than the provider-facing ``metadata``
+        field. ``get_metadata_variable_name_from_kwargs`` picks the target
+        based on whether ``litellm_metadata`` is present, so it must be
+        seeded BEFORE any tag merge runs; otherwise header tags from
+        ``apply_client_tag_policy_pre_auth`` land in ``metadata`` while
+        key tags from ``apply_key_tags_pre_auth`` and the read in
+        ``_tag_max_budget_check`` resolve to ``litellm_metadata``, leaving
+        header tags invisible to per-tag budget enforcement.
+        """
+        if any(metadata_route in route for metadata_route in LITELLM_METADATA_ROUTES):
+            request_data.setdefault("litellm_metadata", {})
+
+    @staticmethod
     def apply_key_tags_pre_auth(
         request_data: dict,
         user_api_key_dict: UserAPIKeyAuth,

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1469,8 +1469,7 @@ async def add_litellm_data_to_request(
         _metadata_variable_name=_metadata_variable_name,
     )
 
-    # Add headers to metadata for guardrails to access (fixes #17477)
-    # Guardrails use metadata["headers"] to access request headers (e.g., User-Agent)
+    # Expose request headers under the metadata field for guardrails (fixes #17477)
     if _metadata_variable_name in data and isinstance(
         data[_metadata_variable_name], dict
     ):

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -108,6 +108,7 @@ def parse_cache_control(cache_control):
 
 LITELLM_METADATA_ROUTES = (
     "batches",
+    "bedrock",
     "/v1/messages",
     "responses",
     "files",

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1751,11 +1751,22 @@ async def test_reject_clientside_metadata_tags_allows_key_tags_without_client_ta
 
 
 @pytest.mark.asyncio
-async def test_common_checks_bedrock_route_keeps_key_tags_out_of_provider_metadata():
-    """GH#30629: key-level tags on a bedrock passthrough request must land in
-    litellm_metadata, never in the provider-facing metadata field (Bedrock rejects
-    non-user_id metadata with HTTP 400). Dropping the litellm_metadata pre-seed makes
-    apply_key_tags_pre_auth fall back to metadata, so this guards that regression.
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+        "/v1/messages",
+    ],
+)
+async def test_common_checks_metadata_route_keeps_key_tags_out_of_provider_metadata(
+    route,
+):
+    """GH#30629: on routes that track tags in litellm_metadata (bedrock, /v1/messages,
+    responses, ...) key-level tags must land in litellm_metadata, never in the
+    provider-facing metadata field (Bedrock rejects non-user_id metadata with HTTP 400).
+    The auth-time pre-seed keys off LITELLM_METADATA_ROUTES, so hardcoding a single route
+    or dropping the pre-seed makes apply_key_tags_pre_auth fall back to metadata; this
+    guards that regression.
     """
     from fastapi import Request
 
@@ -1781,7 +1792,7 @@ async def test_common_checks_bedrock_route_keeps_key_tags_out_of_provider_metada
             end_user_object=None,
             global_proxy_spend=None,
             general_settings={},
-            route="/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+            route=route,
             llm_router=None,
             proxy_logging_obj=MagicMock(),
             valid_token=valid_token,

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -1751,6 +1751,49 @@ async def test_reject_clientside_metadata_tags_allows_key_tags_without_client_ta
 
 
 @pytest.mark.asyncio
+async def test_common_checks_bedrock_route_keeps_key_tags_out_of_provider_metadata():
+    """GH#30629: key-level tags on a bedrock passthrough request must land in
+    litellm_metadata, never in the provider-facing metadata field (Bedrock rejects
+    non-user_id metadata with HTTP 400). Dropping the litellm_metadata pre-seed makes
+    apply_key_tags_pre_auth fall back to metadata, so this guards that regression.
+    """
+    from fastapi import Request
+
+    from litellm.proxy.auth.auth_checks import common_checks
+
+    request_body = {"messages": [{"role": "user", "content": "test"}]}
+
+    mock_request = MagicMock(spec=Request)
+    valid_token = UserAPIKeyAuth(
+        token="test-token",
+        metadata={"tags": ["engineering"]},
+    )
+
+    with patch(
+        "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+        new_callable=AsyncMock,
+        return_value={},
+    ):
+        result = await common_checks(
+            request_body=request_body,
+            team_object=None,
+            user_object=None,
+            end_user_object=None,
+            global_proxy_spend=None,
+            general_settings={},
+            route="/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+            llm_router=None,
+            proxy_logging_obj=MagicMock(),
+            valid_token=valid_token,
+            request=mock_request,
+        )
+
+    assert result is True
+    assert request_body["litellm_metadata"]["tags"] == ["engineering"]
+    assert "metadata" not in request_body
+
+
+@pytest.mark.asyncio
 async def test_virtual_key_soft_budget_check_with_user_obj():
     """Test _virtual_key_soft_budget_check includes user_email when user_obj is provided"""
     alert_triggered = False

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -2690,6 +2690,67 @@ async def test_centralized_common_checks_runs_for_standard_auth():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+        "/v1/messages",
+    ],
+)
+async def test_centralized_common_checks_routes_header_tags_to_litellm_metadata(route):
+    """GH#30629: on LITELLM_METADATA_ROUTES the tag-budget read resolves to
+    litellm_metadata, so the litellm_metadata pre-seed must run before
+    apply_client_tag_policy_pre_auth merges x-litellm-tags. Otherwise header tags
+    land in metadata and silently escape _tag_max_budget_check. This guards the
+    pre-seed call site in _run_centralized_common_checks; dropping it routes header
+    tags back into metadata.
+    """
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    token = UserAPIKeyAuth(api_key="sk-test", user_id="u1")
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"x-litellm-tags", b"tenant:acme")],
+            "query_string": b"",
+        }
+    )
+    request._url = URL(url=route)
+    request_data: dict = {"model": "us.anthropic.claude-sonnet-4-6"}
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._reserve_budget_after_common_checks",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data=request_data,
+                route=route,
+            )
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+    assert request_data["litellm_metadata"]["tags"] == ["tenant:acme"]
+    assert "metadata" not in request_data
+
+
+@pytest.mark.asyncio
 async def test_centralized_common_checks_skipped_for_custom_auth_without_flag():
     """Existing RPS guarantee: custom-auth deployments without
     custom_auth_run_common_checks must not pay the centralized gate.

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -2682,15 +2682,19 @@ async def test_add_litellm_data_to_request_adds_headers_to_metadata():
         version="1.0",
     )
 
-    # Verify headers are added to metadata for guardrails
-    assert "metadata" in result, "metadata should be present in result"
-    assert "headers" in result["metadata"], "headers should be present in metadata"
+    # Verify headers are added to litellm_metadata for guardrails.
+    # Bedrock passthrough uses litellm_metadata to prevent key-level
+    # tags from leaking into the provider payload (GH#30629).
+    assert "litellm_metadata" in result, "litellm_metadata should be present in result"
+    assert (
+        "headers" in result["litellm_metadata"]
+    ), "headers should be present in litellm_metadata"
     assert isinstance(
-        result["metadata"]["headers"], dict
+        result["litellm_metadata"]["headers"], dict
     ), "headers should be a dictionary"
 
     # Verify specific headers are accessible (important for guardrails)
-    headers = result["metadata"]["headers"]
+    headers = result["litellm_metadata"]["headers"]
     assert (
         "user-agent" in headers or "User-Agent" in headers
     ), "User-Agent header should be accessible in metadata"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -99,11 +99,15 @@ class TestGetMetadataVariableName:
     def test_returns_litellm_metadata_for_bedrock_invoke(self):
         # GH#30629: bedrock passthrough must use litellm_metadata
         # to prevent key-level tags from leaking into provider body
-        request = self._make_request("/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke")
+        request = self._make_request(
+            "/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke"
+        )
         assert _get_metadata_variable_name(request) == "litellm_metadata"
 
     def test_returns_litellm_metadata_for_bedrock_converse(self):
-        request = self._make_request("/bedrock/model/us.anthropic.claude-sonnet-4-6/converse")
+        request = self._make_request(
+            "/bedrock/model/us.anthropic.claude-sonnet-4-6/converse"
+        )
         assert _get_metadata_variable_name(request) == "litellm_metadata"
 
 
@@ -4265,6 +4269,99 @@ class TestApplyClientTagPolicyPreAuth:
                 )
             assert exc_info.value.current_cost == 0.50
             assert exc_info.value.max_budget == 0.10
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke",
+            "/v1/messages",
+        ],
+    )
+    async def test_header_tags_visible_to_tag_max_budget_check_on_metadata_route(
+        self, route
+    ):
+        """Regression: on LITELLM_METADATA_ROUTES (bedrock, /v1/messages, ...),
+        common_checks pre-seeds ``litellm_metadata`` and writes key tags there
+        before ``_tag_max_budget_check`` reads from the same key. The auth wrapper
+        calls ``apply_client_tag_policy_pre_auth`` first, so without an earlier
+        pre-seed header tags land in ``metadata`` and the budget check (now
+        resolving to ``litellm_metadata``) silently ignores them. This test mirrors
+        the actual auth-time call order and verifies that an over-budget
+        header-supplied tag still trips ``_tag_max_budget_check``.
+        """
+        from litellm.proxy._types import LiteLLM_BudgetTable, LiteLLM_TagTable
+        from litellm.proxy.auth.auth_checks import common_checks
+        from litellm.proxy.utils import ProxyLogging
+
+        request_mock = _build_request_mock_with_headers(
+            {"x-litellm-tags": "tenant:acme"}
+        )
+        data = {"model": "us.anthropic.claude-sonnet-4-6"}
+        valid_token = UserAPIKeyAuth(
+            token="test-token",
+            api_key="hashed-key",
+            metadata={},
+            team_metadata={},
+        )
+
+        LiteLLMProxyRequestSetup.pre_seed_litellm_metadata_for_route(
+            request_data=data,
+            route=route,
+        )
+        LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth(
+            request=request_mock,
+            request_data=data,
+            user_api_key_dict=valid_token,
+        )
+
+        tag_object = LiteLLM_TagTable(
+            tag_name="tenant:acme",
+            spend=0.0,
+            litellm_budget_table=LiteLLM_BudgetTable(max_budget=0.10),
+        )
+
+        async def mock_get_current_spend(
+            counter_key, fallback_spend, max_budget=None, **kwargs
+        ):
+            if counter_key == "spend:tag:tenant:acme":
+                return 0.50
+            return fallback_spend
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server.prisma_client",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.proxy.proxy_server.get_current_spend",
+                mock_get_current_spend,
+            ),
+            patch(
+                "litellm.proxy.auth.auth_checks.get_tag_objects_batch",
+                new_callable=AsyncMock,
+                return_value={"tenant:acme": tag_object},
+            ),
+        ):
+            with pytest.raises(litellm.BudgetExceededError) as exc_info:
+                await common_checks(
+                    request_body=data,
+                    team_object=None,
+                    user_object=None,
+                    end_user_object=None,
+                    global_proxy_spend=None,
+                    general_settings={},
+                    route=route,
+                    llm_router=None,
+                    proxy_logging_obj=ProxyLogging(user_api_key_cache=None),
+                    valid_token=valid_token,
+                    request=request_mock,
+                )
+            assert exc_info.value.current_cost == 0.50
+            assert exc_info.value.max_budget == 0.10
+
+        assert "metadata" not in data
+        assert data["litellm_metadata"]["tags"] == ["tenant:acme"]
 
 
 class TestApplyKeyTagsPreAuth:

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -96,6 +96,16 @@ class TestGetMetadataVariableName:
         request = self._make_request("/v1/embeddings")
         assert _get_metadata_variable_name(request) == "metadata"
 
+    def test_returns_litellm_metadata_for_bedrock_invoke(self):
+        # GH#30629: bedrock passthrough must use litellm_metadata
+        # to prevent key-level tags from leaking into provider body
+        request = self._make_request("/bedrock/model/us.anthropic.claude-sonnet-4-6/invoke")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
+    def test_returns_litellm_metadata_for_bedrock_converse(self):
+        request = self._make_request("/bedrock/model/us.anthropic.claude-sonnet-4-6/converse")
+        assert _get_metadata_variable_name(request) == "litellm_metadata"
+
 
 def test_get_enforced_params_for_service_account_settings():
     """


### PR DESCRIPTION
## Relevant issues

Fixes #30629

This is a copy of #30666 by @factnn (Zang Peiyu), pushed to an internal branch so CircleCI runs. All credit for the original fix goes to that author; the commit retains their authorship.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Key-level spend-tracking tags were injected into `data["metadata"]` for Bedrock passthrough routes, then forwarded in the provider request body. Bedrock rejects non-`user_id` metadata fields with HTTP 400.

Adding `"bedrock"` to `LITELLM_METADATA_ROUTES` makes tags get stored in `data["litellm_metadata"]` instead. Spend tracking reads from both locations, so tags are preserved for billing without leaking to the upstream provider. The auth-time pre-seed of `litellm_metadata` keys off the shared `LITELLM_METADATA_ROUTES` constant so the auth-time and pre-call routing stay in sync for any route added later.

Because `_tag_max_budget_check` resolves the tag field the same way (`litellm_metadata` once present), the pre-seed has to run before any tag merge. `apply_client_tag_policy_pre_auth` merges `x-litellm-tags` header tags during auth, before `common_checks`, so the pre-seed is invoked in `_run_centralized_common_checks` ahead of it; otherwise header-supplied tags would land in `metadata` and silently bypass per-tag budget enforcement on these routes.

Consistent with the existing handling for `/v1/messages` and `responses` routes.

### Manual QA (live proxy, real Bedrock)

Verified end to end against a local proxy hitting real AWS Bedrock (`us.anthropic.claude-sonnet-4-6`). The setup is identical in both runs; the only variable is the build (issue commit vs this PR's `6bd0af2`).

Setup, run once against each build:

```bash
# 1. virtual key carrying a spend-tracking tag in its metadata
curl -s -X POST 'http://localhost:4000/key/generate' \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"metadata": {"tags": ["CC:cost-center-123"]}}'
# -> "key":"sk-...", "metadata":{"tags":["CC:cost-center-123"]}

# 2. negative case: Bedrock invoke passthrough, body carries metadata (what Claude Code sends)
curl -s -w '\nHTTP %{http_code}\n' -X POST \
  'http://localhost:4000/bedrock/model/bedrock-invoke-sonnet-4-6/invoke' \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"anthropic_version":"bedrock-2023-05-31","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"user_abc123"}}'
```

Before (issue build, root cause present):

```text
HTTP 400
{"detail":{"error":"{\"message\":\"metadata.tags: Extra inputs are not permitted\"}"}}
```

After (this PR, commit `6bd0af2`):

```text
HTTP 200
{"model":"claude-sonnet-4-6","id":"msg_bdrk_01TEootifNwQ1bASX5ypWrtn","type":"message",
 "role":"assistant","content":[{"type":"text","text":"Hi there! How are you doing? ..."}],
 "stop_reason":"max_tokens",...,"usage":{"input_tokens":8,...,"output_tokens":16}}
```

The positive control (same request with no `metadata` field in the body) returns HTTP 200 on both builds, confirming the failure was conditional on an existing `metadata` dict.

Tag is still recorded for billing, not silently dropped. `GET /spend/logs` for the After request shows the key tag retained on the spend log while it no longer reaches the provider body:

```text
model=bedrock/us.anthropic.claude-sonnet-4-6  request_tags=['CC:cost-center-123', ...]
```

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/litellm_pre_call_utils.py`: add `"bedrock"` to `LITELLM_METADATA_ROUTES`; extract `LiteLLMProxyRequestSetup.pre_seed_litellm_metadata_for_route` so the pre-seed is reused
- `litellm/proxy/auth/auth_checks.py`: pre-seed `litellm_metadata` before `apply_key_tags_pre_auth`, keyed off the shared constant rather than a hardcoded `"bedrock"`
- `litellm/proxy/auth/user_api_key_auth.py`: pre-seed `litellm_metadata` in `_run_centralized_common_checks` before `apply_client_tag_policy_pre_auth`, so header (`x-litellm-tags`) tags stay visible to `_tag_max_budget_check` on `LITELLM_METADATA_ROUTES`
- tests: bedrock invoke/converse routing, updated passthrough headers location, parametrized `common_checks` key-tag regression (bedrock and `/v1/messages`), header-tag budget visibility, and a wiring-level regression that fails if the auth-time pre-seed call site is dropped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-time request body shaping and tag budget enforcement on Bedrock and other litellm_metadata routes; incorrect ordering could leak tags to providers or skip tag budgets, but changes are narrow and heavily regression-tested.
> 
> **Overview**
> Fixes **#30629**: key-level spend tags were ending up in provider-facing `metadata` on Bedrock passthrough, which Bedrock rejects with HTTP 400.
> 
> **`bedrock`** is added to **`LITELLM_METADATA_ROUTES`** so tags and proxy-only fields live in **`litellm_metadata`** instead of the upstream payload (same pattern as `/v1/messages`, responses, batches, files). A shared **`pre_seed_litellm_metadata_for_route`** runs **before** any tag merge because metadata target selection keys off whether `litellm_metadata` already exists.
> 
> The pre-seed is wired in **`common_checks`** (before **`apply_key_tags_pre_auth`**) and in **`_run_centralized_common_checks`** (before **`apply_client_tag_policy_pre_auth`**), so **`x-litellm-tags`** and key tags land in the same bucket that **`_tag_max_budget_check`** reads—avoiding silent budget bypass on those routes.
> 
> Tests cover Bedrock routing, passthrough guardrail headers under `litellm_metadata`, and regressions for key/header tag placement and budget enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd0af25e1664166fd2e43cabf484a44e525ff34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
