### PR TITLE
feat(mcp): add resolve_credentials dispatch skeleton

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/__init__.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/__init__.py
@@ -1,15 +1,19 @@
 """Typed upstream-credential resolution for MCP servers.
 
-This subpackage houses the typed credential vocabulary and (in a later PR) the
-``resolve_credentials`` dispatch. A server declares one per-mode config from the
-``AuthConfig`` discriminated union; failures are modeled as values via :mod:`.result`
-(``Result[T, CredError]``) rather than raised, so every seam is total. Nothing here is
-wired onto a live request path yet.
+This subpackage houses the typed credential vocabulary and the ``resolve_credentials``
+dispatch. A server declares one per-mode config from the ``AuthConfig`` discriminated union;
+``UpstreamCredentialProvider.resolve_credentials`` selects one arm and returns an ``httpx.Auth``
+or a typed ``CredError``. Failures are modeled as values via :mod:`.result` (``Result[T,
+CredError]``) rather than raised, so every seam is total. Nothing here is wired onto a live
+request path yet.
 """
 
 from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
     NoOpAuth,
     StaticHeaderAuth,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.resolver import (
+    UpstreamCredentialProvider,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.result import (
     Error,
@@ -45,6 +49,7 @@ __all__ = [
     "Result",
     "NoOpAuth",
     "StaticHeaderAuth",
+    "UpstreamCredentialProvider",
     "AuthSpecKind",
     "CredError",
     "Subject",

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
@@ -1,0 +1,70 @@
+"""The one credential resolver: dispatch on the declared mode, fail closed.
+
+`resolve_credentials` selects exactly one arm off the server's typed `config` and either
+produces an `httpx.Auth` or returns a typed `CredError`. The `match` is over the `AuthConfig`
+variant, so each arm receives its own fully-typed config with no field-presence inference and
+no precedence cascade. It is wildcard-free with an `assert_never` tail, so adding a mode without
+an arm fails the type gate (basedpyright `reportMatchNotExhaustive`); a bypassed gate fails loudly
+at runtime instead of returning `None`.
+
+This skeleton ships every arm as a `not_implemented` stub. Each mode's real body, with its
+injected seam, lands in its own follow-up PR; until then the arm returns a typed error rather
+than silently producing no credential. Pure v2: no imports from v1.
+"""
+
+from __future__ import annotations
+
+import httpx
+from typing_extensions import assert_never
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.result import (
+    Error,
+    Result,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
+    ApiKeyConfig,
+    AuthorizationCodeConfig,
+    AuthSpecKind,
+    AwsSigV4Config,
+    ClientCredentialsConfig,
+    CredError,
+    NoneConfig,
+    PassthroughConfig,
+    ServerSpec,
+    Subject,
+    TokenExchangeConfig,
+)
+
+
+class UpstreamCredentialProvider:
+    """Produces the one `httpx.Auth` for a `(subject, upstream)` pair, per declared mode.
+
+    Collaborators (the per-mode credential stores and token fetchers) are injected as each arm
+    is built; the skeleton needs none, since every arm is a stub.
+    """
+
+    async def resolve_credentials(
+        self, subject: Subject, server: ServerSpec
+    ) -> Result[httpx.Auth, CredError]:
+        match server.config:
+            case NoneConfig():
+                return _not_implemented(AuthSpecKind.none)
+            case ApiKeyConfig():
+                return _not_implemented(AuthSpecKind.api_key)
+            case PassthroughConfig():
+                return _not_implemented(AuthSpecKind.passthrough)
+            case ClientCredentialsConfig():
+                return _not_implemented(AuthSpecKind.client_credentials)
+            case TokenExchangeConfig():
+                return _not_implemented(AuthSpecKind.token_exchange)
+            case AuthorizationCodeConfig():
+                return _not_implemented(AuthSpecKind.authorization_code)
+            case AwsSigV4Config():
+                return _not_implemented(AuthSpecKind.aws_sigv4)
+        assert_never(server.config)
+
+
+def _not_implemented(kind: AuthSpecKind) -> Result[httpx.Auth, CredError]:
+    return Error(
+        CredError.of_not_implemented(f"{kind.value}: resolver arm not implemented yet")
+    )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
@@ -1,0 +1,57 @@
+"""Tests for the resolver dispatch skeleton.
+
+Every mode must reach its own arm and, until that arm is built, return a typed
+`not_implemented` CredError rather than silently producing no credential. Parametrizing over
+one config per mode also guards reachability: if a `case` were dropped, that mode would fall to
+the `assert_never` tail and raise here instead of returning the stub.
+"""
+
+import pytest
+from pydantic import SecretStr
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials import (
+    ApiKeyConfig,
+    AuthorizationCodeConfig,
+    AuthSpecKind,
+    AwsSigV4Config,
+    ClientCredentialsConfig,
+    Error,
+    NoneConfig,
+    PassthroughConfig,
+    ServerSpec,
+    SharedKey,
+    Subject,
+    TokenExchangeConfig,
+    UpstreamCredentialProvider,
+)
+
+_ONE_CONFIG_PER_MODE = [
+    (AuthSpecKind.none, NoneConfig()),
+    (AuthSpecKind.api_key, ApiKeyConfig(key_source=SharedKey(value=SecretStr("k")))),
+    (AuthSpecKind.passthrough, PassthroughConfig()),
+    (AuthSpecKind.client_credentials, ClientCredentialsConfig()),
+    (AuthSpecKind.token_exchange, TokenExchangeConfig()),
+    (AuthSpecKind.authorization_code, AuthorizationCodeConfig()),
+    (AuthSpecKind.aws_sigv4, AwsSigV4Config(region="us-east-1")),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind, config", _ONE_CONFIG_PER_MODE)
+async def test_every_mode_reaches_its_arm_and_returns_not_implemented(kind, config):
+    spec = ServerSpec(
+        server_id="s", resource="https://upstream.example.com", config=config
+    )
+    subject = Subject(tenant_id="", subject_id="")
+
+    result = await UpstreamCredentialProvider().resolve_credentials(subject, spec)
+
+    assert isinstance(result, Error)
+    assert result.error.tag == "not_implemented"
+    assert kind.value in result.error.summary
+
+
+def test_all_seven_modes_are_covered():
+    # Guards that the parametrization (and therefore the dispatch) spans every AuthSpecKind, so a
+    # newly added mode without a test row is caught here rather than slipping through.
+    assert {kind for kind, _ in _ONE_CONFIG_PER_MODE} == set(AuthSpecKind)


### PR DESCRIPTION
## Relevant issues

PR3 of the MCP v2 outbound-credential migration, the per-mode replacement of `resolve_mcp_auth` with a typed `resolve_credentials` resolver described in the "Small MCP Migration" plan. Stacked on PR #31049 (base `litellm_mcp_v2_types`) so this diff shows only the resolver skeleton, not the vocabulary under review there

## Linear ticket

N/A (groundwork for MCP V2)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

This PR adds the resolver dispatch only; every arm is a `not_implemented` stub and nothing is imported on a request path, so there is no proxy surface to curl and production behavior is unchanged by construction. The proof is the dispatch reaching each arm, the exhaustiveness gate, and the lint/type gates.

Every mode reaches its own arm and returns a typed `not_implemented` error (the parametrization spans all seven `AuthSpecKind` members, asserted by a dedicated test, so a dropped `case` would fall to `assert_never` and raise rather than silently passing):

```
$ python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py -q
........                                                                 [100%]
8 passed
```

The exhaustiveness gate is the load-bearing property. basedpyright adds zero errors on the new file, which means the trailing `assert_never(server.config)` type-checks (the union is narrowed to `Never` only because all seven arms are present). Delete any one `case` and basedpyright fails with `reportMatchNotExhaustive`:

```
$ basedpyright --outputjson litellm/.../outbound_credentials/   # errors by rule
{'reportAny': 7}   # all from the types.py tagged union (PR2); resolver.py adds 0

$ ruff check ...   # All checks passed!
$ black --check ... # All done!
```

The seven `reportAny` are the `expression` tagged-union fields carried over from PR2 and unchanged here; the resolver introduces none

## Type

🆕 New Feature

## Changes

Adds `resolver.py`: `UpstreamCredentialProvider.resolve_credentials(subject, server)` dispatches on the server's declared `AuthConfig` variant with one arm per mode. The `match` is wildcard-free and ends in `assert_never(server.config)`, so adding a mode without an arm fails the type gate rather than at runtime, and a mode reaching the resolver always lands in exactly one arm. Each arm is a `not_implemented` stub that returns a typed `CredError` rather than producing no credential; the real bodies, with their injected seams, land one mode per follow-on PR.

The provider takes no collaborators yet, since every arm is a stub; the credential stores and token fetchers are injected as each mode is built. Pure v2: no imports from v1, and nothing is wired into `_create_mcp_client`. The v1 to v2 adapter (`to_subject` / `to_server_spec` / `raise_public`), the `_should_defer` routing predicate, and the `_create_mcp_client` graft land in the next PR alongside the first live modes, since they are meaningless until a mode actually routes through the resolver
