### PR TITLE
fix(responses): retain strong ref to streaming success-logging tasks (GC race)

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -40,7 +40,7 @@ def _get_openai_response_types():
     return openai_types
 
 
-def _log_background_task_failure(task: "asyncio.Task[Any]", *, task_name: str) -> None:
+def _log_background_task_failure(task: asyncio.Task[Any], *, task_name: str) -> None:
     if task.cancelled():
         return
     exception = task.exception()
@@ -84,6 +84,35 @@ def _status_code_for_error_fields(error_type: Optional[str], error_code: Optiona
     if any(field in _CLIENT_ERROR_CODES for field in fields):
         return 400
     return 500
+
+
+# Strong references to fire-and-forget background tasks. The event loop only
+# holds a weak reference to tasks, so an un-referenced task "may get garbage
+# collected at any time, even before it's done" (asyncio docs). Tasks are added
+# here on creation and discarded on completion to keep them alive in between.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _track_background_task(task: asyncio.Task[Any], *, task_name: str) -> None:
+    """Keep a strong reference to a fire-and-forget *task* until it completes.
+
+    Prevents the success-logging / spend-log tasks scheduled via
+    ``asyncio.create_task`` from being garbage-collected mid-execution (which
+    would silently drop the spend-log row). On completion the task is removed
+    from the tracking set and any failure is surfaced via
+    ``_log_background_task_failure``.
+
+    Args:
+        task: The task to keep alive.
+        task_name: Human-readable name used when logging a failure.
+    """
+    _BACKGROUND_TASKS.add(task)
+
+    def _on_done(completed: asyncio.Task[Any]) -> None:
+        _BACKGROUND_TASKS.discard(completed)
+        _log_background_task_failure(completed, task_name=task_name)
+
+    task.add_done_callback(_on_done)
 
 
 class BaseResponsesAPIStreamingIterator:
@@ -331,7 +360,7 @@ class BaseResponsesAPIStreamingIterator:
 
         end_time = datetime.now()
         if is_async:
-            asyncio.create_task(
+            log_task = asyncio.create_task(
                 self.logging_obj.dispatch_success_handlers(
                     logging_response,
                     start_time=self.start_time,
@@ -340,6 +369,7 @@ class BaseResponsesAPIStreamingIterator:
                     prefer_async_handlers=True,
                 )
             )
+            _track_background_task(log_task, task_name="Responses stream success logging")
         else:
             run_async_function(
                 async_function=self.logging_obj.async_success_handler,
@@ -1360,7 +1390,10 @@ class ResponsesWebSocketStreaming:
         if self.input_messages:
             self.logging_obj.model_call_details["messages"] = self.input_messages
         if self.messages:
-            asyncio.create_task(self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True))
+            ws_log_task = asyncio.create_task(
+                self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True)
+            )
+            _track_background_task(ws_log_task, task_name="Responses WebSocket success logging")
 
     async def backend_to_client(self) -> None:
         """Forward events from backend WebSocket to the client."""

--- a/tests/test_litellm/responses/test_streaming_iterator_background_tasks.py
+++ b/tests/test_litellm/responses/test_streaming_iterator_background_tasks.py
@@ -1,0 +1,167 @@
+"""Regression for #31059.
+
+``ResponsesAPIStreamingIterator`` scheduled the success-logging coroutine via a
+bare ``asyncio.create_task(...)`` whose returned task was never referenced. The
+event loop keeps only a weak reference to tasks, so an un-referenced logging
+task can be garbage-collected before it finishes — silently dropping the
+streaming Responses-API spend-log row.
+
+These tests cover the fix: a module-level ``_BACKGROUND_TASKS`` set holds a
+strong reference until completion (surviving GC), failures are still surfaced,
+and the success-logging call site registers its task with the tracker.
+"""
+
+import asyncio
+import gc
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.responses.streaming_iterator import (
+    BaseResponsesAPIStreamingIterator,
+    ResponsesWebSocketStreaming,
+    _BACKGROUND_TASKS,
+    _track_background_task,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_background_tasks():
+    """Keep the module-level set isolated between tests."""
+    _BACKGROUND_TASKS.clear()
+    yield
+    _BACKGROUND_TASKS.clear()
+
+
+@pytest.mark.asyncio
+async def test_track_background_task_holds_strong_ref_then_discards():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _work():
+        started.set()
+        await release.wait()
+
+    task = asyncio.create_task(_work())
+    _track_background_task(task, task_name="unit task")
+
+    await started.wait()
+    # Strong reference retained while the task runs.
+    assert task in _BACKGROUND_TASKS
+
+    release.set()
+    await task
+    # Discarded once complete so the set does not grow unbounded.
+    assert task not in _BACKGROUND_TASKS
+
+
+@pytest.mark.asyncio
+async def test_tracked_task_survives_gc_while_pending():
+    """The actual bug: without a strong reference, the task can be collected
+    mid-flight. The tracker must keep it alive across a GC cycle."""
+    done = asyncio.Event()
+    ran = {"value": False}
+
+    async def _work():
+        await asyncio.sleep(0.05)
+        ran["value"] = True
+        done.set()
+
+    _track_background_task(asyncio.create_task(_work()), task_name="gc-sensitive task")
+    # Drop every local reference the caller might have held, then force GC.
+    gc.collect()
+
+    await asyncio.wait_for(done.wait(), timeout=2.0)
+    assert ran["value"] is True
+    # The discard done-callback fires a tick after the task completes.
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if not _BACKGROUND_TASKS:
+            break
+    assert len(_BACKGROUND_TASKS) == 0
+
+
+@pytest.mark.asyncio
+async def test_tracked_task_failure_is_logged_and_discarded():
+    async def _boom():
+        raise RuntimeError("logging blew up")
+
+    task = asyncio.create_task(_boom())
+    with patch("litellm.responses.streaming_iterator.verbose_logger") as mock_logger:
+        _track_background_task(task, task_name="failing task")
+        # Await the underlying coroutine result without raising into the test.
+        with pytest.raises(RuntimeError):
+            await task
+        # done-callbacks run on the next loop tick.
+        await asyncio.sleep(0)
+
+    assert task not in _BACKGROUND_TASKS
+    mock_logger.error.assert_called_once()
+    assert "failing task" in str(mock_logger.error.call_args)
+
+
+@pytest.mark.asyncio
+async def test_log_completed_response_async_path_tracks_task():
+    """The async success-logging call site must register its task with the
+    tracker so it cannot be GC'd before the spend-log row is written."""
+    iterator = object.__new__(BaseResponsesAPIStreamingIterator)
+    iterator._completed_response_logged = False
+    iterator._persist_completed_response_before_logging = False
+    iterator.completed_response = None
+    iterator.start_time = SimpleNamespace()
+    iterator._completed_response_cache_hit = False
+
+    handler_started = asyncio.Event()
+    handler_release = asyncio.Event()
+
+    async def _fake_dispatch_success_handlers(*args, **kwargs):
+        handler_started.set()
+        await handler_release.wait()
+
+    iterator.logging_obj = MagicMock()
+    iterator.logging_obj.dispatch_success_handlers = _fake_dispatch_success_handlers
+
+    iterator._log_completed_response(is_async=True)
+
+    await asyncio.wait_for(handler_started.wait(), timeout=2.0)
+    assert len(_BACKGROUND_TASKS) == 1
+
+    handler_release.set()
+    # Let the tracked task finish and its done-callback discard it.
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if not _BACKGROUND_TASKS:
+            break
+    assert len(_BACKGROUND_TASKS) == 0
+
+
+@pytest.mark.asyncio
+async def test_websocket_log_messages_tracks_task():
+    """The WebSocket success-logging call site (_log_messages) must register its
+    task with the tracker too — the issue reported both sites."""
+    ws = object.__new__(ResponsesWebSocketStreaming)
+    ws.input_messages = None
+    ws.messages = [{"role": "assistant", "content": "hi"}]
+
+    handler_started = asyncio.Event()
+    handler_release = asyncio.Event()
+
+    async def _fake_dispatch_success_handlers(messages, **kwargs):
+        handler_started.set()
+        await handler_release.wait()
+
+    ws.logging_obj = MagicMock()
+    ws.logging_obj.dispatch_success_handlers = _fake_dispatch_success_handlers
+
+    await ws._log_messages()
+
+    await asyncio.wait_for(handler_started.wait(), timeout=2.0)
+    assert len(_BACKGROUND_TASKS) == 1
+
+    handler_release.set()
+    for _ in range(5):
+        await asyncio.sleep(0)
+        if not _BACKGROUND_TASKS:
+            break
+    assert len(_BACKGROUND_TASKS) == 0


### PR DESCRIPTION
## Summary

Fixes #31059.

In `ResponsesAPIStreamingIterator`, the success-logging path scheduled `logging_obj.async_success_handler(...)` via a bare `asyncio.create_task(...)` whose returned `Task` was never stored. Per the asyncio docs the event loop keeps only a *weak* reference to tasks, so an un-referenced task "may get garbage collected at any time, even before it's done." Under load — or when the client connection closes right after the stream ends — this logging task can be collected before it finishes and the streaming Responses-API spend-log row is then silently never written (the HTTP response is unaffected, so the loss is invisible).

Thanks to @zhishui110 for the detailed report and root-cause analysis.

## Fix

Keep a strong reference to the logging task until it completes, mirroring how `cache_write_task` / `forward_task` are already handled in this same file. Tasks are added to a module-level set on creation and discarded via an `add_done_callback`, which also surfaces any failure through the existing `_log_background_task_failure` helper.

Applied to both call sites called out in the issue:
- `_log_completed_response()` — the async spend-log success path
- `_log_messages()` — the WebSocket responses success path

## Tests

New `tests/test_litellm/responses/test_streaming_iterator_background_tasks.py`:
- strong reference retained while pending, discarded on completion
- the task survives a `gc.collect()` while pending (the actual bug)
- failures are still surfaced via `_log_background_task_failure` and the task is discarded
- both call sites (`_log_completed_response` async path + WebSocket `_log_messages`) register their task with the tracker

`black` + `ruff` clean.
