### PR TITLE
fix(guardrails): fail closed on unmaskable Presidio streaming output

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1077,9 +1077,21 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     else:
                         all_chunks.append(chunk)
                 elif isinstance(chunk, bytes):
+                    if self.mask_pii_fail_closed:
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Presidio apply_to_output cannot mask raw byte-stream output; failing closed.",
+                            should_wrap_with_default_message=False,
+                        )
                     yield chunk  # type: ignore[misc]
                     continue
                 else:
+                    if self.mask_pii_fail_closed:
+                        raise GuardrailRaisedException(
+                            guardrail_name=self.guardrail_name,
+                            message="Presidio apply_to_output cannot mask this mixed/unknown stream shape; failing closed.",
+                            should_wrap_with_default_message=False,
+                        )
                     if all_chunks:
                         # Flush buffered chunks and switch to transparent passthrough for this stream shape.
                         # NOTE: these buffered chunks are emitted unmasked because this
@@ -1125,6 +1137,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             mock_response_stream = convert_model_response_to_streaming(assembled_model_response)
             yield mock_response_stream
 
+        except GuardrailRaisedException:
+            # A fail-closed signal (mask_pii_fail_closed) must propagate, not be
+            # swallowed into an unmasked passthrough below.
+            raise
         except Exception as e:
             verbose_proxy_logger.error(f"Error masking streaming PII output: {str(e)}")
             for chunk in all_chunks:

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -76,6 +76,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         presidio_anonymizer_api_base: Optional[str] = None,
         output_parse_pii: Optional[bool] = False,
         apply_to_output: bool = False,
+        mask_pii_fail_closed: bool = False,
         presidio_ad_hoc_recognizers: Optional[str] = None,
         logging_only: Optional[bool] = None,
         pii_entities_config: Optional[Dict[Union[PiiEntityType, str], PiiAction]] = None,
@@ -93,6 +94,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         self.mock_redacted_text = mock_redacted_text
         self.output_parse_pii = output_parse_pii or False
         self.apply_to_output = apply_to_output
+        self.mask_pii_fail_closed = mask_pii_fail_closed
 
         # When output_parse_pii or apply_to_output is enabled, the guardrail must
         # also run on post_call to unmask/mask the response.  Expand the event_hook
@@ -298,7 +300,12 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 def _fail_on_invalid_response(
                     reason: str,
                 ) -> List[PresidioAnalyzeResponseItem]:
-                    should_fail_closed = bool(self.pii_entities_config) or self.output_parse_pii or self.apply_to_output
+                    should_fail_closed = (
+                        bool(self.pii_entities_config)
+                        or self.output_parse_pii
+                        or self.apply_to_output
+                        or self.mask_pii_fail_closed
+                    )
                     if should_fail_closed:
                         raise GuardrailRaisedException(
                             guardrail_name=self.guardrail_name,

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -1055,6 +1055,17 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         )
         return response
 
