### PR TITLE
feat(models): add zai/glm-5.2 pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36152,6 +36152,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.2": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-4.7": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 1.1e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36158,7 +36158,7 @@
         "input_cost_per_token": 1.4e-06,
         "output_cost_per_token": 4.4e-06,
         "litellm_provider": "zai",
-        "max_input_tokens": 200000,
+        "max_input_tokens": 1000000,
         "max_output_tokens": 128000,
         "mode": "chat",
         "supports_function_calling": true,


### PR DESCRIPTION
## Relevant issues

Closes #31075 (Add zai/glm-5.2 pricing entry — GLM-5.2 missing from model cost map)

## What & Why

Zhipu AI (智谱) released **GLM-5.2** as its new flagship on 2026-06-13, and official pricing is now published. LiteLLM currently has `zai/glm-5` but **no `zai/glm-5.2`**, so downstream cost-resolving tools misattribute GLM-5.2 traffic to GLM-5 and under-count spend. This PR adds the missing entry.

## Changes

Adds a single new key, `zai/glm-5.2`, to `model_prices_and_context_window.json`, inserted in alphabetical order. The entry mirrors the existing `zai/glm-5` structure (same capability flags, same `litellm_provider`, `mode`, and `source`).

```json
"zai/glm-5.2": {
  "cache_creation_input_token_cost": 0,
  "cache_read_input_token_cost": 2.6e-07,
  "input_cost_per_token": 1.4e-06,
  "output_cost_per_token": 4.4e-06,
  "litellm_provider": "zai",
  "max_input_tokens": 1000000,
  "max_output_tokens": 128000,
  "mode": "chat",
  "supports_function_calling": true,
  "supports_prompt_caching": true,
  "supports_reasoning": true,
  "supports_tool_choice": true,
  "source": "https://docs.z.ai/guides/overview/pricing"
}
```

## Pricing source & unit conversion

Prices are taken from the official Z.AI international pricing page (**USD per million tokens**) and converted to **USD per token** by dividing by 1,000,000, expressed in scientific notation to match the file's existing convention:

| Field | Official (per 1M tokens) | Per-token value |
|---|---|---|
| `input_cost_per_token` | $1.4 | `1.4e-06` |
| `output_cost_per_token` | $4.4 | `4.4e-06` |
| `cache_read_input_token_cost` | $0.26 (Cached Input) | `2.6e-07` |
| `cache_creation_input_token_cost` | — (Cached Input Storage is limited-time free) | `0` (matches `zai/glm-5` convention) |

Reference: the domestic 智谱开放平台 page lists CNY prices (输入 8 元, 输出 28 元, 缓存命中 2 元 per 1M tokens). The USD values above are taken directly from the Z.AI international page; the CNY page is included as a secondary reference only.

## Specifications

- **Context window**: 1M tokens (`max_input_tokens: 1000000`; enabled via `glm-5.2[1m]` suffix, per docs.bigmodel.cn "真正可用的 1M 上下文")
- **Max output**: 128K tokens (`max_output_tokens: 128000`)
- **Flat pricing**: GLM-5.2 has a single price row (not tiered by input length like GLM-5/GLM-5-Turbo)

## Pre-Submission Checklist

- [x] **Add testing**: N/A — pure data update to the model cost JSON, no code logic affected.
- [x] Scope isolated to a single file (`model_prices_and_context_window.json`).
- [x] `make lint` passes locally.
- [x] `make test-unit` passes locally.

## Type

🆕 New Feature

## Sources

- https://docs.z.ai/guides/overview/pricing
- https://open.bigmodel.cn/pricing
- https://docs.bigmodel.cn/cn/guide/models/text/glm-5.2
- Reference precedent: PR #22665 (added `zai/glm-5` + `zai/glm-5-code`), issue #22646

## CLA

I have signed / will sign the Contributor License Agreement: https://cla-assistant.io/BerriAI/litellm