### PR TITLE
fix(proxy): serialize team budget_limits to JSON in jsonify_team_object

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3792,6 +3792,10 @@ class PrismaClient:
             db_data["members_with_roles"], list
         ):
             db_data["members_with_roles"] = json.dumps(db_data["members_with_roles"])
+        if db_data.get("budget_limits", None) is not None and isinstance(
+            db_data["budget_limits"], list
+        ):
+            db_data["budget_limits"] = json.dumps(db_data["budget_limits"])
         return db_data
 
     # Define a retrying strategy with exponential backoff

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_get_data.py
@@ -105,6 +105,33 @@ def test_jsonify_team_object_converts_members_to_json_string(
     }
 
 
+def test_jsonify_team_object_converts_budget_limits_to_json_string(
+    prisma_client: PrismaClient,
+) -> None:
+    data = {
+        "team_id": "t1",
+        "budget_limits": [
+            {
+                "budget_duration": "1d",
+                "max_budget": 10.0,
+                "reset_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "budget_duration": "7d",
+                "max_budget": 50.0,
+                "reset_at": "2026-01-07T00:00:00Z",
+            },
+        ],
+        "models": ["gpt-4"],
+    }
+    result = prisma_client.jsonify_team_object(data)
+    assert result == {
+        "team_id": "t1",
+        "budget_limits": json.dumps(data["budget_limits"]),
+        "models": ["gpt-4"],
+    }
+
+
 def test_jsonify_team_object_error_on_non_dict(prisma_client: PrismaClient) -> None:
     with pytest.raises(AttributeError):
         prisma_client.jsonify_team_object(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`POST /team/new` with one or more budget windows against a proxy on the unpatched branch:

```
$ curl -s http://localhost:4061/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"team_alias":"acme","budget_limits":[{"budget_duration":"1d","max_budget":10.0},{"budget_duration":"7d","max_budget":50.0}]}'

{"error":{"message":"Unable to match input value to any allowed input type for the field. Parse errors: [... `budget_limits` should be of any of the following types: `NullableJsonNullValueInput`, ... `budget_limits` should be of any of the following types: `Json`] ...","type":"internal_server_error","code":"500"}}
```

Same request after the fix:

```
$ curl -s http://localhost:4061/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"team_alias":"acme","budget_limits":[{"budget_duration":"1d","max_budget":10.0},{"budget_duration":"7d","max_budget":50.0}]}'

{
  "team_id": "1e1f19b9-67b3-462e-af86-2795229c03f3",
  "team_alias": "acme",
  "budget_limits": [
    {"budget_duration": "1d", "max_budget": 10.0, "reset_at": "2026-06-24T00:00:00Z"},
    {"budget_duration": "7d", "max_budget": 50.0, "reset_at": "2026-06-29T00:00:00Z"}
  ]
}
```

The created row is stored as a JSON array in the `budget_limits` column with each window's `reset_at` initialized. `/team/update` and `/key/generate` with `budget_limits` were unaffected before and after the change

## Type

🐛 Bug Fix

## Changes

`POST /team/new` returned a 500 whenever `budget_limits` was supplied because the team write went through `PrismaClient.jsonify_team_object`, which serializes the `members_with_roles` list to a JSON string but never did the same for `budget_limits`. Prisma's `Json?` column rejects a raw Python list, so the insert failed before anything was written. `/team/update` and `/key/generate` dodged this only because each path calls `json.dumps` on the windows itself before handing them to Prisma; `/team/new` relied on the shared helper, which had no branch for the field

The fix adds the missing `budget_limits` serialization in `jsonify_team_object`, right next to the existing `members_with_roles` branch, guarded by `isinstance(list)` so the `/team/update` path (which already pre-serializes to a string) is untouched and there is no double-encoding. The regression test pins the new behavior and also asserts that a `models` value, which maps to a Postgres `String[]` array rather than a `Json` column, is left as a list, so the test fails on any change that naively serializes every list field
