### PR TITLE
feat(ui): add Amazon Bedrock Mantle to the Add Model provider dropdown

### DIFF
--- a/litellm/proxy/public_endpoints/provider_create_fields.json
+++ b/litellm/proxy/public_endpoints/provider_create_fields.json
@@ -210,6 +210,114 @@
     "default_model_placeholder": "claude-3-opus"
   },
   {
+    "provider": "BedrockMantle",
+    "provider_display_name": "Amazon Bedrock Mantle",
+    "litellm_provider": "bedrock_mantle",
+    "credential_fields": [
+      {
+        "key": "api_key",
+        "label": "Bedrock Mantle API Key",
+        "placeholder": null,
+        "tooltip": "Bearer token for the Bedrock Mantle OpenAI-compatible endpoint. You can provide the raw token or the environment variable (e.g. `os.environ/BEDROCK_MANTLE_API_KEY`). Leave blank to authenticate with AWS SigV4 credentials instead.",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_access_key_id",
+        "label": "AWS Access Key ID",
+        "placeholder": null,
+        "tooltip": "Used for AWS SigV4 auth when no API key is set. You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`).",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_secret_access_key",
+        "label": "AWS Secret Access Key",
+        "placeholder": null,
+        "tooltip": "Used for AWS SigV4 auth when no API key is set. You can provide the raw key or the environment variable (e.g. `os.environ/MY_SECRET_KEY`).",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_session_token",
+        "label": "AWS Session Token",
+        "placeholder": null,
+        "tooltip": "Temporary credentials session token. You can provide the raw token or the environment variable (e.g. `os.environ/MY_SESSION_TOKEN`).",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_region_name",
+        "label": "AWS Region Name",
+        "placeholder": "us-east-1",
+        "tooltip": "Region of the Bedrock Mantle endpoint. Defaults to us-east-1. You can provide the raw value or the environment variable (e.g. `os.environ/AWS_REGION_NAME`).",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_session_name",
+        "label": "AWS Session Name",
+        "placeholder": "my-session",
+        "tooltip": "Name for the AWS session. You can provide the raw value or the environment variable (e.g. `os.environ/MY_SESSION_NAME`).",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_profile_name",
+        "label": "AWS Profile Name",
+        "placeholder": "default",
+        "tooltip": "AWS profile name to use for authentication. You can provide the raw value or the environment variable (e.g. `os.environ/MY_PROFILE_NAME`).",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_role_name",
+        "label": "AWS Role Name",
+        "placeholder": "MyRole",
+        "tooltip": "AWS IAM role name to assume. You can provide the raw value or the environment variable (e.g. `os.environ/MY_ROLE_NAME`).",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "aws_web_identity_token",
+        "label": "AWS Web Identity Token",
+        "placeholder": null,
+        "tooltip": "Web identity token for OIDC authentication. You can provide the raw token or the environment variable (e.g. `os.environ/MY_WEB_IDENTITY_TOKEN`).",
+        "required": false,
+        "field_type": "password",
+        "options": null,
+        "default_value": null
+      },
+      {
+        "key": "api_base",
+        "label": "API Base",
+        "placeholder": "https://bedrock-mantle.us-east-1.api.aws",
+        "tooltip": "Optional. Custom Bedrock Mantle endpoint. Defaults to https://bedrock-mantle.<region>.api.aws. You can provide the raw value or the environment variable (e.g. `os.environ/BEDROCK_MANTLE_API_BASE`).",
+        "required": false,
+        "field_type": "text",
+        "options": null,
+        "default_value": null
+      }
+    ],
+    "default_model_placeholder": "bedrock_mantle/openai.gpt-oss-120b"
+  },
+  {
     "provider": "Anthropic",
     "provider_display_name": "Anthropic",
     "litellm_provider": "anthropic",

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -201,6 +201,48 @@ def test_anthropic_provider_fields_support_byok():
     ), "api_base must appear before api_key in credential_fields (matches AI21 and ANTHROPIC_TEXT convention)."
 
 
