### PR TITLE
fix(proxy): stop x-litellm-tags header tags leaking into Bedrock passthrough body

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -1313,24 +1313,31 @@ class LiteLLMProxyRequestSetup:
         # from (litellm_metadata vs metadata) so the merged tags are visible
         # to _tag_max_budget_check.
         _metadata_variable_name = get_metadata_variable_name_from_kwargs(request_data)
-        metadata = request_data.get(_metadata_variable_name)
+        raw_metadata = request_data.get(_metadata_variable_name)
         # metadata can arrive as a JSON string (multipart/form-data, extra_body).
-        # Parse it so existing tags survive the merge — overwriting the string
-        # with {} would let a caller bypass _tag_max_budget_check on an
-        # over-budget body tag by also sending a within-budget header tag.
-        if isinstance(metadata, str):
-            parsed = safe_json_loads(metadata)
-            metadata = parsed if isinstance(parsed, dict) else {}
-            request_data[_metadata_variable_name] = metadata
-        elif not isinstance(metadata, dict):
-            metadata = {}
-            request_data[_metadata_variable_name] = metadata
+        # Parse it so existing tags survive the merge — dropping the string
+        # would let a caller bypass _tag_max_budget_check on an over-budget
+        # body tag by also sending a within-budget header tag.
+        if isinstance(raw_metadata, str):
+            parsed = safe_json_loads(raw_metadata)
+            existing_metadata = parsed if isinstance(parsed, dict) else {}
+        elif isinstance(raw_metadata, dict):
+            existing_metadata = raw_metadata
+        else:
+            existing_metadata = {}
 
-        existing_tags = metadata.get("tags")
-        metadata["tags"] = LiteLLMProxyRequestSetup._merge_tags(
-            request_tags=existing_tags if isinstance(existing_tags, list) else None,
-            tags_to_add=header_tags,
-        )
+        # Build a new dict instead of mutating existing_metadata: it may be the
+        # request body's metadata object, shared by reference with the cached
+        # body that passthrough routes forward verbatim. An in-place write would
+        # leak these LiteLLM-internal tags into the upstream provider payload.
+        existing_tags = existing_metadata.get("tags")
+        request_data[_metadata_variable_name] = {
+            **existing_metadata,
+            "tags": LiteLLMProxyRequestSetup._merge_tags(
+                request_tags=existing_tags if isinstance(existing_tags, list) else None,
+                tags_to_add=header_tags,
+            ),
+        }
 
 
 async def add_litellm_data_to_request(

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -4256,6 +4256,49 @@ class TestApplyClientTagPolicyPreAuth:
             assert exc_info.value.current_cost == 0.50
             assert exc_info.value.max_budget == 0.10
 
+    @pytest.mark.asyncio
+    async def test_header_tags_do_not_leak_into_forwarded_passthrough_body(self):
+        """GH#30629 follow-up: x-litellm-tags must reach _tag_max_budget_check
+        without leaking into the provider-facing body that passthrough routes
+        forward verbatim.
+
+        request_data["metadata"] is shared by reference with the cached request
+        body, so an in-place write injects the LiteLLM-internal billing tags
+        into the upstream Bedrock payload, which Bedrock rejects with HTTP 400.
+        """
+        from litellm.proxy.common_utils.http_parsing_utils import (
+            _read_request_body,
+            _safe_set_request_parsed_body,
+        )
+
+        request_mock = _build_request_mock_with_headers(
+            {"x-litellm-tags": "billing:cost-center-1"}
+        )
+        request_mock.scope = {}
+        _safe_set_request_parsed_body(
+            request=request_mock,
+            parsed_body={
+                "anthropic_version": "bedrock-2023-05-31",
+                "messages": [{"role": "user", "content": "hi"}],
+                "metadata": {"user_id": "end-user-1"},
+            },
+        )
+
+        auth_body = await _read_request_body(request_mock)
+        LiteLLMProxyRequestSetup.apply_client_tag_policy_pre_auth(
+            request=request_mock,
+            request_data=auth_body,
+            user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key", metadata={}),
+        )
+
+        # _tag_max_budget_check reads the same dict the merge wrote to.
+        assert auth_body["metadata"]["tags"] == ["billing:cost-center-1"]
+
+        # Passthrough re-reads the body from cache and forwards it to Bedrock.
+        forwarded_body = await _read_request_body(request_mock)
+        assert "tags" not in forwarded_body["metadata"]
+        assert forwarded_body["metadata"] == {"user_id": "end-user-1"}
+
 
 class TestApplyKeyTagsPreAuth:
     def test_merges_key_tags_into_metadata(self):


### PR DESCRIPTION
## Relevant issues

Follow-up to #30629. That issue and its fix (#30985) cover key-level `metadata.tags` leaking into the Bedrock passthrough body. This PR closes the sibling vector: tags supplied via the `x-litellm-tags` request header.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`apply_client_tag_policy_pre_auth` merges `x-litellm-tags` into the request body's `metadata` dict before auth so `_tag_max_budget_check` can see them. It did this with an in-place write. That `metadata` dict is shared by reference with the cached parsed body (`request.scope["parsed_body"]`), and the Bedrock passthrough route re-reads that same cached body and forwards it verbatim to AWS. So the LiteLLM-internal billing tags ended up under `metadata` in the upstream payload, and Bedrock's Anthropic schema rejects any non-`user_id` key there with `HTTP 400 "Extra inputs are not permitted"`.

The fix builds a new metadata dict and reassigns `request_data[metadata_var]` rather than mutating the shared object. The budget check still sees the merged tags on `request_data`; the cached body the route forwards stays clean.

To reproduce against a live proxy (real Bedrock call, costs real money), with a Bedrock passthrough model configured and the proxy running on `localhost:4000`:

```bash
curl -sS -i http://localhost:4000/bedrock/model/us.anthropic.claude-sonnet-4-20250514-v1:0/invoke \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -H "x-litellm-tags: team-a,cost-center-7" \
  -d '{
        "anthropic_version": "bedrock-2023-05-31",
        "max_tokens": 16,
        "messages": [{"role": "user", "content": "ping"}],
        "metadata": {"user_id": "end-user-1"}
      }'
```

Before this change the call returns `HTTP 400` with a validation error on `metadata.tags`; after it returns `HTTP 200`, and the `team-a` / `cost-center-7` tags are still recorded for spend tracking (visible at http://localhost:4000/ui/?page=logs).

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/litellm_pre_call_utils.py`: `apply_client_tag_policy_pre_auth` now constructs a fresh metadata dict instead of mutating the request body's metadata object in place, so header tags can no longer leak through the shared cached body into a passthrough provider payload.

`tests/test_litellm/proxy/test_litellm_pre_call_utils.py`: regression test driving the merge through the real request-body cache and asserting the re-read (forwarded) body carries no `tags` while the auth-time body still exposes them to `_tag_max_budget_check`. It fails before the fix and passes after.
