### PR TITLE
fix(mcp): stop 404ing internal-only MCP servers when XFF is on without trusted proxy ranges

### DIFF
--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -42,7 +42,9 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning("Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr)
+                verbose_proxy_logger.warning(
+                    "Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr
+                )
         return networks if networks else IPAddressUtils._DEFAULT_INTERNAL_NETWORKS
 
     @staticmethod
@@ -60,7 +62,9 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning("Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr)
+                verbose_proxy_logger.warning(
+                    "Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr
+                )
         return networks
 
     @staticmethod
@@ -80,7 +84,9 @@ class IPAddressUtils:
     @staticmethod
     def is_internal_ip(
         client_ip: Optional[str],
-        internal_networks: Optional[List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]] = None,
+        internal_networks: Optional[
+            List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
+        ] = None,
     ) -> bool:
         """
         Check if a client IP is from an internal/private network.
@@ -198,9 +204,13 @@ class IPAddressUtils:
             use_xff
             and "x-forwarded-for" in request.headers
             and general_settings.get("mcp_trusted_proxy_ranges")
-            and not IPAddressUtils.is_request_from_trusted_proxy(request, general_settings=general_settings)
+            and not IPAddressUtils.is_request_from_trusted_proxy(
+                request, general_settings=general_settings
+            )
         ):
             direct_ip = request.client.host if request.client else None
-            verbose_proxy_logger.warning("XFF header from untrusted IP %s, ignoring", direct_ip)
+            verbose_proxy_logger.warning(
+                "XFF header from untrusted IP %s, ignoring", direct_ip
+            )
             return direct_ip
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -42,9 +42,7 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning(
-                    "Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr
-                )
+                verbose_proxy_logger.warning("Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr)
         return networks if networks else IPAddressUtils._DEFAULT_INTERNAL_NETWORKS
 
     @staticmethod
@@ -62,9 +60,7 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning(
-                    "Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr
-                )
+                verbose_proxy_logger.warning("Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr)
         return networks
 
     @staticmethod
@@ -84,9 +80,7 @@ class IPAddressUtils:
     @staticmethod
     def is_internal_ip(
         client_ip: Optional[str],
-        internal_networks: Optional[
-            List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
-        ] = None,
+        internal_networks: Optional[List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]] = None,
     ) -> bool:
         """
         Check if a client IP is from an internal/private network.
@@ -152,12 +146,11 @@ class IPAddressUtils:
             if not _warned_xff_without_trusted_ranges:
                 verbose_proxy_logger.warning(
                     "use_x_forwarded_for is enabled but mcp_trusted_proxy_ranges "
-                    "is not configured. X-Forwarded-* headers will NOT be "
-                    "trusted, so MCP OAuth discovery URLs and access-control "
-                    "client IPs will use the proxy's literal request values. "
-                    "Set mcp_trusted_proxy_ranges in "
-                    "general_settings to your reverse-proxy CIDR(s) to allow "
-                    "X-Forwarded-* through."
+                    "is not configured. X-Forwarded-Host/Proto will NOT be "
+                    "trusted when building MCP OAuth discovery URLs, which fall "
+                    "back to the proxy's literal request URL. Set "
+                    "mcp_trusted_proxy_ranges in general_settings to your "
+                    "reverse-proxy CIDR(s) to allow X-Forwarded-* through."
                 )
                 _warned_xff_without_trusted_ranges = True
             return False
@@ -174,9 +167,12 @@ class IPAddressUtils:
         """
         Extract client IP from a FastAPI request for MCP access control.
 
-        Security: Only trusts X-Forwarded-For if:
-        1. use_x_forwarded_for is enabled in settings
-        2. The direct connection is from a trusted proxy (if mcp_trusted_proxy_ranges configured)
+        Honors X-Forwarded-For whenever ``use_x_forwarded_for`` is enabled, so a
+        client behind a reverse proxy is classified by its real (forwarded) IP
+        rather than the proxy's peer address. When ``mcp_trusted_proxy_ranges``
+        is also configured, the forwarded header is only honored if the direct
+        peer falls inside a trusted range; an untrusted peer falls back to its
+        literal IP so a spoofed header cannot grant internal access.
 
         Args:
             request: FastAPI request object
@@ -198,21 +194,13 @@ class IPAddressUtils:
 
         use_xff = general_settings.get("use_x_forwarded_for", False)
 
-        # If XFF is enabled, validate the request comes from a trusted proxy
-        if use_xff and "x-forwarded-for" in request.headers:
-            if not IPAddressUtils.is_request_from_trusted_proxy(
-                request, general_settings=general_settings
-            ):
-                direct_ip = request.client.host if request.client else None
-                if general_settings.get("mcp_trusted_proxy_ranges"):
-                    # Direct connection isn't in any configured trusted CIDR.
-                    verbose_proxy_logger.warning(
-                        "XFF header from untrusted IP %s, ignoring", direct_ip
-                    )
-                    return direct_ip
-                # XFF enabled but no trusted proxy ranges configured: the direct
-                # peer is typically the reverse proxy's own (private) IP, so
-                # returning it would mis-classify external callers as internal.
-                # Fail closed for access control.
-                return ""
+        if (
+            use_xff
+            and "x-forwarded-for" in request.headers
+            and general_settings.get("mcp_trusted_proxy_ranges")
+            and not IPAddressUtils.is_request_from_trusted_proxy(request, general_settings=general_settings)
+        ):
+            direct_ip = request.client.host if request.client else None
+            verbose_proxy_logger.warning("XFF header from untrusted IP %s, ignoring", direct_ip)
+            return direct_ip
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -13,9 +13,10 @@ from fastapi import Request
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.auth.auth_utils import _get_request_ip_address
 
-# One-shot warning so operators upgrading from the prior "always trust X-Forwarded-*"
-# behaviour see an actionable message in their logs the first time it triggers.
+# One-shot warnings so operators upgrading from the prior "always trust X-Forwarded-*"
+# behaviour see an actionable message in their logs the first time each path triggers.
 _warned_xff_without_trusted_ranges = False
+_warned_xff_access_control_without_trusted_ranges = False
 
 
 class IPAddressUtils:
@@ -178,7 +179,11 @@ class IPAddressUtils:
         rather than the proxy's peer address. When ``mcp_trusted_proxy_ranges``
         is also configured, the forwarded header is only honored if the direct
         peer falls inside a trusted range; an untrusted peer falls back to its
-        literal IP so a spoofed header cannot grant internal access.
+        literal IP so a spoofed header cannot grant internal access. With
+        ``use_x_forwarded_for`` enabled but no trusted ranges configured the
+        header is trusted as-is (matching the proxy's wider X-Forwarded-For
+        contract), and a one-shot warning is logged so operators know
+        access control rests on an unvalidated header.
 
         Args:
             request: FastAPI request object
@@ -199,11 +204,14 @@ class IPAddressUtils:
             general_settings = {}
 
         use_xff = general_settings.get("use_x_forwarded_for", False)
+        xff_present = use_xff and "x-forwarded-for" in request.headers
+        trusted_ranges_configured = bool(
+            general_settings.get("mcp_trusted_proxy_ranges")
+        )
 
         if (
-            use_xff
-            and "x-forwarded-for" in request.headers
-            and general_settings.get("mcp_trusted_proxy_ranges")
+            xff_present
+            and trusted_ranges_configured
             and not IPAddressUtils.is_request_from_trusted_proxy(
                 request, general_settings=general_settings
             )
@@ -213,4 +221,24 @@ class IPAddressUtils:
                 "XFF header from untrusted IP %s, ignoring", direct_ip
             )
             return direct_ip
+
+        if xff_present and not trusted_ranges_configured:
+            IPAddressUtils._warn_xff_trusted_for_access_control()
+
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)
+
+    @staticmethod
+    def _warn_xff_trusted_for_access_control() -> None:
+        global _warned_xff_access_control_without_trusted_ranges
+        if _warned_xff_access_control_without_trusted_ranges:
+            return
+        verbose_proxy_logger.warning(
+            "use_x_forwarded_for is enabled but mcp_trusted_proxy_ranges is not "
+            "configured. X-Forwarded-For is trusted as-is for MCP IP-based "
+            "access control, so a caller with direct network access to the proxy "
+            "could spoof an internal IP and reach available_on_public_internet="
+            "false servers. Set mcp_trusted_proxy_ranges in general_settings to "
+            "your reverse-proxy CIDR(s) to validate the proxy before trusting "
+            "X-Forwarded-For."
+        )
+        _warned_xff_access_control_without_trusted_ranges = True

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -60,7 +60,11 @@ class TestIsInternalIp:
 
 
 class TestMCPClientIPExtraction:
-    def test_fails_closed_when_xff_enabled_without_trusted_proxy_ranges(self):
+    def test_honours_xff_for_internal_client_without_trusted_proxy_ranges(self):
+        # LIT-3964 regression: use_x_forwarded_for enabled, no mcp_trusted_proxy_ranges,
+        # internal client behind a load balancer. The forwarded client IP must be
+        # honored (matching use_x_forwarded_for semantics and pre-1.89 behavior) so
+        # the caller is classified internal, not fail-closed to "" and then 404'd.
         request = MagicMock(spec=Request)
         request.client = MagicMock()
         request.client.host = "203.0.113.5"
@@ -71,17 +75,13 @@ class TestMCPClientIPExtraction:
             general_settings={"use_x_forwarded_for": True},
         )
 
-        # XFF is untrusted (no mcp_trusted_proxy_ranges) so it must be ignored,
-        # and we must not trust the direct peer either: fail closed so the caller
-        # is classified as external and is_internal_ip("") is False.
-        assert result == ""
-        assert IPAddressUtils.is_internal_ip(result) is False
+        assert result == "10.0.0.1"
+        assert IPAddressUtils.is_internal_ip(result) is True
 
-    def test_private_proxy_peer_does_not_grant_internal_access(self):
-        # Regression: behind an internal reverse proxy with use_x_forwarded_for
-        # enabled but mcp_trusted_proxy_ranges unset, the direct peer is the
-        # proxy's private IP. Returning it would mis-classify an external caller
-        # as internal and expose available_on_public_internet=false servers.
+    def test_external_client_via_xff_stays_external_without_trusted_proxy_ranges(self):
+        # External caller forwarded through an internal reverse proxy: the forwarded
+        # IP is the real public client, so it is still classified external and cannot
+        # reach available_on_public_internet=false servers.
         request = MagicMock(spec=Request)
         request.client = MagicMock()
         request.client.host = "10.0.0.7"
@@ -92,7 +92,7 @@ class TestMCPClientIPExtraction:
             general_settings={"use_x_forwarded_for": True},
         )
 
-        assert result == ""
+        assert result == "8.8.8.8"
         assert IPAddressUtils.is_internal_ip(result) is False
 
     def test_honours_xff_from_trusted_proxy(self):
@@ -128,6 +128,48 @@ class TestMCPClientIPExtraction:
         assert result == "203.0.113.5"
 
 
+class TestInternalOnlyServerResolutionRegression:
+    """LIT-3964: with use_x_forwarded_for enabled and no mcp_trusted_proxy_ranges,
+    internal-only servers must still resolve for forwarded internal callers
+    (previously failed closed to "" and 404'd every internal-only server)."""
+
+    @patch("litellm.public_mcp_servers", [])
+    @patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"use_x_forwarded_for": True},
+    )
+    def test_internal_only_server_found_for_forwarded_internal_client(self):
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "10.0.0.7"  # load balancer peer
+        request.headers = {"x-forwarded-for": "192.168.1.50"}  # real internal client
+
+        client_ip = IPAddressUtils.get_mcp_client_ip(request)
+        assert client_ip == "192.168.1.50"
+
+        manager = _make_manager([_make_server("internal_math", available_on_public_internet=False)])
+        server = manager.get_mcp_server_by_name("internal_math", client_ip=client_ip)
+        assert server is not None
+        assert server.server_id == "internal_math"
+
+    @patch("litellm.public_mcp_servers", [])
+    @patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"use_x_forwarded_for": True},
+    )
+    def test_internal_only_server_hidden_from_forwarded_external_client(self):
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "10.0.0.7"
+        request.headers = {"x-forwarded-for": "8.8.8.8"}  # real external client
+
+        client_ip = IPAddressUtils.get_mcp_client_ip(request)
+        assert client_ip == "8.8.8.8"
+
+        manager = _make_manager([_make_server("internal_math", available_on_public_internet=False)])
+        assert manager.get_mcp_server_by_name("internal_math", client_ip=client_ip) is None
+
+
 class TestMCPServerIPFiltering:
     """Tests that external callers only see public MCP servers."""
 
