### PR TITLE
fix(handler): stop extra_body from overriding the authorized model

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    Mapping,
     Optional,
     Tuple,
     Union,
@@ -192,6 +193,15 @@ def _google_genai_streaming_hidden_params(
 @lru_cache(maxsize=None)
 def _responses_api_optional_request_param_names() -> frozenset[str]:
     return frozenset(get_type_hints(ResponsesAPIOptionalRequestParams).keys())
+
+
+def _merge_extra_body_preserving_model(
+    transformed_body: Mapping[str, object], extra_body: Mapping[str, object]
+) -> dict[str, object]:
+    merged = {**transformed_body, **extra_body}
+    if "model" in transformed_body:
+        return {**merged, "model": transformed_body["model"]}
+    return merged
 
 
 def _custom_logger_callbacks(logging_obj: Any) -> list[Any]:
@@ -496,7 +506,7 @@ class BaseLLMHTTPHandler:
         )
 
         if extra_body is not None:
-            data = {**data, **extra_body}
+            data = _merge_extra_body_preserving_model(data, extra_body)
 
         headers, signed_json_body = provider_config.sign_request(
             headers=headers,
@@ -2451,7 +2461,7 @@ class BaseLLMHTTPHandler:
         data = BaseResponsesAPIConfig.normalize_responses_api_request_dict(data)
 
         if extra_body:
-            data.update(extra_body)
+            data = _merge_extra_body_preserving_model(data, extra_body)
         stream = bool(stream or data.get("stream"))
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
@@ -2638,7 +2648,7 @@ class BaseLLMHTTPHandler:
         data = BaseResponsesAPIConfig.normalize_responses_api_request_dict(data)
 
         if extra_body:
-            data.update(extra_body)
+            data = _merge_extra_body_preserving_model(data, extra_body)
         stream = bool(stream or data.get("stream"))
 
         # Preserve the OpenAI-style request context (not sent to the provider) for streaming
@@ -11189,7 +11199,7 @@ class BaseLLMHTTPHandler:
         )
 
         if extra_body:
-            data.update(extra_body)
+            data = _merge_extra_body_preserving_model(data, extra_body)
 
         ## LOGGING
         logging_obj.pre_call(
@@ -11304,7 +11314,7 @@ class BaseLLMHTTPHandler:
         )
 
         if extra_body:
-            data.update(extra_body)
+            data = _merge_extra_body_preserving_model(data, extra_body)
 
         ## LOGGING
         logging_obj.pre_call(

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -11199,7 +11199,7 @@ class BaseLLMHTTPHandler:
         )
 
         if extra_body:
-            data = _merge_extra_body_preserving_model(data, extra_body)
+            data.update(extra_body)
 
         ## LOGGING
         logging_obj.pre_call(
@@ -11314,7 +11314,7 @@ class BaseLLMHTTPHandler:
         )
 
         if extra_body:
-            data = _merge_extra_body_preserving_model(data, extra_body)
+            data.update(extra_body)
 
         ## LOGGING
         logging_obj.pre_call(

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -272,6 +272,81 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
     assert client.post.call_args.kwargs["json"]["stream"] is True
 
 
+def test_response_api_handler_extra_body_cannot_override_model():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://chatgpt.example.com/responses"
+    config.transform_responses_api_request.return_value = {
+        "model": "gpt-5.3-codex",
+        "input": "hi",
+        "stream": True,
+    }
+    config.sign_request.return_value = ({}, None)
+    client = HTTPHandler(client=httpx.Client())
+    client.post = Mock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+    logging_obj = Mock()
+
+    handler.response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        extra_body={"model": "attacker-model", "passthrough": "kept"},
+        client=client,
+    )
+
+    sent_body = client.post.call_args.kwargs["json"]
+    assert sent_body["model"] == "gpt-5.3-codex"
+    assert sent_body["passthrough"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_async_response_api_handler_extra_body_cannot_override_model():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://chatgpt.example.com/responses"
+    config.transform_responses_api_request.return_value = {
+        "model": "gpt-5.3-codex",
+        "input": "hi",
+        "stream": True,
+    }
+    config.sign_request.return_value = ({}, None)
+    client = AsyncHTTPHandler()
+    client.post = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://chatgpt.example.com/responses"),
+        )
+    )
+    logging_obj = Mock()
+
+    await handler.async_response_api_handler(
+        model="gpt-5.3-codex",
+        input="hi",
+        responses_api_provider_config=config,
+        response_api_optional_request_params={},
+        custom_llm_provider="chatgpt",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        extra_body={"model": "attacker-model", "passthrough": "kept"},
+        client=client,
+    )
+
+    sent_body = client.post.call_args.kwargs["json"]
+    assert sent_body["model"] == "gpt-5.3-codex"
+    assert sent_body["passthrough"] == "kept"
+
+
 def test_merge_extra_body_preserving_model_blocks_model_override():
     merged = _merge_extra_body_preserving_model(
         {"model": "authorized", "messages": []},

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -18,6 +18,7 @@ from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
     _google_genai_streaming_hidden_params,
+    _merge_extra_body_preserving_model,
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
@@ -269,6 +270,25 @@ async def test_async_response_api_handler_streams_when_provider_transform_adds_s
 
     assert client.post.call_args.kwargs["stream"] is True
     assert client.post.call_args.kwargs["json"]["stream"] is True
+
+
+def test_merge_extra_body_preserving_model_blocks_model_override():
+    merged = _merge_extra_body_preserving_model(
+        {"model": "authorized", "messages": []},
+        {"model": "attacker", "passthrough": "kept"},
+    )
+    assert merged["model"] == "authorized"
+    assert merged["passthrough"] == "kept"
+
+
+def test_merge_extra_body_preserving_model_passes_through_when_no_model():
+    merged = _merge_extra_body_preserving_model(
+        {"input": "hi"},
+        {"model": "from-extra-body", "extra": "kept"},
+    )
+    assert merged["model"] == "from-extra-body"
+    assert merged["extra"] == "kept"
+    assert merged["input"] == "hi"
 
 
 def test_get_agentic_loop_settings_defaults_and_overrides():

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -433,6 +433,28 @@ def test_custom_provider_with_extra_body():
         }
 
 
