### PR TITLE
fix(mcp): stop 404ing internal-only MCP servers behind a load balancer

### DIFF
--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -177,10 +177,10 @@ class IPAddressUtils:
         Security: X-Forwarded-For is trusted only when use_x_forwarded_for is
         enabled and the direct connection is a legitimate proxy, established by
         either the direct peer falling inside mcp_trusted_proxy_ranges, or, when
-        no ranges are configured, the direct peer being a private address (a
-        reverse proxy in front of the gateway). A public, out-of-range, or
-        unknown direct peer is classified by its own address so a forged header
-        cannot grant internal access.
+        no ranges are configured, the direct peer being internal under
+        mcp_internal_ip_ranges (a reverse proxy in front of the gateway). A
+        public, out-of-range, or unknown direct peer is classified by its own
+        address so a forged header cannot grant internal access.
 
         Args:
             request: FastAPI request object
@@ -219,11 +219,17 @@ class IPAddressUtils:
                 # None "no filtering" result. The private-proxy carve-out is what
                 # stops internal-only servers 404ing behind a load balancer
                 # (LIT-3964); set mcp_trusted_proxy_ranges to validate the proxy
-                # explicitly instead of relying on it.
+                # explicitly instead of relying on it. "Internal" here uses the
+                # same mcp_internal_ip_ranges the access-control gate uses, so a
+                # proxy internal under custom CIDRs cannot have its forwarded
+                # client silently inherit its internal classification.
+                internal_networks = IPAddressUtils.parse_internal_networks(
+                    general_settings.get("mcp_internal_ip_ranges")
+                )
                 peer_is_private_proxy = (
                     direct_ip is not None
                     and not general_settings.get("mcp_trusted_proxy_ranges")
-                    and IPAddressUtils.is_internal_ip(direct_ip)
+                    and IPAddressUtils.is_internal_ip(direct_ip, internal_networks)
                 )
                 if not peer_is_private_proxy:
                     verbose_proxy_logger.warning(

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -204,15 +204,26 @@ class IPAddressUtils:
                 request, general_settings=general_settings
             ):
                 direct_ip = request.client.host if request.client else None
-                if general_settings.get("mcp_trusted_proxy_ranges"):
-                    # Direct connection isn't in any configured trusted CIDR.
+                # The X-Forwarded-For header is not trustworthy when either the
+                # operator configured mcp_trusted_proxy_ranges and this direct
+                # peer is not one of them, or no ranges are configured and the
+                # peer is a public address (an untrusted caller connecting to us
+                # directly and spoofing XFF). Classify by the direct connection.
+                untrusted_peer = bool(
+                    general_settings.get("mcp_trusted_proxy_ranges")
+                ) or (
+                    direct_ip is not None
+                    and not IPAddressUtils.is_internal_ip(direct_ip)
+                )
+                if untrusted_peer:
                     verbose_proxy_logger.warning(
-                        "XFF header from untrusted IP %s, ignoring", direct_ip
+                        "Untrusted X-Forwarded-For from %s, ignoring", direct_ip
                     )
                     return direct_ip
