### PR TITLE
feat(providers): add custom_oauth provider for OAuth2 client_credentials on OpenAI-compatible endpoints

### DIFF
--- a/docs/my-website/docs/providers/custom_oauth.md
+++ b/docs/my-website/docs/providers/custom_oauth.md
@@ -1,0 +1,93 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Custom OAuth2 (client credentials)
+
+## Overview
+
+| Property | Details |
+|-------|-------|
+| Description | Call any OpenAI-compatible endpoint that is protected by an OAuth2 `client_credentials` gateway. LiteLLM fetches a bearer token from your token endpoint, caches it until it expires, and injects it on every request. |
+| Provider Route on LiteLLM | `custom_oauth/` |
+| Base URL | Set per model via `api_base` (your OpenAI-compatible endpoint) |
+| Supported Operations | [`/chat/completions`](#sample-usage) |
+
+<br />
+
+Use this when your model server speaks the OpenAI chat API but sits behind an
+OAuth2 token endpoint (token URL + client id/secret) rather than a static API
+key. Point `api_base` at the model server and give LiteLLM the OAuth2 details;
+the bearer token is fetched and refreshed automatically.
+
+## Required variables
+
+The OAuth2 fields can be set per model under `litellm_params`, or via environment
+variables as a fallback.
+
+| litellm_param | Environment variable | Required | Description |
+|-------|-------|-------|-------|
+| `oauth_token_url` | `CUSTOM_OAUTH_TOKEN_URL` | yes | OAuth2 token endpoint |
+| `oauth_client_id` | `CUSTOM_OAUTH_CLIENT_ID` | yes | Client id |
+| `oauth_client_secret` | `CUSTOM_OAUTH_CLIENT_SECRET` | yes | Client secret |
+| `oauth_scope` | `CUSTOM_OAUTH_SCOPE` | no | Space-delimited scope(s) |
+| `api_base` | - | yes | Your OpenAI-compatible endpoint |
+
+## Usage - LiteLLM Python SDK
+
+```python showLineNumbers title="custom_oauth completion"
+import os
+import litellm
+from litellm import completion
+
+response = completion(
+    model="custom_oauth/my-model",
+    messages=[{"role": "user", "content": "Hello, how are you?"}],
+    api_base="https://gateway.internal/v1",
+    oauth_token_url="https://idp.internal/oauth/token",
+    oauth_client_id=os.environ["MY_CLIENT_ID"],
+    oauth_client_secret=os.environ["MY_CLIENT_SECRET"],
+    oauth_scope="my-scope",  # optional
+)
+
+print(response)
+```
+
+## Usage - LiteLLM Proxy
+
+```yaml showLineNumbers title="config.yaml"
+model_list:
+  - model_name: my-secure-llm
+    litellm_params:
+      model: custom_oauth/my-model
+      api_base: https://gateway.internal/v1
+      oauth_token_url: https://idp.internal/oauth/token
+      oauth_client_id: os.environ/MY_CLIENT_ID
+      oauth_client_secret: os.environ/MY_CLIENT_SECRET
+      oauth_scope: my-scope
+```
+
+```bash showLineNumbers title="Start the proxy"
+litellm --config config.yaml
+```
+
+```bash showLineNumbers title="Sample request"
+curl http://0.0.0.0:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "my-secure-llm",
+    "messages": [{"role": "user", "content": "Hello, how are you?"}]
+  }'
+```
+
+## How it works
+
+LiteLLM performs the OAuth2 `client_credentials` grant against `oauth_token_url`,
+reads `access_token` and `expires_in` from the response, and caches the token in
+process until shortly before it expires (refreshing automatically). The token is
+sent as `Authorization: Bearer <token>` to `api_base`, which is otherwise treated
+as a standard OpenAI-compatible endpoint, so request/response shaping and
+streaming behave the same as any OpenAI-compatible provider.
+
+This is the 2-legged (machine-to-machine) flow only. Interactive / authorization-code
+login, per-user tokens, and refresh-token grants are out of scope.

--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -69,9 +69,55 @@ def create_config_class(provider: SimpleProviderConfig):
                 resolved_base = provider.base_url
 
             # Resolve API key
-            resolved_key = api_key or get_secret_str(provider.api_key_env)
+            resolved_key = api_key or (
+                get_secret_str(provider.api_key_env) if provider.api_key_env else None
+            )
 
             return resolved_base, resolved_key
+
+        def validate_environment(
+            self,
+            headers: dict,
+            model: str,
+            messages: List[AllMessageValues],
+            optional_params: dict,
+            litellm_params: dict,
+            api_key: Optional[str] = None,
+            api_base: Optional[str] = None,
+        ) -> dict:
+            """Inject auth; for oauth2_client_credentials fetch+cache a bearer token,
+            otherwise defer to the OpenAI-compatible base (api_key -> Bearer)."""
+            if provider.auth != "oauth2_client_credentials":
+                return super().validate_environment(
+                    headers=headers,
+                    model=model,
+                    messages=messages,
+                    optional_params=optional_params,
+                    litellm_params=litellm_params,
+                    api_key=api_key,
+                    api_base=api_base,
+                )
+
+            from .oauth_authenticator import get_client_credentials_token
+
+            def _oauth_param(key: str, env_var: str) -> Optional[str]:
+                value = litellm_params.get(key)
+                if isinstance(value, str) and value:
+                    return value
+                return get_secret_str(env_var)
+
+            token = get_client_credentials_token(
+                token_url=_oauth_param("oauth_token_url", "CUSTOM_OAUTH_TOKEN_URL"),
+                client_id=_oauth_param("oauth_client_id", "CUSTOM_OAUTH_CLIENT_ID"),
+                client_secret=_oauth_param(
+                    "oauth_client_secret", "CUSTOM_OAUTH_CLIENT_SECRET"
+                ),
+                scope=_oauth_param("oauth_scope", "CUSTOM_OAUTH_SCOPE"),
+            )
+            headers["Authorization"] = f"Bearer {token}"
+            if "content-type" not in headers and "Content-Type" not in headers:
+                headers["Content-Type"] = "application/json"
+            return headers
 
         def get_complete_url(
             self,

--- a/litellm/llms/openai_like/json_loader.py
+++ b/litellm/llms/openai_like/json_loader.py
@@ -14,10 +14,11 @@ class SimpleProviderConfig:
 
     def __init__(self, slug: str, data: dict):
         self.slug = slug
-        self.base_url = data["base_url"]
-        self.api_key_env = data["api_key_env"]
-        self.api_base_env = data.get("api_base_env")
+        self.base_url: Optional[str] = data.get("base_url")
+        self.api_key_env: Optional[str] = data.get("api_key_env")
+        self.api_base_env: Optional[str] = data.get("api_base_env")
         self.base_class = data.get("base_class", "openai_gpt")
+        self.auth: Optional[str] = data.get("auth")
         self.param_mappings = data.get("param_mappings", {})
         self.constraints = data.get("constraints", {})
         self.special_handling = data.get("special_handling", {})

--- a/litellm/llms/openai_like/oauth_authenticator.py
+++ b/litellm/llms/openai_like/oauth_authenticator.py
@@ -1,0 +1,107 @@
+"""
+Generic OAuth2 client_credentials authenticator for OpenAI-compatible providers.
+
+Backs the ``custom_oauth`` provider: fetches and caches a bearer token from any
+standard OAuth2 token endpoint so an OpenAI-compatible endpoint sitting behind an
+OAuth2 client-credentials gateway can be driven purely from config.
+"""
+
+from typing import Optional
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from litellm._logging import verbose_logger
+from litellm.caching.caching import InMemoryCache
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.custom_httpx.http_handler import HTTPHandler, _get_httpx_client
+
+DEFAULT_TOKEN_EXPIRY_SECONDS = 3600
+TOKEN_EXPIRY_BUFFER_SECONDS = 60
+
+_token_cache = InMemoryCache()
+
+
+class OAuthClientCredentialsError(BaseLLMException):
+    """Raised when the OAuth2 client_credentials token flow fails."""
+
+
+class _TokenResponse(BaseModel):
+    access_token: str
+    expires_in: int = DEFAULT_TOKEN_EXPIRY_SECONDS
+
+
+def get_client_credentials_token(
+    token_url: Optional[str],
+    client_id: Optional[str],
+    client_secret: Optional[str],
+    scope: Optional[str] = None,
+    timeout: float = 30.0,
+    http_client: Optional[HTTPHandler] = None,
+) -> str:
+    """
+    Fetch (and cache) an OAuth2 access token using the client_credentials grant.
+
+    The token is cached in-process keyed by (token_url, client_id, scope) until
+    ``TOKEN_EXPIRY_BUFFER_SECONDS`` before the ``expires_in`` returned by the IdP.
+    ``http_client`` is injectable so tests can assert the outbound request without
+    real network access.
+    """
+    if not token_url or not client_id or not client_secret:
+        raise OAuthClientCredentialsError(
+            status_code=401,
+            message=(
+                "custom_oauth requires oauth_token_url, oauth_client_id and "
+                "oauth_client_secret (set them under litellm_params or via the "
+                "CUSTOM_OAUTH_TOKEN_URL / CUSTOM_OAUTH_CLIENT_ID / "
+                "CUSTOM_OAUTH_CLIENT_SECRET environment variables)."
+            ),
+        )
+
+    cache_key = f"custom_oauth:{token_url}:{client_id}:{scope or ''}"
+    cached = _token_cache.get_cache(cache_key)
+    if isinstance(cached, str):
+        return cached
+
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+    }
+    if scope:
+        data["scope"] = scope
+
+    client = http_client or _get_httpx_client()
+    try:
+        response = client.post(token_url, data=data, timeout=timeout)
+        if response is None:
+            raise OAuthClientCredentialsError(
+                status_code=500,
+                message="custom_oauth token request returned no response",
+            )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        raise OAuthClientCredentialsError(
+            status_code=e.response.status_code,
+            message=f"custom_oauth token request failed: {e.response.text}",
+        ) from e
+    except httpx.RequestError as e:
+        raise OAuthClientCredentialsError(
+            status_code=500,
+            message=f"custom_oauth token request error: {e}",
+        ) from e
+
+    try:
+        parsed = _TokenResponse.model_validate(response.json())
+    except ValidationError as e:
+        raise OAuthClientCredentialsError(
+            status_code=500,
+            message=f"custom_oauth token response missing a valid access_token: {e}",
+        ) from e
+
+    ttl = parsed.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
+    if ttl > 0:
+        _token_cache.set_cache(cache_key, parsed.access_token, ttl=ttl)
+
+    verbose_logger.debug("custom_oauth: obtained new access token")
+    return parsed.access_token

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,8 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "custom_oauth": {
+    "auth": "oauth2_client_credentials"
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3287,6 +3287,7 @@ class LlmProviders(str, Enum):
     DASHSCOPE = "dashscope"
     MOONSHOT = "moonshot"
     PUBLICAI = "publicai"
+    CUSTOM_OAUTH = "custom_oauth"
     V0 = "v0"
     MORPH = "morph"
     LAMBDA_AI = "lambda_ai"

--- a/tests/test_litellm/llms/openai_like/test_oauth_authenticator.py
+++ b/tests/test_litellm/llms/openai_like/test_oauth_authenticator.py
@@ -1,0 +1,235 @@
+"""
+Tests for the custom_oauth provider: OAuth2 client_credentials token fetch +
+caching, and bearer injection through the dynamic JSON-provider config.
+
+Regression coverage for https://github.com/BerriAI/litellm/issues/12367
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.llms.openai_like.dynamic_config import create_config_class
+from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.llms.openai_like.oauth_authenticator import (
+    OAuthClientCredentialsError,
+    _token_cache,
+    get_client_credentials_token,
+)
+
+
+@pytest.fixture(autouse=True)
+def _flush_token_cache():
+    _token_cache.flush_cache()
+    yield
+    _token_cache.flush_cache()
+
+
+def _token_client(access_token="tok-abc", expires_in=3600):
+    """A fake HTTPHandler whose .post returns a token response."""
+    client = MagicMock()
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+    }
+    client.post.return_value = response
+    return client
+
+
+class TestClientCredentialsTokenFetch:
+    def test_posts_client_credentials_grant(self):
+        client = _token_client(access_token="tok-1")
+        token = get_client_credentials_token(
+            token_url="https://idp.test/oauth/token",
+            client_id="cid-1",
+            client_secret="secret-1",
+            scope="scope-1",
+            http_client=client,
+        )
+
+        assert token == "tok-1"
+        client.post.assert_called_once()
+        args, kwargs = client.post.call_args
+        assert args[0] == "https://idp.test/oauth/token"
+        data = kwargs["data"]
+        assert data["grant_type"] == "client_credentials"
+        assert data["client_id"] == "cid-1"
+        assert data["client_secret"] == "secret-1"
+        assert data["scope"] == "scope-1"
+
+    def test_scope_omitted_when_not_provided(self):
+        client = _token_client()
+        get_client_credentials_token(
+            token_url="https://idp.test/oauth/token",
+            client_id="cid-2",
+            client_secret="secret-2",
+            http_client=client,
+        )
+        assert "scope" not in client.post.call_args.kwargs["data"]
+
+    def test_token_is_cached_within_ttl(self):
+        client = _token_client(access_token="tok-cached", expires_in=3600)
+        kwargs = dict(
+            token_url="https://idp.test/cache",
+            client_id="cid-cache",
+            client_secret="s",
+            http_client=client,
+        )
+        first = get_client_credentials_token(**kwargs)
+        second = get_client_credentials_token(**kwargs)
+
+        assert first == second == "tok-cached"
+        client.post.assert_called_once()
+
+    def test_not_cached_when_expiry_within_buffer(self):
+        # expires_in (30s) is inside TOKEN_EXPIRY_BUFFER_SECONDS (60s) -> never cached,
+        # so every call re-fetches. Guards the ttl = expires_in - buffer arithmetic.
+        client = _token_client(access_token="tok-short", expires_in=30)
+        kwargs = dict(
+            token_url="https://idp.test/short",
+            client_id="cid-short",
+            client_secret="s",
+            http_client=client,
+        )
+        get_client_credentials_token(**kwargs)
+        get_client_credentials_token(**kwargs)
+
+        assert client.post.call_count == 2
+
+    @pytest.mark.parametrize(
+        "missing",
+        [
+            dict(token_url=None, client_id="c", client_secret="s"),
+            dict(token_url="https://idp.test", client_id=None, client_secret="s"),
+            dict(token_url="https://idp.test", client_id="c", client_secret=None),
+        ],
+    )
+    def test_missing_required_inputs_raise(self, missing):
+        with pytest.raises(OAuthClientCredentialsError):
+            get_client_credentials_token(**missing)
+
+    def test_response_without_access_token_raises(self):
+        client = MagicMock()
+        response = MagicMock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"error": "invalid_client"}
+        client.post.return_value = response
+
+        with pytest.raises(OAuthClientCredentialsError):
+            get_client_credentials_token(
+                token_url="https://idp.test",
+                client_id="c",
+                client_secret="s",
+                http_client=client,
+            )
+
+
+class TestCustomOAuthJSONConfig:
+    def test_registered_with_oauth_auth_and_no_static_endpoint(self):
+        provider = JSONProviderRegistry.get("custom_oauth")
+        assert provider is not None
+        assert provider.auth == "oauth2_client_credentials"
+        assert provider.base_url is None
+        assert provider.api_key_env is None
+
+    def test_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, _api_key, api_base = get_llm_provider(
+            model="custom_oauth/gpt-4o",
+            custom_llm_provider=None,
+            api_base="https://gateway.test/v1",
+            api_key=None,
+        )
+        assert model == "gpt-4o"
+        assert provider == "custom_oauth"
+        assert api_base == "https://gateway.test/v1"
+
+    def test_provider_config_manager_returns_dynamic_config(self):
+        from litellm import LlmProviders
+        from litellm.utils import ProviderConfigManager
+
+        config = ProviderConfigManager.get_provider_chat_config(
+            model="gpt-4o", provider=LlmProviders.CUSTOM_OAUTH
+        )
+        assert config is not None
+        assert config.custom_llm_provider == "custom_oauth"
+
+    def test_get_complete_url_requires_api_base(self):
+        config = create_config_class(JSONProviderRegistry.get("custom_oauth"))()
+        with pytest.raises(ValueError):
+            config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="gpt-4o",
+                optional_params={},
+                litellm_params={},
+            )
+
+
+class TestValidateEnvironment:
+    def test_oauth_bearer_injected_from_litellm_params(self):
+        config = create_config_class(JSONProviderRegistry.get("custom_oauth"))()
+        client = _token_client(access_token="tok-ve")
+
+        with patch(
+            "litellm.llms.openai_like.oauth_authenticator._get_httpx_client",
+            return_value=client,
+        ):
+            headers = config.validate_environment(
+                headers={},
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                optional_params={},
+                litellm_params={
+                    "oauth_token_url": "https://idp.test/token",
+                    "oauth_client_id": "cid-ve",
+                    "oauth_client_secret": "secret-ve",
+                    "oauth_scope": "scope-ve",
+                },
+            )
+
+        assert headers["Authorization"] == "Bearer tok-ve"
+        assert headers["Content-Type"] == "application/json"
+        data = client.post.call_args.kwargs["data"]
+        assert data["client_id"] == "cid-ve"
+        assert data["client_secret"] == "secret-ve"
+        assert data["scope"] == "scope-ve"
+
+    def test_oauth_reads_from_env_when_litellm_params_absent(self, monkeypatch):
+        monkeypatch.setenv("CUSTOM_OAUTH_TOKEN_URL", "https://idp.env/token")
+        monkeypatch.setenv("CUSTOM_OAUTH_CLIENT_ID", "cid-env")
+        monkeypatch.setenv("CUSTOM_OAUTH_CLIENT_SECRET", "secret-env")
+        config = create_config_class(JSONProviderRegistry.get("custom_oauth"))()
+        client = _token_client(access_token="tok-env")
+
+        with patch(
+            "litellm.llms.openai_like.oauth_authenticator._get_httpx_client",
+            return_value=client,
+        ):
+            headers = config.validate_environment(
+                headers={},
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                optional_params={},
+                litellm_params={},
+            )
+
+        assert headers["Authorization"] == "Bearer tok-env"
+        assert client.post.call_args.args[0] == "https://idp.env/token"
+        assert client.post.call_args.kwargs["data"]["client_id"] == "cid-env"
+
+    def test_non_oauth_provider_still_uses_api_key_bearer(self):
+        # Regression: existing JSON providers keep the inherited api_key -> Bearer path.
+        config = create_config_class(JSONProviderRegistry.get("publicai"))()
+        headers = config.validate_environment(
+            headers={},
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={},
+            litellm_params={},
+            api_key="sk-publicai",
+        )
+        assert headers["Authorization"] == "Bearer sk-publicai"


### PR DESCRIPTION
## Relevant issues

Closes #12367

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🆕 New Feature

## Changes

This adds a `custom_oauth` provider so an OpenAI-compatible endpoint that is protected by an OAuth2 client_credentials gateway can be used purely from config, which is what issue #12367 asks for. Client_credentials auth is currently reimplemented per provider (gigachat, sap, azure, databricks, watsonx, github_copilot) and there is no config-only way to point LiteLLM at an arbitrary OAuth-protected OpenAI-compatible endpoint.

On each request LiteLLM performs the client_credentials grant against the configured token endpoint, caches the access token until shortly before it expires, and injects it as `Authorization: Bearer <token>`. Everything else reuses the existing OpenAI-compatible path, so request and response shaping and streaming are unchanged.

Configuration is per model via `litellm_params`, with `CUSTOM_OAUTH_*` environment variable fallbacks:

```yaml
model_list:
  - model_name: my-secure-llm
    litellm_params:
      model: custom_oauth/my-model
      api_base: https://gateway.internal/v1
      oauth_token_url: https://idp.internal/oauth/token
      oauth_client_id: os.environ/MY_CLIENT_ID
      oauth_client_secret: os.environ/MY_CLIENT_SECRET
      oauth_scope: my-scope
```

The implementation extends the existing JSON provider mechanism in `litellm/llms/openai_like` rather than adding a standalone provider, so the wiring stays small: a new `oauth_authenticator` module (token fetch plus in-process caching, with the HTTP client injectable for tests), a `validate_environment` override on the dynamically generated config that only changes behaviour when `auth` is `oauth2_client_credentials`, an optional `auth` field on `SimpleProviderConfig`, the `providers.json` entry, and the `CUSTOM_OAUTH` enum value. Existing JSON providers are unaffected, and a regression test asserts they still use the inherited api_key Bearer path.

Scope is intentionally the 2-legged machine-to-machine flow only. Interactive authorization-code login, per-user tokens, and refresh-token grants are out of scope, since those were the interpretations that stalled the original issue

## Screenshots / Proof of Fix

Opening as a draft. End-to-end proof against a live proxy hitting a real OAuth2 token endpoint plus an OpenAI-compatible model is pending; the proxy run logs (the token request and the injected bearer on the upstream call) will be added here before this is marked ready for review

The change is covered by `tests/test_litellm/llms/openai_like/test_oauth_authenticator.py`, which exercises the grant payload, token caching and refresh-on-expiry, missing-input and malformed-response errors, bearer injection from both `litellm_params` and environment variables, and the no-regression path for existing JSON providers
