### PR TITLE
fix(proxy): strip tool config from health check probes (#31008)

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -47,6 +47,13 @@ _MAX_TOKEN_SUPPORT_MODES: frozenset[str] = frozenset(
     {"chat", "completion", "responses"}
 )
 
+# Tool config is meaningless on a trivial health probe and makes some providers
+# fail it outright (OpenRouter server tools like `openrouter:web_search` 500 the
+# probe). Stripped from both the top-level params and `extra_body` before probing.
+_HEALTH_CHECK_STRIPPED_REQUEST_KEYS: frozenset[str] = frozenset(
+    {"tools", "tool_choice"}
+)
+
 
 def _resolve_health_check_mode(
     model_info: Mapping[str, object], litellm_params: Mapping[str, object]
@@ -452,7 +459,20 @@ def _update_litellm_params_for_health_check(
     - updates the `model` param with the `health_check_model` if it exists Doc: https://docs.litellm.ai/docs/proxy/health#wildcard-routes
     - updates the `voice` param with the `health_check_voice` for `audio_speech` mode if it exists Doc: https://docs.litellm.ai/docs/proxy/health#text-to-speech-models
     - for Bedrock models with region routing (bedrock/region/model), strips the litellm routing prefix but preserves the model ID, and pins `custom_llm_provider` to `bedrock` (only when the deployment hasn't already set one, so an explicit `bedrock_converse` survives) so the bare model id still resolves to the provider (e.g. cross-region ids like `us.cohere.embed-v4:0`)
+    - works on a copy and strips `tools`/`tool_choice` from the top level and `extra_body`; a trivial probe never needs tool config and some providers (e.g. OpenRouter server tools) 500 when it is present
     """
+    litellm_params = {
+        k: v
+        for k, v in litellm_params.items()
+        if k not in _HEALTH_CHECK_STRIPPED_REQUEST_KEYS
+    }
+    _extra_body = litellm_params.get("extra_body")
+    if isinstance(_extra_body, dict):
+        litellm_params["extra_body"] = {
+            k: v
+            for k, v in _extra_body.items()
+            if k not in _HEALTH_CHECK_STRIPPED_REQUEST_KEYS
+        }
     mode = _resolve_health_check_mode(
         model_info, litellm_params  # any-ok: untyped router config dict
     )

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -447,62 +447,6 @@ def test_update_litellm_params_for_health_check():
     )
 
 
-def test_health_check_strips_tool_config_from_probe():
-    """
-    Regression for #31008: health probes must not carry tool configuration.
-
-    OpenRouter server tools configured via `extra_body.tools` (e.g.
-    `openrouter:web_search`) made the trivial probe 500. `tools`/`tool_choice`
-    are stripped from both the top level and `extra_body`, while other
-    `extra_body` fields (e.g. provider routing) are preserved, and the caller's
-    params are never mutated.
-    """
-    from litellm.proxy.health_check import _update_litellm_params_for_health_check
-
-    extra_body = {
-        "tools": [{"type": "openrouter:web_search"}],
-        "tool_choice": "auto",
-        "provider": {"order": ["OpenAI"]},
-    }
-    litellm_params = {
-        "model": "openrouter/openai/gpt-4o-mini",
-        "api_key": "fake_key",
-        "tools": [{"type": "function", "function": {"name": "f"}}],
-        "tool_choice": "auto",
-        "extra_body": extra_body,
-    }
-
-    updated = _update_litellm_params_for_health_check({}, litellm_params)
-
-    # probe is stripped of all tool config, top-level and nested
-    assert "tools" not in updated and "tool_choice" not in updated
-    assert "tools" not in updated["extra_body"]
-    assert "tool_choice" not in updated["extra_body"]
-    assert updated["extra_body"]["provider"] == {"order": ["OpenAI"]}
-    assert isinstance(updated["messages"], list)
-
-    # caller's params are not mutated: a fresh object, no probe fields leaked in,
-    # tool config intact both top-level and nested
-    assert updated is not litellm_params
-    assert "messages" not in litellm_params
-    assert "tools" in litellm_params and "tool_choice" in litellm_params
-    assert extra_body["tools"] == [{"type": "openrouter:web_search"}]
-    assert extra_body["tool_choice"] == "auto"
-    assert updated["extra_body"] is not extra_body
-
-
-def test_health_check_probe_without_extra_body_does_not_crash():
-    """A deployment with no `extra_body` must still build a valid probe."""
-    from litellm.proxy.health_check import _update_litellm_params_for_health_check
-
-    updated = _update_litellm_params_for_health_check(
-        {}, {"model": "openai/gpt-4o-mini", "api_key": "fake_key"}
-    )
-
-    assert "extra_body" not in updated
-    assert isinstance(updated["messages"], list)
-
-
 @pytest.mark.asyncio
 async def test_perform_health_check_filters_by_model_id():
     """

--- a/tests/litellm_utils_tests/test_health_check.py
+++ b/tests/litellm_utils_tests/test_health_check.py
@@ -447,6 +447,62 @@ def test_update_litellm_params_for_health_check():
     )
 
 
+def test_health_check_strips_tool_config_from_probe():
+    """
+    Regression for #31008: health probes must not carry tool configuration.
+
+    OpenRouter server tools configured via `extra_body.tools` (e.g.
+    `openrouter:web_search`) made the trivial probe 500. `tools`/`tool_choice`
+    are stripped from both the top level and `extra_body`, while other
+    `extra_body` fields (e.g. provider routing) are preserved, and the caller's
+    params are never mutated.
+    """
+    from litellm.proxy.health_check import _update_litellm_params_for_health_check
+
+    extra_body = {
+        "tools": [{"type": "openrouter:web_search"}],
+        "tool_choice": "auto",
+        "provider": {"order": ["OpenAI"]},
+    }
+    litellm_params = {
+        "model": "openrouter/openai/gpt-4o-mini",
+        "api_key": "fake_key",
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+        "tool_choice": "auto",
+        "extra_body": extra_body,
+    }
+
+    updated = _update_litellm_params_for_health_check({}, litellm_params)
+
+    # probe is stripped of all tool config, top-level and nested
+    assert "tools" not in updated and "tool_choice" not in updated
+    assert "tools" not in updated["extra_body"]
+    assert "tool_choice" not in updated["extra_body"]
+    assert updated["extra_body"]["provider"] == {"order": ["OpenAI"]}
+    assert isinstance(updated["messages"], list)
+
+    # caller's params are not mutated: a fresh object, no probe fields leaked in,
+    # tool config intact both top-level and nested
+    assert updated is not litellm_params
+    assert "messages" not in litellm_params
+    assert "tools" in litellm_params and "tool_choice" in litellm_params
+    assert extra_body["tools"] == [{"type": "openrouter:web_search"}]
+    assert extra_body["tool_choice"] == "auto"
+    assert updated["extra_body"] is not extra_body
+
+
+def test_health_check_probe_without_extra_body_does_not_crash():
+    """A deployment with no `extra_body` must still build a valid probe."""
+    from litellm.proxy.health_check import _update_litellm_params_for_health_check
+
+    updated = _update_litellm_params_for_health_check(
+        {}, {"model": "openai/gpt-4o-mini", "api_key": "fake_key"}
+    )
+
+    assert "extra_body" not in updated
+    assert isinstance(updated["messages"], list)
+
+
 @pytest.mark.asyncio
 async def test_perform_health_check_filters_by_model_id():
     """

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -516,3 +516,55 @@ def test_autodetected_embedding_skips_reasoning_effort():
 
     assert "reasoning_effort" not in updated
     assert "max_tokens" not in updated
+
+
+def test_health_check_strips_tool_config_from_probe():
+    """
+    Regression for #31008: health probes must not carry tool configuration.
+
+    OpenRouter server tools configured via `extra_body.tools` (e.g.
+    `openrouter:web_search`) made the trivial probe 500. `tools`/`tool_choice`
+    are stripped from both the top level and `extra_body`, while other
+    `extra_body` fields (e.g. provider routing) are preserved, and the caller's
+    params are never mutated.
+    """
+    extra_body = {
+        "tools": [{"type": "openrouter:web_search"}],
+        "tool_choice": "auto",
+        "provider": {"order": ["OpenAI"]},
+    }
+    litellm_params = {
+        "model": "openrouter/openai/gpt-4o-mini",
+        "api_key": "fake_key",
+        "tools": [{"type": "function", "function": {"name": "f"}}],
+        "tool_choice": "auto",
+        "extra_body": extra_body,
+    }
+
+    updated = _update_litellm_params_for_health_check({}, litellm_params)
+
+    # probe is stripped of all tool config, top-level and nested
+    assert "tools" not in updated and "tool_choice" not in updated
+    assert "tools" not in updated["extra_body"]
+    assert "tool_choice" not in updated["extra_body"]
+    assert updated["extra_body"]["provider"] == {"order": ["OpenAI"]}
+    assert isinstance(updated["messages"], list)
+
+    # caller's params are not mutated: a fresh object, no probe fields leaked in,
+    # tool config intact both top-level and nested
+    assert updated is not litellm_params
+    assert "messages" not in litellm_params
+    assert "tools" in litellm_params and "tool_choice" in litellm_params
+    assert extra_body["tools"] == [{"type": "openrouter:web_search"}]
+    assert extra_body["tool_choice"] == "auto"
+    assert updated["extra_body"] is not extra_body
+
+
+def test_health_check_probe_without_extra_body_does_not_crash():
+    """A deployment with no `extra_body` must still build a valid probe."""
+    updated = _update_litellm_params_for_health_check(
+        {}, {"model": "openai/gpt-4o-mini", "api_key": "fake_key"}
+    )
+
+    assert "extra_body" not in updated
+    assert isinstance(updated["messages"], list)


### PR DESCRIPTION
## Relevant issues

Fixes #31008

## Linear ticket

<!-- add "Resolves LIT-XXXX" here if you have an internal ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Config (`health_check_extra_body.yaml`, needs `OPENROUTER_API_KEY` in `.env`):

```yaml
model_list:
  - model_name: openrouter-websearch
    litellm_params:
      model: openrouter/openai/gpt-4o-mini
      api_key: os.environ/OPENROUTER_API_KEY
      extra_body:
        tools:
          - type: openrouter:web_search
general_settings:
  master_key: sk-1234
```

Before the fix (run on the unpatched branch), the deployment is reported unhealthy because the probe inherits `extra_body.tools`:

```bash
curl -s http://localhost:4000/health -H "Authorization: Bearer sk-1234" \
  | jq '{healthy: .healthy_endpoints, unhealthy: .unhealthy_endpoints}'
```

```
PASTE OUTPUT: openrouter-websearch under unhealthy_endpoints with a 500
```

After the fix, the same deployment is healthy and a real completion still uses web search (tools are preserved for live traffic, only probes strip them):

```bash
curl -s http://localhost:4000/health -H "Authorization: Bearer sk-1234" \
  | jq '{healthy: .healthy_endpoints, unhealthy: .unhealthy_endpoints}'

curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"openrouter-websearch","messages":[{"role":"user","content":"What did OpenRouter announce most recently? Use web search."}]}' \
  | jq '.choices[0].message.content'
```

```
PASTE OUTPUT: openrouter-websearch under healthy_endpoints, plus the completion text
```

## Type

🐛 Bug Fix

## Changes

Background and on-demand health checks reuse the deployment's `litellm_params`, so a deployment with `extra_body.tools` (e.g. `openrouter:web_search`) sent those server tools on the trivial probe and OpenRouter 500'd it, while real completions on the same deployment succeeded. `_update_litellm_params_for_health_check` now works on a copy and strips `tools` and `tool_choice` from both the top level and `extra_body` before probing, since a trivial probe never needs tool configuration

`tool_choice` is removed alongside `tools` because some providers reject a `tool_choice` with no `tools`. Other `extra_body` fields such as provider routing are preserved, and the caller's params are no longer mutated; a regression test in `tests/litellm_utils_tests/test_health_check.py` pins both the stripping and the no-mutation behavior