+    def _fail_closed_if_enabled(self, message: str, *, cause: Optional[BaseException] = None) -> None:
+        """Raise a fail-closed ``GuardrailRaisedException`` when
+        ``mask_pii_fail_closed`` is set, so an unmaskable streaming shape blocks
+        instead of forwarding unmasked output; a no-op otherwise."""
+        if self.mask_pii_fail_closed:
+            raise GuardrailRaisedException(
+                guardrail_name=self.guardrail_name,
+                message=message,
+                should_wrap_with_default_message=False,
+            ) from cause
+
     async def _stream_apply_output_masking(
         self,
         response: Any,
@@ -1077,21 +1088,15 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     else:
                         all_chunks.append(chunk)
                 elif isinstance(chunk, bytes):
-                    if self.mask_pii_fail_closed:
-                        raise GuardrailRaisedException(
-                            guardrail_name=self.guardrail_name,
-                            message="Presidio apply_to_output cannot mask raw byte-stream output; failing closed.",
-                            should_wrap_with_default_message=False,
-                        )
+                    self._fail_closed_if_enabled(
+                        "Presidio apply_to_output cannot mask raw byte-stream output; failing closed."
+                    )
                     yield chunk  # type: ignore[misc]
                     continue
                 else:
-                    if self.mask_pii_fail_closed:
-                        raise GuardrailRaisedException(
-                            guardrail_name=self.guardrail_name,
-                            message="Presidio apply_to_output cannot mask this mixed/unknown stream shape; failing closed.",
-                            should_wrap_with_default_message=False,
-                        )
+                    self._fail_closed_if_enabled(
+                        "Presidio apply_to_output cannot mask this mixed/unknown stream shape; failing closed."
+                    )
                     if all_chunks:
                         # Flush buffered chunks and switch to transparent passthrough for this stream shape.
                         # NOTE: these buffered chunks are emitted unmasked because this
@@ -1124,6 +1129,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             assembled_model_response = stream_chunk_builder(chunks=all_chunks, messages=request_data.get("messages"))
 
             if not isinstance(assembled_model_response, ModelResponse):
+                self._fail_closed_if_enabled(
+                    "Presidio apply_to_output could not reassemble the stream to mask it; failing closed."
+                )
                 for chunk in all_chunks:
                     yield chunk
                 return
@@ -1143,6 +1151,14 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             raise
         except Exception as e:
             verbose_proxy_logger.error(f"Error masking streaming PII output: {str(e)}")
+            # Masking failed for a reason other than an explicit fail-closed signal
+            # (analyzer/anonymizer transport error, reconstruction failure, …).
+            # Forwarding the buffered chunks would leak unmasked output, so honor
+            # fail-closed instead of passing through.
+            self._fail_closed_if_enabled(
+                "Presidio apply_to_output failed to mask streaming output; failing closed.",
+                cause=e,
+            )
             for chunk in all_chunks:
                 yield chunk
 

--- a/litellm/proxy/guardrails/guardrail_initializers.py
+++ b/litellm/proxy/guardrails/guardrail_initializers.py
@@ -97,7 +97,10 @@ def initialize_presidio(litellm_params: LitellmParams, guardrail: Guardrail):
             apply_to_output=False,
         )
         params.update(overrides)
-        callback = _OPTIONAL_PresidioPIIMasking(**params)
+        callback = _OPTIONAL_PresidioPIIMasking(
+            **params,
+            mask_pii_fail_closed=bool(litellm_params.mask_pii_fail_closed),
+        )
         litellm.logging_callback_manager.add_litellm_callback(callback)
         return callback
 

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -345,6 +345,12 @@ class PresidioPresidioConfigModelUserInterface(BaseModel):
         # extra param to let the ui know this is a boolean
         json_schema_extra={"ui_type": GuardrailParamUITypes.BOOL},
     )
+    mask_pii_fail_closed: Optional[bool] = Field(
+        default=None,
+        description="When True, a mask-only Presidio guardrail blocks the request (fail closed) if the analyzer errors, instead of forwarding unmasked text",
+        # extra param to let the ui know this is a boolean
+        json_schema_extra={"ui_type": GuardrailParamUITypes.BOOL},
+    )
     presidio_language: Optional[str] = Field(
         default="en",
         description="Language code for Presidio PII analysis (e.g., 'en', 'de', 'es', 'fr')",

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -347,7 +347,7 @@ class PresidioPresidioConfigModelUserInterface(BaseModel):
     )
     mask_pii_fail_closed: Optional[bool] = Field(
         default=None,
-        description="When True, a mask-only Presidio guardrail blocks the request (fail closed) if the analyzer errors, instead of forwarding unmasked text",
+        description="When True, a Presidio masking guardrail fails closed (blocks) instead of forwarding unmasked text. Covers analyzer errors and streaming output that cannot be masked (e.g. raw byte streams, mixed/unknown event streams).",
         # extra param to let the ui know this is a boolean
         json_schema_extra={"ui_type": GuardrailParamUITypes.BOOL},
     )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -1080,6 +1080,55 @@ async def test_analyze_text_invalid_response_raises_when_mask_configured():
 
 
 @pytest.mark.asyncio
