### PR TITLE
feat(focus): include per-user request tags in Vantage export

### DIFF
--- a/litellm/integrations/focus/database.py
+++ b/litellm/integrations/focus/database.py
@@ -32,20 +32,31 @@ class FocusLiteLLMDatabase:
         client = self._ensure_prisma_client()
 
         where_clauses: list[str] = []
+        tag_time_clauses: list[str] = []
         query_params: list[Any] = []
         placeholder_index = 1
         if start_time_utc:
             where_clauses.append(f"dus.updated_at >= ${placeholder_index}::timestamptz")
+            tag_time_clauses.append(
+                f"sl.\"startTime\" >= (${placeholder_index}::timestamptz AT TIME ZONE 'UTC')"
+            )
             query_params.append(start_time_utc)
             placeholder_index += 1
         if end_time_utc:
             where_clauses.append(f"dus.updated_at <= ${placeholder_index}::timestamptz")
+            tag_time_clauses.append(
+                f"sl.\"startTime\" <= (${placeholder_index}::timestamptz AT TIME ZONE 'UTC')"
+            )
             query_params.append(end_time_utc)
             placeholder_index += 1
 
         where_clause = ""
         if where_clauses:
             where_clause = "WHERE " + " AND ".join(where_clauses)
+
+        tag_time_clause = ""
+        if tag_time_clauses:
+            tag_time_clause = "WHERE " + " AND ".join(tag_time_clauses)
 
         limit_clause = ""
         if limit is not None:
@@ -82,13 +93,42 @@ class FocusLiteLLMDatabase:
             tt.team_alias,
             ut.user_email as user_email,
             COALESCE(vt.organization_id, tt.organization_id) as organization_id,
-            ot.organization_alias as organization_alias
+            ot.organization_alias as organization_alias,
+            tag_rollup.request_tags as request_tags
         FROM "LiteLLM_DailyUserSpend" dus
         LEFT JOIN "LiteLLM_VerificationToken" vt ON dus.api_key = vt.token
         LEFT JOIN "LiteLLM_TeamTable" tt ON vt.team_id = tt.team_id
         LEFT JOIN "LiteLLM_UserTable" ut ON dus.user_id = ut.user_id
         LEFT JOIN "LiteLLM_OrganizationTable" ot
             ON ot.organization_id = COALESCE(vt.organization_id, tt.organization_id)
+        LEFT JOIN (
+            SELECT
+                sl."user" AS user_id,
+                to_char(sl."startTime", 'YYYY-MM-DD') AS date,
+                sl.api_key,
+                sl.model,
+                sl.custom_llm_provider,
+                sl.mcp_namespaced_tool_name,
+                ARRAY_AGG(DISTINCT tag_value ORDER BY tag_value) FILTER (WHERE tag_value IS NOT NULL) AS request_tags
+            FROM "LiteLLM_SpendLogs" sl
+            LEFT JOIN LATERAL jsonb_array_elements_text(
+                CASE
+                    WHEN jsonb_typeof(sl.request_tags::jsonb) = 'array'
+                    THEN sl.request_tags::jsonb
+                    ELSE '[]'::jsonb
+                END
+            ) AS elem(tag_value) ON TRUE
+            {tag_time_clause}
+            GROUP BY sl."user",
+                to_char(sl."startTime", 'YYYY-MM-DD'),
+                sl.api_key, sl.model, sl.custom_llm_provider, sl.mcp_namespaced_tool_name
+        ) tag_rollup
+            ON COALESCE(tag_rollup.user_id, '') = COALESCE(dus.user_id, '')
+            AND tag_rollup.date = dus.date
+            AND tag_rollup.api_key = dus.api_key
+            AND COALESCE(tag_rollup.model, '') = COALESCE(dus.model, '')
+            AND COALESCE(tag_rollup.custom_llm_provider, '') = COALESCE(dus.custom_llm_provider, '')
+            AND COALESCE(tag_rollup.mcp_namespaced_tool_name, '') = COALESCE(dus.mcp_namespaced_tool_name, '')
         {where_clause}
         ORDER BY dus.date DESC, dus.created_at DESC
         {limit_clause}

