### PR TITLE
fix(proxy): resolve os.environ/ in DB-stored model litellm_params

### DIFF
--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -16,6 +16,29 @@ def _get_salt_key():
     return salt_key
 
 
+def decrypt_and_resolve_litellm_params(
+    litellm_params: dict[str, object],
+) -> dict[str, object]:
+    """
+    Decrypt each DB-stored litellm_param, then resolve ``os.environ/`` references
+    to their environment values - mirroring ``Router.set_model_list`` so DB-stored
+    models behave identically to ``config.yaml`` ones.
+    """
+    from litellm.secret_managers.main import get_secret_str
+
+    def resolve(key: str, value: object) -> object:
+        if not isinstance(value, str):
+            return value
+        decrypted = decrypt_value_helper(
+            value=value, key=key, return_original_value=True
+        )
+        if isinstance(decrypted, str) and decrypted.startswith("os.environ/"):
+            return get_secret_str(decrypted)
+        return decrypted
+
+    return {key: resolve(key, value) for key, value in litellm_params.items()}
+
+
 def encrypt_value_helper(value: str, new_encryption_key: Optional[str] = None):
     signing_key = new_encryption_key or _get_salt_key()
 

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -33,7 +33,14 @@ def decrypt_and_resolve_litellm_params(
             value=value, key=key, return_original_value=True
         )
         if isinstance(decrypted, str) and decrypted.startswith("os.environ/"):
-            return get_secret_str(decrypted)
+            resolved = get_secret_str(decrypted)
+            if resolved is None:
+                verbose_proxy_logger.warning(
+                    "os.environ/ reference '%s' not found in environment; setting %s=None",
+                    decrypted,
+                    key,
+                )
+            return resolved
         return decrypted
 
     return {key: resolve(key, value) for key, value in litellm_params.items()}

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5203,8 +5203,8 @@ class ProxyConfig:
         for m in db_models:
             _litellm_params = m.litellm_params
             if isinstance(_litellm_params, dict):
