### PR TITLE
fix(anthropic): preserve messages cache usage

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -207,32 +207,13 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         if "delta" not in merged_chunk:
             merged_chunk["delta"] = {}
 
-        uncached_input_tokens = chunk.usage.prompt_tokens or 0
-        if (
-            hasattr(chunk.usage, "prompt_tokens_details")
-            and chunk.usage.prompt_tokens_details
-        ):
-            cached_tokens = (
-                getattr(chunk.usage.prompt_tokens_details, "cached_tokens", 0) or 0
-            )
-            uncached_input_tokens -= cached_tokens
+        from .transformation import LiteLLMAnthropicMessagesAdapter
 
-        usage_dict: UsageDelta = {
-            "input_tokens": uncached_input_tokens,
-            "output_tokens": chunk.usage.completion_tokens or 0,
-        }
-        if (
-            hasattr(chunk.usage, "_cache_creation_input_tokens")
-            and chunk.usage._cache_creation_input_tokens > 0
-        ):
-            usage_dict["cache_creation_input_tokens"] = (
-                chunk.usage._cache_creation_input_tokens
+        usage_dict: UsageDelta = (
+            LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
+                chunk.usage
             )
-        if (
-            hasattr(chunk.usage, "_cache_read_input_tokens")
-            and chunk.usage._cache_read_input_tokens > 0
-        ):
-            usage_dict["cache_read_input_tokens"] = chunk.usage._cache_read_input_tokens
+        )
         merged_chunk["usage"] = usage_dict
         if self.applied_edits and "context_management" not in merged_chunk:
             merged_chunk["context_management"] = ContextManagementResponse(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1404,8 +1404,8 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @staticmethod
     def _positive_int(value: object) -> int:
-        if isinstance(value, int) and value > 0:
-            return value
+        if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+            return int(value)
         return 0
 
     @classmethod

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1404,7 +1404,11 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @staticmethod
     def _positive_int(value: object) -> int:
-        if isinstance(value, (int, float)) and not isinstance(value, bool) and value > 0:
+        if isinstance(value, bool):
+            return 0
+        if isinstance(value, int) and value > 0:
+            return value
+        if isinstance(value, float) and value.is_integer() and value > 0:
             return int(value)
         return 0
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1410,7 +1410,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @classmethod
     def _first_positive_usage_value(
-        cls, usage: Usage, field_names: Tuple[str, ...]
+        cls, usage: Usage, field_names: tuple[str, ...]
     ) -> int:
         for field_name in field_names:
             value = cls._positive_int(getattr(usage, field_name, None))
@@ -1420,7 +1420,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
     @classmethod
     def _first_positive_prompt_tokens_detail_value(
-        cls, usage: Usage, field_names: Tuple[str, ...]
+        cls, usage: Usage, field_names: tuple[str, ...]
     ) -> int:
         prompt_tokens_details = getattr(usage, "prompt_tokens_details", None)
         if prompt_tokens_details is None:
@@ -1444,9 +1444,7 @@ class LiteLLMAnthropicMessagesAdapter:
         )
         if explicit_value > 0:
             return explicit_value
-        return cls._first_positive_prompt_tokens_detail_value(
-            usage, ("cached_tokens",)
-        )
+        return cls._first_positive_prompt_tokens_detail_value(usage, ("cached_tokens",))
 
     @classmethod
     def _get_cache_creation_input_tokens(cls, usage: Usage) -> int:
@@ -1483,9 +1481,7 @@ class LiteLLMAnthropicMessagesAdapter:
         return usage_delta
 
     @classmethod
