### PR TITLE
fix(passthrough,streaming): close Anthropic pass-through + streaming cost-capture gaps

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -292,6 +292,48 @@ def _get_cached_prometheus_logger():
     return _PrometheusLogger
 
 
+def get_model_from_passthrough_model_group(
+    model_call_details: dict,
+) -> Optional[str]:
+    """Recover ``<provider>/<model>`` from a pass-through request's ``model_group``.
+
+    Pass-through requests (``/anthropic/v1/messages``, ``/openai/...`` etc.) reach
+    logging with no resolved model — ``self.model`` is ``"unknown"`` because the
+    model isn't known when the logging object is created. The model IS available
+    via the inferred ``model_group`` of the form ``passthrough/<provider>/<model>``
+    (see ``_infer_model_group_for_passthrough`` in ``pass_through_endpoints.py``).
+
+    Returns ``"<provider>/<model>"`` (a valid litellm model id, since the provider
+    token is a litellm provider prefix) so ``completion_cost`` can price it instead
+    of recording $0 spend. Returns ``None`` when nothing usable can be recovered
+    (no/!passthrough model_group, or no model segment).
+    """
+    try:
+        litellm_params = (model_call_details or {}).get("litellm_params", {}) or {}
+        model_group: Optional[str] = None
+        # metadata may live under either key depending on call path; check both.
+        for meta_key in ("litellm_metadata", "metadata"):
+            metadata = litellm_params.get(meta_key) or {}
+            model_group = metadata.get("model_group")
+            if model_group:
+                break
+
+        if not model_group or not str(model_group).startswith("passthrough/"):
+            return None
+
+        # Format: passthrough/<provider>/<model>
+        parts = str(model_group).split("/", 2)
+        if len(parts) < 3 or not parts[2]:
+            return None
+        provider, model_name = parts[1], parts[2]
+        return f"{provider}/{model_name}"
+    except Exception as e:  # pragma: no cover
+        verbose_logger.debug(
+            "get_model_from_passthrough_model_group: could not recover model: %s", e
+        )
+        return None
+
+
 class Logging(LiteLLMLoggingBaseClass):
     global supabaseClient, promptLayerLogger, weightsBiasesLogger, logfireLogger, capture_exception, add_breadcrumb, lunaryLogger, logfireLogger, prometheusLogger, slack_app
     custom_pricing: bool = False
@@ -1542,10 +1584,23 @@ class Logging(LiteLLMLoggingBaseClass):
         if cache_hit is None:
             cache_hit = self.model_call_details.get("cache_hit", False)
 
