### PR TITLE
fix(bedrock_mantle): honor custom endpoint on the bedrock/mantle/ route

### DIFF
--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -7,10 +7,14 @@ The bedrock-mantle endpoint uses the Anthropic Messages API format but is served
 at a different endpoint (bedrock-mantle.{region}.api.aws) with AWS SigV4 auth.
 """
 
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, cast
 
 from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeConfig,
+)
+from litellm.llms.bedrock.mantle_common import (
+    get_runtime_endpoint_override,
+    resolve_mantle_messages_url,
 )
 from litellm.types.llms.openai import AllMessageValues
 
@@ -20,10 +24,6 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
-
-MANTLE_ENDPOINT_TEMPLATE = (
-    "https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages"
-)
 
 
 class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
@@ -46,7 +46,14 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
         stream: Optional[bool] = None,
     ) -> str:
         region = self._get_aws_region_name(optional_params=optional_params, model=model)
-        return MANTLE_ENDPOINT_TEMPLATE.format(region=region)
+        return resolve_mantle_messages_url(
+            region=region,
+            api_base=api_base,
+            aws_bedrock_runtime_endpoint=get_runtime_endpoint_override(
+                cast(Mapping[str, object], optional_params),
+                cast(Mapping[str, object], litellm_params),
+            ),
+        )
 
     def validate_environment(
         self,

--- a/litellm/llms/bedrock/mantle_common.py
+++ b/litellm/llms/bedrock/mantle_common.py
@@ -1,0 +1,37 @@
+"""
+Shared endpoint resolution for the Bedrock Mantle (Claude Mythos Preview) routes.
+
+The chat (`bedrock/mantle/...`) and Anthropic Messages (`/v1/messages`) configs
+both target the bedrock-mantle endpoint over the Anthropic Messages path. They
+must honor a caller-supplied `api_base` or `aws_bedrock_runtime_endpoint` so a
+deployment can route through a private (VPC) endpoint instead of the public host
+"""
+
+from typing import Mapping, Optional
+
+MANTLE_MESSAGES_PATH = "/anthropic/v1/messages"
+
+
+def get_runtime_endpoint_override(
+    *param_sources: Mapping[str, object]
+) -> Optional[str]:
+    for source in param_sources:
+        value = source.get("aws_bedrock_runtime_endpoint")
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def resolve_mantle_messages_url(
+    region: str,
+    api_base: Optional[str],
+    aws_bedrock_runtime_endpoint: Optional[str],
+) -> str:
+    base = (
+        api_base
+        or aws_bedrock_runtime_endpoint
+        or f"https://bedrock-mantle.{region}.api.aws"
+    ).rstrip("/")
+    if base.endswith(MANTLE_MESSAGES_PATH):
+        return base
+    return f"{base}{MANTLE_MESSAGES_PATH}"

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -6,8 +6,12 @@ AmazonAnthropicClaudeMessagesConfig. Overrides only the URL and model-prefix
 stripping that are specific to the bedrock-mantle endpoint.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Tuple, cast
 
+from litellm.llms.bedrock.mantle_common import (
+    get_runtime_endpoint_override,
+    resolve_mantle_messages_url,
+)
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeMessagesConfig,
 )
@@ -19,10 +23,6 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
-
-MANTLE_ENDPOINT_TEMPLATE = (
-    "https://bedrock-mantle.{region}.api.aws/anthropic/v1/messages"
-)
 
 
 class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
@@ -43,7 +43,14 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         stream: Optional[bool] = None,
     ) -> str:
         region = self._get_aws_region_name(optional_params=optional_params, model=model)
-        return MANTLE_ENDPOINT_TEMPLATE.format(region=region)
+        return resolve_mantle_messages_url(
+            region=region,
+            api_base=api_base,
+            aws_bedrock_runtime_endpoint=get_runtime_endpoint_override(
+                cast(Mapping[str, object], optional_params),
+                cast(Mapping[str, object], litellm_params),
+            ),
+        )
 
     def validate_anthropic_messages_environment(
         self,

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -247,3 +247,154 @@ async def test_mantle_anthropic_messages_sends_workspace_header_and_clean_body()
     assert requests[0]["path"] == "/anthropic/v1/messages"
     assert requests[0]["headers"]["anthropic-workspace"] == "proj_abc123def456"
     assert "aws_bedrock_project_id" not in requests[0]["body"]
+
+
+_VPCE_BASE = "https://vpce-0a1b2c3d.bedrock-mantle.us-east-1.vpce.amazonaws.com"
+
+
+class TestMantleCustomEndpointOverride:
+    """The bedrock/mantle/ route must route through a caller-supplied private
+    endpoint (api_base or aws_bedrock_runtime_endpoint) instead of the hardcoded
+    public host, so deployments behind a VPC endpoint can reach Mantle.
+
+    Each case fails against the previous behaviour, which ignored both overrides
+    and always returned the public bedrock-mantle.{region}.api.aws host.
+    """
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_api_base_overrides_public_host(self, config):
+        url = config.get_complete_url(
+            api_base=_VPCE_BASE,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": "us-east-1"},
+            litellm_params={},
+        )
+        assert url == f"{_VPCE_BASE}/anthropic/v1/messages"
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_aws_bedrock_runtime_endpoint_overrides_public_host(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={
+                "aws_region_name": "us-east-1",
+                "aws_bedrock_runtime_endpoint": _VPCE_BASE,
+            },
+            litellm_params={},
+        )
+        assert url == f"{_VPCE_BASE}/anthropic/v1/messages"
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_aws_bedrock_runtime_endpoint_from_litellm_params(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": "us-east-1"},
+            litellm_params={"aws_bedrock_runtime_endpoint": _VPCE_BASE},
+        )
+        assert url == f"{_VPCE_BASE}/anthropic/v1/messages"
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_api_base_takes_precedence_over_runtime_endpoint(self, config):
+        url = config.get_complete_url(
+            api_base=_VPCE_BASE,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={
+                "aws_region_name": "us-east-1",
+                "aws_bedrock_runtime_endpoint": "https://wrong.example.com",
+            },
+            litellm_params={},
+        )
+        assert url == f"{_VPCE_BASE}/anthropic/v1/messages"
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_override_with_full_path_is_not_doubled(self, config):
+        full = f"{_VPCE_BASE}/anthropic/v1/messages"
+        url = config.get_complete_url(
+            api_base=full,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": "us-east-1"},
+            litellm_params={},
+        )
+        assert url == full
+
+    @pytest.mark.parametrize(
+        "config", [AmazonMantleConfig(), AmazonMantleMessagesConfig()]
+    )
+    def test_no_override_keeps_public_host(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="mantle/anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": "us-west-2"},
+            litellm_params={},
+        )
+        assert url == "https://bedrock-mantle.us-west-2.api.aws/anthropic/v1/messages"
+
+
+def test_mantle_completion_routes_to_custom_endpoint():
+    import litellm
+
+    urls = []
+
+    def mock_post(self, url, data=None, headers=None, **kwargs):
+        urls.append(url)
+        return _anthropic_response(url)
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+        litellm.completion(
+            model="bedrock/mantle/anthropic.claude-mythos-preview",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=10,
+            aws_bedrock_runtime_endpoint=_VPCE_BASE,
+            aws_access_key_id="fake-key",
+            aws_secret_access_key="fake-secret",
+            aws_region_name="us-east-1",
+        )
+
+    assert urls == [f"{_VPCE_BASE}/anthropic/v1/messages"]
+
+
+@pytest.mark.asyncio
+async def test_mantle_anthropic_messages_routes_to_custom_endpoint():
+    import litellm
+
+    urls = []
+
+    async def mock_post(self, url, data=None, headers=None, **kwargs):
+        urls.append(url)
+        return _anthropic_response(url)
+
+    try:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new=mock_post,
+        ):
+            await litellm.anthropic_messages(
+                model="bedrock/mantle/anthropic.claude-mythos-preview",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=10,
+                aws_bedrock_runtime_endpoint=_VPCE_BASE,
+                aws_access_key_id="fake-key",
+                aws_secret_access_key="fake-secret",
+                aws_region_name="us-east-1",
+            )
+    finally:
+        await litellm.close_litellm_async_clients()
+
+    assert urls == [f"{_VPCE_BASE}/anthropic/v1/messages"]


### PR DESCRIPTION
## Relevant issues

The `bedrock/mantle/` route ignored `api_base` and `aws_bedrock_runtime_endpoint`, so a deployment behind a private VPC endpoint could not route Mantle traffic through it. This is the limitation reported against the SigV4 Mantle route; the OpenAI-compatible `bedrock_mantle/` route already honored `api_base`, only the SigV4 `bedrock/mantle/` route did not

## Linear ticket

LIT-3676

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

I do not have Bedrock Mantle access from here, so this needs to be run against a real Mantle endpoint (ideally the cross-account VPC endpoint setup). Runbook to capture the proof:

1. Add two models to a config (swap in a real Mantle model id, region, and your VPC endpoint host):

```yaml
model_list:
  - model_name: mantle-claude-msgs
    litellm_params:
      model: bedrock/mantle/anthropic.claude-mythos-preview
      aws_region_name: us-east-1
      aws_bedrock_runtime_endpoint: https://vpce-xxxxxxxx.bedrock-mantle.us-east-1.vpce.amazonaws.com
  - model_name: mantle-claude-chat
    litellm_params:
      model: bedrock/mantle/anthropic.claude-mythos-preview
      aws_region_name: us-east-1
      api_base: https://vpce-xxxxxxxx.bedrock-mantle.us-east-1.vpce.amazonaws.com
```

2. Start the proxy with debug on:

```
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

3. Hit the Anthropic Messages route (exercises `AmazonMantleMessagesConfig`):

```
curl -s http://localhost:4000/v1/messages \
  -H "x-api-key: $LITELLM_MASTER_KEY" -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"mantle-claude-msgs","max_tokens":64,"messages":[{"role":"user","content":"say hi"}]}'
```

4. Hit the chat route (exercises `AmazonMantleConfig`):

```
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "content-type: application/json" \
  -d '{"model":"mantle-claude-chat","max_tokens":64,"messages":[{"role":"user","content":"say hi"}]}'
```

5. In `litellm.log`, confirm the outbound `POST` for both goes to `https://vpce-xxxxxxxx.bedrock-mantle.us-east-1.vpce.amazonaws.com/anthropic/v1/messages` rather than the public `https://bedrock-mantle.us-east-1.api.aws/...` host. Before this change the outbound host was always the public one regardless of the override

## Type

🐛 Bug Fix

## Changes

Both configs that serve the `bedrock/mantle/` route built their URL from a hardcoded `MANTLE_ENDPOINT_TEMPLATE` and ignored every endpoint override. `AmazonMantleConfig` (chat completions) and `AmazonMantleMessagesConfig` (Anthropic Messages) now resolve the URL through a shared `resolve_mantle_messages_url` helper that honors an explicit `api_base`, then `aws_bedrock_runtime_endpoint` (read from either `optional_params` or `litellm_params`), and falls back to the public `bedrock-mantle.{region}.api.aws` host when neither is set, so behavior is unchanged for callers that pass no override. The Anthropic Messages path is appended to the resolved base, and an override that already includes that path is not doubled. This matches the precedence the standard Bedrock Invoke route already uses through `get_runtime_endpoint`

The endpoint constant that was duplicated across the two transformation files is removed in favor of the shared resolver, so the URL is defined in one place

Tests live in the mapped `tests/test_litellm/llms/bedrock/test_mantle.py`. They cover both configs and both override params at the unit level, the `api_base` over `aws_bedrock_runtime_endpoint` precedence, the no-double-path case, the unchanged default host, and two end-to-end cases through `litellm.completion` and `litellm.anthropic_messages` that assert the outbound request URL is the override. Each override assertion fails against the previous hardcoded behavior and passes with the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_0131GVHAqtD89LLfKvx2e2FP)_