### PR TITLE
ci(image-scan): add Grype image scan for OS + library CVEs

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,65 @@
+name: Image Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+      - litellm_internal_staging
+      - litellm_oss_branch
+      - "litellm_**"
+    paths:
+      - docker/Dockerfile.non_root
+      - uv.lock
+      - ui/litellm-dashboard/package-lock.json
+      - .github/workflows/image-scan.yml
+  schedule:
+    - cron: "41 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  image-scan:
+    name: image-scan
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Download Grype v0.114.0
+        run: |
+          curl -fsSL --retry 3 -o "$RUNNER_TEMP/grype.tar.gz" \
+            https://github.com/anchore/grype/releases/download/v0.114.0/grype_0.114.0_linux_amd64.tar.gz
+          echo "edda0968d8827daab01d32b3cd7de192ae0915005e7bbfcfef9e68e79bc43343  $RUNNER_TEMP/grype.tar.gz" | sha256sum -c -
+          tar xzf "$RUNNER_TEMP/grype.tar.gz" -C "$RUNNER_TEMP" grype
+          chmod +x "$RUNNER_TEMP/grype"
+
+      # Dockerfile.non_root is the rootless variant we ship. The other
+      # Dockerfiles share the same wolfi base and apk set, so OS-layer coverage
+      # is the same; matrix-scan if those variants ever diverge.
+      - name: Build runtime image
+        run: docker build -f docker/Dockerfile.non_root -t litellm-image-scan:${{ github.sha }} .
+
+      # Scans the whole shipped artifact: OS/apk plus every language package
+      # baked into the image, including ones no lockfile declares (e.g. prisma's
+      # vendored node engine) that osv-scan cannot see. osv-scan stays the fast
+      # source-level gate; this is the customer's-eye-view backstop. Credential-
+      # free OSS, run as a pinned, checksum-verified binary; no GitHub Action
+      # dependency and no vendor SaaS callout.
+      - name: Scan image for fixable HIGH/CRITICAL CVEs
+        run: |
+          "$RUNNER_TEMP/grype" litellm-image-scan:${{ github.sha }} \
+            --only-fixed \
+            --fail-on high \
+            --output table


### PR DESCRIPTION
## Relevant issues

