### PR TITLE
feat(ui): track frontend lint counts in a committed snapshot

### DIFF
--- a/.github/workflows/test-litellm-ui-build.yml
+++ b/.github/workflows/test-litellm-ui-build.yml
@@ -111,4 +111,4 @@ jobs:
         if: ${{ !cancelled() && steps.changed.outputs.has_files == 'true' }}
         run: |
           npx eslint . -f json -o "$RUNNER_TEMP/lint-report.json" || true
-          node scripts/check-lint-budgets.mjs "$RUNNER_TEMP/lint-report.json" eslint-budgets.json
+          node scripts/check-lint-budgets.mjs "$RUNNER_TEMP/lint-report.json" eslint-budgets.json --check eslint-metrics.json

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,0 +1,5 @@
+{
+  "@typescript-eslint/no-explicit-any": 2027,
+  "complexity": 128,
+  "max-depth": 61
+}

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "lint:metrics": "node scripts/update-lint-metrics.mjs",
     "test": "vitest",
     "test:dot": "vitest --reporter=dot",
     "test:watch": "vitest -w",

--- a/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
+++ b/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from "fs";
-import { countBudgetViolations } from "./lint-budget-lib.mjs";
+import { countBudgetViolations, findDrift } from "./lint-budget-lib.mjs";
 
 const argv = process.argv.slice(2);
 const positional = [];
