### PR TITLE
feat(spend): warn when spend-attribution metadata diverges from the resolved key

### DIFF
--- a/litellm/proxy/auth/resolvers/divergence.py
+++ b/litellm/proxy/auth/resolvers/divergence.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+class SpendIdentity(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str | None = None
+    team_id: str | None = None
+    org_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FieldDivergence:
+    field: str
+    resolved_value: str | None
+    consumed_value: str | None
+
+
+def resolved_identity_from_key(key: UserAPIKeyAuth) -> SpendIdentity:
+    return SpendIdentity(
+        user_id=key.user_id,
+        team_id=key.team_id,
+        org_id=key.org_id,
+    )
+
+
+def spend_identity_divergence(
+    resolved: SpendIdentity, consumed: SpendIdentity
+) -> tuple[FieldDivergence, ...]:
+    pairs = (
+        ("user_id", resolved.user_id, consumed.user_id),
+        ("team_id", resolved.team_id, consumed.team_id),
+        ("org_id", resolved.org_id, consumed.org_id),
+    )
+    return tuple(
+        FieldDivergence(
+            field=field, resolved_value=resolved_value, consumed_value=consumed_value
+        )
+        for field, resolved_value, consumed_value in pairs
+        if resolved_value != consumed_value
+    )
+
+
+def log_identity_divergence(
+    resolved_key: UserAPIKeyAuth, consumed: SpendIdentity
+) -> None:
+    divergences = spend_identity_divergence(
+        resolved_identity_from_key(resolved_key), consumed
+    )
+    if not divergences:
+        return
+    fields = ", ".join(
+        f"{d.field} (resolved={d.resolved_value!r}, consumed={d.consumed_value!r})"
+        for d in divergences
+    )
+    verbose_proxy_logger.warning(
+        "Spend attribution metadata diverges from the resolved key identity "
+        "[credential_ref=%s]: %s",
+        resolved_key.token,
+        fields,
+    )

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -17,6 +17,10 @@ from litellm.proxy.auth.auth_checks import (
     get_team_object,
     log_db_metrics,
 )
+from litellm.proxy.auth.resolvers.divergence import (
+    SpendIdentity,
+    log_identity_divergence,
+)
 from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.proxy.spend_tracking.spend_log_error_logger import (
@@ -377,6 +381,20 @@ class _ProxyDBLogger(CustomLogger):
                     user_api_key_cache=user_api_key_cache,
                     proxy_logging_obj=proxy_logging_obj,
                 )
+                try:
+                    log_identity_divergence(
+                        key_obj,
+                        SpendIdentity(
+                            user_id=metadata.get("user_api_key_user_id"),
+                            team_id=metadata.get("user_api_key_team_id"),
+                            org_id=metadata.get("user_api_key_org_id"),
+                        ),
+                    )
+                except Exception as divergence_error:
+                    verbose_proxy_logger.debug(
+                        "Spend identity divergence guard failed (non-fatal): %s",
+                        divergence_error,
+                    )
                 if metadata.get("user_api_key_alias") is None:
                     metadata["user_api_key_alias"] = key_obj.key_alias
                 if metadata.get("user_api_key_user_id") is None:

--- a/tests/test_litellm/proxy/auth/test_resolvers_divergence.py
+++ b/tests/test_litellm/proxy/auth/test_resolvers_divergence.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import logging
+
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.auth.resolvers.divergence import (
+    SpendIdentity,
+    log_identity_divergence,
+    spend_identity_divergence,
+)
+
+
+def _key(**overrides: str | None) -> UserAPIKeyAuth:
+    base: dict[str, str | None] = {
+        "token": "hashed-token",
+        "user_id": "u-1",
+        "team_id": "t-1",
+        "org_id": "o-1",
+    }
+    base.update(overrides)
+    return UserAPIKeyAuth(**base)
+
+
+def _consumed(**overrides: str | None) -> SpendIdentity:
+    base: dict[str, str | None] = {
+        "user_id": "u-1",
+        "team_id": "t-1",
+        "org_id": "o-1",
+    }
+    base.update(overrides)
+    return SpendIdentity(**base)
+
+
+def test_consumed_matches_resolved_is_silent(caplog):
+    key = _key()
+    consumed = _consumed()
+
+    assert (
+        spend_identity_divergence(
+            SpendIdentity(user_id="u-1", team_id="t-1", org_id="o-1"),
+            consumed,
+        )
+        == ()
+    )
+
+    with caplog.at_level(logging.WARNING):
+        log_identity_divergence(key, consumed)
+    assert caplog.records == []
+
+
+def test_empty_consumed_metadata_against_populated_key_warns_naming_fields(caplog):
+    key = _key()
+    consumed = _consumed(user_id=None, team_id=None, org_id=None)
+
+    diverged = spend_identity_divergence(
+        SpendIdentity(user_id="u-1", team_id="t-1", org_id="o-1"),
+        consumed,
+    )
+    by_field = {d.field: (d.resolved_value, d.consumed_value) for d in diverged}
+
+    assert set(by_field) == {"user_id", "team_id", "org_id"}
+    assert by_field["user_id"] == ("u-1", None)
+    assert by_field["team_id"] == ("t-1", None)
+    assert by_field["org_id"] == ("o-1", None)
+
+    with caplog.at_level(logging.WARNING):
+        log_identity_divergence(key, consumed)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "user_id" in message and "team_id" in message and "org_id" in message
+
+
+def test_different_consumed_user_id_warns(caplog):
+    key = _key()
+    consumed = _consumed(user_id="u-OTHER")
+
+    diverged = spend_identity_divergence(
+        SpendIdentity(user_id="u-1", team_id="t-1", org_id="o-1"),
+        consumed,
+    )
+    by_field = {d.field: (d.resolved_value, d.consumed_value) for d in diverged}
+
+    assert by_field == {"user_id": ("u-1", "u-OTHER")}
+
+    with caplog.at_level(logging.WARNING):
+        log_identity_divergence(key, consumed)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert "user_id" in message and "u-1" in message and "u-OTHER" in message


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Verified against a live proxy on `localhost:4000` backed by Postgres, hitting the real Anthropic API, running this branch with `PYTHONPATH` pinned to the worktree (the divergence module was confirmed loaded from the worktree, not the main checkout).

The guard sits in the failure-path fallback `_enrich_failure_metadata_with_key_info`, so it only evaluates when a failed request reaches spend logging. On a team-scoped key carrying a user, team, and org, one successful completion and one deliberately failing call (a model the key is not allowed to use, a real 403) both write spend rows with the correct identity:

```
$ psql -c 'select substring(request_id,1,18) request_id, "user" user_id, team_id, organization_id, status
           from "LiteLLM_SpendLogs" order by "startTime" desc limit 2;'

 19ab44a9-5e7d-48ab | a745550f-...-dd7e39faea53 | c1014da1-...-98ef76fb62b8 | 78153153-...-c7d04a35b0b4 | failure
 chatcmpl-36b51980- | a745550f-...-dd7e39faea53 | c1014da1-...-98ef76fb62b8 | 78153153-...-c7d04a35b0b4 | success
```

The failure row carries the resolved user, team, and org, so the enrichment fallback found identity already present and the guard correctly stayed silent: no `Spend attribution metadata diverges from the resolved key identity` warnings and no guard errors in the proxy log (the only traceback is the expected `key_model_access_denied` ProxyException from the 403). This shows the guard is non-disruptive on healthy traffic and that failure-path attribution is intact. The firing behavior, where the consumed metadata identity is missing or different from the freshly fetched key (the empty-metadata misattribution case the design cites), is pinned by the unit tests in `tests/test_litellm/proxy/auth/test_resolvers_divergence.py`: an empty consumed identity against a populated key warns naming exactly user_id, team_id, and org_id, and a matching identity stays silent

## Type

🆕 New Feature

## Changes

Phase 1 of the internal Caller Identity design ("Resolve Once, Consume Everywhere"); the first consumer of the Phase 0 resolved identity work (PR #30887)

The design's failure table calls out spend being mis- or un-attributed when the flattened `user_api_key_*` request metadata is empty or stale, which the spend path silently papers over by falling back to a key lookup. That fallback lives in `_enrich_failure_metadata_with_key_info`; it fetches the key object and fills `metadata["user_api_key_user_id"/"team_id"/"org_id"]` whenever they are None, with no signal that the attribution was missing in the first place. This change turns that silent fill into an observable warning so the divergence surfaces before deploy instead of hiding in the spend logs

`litellm/proxy/auth/resolvers/divergence.py` holds a pure, fully typed comparator. `spend_identity_divergence` compares a resolved `SpendIdentity` against the consumed one and returns the fields that are missing-in-consumed or hold a different value (user_id, team_id, org_id) as an immutable tuple of frozen records. `resolved_identity_from_key` projects the authoritative identity off the fetched key object, `SpendIdentity` is a frozen model so the untyped metadata values are validated at the boundary, and `log_identity_divergence` emits a single structured `verbose_proxy_logger.warning` naming the diverging fields (resolved value vs consumed value) keyed by the hashed token, and is a no-op when nothing diverges

The guard is wired into `_enrich_failure_metadata_with_key_info` right after the key object is fetched and before the existing fill runs, comparing the pre-fill metadata against the key. The existing fill behavior is unchanged; this only adds the warning, and it is wrapped in its own try/except so a guard failure can never affect the enrichment or cost tracking. The change is additive and zero-behavior-change; the only externally observable effect is a warning log on divergence

Tests in `tests/test_litellm/proxy/auth/test_resolvers_divergence.py` cover matching identity (silent), empty consumed metadata against a populated key naming exactly the missing fields (the misattribution case), and a consumed user_id that differs from the key. The enrichment fallback is not cleanly injectable (`get_key_object` and the proxy-server globals it reads are module-level rather than injected), so the warning is asserted through the thin `log_identity_divergence` wrapper rather than by mocking that dependency

