### PR TITLE
fix(ui): label request logs column "Key Alias" to match filter

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -327,7 +327,7 @@ export const createColumns = (sortProps?: LogsSortProps): ColumnDef<LogEntry>[] 
     },
   },
   {
-    header: "Key Name",
+    header: "Key Alias",
     accessorKey: "metadata.user_api_key_alias",
     cell: (info: any) => (
       <Tooltip title={String(info.getValue() || "-")}>


### PR DESCRIPTION
## Summary

The request logs table had a column headed "Key Name" even though its value comes from `metadata.user_api_key_alias` and the page's own filter calls the same thing "Key Alias". This renames the column header to "Key Alias" so the table and the filter agree on one name.

## Screenshots

### Before
<!-- drag screenshot here -->

### After
<!-- drag screenshot here -->

## Test plan
- [x] Open the Logs page (http://localhost:4000/ui/?page=logs), confirm the column previously labeled "Key Name" now reads "Key Alias" and still shows the key's alias value
- [x] Open the "Key Alias" filter on the same page and confirm the column header and filter now use identical wording

## Type

🐛 Bug Fix

## Changes

Renamed the request logs table column header from "Key Name" to "Key Alias" in `ui/litellm-dashboard/src/components/view_logs/columns.tsx`

Resolves LIT-3903