### PR TITLE
feat(router): add PermissionDeniedErrorRetries to RetryPolicy

### DIFF
--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -10,6 +10,7 @@ from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
     ContentPolicyViolationError,
+    PermissionDeniedError,
     RateLimitError,
     Timeout,
 )
@@ -28,6 +29,8 @@ def get_num_retries_from_retry_policy(
     TimeoutErrorRetries: Optional[int] = None
     RateLimitErrorRetries: Optional[int] = None
     ContentPolicyViolationErrorRetries: Optional[int] = None
+    InternalServerErrorRetries: Optional[int] = None
+    PermissionDeniedErrorRetries: Optional[int] = None
     """
     # if we can find the exception then in the retry policy -> return the number of retries
 
@@ -65,6 +68,11 @@ def get_num_retries_from_retry_policy(
         and retry_policy.BadRequestErrorRetries is not None
     ):
         return retry_policy.BadRequestErrorRetries
+    if (
+        isinstance(exception, PermissionDeniedError)
+        and retry_policy.PermissionDeniedErrorRetries is not None
+    ):
+        return retry_policy.PermissionDeniedErrorRetries
 
 
 def reset_retry_policy() -> RetryPolicy:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -506,6 +506,7 @@ class RetryPolicy(BaseModel):
     RateLimitErrorRetries: Optional[int] = None
     ContentPolicyViolationErrorRetries: Optional[int] = None
     InternalServerErrorRetries: Optional[int] = None
+    PermissionDeniedErrorRetries: Optional[int] = None
 
 
 class AlertingConfig(BaseModel):

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -159,13 +159,13 @@ class TestResponseCompliance:
         # schema no longer carries `steps`. Keep this aligned with the live spec.
         schema = spec_dict["components"]["schemas"]["Interaction"]
 
-        # Output fields (readOnly).
+        # Output fields (readOnly). `role` was removed from the `Interaction`
+        # schema by Google; it now lives only on `Turn`.
         output_fields = [
             "id",
             "status",
             "created",
             "updated",
-            "role",
             "steps",
             "usage",
         ]

--- a/tests/test_litellm/test_retry_policy_permission_denied.py
+++ b/tests/test_litellm/test_retry_policy_permission_denied.py
@@ -1,0 +1,42 @@
+"""
+Unit tests for PermissionDeniedErrorRetries in RetryPolicy.
+"""
+
+import httpx
+from unittest.mock import MagicMock
+
+import litellm
+from litellm.router_utils.get_retry_from_policy import get_num_retries_from_retry_policy
+from litellm.types.router import RetryPolicy
+
+
+def _make_permission_denied() -> litellm.exceptions.PermissionDeniedError:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = 403
+    response.headers = httpx.Headers({})
+    return litellm.exceptions.PermissionDeniedError(
+        message="403 Permission Denied",
+        llm_provider="openai",
+        model="gpt-4o",
+        response=response,
+    )
+
+
+def test_permission_denied_retries_returns_configured_value():
+    """PermissionDeniedErrorRetries is returned when a PermissionDeniedError is raised."""
+    policy = RetryPolicy(PermissionDeniedErrorRetries=0)
+    result = get_num_retries_from_retry_policy(
+        exception=_make_permission_denied(),
+        retry_policy=policy,
+    )
+    assert result == 0
+
+
+def test_permission_denied_retries_none_when_not_configured():
+    """Returns None (falls through to default) when PermissionDeniedErrorRetries is not set."""
+    policy = RetryPolicy(RateLimitErrorRetries=3)
+    result = get_num_retries_from_retry_policy(
+        exception=_make_permission_denied(),
+        retry_policy=policy,
+    )
+    assert result is None


### PR DESCRIPTION
## Description
We had an issue were our credit card hit its spending limit and liteLLM kept retrying the LLM calls repeatedly on multiple regions despite them returning HTTP 403 repeatedly

Adds `PermissionDeniedErrorRetries` to `RetryPolicy`, allowing users to control retry behavior on 403 Permission Denied responses.

## Motivation

This is especially important for shared-credential regional routing. If one region returns 403 because the underlying account/project is blocked (for example, billing/spend limit, IAM, or quota policy), every region using the same credentials is likely to return the same 403. Retrying/failing over then creates a cascading effect: repeated failed calls across regions, extra latency, noisier logs/metrics, and no real chance of recovery. PermissionDeniedErrorRetries=0 lets users stop that loop explicitly while preserving failover behavior for setups where regions/deployments use independent credentials.

`should_retry_this_error` explicitly exempts 401/403 from its "non-retryable status codes" guard so that multi-tenant LiteLLM proxy setups with different API keys per deployment can fail over to a working key. However, when **all** regional endpoints share the same credentials (e.g. a single GCP service account across multiple Vertex AI regions), a 403 on one endpoint will 403 on every other — retrying wastes calls and adds latency with no chance of success.

`RetryPolicy` already covers `BadRequestError`, `AuthenticationError`, `RateLimitError`, `ContentPolicyViolationError`, and `InternalServerError`. `PermissionDeniedError` (403) was the only missing entry, forcing users to subclass `Router` and override `should_retry_this_error` just to set retries to 0.

## Changes

- `litellm/types/router.py`: add `PermissionDeniedErrorRetries: Optional[int] = None` to `RetryPolicy`
- `litellm/router_utils/get_retry_from_policy.py`: import `PermissionDeniedError` and handle it in `get_num_retries_from_retry_policy`
- `tests/router_unit_tests/test_router_helper_utils.py`: add `PermissionDeniedError` / `PermissionDeniedErrorRetries=0` to the existing parametrized test

## Usage

```python
from litellm import Router
from litellm.router import RetryPolicy

router = Router(
    model_list=[...],
    retry_policy=RetryPolicy(
        PermissionDeniedErrorRetries=0,  # don't retry 403s when all deployments share credentials
    ),
)
```