### PR TITLE
fix(mcp): stop auth failures on the /mcp path surfacing as cancelled tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -63,7 +63,11 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.proxy._types import SpecialMCPServerNames, UserAPIKeyAuth
+from litellm.proxy._types import (
+    ProxyException,
+    SpecialMCPServerNames,
+    UserAPIKeyAuth,
+)
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
@@ -227,6 +231,28 @@ def _jsonrpc_text_has_top_level_method(text: str) -> bool:
         elif ch == ":":
             expect_key = False
     return False
+
+
+def _proxy_exception_to_http_exception(exc: ProxyException) -> HTTPException:
+    """Map a ``ProxyException`` to an ``HTTPException`` that preserves its real
+    status code and headers.
+
+    ``user_api_key_auth`` raises ``ProxyException`` (not ``HTTPException``) on
+    auth failures. The MCP ASGI handlers re-raise ``HTTPException`` to keep the
+    status and any ``WWW-Authenticate`` challenge, but a ``ProxyException`` would
+    otherwise fall through to their generic handler and be flattened to a 500 —
+    dropping the 401 + challenge an OAuth client needs to re-authenticate, so the
+    tool call surfaces as a cancelled/terminated session instead.
+    """
+    try:
+        status_code = int(exc.code)
+    except (TypeError, ValueError):
+        status_code = 500
+    return HTTPException(
+        status_code=status_code,
+        detail=exc.message,
+        headers=exc.headers or None,
+    )
 
 
 if MCP_AVAILABLE:
@@ -4019,6 +4045,12 @@ if MCP_AVAILABLE:
         except HTTPException:
             # Re-raise HTTP exceptions to preserve status codes and details
             raise
+        except ProxyException as e:
+            # Auth failures from user_api_key_auth arrive as ProxyException, not
+            # HTTPException. Preserve the real status (e.g. 401 + WWW-Authenticate)
+            # so OAuth clients can re-authenticate instead of receiving a generic
+            # 500 that surfaces as a cancelled tool call.
+            raise _proxy_exception_to_http_exception(e)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions
@@ -4136,6 +4168,12 @@ if MCP_AVAILABLE:
             # Re-raise HTTP exceptions to preserve status codes and details
             # (e.g. 401 + WWW-Authenticate challenges from OAuth pass-through).
             raise
+        except ProxyException as e:
+            # Auth failures from user_api_key_auth arrive as ProxyException, not
+            # HTTPException. Preserve the real status (e.g. 401 + WWW-Authenticate)
+            # so OAuth clients can re-authenticate instead of receiving a generic
+            # 500 that surfaces as a cancelled tool call.
+            raise _proxy_exception_to_http_exception(e)
         except Exception as e:
             verbose_logger.exception(f"Error handling MCP request: {e}")
             # Try to send a graceful error response for non-HTTP exceptions

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6293,3 +6293,153 @@ async def test_get_allowed_mcp_servers_from_mcp_server_names_empty_list_fails_cl
     )
 
     assert result == []
