### PR TITLE
fix(gemini): preserve thoughtSignature for server-side tool responses

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1039,9 +1039,9 @@ def _gemini_convert_messages_with_history(
                                 if invocation.get("tool_type"):
                                     tr_dict["toolType"] = invocation["tool_type"]
                                 tr_part: Dict[str, Any] = {"toolResponse": tr_dict}
-                                if "thought_signature" in invocation:
+                                if "response_thought_signature" in invocation:
                                     tr_part["thoughtSignature"] = invocation[
-                                        "thought_signature"
+                                        "response_thought_signature"
                                     ]
                                 assistant_content.append(tr_part)  # type: ignore
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1639,6 +1639,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         # Any orphan responses (shouldn't happen, but be safe)
         for resp_id, resp_entry in tool_responses_by_id.items():
+            if "thought_signature" in resp_entry:
+                resp_entry["response_thought_signature"] = resp_entry[
+                    "thought_signature"
+                ]
             invocations.append(resp_entry)
 
         return invocations if invocations else None

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1633,9 +1633,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             resp = tool_responses_by_id.pop(call_id, None)
             if resp is not None:
                 merged["response"] = resp.get("response")
-                # Keep response signature if call didn't have one
-                if "thought_signature" not in merged and "thought_signature" in resp:
-                    merged["thought_signature"] = resp["thought_signature"]
+                if "thought_signature" in resp:
+                    merged["response_thought_signature"] = resp["thought_signature"]
             invocations.append(merged)
 
         # Any orphan responses (shouldn't happen, but be safe)

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_context_circulation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_context_circulation.py
@@ -62,6 +62,7 @@ class TestExtractServerSideToolInvocations:
         assert result[0]["args"] == {"queries": ["weather Buenos Aires"]}
         assert result[0]["response"] == {"weather": "Sunny, 20°C"}
         assert result[0]["thought_signature"] == "sig_call_1"
+        assert result[0]["response_thought_signature"] == "sig_resp_1"
 
     def test_returns_none_when_no_server_side_tools(self):
         """No toolCall/toolResponse parts → returns None."""
@@ -176,6 +177,27 @@ class TestExtractServerSideToolInvocations:
         assert result[0]["thought_signature"] == "sig_call_1"
         assert result[0]["response_thought_signature"] == "sig_resp_1"
 
+    def test_orphan_response_signature_extraction(self):
+        """Orphan toolResponse is captured and has response_thought_signature set."""
+        parts: List[HttpxPartType] = [
+            {
+                "thoughtSignature": "sig_resp_1",
+                "toolResponse": {
+                    "toolType": "GOOGLE_SEARCH_WEB",
+                    "id": "orphan123",
+                    "response": {"result": "some response"},
+                },
+            },
+        ]
+
+        result = VertexGeminiConfig._extract_server_side_tool_invocations(parts)
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["id"] == "orphan123"
+        assert result[0]["response"] == {"result": "some response"}
+        assert result[0]["response_thought_signature"] == "sig_resp_1"
+
 
 # --- Input re-injection tests ---
 
@@ -268,6 +290,38 @@ class TestReInjectServerSideToolInvocations:
 
         assert len(tool_response_parts) == 1
         assert tool_response_parts[0]["thoughtSignature"] == "sig_resp"
+
+    def test_roundtrip_orphan_response_signature(self):
+        """Orphan response signature is preserved and re-injected into toolResponse part."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "It's sunny in Buenos Aires.",
+                "provider_specific_fields": {
+                    "server_side_tool_invocations": [
+                        {
+                            "tool_type": "GOOGLE_SEARCH_WEB",
+                            "id": "orphan123",
+                            "response": {"result": "some response"},
+                            "response_thought_signature": "sig_orphan_resp",
+                        }
+                    ]
+                },
+            },
+            {"role": "user", "content": "Thanks!"},
+        ]
+
+        contents = _gemini_convert_messages_with_history(messages)
+
+        model_turn = [c for c in contents if c["role"] == "model"]
+        assert len(model_turn) == 1
+
+        parts = model_turn[0]["parts"]
+        tool_response_parts = [p for p in parts if "toolResponse" in p]
+
+        assert len(tool_response_parts) == 1
+        assert tool_response_parts[0]["thoughtSignature"] == "sig_orphan_resp"
 
     def test_no_invocations_no_extra_parts(self):
         """Without server_side_tool_invocations, no extra parts are added."""

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_context_circulation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_context_circulation.py
@@ -22,7 +22,6 @@ from litellm.llms.vertex_ai.gemini.transformation import (
 )
 from litellm.types.llms.vertex_ai import HttpxPartType
 
-
 # --- Response extraction tests ---
 
 
@@ -145,6 +144,38 @@ class TestExtractServerSideToolInvocations:
         assert result[0]["id"] == "exec1"
         assert "response" not in result[0]
 
+    def test_extracts_tool_call_and_response_with_different_signatures(self):
+        """Case where toolCall and toolResponse have different signatures."""
+        parts: List[HttpxPartType] = [
+            {
+                "thoughtSignature": "sig_call_1",
+                "toolCall": {
+                    "toolType": "GOOGLE_SEARCH_WEB",
+                    "id": "abc123",
+                    "args": {"queries": ["weather Buenos Aires"]},
+                },
+            },
+            {
+                "thoughtSignature": "sig_resp_1",
+                "toolResponse": {
+                    "toolType": "GOOGLE_SEARCH_WEB",
+                    "id": "abc123",
+                    "response": {"weather": "Sunny, 20°C"},
+                },
+            },
+        ]
+
+        result = VertexGeminiConfig._extract_server_side_tool_invocations(parts)
+
+        assert result is not None
+        assert len(result) == 1
+        assert result[0]["tool_type"] == "GOOGLE_SEARCH_WEB"
+        assert result[0]["id"] == "abc123"
+        assert result[0]["args"] == {"queries": ["weather Buenos Aires"]}
+        assert result[0]["response"] == {"weather": "Sunny, 20°C"}
+        assert result[0]["thought_signature"] == "sig_call_1"
+        assert result[0]["response_thought_signature"] == "sig_resp_1"
+
 
 # --- Input re-injection tests ---
 
@@ -199,6 +230,44 @@ class TestReInjectServerSideToolInvocations:
         assert tool_response_parts[0]["toolResponse"]["response"] == {
             "weather": "Sunny, 20°C"
         }
+
+    def test_roundtrip_single_invocation_with_different_signatures(self):
+        """Server-side invocations with different signatures for call and response."""
+        messages = [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "It's sunny in Buenos Aires.",
+                "provider_specific_fields": {
+                    "server_side_tool_invocations": [
+                        {
+                            "tool_type": "GOOGLE_SEARCH_WEB",
+                            "id": "abc123",
+                            "args": {"queries": ["weather Buenos Aires"]},
+                            "response": {"weather": "Sunny, 20°C"},
+                            "thought_signature": "sig_call",
+                            "response_thought_signature": "sig_resp",
+                        }
+                    ]
+                },
+            },
+            {"role": "user", "content": "Thanks!"},
+        ]
+
+        contents = _gemini_convert_messages_with_history(messages)
+
+        model_turn = [c for c in contents if c["role"] == "model"]
+        assert len(model_turn) == 1
+
+        parts = model_turn[0]["parts"]
+        tool_call_parts = [p for p in parts if "toolCall" in p]
+        tool_response_parts = [p for p in parts if "toolResponse" in p]
+
+        assert len(tool_call_parts) == 1
+        assert tool_call_parts[0]["thoughtSignature"] == "sig_call"
+
+        assert len(tool_response_parts) == 1
+        assert tool_response_parts[0]["thoughtSignature"] == "sig_resp"
 
     def test_no_invocations_no_extra_parts(self):
         """Without server_side_tool_invocations, no extra parts are added."""


### PR DESCRIPTION
When Gemini API returns toolCall and toolResponse parts, they might have different thoughtSignatures. Previously, LiteLLM merged them into a single dict, overwriting the response's thoughtSignature with the call's.
This fix extracts them separately and re-injects them correctly.

## Proof of Fix

We verified the fix in two ways:
1.  **Local Demo (Before vs After)**: Showing how the bug behaved before the fix and how it behaves now.
2.  **Live E2E Verification**: Confirmed with a live call to `gemini-3.1-flash-lite`.

---

### 1. Local Demo (Before vs After)

We ran a local demo simulation with distinct signatures:
- Call Signature: `sig_call_1`
- Response Signature: `sig_resp_1`

#### ❌ BEFORE (Buggy)
Signatures are not kept separate during extraction, and both parts get the call's signature during re-injection:

```yaml
# Extraction Result
thought_signature: "sig_call_1"
response_thought_signature: null # ❌ Lost

# Re-injection Result (Gemini Format)
- toolCall: { ... }
  thoughtSignature: "sig_call_1"
- toolResponse: { ... }
  thoughtSignature: "sig_call_1" # ❌ Overwritten with Call's signature
```

####  AFTER (Fixed)
Signatures are correctly separated and re-injected:

```yaml
# Extraction Result
thought_signature: "sig_call_1"
response_thought_signature: "sig_resp_1" #  Preserved

# Re-injection Result (Gemini Format)
- toolCall: { ... }
  thoughtSignature: "sig_call_1" #  Correct
- toolResponse: { ... }
  thoughtSignature: "sig_resp_1" #  Correct
```

<details>
<summary>Detailed Demo Logs (Before vs After)</summary>

**Before Logs:**
```
--- Demo: Extraction of different signatures ---
Verification:
  Call Signature (thought_signature): sig_call_1
  Response Signature (response_thought_signature): None
  FAILURE: Signatures are incorrect or merged incorrectly!

--- Demo: Re-injection of different signatures ---
Converted contents (Gemini format):
{
  "role": "model",
  "parts": [
    { "text": "It's sunny in Tokyo." },
    {
      "toolCall": { ... },
      "thoughtSignature": "sig_call_1"
    },
    {
      "toolResponse": { ... },
      "thoughtSignature": "sig_call_1"
    }
  ]
}
Verification:
  Tool Call Part thoughtSignature: sig_call_1
  Tool Response Part thoughtSignature: sig_call_1
  FAILURE: Signatures re-injected incorrectly!
```

**After Logs:**
```
--- Demo: Extraction of different signatures ---
Verification:
  Call Signature (thought_signature): sig_call_1
  Response Signature (response_thought_signature): sig_resp_1
  SUCCESS: Signatures extracted correctly and kept separate!

--- Demo: Re-injection of different signatures ---
Converted contents (Gemini format):
{
  "role": "model",
  "parts": [
    { "text": "It's sunny in Tokyo." },
    {
      "toolCall": { ... },
      "thoughtSignature": "sig_call_1"
    },
    {
      "toolResponse": { ... },
      "thoughtSignature": "sig_resp_1"
    }
  ]
}
Verification:
  Tool Call Part thoughtSignature: sig_call_1
  Tool Response Part thoughtSignature: sig_resp_1
  SUCCESS: Signatures re-injected correctly to respective parts!
```
</details>

---

### 2. Live E2E Verification

Confirmed with a live call to `gemini-3.1-flash-lite` (with `include_server_side_tool_invocations=True` and `google_search` tool).
LiteLLM successfully extracted distinct signatures from the live response:

```json
{
  "thought_signatures": [
    "EqsBCqgB...", // Tool Call Signature
    "EoonCocn..."  // Tool Response Signature
  ],
  "server_side_tool_invocations": [
    {
      "tool_type": "GOOGLE_SEARCH_WEB",
      "id": "1P2xDn2d",
      "args": { "queries": ["current weather in Tokyo"] },
      "thought_signature": "EqsBCqgB...", // Preserved Call Signature
      "response": { "search_suggestions": "..." },
      "response_thought_signature": "EoonCocn..." // Preserved Response Signature
    }
  ]
}
```

---

## Unit Tests

All Gemini unit tests pass:
```bash
uv run pytest tests/test_litellm/llms/vertex_ai/gemini/
# 235 passed, 1 skipped
```

TAG=agy
CONV=755b21d0-3200-40bc-bd1a-bb58a378a9a6