-                _litellm_params = LiteLLM_Params(
-                    **decrypt_and_resolve_litellm_params(_litellm_params)
+                _litellm_params = LiteLLM_Params.model_validate(
+                    decrypt_and_resolve_litellm_params(_litellm_params)
                 )
 
             else:
@@ -5235,8 +5235,8 @@ class ProxyConfig:
             if isinstance(_litellm_params, BaseModel):
                 _litellm_params = _litellm_params.model_dump()
             if isinstance(_litellm_params, dict):
-                _litellm_params = LiteLLM_Params(
-                    **decrypt_and_resolve_litellm_params(_litellm_params)
+                _litellm_params = LiteLLM_Params.model_validate(
+                    decrypt_and_resolve_litellm_params(_litellm_params)
                 )
             else:
                 verbose_proxy_logger.error(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -289,6 +289,7 @@ from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_pr
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_and_resolve_litellm_params,
     decrypt_value_helper,
     encrypt_value_helper,
 )
@@ -5202,15 +5203,9 @@ class ProxyConfig:
         for m in db_models:
             _litellm_params = m.litellm_params
             if isinstance(_litellm_params, dict):
-                # decrypt values
-                for k, v in _litellm_params.items():
-                    if isinstance(v, str):
-                        # decrypt value - returns original value if decryption fails or no key is set
-                        _value = decrypt_value_helper(
-                            value=v, key=k, return_original_value=True
-                        )
-                        _litellm_params[k] = _value
-                _litellm_params = LiteLLM_Params(**_litellm_params)
+                _litellm_params = LiteLLM_Params(
+                    **decrypt_and_resolve_litellm_params(_litellm_params)
+                )
 
             else:
                 verbose_proxy_logger.error(
@@ -5240,13 +5235,9 @@ class ProxyConfig:
             if isinstance(_litellm_params, BaseModel):
                 _litellm_params = _litellm_params.model_dump()
             if isinstance(_litellm_params, dict):
-                # decrypt values
-                for k, v in _litellm_params.items():
-                    decrypted_value = decrypt_value_helper(
-                        value=v, key=k, return_original_value=True
-                    )
-                    _litellm_params[k] = decrypted_value
-                _litellm_params = LiteLLM_Params(**_litellm_params)
+                _litellm_params = LiteLLM_Params(
+                    **decrypt_and_resolve_litellm_params(_litellm_params)
+                )
             else:
                 verbose_proxy_logger.error(
                     f"Invalid model added to proxy db. Invalid litellm params. litellm_params={_litellm_params}"

--- a/tests/test_litellm/proxy/common_utils/test_encrypt_decrypt_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_encrypt_decrypt_utils.py
@@ -1,3 +1,5 @@
+import logging
+
 from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_and_resolve_litellm_params,
 )
@@ -21,3 +23,15 @@ def test_decrypt_and_resolve_litellm_params_passes_plain_values_through():
 def test_decrypt_and_resolve_litellm_params_leaves_non_string_values_untouched():
     out = decrypt_and_resolve_litellm_params({"timeout": 30, "stream": True})
     assert out == {"timeout": 30, "stream": True}
+
+
+def test_decrypt_and_resolve_litellm_params_warns_on_missing_env_var(
+    monkeypatch, caplog
+):
+    monkeypatch.delenv("MY_MISSING_KEY", raising=False)
+    with caplog.at_level(logging.WARNING):
+        out = decrypt_and_resolve_litellm_params(
+            {"api_key": "os.environ/MY_MISSING_KEY", "model": "gpt-4o"}
+        )
+    assert out == {"api_key": None, "model": "gpt-4o"}
+    assert "MY_MISSING_KEY" in caplog.text

--- a/tests/test_litellm/proxy/common_utils/test_encrypt_decrypt_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_encrypt_decrypt_utils.py
@@ -1,0 +1,23 @@
+from litellm.proxy.common_utils.encrypt_decrypt_utils import (
+    decrypt_and_resolve_litellm_params,
+)
+
+
+def test_decrypt_and_resolve_litellm_params_resolves_os_environ(monkeypatch):
+    monkeypatch.setenv("MY_RESOLVE_KEY", "sk-resolved")
+    out = decrypt_and_resolve_litellm_params(
+        {"api_key": "os.environ/MY_RESOLVE_KEY", "model": "gpt-4o"}
+    )
+    assert out == {"api_key": "sk-resolved", "model": "gpt-4o"}
+
+
+def test_decrypt_and_resolve_litellm_params_passes_plain_values_through():
+    out = decrypt_and_resolve_litellm_params(
+        {"api_key": "sk-literal", "model": "gpt-4o"}
+    )
+    assert out == {"api_key": "sk-literal", "model": "gpt-4o"}
+
+
+def test_decrypt_and_resolve_litellm_params_leaves_non_string_values_untouched():
+    out = decrypt_and_resolve_litellm_params({"timeout": 30, "stream": True})
+    assert out == {"timeout": 30, "stream": True}

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -929,6 +929,43 @@ def test_ProxyConfig_decrypt_model_list_from_db_invalid_params_skips():
     assert out == []
 
 
+def test_ProxyConfig_decrypt_model_list_from_db_resolves_os_environ(monkeypatch):
+    monkeypatch.setenv("MY_DB_MODEL_KEY", "sk-resolved-from-env")
+    pc = ProxyConfig()
+    m = SimpleNamespace(
+        model_id="m-1",
+        model_name="gpt-4o",
+        model_info={"id": "m-1"},
+        litellm_params={"api_key": "os.environ/MY_DB_MODEL_KEY", "model": "gpt-4o"},
+        blocked=False,
+    )
+    out = pc.decrypt_model_list_from_db(new_models=[m])
+    assert out[0]["litellm_params"]["api_key"] == "sk-resolved-from-env"
+
+
+def test_ProxyConfig__add_deployment_resolves_os_environ(monkeypatch):
+    monkeypatch.setenv("MY_DB_MODEL_KEY", "sk-resolved-from-env")
+    captured = {}
+
+    def capture(deployment):
+        captured["api_key"] = deployment.litellm_params.api_key
+        return deployment
+
+    fake_router = MagicMock()
+    fake_router.upsert_deployment = MagicMock(side_effect=capture)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", fake_router)
+    pc = ProxyConfig()
+    m = SimpleNamespace(
+        model_id="m-1",
+        model_name="gpt-4o",
+        model_info={"id": "m-1"},
+        litellm_params={"api_key": "os.environ/MY_DB_MODEL_KEY", "model": "gpt-4o"},
+        blocked=False,
+    )
+    pc._add_deployment(db_models=[m])
+    assert captured["api_key"] == "sk-resolved-from-env"
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig._update_llm_router
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

Fixes #30969

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

With `STORE_MODEL_IN_DB=true` and `LITELLM_SALT_KEY` set, run the proxy and reproduce end to end against a real provider. The point is that the env var reference resolves; the dummy value below is just to show the literal string is no longer what gets sent.

1. Start the proxy with a real key exported under an env var:

```
export OPENAI_API_KEY_DB_TEST="$OPENAI_API_KEY"
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Add a DB-stored model whose `api_key` is an `os.environ/` reference:

```
curl -s http://localhost:4000/model/new \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model_name": "db-os-environ-test",
    "litellm_params": {
      "model": "openai/gpt-4o-mini",
      "api_key": "os.environ/OPENAI_API_KEY_DB_TEST"
    }
  }'
```

3. Call the model; it should succeed (before this fix it 401s because `os.environ/OPENAI_API_KEY_DB_TEST` was sent verbatim as the bearer token):

```
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "db-os-environ-test",
    "messages": [{"role": "user", "content": "say hi in one word"}]
  }'
```

A `200` with a normal completion confirms the `os.environ/` reference was resolved before the upstream call.

## Type

🐛 Bug Fix

## Changes

`os.environ/` resolution was only applied in `Router.set_model_list`, the path config.yaml models take. DB-stored models reach the router via `ProxyConfig._add_deployment` and `ProxyConfig.decrypt_model_list_from_db`, which decrypted each `litellm_param` but never ran the resolution, so a value like `api_key: os.environ/MY_KEY` was handed to the deployment as the literal string and every external call 401'd.

Both DB paths now share a new `decrypt_and_resolve_litellm_params` helper in `encrypt_decrypt_utils.py` that decrypts each value and then resolves `os.environ/`-prefixed strings via `get_secret_str`, mirroring `set_model_list`. This also collapses the two duplicated decrypt loops into one helper, so the resolution can't go missing from one path again.

Tests cover both DB paths (`decrypt_model_list_from_db` and `_add_deployment`) asserting an `os.environ/` reference resolves to the real env value, plus unit tests on the helper for plain-string passthrough and non-string values. Removing the resolution line makes the three regression tests fail, so they pin the bug.