### PR TITLE
fix(transcription): accept fractional usage.seconds in diarized_json responses

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2439,7 +2439,7 @@ class ImageResponse(OpenAIImageResponse, BaseLiteLLMOpenAIResponseObject):
 
 class TranscriptionUsageDurationObject(BaseModel):
     type: Literal["duration"]
-    seconds: int
+    seconds: float
 
 
 class TranscriptionUsageInputTokenDetailsObject(BaseModel):

--- a/tests/test_litellm/llms/openai/transcriptions/test_transcription_duration_hidden.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_transcription_duration_hidden.py
@@ -13,7 +13,52 @@ from litellm.cost_calculator import completion_cost
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     convert_to_model_response_object,
 )
-from litellm.types.utils import TranscriptionResponse
+from litellm.types.utils import (
+    TranscriptionResponse,
+    TranscriptionUsageDurationObject,
+)
+
+
+class TestDiarizedJsonUsageParsing:
+    """gpt-4o-transcribe / diarized_json returns a fractional `usage.seconds`."""
+
+    def test_fractional_duration_seconds_does_not_raise(self):
+        """
+        A diarized_json response carries usage={"type": "duration", "seconds": <float>}.
+        OpenAI specs `seconds` as a float, so a fractional value must parse cleanly
+        instead of raising and getting retried until the upstream rate-limits.
+        """
+        response_object = {
+            "text": "speaker_1: Olá",
+            "task": "transcribe",
+            "duration": 295.8,
+            "segments": [
+                {
+                    "id": "seg_001",
+                    "speaker": "speaker_1",
+                    "start": 0.0,
+                    "end": 1.0,
+                    "text": "Olá",
+                    "type": "transcript.text.segment",
+                }
+            ],
+            "usage": {"type": "duration", "seconds": 295.8},
+        }
+
+        result = convert_to_model_response_object(
+            response_object=response_object,
+            model_response_object=TranscriptionResponse(),
+            response_type="audio_transcription",
+        )
+
+        assert isinstance(result.usage, TranscriptionUsageDurationObject)
+        assert result.usage.seconds == 295.8
+
+    def test_usage_duration_object_accepts_float_seconds(self):
+        assert (
+            TranscriptionUsageDurationObject(type="duration", seconds=295.8).seconds
+            == 295.8
+        )
 
 
 class TestTranscriptionDurationNotInResponseBody:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review ([Greptile review: Confidence Score 5/5](https://github.com/BerriAI/litellm/pull/30996#issuecomment-4772034872))

## Screenshots / Proof of Fix

Reproduced against a live proxy on a `gpt-4o-transcribe`-style backend served as an OpenAI-compatible endpoint, hitting a real model with `response_format=diarized_json` (transcript text redacted below).

Before the fix:

```
$ curl -s -w "\nHTTP %{http_code}\n" http://PROXY:4000/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-..." \
    -F "model=<provider>/<model>" \
    -F "response_format=diarized_json" \
    -F "file=@audio.ogg"

{"error":{"message":"litellm.APIConnectionError: APIConnectionError: OpenAIException - Invalid response object
  File ".../convert_dict_to_response.py", line 811, in convert_to_model_response_object
    tr_usage_object = TranscriptionUsageDurationObject(**response_object["usage"])
  pydantic_core.ValidationError: 1 validation error for TranscriptionUsageDurationObject
  seconds
    Input should be a valid integer, got a number with a fractional part
    [type=int_from_float, input_value=295.8, input_type=float]
  ...
HTTP 500
```

With `num_retries` configured this turns into a loop: the upstream returns 200 every time, the parse fails every time, the router keeps retrying until the upstream rate-limits and a 429 reaches the caller.

After the fix:

```
$ curl -s -w "\nHTTP %{http_code}\n" http://PROXY:4000/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-..." \
    -F "model=<provider>/<model>" \
    -F "response_format=diarized_json" \
    -F "file=@audio.ogg"

HTTP 200
keys: ['text', 'usage', 'task', 'duration', 'segments']
usage: {'type': 'duration', 'seconds': 295.8}
duration: 295.8
num_segments: 30
segment[0]: {"id": "seg_001", "start": 43.2, "end": 45.12, "speaker": "speaker_1", "text": "<redacted>", "type": "transcript.text.segment"}
```

## Type

🐛 Bug Fix

## Changes

gpt-4o-transcribe and compatible ASR backends return a `diarized_json` response with `usage={"type": "duration", "seconds": <float>}` (e.g. `295.8`). `TranscriptionUsageDurationObject` typed `seconds` as `int`, so parsing the response raised a pydantic `ValidationError` (`int_from_float`). That error surfaces as an `APIConnectionError`, which the router treats as retryable, so it keeps re-calling the upstream (which keeps returning 200) until the upstream rate-limits and a 429 is returned to the caller.

OpenAI specs this field as a float (see the openai SDK's `UsageDuration.seconds`), so this widens `seconds` to `float`. With the parse succeeding there is no exception left to retry, which removes the loop.

Added a regression test in `test_transcription_duration_hidden.py` that feeds the diarized_json `usage` shape with a fractional `seconds` through `convert_to_model_response_object`; it fails before the change (ValidationError) and passes after.
