### PR TITLE
refactor(responses): strip trailing base64 padding from encrypted ID helpers

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -242,7 +242,7 @@ class ResponsesAPIRequestUtils:
     def _build_encrypted_item_id(model_id: str, item_id: str) -> str:
         """Encode model_id into an output item ID for encrypted-content items.
 
-        Format: ``encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}``
+        Format: ``encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}`` (without base64 trailing = padding)
         """
         assembled = f"litellm:model_id:{model_id};item_id:{item_id}"
         encoded = base64.b64encode(assembled.encode("utf-8")).decode("utf-8").rstrip("=")
@@ -283,7 +283,7 @@ class ResponsesAPIRequestUtils:
         When Codex or other clients send items with encrypted_content but no ID,
         we encode the model_id directly into the encrypted_content itself.
 
-        Format: ``litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}``
+        Format: ``litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}`` (without base64 trailing = padding)
         """
         metadata = f"model_id:{model_id}"
         encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8").rstrip("=")

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -245,7 +245,7 @@ class ResponsesAPIRequestUtils:
         Format: ``encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}``
         """
         assembled = f"litellm:model_id:{model_id};item_id:{item_id}"
-        encoded = base64.b64encode(assembled.encode("utf-8")).decode("utf-8")
+        encoded = base64.b64encode(assembled.encode("utf-8")).decode("utf-8").rstrip("=")
         return f"encitem_{encoded}"
 
     @staticmethod
@@ -286,7 +286,7 @@ class ResponsesAPIRequestUtils:
         Format: ``litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}``
         """
         metadata = f"model_id:{model_id}"
-        encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8")
+        encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8").rstrip("=")
         return f"litellm_enc:{encoded_metadata};{encrypted_content}"
 
     @staticmethod

--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -245,7 +245,9 @@ class ResponsesAPIRequestUtils:
         Format: ``encitem_{base64("litellm:model_id:{model_id};item_id:{original_id}")}`` (without base64 trailing = padding)
         """
         assembled = f"litellm:model_id:{model_id};item_id:{item_id}"
-        encoded = base64.b64encode(assembled.encode("utf-8")).decode("utf-8").rstrip("=")
+        encoded = (
+            base64.b64encode(assembled.encode("utf-8")).decode("utf-8").rstrip("=")
+        )
         return f"encitem_{encoded}"
 
     @staticmethod
@@ -286,7 +288,9 @@ class ResponsesAPIRequestUtils:
         Format: ``litellm_enc:{base64("model_id:{model_id}")};{original_encrypted_content}`` (without base64 trailing = padding)
         """
         metadata = f"model_id:{model_id}"
-        encoded_metadata = base64.b64encode(metadata.encode("utf-8")).decode("utf-8").rstrip("=")
+        encoded_metadata = (
+            base64.b64encode(metadata.encode("utf-8")).decode("utf-8").rstrip("=")
+        )
         return f"litellm_enc:{encoded_metadata};{encrypted_content}"
 
     @staticmethod


### PR DESCRIPTION
### Change Description

#### Problem
Generated response ID helpers (`_build_encrypted_item_id` and `_wrap_encrypted_content_with_model_id`) include trailing base64 `=` padding characters, which can cause issues or unnecessary overhead in URL parameters or specific token-handling paths.

#### Fix
* Appended `.rstrip("=")` to strip the trailing padding from the base64 encoded segments.
* Note: The corresponding decode functions (`_decode_encrypted_item_id` and `_unwrap_encrypted_content_with_model_id`) already feature defensive padding-restoration logic, ensuring backward compatibility and zero round-trip regressions.

#### Testing Proof
Verified locally within the `uv` virtual environment environment:
```bash
uv run pytest tests/test_litellm/router_strategy/ --ignore=tests/test_litellm/router_strategy/adaptive_router/test_state_endpoint.py