### PR TITLE
feat(sap): support multiple orchestration deployments via name filter

### DIFF
--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -195,7 +195,9 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 headers=self.headers,
             ).json()
             if cfg.get("executableId") == "orchestration":
-                valid.append((dep["deploymentUrl"], dep["createdAt"], cfg.get("name", "")))
+                valid.append(
+                    (dep["deploymentUrl"], dep["createdAt"], cfg.get("name", ""))
+                )
 
         if not valid:
             raise GenAIHubOrchestrationError(

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -182,22 +182,18 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     def _resolve_deployment_url(self) -> str:
         client = litellm.module_level_client
-        deployments = client.get(
-            f"{self.base_url}/lm/deployments", headers=self.headers
-        ).json()
+        deployments = client.get(f"{self.base_url}/lm/deployments", headers=self.headers).json()
 
         valid: List[Tuple[str, str, str]] = []
         for dep in deployments.get("resources", []):
             if dep.get("scenarioId") != "orchestration":
                 continue
             cfg = client.get(
-                f'{self.base_url}/lm/configurations/{dep["configurationId"]}',
+                f"{self.base_url}/lm/configurations/{dep['configurationId']}",
                 headers=self.headers,
             ).json()
             if cfg.get("executableId") == "orchestration":
-                valid.append(
-                    (dep["deploymentUrl"], dep["createdAt"], cfg.get("name", ""))
-                )
+                valid.append((dep["deploymentUrl"], dep["createdAt"], cfg.get("name", "")))
 
         if not valid:
             raise GenAIHubOrchestrationError(

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -2,23 +2,25 @@
 Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orchestration Service`v2/completion`
 """
 
+import os
+from functools import cached_property
 from typing import (
+    Any,
+    AsyncIterator,
+    Dict,
+    FrozenSet,
+    Iterator,
     List,
     Optional,
-    Union,
-    Dict,
     Tuple,
-    Any,
     TYPE_CHECKING,
-    Iterator,
-    AsyncIterator,
-    FrozenSet,
+    Union,
 )
-from functools import cached_property
-import litellm
+
 import httpx
+import litellm
 
-
+from litellm._logging import verbose_logger
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse
 
@@ -32,6 +34,11 @@ else:
     LiteLLMLoggingObj = Any
 
 from ..credentials import get_token_creator
+from .handler import (
+    AsyncSAPStreamIterator,
+    GenAIHubOrchestrationError,
+    SAPStreamIterator,
+)
 from .models import (
     ChatCompletionTool,
     OrchestrationRequest,
@@ -41,11 +48,6 @@ from .models import (
     SAPMessage,
     SAPToolChatMessage,
     SAPUserMessage,
-)
-from .handler import (
-    GenAIHubOrchestrationError,
-    AsyncSAPStreamIterator,
-    SAPStreamIterator,
 )
 
 # Keys routed outside SAP orchestration `model.params` (prompt, stream, fallbacks, etc.)
@@ -177,20 +179,58 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     @cached_property
     def deployment_url(self) -> str:
-        # Keep a short, tight client lifecycle here to avoid fd leaks
+        return self._resolve_deployment_url(deployment_name=None)
+
+    def _resolve_deployment_url(self, deployment_name: Optional[str]) -> str:
         client = litellm.module_level_client
-        # with httpx.Client(timeout=30) as client:
-        deployments = client.get(f"{self.base_url}/lm/deployments", headers=self.headers).json()
-        valid: List[Tuple[str, str]] = []
+        deployments = client.get(
+            f"{self.base_url}/lm/deployments", headers=self.headers
+        ).json()
+
+        valid: List[Tuple[str, str, str]] = []
         for dep in deployments.get("resources", []):
-            if dep.get("scenarioId") == "orchestration":
-                cfg = client.get(
-                    f"{self.base_url}/lm/configurations/{dep['configurationId']}",
-                    headers=self.headers,
-                ).json()
-                if cfg.get("executableId") == "orchestration":
-                    valid.append((dep["deploymentUrl"], dep["createdAt"]))
-            # newest first
+            if dep.get("scenarioId") != "orchestration":
+                continue
+            cfg = client.get(
+                f'{self.base_url}/lm/configurations/{dep["configurationId"]}',
+                headers=self.headers,
+            ).json()
+            if cfg.get("executableId") == "orchestration":
+                valid.append((dep["deploymentUrl"], dep["createdAt"], cfg.get("name", "")))
+
+        if not valid:
+            raise GenAIHubOrchestrationError(
+                status_code=404,
+                message="No orchestration deployment found in SAP AI Core.",
+            )
+
+        name_filter = deployment_name or os.environ.get("SAP_ORCHESTRATION_DEPLOYMENT_NAME")
+        if name_filter:
+            filtered = [v for v in valid if v[2] == name_filter]
+            if not filtered:
+                available = [v[2] for v in valid]
+                raise GenAIHubOrchestrationError(
+                    status_code=404,
+                    message=(
+                        f"No orchestration deployment named {name_filter!r} found. "
+                        f"Available: {available}"
+                    ),
+                )
+            valid = filtered
+
+        if len(valid) > 1:
+            sorted_valid = sorted(valid, key=lambda x: x[1], reverse=True)
+            chosen = sorted_valid[0]
+            others = [v[2] or v[0] for v in sorted_valid[1:]]
+            verbose_logger.warning(
+                f"SAP: found {len(valid)} orchestration deployments; using the newest one "
+                f"(name={chosen[2]!r}, url={chosen[0]!r}). "
+                f"Others ignored: {others}. "
+                "Set SAP_ORCHESTRATION_DEPLOYMENT_NAME to select a specific one, "
+                "or use the deployment_name per-call parameter."
+            )
+            return chosen[0]
+
         return sorted(valid, key=lambda x: x[1], reverse=True)[0][0]
 
     @classmethod
@@ -258,8 +298,12 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ):
-        api_base_ = f"{self.deployment_url}/v2/completion"
-        return api_base_
+        deployment_name = litellm_params.get("deployment_name")
+        if deployment_name:
+            base = self._resolve_deployment_url(deployment_name=deployment_name)
+        else:
+            base = self.deployment_url
+        return f"{base}/v2/completion"
 
     def _build_prompt_module(
         self,

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -2,7 +2,6 @@
 Translate from OpenAI's `/v1/chat/completions` to SAP Generative AI Hub's Orchestration Service`v2/completion`
 """
 
-import os
 from functools import cached_property
 from typing import (
     Any,
@@ -179,9 +178,9 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     @cached_property
     def deployment_url(self) -> str:
-        return self._resolve_deployment_url(deployment_name=None)
+        return self._resolve_deployment_url()
 
-    def _resolve_deployment_url(self, deployment_name: Optional[str]) -> str:
+    def _resolve_deployment_url(self) -> str:
         client = litellm.module_level_client
         deployments = client.get(
             f"{self.base_url}/lm/deployments", headers=self.headers
@@ -204,20 +203,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 message="No orchestration deployment found in SAP AI Core.",
             )
 
-        name_filter = deployment_name or os.environ.get("SAP_ORCHESTRATION_DEPLOYMENT_NAME")
-        if name_filter:
-            filtered = [v for v in valid if v[2] == name_filter]
-            if not filtered:
-                available = [v[2] for v in valid]
-                raise GenAIHubOrchestrationError(
-                    status_code=404,
-                    message=(
-                        f"No orchestration deployment named {name_filter!r} found. "
-                        f"Available: {available}"
-                    ),
-                )
-            valid = filtered
-
         if len(valid) > 1:
             sorted_valid = sorted(valid, key=lambda x: x[1], reverse=True)
             chosen = sorted_valid[0]
@@ -226,8 +211,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 f"SAP: found {len(valid)} orchestration deployments; using the newest one "
                 f"(name={chosen[2]!r}, url={chosen[0]!r}). "
                 f"Others ignored: {others}. "
-                "Set SAP_ORCHESTRATION_DEPLOYMENT_NAME to select a specific one, "
-                "or use the deployment_name per-call parameter."
+                "Pass `deployment_url` in `litellm_params` to route to a specific deployment."
             )
             return chosen[0]
 
@@ -298,11 +282,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ):
-        deployment_name = litellm_params.get("deployment_name")
-        if deployment_name:
-            base = self._resolve_deployment_url(deployment_name=deployment_name)
-        else:
-            base = self.deployment_url
+        base = litellm_params.get("deployment_url") or self.deployment_url
         return f"{base}/v2/completion"
 
     def _build_prompt_module(

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -181,6 +181,23 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         return self._resolve_deployment_url()
 
     def _resolve_deployment_url(self) -> str:
+        """Auto-discover the orchestration deployment URL from SAP AI Core.
+
+        This is the **fallback** (step 3) in the URL resolution chain.  It is
+        only called when neither of the faster paths produced a URL:
+
+        1. ``optional_params["deployment_url"]`` — caller-supplied, no network
+           call needed.
+        2. ``AICORE_ORCHESTRATION_DEPLOYMENT_URL`` env var — operator-supplied,
+           no network call needed.
+        3. **This method** — lists all deployments, filters to those whose
+           scenario and executable are both ``"orchestration"``, picks the one
+           with the most recent ``createdAt`` timestamp, and warns when more
+           than one candidate is found.
+
+        Raises:
+            GenAIHubOrchestrationError: if no orchestration deployment exists.
+        """
         client = litellm.module_level_client
         deployments = client.get(f"{self.base_url}/lm/deployments", headers=self.headers).json()
 
@@ -209,7 +226,8 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 f"SAP: found {len(valid)} orchestration deployments; using the newest one "
                 f"(name={chosen[2]!r}, url={chosen[0]!r}). "
                 f"Others ignored: {others}. "
-                "Pass `deployment_url` in `litellm_params` to route to a specific deployment."
+                "Set AICORE_ORCHESTRATION_DEPLOYMENT_URL or pass deployment_url in "
+                "optional_params to route to a specific deployment."
             )
             return chosen[0]
 
@@ -280,7 +298,29 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ):
-        base = litellm_params.get("deployment_url") or self.deployment_url
+        """Resolve the SAP orchestration endpoint URL using a three-step chain.
+
+        Resolution order (first match wins, no network call unless step 3 is
+        reached):
+
+        1. ``optional_params["deployment_url"]`` — caller passes the exact URL
+           as a per-request optional param.  Takes precedence over everything.
+        2. ``AICORE_ORCHESTRATION_DEPLOYMENT_URL`` env var — operator sets this
+           once at deployment time to pin a specific orchestration deployment.
+        3. Auto-discovery via :meth:`_resolve_deployment_url` — lists
+           deployments from the AI Core management API, picks the newest
+           orchestration deployment, and warns when multiple are found.
+        """
+        import os
+
+        # Step 1: per-request override via optional_params
+        base = optional_params.get("deployment_url")
+        # Step 2: env-var override (operator-level, no discovery needed)
+        if not base:
+            base = os.environ.get("AICORE_ORCHESTRATION_DEPLOYMENT_URL")
+        # Step 3: auto-discovery (network call, result is cached on the instance)
+        if not base:
+            base = self.deployment_url
         return f"{base}/v2/completion"
 
     def _build_prompt_module(

--- a/tests/litellm/llms/sap/chat/test_sap_chat_calls.py
+++ b/tests/litellm/llms/sap/chat/test_sap_chat_calls.py
@@ -1,0 +1,117 @@
+"""
+Live / blackbox tests for the SAP GenAI Hub orchestration provider.
+
+These tests make real network calls to SAP AI Core.  They are skipped
+automatically when AICORE_SERVICE_KEY is not set, so CI never runs them.
+
+Run locally:
+    export AICORE_SERVICE_KEY='{ ... json ... }'
+    pytest tests/litellm/llms/sap/chat/test_sap_chat_calls.py -v
+
+All tests use the default SAP model (gpt-4o via the orchestration service)
+unless a specific model is needed for the feature under test.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AICORE_SERVICE_KEY"),
+    reason="Live SAP credentials not available (AICORE_SERVICE_KEY not set)",
+)
+
+_SAP_MODEL = "sap/gpt-4o"
+_MESSAGES = [{"role": "user", "content": "Reply with exactly the word PONG and nothing else."}]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_live_response(response) -> None:
+    """Shared sanity checks for a non-streaming ModelResponse."""
+    assert response is not None
+    assert response.choices, "response.choices is empty"
+    content = response.choices[0].message.content or ""
+    assert content.strip(), "response content is empty"
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — URL resolution chain (multi-orch)
+# ---------------------------------------------------------------------------
+
+
+class TestURLResolution:
+    """Verify the three-step URL resolution chain against a live AI Core tenant.
+
+    Each test exercises exactly one step of the chain so a failure is
+    immediately traceable to a single resolution path.
+    """
+
+    def test_url_via_optional_params(self):
+        """Step 1: deployment_url in optional_params is used directly; no discovery."""
+        import litellm
+
+        # Retrieve the real deployment URL via discovery first so we have a
+        # concrete value to pass back in.  This exercises discovery (step 3)
+        # only as a setup prerequisite; the assertion target is step 1.
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        cfg = GenAIHubOrchestrationConfig()
+        cfg.run_env_setup(os.environ["AICORE_SERVICE_KEY"])
+        known_url = cfg.deployment_url  # triggers discovery once
+
+        response = litellm.completion(
+            model=_SAP_MODEL,
+            messages=_MESSAGES,
+            api_key=os.environ["AICORE_SERVICE_KEY"],
+            deployment_url=known_url,  # passed as optional_param
+        )
+        _assert_live_response(response)
+
+    def test_url_via_env_var(self):
+        """Step 2: AICORE_ORCHESTRATION_DEPLOYMENT_URL env var is used; no discovery."""
+        import litellm
+        from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+        # Resolve URL once to populate the env var for this test.
+        cfg = GenAIHubOrchestrationConfig()
+        cfg.run_env_setup(os.environ["AICORE_SERVICE_KEY"])
+        known_url = cfg.deployment_url
+
+        original = os.environ.get("AICORE_ORCHESTRATION_DEPLOYMENT_URL")
+        try:
+            os.environ["AICORE_ORCHESTRATION_DEPLOYMENT_URL"] = known_url
+            response = litellm.completion(
+                model=_SAP_MODEL,
+                messages=_MESSAGES,
+                api_key=os.environ["AICORE_SERVICE_KEY"],
+                # no deployment_url optional param → should pick up env var
+            )
+        finally:
+            if original is None:
+                os.environ.pop("AICORE_ORCHESTRATION_DEPLOYMENT_URL", None)
+            else:
+                os.environ["AICORE_ORCHESTRATION_DEPLOYMENT_URL"] = original
+
+        _assert_live_response(response)
+
+    def test_url_via_discovery(self):
+        """Step 3: no optional_param, no env var → auto-discovery runs."""
+        import litellm
+
+        # Ensure the env var is absent so we definitely fall through to step 3.
+        original = os.environ.pop("AICORE_ORCHESTRATION_DEPLOYMENT_URL", None)
+        try:
+            response = litellm.completion(
+                model=_SAP_MODEL,
+                messages=_MESSAGES,
+                api_key=os.environ["AICORE_SERVICE_KEY"],
+            )
+        finally:
+            if original is not None:
+                os.environ["AICORE_ORCHESTRATION_DEPLOYMENT_URL"] = original
+
+        _assert_live_response(response)

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -656,7 +656,7 @@ def _mock_deployments(*names: str):
     """Return a mock httpx client whose GET responses simulate AI Core deployment/config APIs."""
     deployments_payload = {
         "resources": [
-            {"scenarioId": "orchestration", "configurationId": f"cfg-{n}", "deploymentUrl": f"https://deploy-{n}.sap.com", "createdAt": f"2024-01-0{i+1}T00:00:00Z"}
+            {"scenarioId": "orchestration", "configurationId": f"cfg-{n}", "deploymentUrl": f"https://deploy-{n}.sap.com", "createdAt": f"2024-01-{i+1:02d}T00:00:00Z"}
             for i, n in enumerate(names)
         ]
     }
@@ -683,54 +683,24 @@ class TestDeploymentSelection:
     def test_single_deployment_returns_its_url(self):
         config = _make_config()
         with patch("litellm.module_level_client", _mock_deployments("my-orch")):
-            url = config._resolve_deployment_url(deployment_name=None)
+            url = config._resolve_deployment_url()
         assert url == "https://deploy-my-orch.sap.com"
 
     def test_multiple_deployments_picks_newest(self):
         config = _make_config()
         with patch("litellm.module_level_client", _mock_deployments("older", "newer")):
-            url = config._resolve_deployment_url(deployment_name=None)
+            url = config._resolve_deployment_url()
         assert url == "https://deploy-newer.sap.com"
 
     def test_multiple_deployments_emits_warning(self):
         config = _make_config()
         with patch("litellm.module_level_client", _mock_deployments("older", "newer")):
             with patch("litellm.llms.sap.chat.transformation.verbose_logger") as mock_log:
-                config._resolve_deployment_url(deployment_name=None)
+                config._resolve_deployment_url()
                 mock_log.warning.assert_called_once()
                 msg = mock_log.warning.call_args[0][0]
                 assert "2 orchestration deployments" in msg
-                assert "SAP_ORCHESTRATION_DEPLOYMENT_NAME" in msg
-
-    def test_deployment_name_arg_selects_by_name(self):
-        config = _make_config()
-        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
-            url = config._resolve_deployment_url(deployment_name="grounding-orch")
-        assert url == "https://deploy-grounding-orch.sap.com"
-
-    def test_env_var_selects_by_name(self, monkeypatch):
-        monkeypatch.setenv("SAP_ORCHESTRATION_DEPLOYMENT_NAME", "plain-orch")
-        config = _make_config()
-        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
-            url = config._resolve_deployment_url(deployment_name=None)
-        assert url == "https://deploy-plain-orch.sap.com"
-
-    def test_deployment_name_arg_takes_priority_over_env_var(self, monkeypatch):
-        monkeypatch.setenv("SAP_ORCHESTRATION_DEPLOYMENT_NAME", "plain-orch")
-        config = _make_config()
-        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
-            url = config._resolve_deployment_url(deployment_name="grounding-orch")
-        assert url == "https://deploy-grounding-orch.sap.com"
-
-    def test_unknown_name_raises_with_available_list(self):
-        from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError
-
-        config = _make_config()
-        with patch("litellm.module_level_client", _mock_deployments("alpha", "beta")):
-            with pytest.raises(GenAIHubOrchestrationError) as exc_info:
-                config._resolve_deployment_url(deployment_name="gamma")
-        assert "gamma" in str(exc_info.value)
-        assert "alpha" in str(exc_info.value) or "beta" in str(exc_info.value)
+                assert "deployment_url" in msg
 
     def test_no_deployments_raises(self):
         from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError
@@ -738,17 +708,32 @@ class TestDeploymentSelection:
         config = _make_config()
         with patch("litellm.module_level_client", _mock_deployments()):
             with pytest.raises(GenAIHubOrchestrationError) as exc_info:
-                config._resolve_deployment_url(deployment_name=None)
+                config._resolve_deployment_url()
         assert "No orchestration deployment found" in str(exc_info.value)
 
-    def test_get_complete_url_uses_deployment_name_from_litellm_params(self):
+    def test_get_complete_url_respects_deployment_url_in_litellm_params(self):
         config = _make_config()
-        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
+        explicit_url = "https://my-custom-deploy.sap.com/v2/inference/deployments/abc123"
+        mock_client = MagicMock()
+        with patch("litellm.module_level_client", mock_client):
             url = config.get_complete_url(
                 api_base=None,
                 api_key=None,
                 model="gpt-4o",
                 optional_params={},
-                litellm_params={"deployment_name": "plain-orch"},
+                litellm_params={"deployment_url": explicit_url},
             )
-        assert url == "https://deploy-plain-orch.sap.com/v2/completion"
+        assert url == f"{explicit_url}/v2/completion"
+        mock_client.get.assert_not_called()
+
+    def test_get_complete_url_falls_back_to_discovery_when_no_deployment_url(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("my-orch")):
+            url = config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="gpt-4o",
+                optional_params={},
+                litellm_params={},
+            )
+        assert url == "https://deploy-my-orch.sap.com/v2/completion"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 import pytest
 from unittest.mock import patch, MagicMock
@@ -700,6 +701,7 @@ class TestDeploymentSelection:
                 mock_log.warning.assert_called_once()
                 msg = mock_log.warning.call_args[0][0]
                 assert "2 orchestration deployments" in msg
+                assert "AICORE_ORCHESTRATION_DEPLOYMENT_URL" in msg
                 assert "deployment_url" in msg
 
     def test_no_deployments_raises(self):
@@ -711,7 +713,8 @@ class TestDeploymentSelection:
                 config._resolve_deployment_url()
         assert "No orchestration deployment found" in str(exc_info.value)
 
-    def test_get_complete_url_respects_deployment_url_in_litellm_params(self):
+    def test_get_complete_url_respects_deployment_url_in_optional_params(self):
+        """Step 1: deployment_url in optional_params skips discovery entirely."""
         config = _make_config()
         explicit_url = "https://my-custom-deploy.sap.com/v2/inference/deployments/abc123"
         mock_client = MagicMock()
@@ -720,20 +723,59 @@ class TestDeploymentSelection:
                 api_base=None,
                 api_key=None,
                 model="gpt-4o",
-                optional_params={},
-                litellm_params={"deployment_url": explicit_url},
+                optional_params={"deployment_url": explicit_url},
+                litellm_params={},
             )
         assert url == f"{explicit_url}/v2/completion"
         mock_client.get.assert_not_called()
 
-    def test_get_complete_url_falls_back_to_discovery_when_no_deployment_url(self):
+    def test_get_complete_url_respects_env_var(self):
+        """Step 2: AICORE_ORCHESTRATION_DEPLOYMENT_URL skips discovery."""
+        config = _make_config()
+        env_url = "https://env-deploy.sap.com/v2/inference/deployments/envid"
+        mock_client = MagicMock()
+        with patch("litellm.module_level_client", mock_client):
+            with patch.dict("os.environ", {"AICORE_ORCHESTRATION_DEPLOYMENT_URL": env_url}):
+                url = config.get_complete_url(
+                    api_base=None,
+                    api_key=None,
+                    model="gpt-4o",
+                    optional_params={},
+                    litellm_params={},
+                )
+        assert url == f"{env_url}/v2/completion"
+        mock_client.get.assert_not_called()
+
+    def test_get_complete_url_optional_params_beats_env_var(self):
+        """Step 1 takes precedence over step 2."""
+        config = _make_config()
+        optional_url = "https://optional-deploy.sap.com/v2/inference/deployments/opt"
+        env_url = "https://env-deploy.sap.com/v2/inference/deployments/envid"
+        mock_client = MagicMock()
+        with patch("litellm.module_level_client", mock_client):
+            with patch.dict("os.environ", {"AICORE_ORCHESTRATION_DEPLOYMENT_URL": env_url}):
+                url = config.get_complete_url(
+                    api_base=None,
+                    api_key=None,
+                    model="gpt-4o",
+                    optional_params={"deployment_url": optional_url},
+                    litellm_params={},
+                )
+        assert url == f"{optional_url}/v2/completion"
+        mock_client.get.assert_not_called()
+
+    def test_get_complete_url_falls_back_to_discovery_when_no_override(self):
+        """Step 3: no optional_param, no env var → discovery runs."""
         config = _make_config()
         with patch("litellm.module_level_client", _mock_deployments("my-orch")):
-            url = config.get_complete_url(
-                api_base=None,
-                api_key=None,
-                model="gpt-4o",
-                optional_params={},
-                litellm_params={},
-            )
+            with patch.dict("os.environ", {}, clear=False):
+                # ensure env var is absent
+                os.environ.pop("AICORE_ORCHESTRATION_DEPLOYMENT_URL", None)
+                url = config.get_complete_url(
+                    api_base=None,
+                    api_key=None,
+                    model="gpt-4o",
+                    optional_params={},
+                    litellm_params={},
+                )
         assert url == "https://deploy-my-orch.sap.com/v2/completion"

--- a/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_transformation.py
@@ -1,5 +1,6 @@
 import warnings
 import pytest
+from unittest.mock import patch, MagicMock
 from pydantic import ValidationError
 
 
@@ -639,3 +640,115 @@ class TestSAPTransformationIntegration:
                 config["config"]["modules"][1]["translation"]["input"]["type"]
                 == "sap_document_translation"
             )
+
+
+def _make_config():
+    from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+    config = GenAIHubOrchestrationConfig()
+    config.token_creator = lambda: "Bearer TEST_TOKEN"
+    config._base_url = "https://api.test-sap.com"
+    config._resource_group = "test-group"
+    return config
+
+
+def _mock_deployments(*names: str):
+    """Return a mock httpx client whose GET responses simulate AI Core deployment/config APIs."""
+    deployments_payload = {
+        "resources": [
+            {"scenarioId": "orchestration", "configurationId": f"cfg-{n}", "deploymentUrl": f"https://deploy-{n}.sap.com", "createdAt": f"2024-01-0{i+1}T00:00:00Z"}
+            for i, n in enumerate(names)
+        ]
+    }
+    configs = {
+        f"cfg-{n}": {"executableId": "orchestration", "name": n}
+        for n in names
+    }
+
+    def fake_get(url, headers=None):
+        resp = MagicMock()
+        if "/lm/deployments" in url:
+            resp.json.return_value = deployments_payload
+        else:
+            cfg_id = url.split("/")[-1]
+            resp.json.return_value = configs.get(cfg_id, {})
+        return resp
+
+    client = MagicMock()
+    client.get.side_effect = fake_get
+    return client
+
+
+class TestDeploymentSelection:
+    def test_single_deployment_returns_its_url(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("my-orch")):
+            url = config._resolve_deployment_url(deployment_name=None)
+        assert url == "https://deploy-my-orch.sap.com"
+
+    def test_multiple_deployments_picks_newest(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("older", "newer")):
+            url = config._resolve_deployment_url(deployment_name=None)
+        assert url == "https://deploy-newer.sap.com"
+
+    def test_multiple_deployments_emits_warning(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("older", "newer")):
+            with patch("litellm.llms.sap.chat.transformation.verbose_logger") as mock_log:
+                config._resolve_deployment_url(deployment_name=None)
+                mock_log.warning.assert_called_once()
+                msg = mock_log.warning.call_args[0][0]
+                assert "2 orchestration deployments" in msg
+                assert "SAP_ORCHESTRATION_DEPLOYMENT_NAME" in msg
+
+    def test_deployment_name_arg_selects_by_name(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
+            url = config._resolve_deployment_url(deployment_name="grounding-orch")
+        assert url == "https://deploy-grounding-orch.sap.com"
+
+    def test_env_var_selects_by_name(self, monkeypatch):
+        monkeypatch.setenv("SAP_ORCHESTRATION_DEPLOYMENT_NAME", "plain-orch")
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
+            url = config._resolve_deployment_url(deployment_name=None)
+        assert url == "https://deploy-plain-orch.sap.com"
+
+    def test_deployment_name_arg_takes_priority_over_env_var(self, monkeypatch):
+        monkeypatch.setenv("SAP_ORCHESTRATION_DEPLOYMENT_NAME", "plain-orch")
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
+            url = config._resolve_deployment_url(deployment_name="grounding-orch")
+        assert url == "https://deploy-grounding-orch.sap.com"
+
+    def test_unknown_name_raises_with_available_list(self):
+        from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError
+
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("alpha", "beta")):
+            with pytest.raises(GenAIHubOrchestrationError) as exc_info:
+                config._resolve_deployment_url(deployment_name="gamma")
+        assert "gamma" in str(exc_info.value)
+        assert "alpha" in str(exc_info.value) or "beta" in str(exc_info.value)
+
+    def test_no_deployments_raises(self):
+        from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError
+
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments()):
+            with pytest.raises(GenAIHubOrchestrationError) as exc_info:
+                config._resolve_deployment_url(deployment_name=None)
+        assert "No orchestration deployment found" in str(exc_info.value)
+
+    def test_get_complete_url_uses_deployment_name_from_litellm_params(self):
+        config = _make_config()
+        with patch("litellm.module_level_client", _mock_deployments("grounding-orch", "plain-orch")):
+            url = config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="gpt-4o",
+                optional_params={},
+                litellm_params={"deployment_name": "plain-orch"},
+            )
+        assert url == "https://deploy-plain-orch.sap.com/v2/completion"


### PR DESCRIPTION
## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Refactor / New Feature

## Summary

Replaces the `litellm_params["deployment_url"]` escape hatch with a clean three-step resolution chain.  The old approach required callers to use a LiteLLM-internal field that is not part of the standard call-site API.  The new approach uses `optional_params` (the correct place for per-request overrides) and a standard env var for operator-level configuration.

## Resolution order (first match wins)

| Step | Source | Network call? |
|------|--------|---------------|
| 1 | `optional_params["deployment_url"]` — per-request caller override | No |
| 2 | `AICORE_ORCHESTRATION_DEPLOYMENT_URL` env var — operator pin | No |
| 3 | `_resolve_deployment_url()` auto-discovery — lists AI Core deployments, picks newest orchestration one, warns when multiple found | Yes (once, cached) |

## What changed

### `litellm/llms/sap/chat/transformation.py`

- `get_complete_url`: removed `litellm_params.get("deployment_url")`, implemented the 3-step chain with inline docstring explaining each step.
- `_resolve_deployment_url`: updated the warning message to reference both `AICORE_ORCHESTRATION_DEPLOYMENT_URL` and `optional_params["deployment_url"]` as the two skip-discovery options.  Added a full docstring describing this method as step 3 of the chain.
- `transform_request`: no change — `optional_params.pop("deployment_url", None)` was already there and stays, ensuring the key never leaks into SAP model params after `get_complete_url` has consumed it.

### `tests/test_litellm/llms/sap/chat/test_sap_transformation.py` (mock, no credentials)

`TestDeploymentSelection` updated:
- `test_get_complete_url_respects_deployment_url_in_optional_params` (was: `_in_litellm_params`) — step 1
- `test_get_complete_url_respects_env_var` — new, step 2
- `test_get_complete_url_optional_params_beats_env_var` — new, step 1 > step 2
- `test_get_complete_url_falls_back_to_discovery_when_no_override` (was: `_no_deployment_url`) — step 3
- `test_multiple_deployments_emits_warning` — updated to assert `AICORE_ORCHESTRATION_DEPLOYMENT_URL` appears in the warning

### `tests/litellm/llms/sap/chat/test_sap_chat_calls.py` (blackbox, requires `AICORE_SERVICE_KEY`)

New file.  `TestURLResolution` with three live tests, one per step.  All three are skipped automatically when `AICORE_SERVICE_KEY` is not set so CI is unaffected.

```
pytest tests/litellm/llms/sap/chat/test_sap_chat_calls.py -v  # skips without creds
pytest tests/test_litellm/llms/sap/chat/test_sap_transformation.py::TestDeploymentSelection -v  # 8/8
```

## Why optional_params instead of litellm_params

`litellm_params` is an internal routing dict (timeout, fallbacks, metadata) that the LiteLLM core fills and passes around.  Callers are not supposed to stuff provider-specific overrides in it.  `optional_params` is exactly the right place for per-request provider parameters — it is what gets forwarded through `get_supported_openai_params` and consumed in `transform_request`.  Using it here is consistent with how every other provider exposes call-level overrides.