+        # pass-through requests (e.g. /anthropic/v1/messages) reach logging
+        # with self.model == "unknown" (the model isn't known when the logging object
+        # is created), so cost is recorded as $0. The model is available via the
+        # inferred model_group ("passthrough/<provider>/<model>"); recover it so
+        # streaming + non-streaming pass-through spend is tracked for all providers.
+        model_for_cost = litellm_model_name or self.model
+        if not model_for_cost or model_for_cost == "unknown":
+            recovered_passthrough_model = get_model_from_passthrough_model_group(
+                self.model_call_details
+            )
+            if recovered_passthrough_model:
+                model_for_cost = recovered_passthrough_model
+
         try:
             response_cost_calculator_kwargs = {
                 "response_object": result,
-                "model": litellm_model_name or self.model,
+                "model": model_for_cost,
                 "cache_hit": cache_hit,
                 "custom_llm_provider": self.model_call_details.get(
                     "custom_llm_provider", None

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1872,6 +1872,30 @@ class CustomStreamWrapper:
         if self.logging_obj._is_sync_litellm_request(litellm_params):
             self.logging_obj.success_handler(processed_chunk, None, None, cache_hit)
 
+    def _log_partial_usage_on_stream_error(self) -> None:
+        """A stream that dies mid-flight (request timeout / mid-stream provider
+        error) otherwise records ZERO usage, even though the provider billed the tokens it
+        generated before the failure — a major source of the billed-vs-tracked gap for long
+        agentic streams. Assemble the partial usage from the chunks already received and log
+        it via the normal success path so spend is tracked. Best-effort: never raise from
+        here and never mask the original streaming error."""
+        try:
+            if self.sent_stream_usage or not self.chunks:
+                return
+            # pass the same context the normal end-of-stream assembler gets, so prompt
+            # tokens fall back to token_counter(messages) when chunks lack explicit usage
+            partial = litellm.stream_chunk_builder(
+                chunks=self.chunks,
+                messages=self.messages,
+                logging_obj=self.logging_obj,
+            )
+            if partial is None:
+                return
+            self.sent_stream_usage = True
+            executor.submit(self.run_success_logging_and_cache_storage, partial, False)
+        except Exception:
+            pass
+
     def finish_reason_handler(self):
         model_response = self.model_response_creator()
         _finish_reason = self.received_finish_reason or self.intermittent_finish_reason
@@ -1980,11 +2004,34 @@ class CustomStreamWrapper:
 
         except StopIteration:
             if self.sent_last_chunk is True:
-                complete_streaming_response = litellm.stream_chunk_builder(
-                    chunks=self.chunks,
-                    messages=self.messages,
-                    logging_obj=self.logging_obj,
-                )
+                try:
+                    complete_streaming_response = litellm.stream_chunk_builder(
+                        chunks=self.chunks,
+                        messages=self.messages,
+                        logging_obj=self.logging_obj,
+                    )
+                except Exception as e:
+                    # stream_chunk_builder can re-raise (as APIError) on large
+                    # agentic tool-use streams. That raise originates INSIDE this
+                    # except-StopIteration handler, so the sibling `except Exception` below
+                    # does NOT catch it — it escapes __next__ and the request is dropped from
+                    # SpendLogs while the provider already billed the tokens. Recover
+                    # best-effort usage from the raw chunks so cost is still tracked.
+                    verbose_logger.warning(
+                        "stream_chunk_builder raised at end-of-stream (%s); logging "
+                        "best-effort usage from chunks.",
+                        str(e),
+                    )
+                    try:
+                        _recovered = self.model_response_creator()
+                        setattr(
+                            _recovered,
+                            "usage",
+                            calculate_total_usage(chunks=self.chunks),
+                        )
+                        complete_streaming_response = _recovered
+                    except Exception:
+                        complete_streaming_response = None
 
                 response = self.model_response_creator()
                 if complete_streaming_response is not None:
@@ -2053,6 +2100,9 @@ class CustomStreamWrapper:
                 return processed_chunk
         except Exception as e:
             traceback_exception = traceback.format_exc()
+            # track tokens billed before the failure (success-only logging
+            # would otherwise record zero usage for this request).
+            self._log_partial_usage_on_stream_error()
             # LOG FAILURE - handle streaming failure logging in the _next_ object, remove `handle_failure` once it's deprecated
             threading.Thread(
                 target=self.logging_obj.failure_handler, args=(e, traceback_exception)
@@ -2209,11 +2259,32 @@ class CustomStreamWrapper:
         except (StopAsyncIteration, StopIteration):
             if self.sent_last_chunk is True:
                 # log the final chunk with accurate streaming values
-                complete_streaming_response = litellm.stream_chunk_builder(
-                    chunks=self.chunks,
-                    messages=self.messages,
-                    logging_obj=self.logging_obj,
-                )
+                try:
+                    complete_streaming_response = litellm.stream_chunk_builder(
+                        chunks=self.chunks,
+                        messages=self.messages,
+                        logging_obj=self.logging_obj,
+                    )
+                except Exception as e:
+                    # see sync __next__ — a raise from stream_chunk_builder here
+                    # originates inside this except handler, escapes __anext__, and drops the
+                    # request from SpendLogs while the provider billed the tokens. Recover
+                    # best-effort usage from the raw chunks so cost is still tracked.
+                    verbose_logger.warning(
+                        "stream_chunk_builder raised at end-of-stream (%s); logging "
+                        "best-effort usage from chunks.",
+                        str(e),
+                    )
+                    try:
+                        _recovered = self.model_response_creator()
+                        setattr(
+                            _recovered,
+                            "usage",
+                            calculate_total_usage(chunks=self.chunks),
+                        )
+                        complete_streaming_response = _recovered
+                    except Exception:
+                        complete_streaming_response = None
 
                 response = self.model_response_creator()
                 if complete_streaming_response is not None:
@@ -2289,6 +2360,9 @@ class CustomStreamWrapper:
             traceback_exception += "\nLiteLLM Default Request Timeout - {}".format(
                 litellm.request_timeout
             )
+            # long agentic streams time out here; track tokens billed before
+            # the timeout instead of recording zero usage.
+            self._log_partial_usage_on_stream_error()
             if self.logging_obj is not None:
                 ## LOGGING
                 threading.Thread(
@@ -2302,6 +2376,9 @@ class CustomStreamWrapper:
             self._handle_stream_fallback_error(e)
         except Exception as e:
             traceback_exception = traceback.format_exc()
+            # track tokens billed before a mid-stream failure (success-only
+            # logging would otherwise record zero usage for this request).
+            self._log_partial_usage_on_stream_error()
             if self.logging_obj is not None:
                 ## LOGGING
                 threading.Thread(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -3658,9 +3658,17 @@ async def _virtual_key_max_budget_check(
         # so a NaN max_budget would silently disable enforcement.  Treat a
         # non-finite max_budget as "no configured limit" rather than as a bypass.
         if math.isfinite(valid_token.max_budget) and spend >= valid_token.max_budget:
+            # Identify the key in the error so callers know which key hit its
+            # budget without an operator having to reverse-map spend->key.
+            # key_name is LiteLLM's masked form (e.g. "sk-...um_g"), which
+            # carries the last 4 chars of the raw key.
+            key_descriptor = valid_token.key_alias or "key"
+            if valid_token.key_name:
+                key_descriptor = f"{key_descriptor} ({valid_token.key_name})"
             raise litellm.BudgetExceededError(
                 current_cost=spend,
                 max_budget=valid_token.max_budget,
+                message=f"Budget has been exceeded! Key={key_descriptor} Current cost: {spend}, Max budget: {valid_token.max_budget}",
             )
 
 

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -12,12 +12,19 @@ from litellm.llms.anthropic import get_anthropic_config
 from litellm.llms.anthropic.chat.handler import (
     ModelResponseIterator as AnthropicModelResponseIterator,
 )
+from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.proxy._types import PassThroughEndpointLoggingTypedDict
 from litellm.proxy.auth.auth_utils import get_end_user_id_from_request_body
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     PassthroughStandardLoggingPayload,
 )
-from litellm.types.utils import LiteLLMBatch, ModelResponse, TextCompletionResponse
+from litellm.types.utils import (
+    Choices,
+    LiteLLMBatch,
+    Message,
+    ModelResponse,
+    TextCompletionResponse,
+)
 
 if TYPE_CHECKING:
     from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -167,6 +174,11 @@ class AnthropicPassthroughLoggingHandler:
                 model, logging_obj
             )
 
+            # record the resolved model on the logging object up-front, so a
+            # failure in cost calculation below cannot leave SpendLogs with model="unknown".
+            if model and model != "unknown":
+                logging_obj.model_call_details["model"] = model
+
             # Prepend custom_llm_provider to model if not already present
             model_for_cost = model
             if custom_llm_provider and not model.startswith(f"{custom_llm_provider}/"):
@@ -191,6 +203,10 @@ class AnthropicPassthroughLoggingHandler:
 
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
+            # the pass-through success path reads SpendLogs spend from
+            # model_call_details["response_cost"] (not from kwargs), so record it here too
+            # — mirrors the batch path. Without this, streaming pass-through logged $0.
+            logging_obj.model_call_details["response_cost"] = response_cost
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )
@@ -262,20 +278,60 @@ class AnthropicPassthroughLoggingHandler:
             if chunk_model:
                 model = chunk_model
 
-        complete_streaming_response = (
-            AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
+        # Record the model up-front so a downstream assembly/cost failure cannot leave
+        # SpendLogs with model="unknown".
+        if model and model != "unknown":
+            litellm_logging_obj.model_call_details["model"] = model
+
+        try:
+            complete_streaming_response = (
+                AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
+                    all_chunks=all_chunks,
+                    litellm_logging_obj=litellm_logging_obj,
+                    model=model,
+                )
+            )
+        except Exception as e:
+            # large / agentic streams (e.g. claude-opus-4-6 with tool-use or
+            # thinking blocks) can make stream_chunk_builder *raise* (it re-raises any
+            # internal assembly failure as litellm.APIError) instead of returning None.
+            # Without this catch the exception escapes the success handler entirely, so
+            # the request is dropped from SpendLogs while Anthropic still bills every
+            # token it generated. Treat a raise the same as a None result so the
+            # usage-only fallback below still recovers cost from the raw SSE events.
+            verbose_proxy_logger.warning(
+                "Anthropic passthrough: stream assembly raised (model=%s): %s; falling "
+                "back to usage-only cost from raw SSE events.",
+                model,
+                e,
+            )
+            complete_streaming_response = None
+        if complete_streaming_response is None:
+            # large / agentic Anthropic streams (e.g. claude-opus-4-6 with
+            # tool-use or thinking blocks) cannot always be reassembled by
+            # stream_chunk_builder, which previously caused the entire request to be
+            # recorded with $0 spend. Anthropic still emits token usage in the
+            # message_start / message_delta SSE events regardless of content shape, so
+            # fall back to a usage-only response so cost is still tracked.
+            verbose_proxy_logger.warning(
+                "Anthropic passthrough: stream_chunk_builder could not assemble the "
+                "stream (model=%s); falling back to usage-only cost from raw SSE events.",
+                model,
+            )
+            complete_streaming_response = AnthropicPassthroughLoggingHandler._build_usage_only_response_from_chunks(
                 all_chunks=all_chunks,
-                litellm_logging_obj=litellm_logging_obj,
                 model=model,
             )
-        )
         if complete_streaming_response is None:
             verbose_proxy_logger.error(
-                "Unable to build complete streaming response for Anthropic passthrough endpoint, not logging..."
+                "Anthropic passthrough: unable to build complete OR usage-only streaming "
+                "response (model=%s); recording model with $0 cost.",
+                model,
             )
+            litellm_logging_obj.model_call_details.setdefault("response_cost", 0.0)
             return {
                 "result": None,
-                "kwargs": {},
+                "kwargs": {"model": model, "response_cost": 0.0},
             }
         kwargs = AnthropicPassthroughLoggingHandler._create_anthropic_response_logging_payload(
             litellm_model_response=complete_streaming_response,
@@ -549,6 +605,138 @@ class AnthropicPassthroughLoggingHandler:
             "Complete streaming response built: %s", complete_streaming_response
         )
         return complete_streaming_response
+
+    @staticmethod
+    def _extract_sse_data(event_str: str) -> Optional[dict]:
+        """Parse the JSON object from the ``data:`` line of an Anthropic SSE event."""
+        for line in event_str.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("data:"):
+                payload = stripped[len("data:") :].strip()
+                if not payload or payload == "[DONE]":
+                    return None
+                try:
+                    return cast(dict, json.loads(payload))
+                except (ValueError, TypeError):
+                    return None
+        return None
+
+    @staticmethod
+    def _build_usage_only_response_from_chunks(
+        all_chunks: Sequence[Union[str, bytes]],
+        model: str,
+    ) -> Optional[ModelResponse]:
+        """
+        Build a usage-bearing ModelResponse from Anthropic SSE token-usage events, for
+        cost tracking when stream_chunk_builder cannot reassemble the stream.
+
+        Anthropic emits usage in ``message_start`` (uncached input + cache tokens, and an
+        initial output_tokens) and the final ``message_delta`` (cumulative output_tokens)
+        regardless of the content/tool shape, so cost is recoverable even when full
+        content assembly fails. Returns ``None`` if no usage event is found.
+        """
+        input_tokens = 0
+        cache_read = 0
+        cache_creation = 0
+        cache_creation_5m: Optional[int] = None
+        cache_creation_1h: Optional[int] = None
+        output_tokens = 0
+        web_search_requests: Optional[int] = None
+        tool_search_requests: Optional[int] = None
+        inference_geo: Optional[str] = None
+        found_usage = False
+        resolved_model = model
+        for _chunk_str in all_chunks:
+            for (
+                event_str
+            ) in AnthropicPassthroughLoggingHandler._split_sse_chunk_into_events(
+                _chunk_str
+            ):
+                data = AnthropicPassthroughLoggingHandler._extract_sse_data(event_str)
+                if not data:
+                    continue
+                event_type = data.get("type")
+                if event_type == "message_start":
+                    message = data.get("message") or {}
+                    if not resolved_model or resolved_model == "unknown":
+                        resolved_model = message.get("model") or resolved_model
+                    usage = message.get("usage") or {}
+                    input_tokens = usage.get("input_tokens") or input_tokens
+                    cache_read = usage.get("cache_read_input_tokens") or cache_read
+                    cache_creation = (
+                        usage.get("cache_creation_input_tokens") or cache_creation
+                    )
+                    _cc = usage.get("cache_creation")
+                    if isinstance(_cc, dict):
+                        cache_creation_5m = _cc.get("ephemeral_5m_input_tokens")
+                        cache_creation_1h = _cc.get("ephemeral_1h_input_tokens")
+                    if usage.get("inference_geo") is not None:
+                        inference_geo = usage.get("inference_geo")
+                    if usage.get("output_tokens") is not None:
+                        output_tokens = usage.get("output_tokens") or output_tokens
+                    found_usage = True
+                elif event_type == "message_delta":
+                    usage = data.get("usage") or {}
+                    if usage.get("output_tokens") is not None:
+                        output_tokens = usage.get("output_tokens")
+                    _stu = usage.get("server_tool_use")
+                    if isinstance(_stu, dict):
+                        if _stu.get("web_search_requests") is not None:
+                            web_search_requests = _stu.get("web_search_requests")
+                        if _stu.get("tool_search_requests") is not None:
+                            tool_search_requests = _stu.get("tool_search_requests")
+                    if usage.get("cache_read_input_tokens") is not None:
+                        cache_read = usage.get("cache_read_input_tokens")
+                    if usage.get("inference_geo") is not None:
+                        inference_geo = usage.get("inference_geo")
+                    found_usage = True
+        if not found_usage:
+            return None
+        # If only the 5m/1h split was provided, derive the cache_creation total from it.
+        if not cache_creation and (cache_creation_5m or cache_creation_1h):
+            cache_creation = (cache_creation_5m or 0) + (cache_creation_1h or 0)
+        # build usage via AnthropicConfig.calculate_usage — the SAME path the
+        # non-streaming and stream_chunk_builder success cases use. The prior approach
+        # (Usage(...) + setattr of cache tokens) left prompt_tokens_details / server_tool_use
+        # / inference_geo unset, so completion_cost priced cache_read/cache_write, web_search
+        # and geo at $0 (undercount). calculate_usage makes prompt_tokens cache-inclusive and
+        # populates prompt_tokens_details + cache_creation_token_details + server_tool_use.
+        usage_object: dict = {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }
+        if cache_read:
+            usage_object["cache_read_input_tokens"] = cache_read
+        if cache_creation:
+            usage_object["cache_creation_input_tokens"] = cache_creation
+        if cache_creation_5m is not None or cache_creation_1h is not None:
+            usage_object["cache_creation"] = {
+                "ephemeral_5m_input_tokens": cache_creation_5m or 0,
+                "ephemeral_1h_input_tokens": cache_creation_1h or 0,
+            }
+        if web_search_requests is not None or tool_search_requests is not None:
+            _server_tool_use: dict = {}
+            if web_search_requests is not None:
+                _server_tool_use["web_search_requests"] = web_search_requests
+            if tool_search_requests is not None:
+                _server_tool_use["tool_search_requests"] = tool_search_requests
+            usage_object["server_tool_use"] = _server_tool_use
+        if inference_geo is not None:
+            usage_object["inference_geo"] = inference_geo
+        usage_obj = AnthropicConfig().calculate_usage(
+            usage_object=usage_object, reasoning_content=None
+        )
+        response = ModelResponse()
+        response.model = resolved_model
+        response.choices = [
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(role="assistant", content=""),
+            )
+        ]
+        setattr(response, "usage", usage_obj)
+        return response
 
     @staticmethod
     def batch_creation_handler(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/base_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/base_passthrough_logging_handler.py
@@ -8,6 +8,9 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.litellm_logging import (
+    get_model_from_passthrough_model_group as _recover_passthrough_model,
+)
+from litellm.litellm_core_utils.litellm_logging import (
     get_standard_logging_object_payload,
 )
 from litellm.llms.base_llm.chat.transformation import BaseConfig
@@ -26,6 +29,20 @@ else:
     EndpointType = Any
 
 from abc import ABC, abstractmethod
+
+
+def get_model_from_passthrough_model_group(
+    logging_obj: LiteLLMLoggingObj,
+) -> Optional[str]:
+    """Recover ``<provider>/<model>`` from a pass-through ``model_group``.
+
+    Thin ``logging_obj``-accepting wrapper over the canonical recovery in
+    ``litellm.litellm_core_utils.litellm_logging.get_model_from_passthrough_model_group``
+    (which the central cost calculator also uses). See that function for details.
+    """
+    return _recover_passthrough_model(
+        getattr(logging_obj, "model_call_details", {}) or {}
+    )
 
 
 class BasePassthroughLoggingHandler(ABC):
@@ -109,6 +126,22 @@ class BasePassthroughLoggingHandler(ABC):
         """
 
         try:
+            # pass-through requests can reach logging with an empty /
+            # "unknown" model (absent from the streamed response or collected
+            # chunks), so completion_cost() fails and the request is recorded with
+            # $0 spend. The real model is still known via the inferred model_group
+            # ("passthrough/<provider>/<model>"); recover it so cost tracking works
+            # across all pass-through providers (openai/cohere/vertex_ai/...).
+            if not model or model == "unknown":
+                recovered_model = get_model_from_passthrough_model_group(logging_obj)
+                if recovered_model:
+                    model = recovered_model
+
+            # record the resolved model up-front so a cost-calc failure cannot
+            # leave SpendLogs with model="unknown".
+            if model and model != "unknown":
+                logging_obj.model_call_details["model"] = model
+
             response_cost = litellm.completion_cost(
                 completion_response=litellm_model_response,
                 model=model,
@@ -116,6 +149,9 @@ class BasePassthroughLoggingHandler(ABC):
 
             kwargs["response_cost"] = response_cost
             kwargs["model"] = model
+            # the pass-through success path reads SpendLogs spend from
+            # model_call_details["response_cost"] (not from kwargs); record it here too.
+            logging_obj.model_call_details["response_cost"] = response_cost
             passthrough_logging_payload: Optional[PassthroughStandardLoggingPayload] = (  # type: ignore
                 kwargs.get("passthrough_logging_payload")
             )
@@ -193,18 +229,36 @@ class BasePassthroughLoggingHandler(ABC):
         """
 
         model = request_body.get("model", "")
+        # recover the model from the inferred model_group if still unknown.
+        if not model or model == "unknown":
+            recovered_model = get_model_from_passthrough_model_group(
+                litellm_logging_obj
+            )
+            if recovered_model:
+                model = recovered_model
+        if model and model != "unknown":
+            litellm_logging_obj.model_call_details["model"] = model
+
         complete_streaming_response = self._build_complete_streaming_response(
             all_chunks=all_chunks,
             litellm_logging_obj=litellm_logging_obj,
             model=model,
         )
         if complete_streaming_response is None:
+            # do not silently drop — record the resolved model so the request is
+            # still attributed (instead of model="unknown" / dropped entirely).
             verbose_proxy_logger.error(
-                "Unable to build complete streaming response for Anthropic passthrough endpoint, not logging..."
+                "Unable to build complete streaming response for %s passthrough endpoint "
+                "(model=%s); recording model with $0 cost.",
+                self.llm_provider_name,
+                model,
             )
+            if model and model != "unknown":
+                litellm_logging_obj.model_call_details["model"] = model
+            litellm_logging_obj.model_call_details.setdefault("response_cost", 0.0)
             return {
                 "result": None,
-                "kwargs": {},
+                "kwargs": {"model": model, "response_cost": 0.0},
             }
         kwargs = self._create_response_logging_payload(
             litellm_model_response=complete_streaming_response,

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -285,8 +285,11 @@ class PassThroughStreamingHandler:
         Returns:
             List of string lines, with each line being a complete data: {} chunk
         """
-        # Combine all bytes and decode to string
-        combined_str = b"".join(raw_bytes).decode("utf-8")
+        # Combine all bytes and decode to string. errors="replace" so a stream
+        # that was cut mid-multibyte-sequence (client disconnect / mid-stream failure) still
+        # decodes and logs the usage events already received, instead of raising and
+        # dropping the whole request from SpendLogs.
+        combined_str = b"".join(raw_bytes).decode("utf-8", errors="replace")
 
         # Split by newlines and filter out empty lines
         lines = [line.strip() for line in combined_str.split("\n") if line.strip()]


### PR DESCRIPTION
## Summary

Streaming and pass-through requests could be logged with `$0` cost, `model="unknown"`, or dropped from SpendLogs **entirely** — while the upstream provider still billed every token. This consolidates fixes for the distinct leak paths into one change, plus a key-identification improvement for budget errors.

## Scenarios fixed (and why each is needed)

Each item is a concrete path where spend was silently lost, which breaks cost attribution, budget enforcement, and chargeback.

1. **Pass-through request logged with `model="unknown"` → priced at $0.**
   `/anthropic/v1/messages`, `/openai/...` etc. reach logging before the model is resolved, so `completion_cost()` cannot price the request.
   → Recover `<provider>/<model>` from the inferred `model_group` in the central cost calculator and the per-provider handlers, and record the resolved model on the logging object **up-front** so a later failure can't leave `model="unknown"`.

2. **`stream_chunk_builder` *raises* on large / agentic streams → the whole request is dropped.**
   Tool-use / thinking / web-search streams can make assembly re-raise (as `APIError`) from **inside** the success handler / `except StopIteration`, so it escapes `__next__` / `__anext__` and the Anthropic pass-through handler. The request never reaches SpendLogs even though every token was billed.
   → Catch the raise in the core `CustomStreamWrapper` (sync **and** async) and in the Anthropic handler, and treat it the same as a `None` result.

3. **Usage-only fallback undercount.**
   When full assembly fails, rebuild usage from the `message_start` / `message_delta` SSE events via `AnthropicConfig.calculate_usage` — the same path the success case uses — so prompt tokens are cache-inclusive and `cache_read` / `cache_write` / `web_search` / geo tokens are priced correctly. The previous fallback (`Usage(...)` + `setattr`) left those fields unset, so they were priced at $0.

4. **Stream dies mid-flight → zero usage logged.**
   Client disconnect / request timeout / mid-stream provider error: success-only logging records nothing, though the provider billed the tokens generated before the failure.
   → `_log_partial_usage_on_stream_error()` assembles partial usage from the chunks already received and logs it via the normal success path, called from the failure/timeout handlers. Best-effort: it never raises and never masks the original streaming error.

5. **A stream cut mid-multibyte-sequence dropped the whole request.**
   `b"".join(raw_bytes).decode("utf-8")` raised, discarding all usage events already received.
   → decode with `errors="replace"`.

6. **Streaming pass-through spend not persisted.**
   The pass-through success path reads spend from `model_call_details["response_cost"]`, not from `kwargs`, so streaming pass-through logged $0 even when the cost was computed.
   → record `response_cost` (and the resolved model) into `model_call_details`.

7. **Opaque virtual-key budget errors.**
   `BudgetExceededError` for a virtual key didn't name the key, forcing operators to reverse-map a spend figure back to a key during an incident.
   → include the key alias + masked key (which carries the last 4 chars) in the error message.

## Repro (headline case — items 1–3)

1. Configure an Anthropic pass-through route on the proxy.
2. Send a **streaming** `POST /anthropic/v1/messages` request that exercises tool-use or a long agentic turn (enough that `stream_chunk_builder` can't reassemble it) — or disconnect the client mid-stream.
3. Inspect SpendLogs for the request:
   - **Before:** recorded with `$0` cost / `model="unknown"`, or missing entirely.
   - **After:** token usage and cost are recorded from the SSE usage events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