-    def _translate_openai_usage_to_anthropic_usage(
-        cls, usage: Usage
-    ) -> AnthropicUsage:
+    def _translate_openai_usage_to_anthropic_usage(cls, usage: Usage) -> AnthropicUsage:
         return cast(
             AnthropicUsage,
             cls._translate_openai_usage_to_anthropic_usage_delta(usage),

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -1402,6 +1402,95 @@ class LiteLLMAnthropicMessagesAdapter:
             return "tool_use"
         return "end_turn"
 
+    @staticmethod
+    def _positive_int(value: object) -> int:
+        if isinstance(value, int) and value > 0:
+            return value
+        return 0
+
+    @classmethod
+    def _first_positive_usage_value(
+        cls, usage: Usage, field_names: Tuple[str, ...]
+    ) -> int:
+        for field_name in field_names:
+            value = cls._positive_int(getattr(usage, field_name, None))
+            if value > 0:
+                return value
+        return 0
+
+    @classmethod
+    def _first_positive_prompt_tokens_detail_value(
+        cls, usage: Usage, field_names: Tuple[str, ...]
+    ) -> int:
+        prompt_tokens_details = getattr(usage, "prompt_tokens_details", None)
+        if prompt_tokens_details is None:
+            return 0
+
+        for field_name in field_names:
+            if isinstance(prompt_tokens_details, dict):
+                value = cls._positive_int(prompt_tokens_details.get(field_name))
+            else:
+                value = cls._positive_int(
+                    getattr(prompt_tokens_details, field_name, None)
+                )
+            if value > 0:
+                return value
+        return 0
+
+    @classmethod
+    def _get_cache_read_input_tokens(cls, usage: Usage) -> int:
+        explicit_value = cls._first_positive_usage_value(
+            usage, ("cache_read_input_tokens", "_cache_read_input_tokens")
+        )
+        if explicit_value > 0:
+            return explicit_value
+        return cls._first_positive_prompt_tokens_detail_value(
+            usage, ("cached_tokens",)
+        )
+
+    @classmethod
+    def _get_cache_creation_input_tokens(cls, usage: Usage) -> int:
+        explicit_value = cls._first_positive_usage_value(
+            usage, ("cache_creation_input_tokens", "_cache_creation_input_tokens")
+        )
+        if explicit_value > 0:
+            return explicit_value
+        return cls._first_positive_prompt_tokens_detail_value(
+            usage, ("cache_creation_tokens", "cache_write_tokens")
+        )
+
+    @classmethod
+    def _translate_openai_usage_to_anthropic_usage_delta(
+        cls, usage: Usage
+    ) -> UsageDelta:
+        cache_read_input_tokens = cls._get_cache_read_input_tokens(usage)
+        cache_creation_input_tokens = cls._get_cache_creation_input_tokens(usage)
+        input_tokens = max(
+            (usage.prompt_tokens or 0)
+            - cache_read_input_tokens
+            - cache_creation_input_tokens,
+            0,
+        )
+
+        usage_delta = UsageDelta(
+            input_tokens=input_tokens,
+            output_tokens=usage.completion_tokens or 0,
+        )
+        if cache_creation_input_tokens > 0:
+            usage_delta["cache_creation_input_tokens"] = cache_creation_input_tokens
+        if cache_read_input_tokens > 0:
+            usage_delta["cache_read_input_tokens"] = cache_read_input_tokens
+        return usage_delta
+
+    @classmethod
+    def _translate_openai_usage_to_anthropic_usage(
+        cls, usage: Usage
+    ) -> AnthropicUsage:
+        return cast(
+            AnthropicUsage,
+            cls._translate_openai_usage_to_anthropic_usage_delta(usage),
+        )
+
     def translate_openai_response_to_anthropic(
         self,
         response: ModelResponse,
@@ -1433,32 +1522,12 @@ class LiteLLMAnthropicMessagesAdapter:
         )
         # extract usage
         usage: Usage = getattr(response, "usage")
-        uncached_input_tokens = usage.prompt_tokens or 0
-        cached_tokens = 0
-        if hasattr(usage, "prompt_tokens_details") and usage.prompt_tokens_details:
-            cached_tokens = (
-                getattr(usage.prompt_tokens_details, "cached_tokens", 0) or 0
-            )
-            uncached_input_tokens -= cached_tokens
-
-        anthropic_usage = AnthropicUsage(
-            input_tokens=uncached_input_tokens,
-            output_tokens=usage.completion_tokens or 0,
-        )
-        if (
-            hasattr(usage, "_cache_creation_input_tokens")
-            and usage._cache_creation_input_tokens > 0
-        ):
-            anthropic_usage["cache_creation_input_tokens"] = (
-                usage._cache_creation_input_tokens
-            )
-        if cached_tokens > 0:
-            anthropic_usage["cache_read_input_tokens"] = cached_tokens
+        anthropic_usage = self._translate_openai_usage_to_anthropic_usage(usage)
 
         if polyfill_result is not None and polyfill_result.iterations_usage is not None:
             message_iteration: UsageIteration = {
                 "type": "message",
-                "input_tokens": uncached_input_tokens,
+                "input_tokens": anthropic_usage["input_tokens"],
                 "output_tokens": usage.completion_tokens or 0,
             }
             anthropic_usage["iterations"] = list(polyfill_result.iterations_usage) + [message_iteration]  # type: ignore[typeddict-unknown-key]
@@ -1647,35 +1716,9 @@ class LiteLLMAnthropicMessagesAdapter:
             else:
                 litellm_usage_chunk = None
             if litellm_usage_chunk is not None:
-                uncached_input_tokens = litellm_usage_chunk.prompt_tokens or 0
-                cached_tokens = 0
-                if (
-                    hasattr(litellm_usage_chunk, "prompt_tokens_details")
-                    and litellm_usage_chunk.prompt_tokens_details
-                ):
-                    cached_tokens = (
-                        getattr(
-                            litellm_usage_chunk.prompt_tokens_details,
-                            "cached_tokens",
-                            0,
-                        )
-                        or 0
-                    )
-                    uncached_input_tokens -= cached_tokens
-
-                usage_delta = UsageDelta(
-                    input_tokens=uncached_input_tokens,
-                    output_tokens=litellm_usage_chunk.completion_tokens or 0,
+                usage_delta = self._translate_openai_usage_to_anthropic_usage_delta(
+                    litellm_usage_chunk
                 )
-                if (
-                    hasattr(litellm_usage_chunk, "_cache_creation_input_tokens")
-                    and litellm_usage_chunk._cache_creation_input_tokens > 0
-                ):
-                    usage_delta["cache_creation_input_tokens"] = (
-                        litellm_usage_chunk._cache_creation_input_tokens
-                    )
-                if cached_tokens > 0:
-                    usage_delta["cache_read_input_tokens"] = cached_tokens
             else:
                 usage_delta = UsageDelta(input_tokens=0, output_tokens=0)
             message_block = MessageBlockDelta(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2146,6 +2146,148 @@ def test_translate_openai_response_to_anthropic_cache_tokens_from_prompt_tokens_
     assert anthropic_response["usage"]["cache_read_input_tokens"] == 30
 
 
+def test_translate_openai_response_to_anthropic_cache_creation_from_prompt_tokens_details():
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+
+    response = ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="stop",
+                message=Message(
+                    role="assistant",
+                    content="Test response",
+                ),
+            )
+        ],
+        model="gpt-4o-2024-08-06",
+        usage=usage,
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=response,
+        tool_name_mapping=None,
+    )
+
+    assert anthropic_response["usage"]["input_tokens"] == 70
+    assert anthropic_response["usage"]["output_tokens"] == 50
+    assert anthropic_response["usage"]["cache_read_input_tokens"] == 30
+    assert anthropic_response["usage"]["cache_creation_input_tokens"] == 20
+
+
+def test_translate_openai_response_to_anthropic_cache_tokens_from_usage_fields():
+    usage = Usage(prompt_tokens=120, completion_tokens=50, total_tokens=170)
+    usage.cache_read_input_tokens = 30
+    usage.cache_creation_input_tokens = 20
+
+    response = ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="stop",
+                message=Message(
+                    role="assistant",
+                    content="Test response",
+                ),
+            )
+        ],
+        model="claude-3-sonnet-20240229",
+        usage=usage,
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=response,
+        tool_name_mapping=None,
+    )
+
+    assert anthropic_response["usage"]["input_tokens"] == 70
+    assert anthropic_response["usage"]["output_tokens"] == 50
+    assert anthropic_response["usage"]["cache_read_input_tokens"] == 30
+    assert anthropic_response["usage"]["cache_creation_input_tokens"] == 20
+
+
+def test_translate_openai_response_to_anthropic_cache_tokens_from_private_usage_fields():
+    usage = Usage(prompt_tokens=120, completion_tokens=50, total_tokens=170)
+
+    response = ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="stop",
+                message=Message(
+                    role="assistant",
+                    content="Test response",
+                ),
+            )
+        ],
+        model="claude-3-sonnet-20240229",
+        usage=usage,
+    )
+    response.usage._cache_read_input_tokens = 30
+    response.usage._cache_creation_input_tokens = 20
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    anthropic_response = adapter.translate_openai_response_to_anthropic(
+        response=response,
+        tool_name_mapping=None,
+    )
+
+    assert anthropic_response["usage"]["input_tokens"] == 70
+    assert anthropic_response["usage"]["output_tokens"] == 50
+    assert anthropic_response["usage"]["cache_read_input_tokens"] == 30
+    assert anthropic_response["usage"]["cache_creation_input_tokens"] == 20
+
+
+def test_translate_streaming_openai_response_to_anthropic_cache_tokens_from_prompt_tokens_details():
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+    response = ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    message_delta = adapter.translate_streaming_openai_response_to_anthropic(
+        response=response,
+        current_content_block_index=0,
+    )
+
+    assert message_delta["usage"]["input_tokens"] == 70
+    assert message_delta["usage"]["output_tokens"] == 50
+    assert message_delta["usage"]["cache_read_input_tokens"] == 30
+    assert message_delta["usage"]["cache_creation_input_tokens"] == 20
+
+
 # =====================================================================
 # Web Search Tool Transformation Tests
 # =====================================================================

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2146,6 +2146,67 @@ def test_translate_openai_response_to_anthropic_cache_tokens_from_prompt_tokens_
     assert anthropic_response["usage"]["cache_read_input_tokens"] == 30
 
 