@@ -148,9 +190,7 @@ class TestMCPServerIPFiltering:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        result = manager.filter_server_ids_by_ip(
-            ["pub", "priv"], client_ip="192.168.1.1"
-        )
+        result = manager.filter_server_ids_by_ip(["pub", "priv"], client_ip="192.168.1.1")
         assert result == ["pub", "priv"]
 
     @patch("litellm.public_mcp_servers", [])
@@ -173,9 +213,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["pub", "priv"], client_ip="8.8.8.8"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="8.8.8.8")
         assert allowed == ["pub"]
         assert blocked == 1
 
@@ -186,9 +224,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["pub", "priv"], client_ip="192.168.1.1"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="192.168.1.1")
         assert allowed == ["pub", "priv"]
         assert blocked == 0
 
@@ -198,9 +234,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["priv"], client_ip=None
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv"], client_ip=None)
         assert allowed == ["priv"]
         assert blocked == 0
 
@@ -211,8 +245,6 @@ class TestFilterServerIdsByIpWithInfo:
         priv2 = _make_server("priv2", available_on_public_internet=False)
         manager = _make_manager([priv1, priv2])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["priv1", "priv2"], client_ip="1.2.3.4"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv1", "priv2"], client_ip="1.2.3.4")
         assert allowed == []
         assert blocked == 2

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -147,7 +147,9 @@ class TestInternalOnlyServerResolutionRegression:
         client_ip = IPAddressUtils.get_mcp_client_ip(request)
         assert client_ip == "192.168.1.50"
 
