### PR TITLE
fix(logging): dedupe success logging for non-streaming anthropic_messages (/v1/messages)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2308,7 +2308,17 @@ class Logging(LiteLLMLoggingBaseClass):
                         isinstance(callback, CustomLogger)
                         and is_sync_request
                         and self.call_type
-                        != CallTypes.pass_through.value  # pass-through endpoints call async_log_success_event
+                        not in (
+                            # both endpoints are always dispatched through the
+                            # async wrapper, which already calls
+                            # async_log_success_event. anthropic_messages
+                            # (/v1/messages) sets no acompletion-style flag, so
+                            # is_sync_request is True here and the sync pass would
+                            # otherwise re-dispatch every CustomLogger, doubling
+                            # OTEL spans + cost/success callbacks.
+                            CallTypes.pass_through.value,
+                            CallTypes.anthropic_messages.value,
+                        )
                     ):  # custom logger class
                         if self.stream and complete_streaming_response is None:
                             callback.log_stream_event(

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3690,3 +3690,51 @@ def test_set_cost_breakdown_stores_reasoning_cost():
         cost_for_built_in_tools_cost_usd_dollar=0.0,
     )
     assert "reasoning_cost" not in no_reasoning.cost_breakdown
+
+
+def test_success_handler_skips_sync_callbacks_for_anthropic_messages(logging_obj):
+    """anthropic_messages (/v1/messages) is always dispatched through the async
+    wrapper, so the sync success_handler pass must not re-dispatch CustomLogger
+    callbacks -- the async handler is the canonical path.
+
+    Regression for the duplicate ``litellm_request`` OTEL spans + double
+    success/cost callbacks on non-streaming /v1/messages. Unlike acompletion,
+    anthropic_messages sets no async flag in litellm_params, so
+    _is_sync_litellm_request is True and the sync pass would otherwise fire.
+    """
+    from litellm.integrations.custom_logger import CustomLogger
+
+    class DummyLogger(CustomLogger):
+        pass
+
+    logging_obj.stream = False
+    logging_obj.call_type = "anthropic_messages"
+    logging_obj.model_call_details["litellm_params"] = {}
+    logging_obj.litellm_params = {}
+
+    dummy_logger = DummyLogger()
+    dummy_logger.log_success_event = MagicMock()
+    dummy_logger.log_stream_event = MagicMock()
+
+    model_response = ModelResponse(
+        id="resp-123",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    with patch.object(
+        logging_obj,
+        "get_combined_callback_list",
+        return_value=[dummy_logger],
+    ):
+        logging_obj.success_handler(result=model_response)
+
+    dummy_logger.log_success_event.assert_not_called()
+    dummy_logger.log_stream_event.assert_not_called()


### PR DESCRIPTION
## Summary

A single **non-streaming** `POST /v1/messages` (`anthropic_messages`) emitted **two** `litellm_request` OTEL spans and fired the success/cost callbacks twice. Plain `/chat/completions` was unaffected.

Closes #31121

## Root cause

`/v1/messages` is always dispatched through the async wrapper, so logging runs via `async_success_handler`. The async path also schedules the sync `success_handler` (via `handle_sync_success_callbacks_for_async_calls`) for legacy sync callbacks. That sync pass is supposed to skip `CustomLogger` dispatch when async already handled it — but the guard only excludes `call_type == pass_through`.

Unlike `acompletion`, `anthropic_messages` sets no async flag in `litellm_params`, so `_is_sync_litellm_request()` returns `True` and `is_sync_request` is `True` in the sync handler. With `anthropic_messages` not excluded, the sync pass re-dispatches every `CustomLogger` (OpenTelemetry, `_ProxyDBLogger` cost tracking, …) on top of the async one → two `litellm_request` spans and double cost/success callbacks. This is the non-streaming counterpart of #29550 / #29598, whose fix is gated on `stream is True`.

## Change

Extend the existing `pass_through` skip in `success_handler` to also cover `anthropic_messages`, so the sync pass no longer re-dispatches `CustomLogger`s — logging happens once via the canonical async path, matching `acompletion`.

## Verifying it doesn't drop logging

End-to-end with `litellm.anthropic_messages(..., mock_response=...)` and a counting `CustomLogger`:

| | sync `log_success_event` | async `async_log_success_event` |
|---|---|---|
| before | 1 | 1 |
| after | 0 | 1 |

Callbacks that reach the async path (otel via `success_callback: ["otel"]`, `_ProxyDBLogger`, any logger in `litellm.callbacks`) keep their single async invocation and lose only the duplicate. A `CustomLogger` reachable *only* via the sync `success_callback` list is already not invoked on `acompletion` either, so this change makes `anthropic_messages` consistent with the other async paths rather than regressing them.

## Tests

Added `test_success_handler_skips_sync_callbacks_for_anthropic_messages`, mirroring the existing sync/async callback tests. It fails before the change (sync callback fires) and passes after. Full `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` passes (104).

<!-- oss-radar:idempotency=auto-20260624-101015.w2.BerriAI_litellm.31121 -->