+def test_translate_openai_usage_to_anthropic_cache_tokens_from_dict_details_with_integral_floats():
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+    )
+    usage.prompt_tokens_details = {
+        "cached_tokens": 30.0,
+        "cache_write_tokens": 20.0,
+    }
+
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
+        usage
+    )
+
+    assert anthropic_usage["input_tokens"] == 70
+    assert anthropic_usage["output_tokens"] == 50
+    assert anthropic_usage["cache_read_input_tokens"] == 30
+    assert anthropic_usage["cache_creation_input_tokens"] == 20
+
+
+def test_translate_openai_usage_to_anthropic_ignores_fractional_cache_tokens():
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+    )
+    usage.prompt_tokens_details = {
+        "cached_tokens": 30.5,
+        "cache_creation_tokens": 20.25,
+    }
+
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
+        usage
+    )
+
+    assert anthropic_usage["input_tokens"] == 120
+    assert anthropic_usage["output_tokens"] == 50
+    assert "cache_read_input_tokens" not in anthropic_usage
+    assert "cache_creation_input_tokens" not in anthropic_usage
+
+
+def test_translate_openai_usage_to_anthropic_ignores_bool_cache_tokens():
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+    )
+    usage.cache_read_input_tokens = True
+    usage.cache_creation_input_tokens = True
+
+    anthropic_usage = LiteLLMAnthropicMessagesAdapter._translate_openai_usage_to_anthropic_usage_delta(
+        usage
+    )
+
+    assert anthropic_usage["input_tokens"] == 120
+    assert anthropic_usage["output_tokens"] == 50
+    assert "cache_read_input_tokens" not in anthropic_usage
+    assert "cache_creation_input_tokens" not in anthropic_usage
+
+
 def test_translate_openai_response_to_anthropic_cache_creation_from_prompt_tokens_details():
     from litellm.types.utils import PromptTokensDetailsWrapper
 
