### PR TITLE
fix(proxy): allow clearing empty-collection user fields via /user/update

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1127,6 +1127,15 @@ def _process_keys_for_user_info(
     return returned_keys
 
 
+# Real LiteLLM_UserTable columns whose empty value ([] / {}) is a deliberate
+# "clear it". The caller dumps with exclude_unset, so an empty value here always
+# means the field was sent on purpose and must reach the DB instead of being
+# dropped by the generic empty-collection filter below.
+USER_FIELDS_CLEARABLE_WHEN_SET = frozenset(
+    {"models", "allowed_cache_controls", "model_max_budget"}
+)
+
+
 def _update_internal_user_params(
     data_json: dict, data: Union[UpdateUserRequest, UpdateUserRequestNoUserIDorEmail]
 ) -> dict:
@@ -1137,6 +1146,9 @@ def _update_internal_user_params(
         if k == "max_budget":
             if "max_budget" in fields_set:
                 non_default_values[k] = v
+        elif k in USER_FIELDS_CLEARABLE_WHEN_SET:
+            if k in fields_set:
+                non_default_values[k] = v
         elif (
             v is not None
             and v
@@ -1145,7 +1157,7 @@ def _update_internal_user_params(
                 {},
             )
             and k not in LiteLLM_ManagementEndpoint_MetadataFields
-        ):  # models default to [], spend defaults to 0, we should not reset these values
+        ):  # drop [] / {} so list/dict fields left unset aren't reset to empty
             non_default_values[k] = v
 
     is_internal_user = False

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1696,6 +1696,52 @@ def test_update_internal_user_params_keeps_original_max_budget_when_not_provided
     assert "user_alias" in non_default_values
 
 
+@pytest.mark.parametrize(
+    "field, empty_value",
+    [
+        ("models", []),
+        ("allowed_cache_controls", []),
+        ("model_max_budget", {}),
+    ],
+)
+def test_update_internal_user_params_clears_empty_collection_field(field, empty_value):
+    """
+    Regression for LIT-3888: an explicitly provided empty list/dict for a real
+    user column must reach the DB update so the field can be cleared via
+    /user/update. Previously [] / {} were filtered out as "defaults" and the old
+    values persisted.
+    """
+    data = UpdateUserRequest(user_id="test_user", **{field: empty_value})
+    data_json = data.model_dump(exclude_unset=True)
+
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    assert field in non_default_values
+    assert non_default_values[field] == empty_value
+
+
+def test_update_internal_user_params_sets_personal_models():
+    """A non-empty models list is still applied unchanged."""
+    data = UpdateUserRequest(user_id="test_user", models=["gpt-4o"])
+    data_json = data.model_dump(exclude_unset=True)
+
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    assert non_default_values["models"] == ["gpt-4o"]
+
+
+def test_update_internal_user_params_keeps_clearable_fields_when_not_provided():
+    """When a clearable field is omitted, its column must be left untouched."""
+    data = UpdateUserRequest(user_id="test_user", user_alias="test_alias")
+    data_json = data.model_dump(exclude_unset=True)
+
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    assert "models" not in non_default_values
+    assert "allowed_cache_controls" not in non_default_values
+    assert "model_max_budget" not in non_default_values
+
+
 def test_generate_request_base_validator():
     """
     Test that GenerateRequestBase validator converts empty string to None for max_budget


### PR DESCRIPTION
## Relevant issues

Addresses PROBLEM 2 of LIT-3888 ("Personal models can't be deleted"), extended to the sibling user fields that share the same root cause. The other problems in that ticket (empty-list-means-everything precedence, budget precedence, hierarchy docs) are out of scope here and tracked separately

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3888 (PROBLEM 2)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Root cause

`/user/update` builds its database update with `_update_internal_user_params`, which dumps the request with `exclude_unset=True` and then drops any value equal to `[]` or `{}`:

```python
elif (
    v is not None
    and v not in ([], {})
    and k not in LiteLLM_ManagementEndpoint_MetadataFields
):
    non_default_values[k] = v
```

Because `exclude_unset=True` already removes fields the caller never sent, the empty-collection filter only ever fires on values the caller set on purpose. So an explicit empty value (a user clearing the field) was treated the same as "not provided", never reached the `user` row, and the previous value persisted. This affected every real user column that defaults to an empty collection: `models`, `allowed_cache_controls` and `model_max_budget`. The same helper backs `/user/bulk_update`, so both endpoints were affected

The fix routes those three columns through the same `fields_set` check `max_budget` already uses: apply the value whenever it was explicitly sent, including when it is empty. `config`, `permissions` and `aliases` are not columns on `LiteLLM_UserTable`, so they intentionally keep going through the empty-collection filter and never reach Prisma

## Screenshots / Proof of Fix

Live proxy against a real Postgres. Create an internal user with `models` and `allowed_cache_controls` populated, then try to clear both with empty lists and read back with `/user/info`

Before the fix (current `litellm_internal_staging`), the cleared values come back:

```
### create user with models + allowed_cache_controls populated
create status=200
BEFORE clear:
  models= ['gpt-5.5'] | allowed_cache_controls= ['no-cache']
### user/update clearing both (models=[], allowed_cache_controls=[])
update status=200
AFTER clear (BUGGY -> both come back):
  models= ['gpt-5.5'] | allowed_cache_controls= ['no-cache']
```

After the fix, the same sequence clears both:

```
### create user with models + allowed_cache_controls populated
create status=200
BEFORE clear:
  models= ['gpt-5.5'] | allowed_cache_controls= ['no-cache']
### user/update clearing both (models=[], allowed_cache_controls=[])
update status=200
AFTER clear (FIXED -> both empty):
  models= [] | allowed_cache_controls= []
```

`model_max_budget` shares the identical code path but requires an enterprise license to set a non-empty value, so it cannot be populated for a before/after on this proxy; it is covered by the unit test below instead. The exact commands used:

```bash
K="$LITELLM_MASTER_KEY"; B=http://localhost:4000; U=lit3888_demo
curl -s -X POST $B/user/new -H "Authorization: Bearer $K" -H 'Content-Type: application/json' \
  -d "{\"user_id\":\"$U\",\"user_role\":\"internal_user\",\"models\":[\"gpt-5.5\"],\"allowed_cache_controls\":[\"no-cache\"]}"
curl -s "$B/user/info?user_id=$U" -H "Authorization: Bearer $K"
curl -s -X POST $B/user/update -H "Authorization: Bearer $K" -H 'Content-Type: application/json' \
  -d "{\"user_id\":\"$U\",\"models\":[],\"allowed_cache_controls\":[]}"
curl -s "$B/user/info?user_id=$U" -H "Authorization: Bearer $K"
```

## Tests

`tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py` parametrizes `_update_internal_user_params` over `models: []`, `allowed_cache_controls: []` and `model_max_budget: {}`, asserting each reaches the update payload (all three fail on the unfixed code). It also keeps a non-empty `models` passthrough case and an omitted-field case proving the columns are left untouched when not sent

## CI note

`make lint-basedpyright` fails on this branch with `reportMissingTypeStubs: 82 over cap 37`. That same failure reproduces on `litellm_internal_staging` with this PR's changes reverted, so it is pre-existing budget drift on the base branch and not introduced here. I did not move the ceiling in this PR

## Type

🐛 Bug Fix

## Changes

`_update_internal_user_params` now applies an explicitly provided value (including an empty list or dict) for the real user columns that default to empty collections (`models`, `allowed_cache_controls`, `model_max_budget`) instead of filtering empty collections out, so those fields can be cleared through `/user/update` and `/user/bulk_update`
