### PR TITLE
fix(anthropic): emit replayable streaming thinking blocks

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -629,6 +629,7 @@ class ModelResponseIterator:
         Optional[ChatCompletionToolCallChunk],
         List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
         Dict[str, Any],
+        Optional[str],
     ]:
         """
         Helper function to handle the content block delta
@@ -636,6 +637,7 @@ class ModelResponseIterator:
         text = ""
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         provider_specific_fields = {}
+        reasoning_content: Optional[str] = None
         content_block = ContentBlockDelta(**chunk)  # type: ignore
         thinking_blocks: List[
             Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
@@ -670,14 +672,24 @@ class ModelResponseIterator:
             thinking_content = content_block["delta"].get("thinking")
             if isinstance(thinking_content, str) and thinking_content:
                 self.reasoning_content_chunks.append(thinking_content)
-            thinking_blocks = [
-                ChatCompletionThinkingBlock(
-                    type="thinking",
-                    thinking=thinking_content or "",
-                    signature=str(content_block["delta"].get("signature") or ""),
-                )
-            ]
-            provider_specific_fields["thinking_blocks"] = thinking_blocks
+                reasoning_content = thinking_content
+
+            signature = content_block["delta"].get("signature")
+            if isinstance(signature, str) and signature:
+                thinking_blocks = [
+                    ChatCompletionThinkingBlock(
+                        type="thinking",
+                        thinking="".join(
+                            cast(str, block["delta"].get("thinking"))
+                            for block in self.content_blocks
+                            if isinstance(block["delta"].get("thinking"), str)
+                        ),
+                        signature=signature,
+                    )
+                ]
+                provider_specific_fields["thinking_blocks"] = thinking_blocks
+                if reasoning_content is None:
+                    reasoning_content = ""
         elif (
             "content" in content_block["delta"]
             and content_block["delta"].get("type") == "compaction_delta"
@@ -688,25 +700,13 @@ class ModelResponseIterator:
                 "content": content_block["delta"]["content"],
             }
 
-        return text, tool_use, thinking_blocks, provider_specific_fields
-
-    def _handle_reasoning_content(
-        self,
-        thinking_blocks: List[
-            Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]
-        ],
-    ) -> Optional[str]:
-        """
-        Handle the reasoning content
-        """
-        reasoning_content = None
-        for block in thinking_blocks:
-            thinking_content = cast(Optional[str], block.get("thinking"))
-            if reasoning_content is None:
-                reasoning_content = ""
-            if thinking_content is not None:
-                reasoning_content += thinking_content
-        return reasoning_content
+        return (
+            text,
+            tool_use,
+            thinking_blocks,
+            provider_specific_fields,
+            reasoning_content,
+        )
 
     def _handle_redacted_thinking_content(
         self,
@@ -802,11 +802,8 @@ class ModelResponseIterator:
                     tool_use,
                     thinking_blocks,
                     provider_specific_fields,
+                    reasoning_content,
                 ) = self._content_block_delta_helper(chunk=chunk)
-                if thinking_blocks:
-                    reasoning_content = self._handle_reasoning_content(
-                        thinking_blocks=thinking_blocks
-                    )
             elif type_chunk == "content_block_start":
                 """
                 event: content_block_start

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -74,6 +74,137 @@ def test_redacted_thinking_content_block_delta():
     assert "thinking_blocks" in model_response.choices[0].delta.provider_specific_fields
 
 