Follow-up to [PR #31133](https://github.com/BerriAI/litellm/pull/31133) (openssl CVE-2026-34182 base-image bump): adds the CI gate that would have caught that class of issue before a customer scanner did. osv-scan only reads `uv.lock` and the npm lockfile, so OS/apk packages and language packages baked into the image (e.g. prisma's vendored node engine) are invisible to it. This adds an image-level scan as the missing gate.

## Linear ticket

[LIT-3967](https://linear.app/litellm-ai/issue/LIT-3967)

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

Infrastructure

## Changes

Adds `.github/workflows/image-scan.yml`. It builds the runtime image and runs Grype (pinned v0.114.0, sha256 verified), failing the build on fixable HIGH/CRITICAL across OS/apk and language packages. Trigger: PRs that touch a Dockerfile or lockfile, plus a nightly cron, plus manual.

Scanner choice: Grype (Anchore, OSS, Apache-2.0). Picked over Trivy and Snyk/Wiz specifically because of the TeamPCP supply chain incident in March 2026, where LiteLLM was backdoored through Trivy. The attack required two conditions: (1) the scanner was pulled via a mutable git tag in a GitHub Action, and (2) it ran in the same job that held `PYPI_PUBLISH`. The hardened pattern here closes both: the scanner is a pinned binary with sha256 verification (no mutable-tag action in the chain), and the scan job carries no publish secrets and no vendor credentials. Snyk and Wiz are credentialed SaaS scanners; they require a token in the scan job and send the SBOM to a third party, which is a strictly larger blast radius than a credential-free local scanner.



**Scan target.** Only `docker/Dockerfile.non_root` is built and scanned. The other Dockerfiles share the same wolfi base and apk set today, so OS-layer coverage is identical, and `Dockerfile.non_root` is the rootless variant (`USER 65534`) we are shipping to customers. Matrix-scan if those variants ever diverge.

## Proof of fix

Grype v0.114.0 run locally with the same flags as CI:
```
# old wolfi-base@sha256:31da6565... (pre-#31133)
HIGH/CRITICAL (fixable): 23 -- libcrypto3, libssl3, busybox, ...
   libcrypto3 3.6.2-r3 -> 3.6.3-r0 apk CVE-2026-45447 High
   libssl3    3.6.2-r3 -> 3.6.3-r0 apk CVE-2026-34183 High
   libssl3    3.6.2-r3 -> 3.6.3-r0 apk CVE-2026-34180 High
   ...

# new wolfi-base@sha256:c61ac691... (current, post-#31133)
HIGH/CRITICAL (fixable): 0
```
osv-scanner returns "No issues found" on the same vulnerable base image, confirming the coverage gap this fills. The full scan also runs on this PR via the new workflow.



## Pinned binary verification

The Grype binary in the workflow is pinned to v0.114.0 with sha256 `edda0968d8827daab01d32b3cd7de192ae0915005e7bbfcfef9e68e79bc43343` for `grype_0.114.0_linux_amd64.tar.gz`. The hash comes from Anchore's official release checksums file and was independently re-fetched and matched at PR-time:

https://github.com/anchore/grype/releases/download/v0.114.0/grype_0.114.0_checksums.txt

## Live test: gate caught the regression end-to-end

To prove the gate actually blocks a vulnerable image (not just synthetic findings), the wolfi-base digest was reverted to the pre-#31133 vulnerable `31da6565...` on a throwaway branch and pushed as test PR #31176. The image-scan job failed with the expected openssl findings:

```
ERROR discovered vulnerabilities at or above the severity threshold
libcrypto3  3.6.2-r3  3.6.3-r0  apk  CVE-2026-45447  High
libssl3     3.6.2-r3  3.6.3-r0  apk  CVE-2026-45447  High
busybox     1.37.0-r57  1.37.0-r58  apk  CVE-2023-39810  High
libcrypto3  3.6.2-r3  3.6.3-r0  apk  CVE-2026-42764  High
libssl3     3.6.2-r3  3.6.3-r0  apk  CVE-2026-42764  High
busybox     1.37.0-r57  1.37.0-r58  apk  CVE-2026-26157  High
libcrypto3  3.6.2-r3  3.6.3-r0  apk  CVE-2026-34183  High
libssl3     3.6.2-r3  3.6.3-r0  apk  CVE-2026-34183  High
libcrypto3  3.6.2-r3  3.6.3-r0  apk  CVE-2026-34180  High
...
image-scan FAILED (run conclusion=failure)
```

Test PR #31176 has been closed and its branch deleted; this PR's branch is untouched. A future PR reintroducing a vulnerable base would be blocked the same way.
## Live test: fork guard skips outside-contributor PRs

Verified end-to-end that the `if:` guard prevents a fork PR from running `docker build` on our hosted runner. From an outside-contributor fork (`Unc1eRick/litellm`), a draft PR was opened against a temporary BerriAI base branch carrying this workflow file. The matrix job conclusion was `skipped`, with `steps_count: 0` (matrix never expanded, no build ever ran):

```
run id: 28136152132
event: pull_request
head_repo: Unc1eRick/litellm
base_repo: BerriAI/litellm
workflow path: .github/workflows/image-scan.yml @ sha 4667e0709c   (fork-guard if: present)
job: image-scan (${{ matrix.dockerfile }})  status=completed conclusion=skipped steps_count=0
```

Skip cause confirmed by elimination: paths filter matched (`Dockerfile` was modified), branches filter matched (`litellm_**`), workflow file was present at the base ref with the `if:` block, and run conclusion was `skipped` (not `action_required`, which a control-plane intercept would produce). Only the job-level `if:` evaluating false produces this exact run shape with zero steps generated. Test branch and PR have been cleaned up.




