### PR TITLE
test(interactions): drop role from Interaction output fields to match Google spec

### DIFF
--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -156,7 +156,10 @@ class TestResponseCompliance:
         # The response is the dedicated `Interaction` schema. Google moved the
         # output-only fields (notably the `steps` array, formerly `outputs`)
         # off `CreateModelInteractionParams` and onto `Interaction`; the request
-        # schema no longer carries `steps`. Keep this aligned with the live spec.
+        # schema no longer carries `steps`. Google later moved `role` off
+        # `Interaction` onto the per-turn `Turn` schema (asserted in
+        # test_turn_schema), so it is no longer a top-level output field here.
+        # Keep this aligned with the live spec.
         schema = spec_dict["components"]["schemas"]["Interaction"]
 
         # Output fields (readOnly).
@@ -165,7 +168,6 @@ class TestResponseCompliance:
             "status",
             "created",
             "updated",
-            "role",
             "steps",
             "usage",
         ]


### PR DESCRIPTION
## Relevant issues

The `misc / Run tests` CI job has been red on `litellm_internal_staging` (and therefore on every open PR) because of `tests/test_litellm/interactions/test_openapi_compliance.py::TestResponseCompliance::test_interaction_response_fields`, which fails with `AssertionError: Output field 'role' not in spec`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Changes

These interactions tests are deliberate canaries; they fetch Google's live OpenAPI spec from `https://ai.google.dev/static/api/interactions.openapi.json` and assert against it so that CI breaks when Google changes the contract and a human reviews the change. Google moved the `role` field off the top-level `Interaction` response schema onto the per-turn `Turn` schema. `Interaction.properties` now lists `id`, `status`, `created`, `updated`, `steps`, `usage`, and others, but no longer `role`, so `test_interaction_response_fields` started failing

This drops `role` from that test's `Interaction` output-field list to match the live spec. Coverage is preserved because `role` on `Turn` is already asserted by `test_turn_schema` in the same file, so this is the realignment the canary is asking for, not a loss of validation

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

Confirmed the test fails on the current `litellm_internal_staging` tip and passes after the change, against Google's live spec:

```
# before (on clean staging)
$ python -m pytest "tests/test_litellm/interactions/test_openapi_compliance.py::TestResponseCompliance::test_interaction_response_fields" -q
FAILED ... - AssertionError: Output field 'role' not in spec
1 failed

# after (this branch)
$ python -m pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
13 passed
```

And confirmed against the live spec where `role` now lives:

```
$ python -c "import httpx; s=httpx.get('https://ai.google.dev/static/api/interactions.openapi.json').json(); \
print('Interaction has role:', 'role' in s['components']['schemas']['Interaction']['properties']); \
print('Turn has role:', 'role' in s['components']['schemas']['Turn']['properties'])"
Interaction has role: False
Turn has role: True
```
