### PR TITLE
fix(guardrails): content filter logs upstream provider errors as not_run, not guardrail failure

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -24,6 +24,7 @@ from typing import (
     cast,
 )
 
+import openai
 import yaml
 from fastapi import HTTPException
 
@@ -2041,6 +2042,13 @@ class ContentFilterGuardrail(CustomGuardrail):
                 pass
         except HTTPException:
             status = "guardrail_intervened"
+            raise
+        except openai.OpenAIError as e:
+            # Upstream provider/stream error propagating through the iterator.
+            # The guardrail never evaluated content, so it must not be recorded
+            # as a guardrail failure. "not_run" is the canonical status here.
+            status = "not_run"
+            exception_str = str(e)
             raise
         except Exception as e:
             status = "guardrail_failed_to_respond"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_upstream_error_not_run.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_upstream_error_not_run.py
@@ -1,0 +1,42 @@
+import openai
+from unittest.mock import MagicMock
+
+import pytest
+
+from litellm.proxy.guardrails.guardrail_hooks.litellm_content_filter.content_filter import (
+    ContentFilterGuardrail,
+)
+from litellm.types.guardrails import GuardrailEventHooks
+
+
+@pytest.mark.asyncio
+async def test_streaming_hook_upstream_error_is_not_run():
+    """
+    When the upstream stream raises a provider error (openai.OpenAIError
+    subclass), the content filter never evaluates content. The error must
+    propagate unchanged and be logged as "not_run", not as a guardrail
+    failure. Regression test for issue #31004.
+    """
+    guardrail = ContentFilterGuardrail(
+        guardrail_name="test-streaming-upstream-error",
+        patterns=[],
+        event_hook=GuardrailEventHooks.during_call,
+    )
+
+    async def mock_stream():
+        raise openai.APIError("Provider returned error", request=MagicMock(), body=None)
+        yield  # pragma: no cover - makes this an async generator
+
+    user_api_key_dict = MagicMock()
+    request_data: dict = {}
+
+    with pytest.raises(openai.APIError):
+        async for _ in guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=user_api_key_dict,
+            response=mock_stream(),
+            request_data=request_data,
+        ):
+            pass
+
+    info = request_data["metadata"]["standard_logging_guardrail_information"][0]
+    assert info["guardrail_status"] == "not_run"


### PR DESCRIPTION
## Fixes #31004

### Problem

When a provider returns an error mid-stream, the exception propagates up through the content filter's `async_post_call_streaming_iterator_hook`, which wraps the response stream. The guardrail never evaluated any content, but the hook's generic `except Exception` arm caught the propagating error, set `status = "guardrail_failed_to_respond"`, and logged it.

The result: upstream provider errors (e.g. an OpenRouter `permission_denied`) surface in guardrail logs and metrics as guardrail failures. When you go to investigate, the guardrail looks responsible for an error it had nothing to do with, which is what the reporter hit while troubleshooting.

### Fix

Add an `except openai.OpenAIError` arm ahead of the generic handler. `openai.OpenAIError` is the common base of litellm's mapped provider exceptions (`APIError`, `RateLimitError`, `BadRequestError`, `Timeout`, etc., which all subclass the corresponding `openai.*` types). On an upstream error the hook now:

- records `status = "not_run"`, the existing `GuardrailStatus` value meaning the guardrail did not evaluate, already understood by the logging layer and the lifecycle UI
- re-raises the original exception unchanged

Genuine guardrail blocks still raise `HTTPException` and are unaffected (every BLOCK path in this filter raises `HTTPException`). The `finally` block still writes its log row, now with a truthful status.

### Scope

Limited to `ContentFilterGuardrail`'s streaming iterator hook. The shared base hook and other guardrails are untouched.

### Test

`tests/test_litellm/proxy/guardrails/guardrail_hooks/content_filter/test_upstream_error_not_run.py`: drives a stream that raises `openai.APIError` through the hook, asserts the exception propagates unchanged and that the logged `guardrail_status` is `not_run` rather than `guardrail_failed_to_respond`. Mocked, no network calls.

### Checks run locally

- `black --check` clean on changed files
- `ruff check` clean
- 227 content_filter unit tests pass
- single-file basedpyright: zero errors on the changed lines

### Open question for maintainers

I kept `exception_str` populated on the `not_run` path for debuggability. If you'd prefer a `not_run` row carry no error string, happy to drop it. I'm also open to suppressing the guardrail log entirely on upstream errors instead of logging with `not_run`, but that changes telemetry semantics, so I went with the lower-impact option.