@@ -2275,6 +2336,41 @@ def test_translate_streaming_openai_response_to_anthropic_cache_tokens_from_prom
         ],
         usage=usage,
     )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    message_delta = adapter.translate_streaming_openai_response_to_anthropic(
+        response=response,
+        current_content_block_index=0,
+    )
+
+    assert message_delta["usage"]["input_tokens"] == 70
+    assert message_delta["usage"]["output_tokens"] == 50
+    assert message_delta["usage"]["cache_read_input_tokens"] == 30
+    assert message_delta["usage"]["cache_creation_input_tokens"] == 20
+
+
+def test_translate_streaming_openai_response_to_anthropic_cache_tokens_from_hidden_params_usage():
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+    response = ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(),
+                finish_reason="stop",
+            )
+        ],
+    )
+    response._hidden_params = {"usage": usage}
 
     adapter = LiteLLMAnthropicMessagesAdapter()
     message_delta = adapter.translate_streaming_openai_response_to_anthropic(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -2384,6 +2384,45 @@ def test_translate_streaming_openai_response_to_anthropic_cache_tokens_from_hidd
     assert message_delta["usage"]["cache_creation_input_tokens"] == 20
 
 
+def test_translate_streaming_openai_response_to_anthropic_cache_tokens_with_applied_edits():
+    from litellm.types.utils import PromptTokensDetailsWrapper
+
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+    response = ModelResponseStream(
+        choices=[
+            StreamingChoices(
+                index=0,
+                delta=Delta(),
+                finish_reason="stop",
+            )
+        ],
+        usage=usage,
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    message_delta = adapter.translate_streaming_openai_response_to_anthropic(
+        response=response,
+        current_content_block_index=0,
+        applied_edits=[{"type": "compact_20260112"}],
+    )
+
+    assert message_delta["usage"]["input_tokens"] == 70
+    assert message_delta["usage"]["output_tokens"] == 50
+    assert message_delta["usage"]["cache_read_input_tokens"] == 30
+    assert message_delta["usage"]["cache_creation_input_tokens"] == 20
+    assert message_delta["context_management"]["applied_edits"][0]["type"] == (
+        "compact_20260112"
+    )
+
+
 # =====================================================================
 # Web Search Tool Transformation Tests
 # =====================================================================

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
@@ -24,6 +24,7 @@ from litellm.types.utils import (
     Message,
     ModelResponse,
     ModelResponseStream,
+    PromptTokensDetailsWrapper,
     StreamingChoices,
     Usage,
 )
@@ -86,6 +87,59 @@ def test_fake_stream_usage_preserved():
     )
     assert message_delta["usage"]["output_tokens"] == 5
     assert message_delta["usage"]["input_tokens"] == 10
+
+
+def test_delayed_usage_chunk_preserves_cache_tokens():
+    usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=5,
+        total_tokens=125,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+    chunks = [
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(content="Two."),
+                    finish_reason=None,
+                )
+            ],
+        ),
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(),
+                    finish_reason="stop",
+                )
+            ],
+        ),
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(),
+                    finish_reason=None,
+                )
+            ],
+            usage=usage,
+        ),
+    ]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="gpt-4o")
+    events = list(wrapper)
+
+    message_delta = next(
+        event for event in events if event.get("type") == "message_delta"
+    )
+
+    assert message_delta["usage"]["input_tokens"] == 70
+    assert message_delta["usage"]["output_tokens"] == 5
+    assert message_delta["usage"]["cache_read_input_tokens"] == 30
+    assert message_delta["usage"]["cache_creation_input_tokens"] == 20
 
 
 def test_splitter_passes_through_non_combined_chunks():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -30,7 +30,9 @@ from litellm.types.utils import (
     ChatCompletionDeltaToolCall,
     Delta,
     Function,
+    PromptTokensDetailsWrapper,
     StreamingChoices,
+    Usage,
 )
 
 
