### PR TITLE
fix(bedrock): close anthropic passthrough metadata to provider schema at egress

### DIFF
--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -1,10 +1,11 @@
 import json
-from typing import TYPE_CHECKING, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 
 from httpx import Response
 
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.base_llm.passthrough.transformation import BasePassthroughConfig
+from litellm.types.llms.anthropic_messages.anthropic_request import AnthropicMetadata
 
 from ..base_aws_llm import BaseAWSLLM
 from ..common_utils import BedrockEventStreamDecoderBase, BedrockModelInfo
@@ -14,6 +15,40 @@ if TYPE_CHECKING:
 
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
     from litellm.types.utils import CostResponseTypes
+
+
+def restrict_anthropic_bedrock_metadata(
+    request_data: Dict[str, object],
+) -> Dict[str, object]:
+    """
+    Project a forwarded Anthropic-on-Bedrock body's ``metadata`` down to the
+    provider's closed schema (:class:`AnthropicMetadata`, ``user_id`` only) before
+    signing.
+
+    AWS rejects every metadata field other than ``user_id`` with
+    ``metadata.<field>: Extra inputs are not permitted``. The proxy enriches the
+    request metadata with internal spend fields (tags, spend_logs_metadata,
+    user_api_key_*), and the passthrough route forwards that body verbatim, so any
+    enrichment lands in the provider payload and 400s the request.
+
+    A new body is returned rather than the input mutated, so the internal request
+    data that spend tracking reads keeps the stripped fields.
+    """
+    metadata = request_data.get("metadata")
+    if "anthropic_version" not in request_data or not isinstance(metadata, dict):
+        return request_data
+
+    metadata_obj = cast(Dict[str, object], metadata)
+    allowed = {
+        k: v for k, v in metadata_obj.items() if k in AnthropicMetadata.model_fields
+    }
+    if allowed == metadata_obj:
+        return request_data
+
+    return {
+        **{k: v for k, v in request_data.items() if k != "metadata"},
+        **({"metadata": allowed} if allowed else {}),
+    }
 
 
 class BedrockPassthroughConfig(
@@ -111,7 +146,7 @@ class BedrockPassthroughConfig(
             service_name="bedrock",
             headers=headers,
             optional_params=optional_params,
-            request_data=request_data or {},
+            request_data=restrict_anthropic_bedrock_metadata(request_data or {}),
             api_base=api_base,
             model=model,
         )

--- a/litellm/llms/bedrock/passthrough/transformation.py
+++ b/litellm/llms/bedrock/passthrough/transformation.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, List, Optional, Tuple, cast
 
 from httpx import Response
 
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 
 
 def restrict_anthropic_bedrock_metadata(
-    request_data: Dict[str, object],
-) -> Dict[str, object]:
+    request_data: dict[str, object],
+) -> dict[str, object]:
     """
     Project a forwarded Anthropic-on-Bedrock body's ``metadata`` down to the
     provider's closed schema (:class:`AnthropicMetadata`, ``user_id`` only) before
@@ -38,7 +38,7 @@ def restrict_anthropic_bedrock_metadata(
     if "anthropic_version" not in request_data or not isinstance(metadata, dict):
         return request_data
 
-    metadata_obj = cast(Dict[str, object], metadata)
+    metadata_obj = cast(dict[str, object], metadata)
     allowed = {
         k: v for k, v in metadata_obj.items() if k in AnthropicMetadata.model_fields
     }

--- a/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
+++ b/tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py
@@ -6,7 +6,16 @@ sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
 
-from litellm.llms.bedrock.passthrough.transformation import BedrockPassthroughConfig
+from litellm.llms.bedrock.passthrough.transformation import (
+    BedrockPassthroughConfig,
+    restrict_anthropic_bedrock_metadata,
+)
+
+_ANTHROPIC_INVOKE_BODY = {
+    "anthropic_version": "bedrock-2023-05-31",
+    "max_tokens": 16,
+    "messages": [{"role": "user", "content": "hi"}],
+}
 
 
 def test_bedrock_passthrough_get_complete_url_default_endpoint():
@@ -505,3 +514,105 @@ def test_bedrock_passthrough_model_id_without_arn():
             f"https://bedrock-runtime.us-east-1.amazonaws.com/model/{model_id}/converse"
         )
         assert url_str == expected_url
+
+
+def test_restrict_metadata_strips_internal_tags_keeps_user_id():
+    """
+    The reported leak (#30629): the proxy merges a key/team/header spend tag into
+    metadata.tags; Anthropic-on-Bedrock 400s on any metadata field but user_id.
+    """
+    body = {
+        **_ANTHROPIC_INVOKE_BODY,
+        "metadata": {"user_id": "user_abc123", "tags": ["CC:cost-center-123"]},
+    }
+
+    out = restrict_anthropic_bedrock_metadata(body)
+
+    assert out["metadata"] == {"user_id": "user_abc123"}
+    assert out["messages"] == _ANTHROPIC_INVOKE_BODY["messages"]
+    assert out["anthropic_version"] == "bedrock-2023-05-31"
+
+
+def test_restrict_metadata_does_not_mutate_input_so_spend_tracking_keeps_tags():
+    body = {
+        **_ANTHROPIC_INVOKE_BODY,
+        "metadata": {"user_id": "user_abc123", "tags": ["CC:cost-center-123"]},
+    }
+
+    restrict_anthropic_bedrock_metadata(body)
+
+    assert body["metadata"] == {
+        "user_id": "user_abc123",
+        "tags": ["CC:cost-center-123"],
+    }
+
+
+def test_restrict_metadata_strips_every_non_user_id_internal_field():
+    body = {
+        **_ANTHROPIC_INVOKE_BODY,
+        "metadata": {
+            "user_id": "user_abc123",
+            "tags": ["a"],
+            "spend_logs_metadata": {"owner": "team-x"},
+            "user_api_key_user_id": "k1",
+        },
+    }
+
+    out = restrict_anthropic_bedrock_metadata(body)
+
+    assert out["metadata"] == {"user_id": "user_abc123"}
+
+
+def test_restrict_metadata_drops_metadata_when_only_internal_fields_remain():
+    body = {**_ANTHROPIC_INVOKE_BODY, "metadata": {"tags": ["a"]}}
+
+    out = restrict_anthropic_bedrock_metadata(body)
+
+    assert "metadata" not in out
+
+
+def test_restrict_metadata_is_noop_when_already_closed_to_user_id():
+    body = {**_ANTHROPIC_INVOKE_BODY, "metadata": {"user_id": "user_abc123"}}
+
+    out = restrict_anthropic_bedrock_metadata(body)
+
+    assert out is body
+
+
+def test_restrict_metadata_is_noop_for_non_anthropic_body():
+    """A non-Anthropic invoke body (no anthropic_version) is forwarded verbatim."""
+    body = {"inputText": "hi", "metadata": {"tags": ["a"], "foo": "bar"}}
+
+    out = restrict_anthropic_bedrock_metadata(body)
+
+    assert out is body
+
+
+def test_restrict_metadata_is_noop_without_metadata():
+    out = restrict_anthropic_bedrock_metadata(_ANTHROPIC_INVOKE_BODY)
+
+    assert out is _ANTHROPIC_INVOKE_BODY
+
+
+def test_sign_request_strips_internal_metadata_before_signing():
+    """
+    Wiring: sign_request must feed the projected body to the AWS signer, so the bytes
+    AWS signs and receives never carry the internal tag.
+    """
+    config = BedrockPassthroughConfig()
+    body = {
+        **_ANTHROPIC_INVOKE_BODY,
+        "metadata": {"user_id": "user_abc123", "tags": ["CC:cost-center-123"]},
+    }
+
+    with patch.object(config, "_sign_request", return_value=({}, b"")) as mock_sign:
+        config.sign_request(
+            headers={},
+            litellm_params={},
+            request_data=body,
+            api_base="https://bedrock-runtime.us-east-1.amazonaws.com/model/m/invoke",
+            model="anthropic.claude-3-5-sonnet",
+        )
+
+    signed_request_data = mock_sign.call_args.kwargs["request_data"]
+    assert signed_request_data["metadata"] == {"user_id": "user_abc123"}


### PR DESCRIPTION
## Relevant issues

Implements the egress hardening from the RCA in #30999 and the category-level guard tracked in #30301, for the leak reported in #30629. Complements #30985 (merged), which stops key/team/header spend tags from landing in `metadata` at the source; this PR adds the structural guard at the single provider egress so any other internal field that reaches `metadata` is dropped too.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

No mock; run against a live proxy hitting real AWS Bedrock. Run the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload 2>&1 | tee litellm.log` and a Bedrock invoke config model `bedrock-invoke-sonnet-4-6` pointing at `us.anthropic.claude-sonnet-4-6`.

1. Generate a virtual key (any key works; the guard does not depend on tags):

```bash
KEY=$(curl -s -X POST 'http://localhost:4000/key/generate' \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{}' | python -c 'import sys,json;print(json.load(sys.stdin)["key"])')
```

2. Send a Bedrock invoke passthrough request whose body carries `metadata` with `user_id` plus a non-`user_id` field. Before this PR AWS returns `HTTP 400 metadata.tags: Extra inputs are not permitted`; with this PR the field is stripped at the egress and the request returns `HTTP 200`, with `user_id` still forwarded:

```bash
curl -s -w '\nHTTP %{http_code}\n' -X POST \
  'http://localhost:4000/bedrock/model/bedrock-invoke-sonnet-4-6/invoke' \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"anthropic_version":"bedrock-2023-05-31","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"metadata":{"user_id":"user_abc123","tags":["CC:cost-center-123"]}}'
```

3. Confirm attribution is preserved: `GET /spend/logs` for that request still shows `user_abc123`, so closing the provider schema does not drop billing data.

## Type

🐛 Bug Fix

## Changes

Anthropic-on-Bedrock accepts `metadata.user_id` and rejects every other metadata field with `metadata.<field>: Extra inputs are not permitted`. The proxy enriches the request metadata with LiteLLM-internal fields (spend tags, `spend_logs_metadata`, `user_api_key_*`), and the invoke/converse passthrough route forwards the request body verbatim, so that enrichment reaches AWS and 400s the request.

#30985 fixed the key/team/header tag vector at the source by routing tags into `litellm_metadata` for Bedrock routes. That is a per-route source patch, so it does not cover the rest of the category: any internal field that still lands in `metadata`, or a client-supplied non-`user_id` field, leaks again. This PR closes the category at the one place every invoke/converse passthrough body is serialized to AWS.

`restrict_anthropic_bedrock_metadata` projects the forwarded body's `metadata` down to the provider's closed schema (the existing `AnthropicMetadata`, `user_id` only) inside `BedrockPassthroughConfig.sign_request`, right before the body is signed. It is gated on `anthropic_version` so only Anthropic-native invoke bodies are touched; Titan/Cohere/Llama/Nova bodies and the Converse schema are forwarded unchanged. The projection builds a new body rather than mutating the cached one, so spend tracking still reads the tags it needs for billing while the bytes signed and sent to AWS carry only `user_id`. This mirrors the closed-schema strip already shipped for `/chat/completions` (#24661) and `/v1/messages` (`validate_anthropic_api_metadata`), now applied at the Bedrock passthrough egress.

Files:

- `litellm/llms/bedrock/passthrough/transformation.py`: add `restrict_anthropic_bedrock_metadata` and call it in `BedrockPassthroughConfig.sign_request`
- `tests/test_litellm/llms/bedrock/passthrough/test_bedrock_passthrough_transformation.py`: regression tests for stripping every non-`user_id` field, preserving `user_id`, not mutating the input body, the `anthropic_version`/no-`metadata` no-op guards, and a wiring test that fails if `sign_request` stops feeding the projected body to the signer