@@ -32,13 +32,13 @@ for (const [rule, { max, target }] of Object.entries(budgets)) {
 
 if (flags.check) {
   const committed = JSON.parse(readFileSync(flags.check, "utf8"));
-  const drifted = Object.keys(counts).filter((rule) => committed[rule] !== counts[rule]);
-  for (const rule of drifted) {
+  const drift = findDrift(committed, counts);
+  for (const { rule, committed: was, actual } of drift) {
     console.error(
-      `::error::${flags.check} is stale for ${rule}: committed ${committed[rule] ?? "missing"}, actual ${counts[rule]}.`,
+      `::error::${flags.check} is stale for ${rule}: committed ${was ?? "missing"}, actual ${actual ?? "not a tracked rule"}.`,
     );
   }
-  if (drifted.length > 0) {
+  if (drift.length > 0) {
     console.error(`::error::Run \`npm run lint:metrics\` and commit ${flags.check}.`);
     failed = true;
   } else {

--- a/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
+++ b/ui/litellm-dashboard/scripts/check-lint-budgets.mjs
@@ -1,22 +1,25 @@
 import { readFileSync } from "fs";
+import { countBudgetViolations } from "./lint-budget-lib.mjs";
 
-const [, , reportPath, budgetsPath] = process.argv;
-
-const report = JSON.parse(readFileSync(reportPath, "utf8"));
-const budgets = JSON.parse(readFileSync(budgetsPath, "utf8"));
-
-const counts = {};
-for (const file of report) {
-  for (const message of file.messages) {
-    if (message.ruleId in budgets) {
-      counts[message.ruleId] = (counts[message.ruleId] || 0) + 1;
-    }
+const argv = process.argv.slice(2);
+const positional = [];
+const flags = {};
+for (let i = 0; i < argv.length; i += 1) {
+  if (argv[i] === "--check") {
+    flags.check = argv[(i += 1)];
+  } else {
+    positional.push(argv[i]);
   }
 }
 
+const [reportPath, budgetsPath] = positional;
+const report = JSON.parse(readFileSync(reportPath, "utf8"));
+const budgets = JSON.parse(readFileSync(budgetsPath, "utf8"));
+const counts = countBudgetViolations(report, budgets);
+
 let failed = false;
 for (const [rule, { max, target }] of Object.entries(budgets)) {
-  const count = counts[rule] || 0;
+  const count = counts[rule];
   const note = count > max ? "OVER BUDGET" : count <= target ? "at target" : `${max - count} of headroom`;
   console.log(`${rule}: ${count} | max: ${max} | target: ${target} | ${note}`);
   if (count > max) {
@@ -24,6 +27,22 @@ for (const [rule, { max, target }] of Object.entries(budgets)) {
       `::error::${rule} budget exceeded (${count} > ${max}). Reduce usage; lower max in eslint-budgets.json as the count drops.`,
     );
     failed = true;
+  }
+}
+
+if (flags.check) {
+  const committed = JSON.parse(readFileSync(flags.check, "utf8"));
+  const drifted = Object.keys(counts).filter((rule) => committed[rule] !== counts[rule]);
+  for (const rule of drifted) {
+    console.error(
+      `::error::${flags.check} is stale for ${rule}: committed ${committed[rule] ?? "missing"}, actual ${counts[rule]}.`,
+    );
+  }
+  if (drifted.length > 0) {
+    console.error(`::error::Run \`npm run lint:metrics\` and commit ${flags.check}.`);
+    failed = true;
+  } else {
+    console.log(`${flags.check} is up to date.`);
   }
 }
 

--- a/ui/litellm-dashboard/scripts/lint-budget-lib.mjs
+++ b/ui/litellm-dashboard/scripts/lint-budget-lib.mjs
@@ -1,0 +1,15 @@
+export function countBudgetViolations(report, budgets) {
+  const counts = {};
+  for (const file of report) {
+    for (const message of file.messages) {
+      if (message.ruleId in budgets) {
+        counts[message.ruleId] = (counts[message.ruleId] || 0) + 1;
+      }
+    }
+  }
+  return Object.fromEntries(
+    Object.keys(budgets)
+      .sort()
+      .map((rule) => [rule, counts[rule] || 0]),
+  );
+}

--- a/ui/litellm-dashboard/scripts/lint-budget-lib.mjs
+++ b/ui/litellm-dashboard/scripts/lint-budget-lib.mjs
@@ -13,3 +13,10 @@ export function countBudgetViolations(report, budgets) {
       .map((rule) => [rule, counts[rule] || 0]),
   );
 }
+
+export function findDrift(committed, actual) {
+  const rules = [...new Set([...Object.keys(actual), ...Object.keys(committed)])].sort();
+  return rules
+    .filter((rule) => committed[rule] !== actual[rule])
+    .map((rule) => ({ rule, committed: committed[rule] ?? null, actual: actual[rule] ?? null }));
+}

--- a/ui/litellm-dashboard/scripts/update-lint-metrics.mjs
+++ b/ui/litellm-dashboard/scripts/update-lint-metrics.mjs
@@ -4,15 +4,16 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { countBudgetViolations } from "./lint-budget-lib.mjs";
 
+const ESLINT_EXIT_LINT_ERRORS = 1;
+
 const budgets = JSON.parse(readFileSync("eslint-budgets.json", "utf8"));
 const dir = mkdtempSync(join(tmpdir(), "litellm-lint-"));
 const reportPath = join(dir, "report.json");
 
 try {
-  // eslint exits non-zero whenever any error-level rule fires; the JSON report is still written.
   execSync(`npx eslint . -f json -o "${reportPath}"`, { stdio: "inherit" });
-} catch {
-  /* report file is what we read below */
+} catch (err) {
+  if (err.status !== ESLINT_EXIT_LINT_ERRORS) throw err;
 }
 
 const report = JSON.parse(readFileSync(reportPath, "utf8"));

--- a/ui/litellm-dashboard/scripts/update-lint-metrics.mjs
+++ b/ui/litellm-dashboard/scripts/update-lint-metrics.mjs
@@ -1,0 +1,24 @@
+import { execSync } from "child_process";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { countBudgetViolations } from "./lint-budget-lib.mjs";
+
+const budgets = JSON.parse(readFileSync("eslint-budgets.json", "utf8"));
+const dir = mkdtempSync(join(tmpdir(), "litellm-lint-"));
+const reportPath = join(dir, "report.json");
+
+try {
+  // eslint exits non-zero whenever any error-level rule fires; the JSON report is still written.
+  execSync(`npx eslint . -f json -o "${reportPath}"`, { stdio: "inherit" });
+} catch {
+  /* report file is what we read below */
+}
+
+const report = JSON.parse(readFileSync(reportPath, "utf8"));
+rmSync(dir, { recursive: true, force: true });
+
+const metrics = countBudgetViolations(report, budgets);
+writeFileSync("eslint-metrics.json", JSON.stringify(metrics, null, 2) + "\n");
+console.log("Updated eslint-metrics.json");
+console.table(metrics);

--- a/ui/litellm-dashboard/tests/lint-budget-lib.test.ts
+++ b/ui/litellm-dashboard/tests/lint-budget-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { countBudgetViolations } from "../scripts/lint-budget-lib.mjs";
+
+const budgets = {
+  "@typescript-eslint/no-explicit-any": { max: 10, target: 5 },
+  complexity: { max: 10, target: 5 },
+};
+
+const file = (...ruleIds: (string | null)[]) => ({ messages: ruleIds.map((ruleId) => ({ ruleId })) });
+
+describe("countBudgetViolations", () => {
+  it("counts only budgeted rules and sums across files", () => {
+    const report = [
+      file("@typescript-eslint/no-explicit-any", "complexity", "max-depth"),
+      file("@typescript-eslint/no-explicit-any", "no-var", null),
+    ];
+    expect(countBudgetViolations(report, budgets)).toEqual({
+      "@typescript-eslint/no-explicit-any": 2,
+      complexity: 1,
+    });
+  });
+
+  it("reports 0 for a budgeted rule with no violations", () => {
+    expect(countBudgetViolations([file("complexity")], budgets)).toEqual({
+      "@typescript-eslint/no-explicit-any": 0,
+      complexity: 1,
+    });
+  });
+
+  it("emits keys in sorted order so the committed snapshot diffs stably", () => {
+    const unsorted = { complexity: { max: 1, target: 1 }, "@typescript-eslint/no-explicit-any": { max: 1, target: 1 } };
+    expect(Object.keys(countBudgetViolations([], unsorted))).toEqual([
+      "@typescript-eslint/no-explicit-any",
+      "complexity",
+    ]);
+  });
+});

--- a/ui/litellm-dashboard/tests/lint-budget-lib.test.ts
+++ b/ui/litellm-dashboard/tests/lint-budget-lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { countBudgetViolations } from "../scripts/lint-budget-lib.mjs";
+import { countBudgetViolations, findDrift } from "../scripts/lint-budget-lib.mjs";
 
 const budgets = {
   "@typescript-eslint/no-explicit-any": { max: 10, target: 5 },
@@ -33,5 +33,23 @@ describe("countBudgetViolations", () => {
       "@typescript-eslint/no-explicit-any",
       "complexity",
     ]);
+  });
+});
+
+describe("findDrift", () => {
+  it("reports no drift when the snapshot matches the actual counts", () => {
+    expect(findDrift({ complexity: 5 }, { complexity: 5 })).toEqual([]);
+  });
+
+  it("detects a changed count", () => {
+    expect(findDrift({ complexity: 5 }, { complexity: 7 })).toEqual([{ rule: "complexity", committed: 5, actual: 7 }]);
+  });
+
+  it("detects a rule missing from the committed snapshot", () => {
+    expect(findDrift({}, { complexity: 7 })).toEqual([{ rule: "complexity", committed: null, actual: 7 }]);
+  });
+
+  it("detects a phantom rule the committed snapshot still carries", () => {
+    expect(findDrift({ "removed-rule": 3 }, {})).toEqual([{ rule: "removed-rule", committed: 3, actual: null }]);
   });
 });


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Summary

The frontend eslint budget for `@typescript-eslint/no-explicit-any` (plus `complexity` and `max-depth`) was computed in CI and thrown away after the pass/fail check, so there was no record of where the count actually sits over time. This persists those counts to `ui/litellm-dashboard/eslint-metrics.json`, committed to the repo, so the trend is queryable straight from git history (`git log -p -- ui/litellm-dashboard/eslint-metrics.json`) and can later feed a dashboard. Run `npm run lint:metrics` to regenerate it. The existing UI lint job now drift-checks the snapshot against the same lint report it already generates, so a PR that shifts a tracked count has to regenerate and commit the file or CI fails with a clear message.

No second eslint run is added in CI; the drift check reuses the report the budget step already produces, and it only runs when a PR touches lintable UI files (same gate as the budget step), since the count can't move otherwise.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Test plan
- [x] `tests/lint-budget-lib.test.ts` — locks the counting invariants the snapshot relies on (only budgeted rules counted, counts sum across files, absent rules report 0, keys emitted sorted) and the drift invariants (changed count, key missing from the snapshot, and a phantom rule the snapshot still carries)
- [x] Generated the initial snapshot with `npm run lint:metrics`; current counts are no-explicit-any 2027 (max 2040), complexity 128 (max 140), max-depth 61 (max 70)
- [x] `npx prettier --check eslint-metrics.json` passes, so the committed format is stable and the drift check (semantic compare) stays green
- [x] Drift check passes when the snapshot is in sync (exit 0) and fails with a regenerate-and-commit error when a count is tampered or a phantom key is present (exit 1)

## Type

🆕 New Feature

## Changes

`check-lint-budgets.mjs` gains a `--check <file>` flag that compares the committed snapshot against freshly computed counts; CI passes `--check eslint-metrics.json`. Counting is factored into `scripts/lint-budget-lib.mjs` so the enforcer and the new `scripts/update-lint-metrics.mjs` generator (wired to `npm run lint:metrics`) can't diverge.
