### PR TITLE
fix(bedrock/claude_platform): strip body params the AWS endpoint rejects

### DIFF
--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -14,7 +14,7 @@ CLAUDE_PLATFORM_BEDROCK_ROUTE = "claude_platform/"
 # must not be forwarded in the Messages API request body (together with any
 # key prefixed "aws_") — the API rejects unknown fields with
 # "Extra inputs are not permitted".
-CLAUDE_PLATFORM_NON_REQUEST_PARAMS = {
+CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS = {
     "workspace_id",
     "anthropic_workspace_id",
     "anthropic-workspace-id",
@@ -25,12 +25,15 @@ CLAUDE_PLATFORM_NON_REQUEST_PARAMS = {
 # endpoint, which rejects them with "Extra inputs are not permitted". Unlike
 # the auth params above these carry user intent, so dropping them is logged at
 # WARNING — the request succeeds but the requested feature is not applied.
-CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS = {
+CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS = {
     "context_management",
 }
 
 
-def filter_claude_platform_request_body(params: dict) -> dict:
+def filter_claude_platform_request_body(
+    params: dict,
+    unsupported_override: Optional[frozenset[str]] = None,
+) -> dict:
     """Return a copy of ``params`` with fields the Claude Platform on AWS
     endpoint rejects removed.
 
@@ -41,15 +44,23 @@ def filter_claude_platform_request_body(params: dict) -> dict:
     WARNING, since those reflect user intent that will not be applied on this
     route.
 
+    ``unsupported_override``, when provided, replaces the default
+    CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS set. Pass an empty frozenset
+    to disable unsupported-param filtering entirely (e.g. when the AWS
+    endpoint adds support before a litellm release).
+
     Filters a copy so callers' ``sign_request`` still sees ``aws_region_name``.
     """
-    dropped_unsupported = [
-        k for k in params if k in CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS
-    ]
+    unsupported = (
+        unsupported_override
+        if unsupported_override is not None
+        else CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS
+    )
+    dropped_unsupported = [k for k in params if k in unsupported]
     if dropped_unsupported:
         verbose_logger.warning(
             "bedrock/claude_platform: dropping unsupported Messages API "
-            "param(s) %s from the request body — the Claude Platform on AWS "
+            "param(s) %s from the request body - the Claude Platform on AWS "
             "(aws-external-anthropic) endpoint does not support them and "
             "rejects unknown fields. The request will proceed without them.",
             dropped_unsupported,
@@ -57,10 +68,27 @@ def filter_claude_platform_request_body(params: dict) -> dict:
     return {
         k: v
         for k, v in params.items()
-        if k not in CLAUDE_PLATFORM_NON_REQUEST_PARAMS
-        and k not in CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS
+        if k not in CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS
+        and k not in unsupported
         and not k.startswith("aws_")
     }
+
+
+def _resolve_unsupported_override(
+    litellm_params: dict,
+) -> Optional[frozenset[str]]:
+    """Read ``claude_platform_unsupported_params`` from litellm_params.
+
+    Returns None (use default set) when the key is absent. Returns a
+    frozenset when present, allowing operators to override or clear the
+    unsupported-param list via proxy config without a code change.
+    """
+    raw = litellm_params.get("claude_platform_unsupported_params")
+    if raw is None:
+        return None
+    if isinstance(raw, (list, set, frozenset, tuple)):
+        return frozenset(raw)
+    return None
 
 
 def strip_claude_platform_route(model: str) -> str:

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -10,7 +10,9 @@ class _SupportsGet(Protocol):
     def get(self, key: str, default: object = None) -> object: ...
 
 
-CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = "aws-external-anthropic"
+CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
+    "aws-external-anthropic"
+)
 CLAUDE_PLATFORM_BEDROCK_ROUTE = "claude_platform/"
 
 # Auth/routing params consumed by validate_environment / sign_request that
@@ -55,7 +57,9 @@ def filter_claude_platform_request_body(
     Filters a copy so callers' ``sign_request`` still sees ``aws_region_name``.
     """
     unsupported = (
-        unsupported_override if unsupported_override is not None else CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS
+        unsupported_override
+        if unsupported_override is not None
+        else CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS
     )
     dropped_unsupported = [k for k in params if k in unsupported]
     if dropped_unsupported:
@@ -69,7 +73,9 @@ def filter_claude_platform_request_body(
     return {
         k: v
         for k, v in params.items()
-        if k not in CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS and k not in unsupported and not k.startswith("aws_")
+        if k not in CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS
+        and k not in unsupported
+        and not k.startswith("aws_")
     }
 
 
@@ -108,10 +114,14 @@ class BedrockClaudePlatformMixin(BaseAWSLLM):
             or litellm_params.get("anthropic-workspace-id")
         )
         if workspace_id is None:
-            workspace_id = optional_params.get("anthropic_workspace_id") or litellm_params.get("anthropic_workspace_id")
+            workspace_id = optional_params.get(
+                "anthropic_workspace_id"
+            ) or litellm_params.get("anthropic_workspace_id")
         if workspace_id is not None:
             return str(workspace_id)
-        return get_secret_str("ANTHROPIC_AWS_WORKSPACE_ID") or get_secret_str("ANTHROPIC_WORKSPACE_ID")
+        return get_secret_str("ANTHROPIC_AWS_WORKSPACE_ID") or get_secret_str(
+            "ANTHROPIC_WORKSPACE_ID"
+        )
 
     def _get_required_aws_region_name(self, optional_params: dict) -> str:
         aws_region_name = (
@@ -149,7 +159,9 @@ class BedrockClaudePlatformMixin(BaseAWSLLM):
         )
         if api_base is None:
             aws_region_name = self._get_required_aws_region_name(optional_params)
-            api_base = f"https://{CLAUDE_PLATFORM_SERVICE_NAME}.{aws_region_name}.api.aws"
+            api_base = (
+                f"https://{CLAUDE_PLATFORM_SERVICE_NAME}.{aws_region_name}.api.aws"
+            )
         if not api_base.endswith("/v1/messages"):
             api_base = f"{api_base.rstrip('/')}/v1/messages"
         return api_base

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -1,6 +1,7 @@
 from typing import Literal, Optional, Tuple
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.secret_managers.main import get_secret_str
 
@@ -8,6 +9,58 @@ CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
     "aws-external-anthropic"
 )
 CLAUDE_PLATFORM_BEDROCK_ROUTE = "claude_platform/"
+
+# Auth/routing params consumed by validate_environment / sign_request that
+# must not be forwarded in the Messages API request body (together with any
+# key prefixed "aws_") — the API rejects unknown fields with
+# "Extra inputs are not permitted".
+CLAUDE_PLATFORM_NON_REQUEST_PARAMS = {
+    "workspace_id",
+    "anthropic_workspace_id",
+    "anthropic-workspace-id",
+}
+
+# Messages API fields that are valid on Anthropic's first-party API but are
+# not yet supported by the Claude Platform on AWS (aws-external-anthropic)
+# endpoint, which rejects them with "Extra inputs are not permitted". Unlike
+# the auth params above these carry user intent, so dropping them is logged at
+# WARNING — the request succeeds but the requested feature is not applied.
+CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS = {
+    "context_management",
+}
+
+
+def filter_claude_platform_request_body(params: dict) -> dict:
+    """Return a copy of ``params`` with fields the Claude Platform on AWS
+    endpoint rejects removed.
+
+    Strips auth/routing config (workspace-id aliases and any ``aws_``-prefixed
+    key) silently, since those are consumed by validate_environment /
+    sign_request and never belong in the body. Strips Messages API fields the
+    AWS endpoint does not support yet (e.g. ``context_management``) with a
+    WARNING, since those reflect user intent that will not be applied on this
+    route.
+
+    Filters a copy so callers' ``sign_request`` still sees ``aws_region_name``.
+    """
+    dropped_unsupported = [
+        k for k in params if k in CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS
+    ]
+    if dropped_unsupported:
+        verbose_logger.warning(
+            "bedrock/claude_platform: dropping unsupported Messages API "
+            "param(s) %s from the request body — the Claude Platform on AWS "
+            "(aws-external-anthropic) endpoint does not support them and "
+            "rejects unknown fields. The request will proceed without them.",
+            dropped_unsupported,
+        )
+    return {
+        k: v
+        for k, v in params.items()
+        if k not in CLAUDE_PLATFORM_NON_REQUEST_PARAMS
+        and k not in CLAUDE_PLATFORM_UNSUPPORTED_REQUEST_PARAMS
+        and not k.startswith("aws_")
+    }
 
 
 def strip_claude_platform_route(model: str) -> str:

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -1,8 +1,12 @@
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional, Protocol, Tuple
 
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+
+class _SupportsGet(Protocol):
+    def get(self, key: str, default: object = None) -> object: ...
 from litellm.secret_managers.main import get_secret_str
 
 CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
@@ -74,8 +78,8 @@ def filter_claude_platform_request_body(
     }
 
 
-def _resolve_unsupported_override(
-    litellm_params: dict,
+def resolve_unsupported_override(
+    litellm_params: _SupportsGet,
 ) -> Optional[frozenset[str]]:
     """Read ``claude_platform_unsupported_params`` from litellm_params.
 
@@ -87,7 +91,7 @@ def _resolve_unsupported_override(
     if raw is None:
         return None
     if isinstance(raw, (list, set, frozenset, tuple)):
-        return frozenset(raw)
+        return frozenset(str(item) for item in raw)
     return None
 
 

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -3,15 +3,14 @@ from typing import Literal, Optional, Protocol, Tuple
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+from litellm.secret_managers.main import get_secret_str
 
 
 class _SupportsGet(Protocol):
     def get(self, key: str, default: object = None) -> object: ...
-from litellm.secret_managers.main import get_secret_str
 
-CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
-    "aws-external-anthropic"
-)
+
+CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = "aws-external-anthropic"
 CLAUDE_PLATFORM_BEDROCK_ROUTE = "claude_platform/"
 
 # Auth/routing params consumed by validate_environment / sign_request that
@@ -56,9 +55,7 @@ def filter_claude_platform_request_body(
     Filters a copy so callers' ``sign_request`` still sees ``aws_region_name``.
     """
     unsupported = (
-        unsupported_override
-        if unsupported_override is not None
-        else CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS
+        unsupported_override if unsupported_override is not None else CLAUDE_PLATFORM_ON_AWS_UNSUPPORTED_REQUEST_PARAMS
     )
     dropped_unsupported = [k for k in params if k in unsupported]
     if dropped_unsupported:
@@ -72,9 +69,7 @@ def filter_claude_platform_request_body(
     return {
         k: v
         for k, v in params.items()
-        if k not in CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS
-        and k not in unsupported
-        and not k.startswith("aws_")
+        if k not in CLAUDE_PLATFORM_ON_AWS_NON_REQUEST_PARAMS and k not in unsupported and not k.startswith("aws_")
     }
 
 
@@ -113,14 +108,10 @@ class BedrockClaudePlatformMixin(BaseAWSLLM):
             or litellm_params.get("anthropic-workspace-id")
         )
         if workspace_id is None:
-            workspace_id = optional_params.get(
-                "anthropic_workspace_id"
-            ) or litellm_params.get("anthropic_workspace_id")
+            workspace_id = optional_params.get("anthropic_workspace_id") or litellm_params.get("anthropic_workspace_id")
         if workspace_id is not None:
             return str(workspace_id)
-        return get_secret_str("ANTHROPIC_AWS_WORKSPACE_ID") or get_secret_str(
-            "ANTHROPIC_WORKSPACE_ID"
-        )
+        return get_secret_str("ANTHROPIC_AWS_WORKSPACE_ID") or get_secret_str("ANTHROPIC_WORKSPACE_ID")
 
     def _get_required_aws_region_name(self, optional_params: dict) -> str:
         aws_region_name = (
@@ -158,9 +149,7 @@ class BedrockClaudePlatformMixin(BaseAWSLLM):
         )
         if api_base is None:
             aws_region_name = self._get_required_aws_region_name(optional_params)
-            api_base = (
-                f"https://{CLAUDE_PLATFORM_SERVICE_NAME}.{aws_region_name}.api.aws"
-            )
+            api_base = f"https://{CLAUDE_PLATFORM_SERVICE_NAME}.{aws_region_name}.api.aws"
         if not api_base.endswith("/v1/messages"):
             api_base = f"{api_base.rstrip('/')}/v1/messages"
         return api_base

--- a/litellm/llms/bedrock/claude_platform/common_utils.py
+++ b/litellm/llms/bedrock/claude_platform/common_utils.py
@@ -1,14 +1,9 @@
-from typing import Literal, Optional, Protocol, Tuple
+from typing import Literal, Optional, Tuple
 
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 from litellm.secret_managers.main import get_secret_str
-
-
-class _SupportsGet(Protocol):
-    def get(self, key: str, default: object = None) -> object: ...
-
 
 CLAUDE_PLATFORM_SERVICE_NAME: Literal["aws-external-anthropic"] = (
     "aws-external-anthropic"
@@ -80,15 +75,21 @@ def filter_claude_platform_request_body(
 
 
 def resolve_unsupported_override(
-    litellm_params: _SupportsGet,
+    litellm_params: object,
 ) -> Optional[frozenset[str]]:
     """Read ``claude_platform_unsupported_params`` from litellm_params.
 
     Returns None (use default set) when the key is absent. Returns a
     frozenset when present, allowing operators to override or clear the
     unsupported-param list via proxy config without a code change.
+
+    Accepts both plain dicts and Pydantic models (GenericLiteLLMParams)
+    since both expose a .get() method.
     """
-    raw = litellm_params.get("claude_platform_unsupported_params")
+    get = getattr(litellm_params, "get", None)
+    if get is None:
+        return None
+    raw = get("claude_platform_unsupported_params")
     if raw is None:
         return None
     if isinstance(raw, (list, set, frozenset, tuple)):

--- a/litellm/llms/bedrock/claude_platform/messages_transformation.py
+++ b/litellm/llms/bedrock/claude_platform/messages_transformation.py
@@ -10,6 +10,7 @@ from litellm.types.router import GenericLiteLLMParams
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
+    _resolve_unsupported_override,
     filter_claude_platform_request_body,
     strip_claude_platform_route,
 )
@@ -66,13 +67,11 @@ class BedrockClaudePlatformMessagesConfig(
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Dict:
-        # Strip auth/routing config (workspace_id, aws_*) and Messages API
-        # fields the AWS endpoint does not support (e.g. context_management)
-        # from the body — the API rejects unknown fields with "Extra inputs
-        # are not permitted".
+        unsupported_override = _resolve_unsupported_override(litellm_params)
         anthropic_messages_optional_request_params = (
             filter_claude_platform_request_body(
-                anthropic_messages_optional_request_params
+                anthropic_messages_optional_request_params,
+                unsupported_override=unsupported_override,
             )
         )
         return super().transform_anthropic_messages_request(

--- a/litellm/llms/bedrock/claude_platform/messages_transformation.py
+++ b/litellm/llms/bedrock/claude_platform/messages_transformation.py
@@ -8,7 +8,11 @@ from litellm.llms.anthropic.experimental_pass_through.messages.transformation im
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.router import GenericLiteLLMParams
 
-from .common_utils import BedrockClaudePlatformMixin, strip_claude_platform_route
+from .common_utils import (
+    BedrockClaudePlatformMixin,
+    filter_claude_platform_request_body,
+    strip_claude_platform_route,
+)
 
 
 class BedrockClaudePlatformMessagesConfig(
@@ -62,6 +66,15 @@ class BedrockClaudePlatformMessagesConfig(
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Dict:
+        # Strip auth/routing config (workspace_id, aws_*) and Messages API
+        # fields the AWS endpoint does not support (e.g. context_management)
+        # from the body — the API rejects unknown fields with "Extra inputs
+        # are not permitted".
+        anthropic_messages_optional_request_params = (
+            filter_claude_platform_request_body(
+                anthropic_messages_optional_request_params
+            )
+        )
         return super().transform_anthropic_messages_request(
             model=strip_claude_platform_route(model),
             messages=messages,

--- a/litellm/llms/bedrock/claude_platform/messages_transformation.py
+++ b/litellm/llms/bedrock/claude_platform/messages_transformation.py
@@ -10,7 +10,7 @@ from litellm.types.router import GenericLiteLLMParams
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
-    _resolve_unsupported_override,
+    resolve_unsupported_override,
     filter_claude_platform_request_body,
     strip_claude_platform_route,
 )
@@ -67,7 +67,7 @@ class BedrockClaudePlatformMessagesConfig(
         litellm_params: GenericLiteLLMParams,
         headers: dict,
     ) -> Dict:
-        unsupported_override = _resolve_unsupported_override(litellm_params)
+        unsupported_override = resolve_unsupported_override(litellm_params)
         anthropic_messages_optional_request_params = (
             filter_claude_platform_request_body(
                 anthropic_messages_optional_request_params,

--- a/litellm/llms/bedrock/claude_platform/messages_transformation.py
+++ b/litellm/llms/bedrock/claude_platform/messages_transformation.py
@@ -10,8 +10,8 @@ from litellm.types.router import GenericLiteLLMParams
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
-    resolve_unsupported_override,
     filter_claude_platform_request_body,
+    resolve_unsupported_override,
     strip_claude_platform_route,
 )
 

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -5,7 +5,10 @@ from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 
-from .common_utils import BedrockClaudePlatformMixin
+from .common_utils import (
+    BedrockClaudePlatformMixin,
+    filter_claude_platform_request_body,
+)
 
 
 class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
@@ -81,6 +84,28 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         )
         anthropic_headers["anthropic-workspace-id"] = workspace_id
         return {**headers, **anthropic_headers}
+
+    def transform_request(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        headers: dict,
+    ) -> dict:
+        # Strip auth/routing config (workspace_id, aws_*) and Messages API
+        # fields the AWS endpoint does not support (e.g. context_management)
+        # from the body — the API rejects unknown fields with "Extra inputs
+        # are not permitted". Filters a copy so sign_request still sees
+        # aws_region_name.
+        optional_params = filter_claude_platform_request_body(optional_params)
+        return super().transform_request(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def get_model_response_iterator(
         self,

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 import litellm
 from litellm.llms.anthropic.chat.transformation import AnthropicConfig
@@ -27,12 +27,12 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         self,
         headers: dict,
         model: str,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
-    ) -> Dict:
+    ) -> dict:
         workspace_id = self._get_workspace_id(optional_params, litellm_params)
         if workspace_id is None:
             raise litellm.AuthenticationError(
@@ -88,7 +88,7 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
     def transform_request(
         self,
         model: str,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         optional_params: dict,
         litellm_params: dict,
         headers: dict,

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -7,7 +7,7 @@ from litellm.types.llms.openai import AllMessageValues
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
-    _resolve_unsupported_override,
+    resolve_unsupported_override,
     filter_claude_platform_request_body,
 )
 
@@ -94,7 +94,7 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        unsupported_override = _resolve_unsupported_override(litellm_params)
+        unsupported_override = resolve_unsupported_override(litellm_params)
         optional_params = filter_claude_platform_request_body(
             optional_params, unsupported_override=unsupported_override
         )

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -7,6 +7,7 @@ from litellm.types.llms.openai import AllMessageValues
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
+    _resolve_unsupported_override,
     filter_claude_platform_request_body,
 )
 
@@ -93,12 +94,10 @@ class BedrockClaudePlatformConfig(BedrockClaudePlatformMixin, AnthropicConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        # Strip auth/routing config (workspace_id, aws_*) and Messages API
-        # fields the AWS endpoint does not support (e.g. context_management)
-        # from the body — the API rejects unknown fields with "Extra inputs
-        # are not permitted". Filters a copy so sign_request still sees
-        # aws_region_name.
-        optional_params = filter_claude_platform_request_body(optional_params)
+        unsupported_override = _resolve_unsupported_override(litellm_params)
+        optional_params = filter_claude_platform_request_body(
+            optional_params, unsupported_override=unsupported_override
+        )
         return super().transform_request(
             model=model,
             messages=messages,

--- a/litellm/llms/bedrock/claude_platform/transformation.py
+++ b/litellm/llms/bedrock/claude_platform/transformation.py
@@ -7,8 +7,8 @@ from litellm.types.llms.openai import AllMessageValues
 
 from .common_utils import (
     BedrockClaudePlatformMixin,
-    resolve_unsupported_override,
     filter_claude_platform_request_body,
+    resolve_unsupported_override,
 )
 
 

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -480,6 +480,31 @@ def test_claude_platform_unsupported_override_allows_context_management():
     assert "context_management" in request_body
 
 
+def test_claude_platform_unsupported_override_ignores_invalid_type():
+    """
+    If claude_platform_unsupported_params is set to a non-collection type
+    (e.g. a string), the override is ignored and defaults apply.
+    """
+    from litellm.llms.bedrock.claude_platform.transformation import (
+        BedrockClaudePlatformConfig,
+    )
+
+    config = BedrockClaudePlatformConfig()
+    request_body = config.transform_request(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+            "max_tokens": 10,
+        },
+        litellm_params={"claude_platform_unsupported_params": "not_a_list"},
+        headers={},
+    )
+
+    assert "context_management" not in request_body
+    assert request_body["max_tokens"] == 10
+
+
 def test_chat_completion_claude_platform_sigv4_body_has_no_auth_params():
     """
     End-to-end (mocked transport): a config-driven SigV4 call with

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -361,14 +361,15 @@ def test_claude_platform_messages_strips_auth_params_from_request_body():
     )
     assert config is not None
 
+    input_params = {
+        "workspace_id": "wrkspc_test",
+        "aws_region_name": "us-west-2",
+        "max_tokens": 10,
+    }
     request_body = config.transform_anthropic_messages_request(
         model="claude_platform/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "hello"}],
-        anthropic_messages_optional_request_params={
-            "workspace_id": "wrkspc_test",
-            "aws_region_name": "us-west-2",
-            "max_tokens": 10,
-        },
+        anthropic_messages_optional_request_params=input_params,
         litellm_params={},
         headers={},
     )
@@ -376,6 +377,8 @@ def test_claude_platform_messages_strips_auth_params_from_request_body():
     assert "workspace_id" not in request_body
     assert "aws_region_name" not in request_body
     assert request_body["max_tokens"] == 10
+    assert input_params["aws_region_name"] == "us-west-2"
+    assert input_params["workspace_id"] == "wrkspc_test"
 
 
 def test_claude_platform_strips_unsupported_context_management_param(caplog):
@@ -433,19 +436,48 @@ def test_claude_platform_messages_strips_unsupported_context_management_param():
     )
     assert config is not None
 
+    input_params = {
+        "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        "max_tokens": 10,
+    }
     request_body = config.transform_anthropic_messages_request(
         model="claude_platform/claude-sonnet-4-6",
         messages=[{"role": "user", "content": "hello"}],
-        anthropic_messages_optional_request_params={
-            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
-            "max_tokens": 10,
-        },
+        anthropic_messages_optional_request_params=input_params,
         litellm_params={},
         headers={},
     )
 
     assert "context_management" not in request_body
     assert request_body["max_tokens"] == 10
+    assert "context_management" in input_params
+
+
+def test_claude_platform_unsupported_override_allows_context_management():
+    """
+    Operators can pass claude_platform_unsupported_params=[] in litellm_params
+    to stop filtering context_management once the AWS endpoint supports it.
+    """
+    from litellm.llms.bedrock.claude_platform.transformation import (
+        BedrockClaudePlatformConfig,
+    )
+
+    config = BedrockClaudePlatformConfig()
+    optional_params = {
+        "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        "max_tokens": 10,
+    }
+
+    request_body = config.transform_request(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params=optional_params,
+        litellm_params={"claude_platform_unsupported_params": []},
+        headers={},
+    )
+
+    assert request_body["max_tokens"] == 10
+    assert "context_management" in request_body
 
 
 def test_chat_completion_claude_platform_sigv4_body_has_no_auth_params():

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -313,6 +313,181 @@ async def test_anthropic_messages_routes_bedrock_claude_platform_to_messages_api
     assert requests[0]["body"]["model"] == "claude-sonnet-4-6"
 
 
+def test_claude_platform_strips_auth_params_from_request_body():
+    """
+    Regression: workspace_id is consumed by validate_environment (sent as the
+    anthropic-workspace-id header) and aws_* params by sign_request, but
+    transform_request used to forward them into the Messages API body, which
+    rejects unknown fields: "workspace_id: Extra inputs are not permitted".
+    """
+    from litellm.llms.bedrock.claude_platform.transformation import (
+        BedrockClaudePlatformConfig,
+    )
+
+    config = BedrockClaudePlatformConfig()
+    optional_params = {
+        "workspace_id": "wrkspc_test",
+        "aws_region_name": "us-west-2",
+        "max_tokens": 10,
+    }
+
+    request_body = config.transform_request(
+        model="claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert "workspace_id" not in request_body
+    assert "aws_region_name" not in request_body
+    assert request_body["max_tokens"] == 10
+    # sign_request still needs the aws_* params — the original dict must not
+    # be mutated by the body transformation.
+    assert optional_params["aws_region_name"] == "us-west-2"
+    assert optional_params["workspace_id"] == "wrkspc_test"
+
+
+def test_claude_platform_messages_strips_auth_params_from_request_body():
+    """
+    Same regression as above for the native /v1/messages path.
+    """
+    import litellm
+    from litellm.types.utils import LlmProviders
+
+    config = litellm.ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="claude_platform/claude-sonnet-4-6",
+        provider=LlmProviders.BEDROCK,
+    )
+    assert config is not None
+
+    request_body = config.transform_anthropic_messages_request(
+        model="claude_platform/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        anthropic_messages_optional_request_params={
+            "workspace_id": "wrkspc_test",
+            "aws_region_name": "us-west-2",
+            "max_tokens": 10,
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert "workspace_id" not in request_body
+    assert "aws_region_name" not in request_body
+    assert request_body["max_tokens"] == 10
+
+
+def test_claude_platform_strips_unsupported_context_management_param(caplog):
+    """
+    Regression: context_management is a valid first-party Anthropic Messages
+    API field, but the Claude Platform on AWS (aws-external-anthropic)
+    endpoint does not support it and rejects it with
+    "context_management: Extra inputs are not permitted". It must be dropped
+    from the body, and — unlike the silent auth-param strip — the drop is
+    logged at WARNING because it reflects user intent that won't be applied.
+    """
+    import logging
+
+    from litellm.llms.bedrock.claude_platform.transformation import (
+        BedrockClaudePlatformConfig,
+    )
+
+    config = BedrockClaudePlatformConfig()
+    optional_params = {
+        "workspace_id": "wrkspc_test",
+        "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        "max_tokens": 10,
+    }
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        request_body = config.transform_request(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hello"}],
+            optional_params=optional_params,
+            litellm_params={},
+            headers={},
+        )
+
+    assert "context_management" not in request_body
+    assert request_body["max_tokens"] == 10
+    # original dict is not mutated
+    assert "context_management" in optional_params
+    # the drop is surfaced to the user
+    assert any(
+        "context_management" in record.message and record.levelno == logging.WARNING
+        for record in caplog.records
+    )
+
+
+def test_claude_platform_messages_strips_unsupported_context_management_param():
+    """
+    Same context_management strip on the native /v1/messages path.
+    """
+    import litellm
+    from litellm.types.utils import LlmProviders
+
+    config = litellm.ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="claude_platform/claude-sonnet-4-6",
+        provider=LlmProviders.BEDROCK,
+    )
+    assert config is not None
+
+    request_body = config.transform_anthropic_messages_request(
+        model="claude_platform/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        anthropic_messages_optional_request_params={
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+            "max_tokens": 10,
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    assert "context_management" not in request_body
+    assert request_body["max_tokens"] == 10
+
+
+def test_chat_completion_claude_platform_sigv4_body_has_no_auth_params():
+    """
+    End-to-end (mocked transport): a config-driven SigV4 call with
+    workspace_id + aws_region_name must not leak either param into the wire
+    body. Uses SigV4 (no api_key) since that is how proxy configs pass
+    aws_region_name.
+    """
+    import litellm
+
+    requests = []
+
+    def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_response(url)
+
+    mock_credentials = Credentials("test-key", "test-secret", "test-token")
+
+    with (
+        patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post),
+        patch(
+            "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM.get_credentials",
+            return_value=mock_credentials,
+        ),
+    ):
+        response = litellm.completion(
+            model="bedrock/claude_platform/claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "hello"}],
+            max_tokens=10,
+            aws_region_name="us-west-2",
+            workspace_id="wrkspc_test",
+        )
+
+    assert response.choices[0].message.content == "ok"
+    assert len(requests) == 1
+    body = requests[0]["body"]
+    assert "workspace_id" not in body
+    assert "aws_region_name" not in body
+    assert requests[0]["headers"]["anthropic-workspace-id"] == "wrkspc_test"
+
+
 def test_sigv4_no_duplicate_content_type_when_caller_sets_lowercase():
     """
     Regression: get_anthropic_headers() supplies "content-type" (lowercase).

--- a/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
+++ b/tests/test_litellm/llms/bedrock/test_claude_platform_provider.py
@@ -505,6 +505,35 @@ def test_claude_platform_unsupported_override_ignores_invalid_type():
     assert request_body["max_tokens"] == 10
 
 
+def test_claude_platform_messages_unsupported_override_allows_context_management():
+    """
+    Messages-path: operators can pass claude_platform_unsupported_params=[]
+    in litellm_params to allow context_management through.
+    """
+    import litellm
+    from litellm.types.utils import LlmProviders
+
+    config = litellm.ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="claude_platform/claude-sonnet-4-6",
+        provider=LlmProviders.BEDROCK,
+    )
+    assert config is not None
+
+    request_body = config.transform_anthropic_messages_request(
+        model="claude_platform/claude-sonnet-4-6",
+        messages=[{"role": "user", "content": "hello"}],
+        anthropic_messages_optional_request_params={
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]},
+            "max_tokens": 10,
+        },
+        litellm_params={"claude_platform_unsupported_params": []},
+        headers={},
+    )
+
+    assert "context_management" in request_body
+    assert request_body["max_tokens"] == 10
+
+
 def test_chat_completion_claude_platform_sigv4_body_has_no_auth_params():
     """
     End-to-end (mocked transport): a config-driven SigV4 call with


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

The `bedrock/claude_platform/` route forwards params into the Messages API request body that the Claude Platform on AWS endpoint rejects as unknown fields (`400 "Extra inputs are not permitted"`). Two categories:

**Auth/routing config** - `workspace_id` is consumed by `validate_environment` (sent as the `anthropic-workspace-id` header) and `aws_*` params feed SigV4 signing, but nothing strips them from the body. A proxy config with `workspace_id` and `aws_region_name` in `litellm_params` fails on every request.

**Unsupported Messages API fields** - `context_management` is a valid first-party Anthropic beta field that the AWS gateway does not support yet, so it gets rejected the same way.

Added `filter_claude_platform_request_body()` in `common_utils.py` and routed both the chat-completions `transform_request` and the native `/v1/messages` `transform_anthropic_messages_request` through it. Auth/routing params are dropped silently; unsupported feature params are dropped with a `verbose_logger.warning` since they carry user intent. Filters a copy so `sign_request` still sees `aws_region_name` and callers' dicts are not mutated.

Reproduced on v1.85.0 through v1.89.3 and current `litellm_internal_staging`.

## Screenshots / Proof of Fix

Start the proxy with a claude_platform model configured:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

Config should include:

```yaml
model_list:
  - model_name: claude-sonnet-4-6
    litellm_params:
      model: bedrock/claude_platform/claude-sonnet-4-6
      aws_region_name: us-east-1
      workspace_id: wrkspc_xxx
```

Test 1 - auth/routing params (`workspace_id` + `aws_region_name` stripped from body):

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}' | jq .
```

Before: `400 "workspace_id: Extra inputs are not permitted"`. After: successful completion

Test 2 - unsupported feature param (`context_management` stripped with warning):

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"context_management":{"type":"ephemeral","max_context_tokens":1000}}' | jq .
```

Before: `400 "context_management: Extra inputs are not permitted"`. After: successful completion (param silently dropped with a warning in proxy logs)