### PR TITLE
fix(proxy): stop double-decrypting email/slack alerting env vars in get_config

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15472,8 +15472,6 @@ async def get_config():
     """
     global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key
     try:
-        import base64
-
         all_available_callbacks = AllCallbacks()
 
         config_data = await proxy_config.get_config()
@@ -15539,18 +15537,10 @@ async def get_config():
             _slack_vars = [
                 "SLACK_WEBHOOK_URL",
             ]
-            _slack_env_vars = {}
-            for _var in _slack_vars:
-                env_variable = environment_variables.get(_var, None)
-                if env_variable is None:
-                    _value = os.getenv("SLACK_WEBHOOK_URL", None)
-                    _slack_env_vars[_var] = _value
-                else:
-                    # decode + decrypt the value
-                    _decrypted_value = decrypt_value_helper(
-                        value=env_variable, key=_var
-                    )
-                    _slack_env_vars[_var] = _decrypted_value
+            _slack_env_vars = {
+                _var: environment_variables.get(_var) or os.getenv(_var)
+                for _var in _slack_vars
+            }
             _slack_env_vars = mask_sensitive_keys(
                 _slack_env_vars, _ALERTING_SENSITIVE_VARS
             )
@@ -15581,15 +15571,9 @@ async def get_config():
             "EMAIL_LOGO_URL",
             "EMAIL_SUPPORT_CONTACT",
         ]
-        _email_env_vars = {}
-        for _var in _email_vars:
-            env_variable = environment_variables.get(_var, None)
-            if env_variable is None:
-                _email_env_vars[_var] = None
-            else:
-                # decode + decrypt the value
-                _decrypted_value = decrypt_value_helper(value=env_variable, key=_var)
-                _email_env_vars[_var] = _decrypted_value
+        _email_env_vars = {
+            _var: environment_variables.get(_var) for _var in _email_vars
+        }
         _email_env_vars = mask_sensitive_keys(_email_env_vars, _ALERTING_SENSITIVE_VARS)
 
         alerting_data.append(

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -857,6 +857,118 @@ def test_get_config_custom_callback_api_env_vars(monkeypatch):
     }
 
 
+def test_get_config_returns_email_settings(monkeypatch):
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/19221
+
+    proxy_config.get_config() already returns environment_variables decrypted
+    (the DB-overlay path decrypts them, and YAML values are plaintext). The
+    /get/config/callbacks email block must therefore surface those values as-is
+    instead of decrypting a second time. The old code ran decrypt_value_helper()
+    on the already-plaintext value, which failed and returned None, so every
+    SMTP_* field came back blank on UI refresh.
+    """
+    from litellm.proxy.proxy_server import app, proxy_config, user_api_key_auth
+
+    smtp_password = "super-secret-app-password"
+    config_data = {
+        "litellm_settings": {},
+        "general_settings": {"alerting": ["email"]},
+        "environment_variables": {
+            "SMTP_HOST": "smtp.resend.com",
+            "SMTP_PORT": "587",
+            "SMTP_USERNAME": "resend",
+            "SMTP_PASSWORD": smtp_password,
+            "SMTP_SENDER_EMAIL": "alerts@example.com",
+            "TEST_EMAIL_ADDRESS": "admin@example.com",
+        },
+    }
+
+    mock_router = MagicMock()
+    mock_router.get_settings.return_value = {}
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", mock_router)
+    monkeypatch.setattr(proxy_config, "get_config", AsyncMock(return_value=config_data))
+
+    original_overrides = app.dependency_overrides.copy()
+    app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+
+    client = TestClient(app)
+    try:
+        response = client.get("/get/config/callbacks")
+    finally:
+        app.dependency_overrides = original_overrides
+
+    assert response.status_code == 200
+    email_alert = next(
+        (a for a in response.json()["alerts"] if a["name"] == "email"), None
+    )
+    assert email_alert is not None
+    variables = email_alert["variables"]
+
+    # Non-sensitive fields round-trip verbatim (None before the fix).
+    assert variables["SMTP_HOST"] == "smtp.resend.com"
+    assert variables["SMTP_PORT"] == "587"
+    assert variables["SMTP_USERNAME"] == "resend"
+    assert variables["SMTP_SENDER_EMAIL"] == "alerts@example.com"
+    assert variables["TEST_EMAIL_ADDRESS"] == "admin@example.com"
+
+    # Password is present but masked: never None, never the raw secret.
+    assert variables["SMTP_PASSWORD"] is not None
+    assert variables["SMTP_PASSWORD"] != smtp_password
+    assert "*" in variables["SMTP_PASSWORD"]
+
+
+def test_get_config_returns_slack_webhook(monkeypatch):
+    """
+    Same double-decryption regression as the email block (issue #19221): the
+    slack alerting block must surface the already-decrypted SLACK_WEBHOOK_URL
+    rather than decrypting it again into None.
+    """
+    from litellm.proxy.proxy_server import app, proxy_config, user_api_key_auth
+
+    webhook_url = "https://hooks.slack.com/services/T00000/B00000/abcdefghijklmnop"
+    config_data = {
+        "litellm_settings": {},
+        "general_settings": {"alerting": ["slack"]},
+        "environment_variables": {"SLACK_WEBHOOK_URL": webhook_url},
+    }
+
+    mock_router = MagicMock()
+    mock_router.get_settings.return_value = {}
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", mock_router)
+
+    mock_logging = MagicMock()
+    mock_logging.slack_alerting_instance.alert_types = ["budget_alerts"]
+    mock_logging.slack_alerting_instance._all_possible_alert_types.return_value = [
+        "budget_alerts"
+    ]
+    mock_logging.slack_alerting_instance.alert_to_webhook_url = {}
+    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_logging_obj", mock_logging)
+    monkeypatch.setattr(proxy_config, "get_config", AsyncMock(return_value=config_data))
+
+    original_overrides = app.dependency_overrides.copy()
+    app.dependency_overrides[user_api_key_auth] = lambda: MagicMock()
+
+    client = TestClient(app)
+    try:
+        response = client.get("/get/config/callbacks")
+    finally:
+        app.dependency_overrides = original_overrides
+
+    assert response.status_code == 200
+    slack_alert = next(
+        (a for a in response.json()["alerts"] if a["name"] == "slack"), None
+    )
+    assert slack_alert is not None
+    masked_url = slack_alert["variables"]["SLACK_WEBHOOK_URL"]
+
+    # Masked, but derived from the real URL (None before the fix).
+    assert masked_url is not None
+    assert masked_url != webhook_url
+    assert masked_url.startswith("http")
+    assert "*" in masked_url
+
+
 # Mock Prisma
 class MockPrisma:
     def __init__(self, database_url=None, proxy_logging_obj=None, http_client=None):