--- a/litellm/integrations/focus/transformer.py
+++ b/litellm/integrations/focus/transformer.py
@@ -22,22 +22,59 @@ _TAG_KEYS = (
     "custom_llm_provider",
 )
 
+_REQUEST_TAGS_KEY = "request_tags"
+_REQUEST_TAGS_TRUNCATED_KEY = "request_tags_truncated"
 
-def _build_tags_expr(available_keys: list[str]) -> pl.Expr:
+# Request tags are caller-controlled and unbounded. Cap how many (and how long)
+# land in a single row's Tags blob so it cannot exceed a destination's per-row
+# size limit (Vantage drops any row over 2 MB). The cap is on characters; even
+# the worst case (64 tags x 128 multibyte chars, double-JSON-encoded then CSV-
+# escaped) is on the order of ~115 KB, well under 2 MB.
+_MAX_REQUEST_TAGS = 64
+_MAX_TAG_LENGTH = 128
+
+
+def _build_tags_expr(tag_columns: list[str]) -> pl.Expr:
     """Build a Polars expression that produces a JSON Tags string per row.
 
     Uses ``pl.struct`` + ``map_elements`` to avoid materialising the entire
     DataFrame to a list of Python dicts.  The JSON serialisation callback
     still runs in Python (GIL-bound), but struct-packing and loop dispatch
     are handled by Polars' Rust engine.
+
+    Request-level tags arrive as a list column and are encoded as a JSON
+    array string so the Tags map stays a flat string-to-string object. The
+    list is capped to a bounded count/length so a flood of caller-supplied
+    tags cannot push the row past a destination's per-row size limit; when
+    that happens a ``request_tags_truncated`` marker carries the true count.
     """
 
-    def _struct_to_json(row: dict) -> str:
-        tags = {k: str(v) for k, v in row.items() if v is not None}
-        return json.dumps(tags) if tags else "{}"
+    def _struct_to_json(row: dict[str, object]) -> str:
+        metadata = {
+            k: str(v)
+            for k, v in row.items()
+            if k != _REQUEST_TAGS_KEY and v is not None
+        }
+        raw_tags = row.get(_REQUEST_TAGS_KEY)
+        if not raw_tags or not isinstance(raw_tags, (list, tuple)):
+            return json.dumps(metadata) if metadata else "{}"
+        total = len(raw_tags)
+        capped: list[str] = [
+            str(t)[:_MAX_TAG_LENGTH] for t in raw_tags[:_MAX_REQUEST_TAGS]
+        ]
+        tags = {
+            **metadata,
+            _REQUEST_TAGS_KEY: json.dumps(capped),
+            **(
+                {_REQUEST_TAGS_TRUNCATED_KEY: str(total)}
+                if total > _MAX_REQUEST_TAGS
+                else {}
+            ),
+        }
+        return json.dumps(tags)
 
     return (
-        pl.struct(available_keys)
+        pl.struct(tag_columns)
         .map_elements(_struct_to_json, return_dtype=pl.String)
         .alias("Tags")
     )
@@ -54,9 +91,9 @@ class FocusTransformer:
             return pl.DataFrame(schema=self.schema)
 
         # Build Tags JSON from metadata columns using vectorized Polars expression
-        available_keys = [k for k in _TAG_KEYS if k in frame.columns]
-        if available_keys:
-            frame = frame.with_columns(_build_tags_expr(available_keys))
+        tag_columns = [k for k in (*_TAG_KEYS, _REQUEST_TAGS_KEY) if k in frame.columns]
+        if tag_columns:
+            frame = frame.with_columns(_build_tags_expr(tag_columns))
         else:
             frame = frame.with_columns(pl.lit("{}").alias("Tags"))
 

