### PR TITLE
fix(realtime): stop revalidating realtime events at the logging boundary

### DIFF
--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -37,6 +37,8 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    SkipValidation,
+    field_serializer,
     field_validator,
 )
 from typing_extensions import Required, TypedDict
@@ -3610,9 +3612,19 @@ class LiteLLMBatch(Batch):
 
 
 class LiteLLMRealtimeStreamLoggingObject(LiteLLMPydanticObjectBase):
-    results: OpenAIRealtimeStreamList
+    # Events are already well-formed provider dicts. Validating them against the
+    # OpenAIRealtimeEvents union makes Pydantic try every member per event, which
+    # floods thousands of ValidationErrors for events outside the union (e.g.
+    # rate_limits.updated), blocks the event loop, and discards the session usage.
+    results: SkipValidation[OpenAIRealtimeStreamList]
     usage: Usage
     _hidden_params: dict = {}
+
+    @field_serializer("results")
+    def _serialize_results(
+        self, results: OpenAIRealtimeStreamList
+    ) -> List[Dict[str, Any]]:
+        return [dict(event) for event in results]
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -505,6 +505,74 @@ def test_realtime_logging_object_allows_null_transcript_in_conversation_item_add
     assert logging_result.results[0]["item"]["content"][0]["transcript"] is None
 
 
