### PR TITLE
fix(guardrails): mask Responses API input in Presidio pre-call hook

### DIFF
--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -35,6 +35,17 @@ def is_text_content_call_type(call_type: str) -> bool:
     return call_type in TEXT_CONTENT_CALL_TYPES
 
 
+# Content-part ``type`` values that carry inspectable text. Chat Completions
+# (and Anthropic) use ``"text"``; the Responses API uses ``"input_text"`` for
+# prompt input and ``"output_text"`` for prior model output replayed in
+# conversation state. All three keep the fragment under the ``"text"`` key, so
+# recognising the Responses variants here is enough to extract and rewrite them
+# — otherwise ``{"type": "input_text", ...}`` parts slip past masking entirely.
+TEXT_CONTENT_PART_TYPES: FrozenSet[str] = frozenset(
+    {"text", "input_text", "output_text"}
+)
+
+
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
     multimodal list). Non-text parts (images, audio, …) are skipped."""
@@ -51,7 +62,7 @@ def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
                 continue
             if not isinstance(part, dict):
                 continue
-            if part.get("type") == "text":
+            if part.get("type") in TEXT_CONTENT_PART_TYPES:
                 text = part.get("text")
                 if isinstance(text, str) and text:
                     yield text
@@ -117,7 +128,7 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                     new_parts.append(visit(part))
                 elif (
                     isinstance(part, dict)
-                    and part.get("type") == "text"
+                    and part.get("type") in TEXT_CONTENT_PART_TYPES
                     and isinstance(part.get("text"), str)
                     and part["text"]
                 ):
@@ -156,7 +167,7 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                 input_value[idx] = visit(item)
             elif (
                 isinstance(item, dict)
-                and item.get("type") == "text"
+                and item.get("type") in TEXT_CONTENT_PART_TYPES
                 and isinstance(item.get("text"), str)
                 and item["text"]
             ):

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -18,13 +18,14 @@ from typing import Any, Callable, Dict, FrozenSet, Iterator, List
 #
 #   /v1/chat/completions   -> "acompletion"
 #   /v1/responses          -> "aresponses"
+#   /v1/messages           -> "anthropic_messages"
 #
 # ``"completion"`` is included for SDK / internal callers that invoke
 # ``pre_call_hook`` directly with the sync name. Embedding, moderation,
 # audio, and transcription endpoints are deliberately excluded — text
 # guardrails on those paths are a separate scope.
 TEXT_CONTENT_CALL_TYPES: FrozenSet[str] = frozenset(
-    {"completion", "acompletion", "aresponses"}
+    {"completion", "acompletion", "aresponses", "anthropic_messages"}
 )
 
 

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -73,14 +73,25 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
     if isinstance(input_value, str):
         return [{"role": "user", "content": input_value}]
     if isinstance(input_value, list):
-        if input_value and all(
-            isinstance(item, dict) and "role" in item for item in input_value
-        ):
-            return list(input_value)
-        # Mixed lists (content-part dicts + bare strings) and pure
-        # string/dict lists all become a single user message; the content
-        # iterator below handles each element type uniformly.
-        return [{"role": "user", "content": input_value}]
+        # Responses ``input`` is a heterogeneous item array: message items
+        # (with ``role``), loose content-part dicts / bare strings, and
+        # non-message items (function_call, function_call_output, reasoning, …).
+        # Handle each independently — an ``all(role)`` check would misclassify a
+        # message item the moment a tool item is mixed in, wrapping the whole
+        # list as one message's content and dropping the real message's text.
+        messages: List[Dict[str, Any]] = []
+        loose_parts: List[Any] = []
+        for item in input_value:
+            if isinstance(item, dict) and "role" in item:
+                messages.append(item)
+            elif isinstance(item, str) or (
+                isinstance(item, dict) and item.get("type") in TEXT_CONTENT_PART_TYPES
+            ):
+                loose_parts.append(item)
+            # else: non-message input item carries no user/assistant prose.
+        if loose_parts:
+            messages.append({"role": "user", "content": loose_parts})
+        return messages
     return []
 
 
@@ -152,27 +163,25 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
             data["input"] = visit(input_value)
         return visited
     if isinstance(input_value, list):
-        # List of full messages: rewrite each message's content.
-        if input_value and all(
-            isinstance(item, dict) and "role" in item for item in input_value
-        ):
-            for item in input_value:
-                if "content" in item:
-                    item["content"] = _rewrite_content(item["content"])
-            return visited
-        # List of content parts and/or bare strings: rewrite in place.
+        # Heterogeneous Responses item array — rewrite each item independently:
+        # message items (with ``role``) have their ``content`` rewritten, loose
+        # content-part dicts / bare strings are rewritten in place, and
+        # non-message items (function_call_output, …) are left untouched. A
+        # message item mixed with tool items must not be skipped.
         for idx, item in enumerate(input_value):
             if isinstance(item, str) and item:
                 visited += 1
                 input_value[idx] = visit(item)
-            elif (
-                isinstance(item, dict)
-                and item.get("type") in TEXT_CONTENT_PART_TYPES
-                and isinstance(item.get("text"), str)
-                and item["text"]
-            ):
-                visited += 1
-                input_value[idx] = {**item, "text": visit(item["text"])}
+            elif isinstance(item, dict):
+                if "role" in item and "content" in item:
+                    item["content"] = _rewrite_content(item["content"])
+                elif (
+                    item.get("type") in TEXT_CONTENT_PART_TYPES
+                    and isinstance(item.get("text"), str)
+                    and item["text"]
+                ):
+                    visited += 1
+                    input_value[idx] = {**item, "text": visit(item["text"])}
         return visited
 
     return visited

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -44,6 +44,7 @@ from litellm.integrations.custom_guardrail import (
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails._content_utils import (
+    is_text_content_call_type,
     iter_message_text,
     walk_user_text,
 )
@@ -747,6 +748,16 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         """
 
         try:
