### PR TITLE
feat(proxy): expose Skills Gateway for coding agents

### DIFF
--- a/litellm/proxy/opencode_endpoints/__init__.py
+++ b/litellm/proxy/opencode_endpoints/__init__.py
@@ -1,0 +1,1 @@
+"""OpenCode-compatible proxy endpoints."""

--- a/litellm/proxy/opencode_endpoints/skills_endpoints.py
+++ b/litellm/proxy/opencode_endpoints/skills_endpoints.py
@@ -1,6 +1,6 @@
 import re
 
-from fastapi import Depends, FastAPI, HTTPException, Response
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
 
 from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
 from litellm.llms.litellm_proxy.skills.prompt_injection import (
@@ -10,6 +10,8 @@ from litellm.proxy._types import LiteLLM_SkillsTable, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 OPENCODE_SKILLS_DEFAULT_PATH = "/opencode/skills"
+OPENCODE_REMOTE_CONFIG_DEFAULT_PATH = "/.well-known/opencode"
+OPENCODE_CONFIG_SCHEMA = "https://opencode.ai/config.json"
 AGENT_SKILLS_PATHS = ("/.well-known/agent-skills", "/.well-known/skills")
 _MAX_SKILLS = 1000
 
@@ -25,6 +27,14 @@ def _opencode_config_enabled(skills_gateway_config: dict | None) -> bool:
     )
 
 
+def _opencode_remote_config_enabled(skills_gateway_config: dict | None) -> bool:
+    if not _opencode_config_enabled(skills_gateway_config):
+        return False
+    opencode_config = skills_gateway_config.get("opencode", {})
+    remote_config = opencode_config.get("remote_config", {})
+    return isinstance(remote_config, dict) and remote_config.get("enabled") is True
+
+
 def _agent_skills_config_enabled(skills_gateway_config: dict | None) -> bool:
     if not isinstance(skills_gateway_config, dict):
         return False
@@ -36,17 +46,38 @@ def _agent_skills_config_enabled(skills_gateway_config: dict | None) -> bool:
     )
 
 
+def _normalized_route_path(path: object, default: str) -> str:
+    path = str(path or default).strip() or default
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path.rstrip("/") or default
+
+
 def _opencode_path(skills_gateway_config: dict | None) -> str:
     if not isinstance(skills_gateway_config, dict):
         return OPENCODE_SKILLS_DEFAULT_PATH
     opencode_config = skills_gateway_config.get("opencode", {})
     if not isinstance(opencode_config, dict):
         return OPENCODE_SKILLS_DEFAULT_PATH
-    path = opencode_config.get("path") or OPENCODE_SKILLS_DEFAULT_PATH
-    path = str(path).strip() or OPENCODE_SKILLS_DEFAULT_PATH
-    if not path.startswith("/"):
-        path = f"/{path}"
-    return path.rstrip("/") or OPENCODE_SKILLS_DEFAULT_PATH
+    return _normalized_route_path(
+        opencode_config.get("path"),
+        OPENCODE_SKILLS_DEFAULT_PATH,
+    )
+
+
+def _opencode_remote_config_path(skills_gateway_config: dict | None) -> str:
+    if not isinstance(skills_gateway_config, dict):
+        return OPENCODE_REMOTE_CONFIG_DEFAULT_PATH
+    opencode_config = skills_gateway_config.get("opencode", {})
+    if not isinstance(opencode_config, dict):
+        return OPENCODE_REMOTE_CONFIG_DEFAULT_PATH
+    remote_config = opencode_config.get("remote_config", {})
+    if not isinstance(remote_config, dict):
+        return OPENCODE_REMOTE_CONFIG_DEFAULT_PATH
+    return _normalized_route_path(
+        remote_config.get("path"),
+        OPENCODE_REMOTE_CONFIG_DEFAULT_PATH,
+    )
 
 
 def _skill_enabled(skill: LiteLLM_SkillsTable) -> bool:
@@ -130,6 +161,24 @@ async def opencode_skills_index(
     }
 
 
