### PR TITLE
fix(ui): add team member soft budget input to team settings

### DIFF
--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -777,7 +777,7 @@ describe("TeamInfoView", () => {
       });
 
       await waitFor(() => {
-        expect(screen.getByText(/Soft Budget:/)).toBeInTheDocument();
+        expect(screen.getAllByText(/Soft Budget:/).length).toBeGreaterThan(0);
         expect(screen.getByText(/\$500\.75/)).toBeInTheDocument();
       });
     });
@@ -854,6 +854,49 @@ describe("TeamInfoView", () => {
             access_group_ids: accessGroupIds,
             team_id: "123",
           }),
+        );
+      });
+    });
+
+    it("should pass team_member_soft_budget to teamUpdateCall when saving team settings", async () => {
+      const user = userEvent.setup({ delay: null });
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(
+        createMockTeamData({
+          models: ["gpt-4"],
+          team_member_budget_table: { soft_budget: 5 } as any,
+        }),
+      );
+      vi.mocked(networking.teamUpdateCall).mockResolvedValue({ data: {}, team_id: "123" } as any);
+
+      renderWithProviders(<TeamInfoView {...defaultProps} />);
+
+      await waitFor(() => {
+        const teamNameElements = screen.queryAllByText("Test Team");
+        expect(teamNameElements.length).toBeGreaterThan(0);
+      });
+
+      const settingsTab = screen.getByRole("tab", { name: "Settings" });
+      await user.click(settingsTab);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /edit settings/i }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("Team Name")).toBeInTheDocument();
+      });
+
+      // The team-member soft budget input lives inside the "Team Member Settings"
+      // accordion, which must be expanded for the field to mount and submit.
+      await user.click(screen.getAllByText("Team Member Settings")[0]);
+
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(networking.teamUpdateCall).toHaveBeenCalledWith(
+          "test-token",
+          expect.objectContaining({ team_member_soft_budget: 5 }),
         );
       });
     });

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -130,6 +130,7 @@ export interface TeamData {
     };
     team_member_budget_table: {
       max_budget: number;
+      soft_budget?: number | null;
       budget_duration: string;
       tpm_limit: number | null;
       rpm_limit: number | null;
@@ -551,6 +552,10 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         updateData.team_member_budget = Number(values.team_member_budget);
       }
 
+      if (values.team_member_soft_budget !== undefined) {
+        updateData.team_member_soft_budget = sanitizeNumeric(values.team_member_soft_budget);
+      }
+
       if (values.team_member_key_duration !== undefined) {
         updateData.team_member_key_duration = values.team_member_key_duration;
       }
@@ -951,6 +956,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                       team_member_tpm_limit: info.team_member_budget_table?.tpm_limit,
                       team_member_rpm_limit: info.team_member_budget_table?.rpm_limit,
                       team_member_budget: info.team_member_budget_table?.max_budget,
+                      team_member_soft_budget: info.team_member_budget_table?.soft_budget,
                       team_member_budget_duration: info.team_member_budget_table?.budget_duration,
                       guardrails: effectiveGuardrails,
                       policies: info.policies || [],
@@ -1081,6 +1087,13 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                           label="Default Budget (USD)"
                           name="team_member_budget"
                           tooltip="Default spend budget for each member in this team."
+                        >
+                          <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
+                        </Form.Item>
+                        <Form.Item
+                          label="Default Soft Budget (USD)"
+                          name="team_member_soft_budget"
+                          tooltip="Alert-only soft budget for each member in this team. Members are warned when it is crossed; requests are not blocked."
                         >
                           <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} />
                         </Form.Item>
@@ -1567,6 +1580,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                         </Tooltip>
                       </Text>
                       <div>Max Budget: {info.team_member_budget_table?.max_budget || "No Limit"}</div>
+                      <div>Soft Budget: {info.team_member_budget_table?.soft_budget || "No Limit"}</div>
                       <div>Budget Duration: {info.team_member_budget_table?.budget_duration || "No Limit"}</div>
                       <div>Key Duration: {info.metadata?.team_member_key_duration || "No Limit"}</div>
                       <div>TPM Limit: {info.team_member_budget_table?.tpm_limit || "No Limit"}</div>


### PR DESCRIPTION
## Relevant issues

Fixes #31097 (UI half; the backend support is in #31197)

## Pre-Submission checklist

- [x] Ensure the UI builds successfully - `npm run build`
- [x] Ensure all UI unit tests pass - `npm run test`
- [x] Add tests for new components or logic
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

This is a UI change. To verify in the dashboard

1. Go to Teams, open a team, click the Settings tab, then Edit Settings
2. Expand the "Team Member Settings" accordion
3. The new "Default Soft Budget (USD)" field appears; set a value and Save
4. Reopen the team settings and confirm the value persists (it is sent as `team_member_soft_budget`)

`npm run build` compiles successfully, and the `TeamInfo` test suite passes, including a new regression test that asserts `team_member_soft_budget` reaches `teamUpdateCall` on save

## Type

Bug Fix

## Changes

Adds a "Default Soft Budget (USD)" input to the Team Member Settings section in `TeamInfo`, reading the existing `team_member_budget_table.soft_budget` and sending `team_member_soft_budget` on save. The local `team_member_budget_table` type is extended with the optional `soft_budget` field. Pairs with the backend support in #31197 so a team-member soft budget can be set from the dashboard, closing the UI side of #31097
