### PR TITLE
fix(cache): route Bedrock semantic-cache sync embedding through the Router (#28244)

### DIFF
--- a/litellm/caching/_embedding_router.py
+++ b/litellm/caching/_embedding_router.py
@@ -27,7 +27,9 @@ def resolve_embedding_router(
     if llm_router is None:
         return None
     router_model_names: list[str] = (
-        [m["model_name"] for m in llm_model_list] if llm_model_list is not None else []
+        [m["model_name"] for m in llm_model_list if "model_name" in m]
+        if llm_model_list is not None
+        else []
     )
     if embedding_model in router_model_names:
         return llm_router

--- a/litellm/caching/_embedding_router.py
+++ b/litellm/caching/_embedding_router.py
@@ -1,0 +1,43 @@
+"""Shared selection of the embedding path for semantic caches.
+
+Both the Redis and qdrant semantic caches need the same decision: when the
+configured embedding model is a proxy Router deployment, embeddings must run
+through the Router so per-deployment auth (e.g. Bedrock aws_role_name) is
+applied. Otherwise fall back to a direct litellm embedding call.
+
+This module is dependency-injected: callers pass the proxy ``llm_router`` and
+``llm_model_list`` in, so the decision logic is unit-testable without importing
+``litellm.proxy.proxy_server``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+
+
+def resolve_embedding_router(
+    embedding_model: str,
+    llm_router: Router | None,
+    llm_model_list: list[dict[str, Any]] | None,
+) -> Router | None:
+    """Return ``llm_router`` iff it serves ``embedding_model`` as a deployment."""
+    if llm_router is None:
+        return None
+    router_model_names: list[str] = (
+        [m["model_name"] for m in llm_model_list] if llm_model_list is not None else []
+    )
+    if embedding_model in router_model_names:
+        return llm_router
+    return None
+
+
+def build_router_embedding_metadata(
+    request_metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Forward the caller's full metadata, flagged as a semantic-cache embedding."""
+    metadata: dict[str, Any] = dict(request_metadata or {})
+    metadata["semantic-cache-embedding"] = True
+    return metadata

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -22,6 +22,7 @@ from litellm.litellm_core_utils.prompt_templates.common_utils import (
 )
 from litellm.types.utils import EmbeddingResponse
 
+from ._embedding_router import build_router_embedding_metadata, resolve_embedding_router
 from .base_cache import BaseCache
 
 
@@ -219,37 +220,46 @@ class QdrantSemanticCache(BaseCache):
         cached_key = payload.get(self.CACHE_KEY_FIELD_NAME)
         return cached_key is not None and str(cached_key) == str(key)
 
-    async def _get_async_embedding(self, prompt: str, **kwargs) -> Any:
-        llm_model_list = None
-        llm_router = None
-
+    def _get_embedding(self, prompt: str, **kwargs: Any) -> Any:
+        """Embed via the proxy Router when it serves the model, else direct."""
         try:
-            from litellm.proxy.proxy_server import (
-                llm_model_list as proxy_llm_model_list,
-                llm_router as proxy_llm_router,
-            )
-
-            llm_model_list = proxy_llm_model_list
-            llm_router = proxy_llm_router
+            from litellm.proxy.proxy_server import llm_model_list, llm_router
         except ImportError:
-            pass
+            llm_model_list = None
+            llm_router = None
 
-        router_model_names = (
-            [m["model_name"] for m in llm_model_list]
-            if llm_model_list is not None
-            else []
+        router = resolve_embedding_router(
+            self.embedding_model, llm_router, llm_model_list
         )
-        if llm_router is not None and self.embedding_model in router_model_names:
-            user_api_key = kwargs.get("metadata", {}).get("user_api_key", "")
-            return await llm_router.aembedding(
+        if router is not None:
+            return router.embedding(
                 model=self.embedding_model,
                 input=prompt,
                 cache={"no-store": True, "no-cache": True},
-                metadata={
-                    "user_api_key": user_api_key,
-                    "semantic-cache-embedding": True,
-                    "trace_id": kwargs.get("metadata", {}).get("trace_id", None),
-                },
+                metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+            )
+        return litellm.embedding(
+            model=self.embedding_model,
+            input=prompt,
+            cache={"no-store": True, "no-cache": True},
+        )
+
+    async def _get_async_embedding(self, prompt: str, **kwargs: Any) -> Any:
+        try:
+            from litellm.proxy.proxy_server import llm_model_list, llm_router
+        except ImportError:
+            llm_model_list = None
+            llm_router = None
+
+        router = resolve_embedding_router(
+            self.embedding_model, llm_router, llm_model_list
+        )
+        if router is not None:
+            return await router.aembedding(
+                model=self.embedding_model,
+                input=prompt,
+                cache={"no-store": True, "no-cache": True},
+                metadata=build_router_embedding_metadata(kwargs.get("metadata")),
             )
 
         return await litellm.aembedding(
@@ -269,11 +279,7 @@ class QdrantSemanticCache(BaseCache):
         # create an embedding for prompt
         embedding_response = cast(
             EmbeddingResponse,
-            litellm.embedding(
-                model=self.embedding_model,
-                input=prompt,
-                cache={"no-store": True, "no-cache": True},
-            ),
+            self._get_embedding(prompt, **kwargs),
         )
 
         # get the embedding
@@ -312,11 +318,7 @@ class QdrantSemanticCache(BaseCache):
         # convert to embedding
         embedding_response = cast(
             EmbeddingResponse,
-            litellm.embedding(
-                model=self.embedding_model,
-                input=prompt,
-                cache={"no-store": True, "no-cache": True},
-            ),
+            self._get_embedding(prompt, **kwargs),
         )
 
         # get the embedding

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -12,7 +12,7 @@ import ast
 import asyncio
 import json
 import os
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 import litellm
 from litellm._logging import print_verbose
@@ -220,7 +220,9 @@ class QdrantSemanticCache(BaseCache):
         cached_key = payload.get(self.CACHE_KEY_FIELD_NAME)
         return cached_key is not None and str(cached_key) == str(key)
 
-    def _get_embedding(self, prompt: str, **kwargs: Any) -> Any:
+    def _get_embedding(
+        self, prompt: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Any:
         """Embed via the proxy Router when it serves the model, else direct."""
         try:
             from litellm.proxy.proxy_server import llm_model_list, llm_router
@@ -236,7 +238,7 @@ class QdrantSemanticCache(BaseCache):
                 model=self.embedding_model,
                 input=prompt,
                 cache={"no-store": True, "no-cache": True},
-                metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+                metadata=build_router_embedding_metadata(metadata),
             )
         return litellm.embedding(
             model=self.embedding_model,
@@ -244,7 +246,9 @@ class QdrantSemanticCache(BaseCache):
             cache={"no-store": True, "no-cache": True},
         )
 
-    async def _get_async_embedding(self, prompt: str, **kwargs: Any) -> Any:
+    async def _get_async_embedding(
+        self, prompt: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Any:
         try:
             from litellm.proxy.proxy_server import llm_model_list, llm_router
         except ImportError:
@@ -259,7 +263,7 @@ class QdrantSemanticCache(BaseCache):
                 model=self.embedding_model,
                 input=prompt,
                 cache={"no-store": True, "no-cache": True},
-                metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+                metadata=build_router_embedding_metadata(metadata),
             )
 
         return await litellm.aembedding(
@@ -279,7 +283,7 @@ class QdrantSemanticCache(BaseCache):
         # create an embedding for prompt
         embedding_response = cast(
             EmbeddingResponse,
-            self._get_embedding(prompt, **kwargs),
+            self._get_embedding(prompt, metadata=kwargs.get("metadata")),
         )
 
         # get the embedding
@@ -318,7 +322,7 @@ class QdrantSemanticCache(BaseCache):
         # convert to embedding
         embedding_response = cast(
             EmbeddingResponse,
-            self._get_embedding(prompt, **kwargs),
+            self._get_embedding(prompt, metadata=kwargs.get("metadata")),
         )
 
         # get the embedding
@@ -390,7 +394,9 @@ class QdrantSemanticCache(BaseCache):
         # get the prompt
         messages = kwargs["messages"]
         prompt = get_str_from_messages(messages)
-        embedding_response = await self._get_async_embedding(prompt, **kwargs)
+        embedding_response = await self._get_async_embedding(
+            prompt, metadata=kwargs.get("metadata")
+        )
 
         # get the embedding
         embedding = embedding_response["data"][0]["embedding"]
@@ -426,7 +432,9 @@ class QdrantSemanticCache(BaseCache):
         messages = kwargs["messages"]
         prompt = get_str_from_messages(messages)
 
-        embedding_response = await self._get_async_embedding(prompt, **kwargs)
+        embedding_response = await self._get_async_embedding(
+            prompt, metadata=kwargs.get("metadata")
+        )
 
         # get the embedding
         embedding = embedding_response["data"][0]["embedding"]

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -16,12 +16,13 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 import litellm
-from litellm._logging import print_verbose
+from litellm._logging import print_verbose, verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_str_from_messages,
 )
 from litellm.types.utils import EmbeddingResponse
 
+from ._embedding_router import build_router_embedding_metadata, resolve_embedding_router
 from .base_cache import BaseCache
 
 
@@ -67,9 +68,6 @@ class RedisSemanticCache(BaseCache):
             Exception: If similarity_threshold is not provided or required Redis
                 connection information is missing
         """
-        from redisvl.extensions.llmcache import SemanticCache  # type: ignore[import-not-found, import-untyped]
-        from redisvl.utils.vectorize import CustomTextVectorizer  # type: ignore[import-not-found, import-untyped]
-
         if index_name is None:
             index_name = self.DEFAULT_REDIS_INDEX_NAME
 
@@ -107,15 +105,39 @@ class RedisSemanticCache(BaseCache):
 
         print_verbose(f"Redis semantic-cache redis_url: {redis_url}")
 
-        # Initialize the Redis vectorizer and cache
-        cache_vectorizer = CustomTextVectorizer(self._get_embedding)
+        # Defer redisvl index construction until first use. redisvl's
+        # CustomTextVectorizer eagerly embeds a probe string at construction;
+        # building lazily ensures that probe runs after llm_router is wired so
+        # per-deployment auth (e.g. Bedrock aws_role_name) is applied.
+        self._index_name = index_name
+        self._redis_url = redis_url
+        self._llmcache = None
 
-        self.llmcache = self._init_semantic_cache(
-            semantic_cache_cls=SemanticCache,
-            index_name=index_name,
-            redis_url=redis_url,
-            cache_vectorizer=cache_vectorizer,
-        )
+    @property
+    def llmcache(self) -> Any:
+        if getattr(self, "_llmcache", None) is None:
+            self._llmcache = self._build_llmcache()
+        return self._llmcache
+
+    @llmcache.setter
+    def llmcache(self, value: Any) -> None:
+        self._llmcache = value
+
+    def _build_llmcache(self) -> Any:
+        from redisvl.extensions.llmcache import SemanticCache  # type: ignore[import-not-found, import-untyped]
+        from redisvl.utils.vectorize import CustomTextVectorizer  # type: ignore[import-not-found, import-untyped]
+
+        try:
+            cache_vectorizer = CustomTextVectorizer(self._get_embedding)
+            return self._init_semantic_cache(
+                semantic_cache_cls=SemanticCache,
+                index_name=self._index_name,
+                redis_url=self._redis_url,
+                cache_vectorizer=cache_vectorizer,
+            )
+        except Exception as e:
+            verbose_logger.error(f"Redis semantic-cache index build failed: {e}")
+            raise
 
     @classmethod
     def _cache_key_filterable_field(cls) -> Dict[str, str]:
@@ -285,27 +307,41 @@ class RedisSemanticCache(BaseCache):
             return dict_method()
         return value
 
-    def _get_embedding(self, prompt: str) -> List[float]:
+    def _get_embedding(self, prompt: str, **kwargs: Any) -> List[float]:
         """
-        Generate an embedding vector for the given prompt using the configured embedding model.
-
-        Args:
-            prompt: The text to generate an embedding for
-
-        Returns:
-            List[float]: The embedding vector
+        Routes through the proxy Router when the embedding model is a Router
+        deployment so per-deployment auth (e.g. Bedrock aws_role_name) applies,
+        mirroring ``_get_async_embedding``; otherwise embeds directly.
         """
-        # Create an embedding from prompt
-        embedding_response = cast(
-            EmbeddingResponse,
-            litellm.embedding(
-                model=self.embedding_model,
-                input=prompt,
-                cache={"no-store": True, "no-cache": True},
-            ),
+        try:
+            from litellm.proxy.proxy_server import llm_model_list, llm_router
+        except ImportError:
+            llm_model_list = None
+            llm_router = None
+
+        router = resolve_embedding_router(
+            self.embedding_model, llm_router, llm_model_list
         )
-        embedding = embedding_response["data"][0]["embedding"]
-        return embedding
+        if router is not None:
+            embedding_response = cast(
+                EmbeddingResponse,
+                router.embedding(
+                    model=self.embedding_model,
+                    input=prompt,
+                    cache={"no-store": True, "no-cache": True},
+                    metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+                ),
+            )
+        else:
+            embedding_response = cast(
+                EmbeddingResponse,
+                litellm.embedding(
+                    model=self.embedding_model,
+                    input=prompt,
+                    cache={"no-store": True, "no-cache": True},
+                ),
+            )
+        return embedding_response["data"][0]["embedding"]
 
     def _get_cache_logic(self, cached_response: Any) -> Any:
         """
@@ -357,7 +393,10 @@ class RedisSemanticCache(BaseCache):
 
             value_str = str(value)
 
-            store_kwargs: Dict[str, Any] = {
+            prompt_embedding = self._get_embedding(prompt, **kwargs)
+
+            store_kwargs: dict[str, Any] = {
+                "vector": prompt_embedding,
                 "filters": self._get_cache_filters(key),
             }
 
@@ -393,8 +432,10 @@ class RedisSemanticCache(BaseCache):
 
             # Check the cache for semantically similar prompts in this exact
             # LiteLLM cache-key scope.
-            check_kwargs: Dict[str, Any] = {
+            prompt_embedding = self._get_embedding(prompt, **kwargs)
+            check_kwargs: dict[str, Any] = {
                 "prompt": prompt,
+                "vector": prompt_embedding,
                 "filter_expression": self._get_cache_key_filter_expression(key),
             }
             results = self.llmcache.check(**check_kwargs)
@@ -446,38 +487,29 @@ class RedisSemanticCache(BaseCache):
         Returns:
             List[float]: The embedding vector
         """
-        from litellm.proxy.proxy_server import llm_model_list, llm_router
-
-        # Route the embedding request through the proxy if appropriate
-        router_model_names = (
-            [m["model_name"] for m in llm_model_list]
-            if llm_model_list is not None
-            else []
-        )
-
         try:
-            if llm_router is not None and self.embedding_model in router_model_names:
-                # Use the router for embedding generation
-                user_api_key = kwargs.get("metadata", {}).get("user_api_key", "")
-                embedding_response = await llm_router.aembedding(
+            from litellm.proxy.proxy_server import llm_model_list, llm_router
+        except ImportError:
+            llm_model_list = None
+            llm_router = None
+
+        router = resolve_embedding_router(
+            self.embedding_model, llm_router, llm_model_list
+        )
+        try:
+            if router is not None:
+                embedding_response = await router.aembedding(
                     model=self.embedding_model,
                     input=prompt,
                     cache={"no-store": True, "no-cache": True},
-                    metadata={
-                        "user_api_key": user_api_key,
-                        "semantic-cache-embedding": True,
-                        "trace_id": kwargs.get("metadata", {}).get("trace_id", None),
-                    },
+                    metadata=build_router_embedding_metadata(kwargs.get("metadata")),
                 )
             else:
-                # Generate embedding directly
                 embedding_response = await litellm.aembedding(
                     model=self.embedding_model,
                     input=prompt,
                     cache={"no-store": True, "no-cache": True},
                 )
-
-            # Extract and return the embedding vector
             return embedding_response["data"][0]["embedding"]
         except Exception as e:
             print_verbose(f"Error generating async embedding: {str(e)}")
@@ -506,7 +538,7 @@ class RedisSemanticCache(BaseCache):
             # Generate embedding for the value (response) to cache
             prompt_embedding = await self._get_async_embedding(prompt, **kwargs)
 
-            store_kwargs: Dict[str, Any] = {
+            store_kwargs: dict[str, Any] = {
                 "vector": prompt_embedding,
                 "filters": self._get_cache_filters(key),
             }
@@ -548,7 +580,7 @@ class RedisSemanticCache(BaseCache):
 
             # Check the cache for semantically similar prompts in this exact
             # LiteLLM cache-key scope.
-            check_kwargs: Dict[str, Any] = {
+            check_kwargs: dict[str, Any] = {
                 "prompt": prompt,
                 "vector": prompt_embedding,
                 "filter_expression": self._get_cache_key_filter_expression(key),

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -124,6 +124,9 @@ class RedisSemanticCache(BaseCache):
         self._llmcache = value
 
     def _build_llmcache(self) -> Any:
+        # CustomTextVectorizer probes its embedding dimension at construction by
+        # embedding "dimension test", so the first cache request issues one extra
+        # billable embedding on top of the request's own.
         from redisvl.extensions.llmcache import SemanticCache  # type: ignore[import-not-found, import-untyped]
         from redisvl.utils.vectorize import CustomTextVectorizer  # type: ignore[import-not-found, import-untyped]
 
@@ -307,7 +310,9 @@ class RedisSemanticCache(BaseCache):
             return dict_method()
         return value
 
-    def _get_embedding(self, prompt: str, **kwargs: Any) -> List[float]:
+    def _get_embedding(
+        self, prompt: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> List[float]:
         """
         Routes through the proxy Router when the embedding model is a Router
         deployment so per-deployment auth (e.g. Bedrock aws_role_name) applies,
@@ -329,7 +334,7 @@ class RedisSemanticCache(BaseCache):
                     model=self.embedding_model,
                     input=prompt,
                     cache={"no-store": True, "no-cache": True},
-                    metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+                    metadata=build_router_embedding_metadata(metadata),
                 ),
             )
         else:
@@ -393,7 +398,9 @@ class RedisSemanticCache(BaseCache):
 
             value_str = str(value)
 
-            prompt_embedding = self._get_embedding(prompt, **kwargs)
+            prompt_embedding = self._get_embedding(
+                prompt, metadata=kwargs.get("metadata")
+            )
 
             store_kwargs: dict[str, Any] = {
                 "vector": prompt_embedding,
@@ -432,7 +439,9 @@ class RedisSemanticCache(BaseCache):
 
             # Check the cache for semantically similar prompts in this exact
             # LiteLLM cache-key scope.
-            prompt_embedding = self._get_embedding(prompt, **kwargs)
+            prompt_embedding = self._get_embedding(
+                prompt, metadata=kwargs.get("metadata")
+            )
             check_kwargs: dict[str, Any] = {
                 "prompt": prompt,
                 "vector": prompt_embedding,
@@ -476,13 +485,15 @@ class RedisSemanticCache(BaseCache):
             print_verbose(f"Error retrieving from Redis semantic cache: {str(e)}")
             kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
 
-    async def _get_async_embedding(self, prompt: str, **kwargs) -> List[float]:
+    async def _get_async_embedding(
+        self, prompt: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> List[float]:
         """
         Asynchronously generate an embedding for the given prompt.
 
         Args:
             prompt: The text to generate an embedding for
-            **kwargs: Additional arguments that may contain metadata
+            metadata: Request metadata forwarded to the Router embedding call
 
         Returns:
             List[float]: The embedding vector
@@ -502,7 +513,7 @@ class RedisSemanticCache(BaseCache):
                     model=self.embedding_model,
                     input=prompt,
                     cache={"no-store": True, "no-cache": True},
-                    metadata=build_router_embedding_metadata(kwargs.get("metadata")),
+                    metadata=build_router_embedding_metadata(metadata),
                 )
             else:
                 embedding_response = await litellm.aembedding(
@@ -536,7 +547,9 @@ class RedisSemanticCache(BaseCache):
             value_str = str(value)
 
             # Generate embedding for the value (response) to cache
-            prompt_embedding = await self._get_async_embedding(prompt, **kwargs)
+            prompt_embedding = await self._get_async_embedding(
+                prompt, metadata=kwargs.get("metadata")
+            )
 
             store_kwargs: dict[str, Any] = {
                 "vector": prompt_embedding,
@@ -576,7 +589,9 @@ class RedisSemanticCache(BaseCache):
                 return None
 
             # Generate embedding for the prompt
-            prompt_embedding = await self._get_async_embedding(prompt, **kwargs)
+            prompt_embedding = await self._get_async_embedding(
+                prompt, metadata=kwargs.get("metadata")
+            )
 
             # Check the cache for semantically similar prompts in this exact
             # LiteLLM cache-key scope.

--- a/tests/test_litellm/caching/test_embedding_router.py
+++ b/tests/test_litellm/caching/test_embedding_router.py
@@ -37,6 +37,16 @@ def test_resolve_returns_none_when_model_list_is_none():
     assert resolve_embedding_router("sem-embed", router, None) is None
 
 
+def test_resolve_skips_entries_missing_model_name():
+    router = MagicMock()
+    model_list = [
+        {"litellm_params": {"model": "bedrock/x"}},
+        {"model_name": "sem-embed"},
+    ]
+    assert resolve_embedding_router("sem-embed", router, model_list) is router
+    assert resolve_embedding_router("other", router, [{"litellm_params": {}}]) is None
+
+
 def test_build_metadata_preserves_request_fields_and_adds_flag():
     md = build_router_embedding_metadata(
         {"user_api_key": "sk-x", "user_api_key_team_id": "team-1", "trace_id": "t-1"}

--- a/tests/test_litellm/caching/test_embedding_router.py
+++ b/tests/test_litellm/caching/test_embedding_router.py
@@ -1,0 +1,57 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.caching._embedding_router import (
+    build_router_embedding_metadata,
+    resolve_embedding_router,
+)
+
+
+def test_resolve_returns_router_when_model_is_a_deployment():
+    router = MagicMock()
+    assert (
+        resolve_embedding_router("sem-embed", router, [{"model_name": "sem-embed"}])
+        is router
+    )
+
+
+def test_resolve_returns_none_when_model_not_in_router():
+    router = MagicMock()
+    assert (
+        resolve_embedding_router("sem-embed", router, [{"model_name": "other"}]) is None
+    )
+
+
+def test_resolve_returns_none_when_router_is_none():
+    assert (
+        resolve_embedding_router("sem-embed", None, [{"model_name": "sem-embed"}])
+        is None
+    )
+
+
+def test_resolve_returns_none_when_model_list_is_none():
+    router = MagicMock()
+    assert resolve_embedding_router("sem-embed", router, None) is None
+
+
+def test_build_metadata_preserves_request_fields_and_adds_flag():
+    md = build_router_embedding_metadata(
+        {"user_api_key": "sk-x", "user_api_key_team_id": "team-1", "trace_id": "t-1"}
+    )
+    assert md == {
+        "user_api_key": "sk-x",
+        "user_api_key_team_id": "team-1",
+        "trace_id": "t-1",
+        "semantic-cache-embedding": True,
+    }
+
+
+def test_build_metadata_handles_none_and_does_not_mutate_input():
+    original = {"user_api_key": "sk-x"}
+    md = build_router_embedding_metadata(original)
+    assert md == {"user_api_key": "sk-x", "semantic-cache-embedding": True}
+    assert original == {"user_api_key": "sk-x"}
+    assert build_router_embedding_metadata(None) == {"semantic-cache-embedding": True}

--- a/tests/test_litellm/caching/test_qdrant_semantic_cache.py
+++ b/tests/test_litellm/caching/test_qdrant_semantic_cache.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -806,3 +807,104 @@ def test_qdrant_semantic_cache_large_vector_size():
         )
         create_payload = put_call.kwargs["json"]
         assert create_payload["vectors"]["size"] == 4096
+
+
+def _router_proxy_module(router, model_name):
+    mod = types.ModuleType("litellm.proxy.proxy_server")
+    mod.llm_router = router
+    mod.llm_model_list = [{"model_name": model_name}]
+    return mod
+
+
+def test_qdrant_sync_get_cache_routes_through_router(monkeypatch):
+    from litellm.caching.qdrant_semantic_cache import QdrantSemanticCache
+
+    cache = QdrantSemanticCache.__new__(QdrantSemanticCache)
+    cache.embedding_model = "sem-embed"
+    cache.qdrant_api_base = "http://test.qdrant.local"
+    cache.collection_name = "test_collection"
+    cache.headers = {"Content-Type": "application/json", "api-key": "test_key"}
+    cache.similarity_threshold = 0.8
+    cache.sync_client = MagicMock()
+    search_response = MagicMock()
+    search_response.status_code = 200
+    search_response.json.return_value = {"result": []}
+    cache.sync_client.post.return_value = search_response
+
+    router = MagicMock()
+    router.embedding = MagicMock(
+        return_value={"data": [{"embedding": [0.3, 0.3, 0.3]}]}
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm.proxy.proxy_server",
+        _router_proxy_module(router, "sem-embed"),
+    )
+
+    with patch("litellm.embedding") as direct_embed:
+        result = cache.get_cache(
+            key="test_key",
+            messages=[{"content": "What is the capital of France?"}],
+            metadata={},
+        )
+
+    assert result is None
+    router.embedding.assert_called_once()
+    assert router.embedding.call_args.kwargs["model"] == "sem-embed"
+    direct_embed.assert_not_called()
+
+
+def test_qdrant_sync_set_cache_falls_back_to_direct(monkeypatch):
+    from litellm.caching.qdrant_semantic_cache import QdrantSemanticCache
+
+    cache = QdrantSemanticCache.__new__(QdrantSemanticCache)
+    cache.embedding_model = "text-embedding-ada-002"
+    cache.qdrant_api_base = "http://test.qdrant.local"
+    cache.collection_name = "test_collection"
+    cache.headers = {"Content-Type": "application/json", "api-key": "test_key"}
+    cache.sync_client = MagicMock()
+    put_response = MagicMock()
+    put_response.status_code = 200
+    cache.sync_client.put.return_value = put_response
+
+    fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
+    fake_proxy.llm_router = None
+    fake_proxy.llm_model_list = None
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
+
+    with patch(
+        "litellm.embedding", return_value={"data": [{"embedding": [0.1, 0.1, 0.1]}]}
+    ) as direct_embed:
+        cache.set_cache(
+            key="test_key",
+            value={"content": "Paris"},
+            messages=[{"content": "What is the capital of France?"}],
+        )
+
+    direct_embed.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_qdrant_async_embedding_forwards_full_metadata(monkeypatch):
+    from litellm.caching.qdrant_semantic_cache import QdrantSemanticCache
+
+    cache = QdrantSemanticCache.__new__(QdrantSemanticCache)
+    cache.embedding_model = "sem-embed"
+
+    router = MagicMock()
+    router.aembedding = AsyncMock(return_value={"data": [{"embedding": [0.1, 0.2]}]})
+    monkeypatch.setitem(
+        sys.modules,
+        "litellm.proxy.proxy_server",
+        _router_proxy_module(router, "sem-embed"),
+    )
+
+    await cache._get_async_embedding(
+        "hello",
+        metadata={"user_api_key": "sk-x", "user_api_key_team_id": "team-1"},
+    )
+
+    md = router.aembedding.call_args.kwargs["metadata"]
+    assert md["user_api_key"] == "sk-x"
+    assert md["user_api_key_team_id"] == "team-1"
+    assert md["semantic-cache-embedding"] is True

--- a/tests/test_litellm/caching/test_redis_semantic_cache.py
+++ b/tests/test_litellm/caching/test_redis_semantic_cache.py
@@ -104,6 +104,7 @@ def test_redis_semantic_cache_get_cache(monkeypatch):
             # Verify llmcache.check was called
             redis_semantic_cache.llmcache.check.assert_called_once_with(
                 prompt="What is the capital of France?",
+                vector=[0.1, 0.2, 0.3],
                 filter_expression="cache-key-filter",
             )
 
@@ -138,10 +139,16 @@ def test_redis_semantic_cache_rejects_unscoped_cache_hit(monkeypatch):
             ]
         )
 
-        with patch.object(
-            redis_semantic_cache,
-            "_get_cache_key_filter_expression",
-            return_value="cache-key-filter",
+        with (
+            patch(
+                "litellm.embedding",
+                return_value={"data": [{"embedding": [0.1, 0.2, 0.3]}]},
+            ),
+            patch.object(
+                redis_semantic_cache,
+                "_get_cache_key_filter_expression",
+                return_value="cache-key-filter",
+            ),
         ):
             metadata = {}
             result = redis_semantic_cache.get_cache(
@@ -176,16 +183,21 @@ def test_redis_semantic_cache_set_cache_stores_cache_key_filter(monkeypatch):
         redis_semantic_cache = RedisSemanticCache(similarity_threshold=0.8)
         redis_semantic_cache.llmcache.store = MagicMock()
 
-        redis_semantic_cache.set_cache(
-            key="test_key",
-            value={"content": "Paris"},
-            messages=[{"content": "What is the capital of France?"}],
-            ttl=60,
-        )
+        with patch(
+            "litellm.embedding",
+            return_value={"data": [{"embedding": [0.1, 0.2, 0.3]}]},
+        ):
+            redis_semantic_cache.set_cache(
+                key="test_key",
+                value={"content": "Paris"},
+                messages=[{"content": "What is the capital of France?"}],
+                ttl=60,
+            )
 
         redis_semantic_cache.llmcache.store.assert_called_once_with(
             "What is the capital of France?",
             "{'content': 'Paris'}",
+            vector=[0.1, 0.2, 0.3],
             filters={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"},
             ttl=60,
         )
@@ -299,10 +311,11 @@ def test_redis_semantic_cache_reraises_unexpected_isolated_index_error(monkeypat
         monkeypatch.setenv("REDIS_PASSWORD", "test_password")
 
         with pytest.raises(ValueError, match="connection failed"):
-            RedisSemanticCache(
+            cache = RedisSemanticCache(
                 similarity_threshold=0.8,
                 index_name="existing_index",
             )
+            _ = cache.llmcache
 
 
 def test_redis_semantic_cache_reraises_unexpected_index_error():
@@ -534,6 +547,7 @@ def test_redis_semantic_cache_set_cache_uses_responses_string_input():
         return_value={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"}
     )
     redis_semantic_cache._get_ttl = MagicMock(return_value=None)
+    redis_semantic_cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     redis_semantic_cache.set_cache(
         key="test_key",
@@ -544,6 +558,7 @@ def test_redis_semantic_cache_set_cache_uses_responses_string_input():
     redis_semantic_cache.llmcache.store.assert_called_once_with(
         "What is the capital of France?",
         "{'content': 'Paris'}",
+        vector=[0.1, 0.2, 0.3],
         filters={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"},
     )
 
@@ -564,6 +579,7 @@ def test_redis_semantic_cache_get_cache_uses_responses_string_input():
             }
         ]
     )
+    redis_semantic_cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     with patch.object(
         redis_semantic_cache,
@@ -581,6 +597,7 @@ def test_redis_semantic_cache_get_cache_uses_responses_string_input():
     assert metadata["semantic-similarity"] == pytest.approx(0.9)
     redis_semantic_cache.llmcache.check.assert_called_once_with(
         prompt="What is the capital of France?",
+        vector=[0.1, 0.2, 0.3],
         filter_expression="cache-key-filter",
     )
 
@@ -594,6 +611,7 @@ def test_redis_semantic_cache_set_cache_flattens_structured_responses_input():
         return_value={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"}
     )
     redis_semantic_cache._get_ttl = MagicMock(return_value=None)
+    redis_semantic_cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     redis_semantic_cache.set_cache(
         key="test_key",
@@ -616,6 +634,7 @@ def test_redis_semantic_cache_set_cache_flattens_structured_responses_input():
     redis_semantic_cache.llmcache.store.assert_called_once_with(
         "What is the capital of France?\nAnswer briefly.",
         "{'content': 'Paris'}",
+        vector=[0.1, 0.2, 0.3],
         filters={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"},
     )
 
@@ -740,6 +759,7 @@ def test_redis_semantic_cache_get_cache_sets_similarity_when_no_results():
     redis_semantic_cache = RedisSemanticCache.__new__(RedisSemanticCache)
     redis_semantic_cache.llmcache = MagicMock()
     redis_semantic_cache.llmcache.check = MagicMock(return_value=[])
+    redis_semantic_cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
 
     with patch.object(
         redis_semantic_cache,
@@ -757,6 +777,7 @@ def test_redis_semantic_cache_get_cache_sets_similarity_when_no_results():
     assert metadata["semantic-similarity"] == 0.0
     redis_semantic_cache.llmcache.check.assert_called_once_with(
         prompt="What is the capital of France?",
+        vector=[0.1, 0.2, 0.3],
         filter_expression="cache-key-filter",
     )
 
@@ -868,6 +889,63 @@ async def test_redis_semantic_cache_async_paths_set_similarity_on_misses():
         vector=[0.1, 0.2, 0.3],
         filter_expression="cache-key-filter",
     )
+
+
+def test_redis_get_embedding_routes_through_router(monkeypatch):
+    import sys
+    import types
+
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.embedding_model = "sem-embed"
+
+    router = MagicMock()
+    router.embedding = MagicMock(return_value={"data": [{"embedding": [0.5, 0.6]}]})
+    fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
+    fake_proxy.llm_router = router
+    fake_proxy.llm_model_list = [{"model_name": "sem-embed"}]
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
+
+    with patch("litellm.embedding") as direct_embed:
+        vec = cache._get_embedding("hello", metadata={"user_api_key": "sk-x"})
+
+    assert vec == [0.5, 0.6]
+    router.embedding.assert_called_once()
+    assert router.embedding.call_args.kwargs["model"] == "sem-embed"
+    assert router.embedding.call_args.kwargs["input"] == "hello"
+    assert router.embedding.call_args.kwargs["cache"] == {
+        "no-store": True,
+        "no-cache": True,
+    }
+    assert router.embedding.call_args.kwargs["metadata"] == {
+        "user_api_key": "sk-x",
+        "semantic-cache-embedding": True,
+    }
+    direct_embed.assert_not_called()
+
+
+def test_redis_get_embedding_falls_back_to_direct(monkeypatch):
+    import sys
+    import types
+
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.embedding_model = "text-embedding-ada-002"
+
+    fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
+    fake_proxy.llm_router = None
+    fake_proxy.llm_model_list = None
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
+
+    with patch(
+        "litellm.embedding", return_value={"data": [{"embedding": [0.1, 0.2]}]}
+    ) as direct_embed:
+        vec = cache._get_embedding("hello")
+
+    assert vec == [0.1, 0.2]
+    direct_embed.assert_called_once()
 
 
 def test_cache_get_cache_passes_responses_input_to_backend_cache():
@@ -988,3 +1066,166 @@ def test_cache_get_cache_passes_responses_input_to_dynamic_cache():
         cached_result={"content": "Paris"},
         max_age=float("inf"),
     )
+
+
+def test_redis_sync_set_cache_passes_precomputed_vector():
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.llmcache = MagicMock()
+    cache._get_cache_filters = MagicMock(
+        return_value={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"}
+    )
+    cache._get_ttl = MagicMock(return_value=None)
+    cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+    cache.set_cache(
+        key="test_key",
+        value={"content": "Paris"},
+        messages=[{"content": "What is the capital of France?"}],
+    )
+
+    cache._get_embedding.assert_called_once()
+    cache.llmcache.store.assert_called_once_with(
+        "What is the capital of France?",
+        "{'content': 'Paris'}",
+        vector=[0.1, 0.2, 0.3],
+        filters={RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key"},
+    )
+
+
+def test_redis_sync_get_cache_passes_precomputed_vector():
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.similarity_threshold = 0.8
+    cache.llmcache = MagicMock()
+    cache.llmcache.check = MagicMock(
+        return_value=[
+            {
+                "prompt": "What is the capital of France?",
+                "response": '{"content": "Paris"}',
+                "vector_distance": 0.1,
+                RedisSemanticCache.CACHE_KEY_FIELD_NAME: "test_key",
+            }
+        ]
+    )
+    cache._get_embedding = MagicMock(return_value=[0.1, 0.2, 0.3])
+
+    with patch.object(
+        cache, "_get_cache_key_filter_expression", return_value="cache-key-filter"
+    ):
+        result = cache.get_cache(
+            key="test_key",
+            messages=[{"content": "What is the capital of France?"}],
+            metadata={},
+        )
+
+    assert result == {"content": "Paris"}
+    cache._get_embedding.assert_called_once()
+    cache.llmcache.check.assert_called_once_with(
+        prompt="What is the capital of France?",
+        vector=[0.1, 0.2, 0.3],
+        filter_expression="cache-key-filter",
+    )
+
+
+@pytest.mark.asyncio
+async def test_redis_async_embedding_forwards_full_metadata(monkeypatch):
+    import sys
+    import types
+
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    cache.embedding_model = "sem-embed"
+
+    router = MagicMock()
+    router.aembedding = AsyncMock(return_value={"data": [{"embedding": [0.1, 0.2]}]})
+    fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
+    fake_proxy.llm_router = router
+    fake_proxy.llm_model_list = [{"model_name": "sem-embed"}]
+    monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
+
+    await cache._get_async_embedding(
+        "hello",
+        metadata={"user_api_key": "sk-x", "user_api_key_team_id": "team-1"},
+    )
+
+    md = router.aembedding.call_args.kwargs["metadata"]
+    assert md["user_api_key"] == "sk-x"
+    assert md["user_api_key_team_id"] == "team-1"  # FAILS today: team_id is dropped
+    assert md["semantic-cache-embedding"] is True
+
+
+def test_redis_init_defers_redisvl_construction(monkeypatch):
+    semantic_cache_mock = MagicMock()
+    custom_vectorizer_mock = MagicMock()
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "redisvl.extensions.llmcache": MagicMock(SemanticCache=semantic_cache_mock),
+            "redisvl.utils.vectorize": MagicMock(
+                CustomTextVectorizer=custom_vectorizer_mock
+            ),
+        },
+    ):
+        from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "6379")
+        monkeypatch.setenv("REDIS_PASSWORD", "test_password")
+
+        cache = RedisSemanticCache(similarity_threshold=0.8)
+
+        semantic_cache_mock.assert_not_called()
+        custom_vectorizer_mock.assert_not_called()
+
+        first = cache.llmcache
+        semantic_cache_mock.assert_called_once()
+        custom_vectorizer_mock.assert_called_once()
+
+        second = cache.llmcache
+        assert first is second
+        semantic_cache_mock.assert_called_once()
+
+
+def test_redis_failed_llmcache_build_is_not_memoized(monkeypatch):
+    built_cache = MagicMock()
+    semantic_cache_mock = MagicMock(
+        side_effect=[ConnectionError("redis down"), built_cache]
+    )
+    custom_vectorizer_mock = MagicMock()
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "redisvl.extensions.llmcache": MagicMock(SemanticCache=semantic_cache_mock),
+            "redisvl.utils.vectorize": MagicMock(
+                CustomTextVectorizer=custom_vectorizer_mock
+            ),
+        },
+    ):
+        from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+        monkeypatch.setenv("REDIS_HOST", "localhost")
+        monkeypatch.setenv("REDIS_PORT", "6379")
+        monkeypatch.setenv("REDIS_PASSWORD", "test_password")
+
+        cache = RedisSemanticCache(similarity_threshold=0.8)
+
+        with pytest.raises(ConnectionError, match="redis down"):
+            _ = cache.llmcache
+
+        assert cache.llmcache is built_cache
+        assert semantic_cache_mock.call_count == 2
+
+
+def test_redis_llmcache_setter_supported():
+    from litellm.caching.redis_semantic_cache import RedisSemanticCache
+
+    cache = RedisSemanticCache.__new__(RedisSemanticCache)
+    sentinel = MagicMock()
+    cache.llmcache = sentinel
+    assert cache.llmcache is sentinel


### PR DESCRIPTION
## Relevant issues

Fixes #28244

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Live proxy + real Redis Stack + real Bedrock (Titan v2 embeddings, Nova-micro chat), with the semantic-cache embedding model configured with `aws_role_name` pointing at a role the proxy identity must assume. Two proxies were run off the same config: one at the pre-fix baseline, one at this branch's HEAD.

The bug is most visible on Redis: pre-fix the proxy crashes at startup, because the eager redisvl dimension-probe embedding runs while `llm_router` is still `None` and cannot resolve the alias or assume the role.

**Pre-fix (baseline): proxy crashes at startup**

```
File ".../litellm/caching/redis_semantic_cache.py", line 111, in __init__
    cache_vectorizer = CustomTextVectorizer(self._get_embedding)
  ...
ValueError: Failed to validate embed method: litellm.BadRequestError: LLM Provider
  NOT provided. Pass in the LLM provider you are trying to call. You passed model=sem-embed
ERROR:    Application startup failed. Exiting.
```

**Post-fix: clean miss -> hit, with the embedding assuming the role**

Each step below prints the actual command (`set -x`, lines prefixed with `+`) before its real output; ids are server-generated UUIDs and timings are curl-measured, so the comparison is a genuine round-trip, not a canned result.

STEP 1 - reset to a known-clean state (stop proxy, FLUSHALL, restart so the RediSearch index is rebuilt and Request #1 is a genuine miss):

<img width="1366" height="587" alt="Step1" src="https://github.com/user-attachments/assets/7ae3018c-adfe-4355-88d4-9c78d844cc56" />

STEP 2 - Request #1 == cache MISS (real sync embed with the assumed role + chat generation, then writes the cache; slow, NEW id, dbsize 0 -> 1):

<img width="1366" height="695" alt="Step2" src="https://github.com/user-attachments/assets/891abf46-4a01-403f-aac3-0167a157d581" />

STEP 3 - Request #2 == cache HIT (identical body, no flush; fast, SAME id as Request #1):

<img width="1368" height="547" alt="Step3" src="https://github.com/user-attachments/assets/d35413e3-2a15-474b-ac9b-a5bba49faf9b" />

STEP 4 - independent confirmation from the proxy log (`Cache Hit!` whose timestamp matches Request #2):

<img width="1365" height="371" alt="Step4" src="https://github.com/user-attachments/assets/65dfed6a-c3ba-466b-98d5-2e1abc7ed7a7" />

The sync dimension-probe embedding now carries the configured role (this is the exact call that crashed pre-fix):

```
model='bedrock/amazon.titan-embed-text-v2:0'
aws_role_name='arn:aws:iam::<ACCT>:role/<assumable-role>'
aws_session_name='litellm-semcache-embed'
input='dimension test'
```

<img width="1369" height="729" alt="Step5" src="https://github.com/user-attachments/assets/43667700-40bf-4d2c-8a34-9b226868f495" />

AWS-side confirmation via CloudTrail: real `sts:AssumeRole` events for the embedder session (`session=litellm-semcache-embed`), absent entirely pre-fix:

<img width="1367" height="250" alt="Step6" src="https://github.com/user-attachments/assets/350c294e-627c-4111-8fb4-7adecefaeffe" />

## Type

🐛 Bug Fix

## Changes

The semantic cache's embedding model is a proxy Router alias whose AWS credentials (`aws_role_name`, `aws_session_name`) live only in the Router deployment's `litellm_params`. The async cache paths already route embeddings through the Router, but the sync paths called `litellm.embedding()` directly, so they could neither resolve the alias nor assume the configured role. Cross-account Bedrock semantic caching failed with `bedrock:InvokeModel is not authorized`. On Redis the failure surfaced at proxy startup, because redisvl's `CustomTextVectorizer.__init__` eagerly fires a dimension-probe embedding during cache construction, while `llm_router` is still `None`.

Fix A makes the sync paths mirror the already-correct async paths. A new shared, dependency-injected helper `litellm/caching/_embedding_router.py` makes the routing decision (`resolve_embedding_router`) and builds the forwarded metadata (`build_router_embedding_metadata`); it takes the proxy globals as arguments so it is unit-testable without importing `litellm.proxy.proxy_server`. Redis and qdrant sync `set_cache`/`get_cache` now precompute the embedding via a new sync `_get_embedding` and pass `vector=` to the backend, exactly as the async `astore`/`acheck` already do. Both async `_get_async_embedding` methods are unified onto the same helper and now forward the caller's full request metadata instead of a hand-picked subset, so sync and async behave identically.

Fix B (Redis only) defers redisvl index construction from `__init__` into a lazy, memoized `llmcache` property. The dimension-probe embedding then fires on first cache use, after `load_config` has wired `llm_router`, so it routes through the Router and assumes the role. A failed build logs at error level and is not memoized, so a transient outage recovers on the next request; the surrounding cache methods still degrade to a miss rather than crashing the proxy.

Tests exercise the public `set_cache`/`get_cache` (not just the private helper): router-vs-direct routing for both caches, the precomputed `vector=` plumbing, full-metadata forwarding on sync and async, the deferred-build (no redisvl construction at `__init__`, built and memoized on first access), and that a failed build is not memoized. All new tests fail on the pre-fix code and pass after.

Known limitation (tracked as a follow-up): `resolve_embedding_router` gates on an exact model-name match, the same check the shipped async path uses. Wildcard/pattern routes, `model_group_alias`, team-public model names, and default deployments still fall back to direct `litellm.embedding` and lose the role.