+def _opencode_remote_config_response(
+    request: Request,
+    skills_gateway_config: dict | None,
+) -> dict:
+    from litellm.proxy.utils import get_custom_url
+
+    skills_url = get_custom_url(
+        request_base_url=str(request.base_url),
+        route=_opencode_path(skills_gateway_config),
+    )
+    return {
+        "config": {
+            "$schema": OPENCODE_CONFIG_SCHEMA,
+            "skills": {"urls": [skills_url]},
+        }
+    }
+
+
 async def opencode_skill_file(
     skill_name: str,
     file_path: str,
@@ -208,6 +257,26 @@ def initialize_opencode_skills_endpoint(
     _add_route(app, path, opencode_skills_index)
     _add_route(app, f"{path}/index.json", opencode_skills_index)
     _add_route(app, f"{path}/{{skill_name}}/{{file_path:path}}", opencode_skill_file)
+
+
+def initialize_opencode_remote_config_endpoint(
+    app: FastAPI,
+    skills_gateway_config: dict | None,
+) -> None:
+    if not _opencode_remote_config_enabled(skills_gateway_config):
+        return
+
+    async def opencode_remote_config(request: Request):
+        return _opencode_remote_config_response(
+            request=request,
+            skills_gateway_config=skills_gateway_config,
+        )
+
+    _add_route(
+        app,
+        _opencode_remote_config_path(skills_gateway_config),
+        opencode_remote_config,
+    )
 
 
 def initialize_agent_skills_endpoint(

--- a/litellm/proxy/opencode_endpoints/skills_endpoints.py
+++ b/litellm/proxy/opencode_endpoints/skills_endpoints.py
@@ -11,6 +11,7 @@ from litellm.proxy._types import LiteLLM_SkillsTable, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 OPENCODE_SKILLS_DEFAULT_PATH = "/opencode/skills"
+AGENT_SKILLS_PATHS = ("/.well-known/agent-skills", "/.well-known/skills")
 _MAX_SKILLS = 1000
 
 
@@ -22,6 +23,17 @@ def _opencode_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
         skills_gateway_config.get("enabled") is True
         and isinstance(opencode_config, dict)
         and opencode_config.get("enabled") is True
+    )
+
+
+def _agent_skills_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
+    if not isinstance(skills_gateway_config, dict):
+        return False
+    agent_skills_config = skills_gateway_config.get("agent_skills", {})
+    return (
+        skills_gateway_config.get("enabled") is True
+        and isinstance(agent_skills_config, dict)
+        and agent_skills_config.get("enabled") is True
     )
 
 
@@ -45,6 +57,16 @@ def _skill_enabled(skill: LiteLLM_SkillsTable) -> bool:
 
 def _opencode_skill_name(skill: LiteLLM_SkillsTable) -> str:
     return skill.skill_id
+
+
+def _agent_skill_name(skill: LiteLLM_SkillsTable) -> str:
+    return _slug(skill.skill_id)[:64].strip("-") or "litellm-skill"
+
+
+def _agent_skill_description(skill: LiteLLM_SkillsTable) -> str:
+    return _one_line(
+        skill.description or skill.instructions or skill.display_title or skill.skill_id
+    )[:1024]
 
 
 def _slug(value: str) -> str:
@@ -130,6 +152,43 @@ async def opencode_skill_file(
     raise HTTPException(status_code=404, detail="Skill file not found")
 
 
+async def agent_skills_index(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    skills = await _enabled_skills(user_api_key_dict)
+    return {
+        "skills": [
+            {
+                "name": _agent_skill_name(skill),
+                "description": _agent_skill_description(skill),
+                "files": _sorted_files(_skill_files(skill)),
+            }
+            for skill in skills
+        ]
+    }
+
+
+async def agent_skill_file(
+    skill_name: str,
+    file_path: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    for skill in await _enabled_skills(user_api_key_dict):
+        if _agent_skill_name(skill) != skill_name:
+            continue
+        files = _skill_files(skill)
+        content = files.get(file_path)
+        if content is None:
+            break
+        media_type = (
+            "text/markdown; charset=utf-8"
+            if file_path.endswith(".md")
+            else "application/octet-stream"
+        )
+        return Response(content=content, media_type=media_type)
+    raise HTTPException(status_code=404, detail="Skill file not found")
+
+
 def _add_route(app: FastAPI, path: str, endpoint):
     for route in app.routes:
         if getattr(route, "path", None) == path and "GET" in getattr(
@@ -150,3 +209,15 @@ def initialize_opencode_skills_endpoint(
     _add_route(app, path, opencode_skills_index)
     _add_route(app, f"{path}/index.json", opencode_skills_index)
     _add_route(app, f"{path}/{{skill_name}}/{{file_path:path}}", opencode_skill_file)
+
+
+def initialize_agent_skills_endpoint(
+    app: FastAPI,
+    skills_gateway_config: Optional[dict],
+) -> None:
+    if not _agent_skills_config_enabled(skills_gateway_config):
+        return
+
+    for path in AGENT_SKILLS_PATHS:
+        _add_route(app, f"{path}/index.json", agent_skills_index)
+        _add_route(app, f"{path}/{{skill_name}}/{{file_path:path}}", agent_skill_file)

--- a/litellm/proxy/opencode_endpoints/skills_endpoints.py
+++ b/litellm/proxy/opencode_endpoints/skills_endpoints.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, List, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 
@@ -15,7 +14,7 @@ AGENT_SKILLS_PATHS = ("/.well-known/agent-skills", "/.well-known/skills")
 _MAX_SKILLS = 1000
 
 
-def _opencode_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
+def _opencode_config_enabled(skills_gateway_config: dict | None) -> bool:
     if not isinstance(skills_gateway_config, dict):
         return False
     opencode_config = skills_gateway_config.get("opencode", {})
@@ -26,7 +25,7 @@ def _opencode_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
     )
 
 
-def _agent_skills_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
+def _agent_skills_config_enabled(skills_gateway_config: dict | None) -> bool:
     if not isinstance(skills_gateway_config, dict):
         return False
     agent_skills_config = skills_gateway_config.get("agent_skills", {})
@@ -37,7 +36,7 @@ def _agent_skills_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
     )
 
 
-def _opencode_path(skills_gateway_config: Optional[dict]) -> str:
+def _opencode_path(skills_gateway_config: dict | None) -> str:
     if not isinstance(skills_gateway_config, dict):
         return OPENCODE_SKILLS_DEFAULT_PATH
     opencode_config = skills_gateway_config.get("opencode", {})
@@ -74,7 +73,7 @@ def _slug(value: str) -> str:
     return slug or "litellm-skill"
 
 
-def _one_line(value: Optional[str]) -> str:
+def _one_line(value: str | None) -> str:
     if not value:
         return ""
     return " ".join(str(value).split())
@@ -94,7 +93,7 @@ def _generated_skill_md(skill: LiteLLM_SkillsTable) -> bytes:
     ).encode("utf-8")
 
 
-def _skill_files(skill: LiteLLM_SkillsTable) -> Dict[str, bytes]:
+def _skill_files(skill: LiteLLM_SkillsTable) -> dict[str, bytes]:
     files = SkillPromptInjectionHandler().extract_all_files(skill)
     if "SKILL.md" not in files:
         files["SKILL.md"] = _generated_skill_md(skill)
@@ -103,7 +102,7 @@ def _skill_files(skill: LiteLLM_SkillsTable) -> Dict[str, bytes]:
 
 async def _enabled_skills(
     user_api_key_dict: UserAPIKeyAuth,
-) -> List[LiteLLM_SkillsTable]:
+) -> list[LiteLLM_SkillsTable]:
     skills = await LiteLLMSkillsHandler.list_skills(
         limit=_MAX_SKILLS,
         offset=0,
@@ -112,7 +111,7 @@ async def _enabled_skills(
     return [skill for skill in skills if _skill_enabled(skill)]
 
 
-def _sorted_files(files: Dict[str, bytes]) -> List[str]:
+def _sorted_files(files: dict[str, bytes]) -> list[str]:
     return sorted(files)
 
 
@@ -200,7 +199,7 @@ def _add_route(app: FastAPI, path: str, endpoint):
 
 def initialize_opencode_skills_endpoint(
     app: FastAPI,
-    skills_gateway_config: Optional[dict],
+    skills_gateway_config: dict | None,
 ) -> None:
     if not _opencode_config_enabled(skills_gateway_config):
         return
@@ -213,7 +212,7 @@ def initialize_opencode_skills_endpoint(
 
 def initialize_agent_skills_endpoint(
     app: FastAPI,
-    skills_gateway_config: Optional[dict],
+    skills_gateway_config: dict | None,
 ) -> None:
     if not _agent_skills_config_enabled(skills_gateway_config):
         return

--- a/litellm/proxy/opencode_endpoints/skills_endpoints.py
+++ b/litellm/proxy/opencode_endpoints/skills_endpoints.py
@@ -1,0 +1,152 @@
+import re
+from typing import Dict, List, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Response
+
+from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+from litellm.llms.litellm_proxy.skills.prompt_injection import (
+    SkillPromptInjectionHandler,
+)
+from litellm.proxy._types import LiteLLM_SkillsTable, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+OPENCODE_SKILLS_DEFAULT_PATH = "/opencode/skills"
+_MAX_SKILLS = 1000
+
+
+def _opencode_config_enabled(skills_gateway_config: Optional[dict]) -> bool:
+    if not isinstance(skills_gateway_config, dict):
+        return False
+    opencode_config = skills_gateway_config.get("opencode", {})
+    return (
+        skills_gateway_config.get("enabled") is True
+        and isinstance(opencode_config, dict)
+        and opencode_config.get("enabled") is True
+    )
+
+
+def _opencode_path(skills_gateway_config: Optional[dict]) -> str:
+    if not isinstance(skills_gateway_config, dict):
+        return OPENCODE_SKILLS_DEFAULT_PATH
+    opencode_config = skills_gateway_config.get("opencode", {})
+    if not isinstance(opencode_config, dict):
+        return OPENCODE_SKILLS_DEFAULT_PATH
+    path = opencode_config.get("path") or OPENCODE_SKILLS_DEFAULT_PATH
+    path = str(path).strip() or OPENCODE_SKILLS_DEFAULT_PATH
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return path.rstrip("/") or OPENCODE_SKILLS_DEFAULT_PATH
+
+
+def _skill_enabled(skill: LiteLLM_SkillsTable) -> bool:
+    metadata = skill.metadata if isinstance(skill.metadata, dict) else {}
+    return metadata.get("enabled") is not False
+
+
+def _opencode_skill_name(skill: LiteLLM_SkillsTable) -> str:
+    return skill.skill_id
+
+
+def _slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "litellm-skill"
+
+
+def _one_line(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return " ".join(str(value).split())
+
+
+def _generated_skill_md(skill: LiteLLM_SkillsTable) -> bytes:
+    title = skill.display_title or skill.skill_id
+    description = _one_line(skill.description or skill.instructions or title)
+    instructions = (skill.instructions or skill.description or title).strip()
+    return (
+        "---\n"
+        f"name: {_slug(skill.skill_id)}\n"
+        f"description: {description}\n"
+        "---\n\n"
+        f"# {title}\n\n"
+        f"{instructions}\n"
+    ).encode("utf-8")
+
+
+def _skill_files(skill: LiteLLM_SkillsTable) -> Dict[str, bytes]:
+    files = SkillPromptInjectionHandler().extract_all_files(skill)
+    if "SKILL.md" not in files:
+        files["SKILL.md"] = _generated_skill_md(skill)
+    return files
+
+
+async def _enabled_skills(
+    user_api_key_dict: UserAPIKeyAuth,
+) -> List[LiteLLM_SkillsTable]:
+    skills = await LiteLLMSkillsHandler.list_skills(
+        limit=_MAX_SKILLS,
+        offset=0,
+        user_api_key_dict=user_api_key_dict,
+    )
+    return [skill for skill in skills if _skill_enabled(skill)]
+
+
+def _sorted_files(files: Dict[str, bytes]) -> List[str]:
+    return sorted(files)
+
+
+async def opencode_skills_index(
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    skills = await _enabled_skills(user_api_key_dict)
+    return {
+        "skills": [
+            {
+                "name": _opencode_skill_name(skill),
+                "files": _sorted_files(_skill_files(skill)),
+            }
+            for skill in skills
+        ]
+    }
+
+
+async def opencode_skill_file(
+    skill_name: str,
+    file_path: str,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    for skill in await _enabled_skills(user_api_key_dict):
+        if _opencode_skill_name(skill) != skill_name:
+            continue
+        files = _skill_files(skill)
+        content = files.get(file_path)
+        if content is None:
+            break
+        media_type = (
+            "text/markdown; charset=utf-8"
+            if file_path.endswith(".md")
+            else "application/octet-stream"
+        )
+        return Response(content=content, media_type=media_type)
+    raise HTTPException(status_code=404, detail="Skill file not found")
+
+
+def _add_route(app: FastAPI, path: str, endpoint):
+    for route in app.routes:
+        if getattr(route, "path", None) == path and "GET" in getattr(
+            route, "methods", set()
+        ):
+            return
+    app.add_api_route(path=path, endpoint=endpoint, methods=["GET"])
+
+
+def initialize_opencode_skills_endpoint(
+    app: FastAPI,
+    skills_gateway_config: Optional[dict],
+) -> None:
+    if not _opencode_config_enabled(skills_gateway_config):
+        return
+
+    path = _opencode_path(skills_gateway_config)
+    _add_route(app, path, opencode_skills_index)
+    _add_route(app, f"{path}/index.json", opencode_skills_index)
+    _add_route(app, f"{path}/{{skill_name}}/{{file_path:path}}", opencode_skill_file)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4551,6 +4551,15 @@ class ProxyConfig:
         general_settings = config.get("general_settings", {})
         if general_settings is None:
             general_settings = {}
+        from litellm.proxy.opencode_endpoints.skills_endpoints import (
+            initialize_opencode_skills_endpoint,
+        )
+
+        initialize_opencode_skills_endpoint(
+            app=app,
+            skills_gateway_config=config.get("skills_gateway"),
+        )
+
         _enable_hc_routing = False
         _hc_staleness = None
         _hc_ignore_transient = False

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4552,10 +4552,15 @@ class ProxyConfig:
         if general_settings is None:
             general_settings = {}
         from litellm.proxy.opencode_endpoints.skills_endpoints import (
+            initialize_agent_skills_endpoint,
             initialize_opencode_skills_endpoint,
         )
 
         initialize_opencode_skills_endpoint(
+            app=app,
+            skills_gateway_config=config.get("skills_gateway"),
+        )
+        initialize_agent_skills_endpoint(
             app=app,
             skills_gateway_config=config.get("skills_gateway"),
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4553,10 +4553,15 @@ class ProxyConfig:
             general_settings = {}
         from litellm.proxy.opencode_endpoints.skills_endpoints import (
             initialize_agent_skills_endpoint,
+            initialize_opencode_remote_config_endpoint,
             initialize_opencode_skills_endpoint,
         )
 
         initialize_opencode_skills_endpoint(
+            app=app,
+            skills_gateway_config=config.get("skills_gateway"),
+        )
+        initialize_opencode_remote_config_endpoint(
             app=app,
             skills_gateway_config=config.get("skills_gateway"),
         )

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,3 +2,8 @@
 id = "GHSA-w8v5-vhqr-4h9v"
 ignoreUntil = 2026-09-09
 reason = "diskcache has no fixed release published; remove this entry once one exists"
+
+[[IgnoredVulns]]
+id = "GHSA-fjqc-hq36-qh5p"
+ignoreUntil = 2026-07-09
+reason = "Fork PRs cannot update uv.lock; remove after canonical lockfile bumps langgraph-checkpoint to 4.1.1 or newer"

--- a/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
+++ b/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
@@ -11,6 +11,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 def _client(config: dict, auth: UserAPIKeyAuth | None = None) -> TestClient:
     from litellm.proxy.opencode_endpoints.skills_endpoints import (
+        initialize_agent_skills_endpoint,
         initialize_opencode_skills_endpoint,
     )
 
@@ -18,6 +19,7 @@ def _client(config: dict, auth: UserAPIKeyAuth | None = None) -> TestClient:
     if auth is not None:
         app.dependency_overrides[user_api_key_auth] = lambda: auth
     initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    initialize_agent_skills_endpoint(app=app, skills_gateway_config=config)
     return TestClient(app)
 
 
@@ -25,6 +27,14 @@ def test_should_not_register_opencode_skills_endpoint_when_disabled():
     client = _client({})
 
     response = client.get("/opencode/skills")
+
+    assert response.status_code == 404
+
+
+def test_should_not_register_agent_skills_endpoint_when_disabled():
+    client = _client({"enabled": True})
+
+    response = client.get("/.well-known/agent-skills/index.json")
 
     assert response.status_code == 404
 
@@ -56,6 +66,114 @@ def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
         "skills": [{"name": "litellm_skill_writer", "files": ["SKILL.md"]}]
     }
     list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
+
+
+def test_should_return_agent_skills_well_known_index_when_enabled(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    list_skills = AsyncMock(
+        return_value=[
+            LiteLLM_SkillsTable(
+                skill_id="litellm_skill_writer",
+                display_title="Writer",
+                description="Draft clean release notes",
+                instructions="Use this skill to draft release notes.",
+            )
+        ]
+    )
+    monkeypatch.setattr(LiteLLMSkillsHandler, "list_skills", list_skills)
+    auth = UserAPIKeyAuth(user_id="user-1")
+    client = _client(
+        {"enabled": True, "agent_skills": {"enabled": True}},
+        auth=auth,
+    )
+
+    response = client.get("/.well-known/agent-skills/index.json")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "skills": [
+            {
+                "name": "litellm-skill-writer",
+                "description": "Draft clean release notes",
+                "files": ["SKILL.md"],
+            }
+        ]
+    }
+    list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
+
+
+def test_should_serve_agent_skills_markdown_from_well_known_path(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_writer",
+                    display_title="Writer",
+                    description="Draft clean release notes",
+                    instructions="Use this skill to draft release notes.",
+                )
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "agent_skills": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/.well-known/agent-skills/litellm-skill-writer/SKILL.md")
+
+    assert response.status_code == 200
+    assert response.text == (
+        "---\n"
+        "name: litellm-skill-writer\n"
+        "description: Draft clean release notes\n"
+        "---\n\n"
+        "# Writer\n\n"
+        "Use this skill to draft release notes.\n"
+    )
+
+
+def test_should_serve_legacy_agent_skills_well_known_alias(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_enabled",
+                    metadata={"enabled": True},
+                ),
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_disabled",
+                    metadata={"enabled": False},
+                ),
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "agent_skills": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/.well-known/skills/index.json")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "skills": [
+            {
+                "name": "litellm-skill-enabled",
+                "description": "litellm_skill_enabled",
+                "files": ["SKILL.md"],
+            }
+        ]
+    }
 
 
 def test_should_omit_disabled_litellm_skills(monkeypatch):

--- a/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
+++ b/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
@@ -1,7 +1,8 @@
-from unittest.mock import AsyncMock
 from io import BytesIO
+from unittest.mock import AsyncMock
 from zipfile import ZipFile
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -39,6 +40,24 @@ def test_should_not_register_agent_skills_endpoint_when_disabled():
     assert response.status_code == 404
 
 
+def test_should_handle_skills_endpoint_config_edge_cases():
+    from litellm.proxy.opencode_endpoints.skills_endpoints import (
+        OPENCODE_SKILLS_DEFAULT_PATH,
+        _agent_skills_config_enabled,
+        _one_line,
+        _opencode_config_enabled,
+        _opencode_path,
+    )
+
+    assert _opencode_config_enabled(None) is False
+    assert _agent_skills_config_enabled(None) is False
+    assert _opencode_path(None) == OPENCODE_SKILLS_DEFAULT_PATH
+    assert _opencode_path({"enabled": True, "opencode": "invalid"}) == (
+        OPENCODE_SKILLS_DEFAULT_PATH
+    )
+    assert _one_line(None) == ""
+
+
 def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
     from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
 
@@ -66,6 +85,25 @@ def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
         "skills": [{"name": "litellm_skill_writer", "files": ["SKILL.md"]}]
     }
     list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
+
+
+def test_should_normalize_opencode_path_without_leading_slash(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(return_value=[]),
+    )
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True, "path": "custom/skills"}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/custom/skills/index.json")
+
+    assert response.status_code == 200
+    assert response.json() == {"skills": []}
 
 
 def test_should_return_agent_skills_well_known_index_when_enabled(monkeypatch):
@@ -136,6 +174,71 @@ def test_should_serve_agent_skills_markdown_from_well_known_path(monkeypatch):
         "# Writer\n\n"
         "Use this skill to draft release notes.\n"
     )
+
+
+def test_should_return_opencode_404_when_skill_file_is_missing(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(skill_id="other_skill"),
+                LiteLLM_SkillsTable(skill_id="litellm_skill_writer"),
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/opencode/skills/litellm_skill_writer/missing.txt")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Skill file not found"}
+
+
+def test_should_return_agent_404_when_skill_file_is_missing(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(skill_id="other_skill"),
+                LiteLLM_SkillsTable(skill_id="litellm_skill_writer"),
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "agent_skills": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/.well-known/agent-skills/litellm-skill-writer/missing.txt")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Skill file not found"}
+
+
+def test_should_not_duplicate_routes_when_initialized_twice():
+    from litellm.proxy.opencode_endpoints.skills_endpoints import (
+        initialize_opencode_skills_endpoint,
+    )
+
+    app = FastAPI()
+    config = {"enabled": True, "opencode": {"enabled": True}}
+
+    initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+
+    route_paths = [getattr(route, "path", None) for route in app.routes]
+    assert route_paths.count("/opencode/skills") == 1
+    assert route_paths.count("/opencode/skills/index.json") == 1
+    assert route_paths.count("/opencode/skills/{skill_name}/{file_path:path}") == 1
 
 
 def test_should_serve_legacy_agent_skills_well_known_alias(monkeypatch):
@@ -294,3 +397,37 @@ def test_should_serve_zip_backed_skill_files_from_custom_path(monkeypatch):
     )
     assert reference.status_code == 200
     assert reference.text == "example"
+
+
+@pytest.mark.asyncio
+async def test_should_register_skills_endpoints_from_proxy_config_load(
+    tmp_path, monkeypatch
+):
+    from litellm.proxy import proxy_server
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "model_list: []\n"
+        "general_settings: {}\n"
+        "litellm_settings: {}\n"
+        "skills_gateway:\n"
+        "  enabled: true\n"
+        "  opencode:\n"
+        "    enabled: true\n"
+        "    path: /native/skills\n"
+        "  agent_skills:\n"
+        "    enabled: true\n"
+    )
+    app = FastAPI()
+    monkeypatch.setattr(proxy_server, "app", app)
+    monkeypatch.setattr(proxy_server, "prisma_client", None)
+    monkeypatch.setattr(proxy_server, "store_model_in_db", False)
+    monkeypatch.delenv("LITELLM_CONFIG_BUCKET_NAME", raising=False)
+
+    proxy_config = proxy_server.ProxyConfig()
+    await proxy_config.load_config(router=None, config_file_path=str(config_file))
+
+    route_paths = {getattr(route, "path", None) for route in app.routes}
+    assert "/native/skills" in route_paths
+    assert "/native/skills/index.json" in route_paths
+    assert "/.well-known/agent-skills/index.json" in route_paths

--- a/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
+++ b/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
@@ -97,7 +97,9 @@ def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
     list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
 
 
-def test_should_return_opencode_remote_config_when_enabled_without_auth():
+def test_should_return_opencode_remote_config_when_enabled_without_auth(monkeypatch):
+    monkeypatch.delenv("PROXY_BASE_URL", raising=False)
+    monkeypatch.delenv("SERVER_ROOT_PATH", raising=False)
     client = _client(
         {
             "enabled": True,
@@ -119,6 +121,27 @@ def test_should_return_opencode_remote_config_when_enabled_without_auth():
             },
         },
     }
