### PR TITLE
fix(moonshot): stop mutating caller messages on tool_choice='required'

### DIFF
--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -238,11 +238,11 @@ class MoonshotChatConfig(OpenAIGPTConfig):
 
         https://platform.moonshot.ai/docs/guide/migrating-from-openai-to-kimi#about-tool_choice
         """
-        messages.append(
+        optional_params.pop("tool_choice")
+        return [
+            *messages,
             {
                 "role": "user",
                 "content": "Please select a tool to handle the current issue.",  # Usually, the Kimi large language model understands the intention to invoke a tool and selects one for invocation
-            }
-        )
-        optional_params.pop("tool_choice")
-        return messages
+            },
+        ]

--- a/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
+++ b/tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py
@@ -305,6 +305,34 @@ class TestMoonshotConfig:
         assert len(result["messages"]) == 2
         assert result["messages"][1]["content"] == "Please select a tool to handle the current issue."
 
+    def test_tool_choice_required_does_not_mutate_input_messages(self):
+        """tool_choice='required' must not mutate the caller's messages list.
+
+        The handling appends a "select a tool" user message; building it in
+        place corrupts the caller's conversation history and makes
+        transform_request non-idempotent across retries.
+        """
+        config = MoonshotChatConfig()
+
+        messages = [{"role": "user", "content": "What's the weather like?"}]
+
+        for _ in range(2):
+            optional_params = {
+                "tool_choice": "required",
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+            }
+            result = config.transform_request(
+                model="moonshot-v1-8k",
+                messages=messages,
+                optional_params=optional_params,
+                litellm_params={},
+                headers={},
+            )
+            # The returned request carries the extra message.
+            assert len(result["messages"]) == 2
+            # The caller's list is untouched, so repeated calls stay idempotent.
+            assert messages == [{"role": "user", "content": "What's the weather like?"}]
+
     def test_tool_choice_non_required_preserved(self):
         """Test that non-'required' tool_choice values are preserved"""
         config = MoonshotChatConfig()


### PR DESCRIPTION
## Relevant issues

None; self-reported

## Type

🐛 Bug Fix

## Changes

When a Moonshot request is sent with `tool_choice="required"`, `MoonshotChatConfig._add_tool_choice_required_message` appended the "Please select a tool to handle the current issue." prompt to the caller's `messages` list in place. Because `transform_request` receives the same list the caller holds, this corrupts the caller's conversation history, and since `transform_request` is not idempotent the prompt is appended again on every retry, so a single message can accumulate multiple copies of the prompt

This builds and returns a new list instead of mutating the input, consistent with the no-mutation guidance in the repo. The visible request body is unchanged for a single call; what changes is that the caller's list is no longer mutated and repeated calls stay idempotent

`optional_params.pop("tool_choice")` is left as-is since dropping the unsupported value is the intended param transformation

A regression test in the mapped `tests/test_litellm/llms/moonshot/test_moonshot_chat_transformation.py` calls `transform_request` twice with the same list and asserts the caller's `messages` is untouched; it fails before this change and passes after. The full moonshot transformation test file passes (41 tests), `ruff check` is clean, and `basedpyright` reports no new findings on the changed file