+def test_realtime_logging_object_does_not_validate_unknown_event_types():
+    """
+    A realtime session emits events outside the OpenAIRealtimeEvents union (e.g.
+    rate_limits.updated, response.function_call_arguments.delta). Building the
+    logging object must not revalidate every event against the union; doing so
+    produces thousands of Pydantic ValidationErrors per session, blocks the event
+    loop, and the raised error discards the session's usage. The events must
+    survive verbatim, the combined usage must be preserved, and serialization
+    must stay clean.
+    """
+    import warnings
+
+    results: OpenAIRealtimeStreamList = [
+        {"type": "session.created", "event_id": "ev0", "session": {"id": "s"}},
+    ]
+    for i in range(50):
+        results += [
+            {
+                "type": "rate_limits.updated",
+                "event_id": f"rl{i}",
+                "rate_limits": [{"name": "requests", "limit": 1000, "remaining": 900}],
+            },
+            {
+                "type": "response.function_call_arguments.delta",
+                "event_id": f"fc{i}",
+                "delta": "{}",
+            },
+            {
+                "type": "response.done",
+                "event_id": f"rd{i}",
+                "response": {
+                    "usage": {
+                        "input_tokens": 4,
+                        "output_tokens": 6,
+                        "total_tokens": 10,
+                    }
+                },
+            },
+        ]
+
+    usage = RealtimeAPITokenUsageProcessor.collect_and_combine_usage_from_realtime_stream_results(
+        results=results
+    )
+    # On unfixed code this raises pydantic ValidationError instead of returning.
+    logging_result = RealtimeAPITokenUsageProcessor.create_logging_realtime_object(
+        usage=usage,
+        results=results,
+    )
+
+    assert logging_result.usage.total_tokens == 500
+    assert len(logging_result.results) == len(results)
+    unknown_types = {
+        r["type"]
+        for r in logging_result.results
+        if r["type"]
+        in ("rate_limits.updated", "response.function_call_arguments.delta")
+    }
+    assert unknown_types == {
+        "rate_limits.updated",
+        "response.function_call_arguments.delta",
+    }
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dumped = logging_result.model_dump()
+    assert len(dumped["results"]) == len(results)
+
+
 def test_realtime_transcription_duration_cost(monkeypatch):
     """
     gpt-realtime-whisper transcription sessions are billed by input audio duration


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/30581

## Linear ticket

Resolves LIT-3919 (realtime websocket audio: time-to-first-audio / dial degradation under load) and LIT-3920 (realtime usage/cost not tracked). Both reported symptoms are the same defect and are fixed by this one change.

## Why websocket audio streaming was affected

At session close the realtime logging object is built by `RealtimeAPITokenUsageProcessor.create_logging_realtime_object` -> `LiteLLMRealtimeStreamLoggingObject(results=...)`. `results` was typed as the strict `OpenAIRealtimeStreamList`, a 16-member `OpenAIRealtimeEvents` TypedDict union, so Pydantic revalidated every stored event against every union member. Events that fall outside that union (for example `rate_limits.updated` and `response.function_call_arguments.delta`, which get stored when `logged_real_time_event_types="*"`) fail all members and raise.

A ~281-event session produces 12,670 ValidationErrors in a single synchronous call. That work runs on the asyncio event loop. Realtime audio is delivered by forwarding frames through that same loop, so when sessions close (heavier with tool calls or full event logging) the flood stalls the loop and delays audio-frame delivery and dial for every other in-flight session, and trips readiness probes which restart pods. The same raised error aborts `async_success_handler`, so the combined usage is discarded and no cost or SpendLogs row is written.

So the audio streaming degradation is event-loop starvation under load, and the missing usage is the same exception aborting the logging path.

## The fix

Type `LiteLLMRealtimeStreamLoggingObject.results` as `SkipValidation[OpenAIRealtimeStreamList]` and serialize the events verbatim with a `field_serializer`. The already-formed event dicts are no longer revalidated at the logging boundary, so the flood disappears, the event loop stays responsive, and the combined usage survives to the cost calculator. The declared type is unchanged for readers; only the redundant validation is skipped.

## Screenshots / Proof of Fix

Realtime is a websocket protocol, so the harness is a short websocket client rather than curl.

Deterministic repro of the flood (a ~281-event session), before and after the fix:

```
# before (strict union)
combined usage total_tokens: 7000
RAISED: ValidationError -> 12670 validation errors for LiteLLMRealtimeStreamLoggingObject
elapsed_ms=12.7

# after (SkipValidation)
combined usage total_tokens: 7000
create_logging_realtime_object OK
elapsed_ms=0.0
```

Live proxy, same `config.yaml` (`logged_real_time_event_types: "*"`), same client, three realtime sessions per phase, BEFORE on the unfixed code and AFTER on this branch (each verified by which `litellm` path the proxy loaded):

```
# BEFORE (unfixed)
$ grep -c "validation errors for LiteLLMRealtimeStreamLoggingObject" before_proxy.log
9          # 3 floods per session: "61 validation errors for LiteLLMRealtimeStreamLoggingObject"
$ grep "Success_Call Error" before_proxy.log | tail -1
[Non-Blocking] LiteLLM.Success_Call Error: 61 validation errors for LiteLLMRealtimeStreamLoggingObject
$ docker exec litfix-pg psql -U litellm -d litellm -c 'select count(*) from "LiteLLM_SpendLogs";'
0          # logging aborted in the flood, usage discarded

# AFTER (this PR)
$ grep -c "validation errors for LiteLLMRealtimeStreamLoggingObject" after_proxy.log
0
$ grep -c "Success_Call Error" after_proxy.log
0
$ docker exec litfix-pg psql -U litellm -d litellm -c 'select count(*) from "LiteLLM_SpendLogs";'
3          # handler runs to completion, one row written per session
```

Audio-token billing is correct: a gpt-realtime-2 session's SpendLogs row matches the published pricing to the cent.

```
 model                 |  spend  | total_tokens | prompt_tokens | completion_tokens
-----------------------+---------+--------------+---------------+-------------------
 openai/gpt-realtime-2  | 0.01058 |          206 |            21 |               185

# 157 output audio tok x $6.4e-5 + 28 output text x $1.6e-5 + 21 input x $4e-6 = $0.01058
```

## Tests and regression review

New regression test `tests/test_litellm/test_cost_calculator.py::test_realtime_logging_object_does_not_validate_unknown_event_types`: builds a session containing event types outside the union and asserts `create_logging_realtime_object` does not raise, the combined usage is preserved, the unknown events survive, and `model_dump` is warning-free. It fails on the strict-union code (raises the ValidationError at `cost_calculator.py:2511`) and passes with the fix.

Suite runs on this branch:

```
tests/test_litellm/test_cost_calculator.py ............................ 71 passed
tests/test_litellm/litellm_core_utils/test_realtime_streaming.py ...... 79 passed
```

Regression review of the serialization path: the only consumer that serializes this object is the StandardLoggingPayload builder (`litellm/litellm_core_utils/litellm_logging.py:5666`, `init_response_obj.model_dump()`), whose result feeds the standard logging payload. For in-union events `model_dump()["results"]` is byte-identical to the input including nested `response.usage`, and `model_dump(mode="json")` / `.json()` are clean under `warnings.simplefilter("error")`. The cost calculator reads `completion_response.results` directly (`litellm/cost_calculator.py:1590`), read-only. Edge cases verified: empty results, all-valid events identical to before, and mixed valid plus out-of-union events all construct, preserve every event and the usage, and index correctly.

## Type

Bug Fix

## Changes

`litellm/types/utils.py`: `LiteLLMRealtimeStreamLoggingObject.results` is now `SkipValidation[OpenAIRealtimeStreamList]` with a `field_serializer` that emits the events as plain dicts, so neither validation nor serialization walks the event union.

`tests/test_litellm/test_cost_calculator.py`: the regression test described above.
