### PR TITLE
fix(bedrock): route application-inference-profile ARNs to converse (#18258)

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -589,6 +589,15 @@ def extract_model_name_from_bedrock_arn(model: str) -> str:
     return model
 
 
+def is_bedrock_application_inference_profile_arn(model: str) -> bool:
+    """
+    An application inference profile ARN ends in an opaque id with no provider
+    substring, so the invoke path cannot resolve a provider from it. Such ARNs
+    must use the converse route, which needs no provider.
+    """
+    return ":application-inference-profile/" in model
+
+
 def strip_bedrock_routing_prefix(model: str) -> str:
     """Strip LiteLLM routing prefixes from model name."""
     for prefix in ["bedrock/", "converse/", "invoke/", "openai/", "nova-2/", "nova/"]:
@@ -877,6 +886,9 @@ class BedrockModelInfo(BaseLLMModelInfo):
         if _model_after_bedrock.startswith(
             "nova-2/"
         ) or _model_after_bedrock.startswith("nova/"):
+            return "converse"
+
+        if is_bedrock_application_inference_profile_arn(model):
             return "converse"
 
         base_model = BedrockModelInfo.get_base_model(model)

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -158,6 +158,68 @@ def test_deepseek_cris():
     assert bedrock_route == "converse"
 
 
+def test_application_inference_profile_arn_routes_to_converse():
+    """
+    Regression for #18258: a bare application-inference-profile ARN passed as
+    `bedrock/arn:...` must route to converse. The ARN ends in an opaque id with
+    no provider substring, so the invoke path cannot build a provider-native
+    body and raises "Unknown provider=None". Converse needs no provider, so it
+    is the correct route.
+    """
+    route = BedrockModelInfo.get_bedrock_route(
+        model="bedrock/arn:aws:bedrock:us-west-2:123412341234:application-inference-profile/a1b2c3"
+    )
+    assert route == "converse"
+
+
+def test_explicit_invoke_prefix_wins_over_application_inference_profile_arn():
+    """
+    An explicit invoke/ prefix is respected even for an application-inference-profile
+    ARN; only the bare `bedrock/arn:...` form is auto-routed to converse. The
+    explicit invoke path remains a dead end for these ARNs (no provider can be
+    derived, so completion raises "Unknown provider=None") by design: a caller
+    that explicitly asks for invoke gets invoke. The auto-route only rescues the
+    documented bare form.
+    """
+    from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+    model = "bedrock/invoke/arn:aws:bedrock:us-west-2:123412341234:application-inference-profile/a1b2c3"
+    assert BedrockModelInfo.get_bedrock_route(model) == "invoke"
+    assert BaseAWSLLM.get_bedrock_invoke_provider(model) is None
+
+
+def test_system_defined_inference_profile_arn_still_routes_to_converse():
+    """
+    A system-defined cross-region inference-profile ARN embeds a known model, so
+    get_base_model resolves it and it already routes to converse. Guards that the
+    application-inference-profile fix does not change this working case.
+    """
+    route = BedrockModelInfo.get_bedrock_route(
+        model="bedrock/arn:aws:bedrock:us-east-1:123:inference-profile/us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+    )
+    assert route == "converse"
+
+
+def test_other_opaque_arn_types_still_route_to_invoke():
+    """
+    Only application-inference-profile ARNs are auto-routed to converse. Other
+    opaque ARNs (provisioned-model, imported-model, custom-model-deployment)
+    also yield no invoke provider, but they are frequently invoke-only with
+    provider-specific body formats, so routing them to converse could break
+    them. Guards the deliberate scope against an over-broad "any opaque ARN ->
+    converse" generalization.
+    """
+    for arn_segment in (
+        "provisioned-model/abcdefgh1234",
+        "imported-model/abcdefgh1234",
+        "custom-model-deployment/abcdefgh1234",
+    ):
+        route = BedrockModelInfo.get_bedrock_route(
+            model=f"bedrock/arn:aws:bedrock:us-east-1:123412341234:{arn_segment}"
+        )
+        assert route == "invoke", f"{arn_segment} should stay on invoke route"
+
+
 def test_govcloud_cross_region_inference_prefix():
     """
     Test that GovCloud models with cross-region inference prefix (us-gov.) are parsed correctly


### PR DESCRIPTION
## Relevant issues

Fixes #18258

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Verified end-to-end against real AWS Bedrock using a live application inference profile ARN backed by `amazon.nova-micro-v1:0`. Two proxies ran the identical config (the bare `model="bedrock/arn:...application-inference-profile/..."` form), differing only in code: one on the base branch (pre-fix) and one on this branch (post-fix). Account id redacted as `<ACCT>`.

Step 1, pre-fix proxy, reproduces the bug from the issue (HTTP 404):

<img width="2547" height="542" alt="Step1" src="https://github.com/user-attachments/assets/17a75cae-42b6-4df8-9108-f94aa4cac25f" />

Step 2, post-fix proxy, identical request now succeeds (HTTP 200):

<img width="2549" height="577" alt="Step2" src="https://github.com/user-attachments/assets/151519f8-bc7e-49a3-9225-ffbdcb6007d1" />

Step 3, the decisive proof from the `--detailed_debug` proxy logs; the routing decision changed from invoke to converse, not just the HTTP status:

<img width="2545" height="890" alt="Step3" src="https://github.com/user-attachments/assets/5e347271-300e-433c-97bb-b55507a4e989" />

## Type

🐛 Bug Fix

## Changes

`BedrockModelInfo.get_bedrock_route()` decides which Bedrock API a model uses. A bare application inference profile ARN passed as `bedrock/arn:...application-inference-profile/<id>` matched no explicit route prefix and no nova prefix, so it fell back to a base-model lookup. `get_base_model` returns the opaque profile id (the segment after the last `/`), which is not in `litellm.bedrock_converse_models`, so routing defaulted to invoke. The invoke path then could not derive a provider from the opaque id and raised `Unknown provider=None` before any AWS call.

The AWS InvokeModel API itself does accept inference profile ARNs; the failure is LiteLLM-internal. The invoke path builds a provider-native request body and selects the transformer by substring-matching a provider name in the model id, which an opaque application-inference-profile id does not contain. The converse path uses one unified schema across providers and needs no provider, which is why the existing `bedrock/converse/arn:...` workaround already works.

This adds a small helper `is_bedrock_application_inference_profile_arn` and one check in `get_bedrock_route` so these ARNs route to converse, making the bare `bedrock/arn:...` form behave the same as the already-documented `bedrock/converse/arn:...` form.

Deliberate scope boundaries, both covered by tests:

- An explicit `invoke/` prefix still wins and remains a dead end for these ARNs by design; a caller that explicitly asks for invoke gets invoke.
- System-defined cross-region `inference-profile/` ARNs that embed a known model already resolve via `get_base_model` and are unaffected.
- Other opaque ARN types (`provisioned-model/`, `imported-model/`, `custom-model-deployment/`) also yield no invoke provider but are frequently invoke-only with provider-specific bodies, so they are intentionally left on the invoke route rather than force-routed to converse.

Known limitations that predate this change and are out of scope here (they affect the existing `bedrock/converse/arn:...` workaround identically): cost attribution for opaque profile ARNs falls back to zero unless `base_model` or custom pricing is set, and region extraction only recognizes `arn:aws:bedrock` (not the `aws-us-gov` or `aws-cn` partitions). Both are worth separate issues.
