### PR TITLE
fix(mcp): resolve OAuth endpoints by server_id when name lookup fails

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -612,7 +612,9 @@ async def authorize(
         else None
     )
     if mcp_server is None and lookup_name:
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name, client_ip=client_ip)
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
+            lookup_name, client_ip=client_ip
+        )
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:
@@ -676,7 +678,9 @@ async def token_endpoint(
         lookup_name, client_ip=client_ip
     )
     if mcp_server is None and lookup_name:
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name, client_ip=client_ip)
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
+            lookup_name, client_ip=client_ip
+        )
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -612,7 +612,7 @@ async def authorize(
         else None
     )
     if mcp_server is None and lookup_name:
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name)
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name, client_ip=client_ip)
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:
@@ -676,7 +676,7 @@ async def token_endpoint(
         lookup_name, client_ip=client_ip
     )
     if mcp_server is None and lookup_name:
-        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name)
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name, client_ip=client_ip)
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:
@@ -997,7 +997,7 @@ async def _build_oauth_protected_resource_response(
         )
         if mcp_server is None:
             mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
-                mcp_server_name
+                mcp_server_name, client_ip=client_ip
             )
 
     # Build resource URL based on the pattern
@@ -1154,7 +1154,7 @@ def _build_oauth_authorization_server_response(
         )
         if mcp_server is None:
             mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
-                mcp_server_name
+                mcp_server_name, client_ip=client_ip
             )
 
     return {
@@ -1324,7 +1324,7 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
     )
     if mcp_server is None:
         mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
-            mcp_server_name
+            mcp_server_name, client_ip=client_ip
         )
     if mcp_server is None:
         return dummy_return

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -611,6 +611,8 @@ async def authorize(
         if lookup_name
         else None
     )
+    if mcp_server is None and lookup_name:
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name)
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:
@@ -673,6 +675,8 @@ async def token_endpoint(
     mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
         lookup_name, client_ip=client_ip
     )
+    if mcp_server is None and lookup_name:
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(lookup_name)
     if mcp_server is None and mcp_server_name is None:
         mcp_server = _resolve_oauth2_server_for_root_endpoints(client_ip=client_ip)
     if mcp_server is None:
@@ -991,6 +995,10 @@ async def _build_oauth_protected_resource_response(
         mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
             mcp_server_name, client_ip=client_ip
         )
+        if mcp_server is None:
+            mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
+                mcp_server_name
+            )
 
     # Build resource URL based on the pattern
     if mcp_server_name:
@@ -1144,6 +1152,10 @@ def _build_oauth_authorization_server_response(
         mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
             mcp_server_name, client_ip=client_ip
         )
+        if mcp_server is None:
+            mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
+                mcp_server_name
+            )
 
     return {
         "issuer": request_base_url,  # point to your proxy
@@ -1310,6 +1322,10 @@ async def register_client(request: Request, mcp_server_name: Optional[str] = Non
     mcp_server = global_mcp_server_manager.get_mcp_server_by_name(
         mcp_server_name, client_ip=client_ip
     )
+    if mcp_server is None:
+        mcp_server = global_mcp_server_manager.get_mcp_server_by_id(
+            mcp_server_name
+        )
     if mcp_server is None:
         return dummy_return
     return await register_client_with_server(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4018,13 +4018,22 @@ class MCPServerManager:
         )
         return IPAddressUtils.is_internal_ip(client_ip, internal_networks)
 
-    def get_mcp_server_by_id(self, server_id: str) -> Optional[MCPServer]:
+    def get_mcp_server_by_id(
+        self, server_id: str, client_ip: Optional[str] = None
+    ) -> Optional[MCPServer]:
         """
-        Get the MCP Server from the server id
+        Get the MCP Server from the server id.
+
+        Args:
+            server_id: The server ID to look up.
+            client_ip: Optional client IP for access control. When provided,
+                       non-public servers are hidden from external IPs.
         """
         registry = self.get_registry()
         for server in registry.values():
             if server.server_id == server_id:
+                if not self._is_server_accessible_from_ip(server, client_ip):
+                    return None
                 return server
         return None
 


### PR DESCRIPTION
## Summary
- Add `get_mcp_server_by_id()` fallback in all OAuth broker endpoints when `get_mcp_server_by_name()` returns None
- Fixes the UI "Authorize & Get Token" flow which sends `server_id` in the URL path
- Preserves IP access controls in the fallback path

## Problem

The OAuth broker endpoints (`authorize`, `register`, `token`, `metadata`) use `get_mcp_server_by_name()` to resolve the MCP server from the URL path parameter. The LiteLLM UI sends the **server_id** (SHA-256 hash from `_generate_stable_server_id()`) in the path -- not the server_name or alias -- causing the lookup to fail.

The error seen is:
```json
{"detail": "MCP server authorization url is not set"}
```

`get_mcp_server_by_id()` already exists in `mcp_server_manager.py` but was not used in the OAuth flow.

## Fix

**`mcp_server_manager.py`**: Added optional `client_ip` parameter to `get_mcp_server_by_id()` and enforced `_is_server_accessible_from_ip()` check -- same guard used by `get_mcp_server_by_name()`. Without this, an external client supplying a server_id could bypass IP-based access controls on private MCP servers.

**`discoverable_endpoints.py`**: Added `get_mcp_server_by_id(lookup_name, client_ip=client_ip)` as a fallback after `get_mcp_server_by_name()` at all 5 call sites.

## Test plan
- [x] authorize endpoint returns 307 redirect with server_id in path
- [x] register endpoint resolves correctly by server_id (200 OK)
- [x] token endpoint resolves correctly by server_id (server resolved, exchange failed with dummy code as expected)
- [x] callback endpoint operates at root `/callback` using encrypted state -- not affected by this change
- [x] name-based lookup still works for all endpoints -- no regression (authorize 307, register 200, token same behavior)

Fixes #30997