### PR TITLE
fix(proxy): support setting soft budget at the team member level

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1761,6 +1761,9 @@ class NewTeamRequest(TeamBase):
     team_member_budget: Optional[float] = (
         None  # allow user to set a budget for all team members
     )
+    team_member_soft_budget: Optional[float] = (
+        None  # allow user to set a soft (alert-only) budget for all team members
+    )
     team_member_rpm_limit: Optional[int] = (
         None  # allow user to set RPM limit for all team members
     )
@@ -1818,6 +1821,7 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     object_permission: Optional[LiteLLM_ObjectPermissionBase] = None
     disable_global_guardrails: Optional[bool] = None
     team_member_budget: Optional[float] = None
+    team_member_soft_budget: Optional[float] = None
     team_member_budget_duration: Optional[str] = None
     team_member_rpm_limit: Optional[int] = None
     team_member_tpm_limit: Optional[int] = None

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -221,6 +221,7 @@ class TeamMemberBudgetHandler:
     @staticmethod
     def should_create_budget(
         team_member_budget: Optional[float] = None,
+        team_member_soft_budget: Optional[float] = None,
         team_member_rpm_limit: Optional[int] = None,
         team_member_tpm_limit: Optional[int] = None,
         team_member_budget_duration: Optional[str] = None,
@@ -229,6 +230,7 @@ class TeamMemberBudgetHandler:
         return any(
             [
                 team_member_budget is not None,
+                team_member_soft_budget is not None,
                 team_member_rpm_limit is not None,
                 team_member_tpm_limit is not None,
                 team_member_budget_duration is not None,
@@ -241,6 +243,7 @@ class TeamMemberBudgetHandler:
         new_team_data_json: dict,
         user_api_key_dict: UserAPIKeyAuth,
         team_member_budget: Optional[float] = None,
+        team_member_soft_budget: Optional[float] = None,
         team_member_rpm_limit: Optional[int] = None,
         team_member_tpm_limit: Optional[int] = None,
         team_member_budget_duration: Optional[str] = None,
@@ -266,6 +269,8 @@ class TeamMemberBudgetHandler:
 
         if team_member_budget is not None:
             budget_request.max_budget = team_member_budget
+        if team_member_soft_budget is not None:
+            budget_request.soft_budget = team_member_soft_budget
         if team_member_rpm_limit is not None:
             budget_request.rpm_limit = team_member_rpm_limit
         if team_member_tpm_limit is not None:
@@ -296,6 +301,7 @@ class TeamMemberBudgetHandler:
         user_api_key_dict: UserAPIKeyAuth,
         updated_kv: dict,
         team_member_budget: Optional[float] = None,
+        team_member_soft_budget: Optional[float] = None,
         team_member_rpm_limit: Optional[int] = None,
         team_member_tpm_limit: Optional[int] = None,
         team_member_budget_duration: Optional[str] = None,
@@ -316,6 +322,8 @@ class TeamMemberBudgetHandler:
 
             if team_member_budget is not None:
                 budget_request.max_budget = team_member_budget
+            if team_member_soft_budget is not None:
+                budget_request.soft_budget = team_member_soft_budget
             if team_member_rpm_limit is not None:
                 budget_request.rpm_limit = team_member_rpm_limit
             if team_member_tpm_limit is not None:
@@ -328,7 +336,7 @@ class TeamMemberBudgetHandler:
                 user_api_key_dict=user_api_key_dict,
             )
             verbose_proxy_logger.info(
-                f"Updated team member budget table: {budget_row.budget_id}, with team_member_budget={team_member_budget}, team_member_rpm_limit={team_member_rpm_limit}, team_member_tpm_limit={team_member_tpm_limit}"
+                f"Updated team member budget table: {budget_row.budget_id}, with team_member_budget={team_member_budget}, team_member_soft_budget={team_member_soft_budget}, team_member_rpm_limit={team_member_rpm_limit}, team_member_tpm_limit={team_member_tpm_limit}"
             )
             if updated_kv.get("metadata") is None:
                 updated_kv["metadata"] = {}
@@ -340,6 +348,7 @@ class TeamMemberBudgetHandler:
                 new_team_data_json=updated_kv,
                 user_api_key_dict=user_api_key_dict,
                 team_member_budget=team_member_budget,
+                team_member_soft_budget=team_member_soft_budget,
                 team_member_rpm_limit=team_member_rpm_limit,
                 team_member_tpm_limit=team_member_tpm_limit,
                 team_member_budget_duration=team_member_budget_duration,
@@ -353,6 +362,7 @@ class TeamMemberBudgetHandler:
     def _clean_team_member_fields(data_dict: dict) -> None:
         """Remove team member fields from data dictionary"""
         data_dict.pop("team_member_budget", None)
+        data_dict.pop("team_member_soft_budget", None)
         data_dict.pop("team_member_budget_duration", None)
         data_dict.pop("team_member_rpm_limit", None)
         data_dict.pop("team_member_tpm_limit", None)
@@ -378,6 +388,8 @@ class TeamMemberBudgetHandler:
             budget_request = BudgetNewRequest(budget_id=team_member_budget_id)
             if "team_member_budget" in explicitly_set_fields:
                 budget_request.max_budget = None
+            if "team_member_soft_budget" in explicitly_set_fields:
+                budget_request.soft_budget = None
             if "team_member_budget_duration" in explicitly_set_fields:
                 budget_request.budget_duration = None
                 budget_request.budget_reset_at = None
@@ -976,6 +988,7 @@ async def new_team(
     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
+    - team_member_soft_budget: Optional[float] - The soft (alert-only) budget allocated to an individual team member. Triggers an alert when crossed, without blocking requests.
     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
@@ -1202,6 +1215,7 @@ async def new_team(
 
         if TeamMemberBudgetHandler.should_create_budget(
             team_member_budget=data.team_member_budget,
+            team_member_soft_budget=data.team_member_soft_budget,
             team_member_rpm_limit=data.team_member_rpm_limit,
             team_member_tpm_limit=data.team_member_tpm_limit,
             team_member_budget_duration=data.team_member_budget_duration,
@@ -1211,6 +1225,7 @@ async def new_team(
                 new_team_data_json=data_json,
                 user_api_key_dict=user_api_key_dict,
                 team_member_budget=data.team_member_budget,
+                team_member_soft_budget=data.team_member_soft_budget,
                 team_member_rpm_limit=data.team_member_rpm_limit,
                 team_member_tpm_limit=data.team_member_tpm_limit,
                 team_member_budget_duration=data.team_member_budget_duration,
@@ -1672,6 +1687,7 @@ async def update_team(
     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
+    - team_member_soft_budget: Optional[float] - The soft (alert-only) budget allocated to an individual team member. Triggers an alert when crossed, without blocking requests.
     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
@@ -1679,6 +1695,7 @@ async def update_team(
     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+    - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
     Example - update team TPM Limit
     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)
@@ -1912,6 +1929,7 @@ async def update_team(
             field
             for field in [
                 "team_member_budget",
+                "team_member_soft_budget",
                 "team_member_rpm_limit",
                 "team_member_tpm_limit",
                 "team_member_budget_duration",
@@ -1923,6 +1941,7 @@ async def update_team(
             _team_member_fields_in_request
             and TeamMemberBudgetHandler.should_create_budget(
                 team_member_budget=data.team_member_budget,
+                team_member_soft_budget=data.team_member_soft_budget,
                 team_member_rpm_limit=data.team_member_rpm_limit,
                 team_member_tpm_limit=data.team_member_tpm_limit,
                 team_member_budget_duration=data.team_member_budget_duration,
@@ -1933,6 +1952,7 @@ async def update_team(
                 user_api_key_dict=user_api_key_dict,
                 updated_kv=updated_kv,
                 team_member_budget=data.team_member_budget,
+                team_member_soft_budget=data.team_member_soft_budget,
                 team_member_rpm_limit=data.team_member_rpm_limit,
                 team_member_tpm_limit=data.team_member_tpm_limit,
                 team_member_budget_duration=data.team_member_budget_duration,

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -1735,6 +1735,7 @@ async def test_update_team_team_member_budget_not_passed_to_db():
             user_api_key_dict,
             updated_kv,
             team_member_budget=None,
+            team_member_soft_budget=None,
             team_member_rpm_limit=None,
             team_member_tpm_limit=None,
             team_member_budget_duration=None,
@@ -2166,6 +2167,7 @@ async def test_update_team_with_team_member_budget_duration():
             user_api_key_dict,
             updated_kv,
             team_member_budget=None,
+            team_member_soft_budget=None,
             team_member_rpm_limit=None,
             team_member_tpm_limit=None,
             team_member_budget_duration=None,
@@ -4826,9 +4828,7 @@ async def test_update_team_standalone_uncapped_team_admin_sets_finite_allowed():
             "team_id": "standalone-uncapped-123",
             "organization_id": None,
             "max_budget": None,
-            "members_with_roles": [
-                {"user_id": "uncapped-team-admin", "role": "admin"}
-            ],
+            "members_with_roles": [{"user_id": "uncapped-team-admin", "role": "admin"}],
         }
         mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
             return_value=mock_existing_team
@@ -9344,3 +9344,67 @@ async def test_team_info_forwards_key_limit_to_get_data():
         )
 
     assert mock_prisma.get_data.await_args.kwargs["limit"] == 7
+
+
+@pytest.mark.asyncio
+async def test_create_team_member_budget_table_sets_soft_budget():
+    """
+    Regression for issue #31097: a team-member-level soft budget must be plumbed
+    onto the underlying budget row when a team is created. Before the fix the
+    handler did not accept or set soft_budget, so the value was silently dropped.
+    """
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        TeamMemberBudgetHandler,
+    )
+
+    assert TeamMemberBudgetHandler.should_create_budget(team_member_soft_budget=42.0)
+
+    created_budget = MagicMock()
+    created_budget.budget_id = "team-budget-abc"
+
+    with patch(
+        "litellm.proxy.management_endpoints.budget_management_endpoints.new_budget",
+        new=AsyncMock(return_value=created_budget),
+    ) as mock_new_budget:
+        await TeamMemberBudgetHandler.create_team_member_budget_table(
+            data=NewTeamRequest(team_alias="acme"),
+            new_team_data_json={},
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+            team_member_soft_budget=42.0,
+        )
+
+    budget_obj = mock_new_budget.call_args.kwargs["budget_obj"]
+    assert budget_obj.soft_budget == 42.0
+    assert budget_obj.max_budget is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_team_member_budget_table_updates_soft_budget():
+    """
+    Regression for issue #31097: updating a team must set the team-member soft
+    budget on the existing budget row (the /team/update path the UI uses).
+    """
+    from types import SimpleNamespace
+
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        TeamMemberBudgetHandler,
+    )
+
+    updated_budget = MagicMock()
+    updated_budget.budget_id = "team-budget-abc"
+    team_table = SimpleNamespace(metadata={"team_member_budget_id": "team-budget-abc"})
+
+    with patch(
+        "litellm.proxy.management_endpoints.budget_management_endpoints.update_budget",
+        new=AsyncMock(return_value=updated_budget),
+    ) as mock_update_budget:
+        await TeamMemberBudgetHandler.upsert_team_member_budget_table(
+            team_table=team_table,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+            updated_kv={},
+            team_member_soft_budget=55.0,
+        )
+
+    budget_obj = mock_update_budget.call_args.kwargs["budget_obj"]
+    assert budget_obj.soft_budget == 55.0

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -13510,6 +13510,7 @@ export interface paths {
          *     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
          *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
          *     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
+         *     - team_member_soft_budget: Optional[float] - The soft (alert-only) budget allocated to an individual team member. Triggers an alert when crossed, without blocking requests.
          *     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
          *     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
          *     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
@@ -13687,6 +13688,7 @@ export interface paths {
          *     - disable_global_guardrails: Optional[bool] - Whether to disable global guardrails for the key.
          *     - object_permission: Optional[LiteLLM_ObjectPermissionBase] - team-specific object permission. Example - {"vector_stores": ["vector_store_1", "vector_store_2"], "agents": ["agent_1", "agent_2"], "agent_access_groups": ["dev_group"]}. IF null or {} then no object permission.
          *     - team_member_budget: Optional[float] - The maximum budget allocated to an individual team member.
+         *     - team_member_soft_budget: Optional[float] - The soft (alert-only) budget allocated to an individual team member. Triggers an alert when crossed, without blocking requests.
          *     - team_member_budget_duration: Optional[str] - The duration of the budget for the team member. Doc [here](https://docs.litellm.ai/docs/proxy/team_budgets)
          *     - team_member_rpm_limit: Optional[int] - The RPM (Requests Per Minute) limit for individual team members.
          *     - team_member_tpm_limit: Optional[int] - The TPM (Tokens Per Minute) limit for individual team members.
@@ -13694,6 +13696,7 @@ export interface paths {
          *     - allowed_passthrough_routes: Optional[List[str]] - List of allowed pass through routes for the team.
          *     - model_rpm_limit: Optional[Dict[str, int]] - The RPM (Requests Per Minute) limit per model for this team. Example: {"gpt-4": 100, "gpt-3.5-turbo": 200}
          *     - model_tpm_limit: Optional[Dict[str, int]] - The TPM (Tokens Per Minute) limit per model for this team. Example: {"gpt-4": 10000, "gpt-3.5-turbo": 20000}
+         *     - mcp_rpm_limit: Optional[Dict[str, int]] - Per-MCP-server RPM limit for this team, keyed by MCP server name (alias if set, else the configured name). Example: {"github": 100, "slack": 200}. Applied across all keys for this team.
          *     Example - update team TPM Limit
          *     - allowed_vector_store_indexes: Optional[List[dict]] - List of allowed vector store indexes for the key. Example - [{"index_name": "my-index", "index_permissions": ["write", "read"]}]. If specified, the key will only be able to use these specific vector store indexes. Create index, using `/v1/indexes` endpoint.
          *     - secret_manager_settings: Optional[dict] - Secret manager settings for the team. [Docs](https://docs.litellm.ai/docs/secret_managers/overview)
@@ -27761,6 +27764,7 @@ export interface components {
             team_id?: string | null;
             /** Team Member Budget */
             team_member_budget?: number | null;
+            team_member_soft_budget?: number | null;
             /** Team Member Budget Duration */
             team_member_budget_duration?: string | null;
             /** Team Member Key Duration */
@@ -31900,6 +31904,7 @@ export interface components {
             team_id: string;
             /** Team Member Budget */
             team_member_budget?: number | null;
+            team_member_soft_budget?: number | null;
             /** Team Member Budget Duration */
             team_member_budget_duration?: string | null;
             /** Team Member Key Duration */


### PR DESCRIPTION
## Relevant issues

Fixes #31097

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Built the proxy image from this branch, ran it against a clean database, then set and updated a team member soft budget through the API. This is a budget management change, so the team and budget round-trip is the realistic proof; there is no LLM call involved

Create a team with a team member soft budget

```
$ curl -sX POST localhost:4000/team/new -H 'Authorization: Bearer sk-1234' \
    -H 'Content-Type: application/json' -d '{"team_alias":"acme","team_member_soft_budget":5}'
```

Read it back through /team/info

```
$ curl -s 'localhost:4000/team/info?team_id=59fd87ac-7091-4ea6-b774-e6a9c1dacf94' -H 'Authorization: Bearer sk-1234'
{
  "team_id": "59fd87ac-7091-4ea6-b774-e6a9c1dacf94",
  "team_member_budget_table": {
    "budget_id": "team-acme-budget-3190094671b14450bdc8cbc07c58c8a2",
    "soft_budget": 5.0
  }
}
```

Update the team member soft budget to 7, then read back

```
team_member_budget_table.soft_budget = 7.0
```

## Type

Bug Fix

## Changes

Team member budgets already plumbed max_budget, rpm, tpm and budget duration, but soft_budget was never threaded through, so a team member soft budget could not be set through the API or the dashboard. This threads team_member_soft_budget through the create (`/team/new`) and update (`/team/update`) paths so it lands on the underlying budget row, and adds regression tests covering both paths

A dashboard input for the team member soft budget will follow as a separate UI PR