-        manager = _make_manager([_make_server("internal_math", available_on_public_internet=False)])
+        manager = _make_manager(
+            [_make_server("internal_math", available_on_public_internet=False)]
+        )
         server = manager.get_mcp_server_by_name("internal_math", client_ip=client_ip)
         assert server is not None
         assert server.server_id == "internal_math"
@@ -166,8 +168,12 @@ class TestInternalOnlyServerResolutionRegression:
         client_ip = IPAddressUtils.get_mcp_client_ip(request)
         assert client_ip == "8.8.8.8"
 
-        manager = _make_manager([_make_server("internal_math", available_on_public_internet=False)])
-        assert manager.get_mcp_server_by_name("internal_math", client_ip=client_ip) is None
+        manager = _make_manager(
+            [_make_server("internal_math", available_on_public_internet=False)]
+        )
+        assert (
+            manager.get_mcp_server_by_name("internal_math", client_ip=client_ip) is None
+        )
 
 
 class TestMCPServerIPFiltering:
@@ -190,7 +196,9 @@ class TestMCPServerIPFiltering:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        result = manager.filter_server_ids_by_ip(["pub", "priv"], client_ip="192.168.1.1")
+        result = manager.filter_server_ids_by_ip(
+            ["pub", "priv"], client_ip="192.168.1.1"
+        )
         assert result == ["pub", "priv"]
 
     @patch("litellm.public_mcp_servers", [])