@@ -105,6 +107,34 @@ def _input_json_deltas(events: List[dict]) -> List[str]:
         if e.get("type") == "content_block_delta"
         and e["delta"].get("type") == "input_json_delta"
     ]
+
+
+def test_held_stop_reason_usage_merge_preserves_openai_cache_token_details():
+    """OpenAI-compatible usage chunks carry cache reads in prompt_tokens_details."""
+    wrapper = AnthropicStreamWrapper(completion_stream=iter([]), model="claude-x")
+    wrapper.holding_stop_reason_chunk = {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn"},
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+
+    usage_chunk = MagicMock()
+    usage_chunk.usage = Usage(
+        prompt_tokens=120,
+        completion_tokens=50,
+        total_tokens=170,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=30,
+            cache_creation_tokens=20,
+        ),
+    )
+
+    merged_chunk = wrapper._merge_usage_into_held_stop_reason_chunk(usage_chunk)
+
+    assert merged_chunk["usage"]["input_tokens"] == 70
+    assert merged_chunk["usage"]["output_tokens"] == 50
+    assert merged_chunk["usage"]["cache_read_input_tokens"] == 30
+    assert merged_chunk["usage"]["cache_creation_input_tokens"] == 20
 
 
 def test_first_text_delta_after_tool_use_is_not_dropped_sync():


