### PR TITLE
fix(mcp): let proxy admins assign MCP servers to teamless keys

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -874,6 +874,8 @@ async def _common_key_generation_helper(
         object_permission=data_json.get("object_permission"),
         team_obj=team_table,
         prisma_client=prisma_client,
+        is_proxy_admin=user_api_key_dict.user_role
+        == LitellmUserRoles.PROXY_ADMIN.value,
     )
     if normalized_object_permission is not None:
         data_json["object_permission"] = normalized_object_permission
@@ -2164,6 +2166,7 @@ async def _validate_mcp_servers_for_key_update(
     existing_key_row: Any,
     prisma_client: Any,
     user_api_key_cache: Any,
+    is_proxy_admin: bool,
 ) -> Optional[dict]:
     """Validate MCP servers in object_permission against the effective team."""
     effective_team_obj = team_obj
@@ -2186,6 +2189,7 @@ async def _validate_mcp_servers_for_key_update(
         object_permission=object_permission_dict,
         team_obj=effective_team_obj,
         prisma_client=prisma_client,
+        is_proxy_admin=is_proxy_admin,
     )
     await validate_key_search_tools_against_team(
         object_permission=object_permission_dict,
@@ -2422,6 +2426,7 @@ async def _validate_update_key_data(
             existing_key_row=existing_key_row,
             prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
+            is_proxy_admin=_is_proxy_admin,
         )
         if normalized_object_permission is not None:
             data.object_permission = LiteLLM_ObjectPermissionBase(

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -469,6 +469,7 @@ async def validate_key_mcp_servers_against_team(
     object_permission: Optional[dict],
     team_obj: Optional["LiteLLM_TeamTableCachedObj"],
     prisma_client: Optional[PrismaClient] = None,
+    is_proxy_admin: bool = False,
 ) -> Optional[dict]:
     """
     Validate that MCP servers requested on a key are within the allowed scope.
@@ -476,12 +477,17 @@ async def validate_key_mcp_servers_against_team(
     Rules:
     - If key is in a team: key's mcp_servers must be a subset of
       (team's allowed servers + allow_all_keys servers)
-    - If key is NOT in a team: key's mcp_servers must only contain
-      allow_all_keys servers
+    - If key is NOT in a team and the caller is a proxy admin: any server or
+      access group may be assigned. A proxy admin can already reach every MCP
+      server, and runtime access is granted directly from the key's own
+      object_permission, so the key is scoped to exactly what the admin selected
+    - If key is NOT in a team and the caller is not a proxy admin: key's
+      mcp_servers must only contain allow_all_keys servers
     - If team has no MCP config: key can only use allow_all_keys servers
 
     Raises HTTPException(403) if validation fails.
     """
+    teamless_admin_assignment = team_obj is None and is_proxy_admin
     requested_servers = _extract_requested_mcp_server_ids(object_permission)
     requested_access_groups = _extract_requested_mcp_access_groups(object_permission)
 
@@ -526,7 +532,11 @@ async def validate_key_mcp_servers_against_team(
             identifier_to_server_ids
         )
 
-        disallowed_servers = active_requested_servers - all_allowed_servers
+        allowed_servers = all_allowed_servers
+        if teamless_admin_assignment:
+            allowed_servers = all_allowed_servers | active_requested_servers
+
+        disallowed_servers = active_requested_servers - allowed_servers
         if disallowed_servers:
             if team_obj is not None:
                 team_id = team_obj.team_id
@@ -557,7 +567,11 @@ async def validate_key_mcp_servers_against_team(
         ):
             team_access_groups = set(team_obj.object_permission.mcp_access_groups)
 
-        disallowed_groups = requested_access_groups - team_access_groups
+        allowed_access_groups = team_access_groups
+        if teamless_admin_assignment:
+            allowed_access_groups = team_access_groups | requested_access_groups
+
+        disallowed_groups = requested_access_groups - allowed_access_groups
         if disallowed_groups:
             if team_obj is not None:
                 team_id = team_obj.team_id

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -354,6 +354,110 @@ async def test_validate_no_team_non_global_server_raises(
 @pytest.mark.asyncio
 @patch(
     "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+    new=_make_mock_mcp_manager("private-server"),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_no_team_proxy_admin_can_assign_private_server(
+    mock_access_groups, mock_allow_all
+):
+    """Proxy admin assigning a non-global server to a teamless key — should pass (LIT-3815)."""
+    result = await validate_key_mcp_servers_against_team(
+        object_permission={"mcp_servers": ["private-server"]},
+        team_obj=None,
+        is_proxy_admin=True,
+    )
+    assert result["mcp_servers"] == ["private-server"]
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+    new=_make_mock_mcp_manager("private-server"),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_no_team_non_admin_private_server_still_raises(
+    mock_access_groups, mock_allow_all
+):
+    """The teamless override is gated on proxy admin — a non-admin still gets 403."""
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_key_mcp_servers_against_team(
+            object_permission={"mcp_servers": ["private-server"]},
+            team_obj=None,
+            is_proxy_admin=False,
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_no_team_proxy_admin_can_assign_access_group(
+    mock_access_groups, mock_allow_all
+):
+    """Proxy admin assigning an access group to a teamless key — should pass (LIT-3815)."""
+    result = await validate_key_mcp_servers_against_team(
+        object_permission={"mcp_access_groups": ["group-1"]},
+        team_obj=None,
+        is_proxy_admin=True,
+    )
+    assert result["mcp_access_groups"] == ["group-1"]
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
+    new=_make_mock_mcp_manager("server-1", "server-outside"),
+)
+@patch(
+    "litellm.proxy.management_helpers.object_permission_utils._get_allow_all_keys_server_ids",
+    return_value=set(),
+)
+@patch(
+    "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._get_mcp_servers_from_access_groups",
+    new_callable=AsyncMock,
+    return_value=[],
+)
+async def test_validate_proxy_admin_still_bounded_by_team_scope(
+    mock_access_groups, mock_allow_all
+):
+    """The override is scoped to teamless keys — an admin assigning beyond a team's scope still raises."""
+    team_obj = _make_team_obj(mcp_servers=["server-1"])
+    with pytest.raises(HTTPException) as exc_info:
+        await validate_key_mcp_servers_against_team(
+            object_permission={"mcp_servers": ["server-1", "server-outside"]},
+            team_obj=team_obj,
+            is_proxy_admin=True,
+        )
+    assert exc_info.value.status_code == 403
+    assert "server-outside" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@patch(
+    "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager",
     new=_make_mock_mcp_manager("some-server"),
 )
 @patch(


### PR DESCRIPTION
## Relevant issues

Admins cannot create teamless keys with MCP server access

## Linear ticket

LIT-3815

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix
https://www.loom.com/share/fc8401ceb867497ab3db2f87fd2d3b12

Run against a live proxy with a proxy-admin key (`$KEY`) and the id of a specific, non-`allow_all_keys` MCP server (`$SERVER`)

Before the fix, creating a teamless key that references the server is rejected

```
curl -s -X POST "$PROXY/key/generate" \
  -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d "{\"object_permission\": {\"mcp_servers\": [\"$SERVER\"]}}"
```

returns the ticket's error

```
{"error":{"message":"... Key is not in a team. Only globally available (allow_all_keys) MCP servers can be assigned: []. Disallowed servers: ['<id>'].","type":"internal_server_error","code":"403"}}
```

After the fix, the same request returns a created key, and the key can call the server's tools at runtime

```
curl -s -X POST "$PROXY/key/generate" \
  -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d "{\"object_permission\": {\"mcp_servers\": [\"$SERVER\"]}}"
```

Edge cases verified against the same proxy: a non-admin caller still gets the 403; a proxy admin can likewise assign an access group to a teamless key

## Type

🐛 Bug Fix

## Changes

In short: a proxy admin couldn't attach a specific MCP server to a teamless key — the request was rejected with a 403, so the only way to grant a non-`allow_all_keys` server was to put the key on a team first. After this fix the admin can create a teamless key, attach the MCP server (on `/key/generate` or later via `/key/update`), and the key can actually use that server's tools at runtime. Attaching the grant and using it now line up.

Creating or updating a key that references a specific (non-`allow_all_keys`) MCP server or access group failed with a 403 when the key had no team. The error advertised on the ticket was "Key is not in a team. Only globally available (allow_all_keys) MCP servers can be assigned"

The root cause is an asymmetry between the create/update path and the runtime path. `validate_key_mcp_servers_against_team` computed the allowed set as the team's servers plus the `allow_all_keys` servers; for a teamless key the team set is empty, so the allowed set collapsed to just `allow_all_keys` and any explicitly-selected server or access group was rejected. The runtime path tells a different story: `get_allowed_mcp_servers` honors a teamless key's own `object_permission.mcp_servers` verbatim, with no team gate and no `allow_all_keys` filter. So the create path refused to persist a grant the run path would have happily served

The fix threads `is_proxy_admin` into the validator from both call sites (`/key/generate` and `/key/update`). When a key has no team and the caller is a proxy admin, the requested servers and access groups are folded into the allowed set so the existing subset checks pass. A proxy admin can already reach every MCP server, so there is nothing to escalate; the grant is scoped to exactly what the admin selected. Non-admins and every team-scoped key are unchanged, so the override is strictly `team_obj is None and is_proxy_admin`. The team-scoped branch is deliberately left alone because runtime intersects a teamed key with its team, so an out-of-team grant there would be silently dropped anyway

Tests live in the mapped file `tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py`: a proxy admin can assign a private server to a teamless key, a proxy admin can assign an access group to a teamless key, a non-admin still gets the 403, and a proxy admin is still bounded by team scope on a teamed key. Neutralizing the fix makes the two positive tests fail with the exact ticket error, so they pin the regression

