### PR TITLE
fix(guardrails): apply custom_code modify(images=...) on the request path

### DIFF
--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -14,6 +14,7 @@ Pattern Overview:
 This pattern can be replicated for other message formats (e.g., Anthropic).
 """
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Union, cast
 
 import litellm
@@ -87,6 +88,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         images_to_check: list[str] = []
         tool_calls_to_check: list[ChatCompletionToolParam] = []
         text_task_mappings: list[tuple[int, int | None]] = []
+        image_task_mappings: list[tuple[int, int]] = []  # mutable-ok: accumulator appended in _extract_inputs
         tool_call_task_mappings: list[tuple[int, int]] = []
 
         # Step 1: Extract all text content, images, and tool calls
@@ -98,13 +100,17 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 images_to_check=images_to_check,
                 tool_calls_to_check=tool_calls_to_check,
                 text_task_mappings=text_task_mappings,
+                image_task_mappings=image_task_mappings,
                 tool_call_task_mappings=tool_call_task_mappings,
                 skip_system_message=skip_system,
                 skip_tool_message=skip_tool,
             )
 
-        # Step 2: Apply guardrail to all texts and tool calls in batch
-        if texts_to_check or tool_calls_to_check:
+        # Step 2: Apply guardrail to texts, tool calls, and images in batch.
+        # images_to_check is included so image-only requests still invoke the
+        # guardrail; otherwise a guardrail that strips/rewrites images would be
+        # bypassed when a message contains only image_url blocks (issue #31071).
+        if texts_to_check or tool_calls_to_check or images_to_check:
             inputs = GenericGuardrailAPIInputs(texts=texts_to_check)
             if images_to_check:
                 inputs["images"] = images_to_check
@@ -163,6 +169,16 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         task_mappings=tool_call_task_mappings,
                     )
 
+                # Step 5: Apply guardrailed images back to messages. No-op when
+                # no images were extracted or the guardrail returned no "images"
+                # key, so guardrails that do not touch images leave them
+                # unchanged (issue #31071).
+                await self._apply_guardrail_responses_to_input_images(
+                    messages=messages,
+                    responses=guardrailed_inputs.get("images"),
+                    task_mappings=image_task_mappings,
+                )
+
         verbose_proxy_logger.debug(
             "OpenAI Chat Completions: Processed input messages: %s",
             data.get("messages"),
@@ -191,6 +207,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
         images_to_check: list[str],
         tool_calls_to_check: list[ChatCompletionToolParam],
         text_task_mappings: list[tuple[int, int | None]],
+        image_task_mappings: list[tuple[int, int]],  # mutable-ok: accumulator appended in _extract_inputs
         tool_call_task_mappings: list[tuple[int, int]],
         skip_system_message: bool = False,
         skip_tool_message: bool = False,
@@ -229,8 +246,10 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                             url = image_url.get("url")
                             if url:
                                 images_to_check.append(url)
+                                image_task_mappings.append((msg_idx, int(content_idx)))
                         elif isinstance(image_url, str):
                             images_to_check.append(image_url)
+                            image_task_mappings.append((msg_idx, int(content_idx)))
 
         # Extract tool calls (typically in assistant messages)
         tool_calls = message.get("tool_calls", None)
@@ -292,6 +311,44 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     if tool_call_idx < len(message_tool_calls):
                         # Replace the tool call with the guardrailed version
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
+
+    async def _apply_guardrail_responses_to_input_images(
+        self,
+        messages: list[dict[str, Any]],  # mutable-ok: image content blocks rewritten/removed in place
+        responses: Sequence[Any] | None,
+        task_mappings: Sequence[tuple[int, int]],
+    ) -> None:
+        """
+        Apply guardrailed images back to input message content.
+
+        No-op when ``responses`` is None (the guardrail did not return an
+        "images" key), so guardrails that do not touch images leave them
+        unchanged. Mirrors the text/tool_call write-back: a returned image at
+        the same position replaces the original ``image_url``; positions with no
+        corresponding returned image (e.g. ``modify(images=[])`` to strip images)
+        have their image content block removed. Removals are applied per message
+        in descending content index so earlier indices stay valid.
+        """
+        if responses is None:
+            return
+        removals: list[tuple[Any, int]] = []  # mutable-ok: local accumulator, applied in a second pass
+        for task_idx, (msg_idx, content_idx) in enumerate(task_mappings):
+            content = messages[msg_idx].get("content")
+            if not isinstance(content, list) or content_idx >= len(content):
+                continue
+            if task_idx < len(responses):
+                new_image = responses[task_idx]
+                image_url = content[content_idx].get("image_url")
+                if isinstance(image_url, dict):
+                    content[content_idx]["image_url"]["url"] = new_image
+                else:
+                    content[content_idx]["image_url"] = new_image
+            else:
+                removals.append((content, content_idx))
+
+        # Delete the highest content index first so earlier indices stay valid.
+        for content, content_idx in sorted(removals, key=lambda r: r[1], reverse=True):
+            del content[content_idx]
 
     async def process_output_response(
         self,

--- a/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
+++ b/tests/test_litellm/llms/openai/chat/guardrail_translation/test_openai_guardrail_handler.py
@@ -12,9 +12,7 @@ from typing import Any, Literal, Optional
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../../../.."))  # Adds the parent directory to the system path
 
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.llms.openai.chat.guardrail_translation.handler import (
@@ -197,9 +195,7 @@ class TestOpenAIChatCompletionsHandlerToolsInput:
         tool = guardrail.last_inputs["tools"][0]
         assert tool["type"] == "function"
         assert tool["function"]["name"] == "get_weather"
-        assert (
-            tool["function"]["description"] == "Get the current weather in a location"
-        )
+        assert tool["function"]["description"] == "Get the current weather in a location"
         assert "parameters" in tool["function"]
 
     @pytest.mark.asyncio
@@ -254,10 +250,7 @@ class TestOpenAIChatCompletionsHandlerToolsInput:
 
         assert guardrail.last_inputs is not None
         # tools should not be in inputs if not provided
-        assert (
-            "tools" not in guardrail.last_inputs
-            or guardrail.last_inputs.get("tools") is None
-        )
+        assert "tools" not in guardrail.last_inputs or guardrail.last_inputs.get("tools") is None
 
     @pytest.mark.asyncio
     async def test_tools_and_tool_calls_both_passed(self):
@@ -329,9 +322,7 @@ class TestOpenAIChatCompletionsHandlerToolCallsInput:
                             "type": "function",
                             "function": {
                                 "name": "get_weather",
-                                "arguments": json.dumps(
-                                    {"location": "San Francisco", "unit": "celsius"}
-                                ),
+                                "arguments": json.dumps({"location": "San Francisco", "unit": "celsius"}),
                             },
                         }
                     ],
@@ -405,10 +396,7 @@ class TestOpenAIChatCompletionsHandlerToolCallsInput:
 
         # Should have 1 tool call
         assert len(guardrail.last_inputs["tool_calls"]) == 1
-        assert (
-            guardrail.last_inputs["tool_calls"][0]["function"]["name"]
-            == "get_current_weather"
-        )
+        assert guardrail.last_inputs["tool_calls"][0]["function"]["name"] == "get_current_weather"
 
         # Verify text content was modified
         assert data["messages"][0]["content"] == "WHAT'S THE WEATHER?"
@@ -648,9 +636,7 @@ class TestOpenAIChatCompletionsHandlerToolCallsOutput:
                                 type="function",
                                 function=Function(
                                     name="web_search",
-                                    arguments=json.dumps(
-                                        {"keywords": "litellm documentation"}
-                                    ),
+                                    arguments=json.dumps({"keywords": "litellm documentation"}),
                                 ),
                             )
                         ],
@@ -673,9 +659,7 @@ class TestOpenAIChatCompletionsHandlerToolCallsOutput:
         assert len(guardrail.last_inputs["tool_calls"]) == 1
 
         # Verify both were modified
-        assert (
-            response.choices[0].message.content == "I'LL SEARCH FOR THAT INFORMATION."
-        )
+        assert response.choices[0].message.content == "I'LL SEARCH FOR THAT INFORMATION."
         response_tool_call = response.choices[0].message.tool_calls[0]
         args = json.loads(response_tool_call.function.arguments)
         assert args["keywords"] == "LITELLM DOCUMENTATION"
@@ -865,9 +849,7 @@ class TestOpenAIChatCompletionsHandlerToolCallsOutput:
                             ChatCompletionMessageToolCall(
                                 id="call_email",
                                 type="function",
-                                function=Function(
-                                    name="send_email", arguments=original
-                                ),
+                                function=Function(name="send_email", arguments=original),
                             )
                         ],
                     ),
@@ -905,16 +887,12 @@ class TestOpenAIChatCompletionsHandlerToolCallsOutput:
                             ChatCompletionMessageToolCall(
                                 id="call_1",
                                 type="function",
-                                function=Function(
-                                    name="send_email", arguments=first_args
-                                ),
+                                function=Function(name="send_email", arguments=first_args),
                             ),
                             ChatCompletionMessageToolCall(
                                 id="call_2",
                                 type="function",
-                                function=Function(
-                                    name="send_email", arguments=second_args
-                                ),
+                                function=Function(name="send_email", arguments=second_args),
                             ),
                         ],
                     ),
@@ -1132,6 +1110,191 @@ class TestGetStructuredMessages:
         assert result is not None
         assert len(result) == 1
         assert isinstance(result[0]["content"], list)
+
+
+class MockImageRewriteGuardrail(CustomGuardrail):
+    """Returns rewritten image urls (same count) and echoes texts."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        result = GenericGuardrailAPIInputs(texts=inputs.get("texts", []))
+        images = inputs.get("images", [])
+        result["images"] = [f"redacted::{img}" for img in images]  # type: ignore
+        return result
+
+
+class MockImageStripGuardrail(CustomGuardrail):
+    """Strips all images via modify(images=[])."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        result = GenericGuardrailAPIInputs(texts=inputs.get("texts", []))
+        result["images"] = []  # type: ignore
+        return result
+
+
+class MockTextOnlyGuardrail(CustomGuardrail):
+    """Returns only texts, never an images key -> images must be left untouched."""
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        return GenericGuardrailAPIInputs(texts=inputs.get("texts", []))
+
+
+class TestOpenAIChatCompletionsHandlerImagesInput:
+    """Issue #31071: guardrail modify(images=...) must be applied back to messages."""
+
+    @pytest.mark.asyncio
+    async def test_images_rewritten_in_input_messages(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockImageRewriteGuardrail(guardrail_name="img")
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "look"},
+                        {"type": "image_url", "image_url": {"url": "http://x/a.png"}},
+                    ],
+                }
+            ]
+        }
+        await handler.process_input_messages(data, guardrail)
+        content = data["messages"][0]["content"]
+        assert content[1]["image_url"]["url"] == "redacted::http://x/a.png"
+
+    @pytest.mark.asyncio
+    async def test_images_stripped_in_input_messages(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockImageStripGuardrail(guardrail_name="strip")
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {"type": "image_url", "image_url": {"url": "http://x/a.png"}},
+                    ],
+                }
+            ]
+        }
+        await handler.process_input_messages(data, guardrail)
+        content = data["messages"][0]["content"]
+        assert all(item.get("type") != "image_url" for item in content)
+        assert any(item.get("type") == "text" for item in content)
+
+    @pytest.mark.asyncio
+    async def test_images_untouched_when_guardrail_omits_images_key(self):
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockTextOnlyGuardrail(guardrail_name="textonly")
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hi"},
+                        {"type": "image_url", "image_url": {"url": "http://x/a.png"}},
+                    ],
+                }
+            ]
+        }
+        await handler.process_input_messages(data, guardrail)
+        content = data["messages"][0]["content"]
+        assert content[1]["image_url"]["url"] == "http://x/a.png"
+
+    @pytest.mark.asyncio
+    async def test_apply_images_str_form_and_partial_removal(self):
+        handler = OpenAIChatCompletionsHandler()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": "http://x/a.png"},
+                    {"type": "image_url", "image_url": {"url": "http://x/b.png"}},
+                ],
+            }
+        ]
+        # One response -> first replaced (str form), second removed.
+        await handler._apply_guardrail_responses_to_input_images(
+            messages=messages,
+            responses=["http://x/A.png"],
+            task_mappings=[(0, 0), (0, 1)],
+        )
+        content = messages[0]["content"]
+        assert len(content) == 1
+        assert content[0]["image_url"] == "http://x/A.png"
+
+    @pytest.mark.asyncio
+    async def test_images_str_form_rewritten_via_process_input_messages(self):
+        # string-form image_url is extracted, sent, and written back end-to-end
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockImageRewriteGuardrail(guardrail_name="imgstr")
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "hi"},
+                        {"type": "image_url", "image_url": "http://x/a.png"},
+                    ],
+                }
+            ]
+        }
+        await handler.process_input_messages(data, guardrail)
+        content = data["messages"][0]["content"]
+        assert content[1]["image_url"] == "redacted::http://x/a.png"
+
+    @pytest.mark.asyncio
+    async def test_apply_images_skips_invalid_mappings(self):
+        # non-list content and out-of-range index are skipped without error
+        handler = OpenAIChatCompletionsHandler()
+        messages = [
+            {"role": "user", "content": "just text"},
+            {"role": "user", "content": [{"type": "text", "text": "x"}]},
+        ]
+        await handler._apply_guardrail_responses_to_input_images(
+            messages=messages,
+            responses=["ignored"],
+            task_mappings=[(0, 0), (1, 5)],
+        )
+        assert messages[0]["content"] == "just text"
+        assert messages[1]["content"] == [{"type": "text", "text": "x"}]
+
+    @pytest.mark.asyncio
+    async def test_image_only_request_invokes_image_guardrail(self):
+        # An image-only message (no text / tool_calls) must still invoke the
+        # guardrail, or image strip/rewrite is bypassed (issue #31071 review).
+        handler = OpenAIChatCompletionsHandler()
+        guardrail = MockImageStripGuardrail(guardrail_name="imgonly")
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": "http://x/a.png"}},
+                    ],
+                }
+            ]
+        }
+        await handler.process_input_messages(data, guardrail)
+        content = data["messages"][0]["content"]
+        # guardrail ran and stripped the image -> no image_url blocks remain
+        assert all(item.get("type") != "image_url" for item in content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

A `custom_code` guardrail returning `modify(images=...)` on the request path had no effect. `texts` and `tool_calls` were written back to the outgoing messages, but `images` were silently dropped, so `modify(images=[])` to strip images or `modify(images=[...])` to rewrite them did nothing and the original image content was forwarded upstream.

## Why

`OpenAIChatCompletionsHandler.process_input_messages` extracts images and sends them to the guardrail, but there was no `image_task_mappings` and no image write-back step — only texts and tool_calls were mapped back onto `messages`.

## Fix

Mirror the existing text/tool_call handling: track each image's `(msg_idx, content_idx)` during extraction, then apply the guardrail's returned images back. A returned image replaces the original `image_url` (dict or string form); positions with no corresponding returned image (e.g. `modify(images=[])`) have their image block removed, deleting per message in descending index so earlier indices stay valid. Only runs when the guardrail returns an `images` key, so guardrails that don't touch images leave them unchanged.

## Tests

Added under `test_openai_guardrail_handler.py`: image rewrite, strip (`images=[]`), str-form `image_url` + partial removal, and a regression test that images are untouched when the guardrail omits the `images` key.

Fixes #31071.