+            # Only mask request types that carry free-form prompt text
+            # (chat completions, Responses API, Anthropic messages). Embedding,
+            # moderation, and audio payloads also expose `input`, but the
+            # masking path below rewrites text fragments in place — running it
+            # on an embedding `input` would silently mutate the payload. This is
+            # the shared gate used by the other text guardrails; the pre-refactor
+            # hook got this implicitly by reading only `data["messages"]`.
+            if not is_text_content_call_type(call_type):
+                return data
+
             content_safety = data.get("content_safety", None)
             verbose_proxy_logger.debug("content_safety: %s", content_safety)
             presidio_config = self.get_presidio_settings_from_request_data(data)

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -43,6 +43,10 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails._content_utils import (
+    iter_message_text,
+    walk_user_text,
+)
 from litellm.types.guardrails import (
     GuardrailEventHooks,
     LitellmParams,
@@ -746,66 +750,35 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             content_safety = data.get("content_safety", None)
             verbose_proxy_logger.debug("content_safety: %s", content_safety)
             presidio_config = self.get_presidio_settings_from_request_data(data)
-            messages = data.get("messages", None)
-            if messages is None:
+
+            # Collect every text fragment from BOTH `messages` and the
+            # Responses-API `input` field. A hook that only reads
+            # `data["messages"]` silently skips `/v1/responses` input; the
+            # shared `_content_utils` helpers normalise both request shapes.
+            fragments = list(dict.fromkeys(iter_message_text(data)))
+            if not fragments:
                 return data
-            tasks = []
-            task_mappings: List[Tuple[int, Optional[int]]] = (
-                []
-            )  # Track (message_index, content_index) for each task
 
-            for msg_idx, m in enumerate(messages):
-                content = m.get("content", None)
-                if content is None:
-                    continue
-                if isinstance(content, str):
-                    tasks.append(
-                        self.check_pii(
-                            text=content,
-                            output_parse_pii=self.output_parse_pii,
-                            presidio_config=presidio_config,
-                            request_data=data,
-                        )
+            # Mask each unique fragment via the analyzer in parallel.
+            masked = await asyncio.gather(
+                *[
+                    self.check_pii(
+                        text=fragment,
+                        output_parse_pii=self.output_parse_pii,
+                        presidio_config=presidio_config,
+                        request_data=data,
                     )
-                    task_mappings.append(
-                        (msg_idx, None)
-                    )  # None indicates string content
-                elif isinstance(content, list):
-                    for content_idx, c in enumerate(content):
-                        text_str = c.get("text", None)
-                        if text_str is None:
-                            continue
-                        tasks.append(
-                            self.check_pii(
-                                text=text_str,
-                                output_parse_pii=self.output_parse_pii,
-                                presidio_config=presidio_config,
-                                request_data=data,
-                            )
-                        )
-                        task_mappings.append((msg_idx, int(content_idx)))
+                    for fragment in fragments
+                ]
+            )
+            mask_map = dict(zip(fragments, masked))
 
-            responses = await asyncio.gather(*tasks)
-
-            # Map responses back to the correct message and content item
-            for task_idx, r in enumerate(responses):
-                mapping = task_mappings[task_idx]
-                msg_idx = cast(int, mapping[0])
-                content_idx_optional = cast(Optional[int], mapping[1])
-                content = messages[msg_idx].get("content", None)
-                if content is None:
-                    continue
-                if isinstance(content, str) and content_idx_optional is None:
-                    messages[msg_idx][
-                        "content"
-                    ] = r  # replace content with redacted string
-                elif isinstance(content, list) and content_idx_optional is not None:
-                    messages[msg_idx]["content"][content_idx_optional]["text"] = r
+            # Rewrite the request body in place across `messages` and `input`.
+            walk_user_text(data, lambda text: mask_map.get(text, text))
 
             verbose_proxy_logger.debug(
-                f"Presidio PII Masking: Redacted pii message: {data['messages']}"
+                "Presidio PII Masking: redacted request body (messages + input)"
             )
-            data["messages"] = messages
             return data
         except Exception as e:
             raise e

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -567,6 +567,40 @@ async def test_responses_api_input_text_content_parts_are_masked(
 
 
 @pytest.mark.asyncio
+async def test_responses_api_mixed_input_items_are_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """Responses `input` can mix a role message with non-message items (e.g.
+    function_call_output) for tool use. The message's PII must still be masked
+    while the tool item is left untouched (issue #30728 / veria-ai review)."""
+    test_data = {
+        "input": [
+            {"role": "user", "content": "my card is 4111-1111-1111-1111"},
+            {"type": "function_call_output", "call_id": "c1", "output": "done"},
+        ],
+        "model": "gpt-4o",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("4111-1111-1111-1111", "[CREDIT_CARD]")
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aresponses",
+    )
+    assert result["input"][0]["content"] == "my card is [CREDIT_CARD]"
+    assert result["input"][1] == {
+        "type": "function_call_output",
+        "call_id": "c1",
+        "output": "done",
+    }
+    assert "4111-1111-1111-1111" not in str(result["input"])
+
+
+@pytest.mark.asyncio
 async def test_both_messages_and_input_are_masked(
     presidio_guardrail, mock_user_api_key, mock_cache
 ):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -529,6 +529,44 @@ async def test_responses_api_input_role_messages_are_masked(
 
 
 @pytest.mark.asyncio
+async def test_responses_api_input_text_content_parts_are_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """Responses API `input` carries prompt text as `input_text` content parts;
+    these must be masked too (issue #30728 / veria-ai review). The earlier
+    refactor only recognised Chat-Completions `text` parts, so `input_text`
+    slipped through unmasked while non-text parts stay untouched."""
+    test_data = {
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "card 4111-1111-1111-1111"},
+                    {"type": "input_image", "image_url": "https://x/y.png"},
+                ],
+            }
+        ],
+        "model": "gpt-4o",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("4111-1111-1111-1111", "[CREDIT_CARD]")
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aresponses",
+    )
+    content = result["input"][0]["content"]
+    assert content[0] == {"type": "input_text", "text": "card [CREDIT_CARD]"}
+    # Non-text part must be left untouched.
+    assert content[1] == {"type": "input_image", "image_url": "https://x/y.png"}
+    assert "4111-1111-1111-1111" not in str(result["input"])
+
+
+@pytest.mark.asyncio
 async def test_both_messages_and_input_are_masked(
     presidio_guardrail, mock_user_api_key, mock_cache
 ):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -477,6 +477,85 @@ async def test_no_messages_field(presidio_guardrail, mock_user_api_key, mock_cac
 
 
 @pytest.mark.asyncio
+async def test_responses_api_input_string_is_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """The Responses API carries the prompt in data['input'] (string), which
+    must be masked like chat `messages` (issue #30728)."""
+    test_data = {
+        "input": "My email is test@example.com and card 4111-1111-1111-1111",
+        "model": "gpt-4o",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("test@example.com", "[EMAIL]").replace(
+            "4111-1111-1111-1111", "[CREDIT_CARD]"
+        )
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aresponses",
+    )
+    assert result["input"] == "My email is [EMAIL] and card [CREDIT_CARD]"
+    assert "test@example.com" not in result["input"]
+    assert "4111-1111-1111-1111" not in result["input"]
+
+
+@pytest.mark.asyncio
+async def test_responses_api_input_role_messages_are_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """Responses API `input` given as a list of role messages must be masked."""
+    test_data = {
+        "input": [{"role": "user", "content": "Contact me at test@example.com"}],
+        "model": "gpt-4o",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("test@example.com", "[EMAIL]")
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aresponses",
+    )
+    assert result["input"][0]["content"] == "Contact me at [EMAIL]"
+    assert "test@example.com" not in result["input"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_both_messages_and_input_are_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """When both `messages` and `input` are present, both must be masked."""
+    test_data = {
+        "messages": [{"role": "user", "content": "msg card 4111-1111-1111-1111"}],
+        "input": "input email test@example.com",
+        "model": "gpt-4o",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("4111-1111-1111-1111", "[CREDIT_CARD]").replace(
+            "test@example.com", "[EMAIL]"
+        )
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aresponses",
+    )
+    assert result["messages"][0]["content"] == "msg card [CREDIT_CARD]"
+    assert result["input"] == "input email [EMAIL]"
+
+
+@pytest.mark.asyncio
 async def test_logging_hook_multimodal_message_format(presidio_guardrail):
     """
     Test Presidio async_logging_hook with multimodal message format for completion call type.

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -556,6 +556,61 @@ async def test_both_messages_and_input_are_masked(
 
 
 @pytest.mark.asyncio
+async def test_non_text_call_type_input_is_not_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """Embedding/moderation calls also expose `data['input']`, but the masking
+    path rewrites text in place and must not mutate non-text payloads. The
+    pre-refactor hook skipped these implicitly by reading only `messages`;
+    the call-type guard preserves that (issue #30728 review feedback)."""
+    test_data = {
+        "input": ["My email is test@example.com", "card 4111-1111-1111-1111"],
+        "model": "text-embedding-3-small",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        raise AssertionError("check_pii should not run for embedding call_type")
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="aembedding",
+    )
+    # Payload returned untouched.
+    assert result["input"] == [
+        "My email is test@example.com",
+        "card 4111-1111-1111-1111",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_input_is_masked(
+    presidio_guardrail, mock_user_api_key, mock_cache
+):
+    """`/v1/messages` (call_type 'anthropic_messages') carries chat text and must
+    be masked — it is part of the text-content call-type set."""
+    test_data = {
+        "messages": [{"role": "user", "content": "Contact me at test@example.com"}],
+        "model": "claude-3-opus-20240229",
+    }
+
+    async def mock_check_pii(text, output_parse_pii, presidio_config, request_data):
+        return text.replace("test@example.com", "[EMAIL]")
+
+    presidio_guardrail.check_pii = mock_check_pii
+    result = await presidio_guardrail.async_pre_call_hook(
+        user_api_key_dict=mock_user_api_key,
+        cache=mock_cache,
+        data=test_data,
+        call_type="anthropic_messages",
+    )
+    assert result["messages"][0]["content"] == "Contact me at [EMAIL]"
+    assert "test@example.com" not in result["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_logging_hook_multimodal_message_format(presidio_guardrail):
     """
     Test Presidio async_logging_hook with multimodal message format for completion call type.

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -66,6 +66,30 @@ def test_iter_message_text_responses_api_list_input_content_parts():
     assert list(iter_message_text(data)) == ["alpha", "beta"]
 
 
+def test_iter_message_text_responses_api_input_text_parts():
+    """veria-ai: Responses API carries prompt text as ``input_text`` parts (and
+    replays model output as ``output_text``); both must be inspected, not just
+    the Chat-Completions ``text`` type."""
+    data = {
+        "input": [
+            {"type": "input_text", "text": "ssn 078-05-1120"},
+            {"type": "input_image", "image_url": "..."},
+            {"type": "output_text", "text": "echoed 078-05-1120"},
+        ]
+    }
+    assert list(iter_message_text(data)) == ["ssn 078-05-1120", "echoed 078-05-1120"]
+
+
+def test_iter_message_text_responses_api_input_text_in_role_messages():
+    data = {
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "alpha"}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "beta"}]},
+        ]
+    }
+    assert list(iter_message_text(data)) == ["alpha", "beta"]
+
+
 def test_iter_message_text_responses_api_list_input_mixed_dicts_and_strings():
     """Greptile P2: mixed-list ``input`` with content-part dicts AND bare
     strings must yield every text fragment — read helpers used to truncate
@@ -158,6 +182,43 @@ def test_walk_user_text_redacts_responses_api_list_input():
     assert visited == 1
     assert data["input"][0] == {"type": "text", "text": "[redacted]AKIAEXAMPLE[/]"}
     assert data["input"][1] == {"type": "image_url", "image_url": {"url": "..."}}
+
+
+def test_walk_user_text_redacts_input_text_parts():
+    """veria-ai: ``input_text`` content parts (top-level Responses input list)
+    must be rewritten in place, not skipped, so the PII is actually masked."""
+    data = {
+        "input": [
+            {"type": "input_text", "text": "AKIAEXAMPLE"},
+            {"type": "input_image", "image_url": "..."},
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("AKIAEXAMPLE", "[REDACTED]"))
+    assert visited == 1
+    assert data["input"][0] == {"type": "input_text", "text": "[REDACTED]"}
+    assert data["input"][1] == {"type": "input_image", "image_url": "..."}
+
+
+def test_walk_user_text_redacts_input_text_and_output_text_in_role_messages():
+    data = {
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "AKIAEXAMPLE"}]},
+            {
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "saw AKIAEXAMPLE"}],
+            },
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("AKIAEXAMPLE", "[REDACTED]"))
+    assert visited == 2
+    assert data["input"][0]["content"][0] == {
+        "type": "input_text",
+        "text": "[REDACTED]",
+    }
+    assert data["input"][1]["content"][0] == {
+        "type": "output_text",
+        "text": "saw [REDACTED]",
+    }
 
 
 def test_walk_user_text_redacts_mixed_list_input():

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -90,6 +90,19 @@ def test_iter_message_text_responses_api_input_text_in_role_messages():
     assert list(iter_message_text(data)) == ["alpha", "beta"]
 
 
+def test_iter_message_text_responses_mixed_message_and_tool_items():
+    """veria-ai: a Responses ``input`` array mixing a role message with a
+    non-message item (e.g. function_call_output) must still surface the
+    message's text — the old all-or-nothing role check dropped it."""
+    data = {
+        "input": [
+            {"role": "user", "content": "card 4111-1111-1111-1111"},
+            {"type": "function_call_output", "call_id": "c1", "output": "done"},
+        ]
+    }
+    assert list(iter_message_text(data)) == ["card 4111-1111-1111-1111"]
+
+
 def test_iter_message_text_responses_api_list_input_mixed_dicts_and_strings():
     """Greptile P2: mixed-list ``input`` with content-part dicts AND bare
     strings must yield every text fragment — read helpers used to truncate
@@ -218,6 +231,25 @@ def test_walk_user_text_redacts_input_text_and_output_text_in_role_messages():
     assert data["input"][1]["content"][0] == {
         "type": "output_text",
         "text": "saw [REDACTED]",
+    }
+
+
+def test_walk_user_text_redacts_mixed_message_and_tool_items():
+    """veria-ai: in a mixed Responses ``input`` array the role message's
+    content is masked in place while non-message items stay untouched."""
+    data = {
+        "input": [
+            {"role": "user", "content": "card 4111-1111-1111-1111"},
+            {"type": "function_call_output", "call_id": "c1", "output": "done"},
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("4111-1111-1111-1111", "[CARD]"))
+    assert visited == 1
+    assert data["input"][0]["content"] == "card [CARD]"
+    assert data["input"][1] == {
+        "type": "function_call_output",
+        "call_id": "c1",
+        "output": "done",
     }
 
 


### PR DESCRIPTION
## Summary

Part of #30728 (problem 2 of 3). The Presidio PII masking pre-call hook only read `data["messages"]` and returned early when it was `None`, so **`/v1/responses` requests — whose prompt lives in `data["input"]` — were never masked**. PII in a Responses API prompt reached the provider unredacted.

## Change

`async_pre_call_hook` now routes text extraction and in-place rewrite through the existing shared helpers in `litellm/proxy/guardrails/_content_utils.py`:

- `iter_message_text(data)` collects every text fragment from **both** `messages` and `input`.
- each unique fragment is masked via `check_pii` in parallel (as before).
- `walk_user_text(data, ...)` rewrites the request body in place across both fields.

This also removes the bespoke message/content index-mapping loop in favour of the shared, tested helpers (net −27 lines).

## Scope / behaviour

- `messages` behaviour is unchanged — every existing test passes (the helpers handle `str` content and `{"type": "text", ...}` parts the same way the old code did).
- Covered Responses API `input` shapes: a plain string, and a list of role messages.
- **Not in this PR:** bare `{"type": "input_text", ...}` content-part lists. `_content_utils` (shared by 6 guardrails) only recognises `type == "text"` today; teaching it `input_text` is a broader change best done separately so all guardrails benefit. Problems 1 (fail-closed on analyzer error) and 3 (streaming output) are also tracked as separate PRs.

## Tests

Added `test_responses_api_input_string_is_masked`, `test_responses_api_input_role_messages_are_masked`, `test_both_messages_and_input_are_masked`. Full file: 66 passed; `_content_utils` suite: 27 passed; mypy/ruff/black clean.
