### PR TITLE
feat: add Modelis (OpenAI-compatible auto-routing gateway) to providers.json

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -114,5 +114,9 @@
     "param_mappings": {
       "max_completion_tokens": "max_tokens"
     }
+  },
+  "modelis": {
+    "base_url": "https://modelishub.com/v1",
+    "api_key_env": "MODELIS_API_KEY"
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2524,6 +2524,15 @@
         "responses": true
       }
     },
+    "modelis": {
+      "display_name": "Modelis (`modelis`)",
+      "url": "https://docs.litellm.ai/docs/providers/modelis",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true
+      }
+    },
     "llamagate": {
       "display_name": "LlamaGate (`llamagate`)",
       "url": "https://docs.litellm.ai/docs/providers/llamagate",


### PR DESCRIPTION
## What

Adds **Modelis** as an OpenAI-compatible provider via the documented self-serve process in [Adding OpenAI-Compatible Providers](https://docs.litellm.ai/docs/contributing/adding_openai_compatible_providers).

[Modelis](https://modelishub.com) is an OpenAI-compatible LLM gateway that auto-routes a single `modelis-auto` model across frontier models (GPT / Claude / Gemini) and exposes the standard `/v1/chat/completions`, `/v1/models`, etc. This mirrors existing aggregator/gateway entries already in `providers.json` (e.g. `aihubmix`, `nano-gpt`, `poe`, `helicone`).

## Change

Minimal addition to `litellm/llms/openai_like/providers.json`:

```json
"modelis": {
  "base_url": "https://modelishub.com/v1",
  "api_key_env": "MODELIS_API_KEY"
}
```

## Usage

```python
import litellm
resp = litellm.completion(
    model="modelis/modelis-auto",
    messages=[{"role": "user", "content": "hello"}],
)
```

## Notes

- The endpoint returns standard OpenAI-format responses; `/v1/models` and `/v1/chat/completions` respond with OpenAI-schema JSON and SDK User-Agents are not blocked.
- Working examples: https://github.com/modelishub/modelis-cookbook