### PR TITLE
fix: preserve model budget spend on key regeneration

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -17,6 +17,7 @@ import math
 import os
 import re
 import secrets
+import time
 import traceback
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
@@ -3289,6 +3290,171 @@ async def _build_model_max_budget_usage(
     return result
 
 
+VIRTUAL_KEY_BUDGET_START_TIME_CACHE_KEY_PREFIX = "virtual_key_budget_start_time"
+
+
+def _coerce_model_max_budget(value: object) -> Mapping[str, object]:
+    if value is None:
+        return {}
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except Exception:  # noqa: BLE001
+            return {}
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+def _get_model_max_budget_for_cache_migration(
+    key_in_db: LiteLLM_VerificationToken,
+    non_default_values: dict,
+) -> Mapping[str, object]:
+    if "model_max_budget" in non_default_values:
+        return _coerce_model_max_budget(non_default_values.get("model_max_budget"))
+    return _coerce_model_max_budget(getattr(key_in_db, "model_max_budget", None))
+
+
+def _model_max_budget_spend_cache_keys(
+    api_key_hash: str, model: str, budget_duration: str
+) -> tuple[str, ...]:
+    keys = [
+        f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:"
+        f"{api_key_hash}:{model}:{budget_duration}"
+    ]
+    if "/" in model:
+        model_without_prefix = model.split("/")[-1]
+        keys.append(
+            f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:"
+            f"{api_key_hash}:{model_without_prefix}:{budget_duration}"
+        )
+    return tuple(keys)
+
+
+def _normalize_cache_ttl_seconds(ttl: object) -> int | None:
+    if ttl is None:
+        return None
+    try:
+        ttl_seconds = int(float(ttl))
+    except (TypeError, ValueError):
+        return None
+    if ttl_seconds > time.time():
+        ttl_seconds = int(ttl_seconds - time.time())
+    if ttl_seconds <= 0:
+        return None
+    return ttl_seconds
+
+
+def _remaining_ttl_from_budget_start_time(
+    budget_start_time: object, budget_duration_seconds: int
+) -> int | None:
+    try:
+        remaining_ttl = budget_duration_seconds - (
+            time.time() - float(budget_start_time)
+        )
+    except (TypeError, ValueError):
+        return None
+    if remaining_ttl <= 0:
+        return None
+    return int(remaining_ttl)
+
+
+async def _get_cache_ttl_seconds(
+    cache_key: str,
+    user_api_key_cache: UserApiKeyCache,
+) -> int | None:
+    ttl = await user_api_key_cache.async_get_ttl(cache_key)
+    return _normalize_cache_ttl_seconds(ttl)
+
+
+async def _copy_cache_value(
+    source_key: str,
+    destination_key: str,
+    ttl: int | None,
+    user_api_key_cache: UserApiKeyCache,
+) -> None:
+    value = await user_api_key_cache.async_get_cache(key=source_key)
+    if value is None:
+        return
+    if ttl is None:
+        await user_api_key_cache.async_set_cache(key=destination_key, value=value)
+        return
+    await user_api_key_cache.async_set_cache(
+        key=destination_key,
+        value=value,
+        ttl=ttl,
+    )
+
+
+async def _migrate_model_max_budget_cache_on_regenerate(
+    *,
+    old_api_key_hash: str,
+    new_api_key_hash: str,
+    model_max_budget: Mapping[str, object],
+    user_api_key_cache: UserApiKeyCache,
+) -> None:
+    if not model_max_budget:
+        return
+
+    start_time_source_key = (
+        f"{VIRTUAL_KEY_BUDGET_START_TIME_CACHE_KEY_PREFIX}:{old_api_key_hash}"
+    )
+    start_time_destination_key = (
+        f"{VIRTUAL_KEY_BUDGET_START_TIME_CACHE_KEY_PREFIX}:{new_api_key_hash}"
+    )
+    budget_start_time = await user_api_key_cache.async_get_cache(
+        key=start_time_source_key
+    )
+
+    for model, budget_info in model_max_budget.items():
+        try:
+            budget_config = BudgetConfig.model_validate(budget_info)
+            if budget_config.budget_duration is None:
+                continue
+            budget_duration_seconds = duration_in_seconds(budget_config.budget_duration)
+        except Exception:  # noqa: BLE001
+            continue
+
+        start_time_ttl = await _get_cache_ttl_seconds(
+            cache_key=start_time_source_key,
+            user_api_key_cache=user_api_key_cache,
+        )
+        if start_time_ttl is None:
+            start_time_ttl = _remaining_ttl_from_budget_start_time(
+                budget_start_time=budget_start_time,
+                budget_duration_seconds=budget_duration_seconds,
+            )
+
+        await _copy_cache_value(
+            source_key=start_time_source_key,
+            destination_key=start_time_destination_key,
+            ttl=start_time_ttl,
+            user_api_key_cache=user_api_key_cache,
+        )
+
+        old_spend_keys = _model_max_budget_spend_cache_keys(
+            api_key_hash=old_api_key_hash,
+            model=model,
+            budget_duration=budget_config.budget_duration,
+        )
+        new_spend_keys = _model_max_budget_spend_cache_keys(
+            api_key_hash=new_api_key_hash,
+            model=model,
+            budget_duration=budget_config.budget_duration,
+        )
+        for source_key, destination_key in zip(old_spend_keys, new_spend_keys):
+            spend_ttl = await _get_cache_ttl_seconds(
+                cache_key=source_key,
+                user_api_key_cache=user_api_key_cache,
+            )
+            await _copy_cache_value(
+                source_key=source_key,
+                destination_key=destination_key,
+                ttl=spend_ttl or start_time_ttl,
+                user_api_key_cache=user_api_key_cache,
+            )
+
+
 @router.post(
     "/v2/key/info",
     tags=["key management"],
@@ -4467,6 +4633,16 @@ async def _execute_virtual_key_regeneration(
     updated_token_dict = dict(updated_token) if updated_token is not None else {}
     updated_token_dict["key"] = new_token
     updated_token_dict["token_id"] = updated_token_dict.pop("token")
+
+    await _migrate_model_max_budget_cache_on_regenerate(
+        old_api_key_hash=hashed_api_key,
+        new_api_key_hash=new_token_hash,
+        model_max_budget=_get_model_max_budget_for_cache_migration(
+            key_in_db=key_in_db,
+            non_default_values=non_default_values,
+        ),
+        user_api_key_cache=user_api_key_cache,
+    )
 
     if hashed_api_key or key:
         await _delete_cache_key_object(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3372,18 +3372,31 @@ async def _copy_cache_value(
     destination_key: str,
     ttl: int | None,
     user_api_key_cache: UserApiKeyCache,
-) -> None:
+) -> bool:
     value = await user_api_key_cache.async_get_cache(key=source_key)
     if value is None:
-        return
+        return False
     if ttl is None:
         await user_api_key_cache.async_set_cache(key=destination_key, value=value)
-        return
-    await user_api_key_cache.async_set_cache(
-        key=destination_key,
-        value=value,
-        ttl=ttl,
-    )
+    else:
+        await user_api_key_cache.async_set_cache(
+            key=destination_key,
+            value=value,
+            ttl=ttl,
+        )
+    return True
+
+
+def _parse_model_budget_entry(
+    model: str, budget_info: object
+) -> tuple[str, BudgetConfig, int] | None:
+    try:
+        budget_config = BudgetConfig.model_validate(budget_info)
+        if budget_config.budget_duration is None:
+            return None
+        return (model, budget_config, duration_in_seconds(budget_config.budget_duration))
+    except Exception:  # noqa: BLE001
+        return None
 
 
 async def _migrate_model_max_budget_cache_on_regenerate(
@@ -3396,42 +3409,46 @@ async def _migrate_model_max_budget_cache_on_regenerate(
     if not model_max_budget:
         return
 
+    valid_budgets = tuple(
+        entry
+        for entry in (
+            _parse_model_budget_entry(model, budget_info)
+            for model, budget_info in model_max_budget.items()
+        )
+        if entry is not None
+    )
+    if not valid_budgets:
+        return
+
     start_time_source_key = (
         f"{VIRTUAL_KEY_BUDGET_START_TIME_CACHE_KEY_PREFIX}:{old_api_key_hash}"
     )
     start_time_destination_key = (
         f"{VIRTUAL_KEY_BUDGET_START_TIME_CACHE_KEY_PREFIX}:{new_api_key_hash}"
     )
-    budget_start_time = await user_api_key_cache.async_get_cache(
-        key=start_time_source_key
+
+    start_time_ttl = await _get_cache_ttl_seconds(
+        cache_key=start_time_source_key,
+        user_api_key_cache=user_api_key_cache,
+    )
+    if start_time_ttl is None:
+        budget_start_time = await user_api_key_cache.async_get_cache(
+            key=start_time_source_key
+        )
+        max_duration_seconds = max(duration for _, _, duration in valid_budgets)
+        start_time_ttl = _remaining_ttl_from_budget_start_time(
+            budget_start_time=budget_start_time,
+            budget_duration_seconds=max_duration_seconds,
+        )
+
+    await _copy_cache_value(
+        source_key=start_time_source_key,
+        destination_key=start_time_destination_key,
+        ttl=start_time_ttl,
+        user_api_key_cache=user_api_key_cache,
     )
 
-    for model, budget_info in model_max_budget.items():
-        try:
-            budget_config = BudgetConfig.model_validate(budget_info)
-            if budget_config.budget_duration is None:
-                continue
-            budget_duration_seconds = duration_in_seconds(budget_config.budget_duration)
-        except Exception:  # noqa: BLE001
-            continue
-
-        start_time_ttl = await _get_cache_ttl_seconds(
-            cache_key=start_time_source_key,
-            user_api_key_cache=user_api_key_cache,
-        )
-        if start_time_ttl is None:
-            start_time_ttl = _remaining_ttl_from_budget_start_time(
-                budget_start_time=budget_start_time,
-                budget_duration_seconds=budget_duration_seconds,
-            )
-
-        await _copy_cache_value(
-            source_key=start_time_source_key,
-            destination_key=start_time_destination_key,
-            ttl=start_time_ttl,
-            user_api_key_cache=user_api_key_cache,
-        )
-
+    for model, budget_config, _ in valid_budgets:
         old_spend_keys = _model_max_budget_spend_cache_keys(
             api_key_hash=old_api_key_hash,
             model=model,
@@ -3447,12 +3464,14 @@ async def _migrate_model_max_budget_cache_on_regenerate(
                 cache_key=source_key,
                 user_api_key_cache=user_api_key_cache,
             )
-            await _copy_cache_value(
+            copied = await _copy_cache_value(
                 source_key=source_key,
                 destination_key=destination_key,
                 ttl=spend_ttl or start_time_ttl,
                 user_api_key_cache=user_api_key_cache,
             )
+            if copied:
+                await user_api_key_cache.async_delete_cache(source_key)
 
 
 @router.post(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10199,6 +10199,7 @@ class _RegenerateModelBudgetCache:
     def __init__(self):
         self.cache = {}
         self.ttls = {}
+        self.deleted = []
 
     async def async_get_cache(self, key, **kwargs):
         return self.cache.get(key)
@@ -10209,6 +10210,11 @@ class _RegenerateModelBudgetCache:
 
     async def async_get_ttl(self, key):
         return self.ttls.get(key)
+
+    async def async_delete_cache(self, key):
+        self.deleted.append(key)
+        self.cache.pop(key, None)
+        self.ttls.pop(key, None)
 
 
 @pytest.mark.asyncio
@@ -10351,6 +10357,108 @@ async def test_execute_virtual_key_regeneration_migrates_model_budget_cache():
     assert cache.ttls[f"virtual_key_budget_start_time:{new_token_hash}"] == 3600
     assert cache.cache[f"virtual_key_spend:{new_token_hash}:gpt-4:1d"] == 0.001
     assert cache.ttls[f"virtual_key_spend:{new_token_hash}:gpt-4:1d"] == 3600
+    assert f"virtual_key_spend:{old_token_hash}:gpt-4:1d" in cache.deleted
+    assert f"virtual_key_spend:{old_token_hash}:gpt-4:1d" not in cache.cache
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_migrates_multi_model_budget_cache_with_ttl_fallback():
+    """
+    Multi-model budgets with mixed durations and no cache-returned TTL must use
+    the longest budget window when computing the start-time TTL fallback,
+    otherwise short-duration models would prematurely expire the shared window.
+    """
+    import time as _time
+
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    old_token_hash = "old-multi-hash"
+    new_token_hash = "new-multi-hash"
+
+    one_day_seconds = 86400
+    seven_days_seconds = 7 * one_day_seconds
+    twelve_hours_ago = _time.time() - 12 * 3600
+
+    existing_key = LiteLLM_VerificationToken(
+        token=old_token_hash,
+        user_id="user-1",
+        models=["gpt-4", "claude-3"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        model_max_budget={
+            "claude-3": {"budget_limit": 0.0001, "time_period": "7d"},
+            "gpt-4": {"budget_limit": 0.0001, "time_period": "1d"},
+        },
+    )
+    mock_prisma_client = _make_regenerate_mock_prisma()
+    mock_prisma_client.db.litellm_verificationtoken.update.return_value = (
+        type(
+            "DictLikeResult",
+            (),
+            {
+                "__iter__": lambda self: iter(
+                    {
+                        "token": new_token_hash,
+                        "key_name": "sk-...ab12",
+                        "user_id": "user-1",
+                    }.items()
+                )
+            },
+        )()
+    )
+
+    cache = _RegenerateModelBudgetCache()
+    cache.cache[f"virtual_key_budget_start_time:{old_token_hash}"] = twelve_hours_ago
+    cache.cache[f"virtual_key_spend:{old_token_hash}:gpt-4:1d"] = 0.0
+    cache.cache[f"virtual_key_spend:{old_token_hash}:claude-3:7d"] = 0.0
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.proxy_server.hash_token",
+            return_value=new_token_hash,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key=old_token_hash,
+            key=old_token_hash,
+            data=None,
+            user_api_key_dict=_make_regenerate_user_api_key_dict(),
+            litellm_changed_by=None,
+            user_api_key_cache=cache,
+            proxy_logging_obj=MagicMock(),
+        )
+
+    migrated_ttl = cache.ttls[f"virtual_key_budget_start_time:{new_token_hash}"]
+    assert migrated_ttl is not None
+    expected_min_ttl = seven_days_seconds - 12 * 3600 - 60
+    assert migrated_ttl >= expected_min_ttl, (
+        f"start-time TTL {migrated_ttl}s must reflect the longest budget window "
+        f"({seven_days_seconds}s), not the shortest"
+    )
+    assert f"virtual_key_spend:{old_token_hash}:gpt-4:1d" in cache.deleted
+    assert f"virtual_key_spend:{old_token_hash}:claude-3:7d" in cache.deleted
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10195,6 +10195,22 @@ def _make_regenerate_existing_key():
     )
 
 
+class _RegenerateModelBudgetCache:
+    def __init__(self):
+        self.cache = {}
+        self.ttls = {}
+
+    async def async_get_cache(self, key, **kwargs):
+        return self.cache.get(key)
+
+    async def async_set_cache(self, key, value, **kwargs):
+        self.cache[key] = value
+        self.ttls[key] = kwargs.get("ttl")
+
+    async def async_get_ttl(self, key):
+        return self.ttls.get(key)
+
+
 @pytest.mark.asyncio
 async def test_execute_virtual_key_regeneration_rejects_over_limit_duration():
     """Regenerate must reject durations exceeding upperbound_key_generate_params.duration."""
@@ -10249,6 +10265,92 @@ async def test_execute_virtual_key_regeneration_rejects_over_limit_duration():
         assert mock_prisma_client.db.litellm_verificationtoken.update.await_count == 0
     finally:
         litellm.upperbound_key_generate_params = original
+
+
+@pytest.mark.asyncio
+async def test_execute_virtual_key_regeneration_migrates_model_budget_cache():
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _execute_virtual_key_regeneration,
+    )
+
+    old_token_hash = "old-token-hash"
+    new_token_hash = "new-token-hash"
+    existing_key = LiteLLM_VerificationToken(
+        token=old_token_hash,
+        user_id="user-1",
+        models=["gpt-4"],
+        team_id=None,
+        max_budget=None,
+        tags=None,
+        model_max_budget={
+            "gpt-4": {
+                "budget_limit": 0.0001,
+                "time_period": "1d",
+            }
+        },
+    )
+    mock_prisma_client = _make_regenerate_mock_prisma()
+    mock_prisma_client.db.litellm_verificationtoken.update.return_value = (
+        type(
+            "DictLikeResult",
+            (),
+            {
+                "__iter__": lambda self: iter(
+                    {
+                        "token": new_token_hash,
+                        "key_name": "sk-...ab12",
+                        "user_id": "user-1",
+                    }.items()
+                )
+            },
+        )()
+    )
+
+    cache = _RegenerateModelBudgetCache()
+    cache.cache[f"virtual_key_budget_start_time:{old_token_hash}"] = 12345.0
+    cache.cache[f"virtual_key_spend:{old_token_hash}:gpt-4:1d"] = 0.001
+    cache.ttls[f"virtual_key_budget_start_time:{old_token_hash}"] = 3600
+    cache.ttls[f"virtual_key_spend:{old_token_hash}:gpt-4:1d"] = 3600
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.get_new_token",
+            new_callable=AsyncMock,
+            return_value="sk-newtoken1234ab12",
+        ),
+        patch(
+            "litellm.proxy.proxy_server.hash_token",
+            return_value=new_token_hash,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._insert_deprecated_key",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.KeyManagementEventHooks.async_key_rotated_hook",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await _execute_virtual_key_regeneration(
+            prisma_client=mock_prisma_client,
+            key_in_db=existing_key,
+            hashed_api_key=old_token_hash,
+            key=old_token_hash,
+            data=None,
+            user_api_key_dict=_make_regenerate_user_api_key_dict(),
+            litellm_changed_by=None,
+            user_api_key_cache=cache,
+            proxy_logging_obj=MagicMock(),
+        )
+
+    assert cache.cache[f"virtual_key_budget_start_time:{new_token_hash}"] == 12345.0
+    assert cache.ttls[f"virtual_key_budget_start_time:{new_token_hash}"] == 3600
+    assert cache.cache[f"virtual_key_spend:{new_token_hash}:gpt-4:1d"] == 0.001
+    assert cache.ttls[f"virtual_key_spend:{new_token_hash}:gpt-4:1d"] == 3600
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Fixes #31079

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Added a regression test for `/key/regenerate` preserving an active `model_max_budget` window across token hash rotation.

Tested locally:

```bash
rtk uv run pytest tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py -k "execute_virtual_key_regeneration"
rtk uv run ruff check litellm/proxy/management_endpoints/key_management_endpoints.py
```

`make test-unit` was not run locally.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Migrates active `virtual_key_budget_start_time:<hash>` cache entries from old token hash to new token hash during `/key/regenerate`
- Migrates active `virtual_key_spend:<hash>:<model>:<duration>` cache entries for configured `model_max_budget` entries
- Preserves the remaining TTL for the existing budget window
- Adds a regression test for model budget cache migration on key regeneration
