### PR TITLE
fix(proxy): resolve env refs for DB-stored models

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1080,6 +1080,16 @@ _OPENAPI_HTTP_METHODS = {
 # `_SSO_SENSITIVE_FIELDS` / `_CACHE_SENSITIVE_FIELDS` constants in the SSO
 # and cache endpoint files.
 _ALERTING_SENSITIVE_VARS: Set[str] = {"SLACK_WEBHOOK_URL", "SMTP_PASSWORD"}
+_DB_LITELLM_PARAM_ENV_REF_KEYS = frozenset(
+    {
+        "api_key",
+        "client_secret",
+        "vertex_credentials",
+        "vertex_ai_credentials",
+        "aws_access_key_id",
+        "aws_secret_access_key",
+    }
+)
 
 
 def _strip_operation_id_method_suffix(operation_id: str) -> str:
@@ -5194,11 +5204,16 @@ class ProxyConfig:
         return deleted_deployments
 
     def _resolve_db_litellm_param(self, key: str, value: Any) -> Any:
+        if not isinstance(value, str):
+            return value
+
         decrypted_value = decrypt_value_helper(
             value=value, key=key, return_original_value=True
         )
-        if isinstance(decrypted_value, str) and decrypted_value.startswith(
-            "os.environ/"
+        if (
+            key in _DB_LITELLM_PARAM_ENV_REF_KEYS
+            and isinstance(decrypted_value, str)
+            and decrypted_value.startswith("os.environ/")
         ):
             return get_secret(decrypted_value)
         return decrypted_value
@@ -5223,10 +5238,7 @@ class ProxyConfig:
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
-                    if isinstance(v, str):
-                        _litellm_params[k] = self._resolve_db_litellm_param(
-                            key=k, value=v
-                        )
+                    _litellm_params[k] = self._resolve_db_litellm_param(key=k, value=v)
                 _litellm_params = LiteLLM_Params(**_litellm_params)
 
             else:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1092,6 +1092,23 @@ _DB_LITELLM_PARAM_ENV_REF_KEYS = frozenset(
 )
 
 
+def _db_model_is_team_scoped(model: Any) -> bool:
+    model_info = getattr(model, "model_info", None)
+    if isinstance(model_info, BaseModel):
+        return getattr(model_info, "team_id", None) is not None
+    if isinstance(model_info, str):
+        try:
+            model_info = json.loads(model_info)
+        except (TypeError, ValueError):
+            model_info = None
+    if isinstance(model_info, dict) and model_info.get("team_id") is not None:
+        return True
+    if getattr(model_info, "team_id", None) is not None:
+        return True
+    model_name = getattr(model, "model_name", None)
+    return isinstance(model_name, str) and model_name.startswith("model_name_")
+
+
 def _strip_operation_id_method_suffix(operation_id: str) -> str:
     base, separator, suffix = operation_id.rpartition("_")
     if separator and suffix in _OPENAPI_HTTP_METHODS:
@@ -5203,7 +5220,9 @@ class ProxyConfig:
                     deleted_deployments += 1
         return deleted_deployments
 
-    def _resolve_db_litellm_param(self, key: str, value: Any) -> Any:
+    def _resolve_db_litellm_param(
+        self, key: str, value: Any, resolve_env_refs: bool = True
+    ) -> Any:
         if not isinstance(value, str):
             return value
 
@@ -5211,7 +5230,8 @@ class ProxyConfig:
             value=value, key=key, return_original_value=True
         )
         if (
-            key in _DB_LITELLM_PARAM_ENV_REF_KEYS
+            resolve_env_refs
+            and key in _DB_LITELLM_PARAM_ENV_REF_KEYS
             and isinstance(decrypted_value, str)
             and decrypted_value.startswith("os.environ/")
         ):
@@ -5235,10 +5255,13 @@ class ProxyConfig:
         ## ADD MODEL LOGIC
         for m in db_models:
             _litellm_params = m.litellm_params
+            resolve_env_refs = not _db_model_is_team_scoped(m)
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
-                    _litellm_params[k] = self._resolve_db_litellm_param(key=k, value=v)
+                    _litellm_params[k] = self._resolve_db_litellm_param(
+                        key=k, value=v, resolve_env_refs=resolve_env_refs
+                    )
                 _litellm_params = LiteLLM_Params(**_litellm_params)
 
             else:
@@ -5266,12 +5289,15 @@ class ProxyConfig:
         _model_list: list = []
         for m in new_models:
             _litellm_params = m.litellm_params
+            resolve_env_refs = not _db_model_is_team_scoped(m)
             if isinstance(_litellm_params, BaseModel):
                 _litellm_params = _litellm_params.model_dump()
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
-                    _litellm_params[k] = self._resolve_db_litellm_param(key=k, value=v)
+                    _litellm_params[k] = self._resolve_db_litellm_param(
+                        key=k, value=v, resolve_env_refs=resolve_env_refs
+                    )
                 _litellm_params = LiteLLM_Params(**_litellm_params)
             else:
                 verbose_proxy_logger.error(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5193,6 +5193,16 @@ class ProxyConfig:
                     deleted_deployments += 1
         return deleted_deployments
 
+    def _resolve_db_litellm_param(self, key: str, value: Any) -> Any:
+        decrypted_value = decrypt_value_helper(
+            value=value, key=key, return_original_value=True
+        )
+        if isinstance(decrypted_value, str) and decrypted_value.startswith(
+            "os.environ/"
+        ):
+            return get_secret(decrypted_value)
+        return decrypted_value
+
     def _add_deployment(self, db_models: list) -> int:
         """
         Iterate through db models
@@ -5214,11 +5224,9 @@ class ProxyConfig:
                 # decrypt values
                 for k, v in _litellm_params.items():
                     if isinstance(v, str):
-                        # decrypt value - returns original value if decryption fails or no key is set
-                        _value = decrypt_value_helper(
-                            value=v, key=k, return_original_value=True
+                        _litellm_params[k] = self._resolve_db_litellm_param(
+                            key=k, value=v
                         )
-                        _litellm_params[k] = _value
                 _litellm_params = LiteLLM_Params(**_litellm_params)
 
             else:
@@ -5251,10 +5259,7 @@ class ProxyConfig:
             if isinstance(_litellm_params, dict):
                 # decrypt values
                 for k, v in _litellm_params.items():
-                    decrypted_value = decrypt_value_helper(
-                        value=v, key=k, return_original_value=True
-                    )
-                    _litellm_params[k] = decrypted_value
+                    _litellm_params[k] = self._resolve_db_litellm_param(key=k, value=v)
                 _litellm_params = LiteLLM_Params(**_litellm_params)
             else:
                 verbose_proxy_logger.error(

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 import os
 from types import SimpleNamespace
-from typing import Any, Dict, List, Optional
-from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -887,6 +887,34 @@ def test_ProxyConfig__add_deployment_invalid_litellm_params_skips(monkeypatch):
     assert pc._add_deployment(db_models=[bad]) == 0
 
 
+def test_ProxyConfig__add_deployment_resolves_env_refs_after_db_decrypt(monkeypatch):
+    monkeypatch.setenv("LITELLM_DB_MODEL_API_KEY", "resolved-secret")
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: value,
+    )
+    fake_router = MagicMock()
+    fake_router.upsert_deployment = MagicMock(return_value=True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", fake_router)
+    pc = ProxyConfig()
+    db_model = SimpleNamespace(
+        model_id="model-1",
+        model_name="env-model",
+        model_info={"id": "model-1"},
+        litellm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "os.environ/LITELLM_DB_MODEL_API_KEY",
+        },
+        blocked=False,
+    )
+
+    added = pc._add_deployment(db_models=[db_model])
+    deployment = fake_router.upsert_deployment.call_args.kwargs["deployment"]
+
+    assert added == 1
+    assert deployment.litellm_params.api_key == "resolved-secret"
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig.decrypt_model_list_from_db
 # ---------------------------------------------------------------------------
@@ -917,6 +945,33 @@ def test_ProxyConfig_decrypt_model_list_from_db_returns_decrypted(monkeypatch):
         "params_model": "gpt-4",
         "id_present": True,
     }
+
+
+def test_ProxyConfig_decrypt_model_list_from_db_resolves_env_refs_after_db_decrypt(
+    monkeypatch,
+):
+    monkeypatch.setenv("LITELLM_DB_MODEL_API_KEY", "resolved-secret")
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: (
+            "os.environ/LITELLM_DB_MODEL_API_KEY" if key == "api_key" else value
+        ),
+    )
+    pc = ProxyConfig()
+    m = SimpleNamespace(
+        model_id="model-1",
+        model_name="env-model",
+        model_info={"id": "model-1"},
+        litellm_params={
+            "api_key": "encrypted-env-ref",
+            "model": "openai/gpt-4o-mini",
+        },
+        blocked=False,
+    )
+
+    out = pc.decrypt_model_list_from_db(new_models=[m])
+
+    assert out[0]["litellm_params"]["api_key"] == "resolved-secret"
 
 
 def test_ProxyConfig_decrypt_model_list_from_db_invalid_params_skips():

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -918,6 +918,40 @@ def test_ProxyConfig__add_deployment_resolves_env_refs_after_db_decrypt(monkeypa
     assert deployment.litellm_params.api_base == "os.environ/LITELLM_MASTER_KEY"
 
 
+def test_ProxyConfig__add_deployment_keeps_team_env_refs_literal(monkeypatch):
+    def fail_on_call(secret_name, *args, **kwargs):
+        raise AssertionError("team DB models should not resolve env refs")
+
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "master-secret")
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: value,
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_secret", fail_on_call)
+    fake_router = MagicMock()
+    fake_router.upsert_deployment = MagicMock(return_value=True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", fake_router)
+    pc = ProxyConfig()
+    db_model = SimpleNamespace(
+        model_id="model-1",
+        model_name="model_name_team-1_abc",
+        model_info={"id": "model-1", "team_id": "team-1"},
+        litellm_params={
+            "model": "openai/gpt-4o-mini",
+            "api_key": "os.environ/LITELLM_MASTER_KEY",
+            "api_base": "https://attacker.example",
+        },
+        blocked=False,
+    )
+
+    added = pc._add_deployment(db_models=[db_model])
+    deployment = fake_router.upsert_deployment.call_args.kwargs["deployment"]
+
+    assert added == 1
+    assert deployment.litellm_params.api_key == "os.environ/LITELLM_MASTER_KEY"
+    assert deployment.litellm_params.api_base == "https://attacker.example"
+
+
 def test_ProxyConfig__resolve_db_litellm_param_skips_non_string_values(monkeypatch):
     def fail_on_call(value, key, return_original_value):
         raise AssertionError("decrypt_value_helper should only receive strings")
@@ -993,6 +1027,39 @@ def test_ProxyConfig_decrypt_model_list_from_db_resolves_env_refs_after_db_decry
 
     assert out[0]["litellm_params"]["api_key"] == "resolved-secret"
     assert out[0]["litellm_params"]["api_base"] == "os.environ/LITELLM_MASTER_KEY"
+
+
+def test_ProxyConfig_decrypt_model_list_from_db_keeps_team_env_refs_literal_after_db_decrypt(
+    monkeypatch,
+):
+    def fail_on_call(secret_name, *args, **kwargs):
+        raise AssertionError("team DB models should not resolve env refs")
+
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "master-secret")
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: (
+            "os.environ/LITELLM_MASTER_KEY" if key == "api_key" else value
+        ),
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_secret", fail_on_call)
+    pc = ProxyConfig()
+    m = SimpleNamespace(
+        model_id="model-1",
+        model_name="model_name_team-1_abc",
+        model_info={"id": "model-1", "team_id": "team-1"},
+        litellm_params={
+            "api_key": "encrypted-env-ref",
+            "api_base": "https://attacker.example",
+            "model": "openai/gpt-4o-mini",
+        },
+        blocked=False,
+    )
+
+    out = pc.decrypt_model_list_from_db(new_models=[m])
+
+    assert out[0]["litellm_params"]["api_key"] == "os.environ/LITELLM_MASTER_KEY"
+    assert out[0]["litellm_params"]["api_base"] == "https://attacker.example"
 
 
 def test_ProxyConfig_decrypt_model_list_from_db_invalid_params_skips():

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -889,6 +889,7 @@ def test_ProxyConfig__add_deployment_invalid_litellm_params_skips(monkeypatch):
 
 def test_ProxyConfig__add_deployment_resolves_env_refs_after_db_decrypt(monkeypatch):
     monkeypatch.setenv("LITELLM_DB_MODEL_API_KEY", "resolved-secret")
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "master-secret")
     monkeypatch.setattr(
         "litellm.proxy.proxy_server.decrypt_value_helper",
         lambda value, key, return_original_value: value,
@@ -904,6 +905,7 @@ def test_ProxyConfig__add_deployment_resolves_env_refs_after_db_decrypt(monkeypa
         litellm_params={
             "model": "openai/gpt-4o-mini",
             "api_key": "os.environ/LITELLM_DB_MODEL_API_KEY",
+            "api_base": "os.environ/LITELLM_MASTER_KEY",
         },
         blocked=False,
     )
@@ -913,6 +915,20 @@ def test_ProxyConfig__add_deployment_resolves_env_refs_after_db_decrypt(monkeypa
 
     assert added == 1
     assert deployment.litellm_params.api_key == "resolved-secret"
+    assert deployment.litellm_params.api_base == "os.environ/LITELLM_MASTER_KEY"
+
+
+def test_ProxyConfig__resolve_db_litellm_param_skips_non_string_values(monkeypatch):
+    def fail_on_call(value, key, return_original_value):
+        raise AssertionError("decrypt_value_helper should only receive strings")
+
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        fail_on_call,
+    )
+    pc = ProxyConfig()
+
+    assert pc._resolve_db_litellm_param(key="tpm", value=100) == 100
 
 
 # ---------------------------------------------------------------------------
@@ -951,10 +967,13 @@ def test_ProxyConfig_decrypt_model_list_from_db_resolves_env_refs_after_db_decry
     monkeypatch,
 ):
     monkeypatch.setenv("LITELLM_DB_MODEL_API_KEY", "resolved-secret")
+    monkeypatch.setenv("LITELLM_MASTER_KEY", "master-secret")
     monkeypatch.setattr(
         "litellm.proxy.proxy_server.decrypt_value_helper",
         lambda value, key, return_original_value: (
-            "os.environ/LITELLM_DB_MODEL_API_KEY" if key == "api_key" else value
+            "os.environ/LITELLM_DB_MODEL_API_KEY"
+            if key == "api_key"
+            else "os.environ/LITELLM_MASTER_KEY" if key == "api_base" else value
         ),
     )
     pc = ProxyConfig()
@@ -964,6 +983,7 @@ def test_ProxyConfig_decrypt_model_list_from_db_resolves_env_refs_after_db_decry
         model_info={"id": "model-1"},
         litellm_params={
             "api_key": "encrypted-env-ref",
+            "api_base": "encrypted-api-base-env-ref",
             "model": "openai/gpt-4o-mini",
         },
         blocked=False,
@@ -972,6 +992,7 @@ def test_ProxyConfig_decrypt_model_list_from_db_resolves_env_refs_after_db_decry
     out = pc.decrypt_model_list_from_db(new_models=[m])
 
     assert out[0]["litellm_params"]["api_key"] == "resolved-secret"
+    assert out[0]["litellm_params"]["api_base"] == "os.environ/LITELLM_MASTER_KEY"
 
 
 def test_ProxyConfig_decrypt_model_list_from_db_invalid_params_skips():


### PR DESCRIPTION
## Relevant issues

Fixes #30969

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Before this change, DB-backed model loading could leave a credential env reference literal after decrypting model params:

```text
decrypt_model_list_from_db(...).litellm_params.api_key = os.environ/LITELLM_RECON_KEY
```

After this change, non-team DB-backed models decrypt first and then resolve credential env refs such as `api_key`. Returned fields such as `api_base` keep literal `os.environ/...` references instead of exposing resolved server env values through model-info responses:

```text
decrypt_model_list_from_db(...).litellm_params.api_key = resolved-secret
decrypt_model_list_from_db(...).litellm_params.api_base = os.environ/LITELLM_MASTER_KEY
```

Team-scoped DB models still decrypt stored values, but `os.environ/...` refs stay literal even on credential fields. That prevents a team admin from binding arbitrary server env vars into outbound provider credentials:

```text
team_model.litellm_params.api_key = os.environ/LITELLM_MASTER_KEY
team_model.litellm_params.api_base = https://attacker.example
```

Validation command used for the direct repro:

```sh
uv run --no-sync python -c "import os; from types import SimpleNamespace; os.environ['LITELLM_RECON_KEY']='resolved-secret'; from litellm.proxy.proxy_server import ProxyConfig; pc=ProxyConfig(); db_model=SimpleNamespace(model_id='model-1', model_name='env-model', litellm_params={'model':'openai/gpt-4o-mini','api_key':'os.environ/LITELLM_RECON_KEY'}, model_info={'id':'model-1'}, blocked=False); out=pc.decrypt_model_list_from_db([db_model]); print(out[0]['litellm_params']['api_key'])"
```

Output:

```text
resolved-secret
```

Live proxy runbook with a real provider key:

1. Start a DB-backed proxy with a master key and a real provider key in the proxy process environment
2. Add a non-team DB-backed model with `/model/new` and set `litellm_params.api_key` to `os.environ/OPENAI_API_KEY`
3. Call `/v1/chat/completions` through the new proxy model
4. Expected result: the provider call succeeds with the resolved credential. Before this fix, the DB-backed path could pass the literal `os.environ/OPENAI_API_KEY` value

Example curl shape:

```sh
curl -s http://localhost:4000/model/new \
  -H "Authorization: Bearer sk-local-master-key" \
  -H "Content-Type: application/json" \
  -d '{"model_name":"db-env-model","litellm_params":{"model":"openai/gpt-4o-mini","api_key":"os.environ/OPENAI_API_KEY"}}'

curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-master-key" \
  -H "Content-Type: application/json" \
  -d '{"model":"db-env-model","messages":[{"role":"user","content":"ping"}],"max_tokens":8}'
```

## Type

Bug Fix

## Changes

DB-stored model params already went through `decrypt_value_helper`, but credential values like `api_key` did not run the `os.environ/...` resolution step used by config.yaml model_list entries. This keeps the decrypt step in both DB model paths, `_add_deployment` and `decrypt_model_list_from_db`, and resolves env refs only for non-team DB credential params that are stripped from model-info responses

Team-scoped DB models are excluded from env-ref resolution after decrypting. A team admin can still store their own raw provider credential, but `os.environ/...` values stay literal and cannot be used to exfiltrate proxy process secrets through a controlled provider endpoint

Regression tests cover both the deployment upsert path and the DB model-list decrypt path, including the encrypted case where decryption returns an `os.environ/...` reference. They also cover both security cases from review: `api_base` stays unresolved, and team-scoped model credentials do not resolve server env refs

Validation run:

```text
uv run --no-sync python -m py_compile litellm/proxy/proxy_server.py tests/test_litellm/proxy/proxy_server/test_proxy_config.py
uv run --no-sync black --check litellm/proxy/proxy_server.py tests/test_litellm/proxy/proxy_server/test_proxy_config.py
uv run --no-sync ruff check litellm/proxy/proxy_server.py tests/test_litellm/proxy/proxy_server/test_proxy_config.py
git --no-pager diff --check
uv run --no-sync pytest tests/test_litellm/proxy/proxy_server/test_proxy_config.py -q
uv run --no-sync pytest tests/test_litellm/proxy/proxy_server -q
```

Results:

```text
92 passed, 1 warning
541 passed, 38 warnings
```
