### PR TITLE
fix(spend): make /spend/tags resilient to double-encoded request_tags

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -218,15 +218,6 @@ async def view_spend_tags(
                 "Database not connected. Connect a database to your proxy - https://docs.litellm.ai/docs/simple_proxy#managing-auth---virtual-keys"
             )
 
-        # run the following SQL query on prisma
-        """
-        SELECT
-        jsonb_array_elements_text(request_tags) AS individual_request_tag,
-        COUNT(*) AS log_count,
-        SUM(spend) AS total_spend
-        FROM "LiteLLM_SpendLogs"
-        GROUP BY individual_request_tag;
-        """
         response = await get_spend_by_tags(
             start_date=start_date, end_date=end_date, prisma_client=prisma_client
         )
@@ -3248,11 +3239,24 @@ async def get_spend_by_tags(
     prisma_client: PrismaClient, start_date=None, end_date=None
 ):
     response = await prisma_client.db.query_raw("""
+        WITH normalized_tags AS (
+            SELECT
+                spend,
+                CASE
+                    WHEN jsonb_typeof(request_tags) = 'array' THEN request_tags
+                    WHEN jsonb_typeof(request_tags) = 'string'
+                         AND (request_tags #>> '{}') ~ '^\\s*\\['
+                        THEN (request_tags #>> '{}')::jsonb
+                    ELSE NULL
+                END AS tags
+            FROM "LiteLLM_SpendLogs"
+        )
         SELECT
-        jsonb_array_elements_text(request_tags) AS individual_request_tag,
-        COUNT(*) AS log_count,
-        SUM(spend) AS total_spend
-        FROM "LiteLLM_SpendLogs"
+            jsonb_array_elements_text(tags) AS individual_request_tag,
+            COUNT(*) AS log_count,
+            SUM(spend) AS total_spend
+        FROM normalized_tags
+        WHERE jsonb_typeof(tags) = 'array'
         GROUP BY individual_request_tag;
         """)
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -97,6 +97,10 @@ def make_ui_spend_logs_mock_prisma(mock_spend_logs, filter_fn, team_lookup_fn=No
     return MockPrismaClient()
 
 
+from collections import Counter
+from typing import Dict, List, Optional, Tuple
+
+from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import (
     LitellmUserRoles,
     Member,
@@ -3786,3 +3790,114 @@ async def test_ui_view_spend_logs_metadata_invalid_json_falls_back_to_empty_dict
         assert body["data"][0]["metadata"] == {}
     finally:
         app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+class _ScalarExtractionError(Exception):
+    """Mirrors PostgreSQL's "cannot extract elements from a scalar" error that
+    ``jsonb_array_elements_text`` raises when a row's request_tags is not a JSON
+    array. A single such row aborts the whole GROUP BY, which is the LIT-3906
+    bug."""
+
+
+def _jsonb_typeof(literal: str) -> str:
+    value = json.loads(literal)
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, dict):
+        return "object"
+    if value is None:
+        return "null"
+    return "number"
+
+
+def _normalized_tags(literal: str, query_guards_strings: bool) -> Optional[List[str]]:
+    typeof = _jsonb_typeof(literal)
+    if typeof == "array":
+        return json.loads(literal)
+    if not query_guards_strings:
+        raise _ScalarExtractionError("cannot extract elements from a scalar")
+    if typeof != "string":
+        return None
+    inner = json.loads(literal)
+    if not inner.lstrip().startswith("["):
+        return None
+    parsed = json.loads(inner)
+    return parsed if isinstance(parsed, list) else None
+
+
+class _FakeSpendLogsJsonbTable:
+    """Faithful emulator of the subset of PostgreSQL JSONB behaviour that
+    ``get_spend_by_tags`` relies on.
+
+    Each seeded row stores ``request_tags`` exactly as the spend-log write path
+    produces it: the tag list is ``safe_dumps``'d to a JSON string and Prisma's
+    ``create_many`` JSON-encodes that string again into the ``Json`` column, so
+    the column literal is ``json.dumps(json.dumps(tags))`` - a JSON scalar
+    string, not a JSON array. ``jsonb_array_elements_text`` raises on a scalar,
+    which is the LIT-3906 bug.
+    """
+
+    def __init__(self, rows: Tuple[Tuple[str, float], ...]) -> None:
+        self._rows = rows
+
+    async def query_raw(self, query: str, *args: object) -> List[Dict[str, object]]:
+        guards_strings = "jsonb_typeof(request_tags) = 'string'" in query
+        expanded = tuple(
+            (tag, spend)
+            for literal, spend in self._rows
+            for tag in (_normalized_tags(literal, guards_strings) or ())
+        )
+        counts = Counter(tag for tag, _ in expanded)
+        spends: Dict[str, float] = {
+            tag: sum(spend for t, spend in expanded if t == tag) for tag in counts
+        }
+        return [
+            {
+                "individual_request_tag": tag,
+                "log_count": counts[tag],
+                "total_spend": spends[tag],
+            }
+            for tag in counts
+        ]
+
+
+def _double_encoded_request_tags(tags: List[str]) -> str:
+    return json.dumps(safe_dumps(tags))
+
+
+@pytest.mark.asyncio
+async def test_get_spend_by_tags_surfaces_scalar_string_tags() -> None:
+    """Regression for LIT-3906: tags stored as a JSON scalar string (the shape
+    the write path produces) must still surface from /spend/tags with the
+    summed spend and correct log count."""
+    rows = (
+        (_double_encoded_request_tags(["prod-tag", "shared"]), 0.10),
+        (_double_encoded_request_tags(["prod-tag"]), 0.05),
+        (_double_encoded_request_tags(["shared"]), 0.02),
+        (json.dumps(["already-array"]), 0.03),
+        (json.dumps(None), 0.99),
+        (json.dumps("not-json-at-all"), 0.99),
+    )
+
+    prisma_client = MagicMock()
+    prisma_client.db = _FakeSpendLogsJsonbTable(rows)
+
+    response = await spend_management_endpoints.get_spend_by_tags(
+        prisma_client=prisma_client
+    )
+
+    by_tag = {r["individual_request_tag"]: r for r in response}
+
+    assert "prod-tag" in by_tag, "double-encoded tag never surfaced from /spend/tags"
+    assert by_tag["prod-tag"]["log_count"] == 2
+    assert by_tag["prod-tag"]["total_spend"] == pytest.approx(0.15)
+
+    assert by_tag["shared"]["log_count"] == 2
+    assert by_tag["shared"]["total_spend"] == pytest.approx(0.12)
+
+    assert by_tag["already-array"]["log_count"] == 1
+    assert by_tag["already-array"]["total_spend"] == pytest.approx(0.03)
+
+    assert "not-json-at-all" not in by_tag


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-3906

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a local proxy, make two chat calls carrying the same tag, then read `/spend/tags` back

```bash
for i in 1 2; do
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{
      "model": "gpt-4o-mini",
      "messages": [{"role": "user", "content": "say hi"}],
      "metadata": {"tags": ["lit-3906-proof"]}
    }'
done

curl -s "http://localhost:4000/spend/tags" -H "Authorization: Bearer sk-1234" | jq .
```

Before this change the `/spend/tags` response omitted `lit-3906-proof` entirely (the underlying query 500s on the first row whose `request_tags` is stored as a JSON scalar string). After this change the tag is returned with `log_count` 2 and the summed `total_spend` from both calls.

## Type

🐛 Bug Fix

## Changes

`/spend/tags` did not surface request tags that demonstrably existed with non-zero spend in `LiteLLM_SpendLogs`. The root cause is on the write path: spend logs serialize `request_tags` with `safe_dumps` into a JSON string before the payload reaches Prisma's `create_many`, which then JSON-encodes that string a second time. The `request_tags` `Json` column therefore stores a JSON scalar string such as `"[\"tag\"]"` rather than a JSON array. `get_spend_by_tags` ran `jsonb_array_elements_text` directly over that column, and Postgres raises "cannot extract elements from a scalar" on the first such row, which aborts the whole `GROUP BY` so the endpoint returned nothing.

Rather than retype `request_tags` across the write path and every downstream consumer (and still leave already-written rows broken), this hardens the aggregation so it tolerates both stored shapes. The query first normalizes `request_tags` into a real `jsonb` array: genuine arrays pass through, JSON-string-wrapped arrays are unwrapped, and anything else becomes `NULL` and is filtered out before expansion. A single malformed row can no longer crash the aggregation, and both legacy and newly written rows now show up.

The regression test seeds rows in the exact double-encoded form the write path produces (via `safe_dumps` then `json.dumps`), plus a proper-array row and non-array rows, and asserts the tags surface with the correct summed spend and counts. It runs the real `get_spend_by_tags` against a faithful emulator of the PostgreSQL JSONB semantics the query depends on, so it fails before the fix (the emulator raises the scalar error, mirroring Postgres) and passes after