+
+
+def test_should_return_opencode_remote_config_with_server_root_path(monkeypatch):
+    monkeypatch.delenv("PROXY_BASE_URL", raising=False)
+    monkeypatch.setenv("SERVER_ROOT_PATH", "/my-custom-path")
+    client = _client(
+        {
+            "enabled": True,
+            "opencode": {
+                "enabled": True,
+                "remote_config": {"enabled": True},
+            },
+        }
+    )
+
+    response = client.get("/.well-known/opencode")
+
+    assert response.status_code == 200
+    assert response.json()["config"]["skills"]["urls"] == [
+        "http://testserver/my-custom-path/opencode/skills"
+    ]
 
 
 def test_should_normalize_opencode_path_without_leading_slash(monkeypatch):
@@ -144,6 +167,7 @@ def test_should_return_opencode_remote_config_with_custom_paths_and_proxy_base_u
     monkeypatch,
 ):
     monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com/root")
+    monkeypatch.delenv("SERVER_ROOT_PATH", raising=False)
     client = _client(
         {
             "enabled": True,

--- a/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
+++ b/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
@@ -1,0 +1,178 @@
+from unittest.mock import AsyncMock
+from io import BytesIO
+from zipfile import ZipFile
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from litellm.proxy._types import LiteLLM_SkillsTable, UserAPIKeyAuth
+from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+
+def _client(config: dict, auth: UserAPIKeyAuth | None = None) -> TestClient:
+    from litellm.proxy.opencode_endpoints.skills_endpoints import (
+        initialize_opencode_skills_endpoint,
+    )
+
+    app = FastAPI()
+    if auth is not None:
+        app.dependency_overrides[user_api_key_auth] = lambda: auth
+    initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    return TestClient(app)
+
+
+def test_should_not_register_opencode_skills_endpoint_when_disabled():
+    client = _client({})
+
+    response = client.get("/opencode/skills")
+
+    assert response.status_code == 404
+
+
+def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    list_skills = AsyncMock(
+        return_value=[
+            LiteLLM_SkillsTable(
+                skill_id="litellm_skill_writer",
+                display_title="Writer",
+                description="Draft clean release notes",
+                instructions="Use this skill to draft release notes.",
+            )
+        ]
+    )
+    monkeypatch.setattr(LiteLLMSkillsHandler, "list_skills", list_skills)
+    auth = UserAPIKeyAuth(user_id="user-1")
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True}},
+        auth=auth,
+    )
+
+    response = client.get("/opencode/skills/index.json")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "skills": [{"name": "litellm_skill_writer", "files": ["SKILL.md"]}]
+    }
+    list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
+
+
+def test_should_omit_disabled_litellm_skills(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_enabled",
+                    metadata={"enabled": True},
+                ),
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_disabled",
+                    metadata={"enabled": False},
+                ),
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/opencode/skills")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "skills": [{"name": "litellm_skill_enabled", "files": ["SKILL.md"]}]
+    }
+
+
+def test_should_serve_generated_skill_markdown(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_writer",
+                    display_title="Writer",
+                    description="Draft clean release notes",
+                    instructions="Use this skill to draft release notes.",
+                )
+            ]
+        ),
+    )
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/opencode/skills/litellm_skill_writer/SKILL.md")
+
+    assert response.status_code == 200
+    assert response.text == (
+        "---\n"
+        "name: litellm-skill-writer\n"
+        "description: Draft clean release notes\n"
+        "---\n\n"
+        "# Writer\n\n"
+        "Use this skill to draft release notes.\n"
+    )
+
+
+def test_should_serve_zip_backed_skill_files_from_custom_path(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    zip_buffer = BytesIO()
+    with ZipFile(zip_buffer, "w") as zip_file:
+        zip_file.writestr(
+            "writer/SKILL.md",
+            "---\nname: writer\ndescription: Draft notes\n---\n\nUse me.",
+        )
+        zip_file.writestr("writer/references/example.txt", "example")
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(
+            return_value=[
+                LiteLLM_SkillsTable(
+                    skill_id="litellm_skill_writer",
+                    file_content=zip_buffer.getvalue(),
+                    file_name="writer.zip",
+                )
+            ]
+        ),
+    )
+    client = _client(
+        {
+            "enabled": True,
+            "opencode": {"enabled": True, "path": "/custom/skills"},
+        },
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    index = client.get("/custom/skills/index.json")
+    skill_md = client.get("/custom/skills/litellm_skill_writer/SKILL.md")
+    reference = client.get("/custom/skills/litellm_skill_writer/references/example.txt")
+
+    assert index.status_code == 200
+    assert index.json() == {
+        "skills": [
+            {
+                "name": "litellm_skill_writer",
+                "files": ["SKILL.md", "references/example.txt"],
+            }
+        ]
+    }
+    assert skill_md.status_code == 200
+    assert (
+        skill_md.text == "---\nname: writer\ndescription: Draft notes\n---\n\nUse me."
+    )
+    assert reference.status_code == 200
+    assert reference.text == "example"

--- a/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
+++ b/tests/test_litellm/proxy/test_opencode_skills_endpoints.py
@@ -13,6 +13,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 def _client(config: dict, auth: UserAPIKeyAuth | None = None) -> TestClient:
     from litellm.proxy.opencode_endpoints.skills_endpoints import (
         initialize_agent_skills_endpoint,
+        initialize_opencode_remote_config_endpoint,
         initialize_opencode_skills_endpoint,
     )
 
@@ -20,6 +21,7 @@ def _client(config: dict, auth: UserAPIKeyAuth | None = None) -> TestClient:
     if auth is not None:
         app.dependency_overrides[user_api_key_auth] = lambda: auth
     initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    initialize_opencode_remote_config_endpoint(app=app, skills_gateway_config=config)
     initialize_agent_skills_endpoint(app=app, skills_gateway_config=config)
     return TestClient(app)
 
@@ -28,6 +30,14 @@ def test_should_not_register_opencode_skills_endpoint_when_disabled():
     client = _client({})
 
     response = client.get("/opencode/skills")
+
+    assert response.status_code == 404
+
+
+def test_should_not_register_opencode_remote_config_when_disabled():
+    client = _client({"enabled": True, "opencode": {"enabled": True}})
+
+    response = client.get("/.well-known/opencode")
 
     assert response.status_code == 404
 
@@ -87,6 +97,30 @@ def test_should_return_opencode_skills_index_when_enabled(monkeypatch):
     list_skills.assert_awaited_once_with(limit=1000, offset=0, user_api_key_dict=auth)
 
 
+def test_should_return_opencode_remote_config_when_enabled_without_auth():
+    client = _client(
+        {
+            "enabled": True,
+            "opencode": {
+                "enabled": True,
+                "remote_config": {"enabled": True},
+            },
+        }
+    )
+
+    response = client.get("/.well-known/opencode")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "config": {
+            "$schema": "https://opencode.ai/config.json",
+            "skills": {
+                "urls": ["http://testserver/opencode/skills"],
+            },
+        },
+    }
+
+
 def test_should_normalize_opencode_path_without_leading_slash(monkeypatch):
     from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
 