--- a/tests/test_litellm/integrations/focus/test_focus_database.py
+++ b/tests/test_litellm/integrations/focus/test_focus_database.py
@@ -1,5 +1,6 @@
 """Tests for FocusLiteLLMDatabase query construction."""
 
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from litellm.integrations.focus.database import FocusLiteLLMDatabase
+from litellm.integrations.focus.transformer import FocusTransformer
 
 
 def _setup_db(monkeypatch: pytest.MonkeyPatch, query_return):
@@ -45,8 +47,12 @@ async def test_should_execute_without_filters(monkeypatch: pytest.MonkeyPatch):
     result = await db.get_usage_data()
 
     query_text, *params = query_mock.await_args.args
-    assert "WHERE" not in query_text
+    assert "dus.updated_at >=" not in query_text
+    assert "dus.updated_at <=" not in query_text
     assert "LIMIT $" not in query_text
+    # no stray WHERE clause anywhere when no window is given; the only legitimate
+    # WHERE is the ARRAY_AGG FILTER, so strip that before asserting
+    assert "WHERE" not in query_text.replace("FILTER (WHERE", "")
     assert params == []
     assert result.height == 1
     assert result["id"][0] == 1
@@ -87,3 +93,74 @@ async def test_should_join_organization_table(monkeypatch: pytest.MonkeyPatch):
     )
     assert "ot.organization_alias as organization_alias" in query_text
     assert 'LEFT JOIN "LiteLLM_OrganizationTable" ot' in query_text
