### PR TITLE
fix(proxy): json-encode team budget_limits on /team/new so Prisma accepts multi-window budgets

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1268,6 +1268,11 @@ async def new_team(
 
         complete_team_data_dict = complete_team_data.model_dump(exclude_none=True)
 
+        if complete_team_data_dict.get("budget_limits") is not None:
+            complete_team_data_dict["budget_limits"] = json.dumps(
+                complete_team_data_dict["budget_limits"]
+            )
+
         # Serialize router_settings to JSON (matching key creation pattern)
         router_settings_value = getattr(data, "router_settings", None)
         router_settings_json = (

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -462,6 +462,66 @@ async def test_new_team_with_object_permission(mock_db_client, mock_admin_auth):
 
 
 @pytest.mark.asyncio
+async def test_new_team_serializes_multi_window_budget_limits(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Regression test for LIT-3896: /team/new must json-encode budget_limits before
+    passing them to Prisma. The LiteLLM_TeamTable.budget_limits column is `Json?`,
+    and jsonify_team_object only stringifies dict values, so a raw Python list
+    reaches Prisma unencoded and the create call 500s.
+    """
+    import json
+
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.get_data = AsyncMock(return_value=None)
+    mock_db_client.update_data = AsyncMock(return_value=MagicMock())
+    mock_db_client.db = MagicMock()
+
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
+    mock_db_client.db.litellm_teamtable.create = AsyncMock(
+        return_value=MagicMock(team_id="team-budget-windows")
+    )
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(return_value=MagicMock())
+    mock_db_client.db.litellm_usertable = MagicMock()
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    from fastapi import Request
+
+    from litellm.models.team import BudgetLimitEntry
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    team_request = NewTeamRequest(
+        team_alias="multi-window-team",
+        budget_limits=[
+            BudgetLimitEntry(budget_duration="1d", max_budget=10.0),
+            BudgetLimitEntry(budget_duration="30d", max_budget=100.0),
+        ],
+    )
+
+    dummy_request = MagicMock(spec=Request)
+
+    await new_team(
+        data=team_request,
+        http_request=dummy_request,
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    created_data = mock_db_client.db.litellm_teamtable.create.call_args.kwargs["data"]
+
+    assert isinstance(created_data["budget_limits"], str)
+
+    decoded = json.loads(created_data["budget_limits"])
+    assert isinstance(decoded, list)
+    assert len(decoded) == 2
+    assert {w["budget_duration"] for w in decoded} == {"1d", "30d"}
+    assert {w["max_budget"] for w in decoded} == {10.0, 100.0}
+    assert all(w.get("reset_at") for w in decoded)
+
+
+@pytest.mark.asyncio
 async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_auth):
     """
     Test that /team/new correctly handles mcp_tool_permissions in object_permission.


### PR DESCRIPTION
## Relevant issues

`POST /team/new` returns a 500 when the request includes multi-window `budget_limits`. Prisma rejects the create with:

```
Unable to match input value to any allowed input type for the field.
Parse errors: [Invalid argument type. `budget_limits` should be of any of the following types: `NullableJsonNullValueInput`, `Json`]
```

The root cause is that the create path builds `complete_team_data_dict = complete_team_data.model_dump(exclude_none=True)` and hands it to the team-create call. That dict flows through `jsonify_team_object` -> `jsonify_object`, which only `json.dumps` values that are a `dict`. `budget_limits` is a `list`, so it passes through unencoded and Prisma refuses it because the `LiteLLM_TeamTable.budget_limits` column is `Json?`. The update path already serializes it via `json.dumps` and the key path does the same, so this aligns `/team/new` with the rest of the codebase.

The fix json-encodes `budget_limits` on the dict right after `model_dump`, parallel to the existing `router_settings` serialization just below it. This is safe against double-encoding: `jsonify_object` leaves strings alone, `TeamRepository._to_model` json-loads when the value is a string, `proxy_server` handles the string case on read, and the reset-budget job tolerates both a list and a json string.

## Linear ticket

LIT-3896

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a local proxy, then create a team with two budget windows and read it back. Before this change the create returns a 500; after it, the create returns 200 with a `team_id` and `GET /team/info` shows both windows persisted with a populated `reset_at`.

```bash
# 1. start the proxy (separate terminal)
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log

# 2. create a team with two budget windows
TEAM_ID=$(curl -s -X POST http://localhost:4000/team/new \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
        "team_alias": "multi-window-team",
        "budget_limits": [
          {"budget_duration": "1d",  "max_budget": 10.0},
          {"budget_duration": "30d", "max_budget": 100.0}
        ]
      }' | tee /dev/stderr | python -c "import sys, json; print(json.load(sys.stdin)['team_id'])")

# 3. read it back and confirm both windows persisted with reset_at
curl -s "http://localhost:4000/team/info?team_id=$TEAM_ID" \
  -H "Authorization: Bearer sk-1234" | python -m json.tool
```

## Type

🐛 Bug Fix

## Changes

`new_team` now serializes `budget_limits` with `json.dumps` on the create payload so the `Json?` column accepts the value, matching how the update and key paths already handle it. Added a regression test `test_new_team_serializes_multi_window_budget_limits` that builds a `NewTeamRequest` with two windows, runs `new_team` with admin auth, captures the data passed to `litellm_teamtable.create`, and asserts the stored `budget_limits` is a json string that decodes to a list carrying both windows plus a populated `reset_at`. The test fails before the fix (the value is a raw list) and passes after