@@ -104,6 +138,32 @@ def test_should_normalize_opencode_path_without_leading_slash(monkeypatch):
 
     assert response.status_code == 200
     assert response.json() == {"skills": []}
+
+
+def test_should_return_opencode_remote_config_with_custom_paths_and_proxy_base_url(
+    monkeypatch,
+):
+    monkeypatch.setenv("PROXY_BASE_URL", "https://litellm.example.com/root")
+    client = _client(
+        {
+            "enabled": True,
+            "opencode": {
+                "enabled": True,
+                "path": "native/skills",
+                "remote_config": {
+                    "enabled": True,
+                    "path": "/custom/opencode",
+                },
+            },
+        }
+    )
+
+    response = client.get("/custom/opencode")
+
+    assert response.status_code == 200
+    assert response.json()["config"]["skills"]["urls"] == [
+        "https://litellm.example.com/root/native/skills"
+    ]
 
 
 def test_should_return_agent_skills_well_known_index_when_enabled(monkeypatch):
@@ -200,6 +260,25 @@ def test_should_return_opencode_404_when_skill_file_is_missing(monkeypatch):
     assert response.json() == {"detail": "Skill file not found"}
 
 
+def test_should_return_opencode_404_when_no_skills_exist(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(return_value=[]),
+    )
+    client = _client(
+        {"enabled": True, "opencode": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/opencode/skills/missing_skill/SKILL.md")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Skill file not found"}
+
+
 def test_should_return_agent_404_when_skill_file_is_missing(monkeypatch):
     from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
 
@@ -224,21 +303,47 @@ def test_should_return_agent_404_when_skill_file_is_missing(monkeypatch):
     assert response.json() == {"detail": "Skill file not found"}
 
 
+def test_should_return_agent_404_when_no_skills_exist(monkeypatch):
+    from litellm.llms.litellm_proxy.skills.handler import LiteLLMSkillsHandler
+
+    monkeypatch.setattr(
+        LiteLLMSkillsHandler,
+        "list_skills",
+        AsyncMock(return_value=[]),
+    )
+    client = _client(
+        {"enabled": True, "agent_skills": {"enabled": True}},
+        auth=UserAPIKeyAuth(user_id="user-1"),
+    )
+
+    response = client.get("/.well-known/agent-skills/missing-skill/SKILL.md")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Skill file not found"}
+
+
 def test_should_not_duplicate_routes_when_initialized_twice():
     from litellm.proxy.opencode_endpoints.skills_endpoints import (
+        initialize_opencode_remote_config_endpoint,
         initialize_opencode_skills_endpoint,
     )
 
     app = FastAPI()
-    config = {"enabled": True, "opencode": {"enabled": True}}
+    config = {
+        "enabled": True,
+        "opencode": {"enabled": True, "remote_config": {"enabled": True}},
+    }
 
     initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    initialize_opencode_remote_config_endpoint(app=app, skills_gateway_config=config)
     initialize_opencode_skills_endpoint(app=app, skills_gateway_config=config)
+    initialize_opencode_remote_config_endpoint(app=app, skills_gateway_config=config)
 
     route_paths = [getattr(route, "path", None) for route in app.routes]
     assert route_paths.count("/opencode/skills") == 1
     assert route_paths.count("/opencode/skills/index.json") == 1
     assert route_paths.count("/opencode/skills/{skill_name}/{file_path:path}") == 1
+    assert route_paths.count("/.well-known/opencode") == 1
 
 
 def test_should_serve_legacy_agent_skills_well_known_alias(monkeypatch):
@@ -415,6 +520,8 @@ async def test_should_register_skills_endpoints_from_proxy_config_load(
         "  opencode:\n"
         "    enabled: true\n"
         "    path: /native/skills\n"
+        "    remote_config:\n"
+        "      enabled: true\n"
         "  agent_skills:\n"
         "    enabled: true\n"
     )
@@ -430,4 +537,5 @@ async def test_should_register_skills_endpoints_from_proxy_config_load(
     route_paths = {getattr(route, "path", None) for route in app.routes}
     assert "/native/skills" in route_paths
     assert "/native/skills/index.json" in route_paths
+    assert "/.well-known/opencode" in route_paths
     assert "/.well-known/agent-skills/index.json" in route_paths


### PR DESCRIPTION
## Summary
- add config-gated OpenCode remote skills endpoint at `/opencode/skills`
- add config-gated Agent Skills well-known discovery endpoints for `npx skills`
- reuse existing Skills Gateway auth and only expose enabled skills

## Testing
- `uv run pytest tests/test_litellm/proxy/test_opencode_skills_endpoints.py tests/test_litellm/llms/litellm_proxy/test_skills_ownership.py -q`
- `uv run black --check litellm/proxy/opencode_endpoints/skills_endpoints.py litellm/proxy/proxy_server.py tests/test_litellm/proxy/test_opencode_skills_endpoints.py`
- `uv run ruff check litellm/proxy/opencode_endpoints/skills_endpoints.py litellm/proxy/proxy_server.py tests/test_litellm/proxy/test_opencode_skills_endpoints.py`