@@ -213,7 +221,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="8.8.8.8")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["pub", "priv"], client_ip="8.8.8.8"
+        )
         assert allowed == ["pub"]
         assert blocked == 1
 
@@ -224,7 +234,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="192.168.1.1")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["pub", "priv"], client_ip="192.168.1.1"
+        )
         assert allowed == ["pub", "priv"]
         assert blocked == 0
 
@@ -234,7 +246,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv"], client_ip=None)
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["priv"], client_ip=None
+        )
         assert allowed == ["priv"]
         assert blocked == 0
 
@@ -245,6 +259,8 @@ class TestFilterServerIdsByIpWithInfo:
         priv2 = _make_server("priv2", available_on_public_internet=False)
         manager = _make_manager([priv1, priv2])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv1", "priv2"], client_ip="1.2.3.4")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["priv1", "priv2"], client_ip="1.2.3.4"
+        )
         assert allowed == []
         assert blocked == 2

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -95,6 +95,61 @@ class TestMCPClientIPExtraction:
         assert result == "8.8.8.8"
         assert IPAddressUtils.is_internal_ip(result) is False
 
+    def test_warns_once_that_xff_is_trusted_for_access_control_without_ranges(self):
+        # Security observability: when XFF is honored for access control without
+        # mcp_trusted_proxy_ranges, operators must be told (once) that the gate
+        # rests on an unvalidated header that a direct caller could spoof.
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "203.0.113.5"
+        request.headers = {"x-forwarded-for": "10.0.0.1"}
+
+        with (
+            patch(
+                "litellm.proxy.auth.ip_address_utils._warned_xff_access_control_without_trusted_ranges",
+                False,
+            ),
+            patch(
+                "litellm.proxy.auth.ip_address_utils.verbose_proxy_logger"
+            ) as mock_logger,
+        ):
+            IPAddressUtils.get_mcp_client_ip(
+                request, general_settings={"use_x_forwarded_for": True}
+            )
+            IPAddressUtils.get_mcp_client_ip(
+                request, general_settings={"use_x_forwarded_for": True}
+            )
+
+        assert mock_logger.warning.call_count == 1
+        message = mock_logger.warning.call_args[0][0]
+        assert "access control" in message.lower()
+        assert "mcp_trusted_proxy_ranges" in message
+
+    def test_no_access_control_warning_when_trusted_ranges_configured(self):
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "10.0.0.5"
+        request.headers = {"x-forwarded-for": "192.168.1.10"}
+
+        with (
+            patch(
+                "litellm.proxy.auth.ip_address_utils._warned_xff_access_control_without_trusted_ranges",
+                False,
+            ),
+            patch(
+                "litellm.proxy.auth.ip_address_utils.verbose_proxy_logger"
+            ) as mock_logger,
+        ):
+            IPAddressUtils.get_mcp_client_ip(
+                request,
+                general_settings={
+                    "use_x_forwarded_for": True,
+                    "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                },
+            )
+
+        mock_logger.warning.assert_not_called()
+
     def test_honours_xff_from_trusted_proxy(self):
         request = MagicMock(spec=Request)
         request.client = MagicMock()


### PR DESCRIPTION
## Relevant issues

Fixes LIT-3964 (regression: all internal-only MCP servers return 404 Not Found)

## Linear ticket

https://linear.app/litellm-ai/issue/LIT-3964/regression-all-internal-only-mcp-servers-are-returning-404-not-found

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Minimal repro config (internal-only server, XFF on, no trusted ranges):

```yaml
general_settings:
  master_key: sk-1234
  use_x_forwarded_for: true
  # deliberately NO mcp_trusted_proxy_ranges

model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: gpt-4o-mini

mcp_servers:
  internal_math:
    transport: stdio
    command: python3
    args:
      - tests/mcp_tests/mcp_server.py
    allow_all_keys: true
    available_on_public_internet: false   # internal-only
```

Run it:

```bash
python litellm/proxy/proxy_cli.py --config <that_file>.yaml --detailed_debug --reload 2>&1 | tee litellm.log
```

Probe the named-server resolution path with and without an X-Forwarded-For header (what a load balancer sends):

```bash
curl -s -o /dev/null -w "with XFF:    %{http_code}\n" \
  -H "X-Forwarded-For: 10.0.0.9" \
  "http://localhost:4000/internal_math/authorize?redirect_uri=http://example/cb"

curl -s -o /dev/null -w "without XFF: %{http_code}\n" \
  "http://localhost:4000/internal_math/authorize?redirect_uri=http://example/cb"
```

Before this fix (v1.89.0 / v1.89.2): `with XFF: 404` (internal-only server hidden), `without XFF:` non-404. After this fix: both are non-404 (the server resolves and the request proceeds to normal auth handling), matching v1.88.0.

## Type

🐛 Bug Fix

## Changes

### Root cause

`IPAddressUtils.get_mcp_client_ip` returned `""` ("fail closed") when `use_x_forwarded_for: true` was set but `mcp_trusted_proxy_ranges` was not configured. That empty IP made `is_internal_ip("")` return `False`, so every `available_on_public_internet=false` server was classified as external, hidden by `_is_server_accessible_from_ip`, and `get_mcp_server_by_name` returned `None`; the MCP discovery / SSE / streamable-HTTP routes then turned that `None` into a 404. The combination of XFF enabled plus no trusted ranges is very common (LiteLLM behind a load balancer), so it broke every internal-only server while looking fine on naive localhost testing (no XFF header means `request.client.host` is `127.0.0.1`).

The fail-closed branch was introduced in #28356 (squash `6d6eda8101`), shipped in v1.89.0; v1.88.x never contained it, matching the working-vs-broken versions reported.

### Fix

Honor `X-Forwarded-For` whenever `use_x_forwarded_for` is enabled, so a client behind a reverse proxy is classified by its real (forwarded) IP rather than the proxy's peer address. This matches pre-1.89 behavior and how the rest of the proxy already treats `use_x_forwarded_for` (e.g. `_check_valid_ip`). The spoof defense is kept only when `mcp_trusted_proxy_ranges` is configured: an untrusted direct peer still falls back to its literal IP so a forged header cannot grant internal access. OAuth discovery URL building is unaffected; it keeps failing closed via `is_request_from_trusted_proxy` and `get_request_base_url`.

The two existing unit tests that encoded the fail-closed empty-string behavior as intended were corrected to assert the restored behavior, and a `TestInternalOnlyServerResolutionRegression` class was added that drives the exact 404 boundary (`get_mcp_client_ip` -> `get_mcp_server_by_name`) for both a forwarded internal client (now resolves) and a forwarded external client (still hidden). A mutation check confirms all four new/updated assertions fail against the old `return ""` code and pass against the fix.
