### PR TITLE
fix(typing): bring reportReturnType back under the basedpyright budget

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5044,9 +5044,7 @@ def completion(  # type: ignore
         if LiteLLM_Proxy_MCP_Handler._should_use_litellm_mcp_gateway(
             tools=tools_for_mcp
         ):
-            # Return coroutine - acompletion will await it
-            # completion() can return a coroutine when MCP tools are present, which acompletion() awaits
-            return acompletion_with_mcp(  # type: ignore[return-value]
+            return acompletion_with_mcp(  # pyright: ignore[reportReturnType]  # MCP path returns a coroutine that acompletion() awaits; completion()'s sync return type omits it
                 model=model,
                 messages=messages,
                 functions=functions,
@@ -5218,12 +5216,16 @@ def completion(  # type: ignore
         logging: LiteLLMLoggingObj = cast(LiteLLMLoggingObj, litellm_logging_obj)
         fallbacks = fallbacks or litellm.model_fallbacks
         if fallbacks is not None:
-            return completion_with_fallbacks(**args)
+            return completion_with_fallbacks(  # pyright: ignore[reportReturnType]  # fallback runner is untyped; resolves to ModelResponse|CustomStreamWrapper at runtime
+                **args
+            )
         if model_list is not None:
             deployments = [
                 m["litellm_params"] for m in model_list if m["model_name"] == model
             ]
-            return litellm.batch_completion_models(deployments=deployments, **args)
+            return litellm.batch_completion_models(  # pyright: ignore[reportReturnType]  # batch path returns a list of responses, outside completion()'s single-response return type
+                deployments=deployments, **args
+            )
         if litellm.model_alias_map and model in litellm.model_alias_map:
             model = litellm.model_alias_map[
                 model
@@ -5545,7 +5547,7 @@ def completion(  # type: ignore
                 else:
                     optional_params["reasoning_effort"] = {"summary": rs_val}
 
-            return responses_api_bridge.completion(
+            return responses_api_bridge.completion(  # pyright: ignore[reportReturnType]  # bridge returns a coroutine on the acompletion path; awaited by the async caller
                 model=model,
                 messages=messages,
                 headers=headers,


### PR DESCRIPTION
## Relevant issues

The LiteLLM Linting check is red on every PR currently branched off `litellm_internal_staging` (for example #30446), failing the basedpyright budget gate:

```
FAIL: basedpyright errors exceed the per-rule ceiling:
  reportReturnType: 143 errors over cap 139
```

This is a staging-level regression, not a problem with any individual PR: the gate (`scripts/type_check_gate.py`) counts absolute codebase-wide errors against the committed ceiling, so a branch off the current staging tip inherits the red regardless of what it changes.

## Root cause

The budget was last ratcheted at `1bd603d1` to baseline 126 (cap 126 + slack 13 = 139). Blaming each of the 143 current `reportReturnType` offenders, exactly four were introduced after that ratchet, all by #30813 ("refactor(completion): extract provider dispatch into typed helpers"):

- `litellm/main.py` MCP dispatch path (`acompletion_with_mcp`)
- the fallbacks path (`completion_with_fallbacks`)
- the batch path (`batch_completion_models`)
- the responses-bridge path (`responses_api_bridge.completion`)

That refactor made basedpyright able to analyze `completion()` for the first time and correctly added `pyright: ignore[reportReturnType]` to the 61 extracted helpers, but it missed these four returns that live in `completion()`'s own body. They take the codebase total from 139 to 143, four over the ceiling.

## Fix

Suppress exactly those four sites with coded, reasoned pyright ignores. Each path returns a coroutine (MCP, responses bridge), a list (batch), or the untyped fallback runner's result, none of which match `completion()`'s declared `Union[ModelResponse, CustomStreamWrapper]`; the async/batch callers handle those shapes. Widening `completion()`'s return type would ripple across thousands of call sites and is out of scope. Note the repo sets `enableTypeIgnoreComments=false`, so the pre-existing `type: ignore[return-value]` on the MCP path was dead and is replaced with a working `pyright: ignore`.

After the fix the codebase total is back to 139, exactly at the ceiling, and the gate passes.

## Type

🐛 Bug Fix

## Changes

Adds four `pyright: ignore[reportReturnType]` suppressions, each with a reason, to the async/batch dispatch returns in `completion()`; no behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cys2zr1vmqLJMrmNvEa3MA)_