### PR TITLE
chore(release): backport #31029 to stable/1.86.x and cut 1.86.7

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -11,6 +11,7 @@ from litellm.proxy._types import (
     LiteLLM_TeamTable,
     ProxyException,
     SpecialHeaders,
+    SpecialMCPServerNames,
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -560,6 +561,15 @@ class MCPRequestHandler:
                     user_api_key_auth
                 )
             )
+
+            # The key explicitly opted out of every MCP server. This overrides
+            # team inheritance and additive grants (mirrors no-default-models).
+            if (
+                SpecialMCPServerNames.no_mcp_servers.value
+                in allowed_mcp_servers_for_key
+            ):
+                return []
+
             allowed_mcp_servers_for_team = (
                 await MCPRequestHandler._get_allowed_mcp_servers_for_team(
                     user_api_key_auth
@@ -908,6 +918,13 @@ class MCPRequestHandler:
                     )
             if key_object_permission is None:
                 return []
+
+            # Sentinel opt-out: surface it unexpanded so the caller can short-circuit
+            # to zero servers instead of inheriting the team.
+            if SpecialMCPServerNames.no_mcp_servers.value in (
+                key_object_permission.mcp_servers or []
+            ):
+                return [SpecialMCPServerNames.no_mcp_servers.value]
 
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             from litellm.proxy._experimental.mcp_server.mcp_server_manager import (

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -66,6 +66,7 @@ from litellm.proxy._types import (
     MCPAuthType,
     MCPTransport,
     MCPTransportType,
+    SpecialMCPServerNames,
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
@@ -931,6 +932,17 @@ class MCPServerManager:
         allow_all_server_ids = self.get_allow_all_keys_server_ids()
 
         try:
+            # The key explicitly opted out of every MCP server. Return zero before
+            # layering on allow_all_keys servers so the opt-out is absolute.
+            key_object_permission = (
+                user_api_key_auth.object_permission if user_api_key_auth else None
+            )
+            if key_object_permission is not None and (
+                SpecialMCPServerNames.no_mcp_servers.value
+                in (key_object_permission.mcp_servers or [])
+            ):
+                return []
+
             # Check if object_permission.mcp_servers is explicitly set
             has_explicit_object_permission = False
             if user_api_key_auth and user_api_key_auth.object_permission:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -56,7 +56,7 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy._types import SpecialMCPServerNames, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.litellm_pre_call_utils import (
     LiteLLMProxyRequestSetup,
@@ -2738,6 +2738,19 @@ if MCP_AVAILABLE:
         """
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
         from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+
+        # A key scoped to no MCP servers opts out of every MCP path. Enforce it
+        # here too, since toolset scoping replaces mcp_servers and would otherwise
+        # drop the sentinel. Checked before the admin branch, mirroring
+        # get_allowed_mcp_servers.
+        original_op = user_api_key_auth.object_permission
+        if original_op is not None and SpecialMCPServerNames.no_mcp_servers.value in (
+            original_op.mcp_servers or []
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="API key is scoped to no MCP servers; toolset access is denied.",
+            )
 
         # Access control: non-admin keys must have this toolset in their grant list.
         # Use _user_has_admin_view so that PROXY_ADMIN_VIEW_ONLY is also treated as admin.

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3364,6 +3364,10 @@ class SpecialModelNames(enum.Enum):
     no_default_models = "no-default-models"
 
 
+class SpecialMCPServerNames(enum.Enum):
+    no_mcp_servers = "no-mcp-servers"
+
+
 class SpecialProxyStrings(enum.Enum):
     default_user_id = "default_user_id"  # global proxy admin
 

--- a/litellm/proxy/management_helpers/object_permission_utils.py
+++ b/litellm/proxy/management_helpers/object_permission_utils.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException, status
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.proxy._types import SpecialMCPServerNames
 from litellm.proxy.utils import PrismaClient
 
 if TYPE_CHECKING:
@@ -265,6 +266,7 @@ def _extract_requested_mcp_server_ids(
     mcp_servers = object_permission.get("mcp_servers")
     if isinstance(mcp_servers, list):
         server_ids.update(mcp_servers)
+        server_ids.discard(SpecialMCPServerNames.no_mcp_servers.value)
 
     mcp_tool_permissions = object_permission.get("mcp_tool_permissions")
     if isinstance(mcp_tool_permissions, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.86.6"
+version = "1.86.7"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -255,7 +255,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.86.6"
+version = "1.86.7"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -18,7 +18,11 @@ from starlette.datastructures import Headers
 from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
     MCPRequestHandler,
 )
-from litellm.proxy._types import SpecialHeaders, UserAPIKeyAuth
+from litellm.proxy._types import (
+    SpecialHeaders,
+    SpecialMCPServerNames,
+    UserAPIKeyAuth,
+)
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 
 
@@ -169,6 +173,53 @@ class TestMCPRequestHandler:
                 # Verify the mock functions were called correctly
                 mock_key_servers.assert_called_once_with(user_api_key_auth)
                 mock_team_servers.assert_called_once_with(user_api_key_auth)
+
+    @pytest.mark.parametrize("team_servers", [[], ["team_server1", "team_server2"]])
+    async def test_no_mcp_servers_sentinel_returns_empty(self, team_servers):
+        """A key scoped to the no-mcp-servers sentinel resolves to zero servers,
+        overriding team inheritance and never leaking the sentinel marker."""
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="test-key", user_id="test-user", team_id="test-team"
+        )
+        key_object_permission = MagicMock()
+        key_object_permission.mcp_servers = [
+            SpecialMCPServerNames.no_mcp_servers.value
+        ]
+
+        with patch.object(
+            MCPRequestHandler,
+            "_get_key_object_permission",
+            return_value=key_object_permission,
+        ), patch.object(
+            MCPRequestHandler,
+            "_get_allowed_mcp_servers_for_team",
+            new_callable=AsyncMock,
+            return_value=team_servers,
+        ):
+            result = await MCPRequestHandler.get_allowed_mcp_servers(user_api_key_auth)
+
+        assert result == []
+
+    async def test_get_allowed_mcp_servers_for_key_returns_sentinel_marker(self):
+        """_get_allowed_mcp_servers_for_key surfaces the sentinel unexpanded so the
+        caller can short-circuit, ignoring any other entries on the key."""
+        user_api_key_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+        key_object_permission = MagicMock()
+        key_object_permission.mcp_servers = [
+            SpecialMCPServerNames.no_mcp_servers.value,
+            "some-other-server",
+        ]
+
+        with patch.object(
+            MCPRequestHandler,
+            "_get_key_object_permission",
+            return_value=key_object_permission,
+        ):
+            result = await MCPRequestHandler._get_allowed_mcp_servers_for_key(
+                user_api_key_auth
+            )
+
+        assert result == [SpecialMCPServerNames.no_mcp_servers.value]
 
     async def test_permission_inheritance_edge_cases(self):
         """Test edge cases in permission inheritance"""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -2457,6 +2457,41 @@ class TestMCPServerManager:
             assert "test_server_2" in result
 
     @pytest.mark.asyncio
+    async def test_no_mcp_servers_sentinel_blocks_allow_all_keys(self):
+        """A key scoped to no-mcp-servers gets zero servers even when allow_all_keys
+        servers exist, and the inner resolver is never consulted."""
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable, UserAPIKeyAuth
+
+        manager = MCPServerManager()
+        object_permission = LiteLLM_ObjectPermissionTable(
+            object_permission_id="perm_no_mcp",
+            mcp_servers=["no-mcp-servers"],
+            mcp_access_groups=[],
+        )
+        user_api_key_auth = UserAPIKeyAuth(
+            api_key="sk-test",
+            user_id="user-123",
+            object_permission=object_permission,
+            object_permission_id="perm_no_mcp",
+        )
+
+        with patch.object(
+            manager, "get_allow_all_keys_server_ids", return_value=["global-server"]
+        ), patch.object(
+            MCPRequestHandler,
+            "get_allowed_mcp_servers",
+            new_callable=AsyncMock,
+            return_value=["leaked-server"],
+        ) as mock_inner:
+            result = await manager.get_allowed_mcp_servers(user_api_key_auth)
+
+        assert result == []
+        mock_inner.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_get_allowed_mcp_servers_anonymous_delegate_requires_oauth2(self):
         """Anonymous delegated auth listing should only include oauth2 servers."""
         from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -93,6 +93,37 @@ class TestApplyToolsetScope:
             await _apply_toolset_scope(auth, "toolset-123")
         assert exc_info.value.status_code == 403
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("user_role", [None, LitellmUserRoles.PROXY_ADMIN.value])
+    async def test_no_mcp_servers_sentinel_denies_toolset_access(self, user_role):
+        """A key scoped to the no-mcp-servers sentinel cannot reach a toolset it
+        would otherwise be granted (even as admin); the opt-out covers the
+        toolset path, which replaces mcp_servers and would drop the sentinel."""
+        from starlette.exceptions import HTTPException
+
+        from litellm.proxy._experimental.mcp_server.server import _apply_toolset_scope
+
+        op = LiteLLM_ObjectPermissionTable(
+            object_permission_id="test",
+            mcp_servers=["no-mcp-servers"],
+            mcp_toolsets=["toolset-123"],
+        )
+        auth = UserAPIKeyAuth(
+            api_key="sk-test", object_permission=op, user_role=user_role
+        )
+
+        resolve = AsyncMock(return_value={"server-a": ["tool1"]})
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server."
+            "global_mcp_server_manager.resolve_toolset_tool_permissions",
+            new=resolve,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await _apply_toolset_scope(auth, "toolset-123")
+
+        assert exc_info.value.status_code == 403
+        resolve.assert_not_awaited()
+
 
 class TestFetchMCPToolsetsAccess:
     """Tests for GET /v1/mcp/toolset access control."""

--- a/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_object_permission_utils.py
@@ -111,6 +111,24 @@ def test_extract_requested_mcp_server_ids_none():
     assert _extract_requested_mcp_server_ids({}) == set()
 
 
+def test_extract_requested_mcp_server_ids_excludes_no_mcp_servers_sentinel():
+    obj_perm = {"mcp_servers": ["no-mcp-servers", "server-1"]}
+    assert _extract_requested_mcp_server_ids(obj_perm) == {"server-1"}
+
+
+@pytest.mark.asyncio
+async def test_validate_no_mcp_servers_sentinel_passes_and_preserved():
+    """A key scoped to no-mcp-servers passes team validation without raising, keeping
+    the sentinel so it is not mistaken for an unknown server and rejected."""
+    team_obj = _make_team_obj(mcp_servers=["server-1"])
+    obj_perm = {"mcp_servers": ["no-mcp-servers"]}
+    await validate_key_mcp_servers_against_team(
+        object_permission=obj_perm,
+        team_obj=team_obj,
+    )
+    assert obj_perm["mcp_servers"] == ["no-mcp-servers"]
+
+
 # ---- Tests for _extract_requested_mcp_access_groups ----
 
 

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.test.tsx
@@ -1,0 +1,100 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderWithProviders } from "../../../tests/test-utils";
+import MCPServerSelector from "./MCPServerSelector";
+import { NO_MCP_SERVERS_SENTINEL } from "../mcp_tools/constants";
+
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
+  useMCPServers: vi.fn(),
+}));
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPAccessGroups", () => ({
+  useMCPAccessGroups: vi.fn(),
+}));
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPToolsets", () => ({
+  useMCPToolsets: vi.fn(),
+}));
+
+vi.mock("antd", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("antd")>();
+  const Select = ({ value, onChange, children, mode }: any) => (
+    <select
+      data-testid="mcp-select"
+      multiple={mode === "multiple"}
+      value={value}
+      onChange={(e) => onChange(Array.from(e.target.selectedOptions, (o) => (o as HTMLOptionElement).value))}
+    >
+      {children}
+    </select>
+  );
+  Select.displayName = "MockSelect";
+  Select.Option = ({ value, disabled, label }: any) => (
+    <option value={value} disabled={disabled}>
+      {label}
+    </option>
+  );
+  Select.Option.displayName = "MockSelectOption";
+  return { ...actual, Select };
+});
+
+import { useMCPAccessGroups } from "@/app/(dashboard)/hooks/mcpServers/useMCPAccessGroups";
+import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
+import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
+
+const mockUseMCPServers = vi.mocked(useMCPServers);
+const mockUseMCPAccessGroups = vi.mocked(useMCPAccessGroups);
+const mockUseMCPToolsets = vi.mocked(useMCPToolsets);
+
+describe("MCPServerSelector no-mcp-servers option", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMCPServers.mockReturnValue({
+      data: [{ server_id: "srv-1", server_name: "Server One" }],
+      isLoading: false,
+    } as any);
+    mockUseMCPAccessGroups.mockReturnValue({ data: [], isLoading: false } as any);
+    mockUseMCPToolsets.mockReturnValue({ data: [], isLoading: false } as any);
+  });
+
+  const optionByValue = (value: string) =>
+    Array.from(screen.getByTestId("mcp-select").querySelectorAll("option")).find(
+      (o) => (o as HTMLOptionElement).value === value,
+    ) as HTMLOptionElement | undefined;
+
+  it("hides the No MCP Servers option by default", () => {
+    renderWithProviders(
+      <MCPServerSelector accessToken="tok" onChange={vi.fn()} value={{ servers: [], accessGroups: [] }} />,
+    );
+    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)).toBeUndefined();
+  });
+
+  it("emits an exclusive sentinel when No MCP Servers is selected", async () => {
+    const onChange = vi.fn();
+    renderWithProviders(
+      <MCPServerSelector
+        accessToken="tok"
+        allowNoMcpServers
+        onChange={onChange}
+        value={{ servers: ["srv-1"], accessGroups: [] }}
+      />,
+    );
+    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)).toBeDefined();
+
+    await userEvent.selectOptions(screen.getByTestId("mcp-select"), [NO_MCP_SERVERS_SENTINEL]);
+
+    expect(onChange).toHaveBeenCalledWith({ servers: [NO_MCP_SERVERS_SENTINEL], accessGroups: [], toolsets: [] });
+  });
+
+  it("disables real server options while the sentinel is selected", () => {
+    renderWithProviders(
+      <MCPServerSelector
+        accessToken="tok"
+        allowNoMcpServers
+        onChange={vi.fn()}
+        value={{ servers: [NO_MCP_SERVERS_SENTINEL], accessGroups: [] }}
+      />,
+    );
+    expect(optionByValue("srv-1")?.disabled).toBe(true);
+    expect(optionByValue(NO_MCP_SERVERS_SENTINEL)?.disabled).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_server_management/MCPServerSelector.tsx
@@ -3,6 +3,7 @@ import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers"
 import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolsets";
 import { Select } from "antd";
 import React from "react";
+import { NO_MCP_SERVERS_SENTINEL } from "@/components/mcp_tools/constants";
 
 interface MCPServerSelectorProps {
   onChange: (selected: { servers: string[]; accessGroups: string[]; toolsets: string[] }) => void;
@@ -16,6 +17,7 @@ interface MCPServerSelectorProps {
   placeholder?: string;
   disabled?: boolean;
   teamId?: string | null;
+  allowNoMcpServers?: boolean;
 }
 
 const TOOLSET_PREFIX = "toolset:";
@@ -28,6 +30,7 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
   placeholder = "Select MCP servers",
   disabled = false,
   teamId,
+  allowNoMcpServers = false,
 }) => {
   const { data: mcpServers = [], isLoading: serversLoading } = useMCPServers(teamId);
   const { data: accessGroups = [], isLoading: groupsLoading } = useMCPAccessGroups();
@@ -77,8 +80,15 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
     ...(value?.toolsets || []).map((id) => `${TOOLSET_PREFIX}${id}`),
   ];
 
+  const hasNoMcpServersSelected = allowNoMcpServers && selectedValues.includes(NO_MCP_SERVERS_SENTINEL);
+
   // Handle selection
   const handleChange = (selected: string[]) => {
+    // "No MCP Servers" is exclusive: picking it clears everything else.
+    if (allowNoMcpServers && selected.includes(NO_MCP_SERVERS_SENTINEL)) {
+      onChange({ servers: [NO_MCP_SERVERS_SENTINEL], accessGroups: [], toolsets: [] });
+      return;
+    }
     const toolsetsSelected = selected
       .filter((v) => v.startsWith(TOOLSET_PREFIX))
       .map((v) => v.slice(TOOLSET_PREFIX.length));
@@ -102,12 +112,21 @@ const MCPServerSelector: React.FC<MCPServerSelectorProps> = ({
         style={{ width: "100%" }}
         disabled={disabled}
         filterOption={(input, option) => {
+          if (option?.value === NO_MCP_SERVERS_SENTINEL) return true;
           const searchText = options.find((opt) => opt.value === option?.value)?.searchText || "";
           return searchText.toLowerCase().includes(input.toLowerCase());
         }}
       >
+        {allowNoMcpServers && (
+          <Select.Option key={NO_MCP_SERVERS_SENTINEL} value={NO_MCP_SERVERS_SENTINEL} label="No MCP Servers">
+            <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+              <span style={{ flex: 1 }}>No MCP Servers</span>
+              <span style={{ color: "#8c8c8c", fontSize: "12px", fontWeight: 500, opacity: 0.8 }}>Block all</span>
+            </div>
+          </Select.Option>
+        )}
         {options.map((opt) => (
-          <Select.Option key={opt.value} value={opt.value} label={opt.label}>
+          <Select.Option key={opt.value} value={opt.value} label={opt.label} disabled={hasNoMcpServersSelected}>
             <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
               <span
                 style={{

--- a/ui/litellm-dashboard/src/components/mcp_tools/constants.ts
+++ b/ui/litellm-dashboard/src/components/mcp_tools/constants.ts
@@ -1,0 +1,2 @@
+// Must match the backend SpecialMCPServerNames.no_mcp_servers enum value.
+export const NO_MCP_SERVERS_SENTINEL = "no-mcp-servers";

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -32,6 +32,7 @@ import { BudgetWindowEntry, BudgetWindowsEditor } from "../key_team_helpers/Budg
 import { getModelDisplayName } from "../key_team_helpers/fetch_available_models_team_key";
 import { Team } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import { NO_MCP_SERVERS_SENTINEL } from "../mcp_tools/constants";
 import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
 import NotificationsManager from "../molecules/notifications_manager";
 import {
@@ -1398,6 +1399,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                           accessToken={accessToken}
                           teamId={selectedCreateKeyTeam?.team_id ?? null}
                           placeholder="Select MCP servers or access groups (optional)"
+                          allowNoMcpServers
                         />
                       </Form.Item>
 
@@ -1417,7 +1419,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                           <div className="mt-6">
                             <MCPToolPermissions
                               accessToken={accessToken}
-                              selectedServers={form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []}
+                              selectedServers={(
+                                form.getFieldValue("allowed_mcp_servers_and_groups")?.servers || []
+                              ).filter((s: string) => s !== NO_MCP_SERVERS_SENTINEL)}
                               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
                               onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
                             />

--- a/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
+++ b/ui/litellm-dashboard/src/components/permissions/MCPServerPermissions.tsx
@@ -4,6 +4,7 @@ import { ServerIcon, ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/
 import { Tooltip } from "antd";
 import { fetchMCPServers, fetchMCPToolsets } from "../networking";
 import { MCPServer, MCPToolset } from "../mcp_tools/types";
+import { NO_MCP_SERVERS_SENTINEL } from "../mcp_tools/constants";
 
 interface MCPServerPermissionsProps {
   mcpServers: string[];
@@ -96,9 +97,13 @@ export function MCPServerPermissions({
     return serverId;
   };
 
+  const blocksAllMcpServers = mcpServers.includes(NO_MCP_SERVERS_SENTINEL);
+
   // Merge servers and access groups into one list
   const mergedItems = [
-    ...mcpServers.map((server) => ({ type: "server", value: server })),
+    ...mcpServers
+      .filter((server) => server !== NO_MCP_SERVERS_SENTINEL)
+      .map((server) => ({ type: "server", value: server })),
     ...mcpAccessGroups.map((group) => ({ type: "accessGroup", value: group })),
   ];
   const totalCount = mergedItems.length + mcpToolsets.length;
@@ -108,12 +113,19 @@ export function MCPServerPermissions({
       <div className="flex items-center gap-2">
         <ServerIcon className="h-4 w-4 text-blue-600" />
         <Text className="font-semibold text-gray-900">MCP Servers</Text>
-        <Badge color="blue" size="xs">
-          {totalCount}
+        <Badge color={blocksAllMcpServers ? "red" : "blue"} size="xs">
+          {blocksAllMcpServers ? "Blocked" : totalCount}
         </Badge>
       </div>
 
-      {totalCount > 0 ? (
+      {blocksAllMcpServers ? (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-50 border border-red-200">
+          <ServerIcon className="h-4 w-4 text-red-400" />
+          <Text className="text-red-700 text-sm">
+            No MCP servers — this key is blocked from all MCP servers, including its team&apos;s servers
+          </Text>
+        </div>
+      ) : totalCount > 0 ? (
         <div className="max-h-[400px] overflow-y-auto space-y-2 pr-1">
           {mergedItems.map((item, index) => {
             const toolsForServer = item.type === "server" ? mcpToolPermissions[item.value] : undefined;

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -19,6 +19,7 @@ import { extractLoggingSettings, formatMetadataForDisplay, stripTagsFromMetadata
 import { BudgetWindowEntry, BudgetWindowsEditor } from "../key_team_helpers/BudgetWindowsEditor";
 import { KeyResponse } from "../key_team_helpers/key_list";
 import MCPServerSelector from "../mcp_server_management/MCPServerSelector";
+import { NO_MCP_SERVERS_SENTINEL } from "../mcp_tools/constants";
 import MCPToolPermissions from "../mcp_server_management/MCPToolPermissions";
 import NotificationsManager from "../molecules/notifications_manager";
 import { getPromptsList, modelAvailableCall, tagListCall } from "../networking";
@@ -618,6 +619,7 @@ export function KeyEditView({
           value={form.getFieldValue("mcp_servers_and_groups")}
           accessToken={accessToken || ""}
           placeholder="Select MCP servers or access groups (optional)"
+          allowNoMcpServers
         />
       </Form.Item>
 
@@ -637,7 +639,9 @@ export function KeyEditView({
           <div className="mb-6">
             <MCPToolPermissions
               accessToken={accessToken || ""}
-              selectedServers={form.getFieldValue("mcp_servers_and_groups")?.servers || []}
+              selectedServers={(form.getFieldValue("mcp_servers_and_groups")?.servers || []).filter(
+                (s: string) => s !== NO_MCP_SERVERS_SENTINEL,
+              )}
               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
               onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
             />

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-10T23:26:07.892848Z"
+exclude-newer = "2026-06-21T01:51:48.825861Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3193,7 +3193,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.86.6"
+version = "1.86.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Relevant issues

Backports #31029 ("feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel") onto stable/1.86.x and cuts 1.86.7. Before this, a virtual key under a team that has MCP servers had no way to opt out of them; an empty list has always meant "inherit the team". The change adds a `no-mcp-servers` sentinel (mirroring `no-default-models` for models) so a key can declare an explicit zero that overrides team inheritance, additive grants, and allow_all_keys servers, and enforces it on the toolset-scoped routes as well.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on the touched files
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## CI (LiteLLM team)

- [ ] **Branch creation CI run** Link:
- [ ] **CI run for the last commit** Link:
- [ ] **Merge / cherry-pick CI run** Links:

## Screenshots / Proof of Fix

Live proxy on stable/1.86.x with the pick applied, hitting the real key-management path. The customer-facing symptom is that before the fix you cannot create a key scoped to zero MCP servers; the sentinel is rejected as an unknown server.

Before the pick (baseline on the line tip):

```
POST /key/generate  {"object_permission":{"mcp_servers":["no-mcp-servers"]}}
HTTP 403
{"error":{"message":"... Only globally available (allow_all_keys) MCP servers can be assigned: []. Disallowed servers: ['no-mcp-servers'].","code":"403"}}
```

After the pick (same request, same proxy):

```
POST /key/generate  {"object_permission":{"mcp_servers":["no-mcp-servers"]}}
HTTP 200   -> key created

GET /key/info?key=<new key>
object_permission.mcp_servers = ['no-mcp-servers']
```

The sentinel is stored verbatim and the read-time enforcement resolves the key to zero MCP servers, including on the `/toolset/{name}/mcp` route (403).

Targeted tests on the line, judged as a delta: baseline before the pick was 281 passed / 0 failures across the four touched test files; after the pick it is 289 passed / 0 failures, i.e. the eight new sentinel tests all pass and nothing regressed.

Deep behavioral stress-test passed: symbol closure is clean (no reference to the dropped normalization machinery anywhere on the tree), the new tests pass as a delta with no regressions, and no existing caller of the five modified functions is broken. Both production callers of `validate_key_mcp_servers_against_team` discard its return value, so the adapted test that no longer asserts on the return value still reflects real behavior.

## Type

🐛 Bug Fix

## Changes

What is included, in order:

- #31029 feat(mcp): scope a key to zero MCP servers with no-mcp-servers sentinel (cherry-picked from staging 19a29e0579)
- bump: version 1.86.6 -> 1.86.7
- chore: refresh uv.lock for 1.86.7

### Adaptation notes

The pick is not byte-identical to the staging commit. `object_permission_utils.py` is roughly 200 lines older on 1.86.x; the write-time normalization machinery (`_rewrite_object_permission_mcp_servers`, `_dedupe_preserving_order`, and friends) was added to staging after this line was cut and is absent here. Two adaptations follow from that:

- The upstream hunk that preserved the sentinel inside `_rewrite_object_permission_mcp_servers` is dropped, because that function does not exist on this line. There is no normalization step here that would expand or strip the sentinel, so it is stored verbatim and the hunk is unnecessary; this is not a behavior loss. The hunk that matters on this line, `_extract_requested_mcp_server_ids` discarding the sentinel so key creation does not 403, is kept and is what the live proof above exercises.
- In `test_object_permission_utils.py`, the upstream `test_rewrite_object_permission_mcp_servers_preserves_sentinel` and its import are dropped (they reference the absent function and would break the module's collection), and `test_validate_no_mcp_servers_sentinel_passes_and_preserved` keeps its behavioral assertions but drops `assert result == obj_perm`, since `validate_key_mcp_servers_against_team` returns `None` on this line rather than the object_permission it returns on staging. The remaining assertions still fail if the discard hunk is removed, so the test stays a real regression guard.

The two enforcement test files and the manager/toolset tests apply unchanged and reference only symbols present on the line.

### UI rebuild

This PR carries the production UI source changes (`MCPServerSelector.tsx`, `create_key_button.tsx`, `MCPServerPermissions.tsx`, `key_edit_view.tsx`, plus a new `mcp_tools/constants.ts`) but does NOT include a rebuilt `litellm/proxy/_experimental/out/` bundle. The Next.js bundle for this stable line will be rebuilt separately after merge. Until then the proxy on stable/1.86.x serves the prior UI for these screens; the backend enforcement above is fully in effect regardless.