+def test_bedrock_mantle_provider_fields():
+    """Amazon Bedrock Mantle must be a selectable provider in the Add Model flow.
+
+    The dropdown is driven entirely by /public/providers/fields, so a missing
+    entry means Mantle cannot be added through the UI at all (regression guard
+    for LIT-3885). The credential fields must match what the backend actually
+    honors: an optional bearer api_key (BYOK), the AWS SigV4 chain, a region,
+    and an api_base override.
+    """
+    app_instance = FastAPI()
+    app_instance.include_router(router)
+    test_client = TestClient(app_instance)
+
+    response = test_client.get("/public/providers/fields")
+    assert response.status_code == 200
+    providers = response.json()
+
+    mantle = next((p for p in providers if p["provider"] == "BedrockMantle"), None)
+    assert mantle is not None, "Bedrock Mantle provider entry not found"
+
+    # provider must equal the UI provider_map key so the model dropdown resolves
+    # bedrock_mantle models; litellm_provider must be the backend slug.
+    assert mantle["provider_display_name"] == "Amazon Bedrock Mantle"
+    assert mantle["litellm_provider"] == "bedrock_mantle"
+    assert mantle["default_model_placeholder"].startswith("bedrock_mantle/")
+
+    fields_by_key = {f["key"]: f for f in mantle["credential_fields"]}
+
+    # Bearer-token auth is BYOK: optional and masked.
+    assert "api_key" in fields_by_key
+    assert fields_by_key["api_key"]["required"] is False
+    assert fields_by_key["api_key"]["field_type"] == "password"
+
+    # AWS SigV4 fallback credentials.
+    assert fields_by_key["aws_access_key_id"]["field_type"] == "password"
+    assert fields_by_key["aws_secret_access_key"]["field_type"] == "password"
+    assert "aws_region_name" in fields_by_key
+
+    # api_base override so admins can target a custom Mantle host without env access.
+    assert fields_by_key["api_base"]["field_type"] == "text"
+
+
 def test_google_ai_studio_provider_fields_expose_api_base():
     """The Google AI Studio (gemini) credential form must let admins set a custom
     api_base so they can point at a Gemini-compatible gateway (e.g. a self-hosted

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -62,6 +62,22 @@ describe("provider_info_helpers", () => {
       expect(result.logo).toBe(providerLogoMap[Providers.Groq]);
     });
 
+    it("should map bedrock_mantle slug to Bedrock Mantle display name and logo", () => {
+      const result = getProviderLogoAndName("bedrock_mantle");
+      expect(result.displayName).toBe(Providers.BedrockMantle);
+      expect(result.logo).toBe(providerLogoMap[Providers.BedrockMantle]);
+    });
+
+    it("should resolve the BedrockMantle enum key to the Bedrock Mantle logo", () => {
+      // The Add Model dropdown passes the provider_map key ("BedrockMantle"),
+      // not the slug ("bedrock_mantle"). Unlike "Bedrock", the key does not
+      // lowercase-match its slug, so without the enum-key fallback this would
+      // render a blank fallback logo for a Bedrock variant (LIT-3885).
+      const result = getProviderLogoAndName("BedrockMantle");
+      expect(result.displayName).toBe(Providers.BedrockMantle);
+      expect(result.logo).toBe(providerLogoMap[Providers.BedrockMantle]);
+    });
+
     it("should handle provider values case-insensitively", () => {
       const result = getProviderLogoAndName("OPENAI");
       expect(result.displayName).toBe(Providers.OpenAI);
@@ -304,6 +320,23 @@ describe("provider_info_helpers", () => {
       expect(result).toContain("bedrock-converse-model");
       expect(result).toContain("bedrock-mantle-model");
       expect(result).not.toContain("openai-model");
+    });
+
+    it("should return only bedrock_mantle models when called with 'BedrockMantle' provider key", () => {
+      // Selecting "Amazon Bedrock Mantle" in the dropdown must populate the
+      // model field with the Mantle models and exclude the regular Bedrock
+      // ones, so onboarding a gpt-oss model is a one-click flow (LIT-3885).
+      const modelMap = {
+        "bedrock_mantle/openai.gpt-oss-120b": { litellm_provider: "bedrock_mantle" },
+        "bedrock_mantle/openai.gpt-5.5": { litellm_provider: "bedrock_mantle" },
+        "bedrock-base": { litellm_provider: "bedrock" },
+        "bedrock-converse-model": { litellm_provider: "bedrock_converse" },
+      };
+      const result = getProviderModels("BedrockMantle" as Providers, modelMap);
+      expect(result).toContain("bedrock_mantle/openai.gpt-oss-120b");
+      expect(result).toContain("bedrock_mantle/openai.gpt-5.5");
+      expect(result).not.toContain("bedrock-base");
+      expect(result).not.toContain("bedrock-converse-model");
     });
 
     it("should include fireworks_ai-embedding-models when called with 'FireworksAI' provider key", () => {

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -318,10 +318,12 @@ export const getProviderLogoAndName = (providerValue: string): { logo: string; d
     return { logo, displayName };
   }
 
-  // Find the enum key by matching provider_map values
-  const enumKey = Object.keys(provider_map).find(
-    (key) => provider_map[key].toLowerCase() === providerValue.toLowerCase(),
-  );
+  // Resolve by the litellm provider slug (e.g. "bedrock_mantle"); fall back to
+  // the enum key (e.g. "BedrockMantle") for callers like the Add Model dropdown
+  // that pass the key instead of the slug.
+  const enumKey =
+    Object.keys(provider_map).find((key) => provider_map[key].toLowerCase() === providerValue.toLowerCase()) ??
+    Object.keys(provider_map).find((key) => key.toLowerCase() === providerValue.toLowerCase());
 
   if (!enumKey) {
     return { logo: "", displayName: providerValue };


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3885

## Linear ticket

[LIT-3885](https://linear.app/litellm-ai/issue/LIT-3885/add-bedrock-mantle-openai-models-through-ui)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile returned 5/5)

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The provider dropdown in the Add Model flow is populated entirely from `provider_create_fields.json` (served at `/public/providers/fields`), so the fix is verifiable directly against a running proxy and in the UI.

1. Start a proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Confirm Bedrock Mantle is now returned by the endpoint that drives the dropdown:

```
curl -s http://localhost:4000/public/providers/fields \
  | jq '.[] | select(.provider=="BedrockMantle")'
```

Expected: an entry with `provider_display_name: "Amazon Bedrock Mantle"`, `litellm_provider: "bedrock_mantle"`, and credential fields (`api_key`, the AWS SigV4 keys, `aws_region_name`, `api_base`).

3. In the UI go to http://localhost:4000/ui/?page=models, open the Add Model tab, and pick "Amazon Bedrock Mantle" from the Provider dropdown. The Bedrock logo renders next to it, the LiteLLM Model Name field lists the `bedrock_mantle/*` models from the cost map (e.g. `bedrock_mantle/openai.gpt-oss-120b`), and the credential form shows the API Key and AWS fields. Add `bedrock_mantle/openai.gpt-oss-120b` with a bearer token or AWS credentials and use Test Connect to send a real request.

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

Bedrock Mantle was already a first-class backend provider with models in the cost map and UI enum/logo entries, but it never appeared in the Add Model provider dropdown because the dropdown is sourced from `provider_create_fields.json` and that file had no `bedrock_mantle` entry. This adds the entry so the provider is selectable, its models populate from the cost map through the existing `getProviderModels` filter, and the credential form exposes what the provider actually honors: an optional bearer `api_key` for BYOK, the AWS SigV4 credential chain, `aws_region_name`, and an `api_base` override.

It also fixes `getProviderLogoAndName` so the provider logo resolves when the function is given the enum key (`BedrockMantle`), which the dropdown passes, rather than the slug. Previously only providers whose key lowercased to their slug (like `bedrock`) resolved a logo, so a Bedrock variant would otherwise fall back to a blank circle. The change is additive; every other caller passes the slug and keeps hitting the existing path.

Tests cover the new behavior: a backend regression test asserts the Mantle entry and its credential fields are served by `/public/providers/fields`, and UI tests assert the dropdown key resolves the Bedrock logo and that selecting Bedrock Mantle returns only the `bedrock_mantle` models