+async def test_analyze_text_mask_only_fails_open_by_default():
+    """
+    Default mask-only config (no pii_entities_config / output / apply_to_output)
+    still fails open on analyzer error, preserving prior behaviour (issue #30728).
+    """
+    presidio = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://mock-presidio:5002/",
+        presidio_anonymizer_api_base="http://mock-presidio:5001/",
+        output_parse_pii=False,
+    )
+    assert presidio.mask_pii_fail_closed is False
+
+    with patch.object(
+        presidio,
+        "_get_session_iterator",
+        _make_mock_session_iterator("Internal Server Error", status=500),
+    ):
+        result = await presidio.analyze_text(
+            text="some text", presidio_config=None, request_data={}
+        )
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_analyze_text_raises_when_mask_pii_fail_closed_set():
+    """
+    With mask_pii_fail_closed=True, a mask-only guardrail blocks (fail closed)
+    on analyzer error instead of forwarding unmasked text (issue #30728).
+    """
+    presidio = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://mock-presidio:5002/",
+        presidio_anonymizer_api_base="http://mock-presidio:5001/",
+        output_parse_pii=False,
+        mask_pii_fail_closed=True,
+    )
+
+    with patch.object(
+        presidio,
+        "_get_session_iterator",
+        _make_mock_session_iterator("Internal Server Error", status=500),
+    ):
+        with pytest.raises(GuardrailRaisedException) as exc_info:
+            await presidio.analyze_text(
+                text="some text", presidio_config=None, request_data={}
+            )
+    assert "PII protection is configured" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_analyze_text_list_with_non_dict_items():
     """
     Test that analyze_text skips non-dict items in the result list.

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2182,6 +2182,66 @@ async def test_streaming_bytes_chunks_are_yielded_not_discarded():
 
 
 @pytest.mark.asyncio
+async def test_streaming_bytes_fail_closed_raises():
+    """With mask_pii_fail_closed=True, raw byte-stream output that cannot be
+    masked must fail closed (raise) instead of passing through unmasked (#30728)."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+        mask_pii_fail_closed=True,
+    )
+
+    async def mock_stream():
+        yield b'data: {"delta":{"text":"SSN 078-05-1120"}}\n\n'
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    with pytest.raises(GuardrailRaisedException):
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=mock_user_api_key,
+            response=mock_stream(),
+            request_data={},
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_streaming_mixed_fail_closed_raises():
+    """With mask_pii_fail_closed=True, a mixed/unknown stream shape that cannot be
+    masked must fail closed rather than flush buffered chunks unmasked (#30728)."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+        mask_pii_fail_closed=True,
+    )
+
+    class FakeResponsesEvent:
+        def __init__(self, event_type):
+            self.type = event_type
+
+    model_chunk = ModelResponseStream(
+        id="chatcmpl-fc-1",
+        choices=[],
+        created=1,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+    )
+
+    async def mock_stream():
+        yield model_chunk
+        yield FakeResponsesEvent("response.completed")
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    with pytest.raises(GuardrailRaisedException):
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=mock_user_api_key,
+            response=mock_stream(),
+            request_data={},
+        ):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_streaming_unmask_path_bytes_passthrough():
     """
     Bytes chunks in the unmasking path should also pass through.

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2242,6 +2242,109 @@ async def test_streaming_mixed_fail_closed_raises():
 
 
 @pytest.mark.asyncio
