### PR TITLE
feat(proxy): allow llm_api_routes virtual keys to list MCP tools via /v1/mcp/tools

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -461,6 +461,7 @@ class LiteLLMRoutes(enum.Enum):
         "/mcp/tools/call",
         "/mcp-rest/tools/list",
         "/mcp-rest/tools/call",
+        "/v1/mcp/tools",
     ]
 
     # MCP server CRUD routes — control-plane. Gated by DISABLE_ADMIN_ENDPOINTS.

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -403,6 +403,34 @@ def test_virtual_key_llm_api_routes_rejects_mcp_multi_segment_admin_subpaths(
     assert exc_info.value.status_code == 403
 
 
+@pytest.mark.parametrize("method", ["GET", "POST"])
+def test_virtual_key_llm_api_routes_allows_v1_mcp_tools(method):
+    """Regression test: virtual keys with allowed_routes=["llm_api_routes"] must
+    be able to list MCP tools via GET /v1/mcp/tools.
+
+    The proxy already exposes `/mcp/tools/list` and `/mcp-rest/tools/list` to
+    llm_api_routes keys, so the equivalent `/v1/mcp/tools` discovery endpoint
+    must be reachable too. Unlike `/v1/mcp/server`, this path has no
+    management write counterpart, so it lives directly in `mcp_inference_routes`
+    rather than behind a method-aware carve-out.
+    """
+
+    assert RouteChecks.is_llm_api_route(route="/v1/mcp/tools") is True
+
+    valid_token = UserAPIKeyAuth(
+        user_id="test_user",
+        allowed_routes=["llm_api_routes"],
+    )
+
+    result = RouteChecks.is_virtual_key_allowed_to_call_route(
+        route="/v1/mcp/tools",
+        valid_token=valid_token,
+        request=_mock_request(method),
+    )
+
+    assert result is True
+
+
 def test_spend_logs_v2_classified_as_management_not_llm_api():
     """Paginated spend logs are a management/spend read route, not an LLM API."""
 

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -403,19 +403,33 @@ def test_virtual_key_llm_api_routes_rejects_mcp_multi_segment_admin_subpaths(
     assert exc_info.value.status_code == 403
 
 
-@pytest.mark.parametrize("method", ["GET", "POST"])
-def test_virtual_key_llm_api_routes_allows_v1_mcp_tools(method):
-    """Regression test: virtual keys with allowed_routes=["llm_api_routes"] must
-    be able to list MCP tools via GET /v1/mcp/tools.
+@pytest.mark.parametrize(
+    "route, method",
+    [
+        ("/mcp", "POST"),
+        ("/mcp/", "POST"),
+        ("/mcp/my-server", "POST"),  # matches the /mcp/{subpath} pattern
+        ("/mcp/tools", "GET"),
+        ("/mcp/tools/list", "POST"),
+        ("/mcp/tools/call", "POST"),
+        ("/mcp-rest/tools/list", "GET"),
+        ("/mcp-rest/tools/call", "POST"),
+        ("/v1/mcp/tools", "GET"),
+    ],
+)
+def test_virtual_key_llm_api_routes_allows_mcp_inference_endpoints(route, method):
+    """Every MCP inference/discovery endpoint must be reachable by virtual keys
+    scoped to allowed_routes=["llm_api_routes"], the default the Create Key UI
+    applies.
 
-    The proxy already exposes `/mcp/tools/list` and `/mcp-rest/tools/list` to
-    llm_api_routes keys, so the equivalent `/v1/mcp/tools` discovery endpoint
-    must be reachable too. Unlike `/v1/mcp/server`, this path has no
-    management write counterpart, so it lives directly in `mcp_inference_routes`
-    rather than behind a method-aware carve-out.
+    /v1/mcp/tools is the most recent addition: before it joined this group a key
+    could list tools via /mcp/tools/list and /mcp-rest/tools/list but got a 403
+    on the equivalent /v1/mcp/tools. Unlike /v1/mcp/server, none of these paths
+    have a management write counterpart, so they live directly in
+    `mcp_inference_routes` rather than behind a method-aware carve-out.
     """
 
-    assert RouteChecks.is_llm_api_route(route="/v1/mcp/tools") is True
+    assert RouteChecks.is_llm_api_route(route=route) is True
 
     valid_token = UserAPIKeyAuth(
         user_id="test_user",
@@ -423,7 +437,7 @@ def test_virtual_key_llm_api_routes_allows_v1_mcp_tools(method):
     )
 
     result = RouteChecks.is_virtual_key_allowed_to_call_route(
-        route="/v1/mcp/tools",
+        route=route,
         valid_token=valid_token,
         request=_mock_request(method),
     )


### PR DESCRIPTION
## Relevant issues

Closes #31016 (the `/v1/mcp/tools` half; see below)

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Background

Issue #31016 asks for two things. The first, letting `llm_api_routes` keys hit GET `/v1/mcp/server` for server discovery, already shipped in v1.88.0 via #28442 as a method-aware (GET-only) carve-out in `is_virtual_key_allowed_to_call_route`. The issue's author tested on 1.87.0, which predates it. Worth noting the issue's literal proposal there (add `/v1/mcp/server` to the `llm_api_routes` list) would have been a security regression, since route matching is path-based, not method-aware, so it would also have granted POST/PUT/DELETE create/edit/delete on the same path to every `llm_api_routes` key. The shipped carve-out is the correct mechanism and is already in place.

This PR addresses the second, still-open half: GET `/v1/mcp/tools`

## Changes

`GET /v1/mcp/tools` returns the MCP tools available to the calling key, the same data already exposed through `/mcp/tools/list` and `/mcp-rest/tools/list`, both of which live in `llm_api_routes` via `mcp_inference_routes`. The `/v1/mcp/tools` path was in no route group at all, so virtual keys created from the UI (which default to `allowed_routes=["llm_api_routes"]`) got a 403 listing tools one way but not the other.

The fix adds `/v1/mcp/tools` to `mcp_inference_routes`. Unlike `/v1/mcp/server`, this path has no management write counterpart (it is GET-only), so it does not need a method-aware carve-out and can sit directly in the route group.

Added a regression test in `tests/test_litellm/proxy/auth/test_route_checks.py`, parametrized over the full set of MCP inference/discovery endpoints (`/mcp`, `/mcp/{subpath}`, `/mcp/tools`, `/mcp/tools/list`, `/mcp/tools/call`, `/mcp-rest/tools/list`, `/mcp-rest/tools/call`, `/v1/mcp/tools`), asserting that a key with `allowed_routes=["llm_api_routes"]` is allowed to call each and that `is_llm_api_route` classifies it correctly. The `/v1/mcp/tools` case fails before this change (403 / `is_llm_api_route` False) and passes after; the rest lock in the existing contract so a future edit cannot silently drop one.

## Screenshots / Proof of Fix

With a proxy running on localhost:4000, create a key scoped to `llm_api_routes` only and confirm it can now list MCP tools where it previously got a 403

```bash
# 1. Create a key with the same default the Create Key UI uses
KEY=$(curl -s http://localhost:4000/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"allowed_routes": ["llm_api_routes"]}' | jq -r .key)

# 2. List MCP tools with that key -> 200 after this change (was 403 before)
curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4000/v1/mcp/tools \
  -H "Authorization: Bearer $KEY"

# 3. See the actual tool payload
curl -s http://localhost:4000/v1/mcp/tools \
  -H "Authorization: Bearer $KEY" | jq .
```

## Type

🆕 New Feature
🐛 Bug Fix