-                # XFF enabled but no trusted proxy ranges configured: the direct
-                # peer is typically the reverse proxy's own (private) IP, so
-                # returning it would mis-classify external callers as internal.
-                # Fail closed for access control.
-                return ""
+                # No trusted ranges configured and an internal (or unknown)
+                # direct peer: a private reverse proxy in front of the gateway,
+                # so honour X-Forwarded-For (parsed below). Set
+                # mcp_trusted_proxy_ranges to validate the proxy explicitly.
+                # Failing closed here made every internal-only MCP server return
+                # 404 behind a load balancer (LIT-3964).
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -174,9 +174,13 @@ class IPAddressUtils:
         """
         Extract client IP from a FastAPI request for MCP access control.
 
-        Security: Only trusts X-Forwarded-For if:
-        1. use_x_forwarded_for is enabled in settings
-        2. The direct connection is from a trusted proxy (if mcp_trusted_proxy_ranges configured)
+        Security: X-Forwarded-For is trusted only when use_x_forwarded_for is
+        enabled and the direct connection is a legitimate proxy, established by
+        either the direct peer falling inside mcp_trusted_proxy_ranges, or, when
+        no ranges are configured, the direct peer being a private address (a
+        reverse proxy in front of the gateway). A public, out-of-range, or
+        unknown direct peer is classified by its own address so a forged header
+        cannot grant internal access.
 
         Args:
             request: FastAPI request object
@@ -204,26 +208,26 @@ class IPAddressUtils:
                 request, general_settings=general_settings
             ):
                 direct_ip = request.client.host if request.client else None
-                # The X-Forwarded-For header is not trustworthy when either the
-                # operator configured mcp_trusted_proxy_ranges and this direct
-                # peer is not one of them, or no ranges are configured and the
-                # peer is a public address (an untrusted caller connecting to us
-                # directly and spoofing XFF). Classify by the direct connection.
-                untrusted_peer = bool(
-                    general_settings.get("mcp_trusted_proxy_ranges")
-                ) or (
+                # X-Forwarded-For is only trustworthy when the direct peer is a
+                # private reverse proxy and the operator has not pinned
+                # mcp_trusted_proxy_ranges (a peer inside those ranges would have
+                # been accepted above). For a public, out-of-range, or unknown
+                # peer, classify by the direct connection so a forged header
+                # cannot reach available_on_public_internet=false servers. An
+                # unknown peer (request.client is None) fails closed to the
+                # external "" sentinel rather than leaking internal access via a
+                # None "no filtering" result. The private-proxy carve-out is what
+                # stops internal-only servers 404ing behind a load balancer
+                # (LIT-3964); set mcp_trusted_proxy_ranges to validate the proxy
+                # explicitly instead of relying on it.
+                peer_is_private_proxy = (
                     direct_ip is not None
-                    and not IPAddressUtils.is_internal_ip(direct_ip)
+                    and not general_settings.get("mcp_trusted_proxy_ranges")
+                    and IPAddressUtils.is_internal_ip(direct_ip)
                 )
-                if untrusted_peer:
+                if not peer_is_private_proxy:
                     verbose_proxy_logger.warning(
                         "Untrusted X-Forwarded-For from %s, ignoring", direct_ip
                     )
-                    return direct_ip
-                # No trusted ranges configured and an internal (or unknown)
-                # direct peer: a private reverse proxy in front of the gateway,
-                # so honour X-Forwarded-For (parsed below). Set
-                # mcp_trusted_proxy_ranges to validate the proxy explicitly.
-                # Failing closed here made every internal-only MCP server return
-                # 404 behind a load balancer (LIT-3964).
+                    return direct_ip or ""
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -152,12 +152,13 @@ class IPAddressUtils:
             if not _warned_xff_without_trusted_ranges:
                 verbose_proxy_logger.warning(
                     "use_x_forwarded_for is enabled but mcp_trusted_proxy_ranges "
-                    "is not configured. X-Forwarded-* headers will NOT be "
-                    "trusted, so MCP OAuth discovery URLs and access-control "
-                    "client IPs will use the proxy's literal request values. "
-                    "Set mcp_trusted_proxy_ranges in "
-                    "general_settings to your reverse-proxy CIDR(s) to allow "
-                    "X-Forwarded-* through."
+                    "is not configured. X-Forwarded-* headers are not validated "
+                    "against a trusted proxy, so MCP OAuth discovery URLs fall "
+                    "back to the proxy's literal request values and MCP "
+                    "access-control honours X-Forwarded-For only when the direct "
+                    "peer is an internal address. Set mcp_trusted_proxy_ranges in "
+                    "general_settings to your reverse-proxy CIDR(s) to validate "
+                    "the proxy explicitly."
                 )
                 _warned_xff_without_trusted_ranges = True
             return False

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -60,7 +60,11 @@ class TestIsInternalIp:
 
 
 class TestMCPClientIPExtraction:
-    def test_fails_closed_when_xff_enabled_without_trusted_proxy_ranges(self):
+    def test_public_direct_peer_spoofing_xff_stays_external(self):
+        # A caller connecting directly to the gateway (public direct peer) with
+        # use_x_forwarded_for on but no mcp_trusted_proxy_ranges cannot spoof an
+        # internal X-Forwarded-For to reach available_on_public_internet=false
+        # servers: the forged XFF is ignored and the real public peer is used.
         request = MagicMock(spec=Request)
         request.client = MagicMock()
         request.client.host = "203.0.113.5"
@@ -71,17 +75,14 @@ class TestMCPClientIPExtraction:
             general_settings={"use_x_forwarded_for": True},
         )
 
-        # XFF is untrusted (no mcp_trusted_proxy_ranges) so it must be ignored,
-        # and we must not trust the direct peer either: fail closed so the caller
-        # is classified as external and is_internal_ip("") is False.
-        assert result == ""
+        assert result == "203.0.113.5"
         assert IPAddressUtils.is_internal_ip(result) is False
 
-    def test_private_proxy_peer_does_not_grant_internal_access(self):
-        # Regression: behind an internal reverse proxy with use_x_forwarded_for
-        # enabled but mcp_trusted_proxy_ranges unset, the direct peer is the
-        # proxy's private IP. Returning it would mis-classify an external caller
-        # as internal and expose available_on_public_internet=false servers.
+    def test_external_client_behind_private_proxy_stays_external(self):
+        # Behind an internal reverse proxy (private direct peer) with XFF on but
+        # no mcp_trusted_proxy_ranges, an external client (public XFF) is still
+        # classified external by its forwarded address, so it cannot reach
+        # internal-only servers.
         request = MagicMock(spec=Request)
         request.client = MagicMock()
         request.client.host = "10.0.0.7"
@@ -92,8 +93,29 @@ class TestMCPClientIPExtraction:
             general_settings={"use_x_forwarded_for": True},
         )
 
-        assert result == ""
+        assert result == "8.8.8.8"
         assert IPAddressUtils.is_internal_ip(result) is False
+
+    def test_internal_client_behind_private_proxy_without_trusted_ranges_is_internal(
+        self,
+    ):
+        # LIT-3964 regression: an internal client reaching the gateway through a
+        # private reverse proxy (private direct peer, internal XFF) with
+        # use_x_forwarded_for on but no mcp_trusted_proxy_ranges must be
+        # classified internal. Returning "" here (the regressed behaviour) made
+        # is_internal_ip("") False, so every internal-only MCP server 404'd.
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.headers = {"x-forwarded-for": "10.0.0.9"}
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={"use_x_forwarded_for": True},
+        )
+
+        assert result == "10.0.0.9"
+        assert IPAddressUtils.is_internal_ip(result) is True
 
     def test_honours_xff_from_trusted_proxy(self):
         request = MagicMock(spec=Request)
@@ -160,6 +182,32 @@ class TestMCPServerIPFiltering:
         manager = _make_manager([priv])
 
         result = manager.filter_server_ids_by_ip(["priv"], client_ip=None)
+        assert result == ["priv"]
+
+    @patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"use_x_forwarded_for": True},
+    )
+    @patch("litellm.public_mcp_servers", [])
+    def test_internal_client_behind_proxy_can_reach_internal_only_server(self):
+        # LIT-3964 end-to-end: the rest/oauth paths extract the client IP via
+        # get_mcp_client_ip and feed it straight into filter_server_ids_by_ip.
+        # With use_x_forwarded_for on, no mcp_trusted_proxy_ranges, a private
+        # proxy peer and an internal forwarded client, the internal-only server
+        # must survive the filter instead of 404ing.
+        priv = _make_server("priv", available_on_public_internet=False)
+        manager = _make_manager([priv])
+
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "10.0.0.1"
+        request.headers = {"x-forwarded-for": "10.0.0.9"}
+        client_ip = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={"use_x_forwarded_for": True},
+        )
+
+        result = manager.filter_server_ids_by_ip(["priv"], client_ip=client_ip)
         assert result == ["priv"]
 
 

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -135,6 +135,29 @@ class TestMCPClientIPExtraction:
         assert result is not None
         assert IPAddressUtils.is_internal_ip(result) is False
 
+    def test_xff_honoured_when_peer_internal_under_custom_ranges(self):
+        # The private-proxy carve-out must use the same internal-range
+        # definition as the access-control gate (mcp_internal_ip_ranges), not
+        # only the RFC1918 defaults. A reverse proxy internal under a custom
+        # CIDR (100.64.0.0/10, outside the defaults) is a private proxy, so its
+        # forwarded client IP must be honoured. Classifying it by defaults would
+        # drop the XFF and return the proxy's own custom-internal IP, letting a
+        # public forwarded client inherit internal access.
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "100.64.0.5"
+        request.headers = {"x-forwarded-for": "8.8.8.8"}
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_internal_ip_ranges": ["100.64.0.0/10"],
+            },
+        )
+
+        assert result == "8.8.8.8"
+
     def test_honours_xff_from_trusted_proxy(self):
         request = MagicMock(spec=Request)
         request.client = MagicMock()
@@ -247,6 +270,41 @@ class TestMCPServerIPFiltering:
         client_ip = IPAddressUtils.get_mcp_client_ip(
             request,
             general_settings={"use_x_forwarded_for": True},
+        )
+
+        result = manager.filter_server_ids_by_ip(["priv"], client_ip=client_ip)
+        assert result == []
+
+    @patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {
+            "use_x_forwarded_for": True,
+            "mcp_internal_ip_ranges": ["100.64.0.0/10"],
+        },
+    )
+    @patch("litellm.public_mcp_servers", [])
+    def test_public_client_via_custom_internal_proxy_cannot_reach_internal_only_server(
+        self,
+    ):
+        # Security: with custom mcp_internal_ip_ranges, a public client forwarded
+        # by a proxy that is internal only under those custom ranges must still
+        # be blocked from internal-only servers. get_mcp_client_ip recognises the
+        # proxy as private and honours the public XFF, and the filter then drops
+        # the internal-only server. Classifying the peer by RFC1918 defaults
+        # would return the proxy's own IP and leak the server to the caller.
+        priv = _make_server("priv", available_on_public_internet=False)
+        manager = _make_manager([priv])
+
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "100.64.0.5"
+        request.headers = {"x-forwarded-for": "8.8.8.8"}
+        client_ip = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_internal_ip_ranges": ["100.64.0.0/10"],
+            },
         )
 
         result = manager.filter_server_ids_by_ip(["priv"], client_ip=client_ip)

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -117,6 +117,24 @@ class TestMCPClientIPExtraction:
         assert result == "10.0.0.9"
         assert IPAddressUtils.is_internal_ip(result) is True
 
+    def test_unknown_direct_peer_spoofing_xff_stays_external(self):
+        # When the ASGI transport does not expose request.client (Unix-socket
+        # transports, some test clients) the direct peer is unknown. With XFF on
+        # and no mcp_trusted_proxy_ranges, a forged internal X-Forwarded-For must
+        # not be trusted. The result must be a non-None external value: returning
+        # None would mean "no filtering" downstream and leak internal access.
+        request = MagicMock(spec=Request)
+        request.client = None
+        request.headers = {"x-forwarded-for": "10.0.0.9"}
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={"use_x_forwarded_for": True},
+        )
+
+        assert result is not None
+        assert IPAddressUtils.is_internal_ip(result) is False
+
     def test_honours_xff_from_trusted_proxy(self):
         request = MagicMock(spec=Request)
         request.client = MagicMock()
@@ -209,6 +227,30 @@ class TestMCPServerIPFiltering:
 
         result = manager.filter_server_ids_by_ip(["priv"], client_ip=client_ip)
         assert result == ["priv"]
+
+    @patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"use_x_forwarded_for": True},
+    )
+    @patch("litellm.public_mcp_servers", [])
+    def test_unknown_peer_spoofing_xff_cannot_reach_internal_only_server(self):
+        # Security regression: if the transport doesn't expose request.client, a
+        # forged internal X-Forwarded-For must not unlock internal-only servers.
+        # get_mcp_client_ip classifies external and the filter drops the private
+        # server. A None result (the fail-open bug) would leave it accessible.
+        priv = _make_server("priv", available_on_public_internet=False)
+        manager = _make_manager([priv])
+
+        request = MagicMock(spec=Request)
+        request.client = None
+        request.headers = {"x-forwarded-for": "10.0.0.9"}
+        client_ip = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={"use_x_forwarded_for": True},
+        )
+
+        result = manager.filter_server_ids_by_ip(["priv"], client_ip=client_ip)
+        assert result == []
 
 
 class TestFilterServerIdsByIpWithInfo:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3964

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Regression: with `use_x_forwarded_for: true` and no `mcp_trusted_proxy_ranges` configured, every internal-only MCP server (`available_on_public_internet: false`) started returning 404 as soon as an `X-Forwarded-For` header was present, which is what every load balancer sends. So this hit real MCP clients (Cursor, mcp-inspector, etc.) during discovery and connection in production while a direct localhost call without XFF looked fine

Root cause is `IPAddressUtils.get_mcp_client_ip` in `litellm/proxy/auth/ip_address_utils.py`. When XFF was enabled and present but no trusted ranges were configured, it returned `""` to "fail closed". That empty string then flowed straight into the IP access-control gate, where `is_internal_ip("")` is `False`, so the caller was classified external; the internal-only server got filtered out of the registry and the named-server lookup (`get_mcp_server_by_name`) raised 404

This was introduced in #28008 (merged to the release line as its internal-staging copy #28356, commit `6d6eda81`). Before that change the same branch fell through to parse XFF, which is why 1.88.0 worked and 1.89.0 / 1.89.2 did not

The fix honours `X-Forwarded-For` when the direct peer is itself internal (a private reverse proxy in front of the gateway), and only ignores it, classifying by the direct connection IP, when the peer is a public address or falls outside the configured trusted ranges. This restores access for internal clients behind a load balancer while actually closing a gap the pre-1.89 behaviour had: a public caller connecting directly to the gateway and spoofing an internal `X-Forwarded-For` is now classified by its real public peer instead of being trusted. The hardened path is unchanged; set `mcp_trusted_proxy_ranges` to validate the proxy explicitly

A follow-up commit hardens the unknown-peer case raised in review (`request.client is None`, possible with Unix-socket transports and some ASGI test clients). The check is now framed as `peer_is_private_proxy`, and the untrusted path returns `direct_ip or ""` so a request with no identifiable peer fails closed to the external `""` sentinel rather than returning `None`, which would mean "no filtering" downstream and leak internal access

A further commit makes the private-proxy check classify the direct peer with the same `mcp_internal_ip_ranges` the access-control gate uses, instead of the RFC1918 defaults. Otherwise a reverse proxy that is internal only under a custom CIDR was treated as untrusted, its `X-Forwarded-For` dropped and its own IP returned, so a public client forwarded through it could inherit the proxy's internal classification and reach internal-only servers

A final commit corrects the one-shot `use_x_forwarded_for` warning text, which still claimed access-control client IPs would use the proxy's literal request values; with the carve-out, access-control now honours `X-Forwarded-For` when the direct peer is internal, so the message would have misled the very operators this fix helps

### Tests

`tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py`:

- `test_internal_client_behind_private_proxy_without_trusted_ranges_is_internal` is the direct regression for LIT-3964; it would return `""` (and 404) before this change
- `test_internal_client_behind_proxy_can_reach_internal_only_server` ties the two halves together end to end the way production does (extract client IP, then `filter_server_ids_by_ip`) and asserts the internal-only server survives the filter
- `test_public_direct_peer_spoofing_xff_stays_external` and `test_external_client_behind_private_proxy_stays_external` keep the security assertions of the two cases #28008 added; both callers are still classified external, just by their real address rather than by the empty-string sentinel
- `test_unknown_direct_peer_spoofing_xff_stays_external` and `test_unknown_peer_spoofing_xff_cannot_reach_internal_only_server` cover the `request.client is None` case: the first asserts the result is non-None and external, the second asserts the internal-only server is dropped by `filter_server_ids_by_ip` so a forged XFF from an unidentifiable peer cannot reach it
- `test_xff_honoured_when_peer_internal_under_custom_ranges` and `test_public_client_via_custom_internal_proxy_cannot_reach_internal_only_server` cover custom `mcp_internal_ip_ranges`: the first asserts the forwarded client IP is honoured when the peer is internal only under a custom CIDR, the second asserts a public forwarded client cannot reach an internal-only server through such a proxy

## Screenshots / Proof of Fix

Minimal config (internal-only server, XFF on, no trusted ranges):

```yaml
general_settings:
  master_key: sk-1234
  use_x_forwarded_for: true

model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: gpt-4o-mini

mcp_servers:
  internal_math:
    transport: stdio
    command: python3
    args:
      - tests/mcp_tests/mcp_server.py
    allow_all_keys: true
    available_on_public_internet: false
```

```
python litellm/proxy/proxy_cli.py --config .yaml --detailed_debug --reload 2>&1 | tee litellm.log
```

```
# WITH an X-Forwarded-For header (what a load balancer sends)
curl -s -o /dev/null -w "with XFF:    %{http_code}\n" \
  -H "X-Forwarded-For: 10.0.0.9" \
  "http://localhost:4000/internal_math/authorize?redirect_uri=http://example/cb"

# WITHOUT the header
curl -s -o /dev/null -w "without XFF: %{http_code}\n" \
  "http://localhost:4000/internal_math/authorize?redirect_uri=http://example/cb"
```

On 1.89.x the `with XFF` line returns 404 (server filtered out); after this fix both lines return the same non-404 (e.g. 400 client_id required, meaning the server was found), matching 1.88.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP access-control IP extraction and trust rules for X-Forwarded-For; mistakes could expose internal-only servers or break clients behind proxies, but behavior is heavily tested and tightens some spoofing cases.
> 
> **Overview**
> Fixes **LIT-3964**: with `use_x_forwarded_for` on and no `mcp_trusted_proxy_ranges`, `get_mcp_client_ip` no longer always returns `""` when `X-Forwarded-For` is present. That empty string made every caller look external and **internal-only MCP servers 404** behind load balancers.
> 
> **`get_mcp_client_ip`** now trusts `X-Forwarded-For` when the direct peer is an internal reverse proxy (`mcp_internal_ip_ranges`, same rules as access control) and trusted ranges are not pinned. Public, out-of-range, or missing `request.client` peers still ignore forged XFF and classify by the direct connection (`direct_ip or ""`), so spoofing cannot reach `available_on_public_internet=false` servers and unknown peers do not return `None` (which would skip filtering).
> 
> The one-shot operator warning text is updated to describe this carve-out vs explicit `mcp_trusted_proxy_ranges`. Tests cover the regression, spoofing, custom internal CIDRs, and end-to-end `filter_server_ids_by_ip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02e05824ff542151b92eb8bf2ed2913c7a38280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->