### PR TITLE
fix(proxy): resolve MCP static header env vars

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1347,9 +1347,7 @@ class MCPServerManager:
     ) -> MCPServer:
         _mcp_info: MCPInfo = mcp_server.mcp_info or {}
         env_dict = _deserialize_json_dict(getattr(mcp_server, "env", None))
-        static_headers_dict = _deserialize_json_dict(
-            getattr(mcp_server, "static_headers", None)
-        )
+        static_headers_dict = _deserialize_json_dict(getattr(mcp_server, "static_headers", None))
         static_headers_dict = resolve_static_header_env_vars(
             static_headers_dict,
             allow_env_var_resolution=getattr(mcp_server, "submitted_by", None) is None,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -104,6 +104,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     merge_mcp_headers,
     normalize_server_name,
     parse_admin_env_vars,
+    resolve_static_header_env_vars,
     split_server_prefix_from_name,
     strip_known_server_prefix,
     validate_mcp_server_name,
@@ -1346,7 +1347,13 @@ class MCPServerManager:
     ) -> MCPServer:
         _mcp_info: MCPInfo = mcp_server.mcp_info or {}
         env_dict = _deserialize_json_dict(getattr(mcp_server, "env", None))
-        static_headers_dict = _deserialize_json_dict(getattr(mcp_server, "static_headers", None))
+        static_headers_dict = _deserialize_json_dict(
+            getattr(mcp_server, "static_headers", None)
+        )
+        static_headers_dict = resolve_static_header_env_vars(
+            static_headers_dict,
+            allow_env_var_resolution=getattr(mcp_server, "submitted_by", None) is None,
+        )
         env_vars_list = self._resolve_env_vars_list(
             mcp_server,
             env_vars_are_encrypted=(

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -26,6 +26,7 @@ from litellm.proxy._experimental.mcp_server.ui_session_utils import (
 from litellm.proxy._experimental.mcp_server.utils import (
     MCPMissingUserEnvVarsError,
     merge_mcp_headers,
+    resolve_static_header_env_vars,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
@@ -1195,7 +1196,7 @@ if MCP_AVAILABLE:
 
             merged_headers = merge_mcp_headers(
                 extra_headers=(None if preview_cred_provider else effective_oauth2_headers),
-                static_headers=request.static_headers,
+                static_headers=resolve_static_header_env_vars(request.static_headers),
             )
 
             client = await global_mcp_server_manager._create_mcp_client(

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -22,6 +22,9 @@ import importlib
 import os
 from urllib.parse import quote
 
+import litellm
+from litellm._logging import verbose_proxy_logger
+
 # Constants
 #
 # NOTE: The environment-backed values below are read once, when this module is
@@ -590,6 +593,48 @@ def build_env_var_setup_url(server_id: str) -> str:
     base = os.environ.get("PROXY_BASE_URL", "").rstrip("/")
     path = f"/ui/?page=mcp-servers&fill_env_vars={quote(server_id, safe='')}"
     return f"{base}{path}" if base else path
+
+
+def resolve_static_header_env_vars(
+    headers: Optional[Mapping[str, str]],
+    *,
+    allow_env_var_resolution: bool = True,
+) -> Optional[dict[str, str]]:
+    """Resolve ``os.environ/VAR`` values in MCP static headers.
+
+    YAML config gets this treatment from ``ProxyConfig._check_for_os_environ_vars``.
+    MCP servers loaded from the DB or tested directly from the UI need the same
+    handling after their ``static_headers`` are materialized.
+    """
+    if not headers:
+        return None
+
+    resolved: dict[str, str] = {}
+    for key, value in headers.items():
+        if isinstance(value, str) and value.startswith("os.environ/"):
+            env_var_name = value.removeprefix("os.environ/")
+            if not allow_env_var_resolution:
+                verbose_proxy_logger.warning(
+                    "MCP static header '%s' references proxy env var '%s', but env "
+                    "resolution is disabled for this MCP server. Dropping the header.",
+                    key,
+                    env_var_name,
+                )
+                continue
+            secret_value = litellm.get_secret(value)
+            if secret_value is None:
+                verbose_proxy_logger.warning(
+                    "MCP static header '%s' references missing env var '%s'. "
+                    "Leaving the header value unresolved.",
+                    key,
+                    env_var_name,
+                )
+                resolved[key] = value
+            else:
+                resolved[key] = str(secret_value)
+        else:
+            resolved[key] = str(value)
+    return resolved
 
 
 def merge_mcp_headers(

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -624,8 +624,7 @@ def resolve_static_header_env_vars(
             secret_value = litellm.get_secret(value)
             if secret_value is None:
                 verbose_proxy_logger.warning(
-                    "MCP static header '%s' references missing env var '%s'. "
-                    "Leaving the header value unresolved.",
+                    "MCP static header '%s' references missing env var '%s'. Leaving the header value unresolved.",
                     key,
                     env_var_name,
                 )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
@@ -943,6 +943,165 @@ class TestSigV4BuildFromTable:
         assert server.aws_region_name is None
         assert server.aws_service_name is None
 
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_resolves_static_header_env_vars(
+        self, monkeypatch
+    ):
+        """MCP servers loaded from DB resolve os.environ/ static header values."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+
+        monkeypatch.setenv("MCP_STATIC_HEADER_SECRET", "resolved-secret")
+
+        table_record = MagicMock()
+        table_record.server_id = "test-header-server"
+        table_record.server_name = "header_server"
+        table_record.alias = None
+        table_record.description = None
+        table_record.url = "https://example.com/mcp"
+        table_record.spec_path = None
+        table_record.transport = "http"
+        table_record.auth_type = "none"
+        table_record.mcp_info = {"server_name": "header_server"}
+        table_record.credentials = None
+        table_record.extra_headers = None
+        table_record.static_headers = json.dumps(
+            {
+                "Authorization": "os.environ/MCP_STATIC_HEADER_SECRET",
+                "X-Static": "literal",
+            }
+        )
+        table_record.command = None
+        table_record.args = []
+        table_record.env = None
+        table_record.env_vars = None
+        table_record.mcp_access_groups = []
+        table_record.allowed_tools = []
+        table_record.disallowed_tools = None
+        table_record.allow_all_keys = False
+        table_record.available_on_public_internet = True
+        table_record.authorization_url = None
+        table_record.token_url = None
+        table_record.registration_url = None
+        table_record.created_at = None
+        table_record.updated_at = None
+        table_record.client_id = None
+        table_record.client_secret = None
+        table_record.tool_name_to_display_name = None
+        table_record.tool_name_to_description = None
+        table_record.byok_api_key_help_url = None
+        table_record.oauth2_flow = None
+        table_record.instructions = None
+        table_record.source_url = None
+        table_record.submitted_by = None
+
+        manager = MCPServerManager()
+
+        server = await manager.build_mcp_server_from_table(table_record)
+
+        assert server.static_headers == {
+            "Authorization": "resolved-secret",
+            "X-Static": "literal",
+        }
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_user_submission_drops_static_header_env_vars(
+        self, monkeypatch, caplog
+    ):
+        """User-submitted MCP servers must not resolve proxy env vars in static headers."""
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServerManager,
+        )
+
+        monkeypatch.setenv("MCP_STATIC_HEADER_SECRET", "resolved-secret")
+        caplog.set_level("WARNING", logger="LiteLLM Proxy")
+
+        table_record = MagicMock()
+        table_record.server_id = "submitted-header-server"
+        table_record.server_name = "submitted_header_server"
+        table_record.alias = None
+        table_record.description = None
+        table_record.url = "https://example.com/mcp"
+        table_record.spec_path = None
+        table_record.transport = "http"
+        table_record.auth_type = "none"
+        table_record.mcp_info = {"server_name": "submitted_header_server"}
+        table_record.credentials = None
+        table_record.extra_headers = None
+        table_record.static_headers = json.dumps(
+            {
+                "Authorization": "os.environ/MCP_STATIC_HEADER_SECRET",
+                "X-Static": "literal",
+            }
+        )
+        table_record.command = None
+        table_record.args = []
+        table_record.env = None
+        table_record.env_vars = None
+        table_record.mcp_access_groups = []
+        table_record.allowed_tools = []
+        table_record.disallowed_tools = None
+        table_record.allow_all_keys = False
+        table_record.available_on_public_internet = True
+        table_record.authorization_url = None
+        table_record.token_url = None
+        table_record.registration_url = None
+        table_record.created_at = None
+        table_record.updated_at = None
+        table_record.client_id = None
+        table_record.client_secret = None
+        table_record.tool_name_to_display_name = None
+        table_record.tool_name_to_description = None
+        table_record.byok_api_key_help_url = None
+        table_record.oauth2_flow = None
+        table_record.instructions = None
+        table_record.source_url = None
+        table_record.submitted_by = "user-submitter"
+
+        manager = MCPServerManager()
+
+        server = await manager.build_mcp_server_from_table(table_record)
+
+        assert server.static_headers == {"X-Static": "literal"}
+        assert (
+            "MCP static header 'Authorization' references proxy env var "
+            "'MCP_STATIC_HEADER_SECRET'" in caplog.text
+        )
+        assert "Dropping the header." in caplog.text
+
+    def test_resolve_static_header_env_vars_warns_when_env_missing(
+        self, monkeypatch, caplog
+    ):
+        """Missing os.environ/ header values are left unresolved with a warning."""
+        from litellm.proxy._experimental.mcp_server.utils import (
+            resolve_static_header_env_vars,
+        )
+
+        monkeypatch.delenv("MCP_MISSING_STATIC_HEADER_SECRET", raising=False)
+        caplog.set_level("WARNING", logger="LiteLLM Proxy")
+
+        result = resolve_static_header_env_vars(
+            {"Authorization": "os.environ/MCP_MISSING_STATIC_HEADER_SECRET"}
+        )
+
+        assert result == {
+            "Authorization": "os.environ/MCP_MISSING_STATIC_HEADER_SECRET"
+        }
+        assert (
+            "MCP static header 'Authorization' references missing env var "
+            "'MCP_MISSING_STATIC_HEADER_SECRET'" in caplog.text
+        )
+
+    def test_resolve_static_header_env_vars_keeps_empty_headers_none(self):
+        """Empty static headers stay unset instead of becoming an empty dict."""
+        from litellm.proxy._experimental.mcp_server.utils import (
+            resolve_static_header_env_vars,
+        )
+
+        assert resolve_static_header_env_vars(None) is None
+        assert resolve_static_header_env_vars({}) is None
+
 
 class TestDecryptCredentials:
     """Test decrypt_credentials helper."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
@@ -995,6 +995,12 @@ class TestSigV4BuildFromTable:
         table_record.instructions = None
         table_record.source_url = None
         table_record.submitted_by = None
+        table_record.token_exchange_endpoint = None
+        table_record.audience = None
+        table_record.subject_token_type = None
+        table_record.token_exchange_profile = None
+        table_record.timeout = None
+        table_record.max_concurrent_requests = None
 
         manager = MCPServerManager()
 
@@ -1058,6 +1064,12 @@ class TestSigV4BuildFromTable:
         table_record.instructions = None
         table_record.source_url = None
         table_record.submitted_by = "user-submitter"
+        table_record.token_exchange_endpoint = None
+        table_record.audience = None
+        table_record.subject_token_type = None
+        table_record.token_exchange_profile = None
+        table_record.timeout = None
+        table_record.max_concurrent_requests = None
 
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 from datetime import datetime
-import sys
 from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -22,9 +21,9 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.types.mcp import MCPAuth
 
-if sys.version_info >= (3, 11):
+try:
     from builtins import BaseExceptionGroup
-else:
+except ImportError:  # pragma: no cover - Python < 3.11 compatibility
     from exceptiongroup import BaseExceptionGroup
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -2570,7 +2570,7 @@ class TestPreviewOpenAPITools:
 
         registered_summary_to_name: dict = {}
 
-        def fake_create_tool_function(path, method, operation, base_url):  # noqa: ANN001
+        def fake_create_tool_function(path, method, operation, base_url):
             def _f():
                 return None
 
@@ -2583,7 +2583,7 @@ class TestPreviewOpenAPITools:
         )
 
         class _StubRegistry:
-            def register_tool(self, name, description, input_schema, handler):  # noqa: ANN001
+            def register_tool(self, name, description, input_schema, handler):
                 registered_summary_to_name[description] = name
 
         monkeypatch.setattr(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from datetime import datetime
+import sys
 from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -20,6 +21,11 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.types.mcp import MCPAuth
+
+if sys.version_info >= (3, 11):
+    from builtins import BaseExceptionGroup
+else:
+    from exceptiongroup import BaseExceptionGroup
 
 
 def _build_request(
@@ -150,6 +156,56 @@ class TestExecuteWithMcpClient:
         assert captured["extra_headers"] == {
             "X-OAuth": "1",
             "Authorization": "STATIC token",
+        }
+
+    @pytest.mark.asyncio
+    async def test_resolves_static_header_env_vars(self, monkeypatch):
+        """UI test calls resolve os.environ/ static header values before forwarding."""
+        captured: dict = {}
+        monkeypatch.setenv("MCP_STATIC_HEADER_SECRET", "resolved-secret")
+
+        def fake_build_stdio_env(server, raw_headers):
+            return None
+
+        async def fake_create_client(*args, **kwargs):
+            captured["extra_headers"] = kwargs.get("extra_headers")
+            return object()
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_build_stdio_env",
+            fake_build_stdio_env,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_create_mcp_client",
+            fake_create_client,
+            raising=False,
+        )
+
+        async def ok_operation(client):
+            return {"status": "ok"}
+
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=MCPAuth.none,
+            static_headers={
+                "Authorization": "os.environ/MCP_STATIC_HEADER_SECRET",
+                "X-Static": "literal",
+            },
+        )
+
+        result = await rest_endpoints._execute_with_mcp_client(
+            payload,
+            ok_operation,
+        )
+
+        assert result["status"] == "ok"
+        assert captured["extra_headers"] == {
+            "Authorization": "resolved-secret",
+            "X-Static": "literal",
         }
 
     @pytest.mark.asyncio
@@ -2410,7 +2466,7 @@ class TestPreviewOpenAPITools:
     async def test_preview_sanitizes_slash_in_operation_id(self, monkeypatch):
         import re
 
-        async def fake_load_spec(spec_path):  # noqa: ANN001
+        async def fake_load_spec(spec_path):
             return {
                 "paths": {
                     "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs": {
@@ -2487,7 +2543,7 @@ class TestPreviewOpenAPITools:
             }
         }
 
-        async def fake_load_spec(spec_path):  # noqa: ANN001
+        async def fake_load_spec(spec_path):
             return spec
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Relevant issues

Fixes #31050

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I have requested a Greptile review and previously received a **Confidence Score of 5/5**; a fresh review is requested for the rebased head

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
- [x] **CI run for the last commit** - current-head rollup completed with no failures
- [ ] **Merge / cherry-pick CI run**

## Screenshots / Proof of Fix

Before this change, MCP servers saved through the UI/DB path could keep static header values such as `os.environ/MCP_STATIC_HEADER_SECRET` as literal strings. The YAML config path resolves these references, but the DB table hydration path and the UI Test Connection path did not.

After this change:

- `MCPServerManager.build_mcp_server_from_table(...)` resolves `os.environ/...` values after deserializing DB-backed `static_headers`
- user-submitted MCP servers drop proxy-env header references instead of exposing proxy secrets
- the admin-only UI Test Connection path resolves request `static_headers` before creating the MCP client
- literal values and the newer `${NAME}` per-user interpolation syntax remain unchanged
- missing env vars remain unresolved but emit an operator-visible warning

Validation after rebasing onto `litellm_internal_staging@b9008cca`:

```text
Focused static-header tests: 5 passed, 1 warning
BaseExceptionGroup regression: 1 passed, 1 warning

ruff check <five touched source/test files>
# All checks passed!

python -m py_compile <five touched source/test files>
# passed

git diff --check origin/litellm_internal_staging...HEAD
# passed

GitHub current-head check rollup
# 81 success, 1 conditional skip, 0 failures, 0 pending
```

I did not run the full `make test-unit` suite locally because this change is limited to MCP static-header materialization. GitHub completed the repository-wide checks on the refreshed head without failures.

## Type

Bug Fix
Test

## Changes

- Added `resolve_static_header_env_vars(...)` for MCP static headers
- Applied it when hydrating MCP servers from DB rows, with admin/user security gating
- Applied it when testing MCP connections directly from UI request payloads
- Added regression coverage for DB-loaded servers, user-submitted servers, missing env vars, empty headers, and direct Test Connection requests
- Kept the `BaseExceptionGroup` compatibility regression valid across supported Python targets