+def test_extra_body_cannot_override_authorized_model():
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+    with patch.object(client, "post") as mock_post:
+        try:
+            litellm.completion(
+                model="deepseek/deepseek-chat",
+                messages=[{"role": "user", "content": "Hello, how are you?"}],
+                extra_body={"model": "deepseek/some-other-model", "passthrough": "kept"},
+                api_key="fake-key-for-testing",
+                client=client,
+            )
+        except Exception:
+            pass
+
+        mock_post.assert_called_once()
+        sent_body = json.loads(mock_post.call_args.kwargs["data"])
+        assert sent_body["model"] == "deepseek-chat"
+        assert sent_body["passthrough"] == "kept"
+
+
 @pytest.fixture(autouse=True)
 def set_openrouter_api_key():
     original_api_key = os.environ.get("OPENROUTER_API_KEY")


### PR DESCRIPTION
## Relevant issues

Closes #31118

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This is a server-side enforcement fix, so the cleanest live proof is a virtual key scoped to a single model that then tries to escape via `extra_body.model`. Point a `config.yaml` at a real provider (any OpenAI-compatible one that reads `model` from the body works; the example uses Deepseek) and define a key allowed only for the cheap model

```yaml
model_list:
  - model_name: allowed-model
    litellm_params:
      model: deepseek/deepseek-chat
      api_key: os.environ/DEEPSEEK_API_KEY
```

```bash
export DEEPSEEK_API_KEY=...   # not committed anywhere
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug --reload 2>&1 | tee litellm.log
```

Then send a request that names the allowed model at the top level but tries to swap it through `extra_body`

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{
    "model": "allowed-model",
    "messages": [{"role": "user", "content": "say hi"}],
    "extra_body": {"model": "deepseek/deepseek-reasoner"}
  }' | jq '.model'
```

In the proxy's `--detailed_debug` output, inspect the JSON body sent upstream (the `POST Request Sent from LiteLLM` line). Before this change it carries `"model": "deepseek-reasoner"`, so the caller ran a model the key was never authorized or budgeted for. After this change the body keeps `"model": "deepseek-chat"`, the authorized one, while any other `extra_body` field still passes through

## Type

🐛 Bug Fix

## Changes

The shared `BaseLLMHTTPHandler` merged caller-controlled `extra_body` over the body produced by `transform_request()` with `data = {**data, **extra_body}`. Because `extra_body` won the merge, a caller could set `extra_body: {"model": "..."}` and override the `model` that the provider transform chose. Proxy model-access and budget enforcement runs at the auth layer on the top-level `model` parameter and never inspects `extra_body`, so for any OpenAI-compatible provider that reads `model` from the request body the upstream call would run a different model than the one the request was authorized and accounted against

This came out of the review on #31053. The behavior is not specific to Cloudflare or that PR; it is generic to every provider routed through `BaseLLMHTTPHandler`, and `extra_body` is a documented passthrough escape hatch, so the right place to close it is once in the shared handler rather than per provider

A small pure helper `_merge_extra_body_preserving_model` now performs the merge and re-asserts the transform's `model` afterward, so `extra_body` can no longer change which model executes while every other field still merges through. It takes `Mapping[str, object]` and is applied at the three body-merge points where the model lives in the request body and is therefore overridable: chat completion and the sync and async responses API paths. The Google `generate_content` paths are intentionally left as-is because that API pins the model in the request URL (`models/{model}:generateContent`), so `extra_body` cannot redirect which model runs there

Tests cover the regression end to end through `completion` for an OpenAI-compatible provider (a request whose `extra_body` tries to swap the model still posts the authorized model upstream and keeps other `extra_body` fields), at the responses surface through the sync and async `response_api_handler` (same property on that API), and at the unit level for the helper (model override is blocked when the transform set a model, and `extra_body` passes through untouched when it did not). Every one of these tests fails on the old code and passes on the new