+
+
+@pytest.mark.asyncio
+async def test_should_join_spend_logs_for_per_user_request_tags(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    db, query_mock = _setup_db(monkeypatch, [])
+
+    await db.get_usage_data()
+
+    query_text, *_ = query_mock.await_args.args
+    assert 'FROM "LiteLLM_SpendLogs" sl' in query_text
+    assert "jsonb_array_elements_text" in query_text
+    assert "tag_rollup.request_tags as request_tags" in query_text
+    # exact per-user attribution: tags join on user_id so a shared api_key
+    # never leaks one user's tags onto another user's export row
+    assert "COALESCE(tag_rollup.user_id, '') = COALESCE(dus.user_id, '')" in query_text
+
+
+@pytest.mark.asyncio
+async def test_should_scope_tag_subquery_to_time_window(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The SpendLogs tag aggregation must be bounded to the requested time
+    window (using the startTime index) instead of scanning all history."""
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    db, query_mock = _setup_db(monkeypatch, [])
+
+    await db.get_usage_data(start_time_utc=start, end_time_utc=end)
+
+    query_text, *params = query_mock.await_args.args
+    # window filter converts the bound param to the column's naive-UTC frame so
+    # it is independent of the Postgres session TimeZone
+    assert "sl.\"startTime\" >= ($1::timestamptz AT TIME ZONE 'UTC')" in query_text
+    assert "sl.\"startTime\" <= ($2::timestamptz AT TIME ZONE 'UTC')" in query_text
+    # bucketing must NOT apply AT TIME ZONE to the column (startTime is already
+    # naive-UTC; rendering it in the session TZ would shift the date and break
+    # the join with dus.date on non-UTC sessions)
+    assert "to_char(sl.\"startTime\", 'YYYY-MM-DD')" in query_text
+    assert "AT TIME ZONE 'UTC', 'YYYY-MM-DD'" not in query_text
+    assert params == [start, end]
+
+
+@pytest.mark.asyncio
+async def test_request_tags_flow_from_db_array_into_focus_tags(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Postgres returns the aggregated tags as an array; it must survive the
+    DataFrame round-trip and land inside the transformed FOCUS Tags column."""
+    row = {
+        "date": "2024-01-01",
+        "user_id": "user",
+        "api_key": "sk-test",
+        "api_key_alias": "prod-key",
+        "model": "gpt-4o",
+        "model_group": "gpt-4o",
+        "custom_llm_provider": "openai",
+        "spend": 0.05,
+        "api_requests": 1,
+        "team_id": "team-1",
+        "team_alias": "Platform",
+        "request_tags": ["prod", "checkout"],
+    }
+    db, _ = _setup_db(monkeypatch, [row])
+
+    frame = await db.get_usage_data()
+    normalized = FocusTransformer().transform(frame)
+
+    tags = json.loads(normalized["Tags"][0])
+    assert json.loads(tags["request_tags"]) == ["prod", "checkout"]

--- a/tests/test_litellm/integrations/focus/test_transformer.py
+++ b/tests/test_litellm/integrations/focus/test_transformer.py
@@ -38,6 +38,114 @@ def test_should_include_organization_fields_in_tags():
     assert tags["team_id"] == "team-1"
 
 
+def test_should_include_request_tags_in_tags():
+    frame = pl.DataFrame(
+        {
+            "date": [date(2024, 1, 2)],
+            "spend": [1.25],
+            "api_requests": [1],
+            "api_key": ["hashed-key"],
+            "api_key_alias": ["prod-key"],
+            "model": ["gpt-4o"],
+            "model_group": ["gpt-4o"],
+            "custom_llm_provider": ["openai"],
+            "team_id": ["team-1"],
+            "team_alias": ["Platform"],
+            "request_tags": [["prod", "checkout"]],
+        }
+    )
+
+    normalized = FocusTransformer().transform(frame)
+
+    tags = json.loads(normalized["Tags"][0])
+    assert json.loads(tags["request_tags"]) == ["prod", "checkout"]
+    assert tags["team_id"] == "team-1"
+    assert "request_tags_truncated" not in tags
+
+
+def test_should_cap_unbounded_request_tags():
+    """Caller-supplied tags are unbounded; the export must cap how many and how
+    long they are so one row cannot exceed a destination's per-row size limit,
+    and must record the true count via request_tags_truncated."""
+    long_tag = "x" * 500
+    many_tags = [f"tag-{i}" for i in range(70)]
+    frame = pl.DataFrame(
+        {
+            "date": [date(2024, 1, 2)],
+            "spend": [1.0],
+            "api_requests": [1],
+            "api_key": ["hashed-key"],
+            "api_key_alias": ["prod-key"],
+            "model": ["gpt-4o"],
+            "model_group": ["gpt-4o"],
+            "custom_llm_provider": ["openai"],
+            "team_id": ["team-1"],
+            "team_alias": ["Platform"],
+            "request_tags": [[long_tag, *many_tags]],
+        }
+    )
+
+    normalized = FocusTransformer().transform(frame)
+
+    tags = json.loads(normalized["Tags"][0])
+    emitted = json.loads(tags["request_tags"])
+    assert len(emitted) == 64  # _MAX_REQUEST_TAGS
+    assert all(len(t) <= 128 for t in emitted)  # _MAX_TAG_LENGTH
+    assert tags["request_tags_truncated"] == "71"  # 1 long + 70
+
+
+def test_should_not_mark_truncated_at_exactly_the_cap():
+    """Exactly _MAX_REQUEST_TAGS tags is not truncation: all are kept and no
+    marker is emitted (guards the `>` vs `>=` boundary)."""
+    exactly_cap = [f"tag-{i}" for i in range(64)]
+    frame = pl.DataFrame(
+        {
+            "date": [date(2024, 1, 2)],
+            "spend": [1.0],
+            "api_requests": [1],
+            "api_key": ["hashed-key"],
+            "api_key_alias": ["prod-key"],
+            "model": ["gpt-4o"],
+            "model_group": ["gpt-4o"],
+            "custom_llm_provider": ["openai"],
+            "team_id": ["team-1"],
+            "team_alias": ["Platform"],
+            "request_tags": [exactly_cap],
+        }
+    )
+
+    normalized = FocusTransformer().transform(frame)
+
+    tags = json.loads(normalized["Tags"][0])
+    assert len(json.loads(tags["request_tags"])) == 64
+    assert "request_tags_truncated" not in tags
+
+
+def test_should_omit_request_tags_when_empty():
+    frame = pl.DataFrame(
+        {
+            "date": [date(2024, 1, 2)],
+            "spend": [1.25],
+            "api_requests": [1],
+            "api_key": ["hashed-key"],
+            "api_key_alias": ["prod-key"],
+            "model": ["gpt-4o"],
+            "model_group": ["gpt-4o"],
+            "custom_llm_provider": ["openai"],
+            "team_id": ["team-1"],
+            "team_alias": ["Platform"],
+        }
+    ).with_columns(
+        pl.Series("request_tags", [None], dtype=pl.List(pl.String)),
+    )
+
+    normalized = FocusTransformer().transform(frame)
+
+    tags = json.loads(normalized["Tags"][0])
+    assert "request_tags" not in tags
+    assert tags["team_id"] == "team-1"
+
+
 def test_should_omit_missing_organization_fields_from_tags():
     frame = pl.DataFrame(
         {


### PR DESCRIPTION
## Relevant issues

Request-level tags (`x-litellm-tags`) are stored on each request and shown in Spend Logs, but they never reached the Vantage/FOCUS usage export, so customers could not attribute or filter exported cost by tag

## Linear ticket

Resolves LIT-3684

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` (focus suite: 79 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review (received 5/5)

## Type

🐛 Bug Fix

## Changes

The Vantage/FOCUS export is built from `LiteLLM_DailyUserSpend`, which carries no tags, so the exported FOCUS `Tags` object only ever contained entity metadata (user, model, team). Request tags had no path into the export

This change sources request tags from `LiteLLM_SpendLogs`, which keeps both `user` and `request_tags` on every request. `FocusLiteLLMDatabase.get_usage_data()` now LEFT JOINs an aggregation over `LiteLLM_SpendLogs` (unnesting `request_tags` with `jsonb_array_elements_text`, grouped by user, day, api_key, model, custom_llm_provider, mcp_namespaced_tool_name) and the transformer writes the resulting tags into the FOCUS `Tags` map. Because the join includes `user_id`, tags are attributed to the exact user, so a shared api_key never leaks one user's tags onto another user's export row

Request tags are caller-controlled and unbounded, and the Vantage destination silently drops any single row over 2 MB. To prevent a tag flood from suppressing a cost row, the transformer caps the tags written into one row to 64 entries of 128 chars each and, when it truncates, records the true count in a `request_tags_truncated` marker. 64 * 128 bytes is a small fraction of the 2 MB limit, leaving headroom for the metadata fields.

Timezone handling is session independent. `LiteLLM_SpendLogs."startTime"` is `timestamp without time zone` storing UTC wall-clock, and `dus.date` is the pure UTC date string. The day bucket therefore uses a plain `to_char(sl."startTime", 'YYYY-MM-DD')` with no `AT TIME ZONE` on the column, and the window filter converts the bound parameter into the column frame with `($n::timestamptz AT TIME ZONE 'UTC')`, mirroring the existing spend-tracking queries. This keeps the join correct regardless of the Postgres session TimeZone and lets the windowed path use `@@index([startTime])`. The join normalizes nullable columns with `COALESCE(x,'') = COALESCE(y,'')` because `LiteLLM_DailyUserSpend` stores empty string while `LiteLLM_SpendLogs` stores NULL for `mcp_namespaced_tool_name`

### Why SpendLogs and not the DailyTagSpend rollup

The first cut joined the `LiteLLM_DailyTagSpend` daily rollup, which is cheaper, but that table has no `user_id` (its grain is the tag), so on a shared api_key it blurs tags across the users who share that key. This is reachable in production, not just theoretical: with `general_settings.user_header_mappings` a single gateway key carries a different internal `user_id` per request, so the rollup would mix those users' tags. SpendLogs is the only source with both the tag and the per-request user, which the original report explicitly asked for

### Alternative considered: add `user_id` to `LiteLLM_DailyTagSpend`

An alternative that keeps the export on the cheap daily rollup is to add `user_id` to `LiteLLM_DailyTagSpend` (column plus its `@@unique` key), populate it in the daily tag write path (the value is already in the payload), and join the rollup on `user_id`. Tradeoff: it fixes attribution once at write time and keeps every export cheap, but it costs a schema migration that recreates the tag table's unique index, it grows that rollup only for genuinely shared keys, and roughly eight other readers of `LiteLLM_DailyTagSpend` would need a pass to confirm they do not double count. The SpendLogs route taken here needs no migration; its cost is that the export query scales with request volume in the window rather than with the small rollup. For a tag-attribution feature that is exported repeatedly, the write-time rollup fix is the better long-term option and is worth a follow-up if export latency on large tenants becomes a concern

### Known limitations

`LiteLLM_SpendLogs` has no `endpoint` column, while the `DailyUserSpend` grain includes `endpoint`, so two export rows that differ only by `endpoint` share the same tag set. Per-user, per-model, per-provider attribution is exact. A full export with no time window aggregates the whole `SpendLogs` table; windowed exports use the `startTime` index. `request_tags` is emitted as a JSON-array string nested inside the FOCUS `Tags` map (FOCUS `Tags` is a flat string to string map), so a consumer reads it with a second parse; confirm this shape matches what the Vantage side expects

## Screenshots / Proof of Fix

All runs use a live proxy on a real Postgres with real Anthropic calls (`claude-haiku-4-5`)

Tags now reach the export. A tagged request, then the export preview

```bash
curl -s -X POST http://localhost:4010/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -H "x-litellm-tags: env:prod,team:checkout" \
  -d '{"model":"haiku45","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'

curl -s -X POST http://localhost:4010/vantage/dry-run \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"limit":100}'
# Tags -> {"user_id":"...","model":"...","request_tags":"[\"env:prod\",\"team:checkout\"]"}
```

Per-user attribution is exact on a shared key. Two users hit the same key (master key) in one request each via the `X-User-Id` header (`general_settings.user_header_mappings`), with different tags, then the export keeps them separate

```bash
curl -s -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "X-User-Id: alice" -H "x-litellm-tags: env:prod" \
  -d '{"model":"haiku45","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'
curl -s -X POST http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "X-User-Id: bob" -H "x-litellm-tags: env:dev" \
  -d '{"model":"haiku45","messages":[{"role":"user","content":"hi"}],"max_tokens":10}'

curl -s -X POST http://localhost:4010/vantage/dry-run -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"limit":100}'
```

```
user=alice | request_tags=['env:prod']     # only alice's tag
user=bob   | request_tags=['env:dev']      # only bob's tag, no cross-user leakage
```

Timezone independence. With the DB session set to `America/Los_Angeles` and a request at `02:00` UTC (which is the prior day in LA), the tag still joins to the correct UTC day in the export, where the earlier column-side `AT TIME ZONE 'UTC'` form would have shifted the date and dropped the tag

```
DB session: America/Los_Angeles
02:00-UTC request -> export request_tags = ['boundary:tag']   # tag preserved
```

Tag flood is bounded. A request carrying 70 tags (72 distinct after the proxy's own User-Agent tags) exports a row capped at 64 tags with `request_tags_truncated: "72"`, so the row stays well under the 2 MB destination limit instead of being dropped

```
emitted tag count: 64
request_tags_truncated: 72
all tags <= 128 chars: True
```

Tests: 80 focus tests pass. The per-user join, the SpendLogs source, the session-independent time-window scoping, and the transformer encoding each fail when the corresponding logic is reverted
