### PR TITLE
perf(otel): resolve LITELLM_OTEL_V2 flag once instead of rebuilding settings per call

### DIFF
--- a/litellm/integrations/otel/model/config.py
+++ b/litellm/integrations/otel/model/config.py
@@ -1,6 +1,7 @@
 """Typed configuration for the OpenTelemetry instrumentation."""
 
 from enum import Enum
+from functools import lru_cache
 from typing import Any, List
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
@@ -47,7 +48,12 @@ class _OTelV2Flag(BaseSettings):
     enabled: bool = Field(default=False, validation_alias=AliasChoices(OTEL_V2_ENV))
 
 
+@lru_cache(maxsize=1)
 def is_otel_v2_enabled() -> bool:
+    # Resolved once at startup and cached: constructing the pydantic-settings
+    # model re-scans the environment and cost ~28us, which on the proxy hot path
+    # (auth, logging-callback setup) compounded into a measurable throughput
+    # regression. Tests that toggle the env must call ``is_otel_v2_enabled.cache_clear()``.
     return _OTelV2Flag().enabled
 
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_mount.py
@@ -35,6 +35,13 @@ from litellm.integrations.otel.mount import (  # noqa: E402
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_otel_v2_flag_cache():
+    is_otel_v2_enabled.cache_clear()
+    yield
+    is_otel_v2_enabled.cache_clear()
+
+
 class _FakeSpan:
     """Minimal recording span capturing what the hook writes."""
 
@@ -70,8 +77,10 @@ def _instrumented_app():
 def test_gate_toggles_with_env(monkeypatch):
     """The startup mount is guarded by this flag."""
     monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+    is_otel_v2_enabled.cache_clear()
     assert is_otel_v2_enabled() is False
     monkeypatch.setenv("LITELLM_OTEL_V2", "1")
+    is_otel_v2_enabled.cache_clear()
     assert is_otel_v2_enabled() is True
 
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -1,6 +1,8 @@
 """Tests for the OTel v2 sources of truth: span registry, semconv keys, config,
 and the typed StandardLoggingPayload adapter. These need no OTel SDK."""
 
+import pytest
+
 from litellm.integrations.otel import (
     BAGGAGE_PROMOTED_KEYS,
     DB,
@@ -26,6 +28,13 @@ from litellm.integrations.otel.model.spans import (
     root_roles,
     validate_registry,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_otel_v2_flag_cache():
+    is_otel_v2_enabled.cache_clear()
+    yield
+    is_otel_v2_enabled.cache_clear()
 
 
 def _sample_payload(**overrides):
@@ -561,9 +570,35 @@ def test_capture_message_content_normalizer_only_touches_strings():
 
 def test_v2_flag_is_off_by_default(monkeypatch):
     monkeypatch.delenv("LITELLM_OTEL_V2", raising=False)
+    is_otel_v2_enabled.cache_clear()
     assert is_otel_v2_enabled() is False
     monkeypatch.setenv("LITELLM_OTEL_V2", "true")
+    is_otel_v2_enabled.cache_clear()
     assert is_otel_v2_enabled() is True
+
+
+def test_v2_flag_resolved_once_not_per_call(monkeypatch):
+    """Regression for LIT-3895: ``is_otel_v2_enabled`` sits on the proxy hot path
+    (auth, logging-callback setup). Building the pydantic-settings model on every
+    call re-scanned the environment at ~28us a pop and dropped throughput, so the
+    flag must be resolved once and cached rather than reconstructed per call."""
+    from litellm.integrations.otel.model import config as config_mod
+
+    constructions = 0
+    real_flag = config_mod._OTelV2Flag
+
+    def _counting_flag(*args, **kwargs):
+        nonlocal constructions
+        constructions += 1
+        return real_flag(*args, **kwargs)
+
+    monkeypatch.setattr(config_mod, "_OTelV2Flag", _counting_flag)
+    config_mod.is_otel_v2_enabled.cache_clear()
+
+    for _ in range(50):
+        config_mod.is_otel_v2_enabled()
+
+    assert constructions == 1
 
 
 def test_config_from_env(monkeypatch):


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3895

## Linear ticket

LIT-3895

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Load tests use a fast local mock OpenAI backend so the proxy's own CPU cost dominates; real-provider latency variance would otherwise swamp a sub-millisecond per-request delta. Throughput at concurrency 1 (no queueing, so latency is pure proxy overhead), with each litellm version installed into a clean venv against the mock.

The changed function, before and after:

```
is_otel_v2_enabled(): 28.4 us/call  ->  0.018 us/call (cached)
```

Per-request latency at concurrency 1:

| path | v1.87.3 | v1.89.2 (stock) | v1.89.2 + fix |
|---|---|---|---|
| master-key | 2.3 ms | 2.6 ms | 2.3 ms |
| virtual-key + Postgres | 2.5 ms | 3.1 ms | 2.6 ms |

This branch's source against the mock, master-key path at concurrency 50: 338 RPS without the fix, 431 RPS with it.

OpenTelemetry v2 (`LITELLM_OTEL_V2=true`) located the added time in the `auth` phase span and pre/post processing rather than the `chat` LLM-call span; an in-process cProfile of `acompletion` was identical across versions, confirming the regression is proxy-layer only.

Real-provider end-to-end check on this branch (real OpenAI `gpt-4o-mini`, OTEL on) returned a correct 200 with the flag resolving enabled:

```
content: Hello, how are you?
usage: {'completion_tokens': 6, 'prompt_tokens': 13, 'total_tokens': 19}
```

## Type

🐛 Bug Fix

## Changes

`is_otel_v2_enabled()` constructed a pydantic-settings model (`_OTelV2Flag`) on every call. That construction re-scans the process environment and costs about 28 microseconds. The flag is read several times along the proxy request hot path (auth, logging-callback setup, `proxy_server`), so the cost compounded into per-request CPU overhead and the throughput regression reported between v1.87.3 and v1.89.2. Caching this one function alone restores throughput to the pre-regression baseline in the load tests above.

Because the flag is a process-level setting fixed at startup, it is now resolved once with `lru_cache`. The two tests that toggle `LITELLM_OTEL_V2` at runtime call `is_otel_v2_enabled.cache_clear()`, and a new regression test (`test_v2_flag_resolved_once_not_per_call`) asserts the settings model is constructed only once across 50 calls; it fails on the pre-fix code
