### PR TITLE
ci: re-run the basedpyright budget gate on push to long-lived branches

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -7,12 +7,19 @@ on:
       - litellm_internal_staging
       - litellm_oss_branch
       - "litellm_**"
+  push:
+    branches:
+      - main
+      - litellm_internal_staging
+      - litellm_oss_branch
+      - "litellm_**"
 
 permissions:
   contents: read
 
 jobs:
   lint:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -106,6 +113,7 @@ jobs:
   # must be kept OUT of the branch-protection required-checks list so a justified
   # bump can still be merged by a human who has seen and accepted the red.
   budget-ratchet:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -129,6 +137,7 @@ jobs:
           python scripts/budget_ratchet_check.py --base "$BASE_SHA"
 
   secret-scan:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -163,3 +172,42 @@ jobs:
           else
             echo "GITGUARDIAN_API_KEY not set, skipping ggshield scan"
           fi
+
+  # Re-runs the absolute-count gates against the post-merge tree. The PR `lint`
+  # job checks out each PR head in isolation, so two PRs that each pass on their
+  # own stale base can still push a codebase-wide count (e.g. the basedpyright
+  # per-rule budget) over its ceiling once both land -- "green apart, red
+  # together". Nothing re-evaluates the budget on the merge result, so the breach
+  # only surfaces on the next unlucky PR that happens to be checked out after the
+  # count crossed the line. Running the same absolute gate on push to the
+  # long-lived branches catches the accumulation on the merge commit itself.
+  post-merge-budget:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.9"
+
+      - name: Install dependencies
+        run: |
+          uv sync --frozen
+
+      - name: Re-check basedpyright per-rule budget on the merged tree
+        run: |
+          (uv run --no-sync basedpyright --outputjson || true) | uv run --no-sync python scripts/type_check_gate.py


### PR DESCRIPTION
## Relevant issues

Follow-up to the `reportReturnType` budget breach that turned the LiteLLM Linting check red on every PR branched off `litellm_internal_staging` (for example #30446, fixed in #31103). That was a symptom; this PR closes the hole that let it land in the first place.

## Root cause

The basedpyright gate (`scripts/type_check_gate.py`) counts absolute codebase-wide errors per rule against a committed ceiling in `basedpyright-code-budget.json`. Unlike the ruff and type-discipline gates it is not a delta-vs-base check; it judges the whole tree. But the linting workflow only ran it on `pull_request`, against each PR's own head. Two PRs that each pass in isolation can together push a per-rule count over its ceiling once both merge, and nothing re-evaluated the budget on the merge commit. So the breach stayed invisible until the next PR happened to be checked out after the count had already crossed the line, at which point an unrelated PR inherited a red that it did nothing to cause. Green apart, red together.

## Fix

Add a `push` trigger on the long-lived branches (`main`, `litellm_internal_staging`, `litellm_oss_branch`, `litellm_**`) and a `post-merge-budget` job that re-runs the absolute basedpyright gate on the merged tree. Accumulation now turns the branch red on the merge commit itself instead of ambushing the next PR. The existing `pull_request` jobs (`lint`, `budget-ratchet`, `secret-scan`) are guarded with `if: github.event_name == 'pull_request'` so their delta-vs-base steps, which need a PR base SHA that does not exist on push, don't misfire.

Complementary and out of scope for this repo change: enabling "Require branches to be up to date before merging" in branch protection for staging would force each PR to re-test against the latest base before landing, which would have caught this on the PR side too.

## Type

🚄 Infrastructure

## Changes

`.github/workflows/test-linting.yml`: add a push trigger and a `post-merge-budget` job that re-runs the absolute basedpyright gate on long-lived branches; scope the pull_request-only jobs with an event guard. No application code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cys2zr1vmqLJMrmNvEa3MA)_