### PR TITLE
fix(triton): json-encode nested dict/list params before sending to Triton

### DIFF
--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -205,7 +205,7 @@ class TritonGenerateConfig(TritonConfig):
             "stream": bool(stream),
         }
         for k, v in inference_params.items():
-            if isinstance(v, (dict, list)):
+            if isinstance(v, (dict, list, tuple)):
                 # Triton's `parameters` field only accepts int/bool/string values.
                 # JSON-encode nested structures (e.g. chat_template_kwargs) so they
                 # survive the round trip; backends can json.loads() them back.

--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -204,7 +204,14 @@ class TritonGenerateConfig(TritonConfig):
             },
             "stream": bool(stream),
         }
-        data_for_triton["parameters"].update(inference_params)
+        for k, v in inference_params.items():
+            if isinstance(v, (dict, list)):
+                # Triton's `parameters` field only accepts int/bool/string values.
+                # JSON-encode nested structures (e.g. chat_template_kwargs) so they
+                # survive the round trip; backends can json.loads() them back.
+                data_for_triton["parameters"][k] = json.dumps(v)
+            else:
+                data_for_triton["parameters"][k] = v
         return data_for_triton
 
     def transform_response(

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -401,6 +401,26 @@ def test_triton_generate_request_serializes_dict_params():
     }
 
 
+def test_triton_generate_request_serializes_tuple_params():
+    """Tuples must be JSON-encoded too, not just dict/list (Triton only accepts int/bool/string)."""
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={
+            "max_tokens": 10,
+            "stop_sequences": ("foo", "bar"),
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert isinstance(data_for_triton["parameters"]["stop_sequences"], str)
+    assert json.loads(data_for_triton["parameters"]["stop_sequences"]) == ["foo", "bar"]
+
+
 def test_triton_generate_raw_request():
     from litellm.utils import return_raw_request
     from litellm.types.utils import CallTypes

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -371,6 +371,36 @@ async def test_triton_embeddings():
         pytest.fail(f"Error occurred: {e}")
 
 
+def test_triton_generate_request_serializes_dict_params():
+    """
+    Triton's `parameters` field only accepts int/bool/string values.
+    Nested dict/list params (e.g. chat_template_kwargs, used to disable
+    thinking) must be JSON-encoded rather than forwarded as raw objects,
+    otherwise Triton rejects the request with an invalid type error.
+    """
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    data_for_triton = config.transform_request(
+        model="triton/qwen3.6-27b",
+        messages=[{"role": "user", "content": "test?"}],
+        optional_params={
+            "max_tokens": 10,
+            "temperature": 0.7,
+            "chat_template_kwargs": {"enable_thinking": False},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert data_for_triton["parameters"]["max_tokens"] == 10
+    assert data_for_triton["parameters"]["temperature"] == 0.7
+    assert isinstance(data_for_triton["parameters"]["chat_template_kwargs"], str)
+    assert json.loads(data_for_triton["parameters"]["chat_template_kwargs"]) == {
+        "enable_thinking": False
+    }
+
+
 def test_triton_generate_raw_request():
     from litellm.utils import return_raw_request
     from litellm.types.utils import CallTypes


### PR DESCRIPTION
## Summary
- Fixes #31092 — Triton requests crash when extra OpenAI-style params (e.g. `chat_template_kwargs`, used to disable model "thinking") are forwarded to Triton's `/generate` endpoint.
- Root cause: `TritonGenerateConfig.transform_request` blindly merges all non-default `optional_params` into Triton's `parameters` object via `dict.update()`. Triton's own error message confirms `parameters` only accepts `int`/`bool`/`string` values: `"parameter 'chat_template_kwargs' has invalid type. It should be either 'int', 'bool', or 'string'."`
- Fix: JSON-encode any `dict`/`list` valued param before adding it to `parameters`, so structured values like `chat_template_kwargs` survive the round trip as a string. Triton-side custom backends (e.g. vLLM backend) can `json.loads()` the value back.
- Scalar params (e.g. `max_tokens`, `temperature`) are unaffected — same behavior as before.

## Test plan
- [x] Added `test_triton_generate_request_serializes_dict_params` in `tests/llm_translation/test_triton.py`, asserting `chat_template_kwargs` is JSON-encoded while scalars pass through unchanged.
- [x] Verified manually that the existing `max_tokens`-only request shape (covered by `test_completion_triton_generate_api`) is unchanged.