+def test_streaming_thinking_blocks_are_replayable_after_signature_delta():
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 1. "},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 2."},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "signature_delta", "signature": "sig-final"},
+        },
+    ]
+
+    parsed_chunks = [
+        model_response_iterator.chunk_parser(chunk=chunk) for chunk in chunks
+    ]
+    reasoning_content = "".join(
+        getattr(chunk.choices[0].delta, "reasoning_content", None) or ""
+        for chunk in parsed_chunks
+    )
+    thinking_blocks = tuple(
+        block
+        for chunk in parsed_chunks
+        for block in (getattr(chunk.choices[0].delta, "thinking_blocks", None) or [])
+    )
+    expected_thinking_block = {
+        "type": "thinking",
+        "thinking": "Step 1. Step 2.",
+        "signature": "sig-final",
+    }
+
+    assert reasoning_content == "Step 1. Step 2."
+    assert thinking_blocks == (expected_thinking_block,)
+    assert parsed_chunks[-1].choices[0].delta.provider_specific_fields == {
+        "thinking_blocks": [expected_thinking_block]
+    }
+
+
+def test_streaming_unsigned_thinking_deltas_keep_reasoning_content():
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 1. "},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 2."},
+        },
+        {"type": "content_block_stop", "index": 0},
+    ]
+
+    parsed_chunks = [
+        model_response_iterator.chunk_parser(chunk=chunk) for chunk in chunks
+    ]
+    reasoning_content = "".join(
+        getattr(chunk.choices[0].delta, "reasoning_content", None) or ""
+        for chunk in parsed_chunks
+    )
+    thinking_blocks = tuple(
+        block
+        for chunk in parsed_chunks
+        for block in (getattr(chunk.choices[0].delta, "thinking_blocks", None) or [])
+    )
+
+    assert reasoning_content == "Step 1. Step 2."
+    assert thinking_blocks == ()
+
+
+def test_streaming_truncated_thinking_deltas_keep_reasoning_content():
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=False
+    )
+    chunks = [
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "thinking", "thinking": ""},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 1. "},
+        },
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "thinking_delta", "thinking": "Step 2."},
+        },
+    ]
+
+    parsed_chunks = [
+        model_response_iterator.chunk_parser(chunk=chunk) for chunk in chunks
+    ]
+    reasoning_content = "".join(
+        getattr(chunk.choices[0].delta, "reasoning_content", None) or ""
+        for chunk in parsed_chunks
+    )
+    thinking_blocks = tuple(
+        block
+        for chunk in parsed_chunks
+        for block in (getattr(chunk.choices[0].delta, "thinking_blocks", None) or [])
+    )
+
+    assert reasoning_content == "Step 1. Step 2."
+    assert thinking_blocks == ()
+
+
 def test_handle_json_mode_chunk_response_format_tool():
     model_response_iterator = ModelResponseIterator(
         streaming_response=MagicMock(), sync_stream=True, json_mode=True


### PR DESCRIPTION
## Relevant issues

Fixes #29428

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

This fixes native Anthropic streaming thinking block conversion. Before this change, LiteLLM emitted one `delta.thinking_blocks` entry per `thinking_delta` and `signature_delta`, which produced unreplayable blocks with empty signatures or empty thinking text

Before:

```text
reasoning= Step 1. Step 2.
thinking_blocks= [
  {'type': 'thinking', 'thinking': 'Step 1. ', 'signature': ''},
  {'type': 'thinking', 'thinking': 'Step 2.', 'signature': ''},
  {'type': 'thinking', 'thinking': '', 'signature': 'sig-final'}
]
```

After:

```text
signed reasoning= 'Step 1. Step 2.'
signed thinking_blocks= [{'type': 'thinking', 'thinking': 'Step 1. Step 2.', 'signature': 'sig-final'}]
```

Unsigned and truncated streams keep incremental thinking in `reasoning_content` and do not emit invalid unsigned `thinking_blocks`:

```text
unsigned reasoning= 'Step 1. Step 2.'
unsigned thinking_blocks= []

truncated reasoning= 'Step 1. Step 2.'
truncated thinking_blocks= []
```

Validation run:

```sh
uv run --no-sync pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py -q
uv run --no-sync pytest tests/test_litellm/llms/anthropic -q
uv run --no-sync black --check litellm/llms/anthropic/chat/handler.py tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
uv run --no-sync ruff check litellm/llms/anthropic/chat/handler.py
uv run --no-sync ruff check --ignore T201 tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
```

Results:

```text
33 passed
953 passed
All checks passed
```

I also ran `make test-unit`. It completed setup and Prisma generation, then failed during pytest collection before running tests because pytest imported `tests/test_litellm/models/test_models.py` as `test_models` and then tried to collect `tests/test_litellm/proxy/client/test_models.py` under the same module name. Removing `tests/**/__pycache__` and `tests/**/*.pyc` did not change that collection failure

Live proxy proof runbook for a reviewer with `ANTHROPIC_API_KEY` set:

```sh
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

Then in another shell:

```sh
curl -N http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "anthropic-haiku-4-5",
    "stream": true,
    "messages": [
      {"role": "user", "content": "Think briefly, then answer with the word done."}
    ],
    "max_tokens": 2048,
    "thinking": {"type": "enabled", "budget_tokens": 1024}
  }'
```

Expected behavior: incremental thinking continues to stream as reasoning content, and any emitted `thinking_blocks` entry is replayable because it contains the full thinking text with the final signature instead of separate unsigned fragments

I could not run this live provider proof locally because this checkout has no `ANTHROPIC_API_KEY` available in the environment or `.env`

## Type

Bug Fix
Test

## Changes

This updates the native Anthropic streaming parser so `thinking_delta` chunks continue to stream as `reasoning_content`, while `thinking_blocks` are only emitted once Anthropic sends the final `signature_delta`

The emitted `thinking_blocks` value is now replayable because it contains the full accumulated thinking text and the final signature in a single block

This also adds regression coverage for signed thinking streams, unsigned/no-signature streams, truncated thinking streams, and preserves the existing redacted thinking behavior
