### PR TITLE
fix(websearch_interception): return complete native web search results

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -1016,12 +1016,24 @@ class WebSearchInterceptionLogger(CustomLogger):
             f"WebSearchInterception: Using max_tokens={max_tokens} for follow-up request"
         )
 
+        # Force the synthesis call to answer from the search results instead of
+        # searching again. A client may pin tool_choice to the web_search tool
+        # for its dedicated search sub-request (Claude Code does this); left
+        # as-is the model emits another tool_use on the follow-up and the
+        # response comes back with no answer text. Relaxing it to "auto" is not
+        # enough — with the web_search tool still advertised the model often
+        # re-searches on its own, and this loop is single-shot so that second
+        # tool_use is passed through unanswered. tool_choice="none" keeps the
+        # tool definitions valid for strict backends while compelling the model
+        # to synthesize a textual reply.
         optional_params_without_max_tokens = {
             k: v
             for k, v in anthropic_messages_optional_request_params.items()
             if k != "max_tokens"
         }
+        optional_params_without_max_tokens["tool_choice"] = {"type": "none"}
         kwargs_for_followup = self._prepare_followup_kwargs(kwargs)
+        kwargs_for_followup.pop("tool_choice", None)
 
         if logging_obj is not None:
             agentic_params = logging_obj.model_call_details.get(

--- a/litellm/integrations/websearch_interception/transformation.py
+++ b/litellm/integrations/websearch_interception/transformation.py
@@ -391,13 +391,19 @@ class WebSearchTransformation:
                 url = getattr(r, "url", "") or ""
                 title = getattr(r, "title", "") or ""
                 page_age = getattr(r, "date", None) or getattr(r, "last_updated", None)
+                snippet = getattr(r, "snippet", "") or ""
                 items.append(
                     {
                         "type": "web_search_result",
                         "url": url,
                         "title": title,
                         "page_age": page_age,
-                        "encrypted_content": "",
+                        # The provider snippet is the only result text we have.
+                        # Anthropic's native block carries body text in
+                        # encrypted_content, so pass the snippet through there
+                        # rather than dropping it (client citation panels render
+                        # empty otherwise).
+                        "encrypted_content": snippet,
                     }
                 )
         return {

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -133,7 +133,30 @@ class TestBuildWebSearchToolResultBlock:
         assert first["url"] == "https://docs.litellm.ai/"
         assert first["title"] == "LiteLLM Docs"
         assert first["page_age"] == "2025-01-15"
-        assert first["encrypted_content"] == ""
+        # The provider snippet is passed through encrypted_content so client
+        # citation panels render result text instead of an empty shell.
+        assert first["encrypted_content"] == "Unified interface for LLMs."
+
+    def test_snippet_passthrough_for_all_results(self):
+        block = WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="toolu_abc",
+            search_response=_make_search_response(),
+        )
+        snippets = [item["encrypted_content"] for item in block["content"]]
+        assert snippets == [
+            "Unified interface for LLMs.",
+            "Pay-per-use pricing model.",
+        ]
+
+    def test_empty_snippet_stays_empty_string(self):
+        response = SearchResponse(
+            results=[SearchResult(title="No Snippet", url="https://x.test/", snippet="")]
+        )
+        block = WebSearchTransformation.build_web_search_tool_result_block(
+            tool_use_id="toolu_abc",
+            search_response=response,
+        )
+        assert block["content"][0]["encrypted_content"] == ""
 
     def test_handles_none_search_response(self):
         block = WebSearchTransformation.build_web_search_tool_result_block(
@@ -482,3 +505,47 @@ class TestLegacyPathMatchesNewPath:
         assert out["content"][0]["type"] == "web_search_tool_result"
         assert out["content"][0]["tool_use_id"] == "toolu_legacy"
         assert out["content"][1]["type"] == "text"
+
+
+class TestFollowupDisablesToolChoice:
+    """The synthesis (follow-up) call must answer from the search results
+    instead of searching again. A client that forced ``tool_choice`` at the
+    web_search tool (Claude Code does) would otherwise make the model emit
+    another tool_use with no answer text, and since this loop is single-shot
+    that second tool_use is passed through unanswered. The follow-up patch
+    pins ``tool_choice`` to ``{"type": "none"}``."""
+
+    @pytest.mark.asyncio
+    async def test_followup_patch_sets_tool_choice_none(self):
+        logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
+        tool_calls = [
+            {
+                "id": "toolu_x",
+                "type": "tool_use",
+                "name": "litellm_web_search",
+                "input": {"query": "q"},
+            }
+        ]
+
+        with patch.object(
+            logger,
+            "_execute_search",
+            new=AsyncMock(return_value=("Title: x\nURL: y", _make_search_response())),
+        ):
+            patch_obj, _ = await logger._build_anthropic_request_patch(
+                model="bedrock/claude",
+                messages=[{"role": "user", "content": "hi"}],
+                tool_calls=tool_calls,
+                thinking_blocks=[],
+                # Client forced the search tool on the original request.
+                anthropic_messages_optional_request_params={
+                    "tool_choice": {"type": "tool", "name": "litellm_web_search"},
+                },
+                logging_obj=MagicMock(model_call_details={}),
+                kwargs={"tool_choice": {"type": "tool", "name": "litellm_web_search"}},
+            )
+
+        # optional_params drives the follow-up call; forcing must be cleared.
+        assert patch_obj.optional_params["tool_choice"] == {"type": "none"}
+        # The forwarded kwargs must not smuggle the original forcing back in.
+        assert "tool_choice" not in patch_obj.kwargs


### PR DESCRIPTION
## Summary

Native `web_search_*` clients (Claude Code, the Anthropic SDK) were getting **incomplete** responses from the websearch interception agentic loop. Two independent gaps, both in the path that serves clients whose backend (e.g. Bedrock) can't run web search natively:

**1. Result blocks dropped the snippet.** `build_web_search_tool_result_block` hardcoded `encrypted_content` to `""`. Native clients render their citation panel from that field, so every result came back as a title+url shell with no body text — even though the snippet was already present on the `SearchResult`. Fix: pass `SearchResult.snippet` through.

**2. The synthesis (follow-up) call re-searched instead of answering.** The agentic-loop follow-up inherited the original request's forced `tool_choice`. Claude Code's dedicated search sub-request pins `tool_choice` at the web_search tool; carried into the follow-up, the model emits *another* `tool_use` instead of synthesizing an answer. Because the loop is single-shot, that second tool_use is passed straight through to the client with **no text block at all**. Relaxing to `"auto"` isn't enough — with the web_search tool still advertised the model frequently re-searches on its own. Fix: pin the follow-up `tool_choice` to `{"type": "none"}`, which keeps the tool definitions valid for strict backends while compelling the model to produce a textual reply.

### Before / after (native client, forced `tool_choice`)
```
before: content = [web_search_tool_result(empty shells), tool_use]   # no answer text
after:  content = [web_search_tool_result(with snippets), text]      # cited answer
```

These are follow-up issues found in the same handler/transformation after #30944 (which fixed the tool_choice rename so forced web_search reaches the agentic loop in the first place); they are otherwise independent of that change.

## Changes
- `transformation.py` — `build_web_search_tool_result_block` passes the provider snippet through `encrypted_content` (empty-string fallback preserved when absent).
- `handler.py` — `_build_anthropic_request_patch` sets the follow-up `tool_choice` to `{"type": "none"}` and strips any forced `tool_choice` from the forwarded kwargs. Covers both the typed-plan and legacy agentic-loop paths; the OpenAI chat-completion path is untouched.

## Test plan
- [x] `tests/test_litellm/integrations/websearch_interception/` — 81 passed, 2 skipped
- [x] New regression tests: snippet passthrough (+ empty-snippet fallback), and follow-up `tool_choice` override (set to `none`, original forcing not smuggled via kwargs)