+async def test_streaming_masking_error_fail_closed_raises():
+    """With mask_pii_fail_closed=True, a non-GuardrailRaisedException error during
+    masking (analyzer/anonymizer transport, reconstruction) must fail closed, not
+    flush the buffered chunks unmasked (#30728 / veria-ai review)."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+        mask_pii_fail_closed=True,
+    )
+    model_chunk = ModelResponseStream(
+        id="chatcmpl-err-1",
+        choices=[],
+        created=1,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+    )
+
+    async def mock_stream():
+        yield model_chunk
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    with patch(
+        "litellm.main.stream_chunk_builder",
+        side_effect=RuntimeError("analyzer transport error"),
+    ):
+        with pytest.raises(GuardrailRaisedException):
+            async for _ in guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=mock_user_api_key,
+                response=mock_stream(),
+                request_data={},
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_streaming_unreconstructable_fail_closed_raises():
+    """With mask_pii_fail_closed=True, a stream that cannot be reassembled into a
+    ModelResponse must fail closed rather than forward buffered chunks unmasked."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+        mask_pii_fail_closed=True,
+    )
+    model_chunk = ModelResponseStream(
+        id="chatcmpl-err-2",
+        choices=[],
+        created=1,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+    )
+
+    async def mock_stream():
+        yield model_chunk
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    with patch("litellm.main.stream_chunk_builder", return_value=None):
+        with pytest.raises(GuardrailRaisedException):
+            async for _ in guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=mock_user_api_key,
+                response=mock_stream(),
+                request_data={},
+            ):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_streaming_masking_error_fails_open_when_flag_off():
+    """Default (mask_pii_fail_closed=False): a masking error still forwards the
+    buffered chunks (fail open) — the new fail-closed behavior is opt-in."""
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        mock_testing=True,
+        apply_to_output=True,
+    )
+    model_chunk = ModelResponseStream(
+        id="chatcmpl-open-1",
+        choices=[],
+        created=1,
+        model="gpt-4",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+    )
+
+    async def mock_stream():
+        yield model_chunk
+
+    mock_user_api_key = UserAPIKeyAuth(api_key="test-key")
+    collected = []
+    with patch(
+        "litellm.main.stream_chunk_builder",
+        side_effect=RuntimeError("analyzer transport error"),
+    ):
+        async for out in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=mock_user_api_key,
+            response=mock_stream(),
+            request_data={},
+        ):
+            collected.append(out)
+    assert model_chunk in collected
+
+
+@pytest.mark.asyncio
 async def test_streaming_unmask_path_bytes_passthrough():
     """
     Bytes chunks in the unmasking path should also pass through.


### PR DESCRIPTION
## Summary

Part of #30728 (problem 3 of 3). With `apply_to_output=True`, `_stream_apply_output_masking` can only mask output it can reconstruct from buffered `ModelResponseStream` chunks. Raw byte streams (e.g. Anthropic native SSE) and mixed / unknown stream shapes (e.g. `/v1/responses` events) were forwarded to the client **unmasked** — only a `verbose_proxy_logger.warning` was emitted. (The unmask path has `_unmask_sse_bytes_chunk` for SSE bytes; the mask path had no equivalent.)

## Change

Reuses the `mask_pii_fail_closed` flag (default `False`): when set, an unmaskable streaming shape raises `GuardrailRaisedException` instead of passing through unmasked. A `except GuardrailRaisedException: raise` is added ahead of the generic handler so the fail-closed signal isn't swallowed back into an unmasked passthrough.

Default behaviour is unchanged — without the flag, bytes/mixed/unknown streams still pass through with a warning, so existing tests are untouched.

> ⚠️ **Stacked on #31062** (which introduces `mask_pii_fail_closed`). The first commit here is #31062; please review only the **second** commit (`fail closed on unmaskable Presidio streaming output`). I'll rebase onto `litellm_oss_branch` once #31062 merges.

## Tests

- `test_streaming_bytes_fail_closed_raises` — byte-stream output + flag → raises.
- `test_streaming_mixed_fail_closed_raises` — `ModelResponseStream` + unknown event + flag → raises.
- Existing passthrough/warn streaming tests still pass (default flag off).

Full presidio suite: 67 passed; mypy/ruff/black clean.