+
+
+class TestProxyExceptionToHttpException:
+    """Auth failures reach the MCP ASGI handlers as ProxyException, not
+    HTTPException. The handlers must map them back to their real status and
+    headers; otherwise they fall through to the generic 500 handler, dropping
+    the 401 + WWW-Authenticate challenge an OAuth client needs to re-authenticate
+    and surfacing the tool call as a cancelled/terminated session.
+    """
+
+    def test_preserves_401_status_and_www_authenticate_header(self):
+        from litellm.proxy._experimental.mcp_server.server import (
+            _proxy_exception_to_http_exception,
+        )
+        from litellm.proxy._types import ProxyException
+
+        exc = ProxyException(
+            message="Authentication Error, invalid token",
+            type="auth_error",
+            param="key",
+            code=401,
+            headers={"WWW-Authenticate": 'Bearer resource_metadata="/x"'},
+        )
+
+        http_exc = _proxy_exception_to_http_exception(exc)
+
+        assert http_exc.status_code == 401
+        assert http_exc.detail == "Authentication Error, invalid token"
+        assert http_exc.headers["WWW-Authenticate"] == 'Bearer resource_metadata="/x"'
+
+    def test_preserves_403_status(self):
+        from litellm.proxy._experimental.mcp_server.server import (
+            _proxy_exception_to_http_exception,
+        )
+        from litellm.proxy._types import ProxyException
+
+        http_exc = _proxy_exception_to_http_exception(
+            ProxyException(
+                message="Forbidden", type="auth_error", param="key", code=403
+            )
+        )
+
+        assert http_exc.status_code == 403
+
+    def test_non_numeric_code_falls_back_to_500(self):
+        from litellm.proxy._experimental.mcp_server.server import (
+            _proxy_exception_to_http_exception,
+        )
+        from litellm.proxy._types import ProxyException
+
+        # ProxyException normalises code to the string "None" when unset.
+        http_exc = _proxy_exception_to_http_exception(
+            ProxyException(message="boom", type="server_error", param=None, code=None)
+        )
+
+        assert http_exc.status_code == 500
+
+
+class TestStreamableHttpAuthErrorMapping:
+    """End-to-end guard for the handler wiring: a ProxyException from auth must
+    propagate as the real HTTPException (401 + WWW-Authenticate), not be
+    flattened to a generic 500 by the catch-all handler.
+    """
+
+    @pytest.mark.asyncio
+    async def test_streamable_http_propagates_proxy_exception_as_401(self):
+        from litellm.proxy._experimental.mcp_server import server as mcp_module
+        from litellm.proxy._types import ProxyException
+
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/mcp/some_server",
+            "headers": [(b"x-litellm-api-key", b"sk-bad")],
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"{}", "more_body": False}
+
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        auth_failure = ProxyException(
+            message="Authentication Error, invalid token",
+            type="auth_error",
+            param="key",
+            code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+        with patch.object(
+            mcp_module,
+            "extract_mcp_auth_context",
+            new=AsyncMock(side_effect=auth_failure),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await mcp_module.handle_streamable_http_mcp(scope, receive, send)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+        # Must not have emitted a 500 body via the generic catch-all.
+        assert not any(
+            m.get("type") == "http.response.start" and m.get("status") == 500
+            for m in sent
+        )
+
+    @pytest.mark.asyncio
+    async def test_sse_propagates_proxy_exception_as_401(self):
+        from litellm.proxy._experimental.mcp_server import server as mcp_module
+        from litellm.proxy._types import ProxyException
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/mcp/some_server",
+            "headers": [(b"x-litellm-api-key", b"sk-bad")],
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        auth_failure = ProxyException(
+            message="Authentication Error, invalid token",
+            type="auth_error",
+            param="key",
+            code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+        with patch.object(
+            mcp_module,
+            "extract_mcp_auth_context",
+            new=AsyncMock(side_effect=auth_failure),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await mcp_module.handle_sse_mcp(scope, receive, send)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.headers["WWW-Authenticate"] == "Bearer"
+        assert not any(
+            m.get("type") == "http.response.start" and m.get("status") == 500
+            for m in sent
+        )


### PR DESCRIPTION
## Relevant issues

Relates to the MCP stability work item "OAuth MCP tool calls return cancelled / ASGI errors on all servers". This fixes how auth failures are surfaced on the `/mcp` path; the scope note below states what it does and does not claim

## What was wrong

`user_api_key_auth` raises `ProxyException`, not `HTTPException`, on an auth failure. The streamable-HTTP and SSE MCP handlers only re-raised `HTTPException` to preserve status and headers, so a `ProxyException` fell through to the catch-all and was flattened to a generic 500, dropping the real status (for example 401) and any `WWW-Authenticate` challenge. MCP clients render a 500 on the JSON-RPC POST as a cancelled or terminated session, and an OAuth client never receives the 401 it needs to re-authenticate. Because auth runs before any server routing, one rejected credential fails every targeted server at once

## The fix

Map `ProxyException` back to its real status and headers in both ASGI handlers (`handle_streamable_http_mcp`, `handle_sse_mcp`) via a small `_proxy_exception_to_http_exception` helper, inserted before the generic `except Exception`. A genuine auth failure now returns its real status instead of a cancelled session. As one example, a key sent without the documented `Bearer ` prefix is rejected with a clear 401 that tells the caller to fix the header; the auth layer already produced that error, it was just being flattened to a 500. The documented and UI-generated header form is `Bearer <key>` (the dashboard MCP connect snippets and the README both show it), which is unaffected

## Scope (what this does not claim)

This narrowly fixes error surfacing on the `/mcp` auth path; it does not change what counts as a valid credential, and an un-prefixed key is still rejected (now as a 401 rather than a 500). It is not claimed to be the sole cause of every "cancelled on all servers" report. The change only affects the auth-failure path, so a correctly configured client that sends a valid `Bearer <key>` and whose auth succeeds is unaffected; if the symptom is still seen with valid Bearer credentials, the cause is elsewhere in the streamable transport and is tracked separately

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:
- [ ] CI run for the last commit
       Link:
- [ ] Merge / cherry-pick CI run
       Links:

## Reproduction (bug present)

Reproduced live against the sandbox gateway (real gateway, real key, key redacted), which runs code without this fix. An un-prefixed key is rejected by auth, but the rejection is surfaced as a generic 500 that MCP clients render as a cancelled session rather than the 401 the auth layer produced.

```
# Un-prefixed key on /mcp/ initialize -> 500, rendered by clients as cancelled
$ curl -s -i -X POST https://gateway.litellm-sandbox.ai/mcp/ \
    -H "x-litellm-api-key: $KEY" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
HTTP/2 500
content-type: application/json
{"error":"MCP request failed","details":"Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix."}
```

## Proof of Fix

Run against a local proxy on this branch (a test MCP server "math_noauth" registered via config). An un-prefixed key now returns a clear 401 instead of a 500, the documented `Bearer ` form returns a 200 with a real `initialize` result, and a genuinely invalid key returns a 401.

```
# Un-prefixed key on /mcp/<server> initialize -> 401 (was 500), clear auth error
$ curl -s -i -X POST http://localhost:4000/mcp/math_noauth \
    -H "x-litellm-api-key: $KEY" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
HTTP/1.1 401 Unauthorized
content-type: application/json
{"detail":"Authentication Error, Malformed API Key passed in. Ensure Key has `Bearer ` prefix."}

# Documented Bearer form on /mcp/<server> initialize -> 200 + initialize result
$ curl -s -i -X POST http://localhost:4000/mcp/math_noauth \
    -H "x-litellm-api-key: Bearer $KEY" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
HTTP/1.1 200 OK
content-type: text/event-stream
mcp-session-id: <redacted>
event: message
data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"experimental":{},"prompts":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false},"tools":{"listChanged":false}},"serverInfo":{"name":"math_noauth","version":"1.0.0"}}}

# Genuinely invalid key on /mcp/ initialize -> 401 (was 500)
$ curl -s -i -X POST http://localhost:4000/mcp/ \
    -H "x-litellm-api-key: sk-this-key-does-not-exist" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
HTTP/1.1 401 Unauthorized
content-type: application/json
{"detail":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...xist, Key Hash (Token) =<redacted>. Unable to find token in cache or `LiteLLM_VerificationTokenTable`"}
```

The 401 carries whatever `WWW-Authenticate` challenge the auth layer attaches, for example on the OAuth discovery path; a plain bad key has none, and that header preservation is covered by the unit tests

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/_experimental/mcp_server/server.py`: add `_proxy_exception_to_http_exception` and catch `ProxyException` in both the streamable-HTTP and SSE handlers, before the generic `except Exception`, mapping it to its real status and headers so a 401 with any `WWW-Authenticate` challenge reaches the client instead of a 500

Regression tests assert that a `ProxyException(401)` raised during auth propagates as a 401 with `WWW-Authenticate` from both the streamable-HTTP and SSE handlers, and unit-test the converter for the 401, 403, and non-numeric-code cases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to MCP ASGI error handling on the auth-failure path; does not alter credential validation logic, with tests guarding 401/403 propagation.
> 
> **Overview**
> **MCP `/mcp` auth failures** from `user_api_key_auth` were raised as `ProxyException` but only `HTTPException` was re-raised in the streamable-HTTP and SSE ASGI handlers, so auth errors fell through to the generic handler and became **500** responses. Clients then saw cancelled/terminated sessions instead of **401** with **`WWW-Authenticate`**.
> 
> This PR adds **`_proxy_exception_to_http_exception`** and handles **`ProxyException`** in **`handle_streamable_http_mcp`** and **`handle_sse_mcp`** (before the catch-all), mapping status, message, and headers so OAuth clients can re-authenticate. Regression tests cover the converter and both handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592c039019803858b40de663aafed595dfb01566. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->