### PR DESCRIPTION
## Relevant issues

Related to https://github.com/BerriAI/litellm/issues/31069

## Linear ticket

N/A

## Why Anthropic messages cache usage was affected

The experimental Anthropic `/v1/messages` adapter translates OpenAI-compatible responses into Anthropic message responses. Cache usage can arrive in a few OpenAI/LiteLLM shapes: direct Anthropic-style fields, private LiteLLM usage fields, or OpenAI `prompt_tokens_details` fields such as `cached_tokens`, `cache_creation_tokens`, and `cache_write_tokens`.

Before this change, those paths were handled inconsistently. Some code paths subtracted cached tokens from `input_tokens`, but did not preserve the corresponding Anthropic `cache_read_input_tokens` or `cache_creation_input_tokens` fields. That meant clients could see lower billable input tokens while the cache-hit / cache-write breakdown disappeared from the Anthropic-compatible response.

The issue showed up across more than one path: non-streaming response translation, direct final streaming chunk translation, and delayed streaming usage merging each had their own usage conversion behavior.

## The fix

Centralize OpenAI-compatible usage conversion in the Anthropic messages adapter and reuse it from all three response paths.

The shared helper now preserves:

- cache reads from `cache_read_input_tokens`, `_cache_read_input_tokens`, or `prompt_tokens_details.cached_tokens`
- cache creation from `cache_creation_input_tokens`, `_cache_creation_input_tokens`, `prompt_tokens_details.cache_creation_tokens`, or `prompt_tokens_details.cache_write_tokens`
- Anthropic `input_tokens` as prompt tokens minus cache read and cache creation tokens, floored at zero

This keeps the existing streaming behavior: it does not buffer an entire upstream stream just to backfill final cache-hit counts into the initial synthetic `message_start` event. For upstreams that only report usage at the end of the stream, the real cache usage is preserved on the final `message_delta.usage`.

## Screenshots / Proof of Fix

Backend-only adapter change; screenshots are not applicable.

PR-scoped regression tests pass with the repo-required uv version:

```bash
uvx --from uv==0.10.9 uv run --no-sync pytest -q \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
```

Result:

```text
........................................................................ [ 63%]
.........................................                                [100%]
113 passed in 4.27s
```

Additional local checks:

```bash
git diff --check upstream/litellm_internal_staging...HEAD
python3 -m py_compile \
  litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py \
  litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py \
  tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
```

Both commands completed successfully with no output.

GitHub Actions unit shards and lint checks are passing on the PR. The external Veria AI review is still pending.

## Tests and regression review

New regression coverage exercises both non-streaming and streaming Anthropic message translation:

- `test_anthropic_experimental_pass_through_adapters_transformation.py`: verifies cache reads and cache creation survive from direct fields, private LiteLLM fields, and OpenAI `prompt_tokens_details` fields.
- `test_streaming_iterator_combined_chunk.py`: verifies delayed streaming usage merging preserves cache usage when final usage arrives after the held stop-reason chunk.
- `test_streaming_iterator_first_delta.py`: verifies first-delta streaming behavior remains intact.

Plain local `make test-unit` was not marked as passed locally: the unsharded target currently fails during pytest collection on an existing duplicate `test_models.py` module-name collision outside this PR. The corresponding GitHub unit shards pass because they run those paths separately.

## Type

Bug Fix / Test

## Changes

`litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`: adds shared OpenAI-compatible usage-to-Anthropic usage conversion and applies it to non-streaming responses plus direct streaming final usage translation.

`litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py`: uses the shared conversion helper when merging delayed streaming usage into the held final chunk.

`tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/*`: adds regression coverage for direct usage fields, private LiteLLM usage fields, `prompt_tokens_details` cache fields, and streaming usage merge behavior.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

N/A

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:
