### PR TITLE
feat(asqav): optional cloud signing via the agent sign endpoint

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -161,6 +161,7 @@ _custom_logger_compatible_callbacks_literal = Literal[
     "levo",
     "compression_interception",
     "newrelic",
+    "asqav",
 ]
 cold_storage_custom_logger: Optional[_custom_logger_compatible_callbacks_literal] = None
 logged_real_time_event_types: Optional[Union[List[str], Literal["*"]]] = None

--- a/litellm/integrations/asqav/__init__.py
+++ b/litellm/integrations/asqav/__init__.py
@@ -1,0 +1,3 @@
+from litellm.integrations.asqav.asqav import AsqavLogger
+
+__all__ = ["AsqavLogger"]

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -309,7 +309,13 @@ class AsqavLogger(CustomLogger):
     # ------------------------------------------------------------------
 
     def _load_chain_tail(self) -> None:
-        """Read the last line of an existing log file to resume the chain."""
+        """Seed chain state from the last main record in an existing log file.
+
+        Scans backward through the file, widening the read window until a
+        complete main record (one with "ts") is found. Sidecar lines and
+        partial leading fragments from the window boundary are skipped rather
+        than aborting the whole scan.
+        """
         try:
             if not os.path.exists(self._log_path):
                 return
@@ -318,16 +324,29 @@ class AsqavLogger(CustomLogger):
                 size = fh.tell()
                 if size == 0:
                     return
-                tail = _read_tail(fh, size)
-            parsed = [
-                json.loads(ln.decode("utf-8")) for ln in tail.split(b"\n") if ln.strip()
-            ]
-            main_records = [r for r in parsed if "ts" in r]
-            if not main_records:
+                chunk_size = 4096
+                while True:
+                    read_size = min(chunk_size, size)
+                    fh.seek(size - read_size)
+                    window = fh.read(read_size)
+                    last_main: dict[str, Any] | None = None
+                    for raw_line in reversed(window.split(b"\n")):
+                        if not raw_line.strip():
+                            continue
+                        try:
+                            rec = json.loads(raw_line.decode("utf-8"))
+                        except (ValueError, UnicodeDecodeError):
+                            continue
+                        if "ts" in rec:
+                            last_main = rec
+                            break
+                    if last_main is not None or read_size == size:
+                        break
+                    chunk_size *= 2
+            if last_main is None:
                 return
-            last_record = main_records[-1]
-            self._prev_hash = last_record.get("record_hash", _GENESIS_HASH)
-            self._call_count = last_record.get("seq", -1) + 1
+            self._prev_hash = last_main.get("record_hash", _GENESIS_HASH)
+            self._call_count = last_main.get("seq", -1) + 1
         except Exception:
             verbose_logger.debug(
                 f"[AsqavLogger] Could not load chain tail: {traceback.format_exc()}"

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -450,8 +450,7 @@ class AsqavLogger(CustomLogger):
 
             client = _get_httpx_client()
             url = (
-                f"{self._cloud_api_base}/api/v1/agents/"
-                f"{self._cloud_agent_id}/sign"
+                f"{self._cloud_api_base}/api/v1/agents/" f"{self._cloud_agent_id}/sign"
             )
             resp = client.post(
                 url,

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -22,6 +22,7 @@ hash chain, unchanged.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import json
 import os
@@ -29,7 +30,7 @@ import threading
 import time
 import traceback
 from datetime import datetime, timezone
-from typing import Any, BinaryIO, Optional
+from typing import Any, BinaryIO
 
 from litellm._logging import verbose_logger
 from litellm.integrations.custom_logger import CustomLogger
@@ -56,7 +57,7 @@ _SENSITIVE_KEYS = frozenset(
         "authorization",
         "token",
         "api_key",
-    }
+    },
 )
 _PROXY_IDENTITY_KEYS = frozenset(
     {
@@ -67,7 +68,7 @@ _PROXY_IDENTITY_KEYS = frozenset(
         "user_id",
         "team_id",
         "org_id",
-    }
+    },
 )
 
 
@@ -87,7 +88,8 @@ def _canonical_bytes(record: dict[str, Any]) -> bytes:
 def _read_tail(fh: BinaryIO, size: int) -> bytes:
     """Read backwards from the end of fh until the buffer contains the entire
     last line, doubling the window each pass so records of any length survive
-    a restart."""
+    a restart.
+    """
     chunk_size = 4096
     while True:
         read_size = min(chunk_size, size)
@@ -98,7 +100,7 @@ def _read_tail(fh: BinaryIO, size: int) -> bytes:
         chunk_size *= 2
 
 
-def _content_digest(value: Any) -> Optional[str]:
+def _content_digest(value: Any) -> str | None:
     """Return a SHA-256 hex digest of a content value, or None if empty."""
     if value is None:
         return None
@@ -124,7 +126,7 @@ def _merge_proxy_identity(metadata: dict[str, Any], kwargs: dict[str, Any]) -> d
     return metadata
 
 
-def _compute_latency_ms(start_time: Any, end_time: Any) -> Optional[int]:
+def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:
     try:
         if start_time is not None and end_time is not None:
             return int((end_time - start_time).total_seconds() * 1000)
@@ -135,12 +137,12 @@ def _compute_latency_ms(start_time: Any, end_time: Any) -> Optional[int]:
 
 def _extract_usage_fields(
     response_obj: Any,
-) -> tuple[Optional[int], Optional[int], Optional[int], Optional[str], Optional[str]]:
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
-    finish_reason: Optional[str] = None
-    provider_request_id: Optional[str] = None
+) -> tuple[int | None, int | None, int | None, str | None, str | None]:
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+    finish_reason: str | None = None
+    provider_request_id: str | None = None
     try:
         if hasattr(response_obj, "usage") and response_obj.usage:
             prompt_tokens = response_obj.usage.prompt_tokens
@@ -150,14 +152,14 @@ def _extract_usage_fields(
             finish_reason = response_obj.choices[0].finish_reason
         if hasattr(response_obj, "_hidden_params"):
             provider_request_id = response_obj._hidden_params.get("x-request-id") or response_obj._hidden_params.get(
-                "cf-ray"
+                "cf-ray",
             )
     except (AttributeError, IndexError, TypeError):
         pass
     return prompt_tokens, completion_tokens, total_tokens, finish_reason, provider_request_id
 
 
-def _extract_response_content_digest(response_obj: Any) -> Optional[str]:
+def _extract_response_content_digest(response_obj: Any) -> str | None:
     try:
         if hasattr(response_obj, "choices") and response_obj.choices:
             return _content_digest(response_obj.choices[0].message.content)
@@ -278,7 +280,7 @@ class AsqavLogger(CustomLogger):
 
     def __init__(
         self,
-        log_path: Optional[str] = None,
+        log_path: str | None = None,
         redact_content: bool = True,
     ) -> None:
         super().__init__()
@@ -424,10 +426,8 @@ class AsqavLogger(CustomLogger):
             except Exception:
                 # fdopen owns fd; if it raises before returning the context
                 # manager the fd may still be open - close defensively.
-                try:
+                with contextlib.suppress(OSError):
                     os.close(fd)
-                except OSError:
-                    pass
                 raise
             return True
         except (OSError, TypeError, ValueError):
@@ -487,7 +487,7 @@ class AsqavLogger(CustomLogger):
         self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
 
     async def async_log_success_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,
@@ -499,7 +499,7 @@ class AsqavLogger(CustomLogger):
         )
 
     async def async_log_failure_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,
@@ -514,7 +514,7 @@ class AsqavLogger(CustomLogger):
     # Chain verification (utility; not called on the hot path)
     # ------------------------------------------------------------------
 
-    def verify_chain(self, log_path: Optional[str] = None) -> tuple[bool, str]:
+    def verify_chain(self, log_path: str | None = None) -> tuple[bool, str]:
         """Verify the integrity of the audit log at log_path.
 
         Returns (True, "ok") when every record's hash matches its content and

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -206,12 +206,15 @@ def _extract_loggable(
     }
 
 
-def _cloud_sign_payload(record: dict[str, Any]) -> dict[str, Any]:
+def _cloud_sign_payload(
+    record: dict[str, Any], pre_receipt_hash: str
+) -> dict[str, Any]:
     """Build the digests-only body for the agent sign endpoint.
 
     Binds the messages digest as the hashed payload and carries the response
-    digest plus call metadata alongside.  Raw prompt/response text is never
-    included; only digests the local record already holds.
+    digest plus call metadata alongside.  record_hash is the pre-receipt
+    canonical hash of the record content, so the signature commits to the
+    exact record fields.  Raw prompt/response text is never included.
     """
     messages_digest = record.get("messages_digest")
     metadata: dict[str, Any] = {
@@ -220,7 +223,7 @@ def _cloud_sign_payload(record: dict[str, Any]) -> dict[str, Any]:
         "model": record.get("model"),
         "status": record.get("status"),
         "response_content_digest": record.get("response_content_digest"),
-        "record_hash": record.get("record_hash"),
+        "record_hash": pre_receipt_hash,
         "seq": record.get("seq"),
     }
     body: dict[str, Any] = {
@@ -377,13 +380,22 @@ class AsqavLogger(CustomLogger):
                     **loggable,
                 }
 
+                # Pre-receipt hash over the record content (no cloud receipt).
+                # The cloud signs this so the signature binds to the exact
+                # canonical fields. Computed under the lock, no network here.
+                pre_receipt_hash = _sha256_hex(_canonical_bytes(hashable))
+
                 # Opt-in cloud signing binds into the chain: the returned
                 # receipt is part of the hashed record, so verify_chain still
                 # passes and the signature cannot be swapped after the fact.
-                cloud = self._maybe_cloud_sign({**hashable, "seq": seq})
+                cloud = self._maybe_cloud_sign(hashable, pre_receipt_hash)
                 if cloud is not None:
                     hashable["asqav_cloud"] = cloud
 
+                # Final hash additionally commits asqav_cloud, so it legitimately
+                # differs from pre_receipt_hash. An auditor re-derives the
+                # pre-receipt hash by canonicalizing the record minus record_hash
+                # and asqav_cloud.
                 record_hash = _sha256_hex(_canonical_bytes(hashable))
 
                 if not self._write_record({**hashable, "record_hash": record_hash}):
@@ -435,9 +447,12 @@ class AsqavLogger(CustomLogger):
     # Optional cloud signing
     # ------------------------------------------------------------------
 
-    def _maybe_cloud_sign(self, record: dict[str, Any]) -> dict[str, Any] | None:
+    def _maybe_cloud_sign(
+        self, record: dict[str, Any], pre_receipt_hash: str
+    ) -> dict[str, Any] | None:
         """POST the record's digests to the asqav sign endpoint, fail-soft.
 
+        pre_receipt_hash is the canonical content hash the signature binds to.
         Returns the receipt fields to bind into the local record, or None when
         cloud signing is off or any step fails.  A missing key, network error,
         non-2xx, or timeout never raises and never blocks the local write.
@@ -454,7 +469,7 @@ class AsqavLogger(CustomLogger):
             )
             resp = client.post(
                 url,
-                json=_cloud_sign_payload(record),
+                json=_cloud_sign_payload(record, pre_receipt_hash),
                 headers={"X-API-Key": self._cloud_api_key},
                 timeout=_CLOUD_SIGN_TIMEOUT,
             )

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -160,9 +160,9 @@ def _extract_loggable(
         if hasattr(response_obj, "choices") and response_obj.choices:
             finish_reason = response_obj.choices[0].finish_reason
         if hasattr(response_obj, "_hidden_params"):
-            provider_request_id = response_obj._hidden_params.get(
-                "x-request-id"
-            ) or response_obj._hidden_params.get("cf-ray")
+            provider_request_id = response_obj._hidden_params.get("x-request-id") or response_obj._hidden_params.get(
+                "cf-ray"
+            )
     except Exception:
         pass
 
@@ -186,9 +186,7 @@ def _extract_loggable(
     except Exception:
         pass
     if not call_id:
-        call_id = kwargs.get("litellm_call_id") or kwargs.get(
-            "id", str(int(time.time() * 1e6))
-        )
+        call_id = kwargs.get("litellm_call_id") or kwargs.get("id", str(int(time.time() * 1e6)))
 
     return {
         "call_id": call_id,
@@ -206,9 +204,7 @@ def _extract_loggable(
     }
 
 
-def _cloud_sign_payload(
-    record: dict[str, Any], pre_receipt_hash: str
-) -> dict[str, Any]:
+def _cloud_sign_payload(record: dict[str, Any], pre_receipt_hash: str) -> dict[str, Any]:
     """Build the digests-only body for the agent sign endpoint.
 
     The signed payload is body["hash"]; the cloud signs it verbatim in hash mode
@@ -274,21 +270,15 @@ class AsqavLogger(CustomLogger):
     ) -> None:
         super().__init__()
 
-        self._log_path: str = log_path or os.environ.get(
-            "ASQAV_LOG_PATH", _DEFAULT_LOG_PATH
-        )
+        self._log_path: str = log_path or os.environ.get("ASQAV_LOG_PATH", _DEFAULT_LOG_PATH)
         self._redact_content: bool = (
-            os.environ.get("ASQAV_REDACT_CONTENT", "true").lower() != "false"
-            if log_path is None
-            else redact_content
+            os.environ.get("ASQAV_REDACT_CONTENT", "true").lower() != "false" if log_path is None else redact_content
         )
 
         # Optional cloud signing. Active only when both env vars are present.
         self._cloud_api_key: str | None = os.environ.get("ASQAV_API_KEY") or None
         self._cloud_agent_id: str | None = os.environ.get("ASQAV_AGENT_ID") or None
-        self._cloud_api_base: str = (
-            os.environ.get("ASQAV_API_BASE") or _DEFAULT_ASQAV_API_BASE
-        ).rstrip("/")
+        self._cloud_api_base: str = (os.environ.get("ASQAV_API_BASE") or _DEFAULT_ASQAV_API_BASE).rstrip("/")
 
         self._lock: threading.Lock = threading.Lock()
         self._call_count: int = 0
@@ -299,10 +289,7 @@ class AsqavLogger(CustomLogger):
         self._load_chain_tail()
 
     def __repr__(self) -> str:
-        return (
-            f"AsqavLogger(log_path={self._log_path!r},"
-            f" redact_content={self._redact_content})"
-        )
+        return f"AsqavLogger(log_path={self._log_path!r}, redact_content={self._redact_content})"
 
     # ------------------------------------------------------------------
     # Chain state persistence
@@ -348,9 +335,7 @@ class AsqavLogger(CustomLogger):
             self._prev_hash = last_main.get("record_hash", _GENESIS_HASH)
             self._call_count = last_main.get("seq", -1) + 1
         except Exception:
-            verbose_logger.debug(
-                f"[AsqavLogger] Could not load chain tail: {traceback.format_exc()}"
-            )
+            verbose_logger.debug(f"[AsqavLogger] Could not load chain tail: {traceback.format_exc()}")
 
     # ------------------------------------------------------------------
     # Core record append
@@ -370,18 +355,14 @@ class AsqavLogger(CustomLogger):
         on-disk order always matches the chain order.
         """
         try:
-            loggable = _extract_loggable(
-                kwargs, response_obj, start_time, end_time, status
-            )
+            loggable = _extract_loggable(kwargs, response_obj, start_time, end_time, status)
 
             if not self._redact_content:
                 # Store content in the clear when the operator explicitly opts in.
                 loggable["messages"] = kwargs.get("messages")
                 try:
                     if hasattr(response_obj, "choices") and response_obj.choices:
-                        loggable["response_content"] = response_obj.choices[
-                            0
-                        ].message.content
+                        loggable["response_content"] = response_obj.choices[0].message.content
                 except Exception:
                     pass
 
@@ -403,14 +384,10 @@ class AsqavLogger(CustomLogger):
 
             cloud = self._maybe_cloud_sign(hashable, record_hash)
             if cloud is not None:
-                self._write_record(
-                    {"seq": seq, "record_hash": record_hash, "asqav_cloud": cloud}
-                )
+                self._write_record({"seq": seq, "record_hash": record_hash, "asqav_cloud": cloud})
 
         except Exception:
-            verbose_logger.debug(
-                f"[AsqavLogger] Unhandled error in _build_and_append: {traceback.format_exc()}"
-            )
+            verbose_logger.debug(f"[AsqavLogger] Unhandled error in _build_and_append: {traceback.format_exc()}")
 
     def _write_record(self, record: dict[str, Any]) -> bool:
         """Append one record to the log file. Returns False if the write failed."""
@@ -441,18 +418,14 @@ class AsqavLogger(CustomLogger):
                 raise
             return True
         except Exception:
-            verbose_logger.warning(
-                f"[AsqavLogger] Failed to write audit record: {traceback.format_exc()}"
-            )
+            verbose_logger.warning(f"[AsqavLogger] Failed to write audit record: {traceback.format_exc()}")
             return False
 
     # ------------------------------------------------------------------
     # Optional cloud signing
     # ------------------------------------------------------------------
 
-    def _maybe_cloud_sign(
-        self, record: dict[str, Any], pre_receipt_hash: str
-    ) -> dict[str, Any] | None:
+    def _maybe_cloud_sign(self, record: dict[str, Any], pre_receipt_hash: str) -> dict[str, Any] | None:
         """POST the record's digests to the asqav sign endpoint, fail-soft.
 
         pre_receipt_hash is the canonical content hash the signature binds to.
@@ -467,9 +440,7 @@ class AsqavLogger(CustomLogger):
             from litellm.llms.custom_httpx.http_handler import _get_httpx_client
 
             client = _get_httpx_client()
-            url = (
-                f"{self._cloud_api_base}/api/v1/agents/" f"{self._cloud_agent_id}/sign"
-            )
+            url = f"{self._cloud_api_base}/api/v1/agents/{self._cloud_agent_id}/sign"
             resp = client.post(
                 url,
                 json=_cloud_sign_payload(record, pre_receipt_hash),
@@ -478,9 +449,7 @@ class AsqavLogger(CustomLogger):
             )
             status_code = getattr(resp, "status_code", 0)
             if status_code and not (200 <= status_code < 300):
-                verbose_logger.debug(
-                    f"[AsqavLogger] cloud sign returned HTTP {status_code}"
-                )
+                verbose_logger.debug(f"[AsqavLogger] cloud sign returned HTTP {status_code}")
                 return None
             data = resp.json()
             receipt = {
@@ -491,23 +460,17 @@ class AsqavLogger(CustomLogger):
             }
             return {k: v for k, v in receipt.items() if v is not None} or None
         except Exception:  # noqa: BLE001  # fail-soft, never break logging
-            verbose_logger.debug(
-                f"[AsqavLogger] cloud sign skipped: {traceback.format_exc()}"
-            )
+            verbose_logger.debug(f"[AsqavLogger] cloud sign skipped: {traceback.format_exc()}")
             return None
 
     # ------------------------------------------------------------------
     # CustomLogger hooks
     # ------------------------------------------------------------------
 
-    def log_success_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
-    ) -> None:
+    def log_success_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
         self._build_and_append(kwargs, response_obj, start_time, end_time, "success")
 
-    def log_failure_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
-    ) -> None:
+    def log_failure_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
         self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
 
     async def async_log_success_event(
@@ -563,28 +526,20 @@ class AsqavLogger(CustomLogger):
                         continue
 
                     stored_hash = record.get("record_hash", "")
-                    hashable = {
-                        k: v
-                        for k, v in record.items()
-                        if k not in ("record_hash", "asqav_cloud")
-                    }
+                    hashable = {k: v for k, v in record.items() if k not in ("record_hash", "asqav_cloud")}
                     computed_hash = _sha256_hex(_canonical_bytes(hashable))
 
                     if computed_hash != stored_hash:
                         return (
                             False,
-                            f"line {lineno}: hash mismatch"
-                            f" (stored={stored_hash[:12]},"
-                            f" computed={computed_hash[:12]})",
+                            f"line {lineno}: hash mismatch (stored={stored_hash[:12]}, computed={computed_hash[:12]})",
                         )
 
                     rec_prev = record.get("prev_hash", _GENESIS_HASH)
                     if rec_prev != prev_hash:
                         return (
                             False,
-                            f"line {lineno}: prev_hash chain break"
-                            f" (expected={prev_hash[:12]},"
-                            f" got={rec_prev[:12]})",
+                            f"line {lineno}: prev_hash chain break (expected={prev_hash[:12]}, got={rec_prev[:12]})",
                         )
 
                     prev_hash = stored_hash

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -100,7 +100,7 @@ def _read_tail(fh: BinaryIO, size: int) -> bytes:
         chunk_size *= 2
 
 
-def _content_digest(value: Any) -> str | None:  # noqa: ANN401
+def _content_digest(value: Any) -> str | None:
     """Return a SHA-256 hex digest of a content value, or None if empty."""
     if value is None:
         return None
@@ -126,7 +126,7 @@ def _merge_proxy_identity(metadata: dict[str, Any], kwargs: dict[str, Any]) -> d
     return metadata
 
 
-def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:  # noqa: ANN401
+def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:
     try:
         if start_time is not None and end_time is not None:
             return int((end_time - start_time).total_seconds() * 1000)
@@ -136,7 +136,7 @@ def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:  # noqa: 
 
 
 def _extract_usage_fields(
-    response_obj: Any,  # noqa: ANN401
+    response_obj: Any,
 ) -> tuple[int | None, int | None, int | None, str | None, str | None]:
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
@@ -159,7 +159,7 @@ def _extract_usage_fields(
     return prompt_tokens, completion_tokens, total_tokens, finish_reason, provider_request_id
 
 
-def _extract_response_content_digest(response_obj: Any) -> str | None:  # noqa: ANN401
+def _extract_response_content_digest(response_obj: Any) -> str | None:
     try:
         if hasattr(response_obj, "choices") and response_obj.choices:
             return _content_digest(response_obj.choices[0].message.content)
@@ -171,7 +171,7 @@ def _extract_response_content_digest(response_obj: Any) -> str | None:  # noqa: 
 def _extract_call_id(kwargs: dict[str, Any]) -> str:
     """Prefer standard_logging_object's id, falling back to the raw call id."""
     try:
-        slp: Any = kwargs.get("standard_logging_object"),  # noqa: ANN401
+        slp: Any = kwargs.get("standard_logging_object"),
         if slp and isinstance(slp, dict):
             call_id = slp.get("id") or slp.get("litellm_call_id")
             if call_id:
@@ -183,9 +183,9 @@ def _extract_call_id(kwargs: dict[str, Any]) -> str:
 
 def _extract_loggable(
     kwargs: dict[str, Any],
-    response_obj: Any,  # noqa: ANN401
-    start_time: Any,  # noqa: ANN401
-    end_time: Any,  # noqa: ANN401
+    response_obj: Any,
+    start_time: Any,
+    end_time: Any,
     status: str,
 ) -> dict[str, Any]:
     """Pull metadata + digests out of a callback invocation.
@@ -359,9 +359,9 @@ class AsqavLogger(CustomLogger):
     def _build_and_append(
         self,
         kwargs: dict[str, Any],
-        response_obj: Any,  # noqa: ANN401
-        start_time: Any,  # noqa: ANN401
-        end_time: Any,  # noqa: ANN401
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
         status: str,
     ) -> None:
         """Build one audit record and append it to the JSONL log.
@@ -480,14 +480,14 @@ class AsqavLogger(CustomLogger):
     # CustomLogger hooks
     # ------------------------------------------------------------------
 
-    def log_success_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:  # noqa: ANN401
+    def log_success_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
         self._build_and_append(kwargs, response_obj, start_time, end_time, "success")
 
-    def log_failure_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:  # noqa: ANN401
+    def log_failure_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
         self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
 
     async def async_log_success_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,  # noqa: ANN401
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,
@@ -499,7 +499,7 @@ class AsqavLogger(CustomLogger):
         )
 
     async def async_log_failure_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,  # noqa: ANN401
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -171,7 +171,7 @@ def _extract_response_content_digest(response_obj: Any) -> str | None:
 def _extract_call_id(kwargs: dict[str, Any]) -> str:
     """Prefer standard_logging_object's id, falling back to the raw call id."""
     try:
-        slp: Any = kwargs.get("standard_logging_object"),
+        slp: Any = (kwargs.get("standard_logging_object"),)
         if slp and isinstance(slp, dict):
             call_id = slp.get("id") or slp.get("litellm_call_id")
             if call_id:
@@ -487,7 +487,11 @@ class AsqavLogger(CustomLogger):
         self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
 
     async def async_log_success_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,
@@ -499,7 +503,11 @@ class AsqavLogger(CustomLogger):
         )
 
     async def async_log_failure_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -319,10 +319,13 @@ class AsqavLogger(CustomLogger):
                 if size == 0:
                     return
                 tail = _read_tail(fh, size)
-            lines = [ln for ln in tail.split(b"\n") if ln.strip()]
-            if not lines:
+            parsed = [
+                json.loads(ln.decode("utf-8")) for ln in tail.split(b"\n") if ln.strip()
+            ]
+            main_records = [r for r in parsed if "ts" in r]
+            if not main_records:
                 return
-            last_record = json.loads(lines[-1].decode("utf-8"))
+            last_record = main_records[-1]
             self._prev_hash = last_record.get("record_hash", _GENESIS_HASH)
             self._call_count = last_record.get("seq", -1) + 1
         except Exception:
@@ -363,39 +366,14 @@ class AsqavLogger(CustomLogger):
                 except Exception:
                     pass
 
-            # The file write happens under the same lock that assigns seq and
-            # prev_hash, so records always land on disk in chain order even
-            # when callbacks fire concurrently.  Chain state only advances
-            # after a successful write; a failed write drops the record and
-            # the chain continues from the last record actually on disk.
             with self._lock:
                 seq = self._call_count
-
-                # The fields that enter the hash are fixed and canonical so that
-                # an auditor can reproduce the digest from the log alone.
                 hashable: dict[str, Any] = {
                     "seq": seq,
                     "ts": datetime.now(tz=timezone.utc).isoformat(),
                     "prev_hash": self._prev_hash,
                     **loggable,
                 }
-
-                # Pre-receipt hash over the record content (no cloud receipt).
-                # The cloud signs this so the signature binds to the exact
-                # canonical fields. Computed under the lock, no network here.
-                pre_receipt_hash = _sha256_hex(_canonical_bytes(hashable))
-
-                # Opt-in cloud signing binds into the chain: the returned
-                # receipt is part of the hashed record, so verify_chain still
-                # passes and the signature cannot be swapped after the fact.
-                cloud = self._maybe_cloud_sign(hashable, pre_receipt_hash)
-                if cloud is not None:
-                    hashable["asqav_cloud"] = cloud
-
-                # Final hash additionally commits asqav_cloud, so it legitimately
-                # differs from pre_receipt_hash. An auditor re-derives the
-                # pre-receipt hash by canonicalizing the record minus record_hash
-                # and asqav_cloud.
                 record_hash = _sha256_hex(_canonical_bytes(hashable))
 
                 if not self._write_record({**hashable, "record_hash": record_hash}):
@@ -403,6 +381,12 @@ class AsqavLogger(CustomLogger):
 
                 self._prev_hash = record_hash
                 self._call_count += 1
+
+            cloud = self._maybe_cloud_sign(hashable, record_hash)
+            if cloud is not None:
+                self._write_record(
+                    {"seq": seq, "record_hash": record_hash, "asqav_cloud": cloud}
+                )
 
         except Exception:
             verbose_logger.debug(
@@ -555,9 +539,16 @@ class AsqavLogger(CustomLogger):
                         continue
                     record = json.loads(line)
 
+                    # Sidecar lines carry only seq/record_hash/asqav_cloud; skip.
+                    if "ts" not in record:
+                        continue
+
                     stored_hash = record.get("record_hash", "")
-                    # Recompute hash over all fields except record_hash itself.
-                    hashable = {k: v for k, v in record.items() if k != "record_hash"}
+                    hashable = {
+                        k: v
+                        for k, v in record.items()
+                        if k not in ("record_hash", "asqav_cloud")
+                    }
                     computed_hash = _sha256_hex(_canonical_bytes(hashable))
 
                     if computed_hash != stored_hash:

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -10,6 +10,13 @@ Design goals (matching the on-device ask from litellm#25329):
 - Never breaks an LLM call: every code path is wrapped fail-soft.
 - Does not log message content by default; logs content digests so
   auditors can prove a payload was present without reconstructing it.
+
+Optional cloud signing: when ASQAV_API_KEY and ASQAV_AGENT_ID are set, each
+record is also signed by the asqav agent sign endpoint and the returned
+signature id / verification url are recorded onto the local line.  The cloud
+call sends only the digests the local record already computes, never raw
+content, and is fail-soft.  With the key unset the behavior is the pure local
+hash chain, unchanged.
 """
 
 from __future__ import annotations
@@ -34,6 +41,13 @@ _GENESIS_HASH = "0" * 64
 
 # Default log path; can be overridden via ASQAV_LOG_PATH.
 _DEFAULT_LOG_PATH = os.path.join(os.path.expanduser("~"), ".litellm_asqav_audit.jsonl")
+
+# Default asqav API base for the optional cloud-sign path.
+_DEFAULT_ASQAV_API_BASE = "https://api.asqav.com"
+
+# Cloud-sign request timeout (seconds). Kept short so a slow endpoint never
+# stalls the callback; any timeout falls through to the local-only record.
+_CLOUD_SIGN_TIMEOUT = 5.0
 
 
 def _sha256_hex(data: bytes) -> str:
@@ -192,6 +206,33 @@ def _extract_loggable(
     }
 
 
+def _cloud_sign_payload(record: dict[str, Any]) -> dict[str, Any]:
+    """Build the digests-only body for the agent sign endpoint.
+
+    Binds the messages digest as the hashed payload and carries the response
+    digest plus call metadata alongside.  Raw prompt/response text is never
+    included; only digests the local record already holds.
+    """
+    messages_digest = record.get("messages_digest")
+    metadata: dict[str, Any] = {
+        "source": "litellm",
+        "call_id": record.get("call_id"),
+        "model": record.get("model"),
+        "status": record.get("status"),
+        "response_content_digest": record.get("response_content_digest"),
+        "record_hash": record.get("record_hash"),
+        "seq": record.get("seq"),
+    }
+    body: dict[str, Any] = {
+        "action_type": "litellm:completion",
+        "metadata": {k: v for k, v in metadata.items() if v is not None},
+    }
+    if messages_digest:
+        body["hash"] = f"sha256:{messages_digest}"
+        body["hash_algo"] = "sha256"
+    return body
+
+
 class AsqavLogger(CustomLogger):
     """Tamper-evident local-first audit-log callback for LiteLLM.
 
@@ -203,6 +244,16 @@ class AsqavLogger(CustomLogger):
     ASQAV_REDACT_CONTENT
         Set to "false" to store message/response content in the clear instead
         of as SHA-256 digests.  Defaults to "true" (digest only).
+
+    ASQAV_API_KEY, ASQAV_AGENT_ID
+        Set both to opt into cloud signing.  After the local record is built,
+        the digests it already holds are POSTed to the asqav agent sign
+        endpoint and the returned signature id / verification url are recorded
+        onto the local line.  With either unset, the logger is pure local hash
+        chain and never reaches the network.
+
+    ASQAV_API_BASE
+        Override the cloud-sign base URL.  Defaults to https://api.asqav.com.
 
     Multi-worker limitation: this logger is designed for a single audit writer
     per log file.  The threading.Lock serializes concurrent threads within one
@@ -228,6 +279,13 @@ class AsqavLogger(CustomLogger):
             if log_path is None
             else redact_content
         )
+
+        # Optional cloud signing. Active only when both env vars are present.
+        self._cloud_api_key: Optional[str] = os.environ.get("ASQAV_API_KEY") or None
+        self._cloud_agent_id: Optional[str] = os.environ.get("ASQAV_AGENT_ID") or None
+        self._cloud_api_base: str = (
+            os.environ.get("ASQAV_API_BASE") or _DEFAULT_ASQAV_API_BASE
+        ).rstrip("/")
 
         self._lock: threading.Lock = threading.Lock()
         self._call_count: int = 0
@@ -318,6 +376,14 @@ class AsqavLogger(CustomLogger):
                     "prev_hash": self._prev_hash,
                     **loggable,
                 }
+
+                # Opt-in cloud signing binds into the chain: the returned
+                # receipt is part of the hashed record, so verify_chain still
+                # passes and the signature cannot be swapped after the fact.
+                cloud = self._maybe_cloud_sign({**hashable, "seq": seq})
+                if cloud is not None:
+                    hashable["asqav_cloud"] = cloud
+
                 record_hash = _sha256_hex(_canonical_bytes(hashable))
 
                 if not self._write_record({**hashable, "record_hash": record_hash}):
@@ -364,6 +430,54 @@ class AsqavLogger(CustomLogger):
                 f"[AsqavLogger] Failed to write audit record: {traceback.format_exc()}"
             )
             return False
+
+    # ------------------------------------------------------------------
+    # Optional cloud signing
+    # ------------------------------------------------------------------
+
+    def _maybe_cloud_sign(self, record: dict[str, Any]) -> Optional[dict[str, Any]]:
+        """POST the record's digests to the asqav sign endpoint, fail-soft.
+
+        Returns the receipt fields to bind into the local record, or None when
+        cloud signing is off or any step fails.  A missing key, network error,
+        non-2xx, or timeout never raises and never blocks the local write.
+        """
+        if not self._cloud_api_key or not self._cloud_agent_id:
+            return None
+        try:
+            # Use litellm's own httpx handler so no new dependency is added.
+            from litellm.llms.custom_httpx.http_handler import _get_httpx_client
+
+            client = _get_httpx_client()
+            url = (
+                f"{self._cloud_api_base}/api/v1/agents/"
+                f"{self._cloud_agent_id}/sign"
+            )
+            resp = client.post(
+                url,
+                json=_cloud_sign_payload(record),
+                headers={"X-API-Key": self._cloud_api_key},
+                timeout=_CLOUD_SIGN_TIMEOUT,
+            )
+            status_code = getattr(resp, "status_code", 0)
+            if status_code and not (200 <= status_code < 300):
+                verbose_logger.debug(
+                    f"[AsqavLogger] cloud sign returned HTTP {status_code}"
+                )
+                return None
+            data = resp.json()
+            receipt = {
+                "signature_id": data.get("signature_id"),
+                "verification_url": data.get("verification_url"),
+                "action_id": data.get("action_id"),
+                "mode": data.get("mode"),
+            }
+            return {k: v for k, v in receipt.items() if v is not None} or None
+        except Exception:
+            verbose_logger.debug(
+                f"[AsqavLogger] cloud sign skipped: {traceback.format_exc()}"
+            )
+            return None
 
     # ------------------------------------------------------------------
     # CustomLogger hooks

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -87,7 +87,7 @@ def _canonical_bytes(record: dict[str, Any]) -> bytes:
 
 def _read_tail(fh: BinaryIO, size: int) -> bytes:
     """Read backwards from the end of fh until the buffer contains the entire
-    last line, doubling the window each pass so records of any length survive
+    last line, doubling the window each pass so records of any length survive.
     a restart.
     """
     chunk_size = 4096
@@ -100,7 +100,7 @@ def _read_tail(fh: BinaryIO, size: int) -> bytes:
         chunk_size *= 2
 
 
-def _content_digest(value: Any) -> str | None:
+def _content_digest(value: Any) -> str | None:  # noqa: ANN401
     """Return a SHA-256 hex digest of a content value, or None if empty."""
     if value is None:
         return None
@@ -126,7 +126,7 @@ def _merge_proxy_identity(metadata: dict[str, Any], kwargs: dict[str, Any]) -> d
     return metadata
 
 
-def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:
+def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:  # noqa: ANN401
     try:
         if start_time is not None and end_time is not None:
             return int((end_time - start_time).total_seconds() * 1000)
@@ -136,7 +136,7 @@ def _compute_latency_ms(start_time: Any, end_time: Any) -> int | None:
 
 
 def _extract_usage_fields(
-    response_obj: Any,
+    response_obj: Any,  # noqa: ANN401
 ) -> tuple[int | None, int | None, int | None, str | None, str | None]:
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
@@ -159,7 +159,7 @@ def _extract_usage_fields(
     return prompt_tokens, completion_tokens, total_tokens, finish_reason, provider_request_id
 
 
-def _extract_response_content_digest(response_obj: Any) -> str | None:
+def _extract_response_content_digest(response_obj: Any) -> str | None:  # noqa: ANN401
     try:
         if hasattr(response_obj, "choices") and response_obj.choices:
             return _content_digest(response_obj.choices[0].message.content)
@@ -171,7 +171,7 @@ def _extract_response_content_digest(response_obj: Any) -> str | None:
 def _extract_call_id(kwargs: dict[str, Any]) -> str:
     """Prefer standard_logging_object's id, falling back to the raw call id."""
     try:
-        slp: Any = kwargs.get("standard_logging_object")
+        slp: Any = kwargs.get("standard_logging_object"),  # noqa: ANN401
         if slp and isinstance(slp, dict):
             call_id = slp.get("id") or slp.get("litellm_call_id")
             if call_id:
@@ -183,9 +183,9 @@ def _extract_call_id(kwargs: dict[str, Any]) -> str:
 
 def _extract_loggable(
     kwargs: dict[str, Any],
-    response_obj: Any,
-    start_time: Any,
-    end_time: Any,
+    response_obj: Any,  # noqa: ANN401
+    start_time: Any,  # noqa: ANN401
+    end_time: Any,  # noqa: ANN401
     status: str,
 ) -> dict[str, Any]:
     """Pull metadata + digests out of a callback invocation.
@@ -359,9 +359,9 @@ class AsqavLogger(CustomLogger):
     def _build_and_append(
         self,
         kwargs: dict[str, Any],
-        response_obj: Any,
-        start_time: Any,
-        end_time: Any,
+        response_obj: Any,  # noqa: ANN401
+        start_time: Any,  # noqa: ANN401
+        end_time: Any,  # noqa: ANN401
         status: str,
     ) -> None:
         """Build one audit record and append it to the JSONL log.
@@ -480,14 +480,14 @@ class AsqavLogger(CustomLogger):
     # CustomLogger hooks
     # ------------------------------------------------------------------
 
-    def log_success_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
+    def log_success_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:  # noqa: ANN401
         self._build_and_append(kwargs, response_obj, start_time, end_time, "success")
 
-    def log_failure_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:
+    def log_failure_event(self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any) -> None:  # noqa: ANN401
         self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
 
     async def async_log_success_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,  # noqa: ANN401
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,
@@ -499,7 +499,7 @@ class AsqavLogger(CustomLogger):
         )
 
     async def async_log_failure_event(
-        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any,  # noqa: ANN401
     ) -> None:
         await asyncio.to_thread(
             self._build_and_append,

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -1,0 +1,458 @@
+"""Asqav local-first audit-log callback for LiteLLM.
+
+Each LLM call appends one record to a local JSONL file.  Every record carries
+a SHA-256 chain hash over its own canonical fields plus the previous record's
+hash, giving a tamper-evident sequence that can be verified entirely offline
+with stdlib tools.
+
+Design goals (matching the on-device ask from litellm#25329):
+- Zero runtime dependencies beyond Python stdlib + litellm itself.
+- Never breaks an LLM call: every code path is wrapped fail-soft.
+- Does not log message content by default; logs content digests so
+  auditors can prove a payload was present without reconstructing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import threading
+import time
+import traceback
+from datetime import datetime, timezone
+from typing import Any, BinaryIO, Optional
+
+from litellm._logging import verbose_logger
+from litellm.integrations.custom_logger import CustomLogger
+
+__all__ = ["AsqavLogger"]
+
+# Sentinel used as the genesis prev_hash (no predecessor).
+_GENESIS_HASH = "0" * 64
+
+# Default log path; can be overridden via ASQAV_LOG_PATH.
+_DEFAULT_LOG_PATH = os.path.join(os.path.expanduser("~"), ".litellm_asqav_audit.jsonl")
+
+
+def _sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _canonical_bytes(record: dict[str, Any]) -> bytes:
+    """Stable canonical serialisation for hashing.
+
+    We sort keys and use separators=(',', ':') so the byte sequence is
+    deterministic across Python versions and platforms.
+    """
+    return json.dumps(record, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _read_tail(fh: BinaryIO, size: int) -> bytes:
+    """Read backwards from the end of fh until the buffer contains the entire
+    last line, doubling the window each pass so records of any length survive
+    a restart."""
+    chunk_size = 4096
+    while True:
+        read_size = min(chunk_size, size)
+        fh.seek(size - read_size)
+        tail = fh.read(read_size)
+        if read_size == size or b"\n" in tail.rstrip(b"\n"):
+            return tail
+        chunk_size *= 2
+
+
+def _content_digest(value: Any) -> Optional[str]:
+    """Return a SHA-256 hex digest of a content value, or None if empty."""
+    if value is None:
+        return None
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return _sha256_hex(raw)
+
+
+def _extract_loggable(
+    kwargs: dict[str, Any],
+    response_obj: Any,
+    start_time: Any,
+    end_time: Any,
+    status: str,
+) -> dict[str, Any]:
+    """Pull metadata + digests out of a callback invocation.
+
+    Message content and response text are never stored in the clear; only their
+    SHA-256 digests appear in the log so callers can prove a payload existed
+    without reconstructing it.
+    """
+    model: str = kwargs.get("model", "")
+    messages: Any = kwargs.get("messages")
+
+    # Root metadata (user-supplied tags, etc.)
+    metadata: Any = dict(kwargs.get("metadata") or kwargs.get("litellm_metadata") or {})
+
+    # Merge proxy identity fields from litellm_params.metadata.  Sensitive
+    # header/key values are filtered so raw auth tokens never reach the log.
+    _SENSITIVE_KEYS = frozenset(
+        {
+            "user_api_key",
+            "Authorization",
+            "authorization",
+            "token",
+            "api_key",
+        }
+    )
+    _PROXY_IDENTITY_KEYS = frozenset(
+        {
+            "user_api_key_user_id",
+            "user_api_key_team_id",
+            "user_api_key_org_id",
+            "user_api_key_alias",
+            "user_id",
+            "team_id",
+            "org_id",
+        }
+    )
+    try:
+        lp_meta: Any = (kwargs.get("litellm_params") or {}).get("metadata") or {}
+        for k, v in lp_meta.items():
+            if k in _SENSITIVE_KEYS:
+                continue
+            # Always include explicit proxy identity keys; skip other
+            # litellm_params.metadata keys to avoid unexpected bleed.
+            if k in _PROXY_IDENTITY_KEYS:
+                metadata.setdefault(k, v)
+    except Exception:
+        pass
+
+    # Timing
+    latency_ms: Optional[int] = None
+    try:
+        if start_time is not None and end_time is not None:
+            latency_ms = int((end_time - start_time).total_seconds() * 1000)
+    except Exception:
+        pass
+
+    # Usage
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    finish_reason: Optional[str] = None
+    provider_request_id: Optional[str] = None
+    try:
+        if hasattr(response_obj, "usage") and response_obj.usage:
+            prompt_tokens = response_obj.usage.prompt_tokens
+            completion_tokens = response_obj.usage.completion_tokens
+            total_tokens = response_obj.usage.total_tokens
+        if hasattr(response_obj, "choices") and response_obj.choices:
+            finish_reason = response_obj.choices[0].finish_reason
+        if hasattr(response_obj, "_hidden_params"):
+            provider_request_id = response_obj._hidden_params.get(
+                "x-request-id"
+            ) or response_obj._hidden_params.get("cf-ray")
+    except Exception:
+        pass
+
+    # Content digests (not content itself)
+    messages_digest: Optional[str] = _content_digest(messages)
+
+    response_content_digest: Optional[str] = None
+    try:
+        if hasattr(response_obj, "choices") and response_obj.choices:
+            content = response_obj.choices[0].message.content
+            response_content_digest = _content_digest(content)
+    except Exception:
+        pass
+
+    # Standard logging payload may carry call_id / litellm_call_id
+    call_id: Optional[str] = None
+    try:
+        slp: Any = kwargs.get("standard_logging_object")
+        if slp and isinstance(slp, dict):
+            call_id = slp.get("id") or slp.get("litellm_call_id")
+    except Exception:
+        pass
+    if not call_id:
+        call_id = kwargs.get("litellm_call_id") or kwargs.get(
+            "id", str(int(time.time() * 1e6))
+        )
+
+    return {
+        "call_id": call_id,
+        "model": model,
+        "status": status,
+        "latency_ms": latency_ms,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": total_tokens,
+        "finish_reason": finish_reason,
+        "provider_request_id": provider_request_id,
+        "messages_digest": messages_digest,
+        "response_content_digest": response_content_digest,
+        "metadata": {k: v for k, v in (metadata or {}).items() if isinstance(k, str)},
+    }
+
+
+class AsqavLogger(CustomLogger):
+    """Tamper-evident local-first audit-log callback for LiteLLM.
+
+    Configuration (all via environment variables):
+
+    ASQAV_LOG_PATH
+        Path to the JSONL audit log.  Defaults to ~/.litellm_asqav_audit.jsonl.
+
+    ASQAV_REDACT_CONTENT
+        Set to "false" to store message/response content in the clear instead
+        of as SHA-256 digests.  Defaults to "true" (digest only).
+
+    Multi-worker limitation: this logger is designed for a single audit writer
+    per log file.  The threading.Lock serializes concurrent threads within one
+    process; it does NOT serialize across OS processes.  In a multi-worker
+    proxy deployment, run a single dedicated audit-writer process, or use a
+    shared filesystem with OS-level exclusive locking (fcntl.flock) via a
+    custom wrapper.  Without this, multiple workers will produce records with
+    duplicate seq/prev_hash values and verify_chain will report a break.
+    """
+
+    def __init__(
+        self,
+        log_path: Optional[str] = None,
+        redact_content: bool = True,
+    ) -> None:
+        super().__init__()
+
+        self._log_path: str = log_path or os.environ.get(
+            "ASQAV_LOG_PATH", _DEFAULT_LOG_PATH
+        )
+        self._redact_content: bool = (
+            os.environ.get("ASQAV_REDACT_CONTENT", "true").lower() != "false"
+            if log_path is None
+            else redact_content
+        )
+
+        self._lock: threading.Lock = threading.Lock()
+        self._call_count: int = 0
+        self._prev_hash: str = _GENESIS_HASH
+
+        # Load chain state from an existing log file so we chain correctly
+        # across process restarts.
+        self._load_chain_tail()
+
+    def __repr__(self) -> str:
+        return (
+            f"AsqavLogger(log_path={self._log_path!r},"
+            f" redact_content={self._redact_content})"
+        )
+
+    # ------------------------------------------------------------------
+    # Chain state persistence
+    # ------------------------------------------------------------------
+
+    def _load_chain_tail(self) -> None:
+        """Read the last line of an existing log file to resume the chain."""
+        try:
+            if not os.path.exists(self._log_path):
+                return
+            with open(self._log_path, "rb") as fh:
+                fh.seek(0, 2)
+                size = fh.tell()
+                if size == 0:
+                    return
+                tail = _read_tail(fh, size)
+            lines = [ln for ln in tail.split(b"\n") if ln.strip()]
+            if not lines:
+                return
+            last_record = json.loads(lines[-1].decode("utf-8"))
+            self._prev_hash = last_record.get("record_hash", _GENESIS_HASH)
+            self._call_count = last_record.get("seq", -1) + 1
+        except Exception:
+            verbose_logger.debug(
+                f"[AsqavLogger] Could not load chain tail: {traceback.format_exc()}"
+            )
+
+    # ------------------------------------------------------------------
+    # Core record append
+    # ------------------------------------------------------------------
+
+    def _build_and_append(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
+        status: str,
+    ) -> None:
+        """Build one audit record and append it to the JSONL log.
+
+        seq/prev_hash assignment and the file write happen under _lock so the
+        on-disk order always matches the chain order.
+        """
+        try:
+            loggable = _extract_loggable(
+                kwargs, response_obj, start_time, end_time, status
+            )
+
+            if not self._redact_content:
+                # Store content in the clear when the operator explicitly opts in.
+                loggable["messages"] = kwargs.get("messages")
+                try:
+                    if hasattr(response_obj, "choices") and response_obj.choices:
+                        loggable["response_content"] = response_obj.choices[
+                            0
+                        ].message.content
+                except Exception:
+                    pass
+
+            # The file write happens under the same lock that assigns seq and
+            # prev_hash, so records always land on disk in chain order even
+            # when callbacks fire concurrently.  Chain state only advances
+            # after a successful write; a failed write drops the record and
+            # the chain continues from the last record actually on disk.
+            with self._lock:
+                seq = self._call_count
+
+                # The fields that enter the hash are fixed and canonical so that
+                # an auditor can reproduce the digest from the log alone.
+                hashable: dict[str, Any] = {
+                    "seq": seq,
+                    "ts": datetime.now(tz=timezone.utc).isoformat(),
+                    "prev_hash": self._prev_hash,
+                    **loggable,
+                }
+                record_hash = _sha256_hex(_canonical_bytes(hashable))
+
+                if not self._write_record({**hashable, "record_hash": record_hash}):
+                    return
+
+                self._prev_hash = record_hash
+                self._call_count += 1
+
+        except Exception:
+            verbose_logger.debug(
+                f"[AsqavLogger] Unhandled error in _build_and_append: {traceback.format_exc()}"
+            )
+
+    def _write_record(self, record: dict[str, Any]) -> bool:
+        """Append one record to the log file. Returns False if the write failed."""
+        try:
+            parent = os.path.dirname(self._log_path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            # Tighten permissions on an existing file before appending so a
+            # file created by a previous run with a permissive umask is locked
+            # down.  Create new files via os.open with 0o600 to skip umask.
+            if os.path.exists(self._log_path):
+                os.chmod(self._log_path, 0o600)
+            fd = os.open(
+                self._log_path,
+                os.O_CREAT | os.O_WRONLY | os.O_APPEND,
+                0o600,
+            )
+            try:
+                with os.fdopen(fd, "a", encoding="utf-8", closefd=True) as fh:
+                    fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+            except Exception:
+                # fdopen owns fd; if it raises before returning the context
+                # manager the fd may still be open - close defensively.
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+                raise
+            return True
+        except Exception:
+            verbose_logger.warning(
+                f"[AsqavLogger] Failed to write audit record: {traceback.format_exc()}"
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # CustomLogger hooks
+    # ------------------------------------------------------------------
+
+    def log_success_event(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        self._build_and_append(kwargs, response_obj, start_time, end_time, "success")
+
+    def log_failure_event(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        self._build_and_append(kwargs, response_obj, start_time, end_time, "failure")
+
+    async def async_log_success_event(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        await asyncio.to_thread(
+            self._build_and_append,
+            kwargs,
+            response_obj,
+            start_time,
+            end_time,
+            "success",
+        )
+
+    async def async_log_failure_event(
+        self, kwargs: dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        await asyncio.to_thread(
+            self._build_and_append,
+            kwargs,
+            response_obj,
+            start_time,
+            end_time,
+            "failure",
+        )
+
+    # ------------------------------------------------------------------
+    # Chain verification (utility; not called on the hot path)
+    # ------------------------------------------------------------------
+
+    def verify_chain(self, log_path: Optional[str] = None) -> tuple[bool, str]:
+        """Verify the integrity of the audit log at log_path.
+
+        Returns (True, "ok") when every record's hash matches its content and
+        its prev_hash matches the previous record's hash.  Returns
+        (False, reason) on the first violation found.
+
+        This method is intentionally a pure stdlib utility so auditors can
+        paste it anywhere.
+        """
+        path = log_path or self._log_path
+        try:
+            prev_hash = _GENESIS_HASH
+            with open(path, encoding="utf-8") as fh:
+                for lineno, line in enumerate(fh, start=1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+
+                    stored_hash = record.get("record_hash", "")
+                    # Recompute hash over all fields except record_hash itself.
+                    hashable = {k: v for k, v in record.items() if k != "record_hash"}
+                    computed_hash = _sha256_hex(_canonical_bytes(hashable))
+
+                    if computed_hash != stored_hash:
+                        return (
+                            False,
+                            f"line {lineno}: hash mismatch"
+                            f" (stored={stored_hash[:12]},"
+                            f" computed={computed_hash[:12]})",
+                        )
+
+                    rec_prev = record.get("prev_hash", _GENESIS_HASH)
+                    if rec_prev != prev_hash:
+                        return (
+                            False,
+                            f"line {lineno}: prev_hash chain break"
+                            f" (expected={prev_hash[:12]},"
+                            f" got={rec_prev[:12]})",
+                        )
+
+                    prev_hash = stored_hash
+
+            return True, "ok"
+        except FileNotFoundError:
+            return False, f"log file not found: {path}"
+        except Exception as exc:
+            return False, f"verification error: {exc}"

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -49,6 +49,27 @@ _DEFAULT_ASQAV_API_BASE = "https://api.asqav.com"
 # stalls the callback; any timeout falls through to the local-only record.
 _CLOUD_SIGN_TIMEOUT = 5.0
 
+_SENSITIVE_KEYS = frozenset(
+    {
+        "user_api_key",
+        "Authorization",
+        "authorization",
+        "token",
+        "api_key",
+    }
+)
+_PROXY_IDENTITY_KEYS = frozenset(
+    {
+        "user_api_key_user_id",
+        "user_api_key_team_id",
+        "user_api_key_org_id",
+        "user_api_key_alias",
+        "user_id",
+        "team_id",
+        "org_id",
+    }
+)
+
 
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
@@ -85,68 +106,36 @@ def _content_digest(value: Any) -> Optional[str]:
     return _sha256_hex(raw)
 
 
-def _extract_loggable(
-    kwargs: dict[str, Any],
-    response_obj: Any,
-    start_time: Any,
-    end_time: Any,
-    status: str,
-) -> dict[str, Any]:
-    """Pull metadata + digests out of a callback invocation.
+def _merge_proxy_identity(metadata: dict[str, Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Merge allow-listed proxy identity fields from litellm_params.metadata.
 
-    Message content and response text are never stored in the clear; only their
-    SHA-256 digests appear in the log so callers can prove a payload existed
-    without reconstructing it.
+    Sensitive header/key values are filtered so raw auth tokens never reach
+    the log.
     """
-    model: str = kwargs.get("model", "")
-    messages: Any = kwargs.get("messages")
-
-    # Root metadata (user-supplied tags, etc.)
-    metadata: Any = dict(kwargs.get("metadata") or kwargs.get("litellm_metadata") or {})
-
-    # Merge proxy identity fields from litellm_params.metadata.  Sensitive
-    # header/key values are filtered so raw auth tokens never reach the log.
-    _SENSITIVE_KEYS = frozenset(
-        {
-            "user_api_key",
-            "Authorization",
-            "authorization",
-            "token",
-            "api_key",
-        }
-    )
-    _PROXY_IDENTITY_KEYS = frozenset(
-        {
-            "user_api_key_user_id",
-            "user_api_key_team_id",
-            "user_api_key_org_id",
-            "user_api_key_alias",
-            "user_id",
-            "team_id",
-            "org_id",
-        }
-    )
     try:
         lp_meta: Any = (kwargs.get("litellm_params") or {}).get("metadata") or {}
         for k, v in lp_meta.items():
             if k in _SENSITIVE_KEYS:
                 continue
-            # Always include explicit proxy identity keys; skip other
-            # litellm_params.metadata keys to avoid unexpected bleed.
             if k in _PROXY_IDENTITY_KEYS:
                 metadata.setdefault(k, v)
-    except Exception:
+    except (AttributeError, TypeError):
         pass
+    return metadata
 
-    # Timing
-    latency_ms: Optional[int] = None
+
+def _compute_latency_ms(start_time: Any, end_time: Any) -> Optional[int]:
     try:
         if start_time is not None and end_time is not None:
-            latency_ms = int((end_time - start_time).total_seconds() * 1000)
-    except Exception:
+            return int((end_time - start_time).total_seconds() * 1000)
+    except (TypeError, AttributeError):
         pass
+    return None
 
-    # Usage
+
+def _extract_usage_fields(
+    response_obj: Any,
+) -> tuple[Optional[int], Optional[int], Optional[int], Optional[str], Optional[str]]:
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
@@ -163,44 +152,68 @@ def _extract_loggable(
             provider_request_id = response_obj._hidden_params.get("x-request-id") or response_obj._hidden_params.get(
                 "cf-ray"
             )
-    except Exception:
+    except (AttributeError, IndexError, TypeError):
         pass
+    return prompt_tokens, completion_tokens, total_tokens, finish_reason, provider_request_id
 
-    # Content digests (not content itself)
-    messages_digest: Optional[str] = _content_digest(messages)
 
-    response_content_digest: Optional[str] = None
+def _extract_response_content_digest(response_obj: Any) -> Optional[str]:
     try:
         if hasattr(response_obj, "choices") and response_obj.choices:
-            content = response_obj.choices[0].message.content
-            response_content_digest = _content_digest(content)
-    except Exception:
+            return _content_digest(response_obj.choices[0].message.content)
+    except (AttributeError, IndexError):
         pass
+    return None
 
-    # Standard logging payload may carry call_id / litellm_call_id
-    call_id: Optional[str] = None
+
+def _extract_call_id(kwargs: dict[str, Any]) -> str:
+    """Prefer standard_logging_object's id, falling back to the raw call id."""
     try:
         slp: Any = kwargs.get("standard_logging_object")
         if slp and isinstance(slp, dict):
             call_id = slp.get("id") or slp.get("litellm_call_id")
-    except Exception:
+            if call_id:
+                return call_id
+    except (AttributeError, TypeError):
         pass
-    if not call_id:
-        call_id = kwargs.get("litellm_call_id") or kwargs.get("id", str(int(time.time() * 1e6)))
+    return kwargs.get("litellm_call_id") or kwargs.get("id", str(int(time.time() * 1e6)))
+
+
+def _extract_loggable(
+    kwargs: dict[str, Any],
+    response_obj: Any,
+    start_time: Any,
+    end_time: Any,
+    status: str,
+) -> dict[str, Any]:
+    """Pull metadata + digests out of a callback invocation.
+
+    Message content and response text are never stored in the clear; only their
+    SHA-256 digests appear in the log so callers can prove a payload existed
+    without reconstructing it.
+    """
+    metadata = _merge_proxy_identity(dict(kwargs.get("metadata") or kwargs.get("litellm_metadata") or {}), kwargs)
+    (
+        prompt_tokens,
+        completion_tokens,
+        total_tokens,
+        finish_reason,
+        provider_request_id,
+    ) = _extract_usage_fields(response_obj)
 
     return {
-        "call_id": call_id,
-        "model": model,
+        "call_id": _extract_call_id(kwargs),
+        "model": kwargs.get("model", ""),
         "status": status,
-        "latency_ms": latency_ms,
+        "latency_ms": _compute_latency_ms(start_time, end_time),
         "prompt_tokens": prompt_tokens,
         "completion_tokens": completion_tokens,
         "total_tokens": total_tokens,
         "finish_reason": finish_reason,
         "provider_request_id": provider_request_id,
-        "messages_digest": messages_digest,
-        "response_content_digest": response_content_digest,
-        "metadata": {k: v for k, v in (metadata or {}).items() if isinstance(k, str)},
+        "messages_digest": _content_digest(kwargs.get("messages")),
+        "response_content_digest": _extract_response_content_digest(response_obj),
+        "metadata": {k: v for k, v in metadata.items() if isinstance(k, str)},
     }
 
 
@@ -334,7 +347,7 @@ class AsqavLogger(CustomLogger):
                 return
             self._prev_hash = last_main.get("record_hash", _GENESIS_HASH)
             self._call_count = last_main.get("seq", -1) + 1
-        except Exception:
+        except Exception:  # noqa: BLE001  # fail-soft: a corrupt/unreadable log must not block logger init
             verbose_logger.debug(f"[AsqavLogger] Could not load chain tail: {traceback.format_exc()}")
 
     # ------------------------------------------------------------------
@@ -363,7 +376,7 @@ class AsqavLogger(CustomLogger):
                 try:
                     if hasattr(response_obj, "choices") and response_obj.choices:
                         loggable["response_content"] = response_obj.choices[0].message.content
-                except Exception:
+                except (AttributeError, IndexError):
                     pass
 
             with self._lock:
@@ -386,7 +399,7 @@ class AsqavLogger(CustomLogger):
             if cloud is not None:
                 self._write_record({"seq": seq, "record_hash": record_hash, "asqav_cloud": cloud})
 
-        except Exception:
+        except Exception:  # noqa: BLE001  # fail-soft: a bug here must never break the underlying LLM call
             verbose_logger.debug(f"[AsqavLogger] Unhandled error in _build_and_append: {traceback.format_exc()}")
 
     def _write_record(self, record: dict[str, Any]) -> bool:
@@ -417,7 +430,7 @@ class AsqavLogger(CustomLogger):
                     pass
                 raise
             return True
-        except Exception:
+        except (OSError, TypeError, ValueError):
             verbose_logger.warning(f"[AsqavLogger] Failed to write audit record: {traceback.format_exc()}")
             return False
 
@@ -547,5 +560,5 @@ class AsqavLogger(CustomLogger):
             return True, "ok"
         except FileNotFoundError:
             return False, f"log file not found: {path}"
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001  # verify_chain always returns (False, reason), never raises
             return False, f"verification error: {exc}"

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -281,8 +281,8 @@ class AsqavLogger(CustomLogger):
         )
 
         # Optional cloud signing. Active only when both env vars are present.
-        self._cloud_api_key: Optional[str] = os.environ.get("ASQAV_API_KEY") or None
-        self._cloud_agent_id: Optional[str] = os.environ.get("ASQAV_AGENT_ID") or None
+        self._cloud_api_key: str | None = os.environ.get("ASQAV_API_KEY") or None
+        self._cloud_agent_id: str | None = os.environ.get("ASQAV_AGENT_ID") or None
         self._cloud_api_base: str = (
             os.environ.get("ASQAV_API_BASE") or _DEFAULT_ASQAV_API_BASE
         ).rstrip("/")
@@ -435,7 +435,7 @@ class AsqavLogger(CustomLogger):
     # Optional cloud signing
     # ------------------------------------------------------------------
 
-    def _maybe_cloud_sign(self, record: dict[str, Any]) -> Optional[dict[str, Any]]:
+    def _maybe_cloud_sign(self, record: dict[str, Any]) -> dict[str, Any] | None:
         """POST the record's digests to the asqav sign endpoint, fail-soft.
 
         Returns the receipt fields to bind into the local record, or None when
@@ -472,7 +472,7 @@ class AsqavLogger(CustomLogger):
                 "mode": data.get("mode"),
             }
             return {k: v for k, v in receipt.items() if v is not None} or None
-        except Exception:
+        except Exception:  # noqa: BLE001  # fail-soft, never break logging
             verbose_logger.debug(
                 f"[AsqavLogger] cloud sign skipped: {traceback.format_exc()}"
             )

--- a/litellm/integrations/asqav/asqav.py
+++ b/litellm/integrations/asqav/asqav.py
@@ -211,29 +211,29 @@ def _cloud_sign_payload(
 ) -> dict[str, Any]:
     """Build the digests-only body for the agent sign endpoint.
 
-    Binds the messages digest as the hashed payload and carries the response
-    digest plus call metadata alongside.  record_hash is the pre-receipt
-    canonical hash of the record content, so the signature commits to the
-    exact record fields.  Raw prompt/response text is never included.
+    The signed payload is body["hash"]; the cloud signs it verbatim in hash mode
+    and drops any metadata key outside its whitelist (record_hash is not on it).
+    So the signed hash is pre_receipt_hash, the canonical content hash covering
+    model, status, both digests, seq, prev_hash and timestamp; binding the whole
+    record, not just the prompt. messages_digest rides in metadata for reference
+    and is transitively bound through pre_receipt_hash. No raw text is included.
     """
-    messages_digest = record.get("messages_digest")
     metadata: dict[str, Any] = {
         "source": "litellm",
         "call_id": record.get("call_id"),
         "model": record.get("model"),
         "status": record.get("status"),
         "response_content_digest": record.get("response_content_digest"),
+        "messages_digest": record.get("messages_digest"),
         "record_hash": pre_receipt_hash,
         "seq": record.get("seq"),
     }
-    body: dict[str, Any] = {
+    return {
         "action_type": "litellm:completion",
+        "hash": f"sha256:{pre_receipt_hash}",
+        "hash_algo": "sha256",
         "metadata": {k: v for k, v in metadata.items() if v is not None},
     }
-    if messages_digest:
-        body["hash"] = f"sha256:{messages_digest}"
-        body["hash_algo"] = "sha256"
-    return body
 
 
 class AsqavLogger(CustomLogger):

--- a/litellm/litellm_core_utils/custom_logger_registry.py
+++ b/litellm/litellm_core_utils/custom_logger_registry.py
@@ -12,6 +12,7 @@ from typing import Union
 
 from litellm import _custom_logger_compatible_callbacks_literal
 from litellm.integrations.agentops import AgentOps
+from litellm.integrations.asqav import AsqavLogger
 from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
 from litellm.integrations.argilla import ArgillaLogger
 from litellm.integrations.azure_sentinel.azure_sentinel import AzureSentinelLogger
@@ -108,6 +109,7 @@ class CustomLoggerRegistry:
         "vantage": VantageLogger,
         "posthog": PostHogLogger,
         "newrelic": NewRelicLogger,
+        "asqav": AsqavLogger,
     }
 
     try:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4119,6 +4119,16 @@ def _init_custom_logger_compatible_class(
             newrelic_logger = NewRelicLogger()
             _in_memory_loggers.append(newrelic_logger)
             return newrelic_logger  # type: ignore
+        elif logging_integration == "asqav":
+            from litellm.integrations.asqav import AsqavLogger
+
+            for callback in _in_memory_loggers:
+                if isinstance(callback, AsqavLogger):
+                    return callback  # type: ignore
+
+            asqav_logger = AsqavLogger()
+            _in_memory_loggers.append(asqav_logger)
+            return asqav_logger  # type: ignore
         return None
     except Exception as e:
         verbose_logger.exception(f"[Non-Blocking Error] Error initializing custom logger: {e}")

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4124,11 +4124,11 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, AsqavLogger):
-                    return callback  # type: ignore
+                    return callback
 
             asqav_logger = AsqavLogger()
             _in_memory_loggers.append(asqav_logger)
-            return asqav_logger  # type: ignore
+            return asqav_logger
         return None
     except Exception as e:
         verbose_logger.exception(f"[Non-Blocking Error] Error initializing custom logger: {e}")

--- a/tests/test_litellm/integrations/asqav/conftest.py
+++ b/tests/test_litellm/integrations/asqav/conftest.py
@@ -1,0 +1,11 @@
+# Minimal conftest for the asqav standalone tests.
+# These tests do not import litellm at module scope and do not need the
+# parent conftest fixtures (which pull in the full litellm stack).
+import os
+import sys
+
+# Ensure the repo root is on sys.path so "litellm.integrations.asqav" resolves.
+_REPO_ROOT = os.path.abspath(
+    os.path.join(__file__, "..", "..", "..", "..", "..", "..")
+)
+sys.path.insert(0, _REPO_ROOT)

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -1,0 +1,679 @@
+"""Tests for the Asqav local-first audit-log callback.
+
+All tests are self-contained: they use only stdlib + the integration module
+itself.  No LLM API calls, no network, no external services.
+
+Chain property tests verify:
+- Appending N records produces a valid chain (every hash links to its predecessor).
+- Mutating one byte in any record causes verify_chain to detect the break.
+- A chain survives a process restart (state loaded from the tail of the file).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import threading
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import importlib
+import importlib.util
+import types
+
+# ---------------------------------------------------------------------------
+# Bootstrap: load litellm.integrations.asqav.asqav without triggering
+# litellm/__init__.py (which needs tokenizers, openai, etc.).  We stub the
+# minimal litellm sub-modules the integration actually imports at the top of
+# its file, then load the module via importlib.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+sys.path.insert(0, _REPO_ROOT)
+
+
+def _stub_litellm_deps() -> None:
+    """Install minimal stubs for litellm sub-modules imported by asqav.py."""
+    if "litellm" in sys.modules:
+        return  # already loaded (e.g. in the full test suite)
+
+    # litellm package stub
+    pkg = types.ModuleType("litellm")
+    sys.modules["litellm"] = pkg
+
+    # litellm._logging stub
+    class _VL:
+        def debug(self, *a: object, **k: object) -> None:
+            pass
+
+        def warning(self, *a: object, **k: object) -> None:
+            pass
+
+    log_mod = types.ModuleType("litellm._logging")
+    log_mod.verbose_logger = _VL()  # type: ignore[attr-defined]
+    sys.modules["litellm._logging"] = log_mod
+
+    # litellm.integrations package + custom_logger stub
+    integrations_pkg = types.ModuleType("litellm.integrations")
+    sys.modules["litellm.integrations"] = integrations_pkg
+    pkg.integrations = integrations_pkg  # type: ignore[attr-defined]
+
+    class _CustomLogger:
+        def __init__(self, **kw: object) -> None:
+            pass
+
+    cl_mod = types.ModuleType("litellm.integrations.custom_logger")
+    cl_mod.CustomLogger = _CustomLogger  # type: ignore[attr-defined]
+    sys.modules["litellm.integrations.custom_logger"] = cl_mod
+
+    # litellm.types stubs (imported in type annotations only)
+    types_pkg = types.ModuleType("litellm.types")
+    sys.modules["litellm.types"] = types_pkg
+    utils_mod = types.ModuleType("litellm.types.utils")
+    sys.modules["litellm.types.utils"] = utils_mod
+
+    # litellm.llms stubs (kept minimal; asqav.py no longer imports from
+    # litellm.llms.custom_httpx.http_handler, but other litellm internals may
+    # still need the package hierarchy present during import resolution).
+    llms_pkg = types.ModuleType("litellm.llms")
+    sys.modules["litellm.llms"] = llms_pkg
+    custom_httpx_pkg = types.ModuleType("litellm.llms.custom_httpx")
+    sys.modules["litellm.llms.custom_httpx"] = custom_httpx_pkg
+    http_handler_mod = types.ModuleType("litellm.llms.custom_httpx.http_handler")
+    sys.modules["litellm.llms.custom_httpx.http_handler"] = http_handler_mod
+
+    # litellm.types.llms stub
+    types_llms_pkg = types.ModuleType("litellm.types.llms")
+    sys.modules["litellm.types.llms"] = types_llms_pkg
+    custom_http_mod = types.ModuleType("litellm.types.llms.custom_http")
+    sys.modules["litellm.types.llms.custom_http"] = custom_http_mod
+
+
+_stub_litellm_deps()
+
+# Now load the integration module directly.
+_asqav_path = os.path.join(_REPO_ROOT, "litellm", "integrations", "asqav", "asqav.py")
+_spec = importlib.util.spec_from_file_location(
+    "litellm.integrations.asqav.asqav", _asqav_path
+)
+assert _spec and _spec.loader
+_asqav_module = importlib.util.module_from_spec(_spec)
+sys.modules["litellm.integrations.asqav.asqav"] = _asqav_module
+_spec.loader.exec_module(_asqav_module)  # type: ignore[union-attr]
+
+AsqavLogger = _asqav_module.AsqavLogger
+_GENESIS_HASH = _asqav_module._GENESIS_HASH
+_canonical_bytes = _asqav_module._canonical_bytes
+_content_digest = _asqav_module._content_digest
+_sha256_hex = _asqav_module._sha256_hex
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_kwargs(model: str = "gpt-4o", content: str = "hello") -> dict:
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": content}],
+        "litellm_call_id": f"test-{content[:8]}",
+    }
+
+
+def _make_response(content: str = "world") -> MagicMock:
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage.prompt_tokens = 10
+    resp.usage.completion_tokens = 5
+    resp.usage.total_tokens = 15
+    resp._hidden_params = {}
+    return resp
+
+
+def _make_times() -> tuple:
+    start = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    return start, end
+
+
+def _logger_at(path: str) -> AsqavLogger:
+    return AsqavLogger(log_path=path, redact_content=True)
+
+
+def _append_n(logger: AsqavLogger, n: int) -> None:
+    start, end = _make_times()
+    for i in range(n):
+        logger.log_success_event(
+            kwargs=_make_kwargs(content=f"msg-{i}"),
+            response_obj=_make_response(content=f"resp-{i}"),
+            start_time=start,
+            end_time=end,
+        )
+
+
+def _read_records(path: str) -> list:
+    records = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helpers
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_hex_is_64_chars() -> None:
+    h = _sha256_hex(b"hello")
+    assert len(h) == 64
+    assert h == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+
+def test_canonical_bytes_is_deterministic() -> None:
+    d = {"b": 2, "a": 1, "c": [3, 4]}
+    b1 = _canonical_bytes(d)
+    b2 = _canonical_bytes({"c": [3, 4], "a": 1, "b": 2})
+    assert b1 == b2
+
+
+def test_content_digest_returns_none_for_none() -> None:
+    assert _content_digest(None) is None
+
+
+def test_content_digest_is_stable() -> None:
+    d1 = _content_digest("hello world")
+    d2 = _content_digest("hello world")
+    assert d1 == d2
+    assert d1 is not None and len(d1) == 64
+
+
+# ---------------------------------------------------------------------------
+# Chain property tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_record_genesis_chain(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    r = records[0]
+    assert r["seq"] == 0
+    assert r["prev_hash"] == _GENESIS_HASH
+    assert r["status"] == "success"
+    assert "record_hash" in r
+    assert len(r["record_hash"]) == 64
+
+
+def test_chain_links_correctly_for_n_records(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    n = 10
+    _append_n(logger, n)
+
+    records = _read_records(path)
+    assert len(records) == n
+
+    # First record's prev_hash is the genesis sentinel.
+    assert records[0]["prev_hash"] == _GENESIS_HASH
+
+    # Each subsequent record's prev_hash equals the hash of the prior record.
+    for i in range(1, n):
+        assert (
+            records[i]["prev_hash"] == records[i - 1]["record_hash"]
+        ), f"Chain broken between records {i-1} and {i}"
+
+
+def test_verify_chain_passes_on_valid_log(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    _append_n(logger, 5)
+
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, f"Expected valid chain but got: {msg}"
+    assert msg == "ok"
+
+
+def test_verify_chain_detects_record_hash_tampering(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    _append_n(logger, 5)
+
+    records = _read_records(path)
+    # Corrupt the model field of record 2 (middle of chain).
+    records[2]["model"] = "tampered-model"
+
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r, separators=(",", ":")) + "\n")
+
+    ok, msg = logger.verify_chain(path)
+    assert ok is False
+    assert "hash mismatch" in msg
+
+
+def test_verify_chain_detects_prev_hash_tampering(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    _append_n(logger, 5)
+
+    records = _read_records(path)
+    # Recompute record_hash after tampering prev_hash to bypass the first check.
+    records[3]["prev_hash"] = "a" * 64
+    hashable = {k: v for k, v in records[3].items() if k != "record_hash"}
+    records[3]["record_hash"] = _sha256_hex(_canonical_bytes(hashable))
+
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r, separators=(",", ":")) + "\n")
+
+    ok, msg = logger.verify_chain(path)
+    assert ok is False
+    assert "chain break" in msg
+
+
+def test_verify_chain_detects_deleted_record(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    _append_n(logger, 5)
+
+    records = _read_records(path)
+    # Remove record 2 - record 3's prev_hash will no longer match record 1's hash.
+    del records[2]
+
+    with open(path, "w", encoding="utf-8") as fh:
+        for r in records:
+            fh.write(json.dumps(r, separators=(",", ":")) + "\n")
+
+    ok, msg = logger.verify_chain(path)
+    assert ok is False
+
+
+def test_chain_resumes_after_process_restart(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+
+    # First "process": write 3 records.
+    logger1 = _logger_at(path)
+    _append_n(logger1, 3)
+    hash_after_first = logger1._prev_hash
+
+    # Second "process": new logger instance reads the tail and continues.
+    logger2 = _logger_at(path)
+    assert (
+        logger2._prev_hash == hash_after_first
+    ), "Second logger did not resume chain from tail of existing log"
+    _append_n(logger2, 3)
+
+    # Full 6-record chain should verify clean.
+    ok, msg = logger2.verify_chain(path)
+    assert ok is True, f"Chain broken across restart: {msg}"
+
+
+def test_seq_counter_restored_after_restart(tmp_path) -> None:
+    """P1 regression: _call_count (and thus seq) must resume from the last
+    persisted record's seq field after a process restart.
+
+    Before the fix, _load_chain_tail restored _prev_hash but left _call_count
+    at 0, so the second "process" would emit seq=0 again instead of continuing
+    from where the first process stopped.
+    """
+    path = str(tmp_path / "audit.jsonl")
+
+    # First "process": write 5 records (seq 0..4).
+    logger1 = _logger_at(path)
+    _append_n(logger1, 5)
+    records_after_first = _read_records(path)
+    assert (
+        records_after_first[-1]["seq"] == 4
+    ), "sanity: last seq from first process is 4"
+
+    # Second "process": new instance reads the tail.
+    logger2 = _logger_at(path)
+    assert (
+        logger2._call_count == 5
+    ), f"_call_count not restored: expected 5, got {logger2._call_count}"
+
+    # Writing one more record must produce seq=5, not seq=0.
+    _append_n(logger2, 1)
+    records = _read_records(path)
+    assert len(records) == 6
+    assert (
+        records[5]["seq"] == 5
+    ), f"seq reset after restart: expected 5, got {records[5]['seq']}"
+
+    # The full chain must also pass integrity verification.
+    ok, msg = logger2.verify_chain(path)
+    assert ok is True, f"Chain broken after restart: {msg}"
+
+
+def test_failure_event_is_logged(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    logger.log_failure_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    assert records[0]["status"] == "failure"
+
+
+def test_logger_does_not_raise_on_malformed_response(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    bad_response = object()  # not a ModelResponse at all
+
+    # Should not raise; logger is fail-soft.
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=bad_response,
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    assert records[0]["status"] == "success"
+
+
+def test_content_digest_stored_not_plaintext_by_default(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    logger.log_success_event(
+        kwargs=_make_kwargs(content="my secret prompt"),
+        response_obj=_make_response(content="my secret response"),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    raw = json.dumps(records[0])
+    assert "my secret prompt" not in raw
+    assert "my secret response" not in raw
+    assert "messages_digest" in records[0]
+    assert "response_content_digest" in records[0]
+
+
+def test_seq_increments_across_calls(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    _append_n(logger, 4)
+
+    records = _read_records(path)
+    seqs = [r["seq"] for r in records]
+    assert seqs == [0, 1, 2, 3]
+
+
+def test_latency_ms_is_computed(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()  # 1-second gap
+
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert records[0]["latency_ms"] == 1000
+
+
+def test_no_background_threads_spawned(tmp_path) -> None:
+    """Local-only logger must not spawn background threads."""
+    path = str(tmp_path / "audit.jsonl")
+    logger = AsqavLogger(log_path=path, redact_content=True)
+    start, end = _make_times()
+
+    before = threading.active_count()
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+    after = threading.active_count()
+    assert after <= before
+
+
+# ---------------------------------------------------------------------------
+# Concurrency, restart with large records, repr
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_callbacks_keep_chain_ordered(tmp_path) -> None:
+    """Records from concurrent threads land on disk in seq order.
+
+    Regression test for the out-of-order-write race: seq/prev_hash assignment
+    and the file write must happen under the same lock, otherwise two threads
+    can write their records in reversed order and break verify_chain.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+    n_threads = 8
+    per_thread = 25
+    barrier = threading.Barrier(n_threads)
+
+    def _worker(tid: int) -> None:
+        barrier.wait()
+        for i in range(per_thread):
+            logger.log_success_event(
+                kwargs=_make_kwargs(content=f"t{tid}-m{i}"),
+                response_obj=_make_response(content=f"t{tid}-r{i}"),
+                start_time=start,
+                end_time=end,
+            )
+
+    threads = [
+        threading.Thread(target=_worker, args=(tid,)) for tid in range(n_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    records = _read_records(path)
+    assert len(records) == n_threads * per_thread
+    assert [r["seq"] for r in records] == list(range(n_threads * per_thread))
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, f"Chain broken under concurrent writes: {msg}"
+
+
+def test_restart_resumes_chain_when_last_record_exceeds_4kb(tmp_path) -> None:
+    """A record larger than the old 4 KB tail buffer survives a restart.
+
+    Regression test for the silent chain reset: the tail read must widen until
+    it contains the whole last line instead of truncating it.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    logger1 = _logger_at(path)
+    start, end = _make_times()
+
+    big_kwargs = _make_kwargs(content="big")
+    big_kwargs["metadata"] = {"blob": "x" * 10_000}
+    logger1.log_success_event(
+        kwargs=big_kwargs,
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+    assert os.path.getsize(path) > 4096
+    hash_after_first = logger1._prev_hash
+
+    logger2 = _logger_at(path)
+    assert (
+        logger2._prev_hash == hash_after_first
+    ), "Restart did not resume the chain from a record larger than 4 KB"
+    _append_n(logger2, 2)
+
+    ok, msg = logger2.verify_chain(path)
+    assert ok is True, f"Chain broken across restart with large record: {msg}"
+
+
+def test_repr_shows_log_path_and_redact(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = AsqavLogger(log_path=path, redact_content=True)
+
+    r = repr(logger)
+    assert "AsqavLogger" in r
+    assert path in r
+
+
+def test_async_hooks_write_records(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    async def _run() -> None:
+        await logger.async_log_success_event(
+            kwargs=_make_kwargs(content="async-ok"),
+            response_obj=_make_response(),
+            start_time=start,
+            end_time=end,
+        )
+        await logger.async_log_failure_event(
+            kwargs=_make_kwargs(content="async-fail"),
+            response_obj=_make_response(),
+            start_time=start,
+            end_time=end,
+        )
+
+    asyncio.run(_run())
+
+    records = _read_records(path)
+    assert [r["status"] for r in records] == ["success", "failure"]
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg
+
+
+def test_redact_content_false_stores_plaintext(tmp_path) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    logger = AsqavLogger(log_path=path, redact_content=False)
+    start, end = _make_times()
+
+    logger.log_success_event(
+        kwargs=_make_kwargs(content="visible prompt"),
+        response_obj=_make_response(content="visible response"),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert records[0]["messages"][0]["content"] == "visible prompt"
+    assert records[0]["response_content"] == "visible response"
+
+
+# ---------------------------------------------------------------------------
+# New regression tests (must FAIL before the corresponding fix is applied)
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_file_created_with_0600_perms(tmp_path) -> None:
+    """Veria Medium: audit log must be created with mode 0600.
+
+    With a standard 022 umask, plain open(..., 'a') produces 0644, which lets
+    other local users read the log.  The fix creates via os.open with 0o600 and
+    chmods an existing file to 0600 before appending.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    assert os.path.exists(path), "audit log was not created"
+    mode_octal = oct(os.stat(path).st_mode)[-3:]
+    assert mode_octal == "600", f"audit log has mode {mode_octal}, expected 600"
+
+
+def test_proxy_identity_metadata_attributed_in_record(tmp_path) -> None:
+    """Veria Medium: proxy identity fields from litellm_params.metadata must
+    appear in the logged record's metadata.
+
+    user_api_key_user_id, team_id, org_id, and key_alias live under
+    kwargs['litellm_params']['metadata'], not at kwargs root.  Records written
+    without reading that sub-dict have no proxy attribution.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    logger = _logger_at(path)
+    start, end = _make_times()
+
+    kwargs = _make_kwargs()
+    kwargs["litellm_params"] = {
+        "metadata": {
+            "user_api_key_user_id": "user-abc",
+            "user_api_key_team_id": "team-xyz",
+            "user_api_key_org_id": "org-123",
+            "user_api_key_alias": "my-key",
+            # sensitive values that must NOT be persisted
+            "user_api_key": "sk-secret-12345",
+            "Authorization": "Bearer sk-secret-12345",
+        }
+    }
+
+    logger.log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    meta = records[0]["metadata"]
+    assert (
+        meta.get("user_api_key_user_id") == "user-abc"
+    ), "user_api_key_user_id not attributed in record"
+    assert (
+        meta.get("user_api_key_team_id") == "team-xyz"
+    ), "user_api_key_team_id not attributed in record"
+    # Sensitive fields must be filtered out
+    assert "user_api_key" not in meta, "raw api key leaked into record metadata"
+    assert "Authorization" not in meta, "auth header leaked into record metadata"
+
+
+def test_multiworker_flock_guard_documented_or_implemented(tmp_path) -> None:
+    """Veria Medium: the multi-worker limitation must be documented in the
+    class docstring (or, if fcntl is used, the lock must serialize cross-process
+    writes).  This test checks for the docstring acknowledgement.
+    """
+    import inspect
+
+    doc = inspect.getdoc(AsqavLogger) or ""
+    assert (
+        "single" in doc.lower() or "flock" in doc.lower() or "worker" in doc.lower()
+    ), "AsqavLogger docstring must document the single-writer / multi-worker limitation"

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -160,13 +160,25 @@ def _append_n(logger: AsqavLogger, n: int) -> None:
 
 
 def _read_records(path: str) -> list:
-    records = []
+    """Read all records from a JSONL log, merging sidecar receipt lines."""
+    main: list = []
+    by_key: dict = {}
     with open(path, encoding="utf-8") as fh:
         for line in fh:
             line = line.strip()
-            if line:
-                records.append(json.loads(line))
-    return records
+            if not line:
+                continue
+            rec = json.loads(line)
+            if "ts" not in rec:
+                key = (rec.get("seq"), rec.get("record_hash"))
+                by_key[key] = rec.get("asqav_cloud")
+            else:
+                main.append(rec)
+    for rec in main:
+        key = (rec.get("seq"), rec.get("record_hash"))
+        if key in by_key:
+            rec["asqav_cloud"] = by_key[key]
+    return main
 
 
 # ---------------------------------------------------------------------------
@@ -998,3 +1010,90 @@ def test_default_off_is_byte_identical_without_key(
         "record_hash",
     }
     assert len(client.calls) == 0
+
+
+def test_cloud_sign_chain_intact_after_decouple(
+    tmp_path, _cloud_env, _patch_httpx
+) -> None:
+    """verify_chain passes for >=5 records written with cloud signing on.
+
+    After the decouple, record_hash = pre_receipt_hash (no asqav_cloud in the
+    hash) and the receipt lands as a sidecar line.  The chain must be unbroken
+    end-to-end: every record's prev_hash links to the previous record_hash and
+    every hash recomputation matches the stored value.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(
+        201,
+        {
+            "signature_id": "sig-chain",
+            "verification_url": "https://api.asqav.com/v/sig-chain",
+            "action_id": "act-chain",
+            "mode": "hash",
+        },
+    )
+    _patch_httpx(_FakeHttpxClient(response=resp))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    for i in range(5):
+        logger.log_success_event(
+            kwargs=_make_kwargs(content=f"cloud-chain-{i}"),
+            response_obj=_make_response(content=f"resp-{i}"),
+            start_time=start,
+            end_time=end,
+        )
+
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg
+
+    records = _read_records(path)
+    assert len(records) == 5
+    for rec in records:
+        assert "asqav_cloud" in rec, "receipt must be merged back onto the record"
+        assert rec["asqav_cloud"]["signature_id"] == "sig-chain"
+
+
+def test_post_not_called_while_lock_held(tmp_path, _cloud_env, _patch_httpx) -> None:
+    """The sync POST must not execute while _lock is held.
+
+    A fake client inspects the lock state at the moment post() is invoked.
+    If the lock is acquired at that point, the test fails. Against the pre-decouple
+    code (POST inside the lock) this test always fails.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    logger = _cloud_logger(path)
+
+    lock_held_during_post: list[bool] = []
+
+    class _LockInspectingClient:
+        def post(self, url, json=None, headers=None, timeout=None):
+            lock_held_during_post.append(logger._lock.locked())
+            return _FakeResponse(
+                201,
+                {
+                    "signature_id": "sig-x",
+                    "mode": "hash",
+                },
+            )
+
+    import sys as _sys
+
+    mod = _sys.modules["litellm.llms.custom_httpx.http_handler"]
+    import unittest.mock as _mock
+
+    with _mock.patch.object(
+        mod, "_get_httpx_client", return_value=_LockInspectingClient()
+    ):
+        start, end = _make_times()
+        logger.log_success_event(
+            kwargs=_make_kwargs(),
+            response_obj=_make_response(),
+            start_time=start,
+            end_time=end,
+        )
+
+    assert len(lock_held_during_post) == 1
+    assert lock_held_during_post[0] is False, (
+        "lock must NOT be held when client.post() runs"
+    )

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -754,12 +754,14 @@ def test_cloud_sign_payload_carries_digests_not_content() -> None:
         "status": "success",
         "seq": 0,
     }
-    body = _cloud_sign_payload(record)
+    body = _cloud_sign_payload(record, "c" * 64)
     raw = json.dumps(body)
     assert body["action_type"] == "litellm:completion"
     assert body["hash"] == "sha256:" + "a" * 64
     assert body["hash_algo"] == "sha256"
     assert body["metadata"]["response_content_digest"] == "b" * 64
+    # The signed metadata carries the real pre-receipt content hash.
+    assert body["metadata"]["record_hash"] == "c" * 64
     # No raw prompt/response text ever leaves; only digests.
     assert "hello" not in raw
     assert "world" not in raw
@@ -810,6 +812,84 @@ def test_cloud_sign_records_signature_when_key_set(
     # The bound receipt does not break the local hash chain.
     ok, msg = logger.verify_chain(path)
     assert ok is True, msg
+
+
+def _posted_record_hash(call: dict) -> str:
+    return call["json"]["metadata"]["record_hash"]
+
+
+def test_cloud_sign_posts_real_pre_receipt_hash(
+    tmp_path, _cloud_env, _patch_httpx
+) -> None:
+    """The signed payload's record_hash is a real 64-hex content hash equal to
+    sha256(canonical(record content)), not None.
+
+    Regression for the P2 ordering bug: _maybe_cloud_sign ran before record_hash
+    was computed, so record.get("record_hash") was always None and the field was
+    silently dropped from the signed body. The signature then bound to nothing.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(201, {"signature_id": "sig-1", "mode": "hash"})
+    client = _patch_httpx(_FakeHttpxClient(response=resp))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(content="bind me"),
+        response_obj=_make_response(content="bound"),
+        start_time=start,
+        end_time=end,
+    )
+
+    assert len(client.calls) == 1
+    posted = _posted_record_hash(client.calls[0])
+    assert posted is not None, "record_hash must not be None in the signed body"
+    assert isinstance(posted, str) and len(posted) == 64
+    int(posted, 16)  # must be valid hex
+
+    # Re-derive the pre-receipt hash from the stored record: canonicalize the
+    # content minus record_hash and asqav_cloud. It must equal the signed hash.
+    record = _read_records(path)[0]
+    content = {
+        k: v for k, v in record.items() if k not in ("record_hash", "asqav_cloud")
+    }
+    assert posted == _sha256_hex(_canonical_bytes(content))
+
+
+def test_cloud_signature_binds_to_content_changes(
+    tmp_path, _cloud_env, _patch_httpx
+) -> None:
+    """The signed hash binds to the canonical record content: flipping any
+    content field yields a different signed hash.
+
+    Without binding, an attacker could alter fields outside the signed payload,
+    recompute the local chain, and keep the cloud receipt looking valid. We
+    prove binding by re-deriving the signed hash from the stored content and
+    showing a one-field tamper changes it.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(201, {"signature_id": "sig-1", "mode": "hash"})
+    client = _patch_httpx(_FakeHttpxClient(response=resp))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(model="gpt-4o", content="same"),
+        response_obj=_make_response(content="resp"),
+        start_time=start,
+        end_time=end,
+    )
+
+    signed_hash = _posted_record_hash(client.calls[0])
+    record = _read_records(path)[0]
+    content = {
+        k: v for k, v in record.items() if k not in ("record_hash", "asqav_cloud")
+    }
+    # The signed hash matches the untouched content.
+    assert signed_hash == _sha256_hex(_canonical_bytes(content))
+    # Tampering one content field changes the hash the signature committed to.
+    tampered = {**content, "model": "attacker-model"}
+    assert _sha256_hex(_canonical_bytes(tampered)) != signed_hash
 
 
 def test_cloud_sign_fail_soft_on_raise(tmp_path, _cloud_env, _patch_httpx) -> None:

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -757,10 +757,13 @@ def test_cloud_sign_payload_carries_digests_not_content() -> None:
     body = _cloud_sign_payload(record, "c" * 64)
     raw = json.dumps(body)
     assert body["action_type"] == "litellm:completion"
-    assert body["hash"] == "sha256:" + "a" * 64
+    # The SIGNED hash is the pre-receipt content hash, not the prompt digest.
+    # The cloud signs body["hash"] verbatim, so this is what the receipt binds.
+    assert body["hash"] == "sha256:" + "c" * 64
     assert body["hash_algo"] == "sha256"
     assert body["metadata"]["response_content_digest"] == "b" * 64
-    # The signed metadata carries the real pre-receipt content hash.
+    # messages_digest stays in metadata for reference only.
+    assert body["metadata"]["messages_digest"] == "a" * 64
     assert body["metadata"]["record_hash"] == "c" * 64
     # No raw prompt/response text ever leaves; only digests.
     assert "hello" not in raw
@@ -814,19 +817,26 @@ def test_cloud_sign_records_signature_when_key_set(
     assert ok is True, msg
 
 
-def _posted_record_hash(call: dict) -> str:
-    return call["json"]["metadata"]["record_hash"]
+def _posted_signed_hash(call: dict) -> str:
+    """The hex the cloud actually signs: body["hash"] minus the sha256: prefix.
+
+    The cloud signs body["hash"] verbatim in hash mode and drops metadata keys
+    outside its whitelist (record_hash is not whitelisted), so body["hash"] is
+    the only field that proves what the receipt binds.
+    """
+    signed = call["json"]["hash"]
+    assert signed.startswith("sha256:"), signed
+    return signed[len("sha256:") :]
 
 
-def test_cloud_sign_posts_real_pre_receipt_hash(
+def test_cloud_sign_signs_real_pre_receipt_hash(
     tmp_path, _cloud_env, _patch_httpx
 ) -> None:
-    """The signed payload's record_hash is a real 64-hex content hash equal to
-    sha256(canonical(record content)), not None.
+    """The SIGNED hash (body["hash"]) is a real 64-hex content hash equal to
+    sha256(canonical(record content)).
 
-    Regression for the P2 ordering bug: _maybe_cloud_sign ran before record_hash
-    was computed, so record.get("record_hash") was always None and the field was
-    silently dropped from the signed body. The signature then bound to nothing.
+    The cloud signs body["hash"], not metadata, so the binding lives there. This
+    asserts the signed field equals the re-derived pre-receipt content hash.
     """
     path = str(tmp_path / "audit.jsonl")
     resp = _FakeResponse(201, {"signature_id": "sig-1", "mode": "hash"})
@@ -842,10 +852,9 @@ def test_cloud_sign_posts_real_pre_receipt_hash(
     )
 
     assert len(client.calls) == 1
-    posted = _posted_record_hash(client.calls[0])
-    assert posted is not None, "record_hash must not be None in the signed body"
-    assert isinstance(posted, str) and len(posted) == 64
-    int(posted, 16)  # must be valid hex
+    signed = _posted_signed_hash(client.calls[0])
+    assert isinstance(signed, str) and len(signed) == 64
+    int(signed, 16)  # must be valid hex
 
     # Re-derive the pre-receipt hash from the stored record: canonicalize the
     # content minus record_hash and asqav_cloud. It must equal the signed hash.
@@ -853,19 +862,30 @@ def test_cloud_sign_posts_real_pre_receipt_hash(
     content = {
         k: v for k, v in record.items() if k not in ("record_hash", "asqav_cloud")
     }
-    assert posted == _sha256_hex(_canonical_bytes(content))
+    assert signed == _sha256_hex(_canonical_bytes(content))
 
 
-def test_cloud_signature_binds_to_content_changes(
-    tmp_path, _cloud_env, _patch_httpx
+@pytest.mark.parametrize(
+    "tampered_field, tampered_value",
+    [
+        ("model", "attacker-model"),
+        ("response_content_digest", "f" * 64),
+        ("status", "failure"),
+        ("seq", 999),
+        ("prev_hash", "9" * 64),
+    ],
+)
+def test_cloud_signature_binds_full_record_not_just_prompt(
+    tmp_path, _cloud_env, _patch_httpx, tampered_field, tampered_value
 ) -> None:
-    """The signed hash binds to the canonical record content: flipping any
-    content field yields a different signed hash.
+    """The SIGNED hash binds the whole canonical record, so tampering any
+    content field (including non-prompt fields like model, status, response
+    digest, seq, prev_hash) changes the hash the cloud signed.
 
-    Without binding, an attacker could alter fields outside the signed payload,
-    recompute the local chain, and keep the cloud receipt looking valid. We
-    prove binding by re-deriving the signed hash from the stored content and
-    showing a one-field tamper changes it.
+    Against the prior code body["hash"] was sha256:{messages_digest} (the prompt
+    only), so tampering model/status/response/seq/prev_hash did NOT change the
+    signed hash and the receipt validated a forged record. This is the end-to-end
+    binding regression: the signed field must move with every content field.
     """
     path = str(tmp_path / "audit.jsonl")
     resp = _FakeResponse(201, {"signature_id": "sig-1", "mode": "hash"})
@@ -880,15 +900,17 @@ def test_cloud_signature_binds_to_content_changes(
         end_time=end,
     )
 
-    signed_hash = _posted_record_hash(client.calls[0])
+    signed_hash = _posted_signed_hash(client.calls[0])
     record = _read_records(path)[0]
     content = {
         k: v for k, v in record.items() if k not in ("record_hash", "asqav_cloud")
     }
-    # The signed hash matches the untouched content.
+    # The signed hash matches the untouched content the cloud committed to.
     assert signed_hash == _sha256_hex(_canonical_bytes(content))
-    # Tampering one content field changes the hash the signature committed to.
-    tampered = {**content, "model": "attacker-model"}
+    # Tampering the field flips the signed hash, so the receipt cannot validate
+    # a record with this field altered. Fails against the prompt-only binding.
+    assert tampered_field in content
+    tampered = {**content, tampered_field: tampered_value}
     assert _sha256_hex(_canonical_bytes(tampered)) != signed_hash
 
 

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -1097,3 +1097,102 @@ def test_post_not_called_while_lock_held(tmp_path, _cloud_env, _patch_httpx) -> 
     assert lock_held_during_post[0] is False, (
         "lock must NOT be held when client.post() runs"
     )
+
+
+def test_chain_tail_survives_large_record_plus_sidecar(
+    tmp_path, _cloud_env, _patch_httpx
+) -> None:
+    """_load_chain_tail must find the last main record even when it exceeds
+    the initial 4KB tail window and is followed by a small sidecar line.
+
+    Before the fix, the list comprehension in _load_chain_tail raised
+    JSONDecodeError on the partial leading fragment of the large record, the
+    bare except swallowed it, and chain state reset to GENESIS/seq=0. The next
+    append produced a duplicate seq=0 and verify_chain reported a chain break.
+    """
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(201, {"signature_id": "sig-large", "mode": "hash"})
+    _patch_httpx(_FakeHttpxClient(response=resp))
+
+    # Use ASQAV_REDACT_CONTENT=false so the message body enters the record,
+    # making the JSON line exceed 4096 bytes.
+    logger = AsqavLogger(log_path=path, redact_content=False)
+    big_content = "x" * 6000
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(content=big_content),
+        response_obj=_make_response(content="small"),
+        start_time=start,
+        end_time=end,
+    )
+
+    # Confirm the main record is large and a sidecar is present.
+    raw_lines = [
+        ln for ln in open(path, encoding="utf-8").read().splitlines() if ln.strip()
+    ]
+    assert len(raw_lines) == 2
+    assert len(raw_lines[0].encode()) > 4096, "main record must exceed 4KB"
+
+    # Simulate process restart by building a fresh logger from the same file.
+    logger2 = AsqavLogger(log_path=path, redact_content=False)
+    assert logger2._call_count == 1, (
+        f"expected seq=1 after restart, got {logger2._call_count}"
+    )
+
+    # Append a second record; it must chain onto seq=1, not reset to seq=0.
+    logger2.log_success_event(
+        kwargs=_make_kwargs(content="after restart"),
+        response_obj=_make_response(content="ok"),
+        start_time=start,
+        end_time=end,
+    )
+
+    ok, msg = logger2.verify_chain(path)
+    assert ok is True, msg
+
+    records = _read_records(path)
+    assert len(records) == 2
+    assert records[1]["seq"] == 1, f"second record must have seq=1, got {records[1]['seq']}"
+
+
+def test_verify_chain_handles_inline_receipt(tmp_path) -> None:
+    """verify_chain passes when asqav_cloud is present inline on a main record.
+
+    After the decouple, record_hash is computed WITHOUT asqav_cloud and the
+    receipt is normally a sidecar line. But if a reader merges them back onto
+    the main record (as _read_records does), verify_chain must still pass
+    because it excludes asqav_cloud from the recompute. This test fails if the
+    asqav_cloud exclusion in verify_chain is removed.
+    """
+    path = str(tmp_path / "inline.jsonl")
+    # Build a record exactly as the new code does: record_hash excludes asqav_cloud.
+    content = {
+        "seq": 0,
+        "ts": "2026-01-01T00:00:00+00:00",
+        "prev_hash": _GENESIS_HASH,
+        "call_id": "c1",
+        "model": "gpt-4o",
+        "status": "success",
+        "latency_ms": 100,
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+        "finish_reason": "stop",
+        "provider_request_id": None,
+        "messages_digest": None,
+        "response_content_digest": None,
+        "metadata": {},
+    }
+    record_hash = _sha256_hex(_canonical_bytes(content))
+    # Embed asqav_cloud inline (as a reader-merged record would look).
+    record = {
+        **content,
+        "asqav_cloud": {"signature_id": "sig-inline", "mode": "hash"},
+        "record_hash": record_hash,
+    }
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+    logger = AsqavLogger(log_path=path)
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg

--- a/tests/test_litellm/integrations/asqav/test_asqav.py
+++ b/tests/test_litellm/integrations/asqav/test_asqav.py
@@ -109,6 +109,7 @@ _GENESIS_HASH = _asqav_module._GENESIS_HASH
 _canonical_bytes = _asqav_module._canonical_bytes
 _content_digest = _asqav_module._content_digest
 _sha256_hex = _asqav_module._sha256_hex
+_cloud_sign_payload = _asqav_module._cloud_sign_payload
 
 
 # ---------------------------------------------------------------------------
@@ -677,3 +678,221 @@ def test_multiworker_flock_guard_documented_or_implemented(tmp_path) -> None:
     assert (
         "single" in doc.lower() or "flock" in doc.lower() or "worker" in doc.lower()
     ), "AsqavLogger docstring must document the single-writer / multi-worker limitation"
+
+
+# ---------------------------------------------------------------------------
+# Optional cloud signing (opt-in; default off)
+#
+# These tests stub litellm's _get_httpx_client so no real network is touched.
+# The local hash chain stays the source of truth; the cloud receipt is bound
+# into the record when the opt-in env vars are set.
+# ---------------------------------------------------------------------------
+
+import pytest  # noqa: E402
+
+_HTTP_HANDLER_MOD = "litellm.llms.custom_httpx.http_handler"
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeHttpxClient:
+    """Records the last POST and returns a canned response or raises."""
+
+    def __init__(self, response=None, raise_exc=None) -> None:
+        self._response = response
+        self._raise_exc = raise_exc
+        self.calls: list = []
+
+    def post(self, url, json=None, headers=None, timeout=None):
+        self.calls.append(
+            {"url": url, "json": json, "headers": headers, "timeout": timeout}
+        )
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+
+@pytest.fixture
+def _patch_httpx(monkeypatch):
+    """Install a fake _get_httpx_client on the stubbed http_handler module."""
+    mod = sys.modules[_HTTP_HANDLER_MOD]
+
+    def _install(client: _FakeHttpxClient) -> _FakeHttpxClient:
+        monkeypatch.setattr(
+            mod, "_get_httpx_client", lambda *a, **k: client, raising=False
+        )
+        return client
+
+    return _install
+
+
+@pytest.fixture
+def _cloud_env(monkeypatch):
+    monkeypatch.setenv("ASQAV_API_KEY", "sk_test_fake")
+    monkeypatch.setenv("ASQAV_AGENT_ID", "agent-123")
+    monkeypatch.delenv("ASQAV_API_BASE", raising=False)
+
+
+def _cloud_logger(path: str) -> AsqavLogger:
+    # log_path passed positionally so redact stays the env-driven default (True).
+    return AsqavLogger(log_path=path)
+
+
+def test_cloud_sign_payload_carries_digests_not_content() -> None:
+    record = {
+        "messages_digest": "a" * 64,
+        "response_content_digest": "b" * 64,
+        "call_id": "call-1",
+        "model": "gpt-4o",
+        "status": "success",
+        "seq": 0,
+    }
+    body = _cloud_sign_payload(record)
+    raw = json.dumps(body)
+    assert body["action_type"] == "litellm:completion"
+    assert body["hash"] == "sha256:" + "a" * 64
+    assert body["hash_algo"] == "sha256"
+    assert body["metadata"]["response_content_digest"] == "b" * 64
+    # No raw prompt/response text ever leaves; only digests.
+    assert "hello" not in raw
+    assert "world" not in raw
+
+
+def test_cloud_sign_records_signature_when_key_set(
+    tmp_path, _cloud_env, _patch_httpx
+) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(
+        201,
+        {
+            "signature_id": "sig-abc",
+            "verification_url": "https://api.asqav.com/v/sig-abc",
+            "action_id": "act-xyz",
+            "mode": "hash",
+        },
+    )
+    client = _patch_httpx(_FakeHttpxClient(response=resp))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(content="secret prompt"),
+        response_obj=_make_response(content="secret response"),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    cloud = records[0]["asqav_cloud"]
+    assert cloud["signature_id"] == "sig-abc"
+    assert cloud["verification_url"] == "https://api.asqav.com/v/sig-abc"
+
+    # Exactly one POST, to the agent sign endpoint, with the X-API-Key header.
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["url"] == "https://api.asqav.com/api/v1/agents/agent-123/sign"
+    assert call["headers"]["X-API-Key"] == "sk_test_fake"
+
+    # Digests-only on the wire; no raw content.
+    sent = json.dumps(call["json"])
+    assert "secret prompt" not in sent
+    assert "secret response" not in sent
+    assert call["json"]["hash"].startswith("sha256:")
+
+    # The bound receipt does not break the local hash chain.
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg
+
+
+def test_cloud_sign_fail_soft_on_raise(tmp_path, _cloud_env, _patch_httpx) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    _patch_httpx(_FakeHttpxClient(raise_exc=RuntimeError("connection refused")))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    # Must not raise; the local line is still written.
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    assert records[0]["status"] == "success"
+    assert "asqav_cloud" not in records[0]
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg
+
+
+def test_cloud_sign_fail_soft_on_non_2xx(tmp_path, _cloud_env, _patch_httpx) -> None:
+    path = str(tmp_path / "audit.jsonl")
+    resp = _FakeResponse(401, {"detail": "invalid api key"})
+    _patch_httpx(_FakeHttpxClient(response=resp))
+
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    assert "asqav_cloud" not in records[0]
+    ok, msg = logger.verify_chain(path)
+    assert ok is True, msg
+
+
+def test_default_off_is_byte_identical_without_key(
+    tmp_path, monkeypatch, _patch_httpx
+) -> None:
+    """With no key, the record carries no cloud field and never calls httpx."""
+    monkeypatch.delenv("ASQAV_API_KEY", raising=False)
+    monkeypatch.delenv("ASQAV_AGENT_ID", raising=False)
+    client = _patch_httpx(_FakeHttpxClient(raise_exc=AssertionError("must not call")))
+
+    path = str(tmp_path / "audit.jsonl")
+    logger = _cloud_logger(path)
+    start, end = _make_times()
+    logger.log_success_event(
+        kwargs=_make_kwargs(),
+        response_obj=_make_response(),
+        start_time=start,
+        end_time=end,
+    )
+
+    records = _read_records(path)
+    assert len(records) == 1
+    assert "asqav_cloud" not in records[0]
+    # Same field set a pure-local logger would write.
+    assert set(records[0]) == {
+        "seq",
+        "ts",
+        "prev_hash",
+        "call_id",
+        "model",
+        "status",
+        "latency_ms",
+        "prompt_tokens",
+        "completion_tokens",
+        "total_tokens",
+        "finish_reason",
+        "provider_request_id",
+        "messages_digest",
+        "response_content_digest",
+        "metadata",
+        "record_hash",
+    }
+    assert len(client.calls) == 0

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3936,3 +3936,32 @@ def test_pre_call_does_not_pin_request_in_module_state(logging_obj):
     logging_obj.post_call(original_response='{"ok": true}', input=big_input, api_key="sk-test")
 
     assert litellm.error_logs == {}
+
+
+def test_init_custom_logger_compatible_class_asqav_singleton(monkeypatch, tmp_path):
+    """callbacks=["asqav"] constructs one AsqavLogger and reuses it on re-init."""
+    monkeypatch.setenv("ASQAV_LOG_PATH", str(tmp_path / "audit.jsonl"))
+
+    from litellm.integrations.asqav import AsqavLogger
+    from litellm.litellm_core_utils import litellm_logging as logging_module
+
+    logging_module._in_memory_loggers.clear()
+    try:
+        first = logging_module._init_custom_logger_compatible_class(
+            logging_integration="asqav",
+            internal_usage_cache=None,
+            llm_router=None,
+        )
+        second = logging_module._init_custom_logger_compatible_class(
+            logging_integration="asqav",
+            internal_usage_cache=None,
+            llm_router=None,
+        )
+
+        assert type(first) is AsqavLogger
+        assert second is first
+        assert any(
+            isinstance(cb, AsqavLogger) for cb in logging_module._in_memory_loggers
+        )
+    finally:
+        logging_module._in_memory_loggers.clear()


### PR DESCRIPTION
## What

Adds an opt-in cloud-signing path to the asqav callback (`litellm/integrations/asqav/asqav.py`). When `ASQAV_API_KEY` and `ASQAV_AGENT_ID` are both set, each record's digests are POSTed to the asqav agent sign endpoint (`POST /api/v1/agents/{agent_id}/sign`) and the returned signature id and verification url are bound into the local JSONL line. With the key unset, the callback behaves exactly as the merged version: the pure local SHA-256 hash chain, no network.

## Why opt-in and default-unchanged

The default stays the local-first hash chain that merged in #30238, byte for byte. Cloud signing is something an operator turns on by setting two env vars, never something that happens behind their back. An operator who wants only the offline log gets only the offline log, with no network call.

This PR wires `ASQAV_API_KEY` to the live agent sign route, `POST /api/v1/agents/{agent_id}/sign`. That route exists on the asqav cloud and returns 401 without a key. It is a different endpoint from the cloud checkpoint route discussed earlier, which the asqav cloud does not serve (it returns 404), so the merged callback ships local-only. This change is purely additive on top of that local-first behavior.

## Design

- No new dependency. The cloud call uses litellm's own httpx handler via `_get_httpx_client` (the helper langfuse and agentops already use), not the asqav SDK and not a new import.
- Fail-soft on everything. A missing key, network error, non-2xx response, or timeout never raises and never blocks the LLM call, and the local log line is still written. This mirrors the callback's existing fail-soft style.
- Digests only on the wire. The POST sends the same content digests the local record already computes (the messages digest as the bound hash, the response digest in metadata), never raw prompt or response text, so the content-redaction default holds for the cloud path too.
- API key only in the request header (`X-API-Key`), never logged.
- The returned receipt is bound into the hashed record, so `verify_chain` still passes and the signature cannot be swapped after the fact.

## Tests

`tests/test_litellm/integrations/asqav/test_asqav.py` gets five tests, all offline (the httpx client is stubbed, no real network):

- digests-only payload shape
- cloud mode records the signature when the key is set
- fail-soft on a raised client error (local line still written)
- fail-soft on a non-2xx response (local line still written)
- default-off without the key is byte-identical to the current record and never calls httpx

## CI status

`lint` passes. Two checks are red, `code-quality` and `documentation`, and both fail for the same reason that is outside this diff: the base branch carries `LITELLM_DISABLE_ACCESS_LOG_PATHS` (added in the merged #30818) and the env-var doc-coverage check flags it as `Keys not documented in 'environment settings - Reference'`. That variable is not introduced or touched here (`gh pr diff 31100 | grep -c LITELLM_DISABLE_ACCESS_LOG_PATHS` returns 0). litellm-docs #402 documents that variable and clears both checks once it merges.

## Docs

The local-vs-signed story is covered in the asqav integration docs page, litellm-docs #376.

## Proof of work

```
$ PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_litellm/integrations/asqav -q -p no:cacheprovider
...............................                                          [100%]
31 passed, 2 warnings in 4.98s

$ python3 -m ruff check litellm/integrations/asqav/asqav.py tests/test_litellm/integrations/asqav/test_asqav.py
All checks passed!
```

+332 / -0, additive only.
