### PR TITLE
test(responses): guard Azure /responses native routing (LIT-2986)

### DIFF
--- a/tests/test_litellm/responses/test_responses_api_bridge_flag.py
+++ b/tests/test_litellm/responses/test_responses_api_bridge_flag.py
@@ -10,12 +10,16 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 
 import litellm
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager
 
 
 class TestUseResponsesApiBridgeFlag:
@@ -280,3 +284,83 @@ class TestUseResponsesApiBridgeFlag:
 
         mock_native_handler.assert_called_once()
         assert result is not None
+
+
+class TestAzureResponsesNativeRoutingRegression:
+    """Regression coverage for LIT-2986.
+
+    Azure OpenAI native /responses must route to the native responses handler,
+    never the chat-completions bridge. When Azure was (incorrectly) sent through
+    the bridge, streaming collapsed to delta-only events and broke clients such as
+    Codex CLI that depend on the full lifecycle (response.created, output_item.added,
+    content_part.added, the matching .done events, response.completed).
+
+    The trigger was the dispatch branch `responses_api_provider_config is None or
+    use_chat_completions_api is True`. Unlike the tests above, these exercise the
+    *real* provider-config resolution instead of mocking it, so they fail if Azure
+    ever stops resolving a native responses config (the original root cause).
+    """
+
+    @pytest.mark.parametrize(
+        "model, expected_config",
+        [
+            ("gpt-4o", litellm.AzureOpenAIResponsesAPIConfig),
+            ("gpt-5", litellm.AzureOpenAIResponsesAPIConfig),
+            ("o4-mini", litellm.AzureOpenAIOSeriesResponsesAPIConfig),
+        ],
+    )
+    def test_azure_resolves_native_responses_config(self, model, expected_config):
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model=model, provider=LlmProviders.AZURE
+        )
+        assert config is not None
+        assert isinstance(config, expected_config)
+
+    @patch(
+        "litellm.responses.main.litellm_completion_transformation_handler.response_api_handler"
+    )
+    @patch("litellm.responses.main.base_llm_http_handler.response_api_handler")
+    def test_azure_responses_routes_native_not_bridge(
+        self, mock_native_handler, mock_bridge_handler
+    ):
+        mock_native_handler.return_value = MagicMock()
+        mock_bridge_handler.return_value = MagicMock()
+
+        litellm.responses(
+            model="azure/gpt-4o",
+            input="Hello",
+            api_base="https://example.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-04-01-preview",
+            litellm_logging_obj=MagicMock(),
+        )
+
+        mock_native_handler.assert_called_once()
+        mock_bridge_handler.assert_not_called()
+        assert (
+            mock_native_handler.call_args.kwargs["responses_api_provider_config"]
+            is not None
+        )
+
+    @patch(
+        "litellm.responses.main.litellm_completion_transformation_handler.response_api_handler"
+    )
+    @patch("litellm.responses.main.base_llm_http_handler.response_api_handler")
+    def test_azure_streaming_responses_routes_native_not_bridge(
+        self, mock_native_handler, mock_bridge_handler
+    ):
+        mock_native_handler.return_value = MagicMock()
+        mock_bridge_handler.return_value = MagicMock()
+
+        litellm.responses(
+            model="azure/gpt-4o",
+            input="Hello",
+            stream=True,
+            api_base="https://example.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-04-01-preview",
+            litellm_logging_obj=MagicMock(),
+        )
+
+        mock_native_handler.assert_called_once()
+        mock_bridge_handler.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Azure OpenAI native /responses streaming regression reported on 1.83.14: through the LiteLLM proxy the SSE stream could collapse to delta-only events (`response.output_text.delta` then `response.completed`), dropping the init/`.done` lifecycle events that clients like Codex CLI need to build stream state.

## Linear ticket

LIT-2986

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The reported collapse no longer reproduces on the latest `litellm_internal_staging`. I stood up a proxy with two deployments against the same Azure endpoint, one on the native path (`azure/...`) and one that always takes the chat-completions bridge (`azure_ai/...`), and streamed `/v1/responses` through both. Both now emit the complete lifecycle:

```
$ curl -sN $PROXY/v1/responses -H "Authorization: Bearer $KEY" \
    -d '{"model":"azure-responses-native","input":"say hi","stream":true}' | grep -o '"type":"[^"]*"' | sort | uniq -c
   1 "type":"response.created"
   1 "type":"response.in_progress"
   1 "type":"response.output_item.added"
   1 "type":"response.content_part.added"
   2 "type":"response.output_text.delta"
   1 "type":"response.output_text.done"
   1 "type":"response.content_part.done"
   1 "type":"response.output_item.done"
   1 "type":"response.completed"
```

The native Azure path is selected by the dispatch in `litellm/responses/main.py`:

```python
if responses_api_provider_config is None or use_chat_completions_api is True:
    return litellm_completion_transformation_handler.response_api_handler(...)
```

For `custom_llm_provider == "azure"`, `ProviderConfigManager.get_provider_responses_api_config` already returns a native config (`AzureOpenAIResponsesAPIConfig`, or `AzureOpenAIOSeriesResponsesAPIConfig` for o-series), so Azure does not hit the bridge unless the caller explicitly opts in via `use_chat_completions_api=True` or the `openai/chat_completions/<model>` prefix. The original collapse was the bridge dropping lifecycle events; the bridge now reconstructs the full lifecycle as well, so neither path regresses.

Rather than special-casing `custom_llm_provider == "azure"` to force `use_chat_completions_api = False` (which would silently override an explicit caller opt-in), this PR locks in the behavior that actually matters with a regression test, since the existing dispatch tests all mock the provider-config resolution and so never covered the real Azure resolution that was the root cause.

## Type

✅ Test

## Changes

Adds `TestAzureResponsesNativeRoutingRegression` to `tests/test_litellm/responses/test_responses_api_bridge_flag.py`. Unlike the existing tests, it does not mock `get_provider_responses_api_config`; it exercises the real `ProviderConfigManager` and asserts that:

- `azure/*` gpt and o-series models resolve a non-null native responses config
- a plain `azure/gpt-4o` `/responses` call dispatches to the native handler and never the chat-completions bridge, for both non-streaming and `stream=True`

A mutation check confirms the guard bites: forcing the Azure resolution to `None` flips the dispatch to the bridge, which fails the new assertions.