### PR DESCRIPTION
## Relevant issues

Fixes #19221

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy on a Postgres-backed instance with `store_model_in_db: true` and a fixed `LITELLM_SALT_KEY` (the key never changes between the two runs below; only the code differs).

Step 1, save the email settings exactly as the Admin UI "Save Changes" button does:

```
curl -s -X POST http://localhost:4000/config/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"general_settings":{"alerting":["email"]},"environment_variables":{"SMTP_HOST":"smtp.resend.com","SMTP_PORT":"587","SMTP_USERNAME":"resend","SMTP_PASSWORD":"super-secret-app-password","SMTP_SENDER_EMAIL":"alerts@example.com","TEST_EMAIL_ADDRESS":"admin@example.com"}}'

{"message":"Config updated successfully"}
```

Step 2, read them back the way a page refresh does (`GET /get/config/callbacks`), filtered to the email block.

Before this fix (same saved DB row, pre-fix code):

```
{
  "name": "email",
  "variables": {
    "SMTP_HOST": null,
    "SMTP_PORT": null,
    "SMTP_USERNAME": null,
    "SMTP_PASSWORD": null,
    "SMTP_SENDER_EMAIL": null,
    "TEST_EMAIL_ADDRESS": null,
    "EMAIL_LOGO_URL": null,
    "EMAIL_SUPPORT_CONTACT": null
  }
}
```

and the proxy log shows the misleading decryption error users reported, even though the salt key was never touched:

```
encrypt_decrypt_utils.py:74 - Error decrypting value for key: SMTP_HOST, Did your master_key/salt key change recently?
encrypt_decrypt_utils.py:74 - Error decrypting value for key: SMTP_PORT, Did your master_key/salt key change recently?
encrypt_decrypt_utils.py:74 - Error decrypting value for key: SMTP_PASSWORD, Did your master_key/salt key change recently?
...
```

After this fix (same saved DB row, fixed code):

```
{
  "name": "email",
  "variables": {
    "SMTP_HOST": "smtp.resend.com",
    "SMTP_PORT": "587",
    "SMTP_USERNAME": "resend",
    "SMTP_PASSWORD": "supe*****************word",
    "SMTP_SENDER_EMAIL": "alerts@example.com",
    "TEST_EMAIL_ADDRESS": "admin@example.com",
    "EMAIL_LOGO_URL": null,
    "EMAIL_SUPPORT_CONTACT": null
  }
}
```

The settings now survive a refresh, the password stays masked, and the two optional fields that were never set stay null.

## Type

🐛 Bug Fix

## Changes

The Admin UI saves SMTP/email server settings via `POST /config/update`, which encrypts them and stores them in the `environment_variables` row of `LiteLLM_Config`. On a refresh the UI reads them back via `GET /get/config/callbacks` (`get_config()`), and every `SMTP_*` field came back blank.

The root cause is a double decryption. By the time `get_config()` reads `environment_variables`, the values are already plaintext: the DB overlay path decrypts the whole section in `ProxyConfig._update_config_fields` before returning it, and YAML-sourced values are plaintext to begin with. The slack and email blocks in `get_config()` then called `decrypt_value_helper()` on that plaintext a second time. The second decrypt always fails (plaintext is not valid ciphertext), and the helper swallows the error and returns `None`, so the whole email form rendered empty. It also logged the misleading "Did your master_key/salt key change recently?" error, which is the "encryption error" several people hit in the thread, even when no key had changed.

The sibling reader `process_callback()` (used for langfuse, datadog, and the other logging callbacks) already consumes the same `environment_variables` dict as plaintext with no decrypt step, which is why those integrations displayed fine while only the SMTP values broke. This change makes the slack and email blocks follow that same convention and read the already-decrypted values directly. Sensitive-value masking via `mask_sensitive_keys` is unchanged, so `SMTP_PASSWORD` and `SLACK_WEBHOOK_URL` are still never returned verbatim.

Tests: `test_get_config_returns_email_settings` and `test_get_config_returns_slack_webhook` in `tests/test_litellm/proxy/test_proxy_server.py` drive `GET /get/config/callbacks` with already-decrypted env vars and assert the real values come back rather than `None`. Both fail on the pre-fix code (the email one with the same `CryptoError: Decryption failed` the proxy was swallowing) and pass after.

Out of scope: the thread also mentions a `Service=smtp_email not in ...` 400 from the callback "Test" button. That is a separate naming mismatch in `/health/services` (it accepts `email` but not the registered logger names `smtp_email` / `resend_email` / `sendgrid_email`) and is better handled in its own PR
