### PR TITLE
Add balanced smart router strategy

### DIFF
--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -71,6 +71,51 @@ proxy_config:
         api_key: eXaMpLeOnLy
 ```
 
+#### Example `balanced-smart` routing strategy
+
+`balanced-smart` is a built-in router strategy for deployments that need bounded
+load balancing. It routes by per-backend active request count, observed tokens
+per second, observed request latency, and recent failures. When all healthy
+deployments are at `max_concurrent_requests`, the request waits for up to
+`max_queue_ttl_s`; after that the router returns no deployment and normal
+LiteLLM retry/fallback handling can take over.
+
+```yaml
+replicaCount: 2
+
+proxy_config:
+  litellm_settings:
+    cache: true
+    cache_params:
+      type: redis
+  router_settings:
+    routing_strategy: balanced-smart
+    routing_strategy_args:
+      max_concurrent_requests: 10
+      max_queue_ttl_s: 1
+      queue_poll_s: 0.01
+      default_tokens_per_second: 50
+      active_request_weight: 10
+      tokens_per_second_weight: 1
+      ttft_weight: 1
+      failure_penalty: 5
+      failure_cooldown_s: 5
+      ewma_alpha: 0.2
+  model_list:
+    - model_name: gpt-4o
+      litellm_params:
+        model: openai/gpt-4o
+        api_key: os.environ/OPENAI_API_KEY
+      model_info:
+        balanced_smart_backend_id: openai-primary
+```
+
+For multiple LiteLLM pods, configure a shared Redis cache as shown above. Redis
+is used for the atomic active-request counter and metric state, so
+`max_concurrent_requests` is enforced across pods instead of per process. Use
+`model_info.balanced_smart_backend_id` when several LiteLLM model entries point
+to the same physical backend and should share one capacity pool.
+
 #### Example using existing `proxyConfigMap` instead of creating it:
 
 ```

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -164,6 +164,14 @@ proxy_config:
         api_base: https://exampleopenaiendpoint-production.up.railway.app/
   general_settings:
     master_key: os.environ/PROXY_MASTER_KEY
+  # router_settings:
+  #   routing_strategy: balanced-smart
+  #   routing_strategy_args:
+  #     max_concurrent_requests: 10
+  #     max_queue_ttl_s: 1
+  #     queue_poll_s: 0.01
+  #     default_tokens_per_second: 50
+  #     failure_cooldown_s: 5
 
 resources:
   {}

--- a/litellm/proxy/README.md
+++ b/litellm/proxy/README.md
@@ -30,6 +30,38 @@ print(response)
 
 [**See how to call Huggingface,Bedrock,TogetherAI,Anthropic, etc.**](https://docs.litellm.ai/docs/simple_proxy)
 
+## Balanced smart routing
+
+Set `router_settings.routing_strategy: balanced-smart` in proxy config to route
+by active requests, observed tokens per second, request latency, bounded queue
+TTL, and recent failures.
+
+```yaml
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis
+
+router_settings:
+  routing_strategy: balanced-smart
+  routing_strategy_args:
+    max_concurrent_requests: 10
+    max_queue_ttl_s: 1
+    queue_poll_s: 0.01
+    default_tokens_per_second: 50
+    active_request_weight: 10
+    tokens_per_second_weight: 1
+    ttft_weight: 1
+    failure_penalty: 5
+    failure_cooldown_s: 5
+    ewma_alpha: 0.2
+```
+
+Use a shared Redis cache for multi-pod deployments so concurrency and metrics
+are shared across LiteLLM pods. If multiple model entries target the same
+physical backend, set the same `model_info.balanced_smart_backend_id` on those
+entries so they share one capacity pool.
+
 
 ---
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -136,6 +136,7 @@ from litellm.router_utils.router_callbacks.track_deployment_metrics import (
     increment_deployment_failures_for_current_minute,
     increment_deployment_successes_for_current_minute,
 )
+from litellm.router_strategy.balanced_smart import BalancedSmartRoutingHandler
 from litellm.scheduler import FlowItem, Scheduler
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -320,6 +321,7 @@ class Router:
             "latency-based-routing",
             "cost-based-routing",
             "usage-based-routing-v2",
+            "balanced-smart",
         ] = "simple-shuffle",
         optional_pre_call_checks: Optional[OptionalPreCallChecks] = None,
         routing_strategy_args: dict = {},  # just for latency-based
@@ -364,7 +366,7 @@ class Router:
             retry_after (int): Minimum time to wait before retrying a failed request. Defaults to 0.
             allowed_fails (Optional[int]): Number of allowed fails before adding to cooldown. Defaults to None.
             cooldown_time (float): Time to cooldown a deployment after failure in seconds. Defaults to 1.
-            routing_strategy (Literal["simple-shuffle", "least-busy", "usage-based-routing", "latency-based-routing", "cost-based-routing"]): Routing strategy used for the implicit "default" group (any model not claimed by an entry in `routing_groups`). Defaults to "simple-shuffle".
+            routing_strategy (Literal["simple-shuffle", "least-busy", "usage-based-routing", "usage-based-routing-v2", "latency-based-routing", "cost-based-routing", "balanced-smart"]): Routing strategy used for the implicit "default" group (any model not claimed by an entry in `routing_groups`). Defaults to "simple-shuffle".
             routing_strategy_args (dict): Additional args for the default group's routing strategy (e.g. latency window). Defaults to {}.
             routing_groups (Optional[List[RoutingGroup]]): Named subsets of `model_name`s that use a per-group routing strategy and args. Each model belongs to at most one explicit group; everything else lands in the implicit "default" group driven by `routing_strategy` / `routing_strategy_args`. Defaults to None.
             alerting_config (AlertingConfig): Slack alerting configuration. Defaults to None.
@@ -855,6 +857,7 @@ class Router:
         "usage-based-routing-v2": "lowesttpm_logger_v2",
         "latency-based-routing": "lowestlatency_logger",
         "cost-based-routing": "lowestcost_logger",
+        "balanced-smart": "balanced_smart_logger",
     }
 
     @staticmethod
@@ -927,6 +930,11 @@ class Router:
                     router_cache=self.cache,
                     routing_args={},
                 )
+            case RoutingStrategy.BALANCED_SMART.value:
+                selector = BalancedSmartRoutingHandler(
+                    router_cache=self.cache,
+                    routing_args=routing_strategy_args,
+                )
 
         if (
             selector is not None
@@ -974,6 +982,7 @@ class Router:
         self.lowesttpm_logger_v2: Optional[LowestTPMLoggingHandler_v2] = None
         self.lowestlatency_logger: Optional[LowestLatencyLoggingHandler] = None
         self.lowestcost_logger: Optional[LowestCostLoggingHandler] = None
+        self.balanced_smart_logger: Optional[BalancedSmartRoutingHandler] = None
 
         selector = self._build_strategy_selector(
             strategy=routing_strategy,
@@ -1148,6 +1157,14 @@ class Router:
                     input=input,
                     request_kwargs=request_kwargs,
                 )
+            case "balanced-smart":
+                return await selector.async_get_available_deployments(
+                    model_group=model,
+                    healthy_deployments=healthy_deployments,
+                    messages=messages,
+                    input=input,
+                    request_kwargs=request_kwargs,
+                )
             case _:
                 return None
 
@@ -1186,6 +1203,14 @@ class Router:
                     input=input,
                 )
             case "latency-based-routing":
+                return selector.get_available_deployments(
+                    model_group=model,
+                    healthy_deployments=healthy_deployments,
+                    messages=messages,
+                    input=input,
+                    request_kwargs=request_kwargs,
+                )
+            case "balanced-smart":
                 return selector.get_available_deployments(
                     model_group=model,
                     healthy_deployments=healthy_deployments,
@@ -11312,6 +11337,7 @@ class Router:
             and self.routing_strategy != "cost-based-routing"
             and self.routing_strategy != "latency-based-routing"
             and self.routing_strategy != "least-busy"
+            and self.routing_strategy != "balanced-smart"
         ):  # prevent regressions for other routing strategies, that don't have async get available deployments implemented.
             return self.get_available_deployment(
                 model=model,

--- a/litellm/router_strategy/balanced_smart.py
+++ b/litellm/router_strategy/balanced_smart.py
@@ -1,0 +1,509 @@
+import random
+import time
+from dataclasses import asdict, dataclass, fields
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_logger import CustomLogger
+
+
+@dataclass
+class BalancedSmartRoutingArgs:
+    max_queue_ttl_s: float = 1.0
+    queue_poll_s: float = 0.01
+    max_concurrent_requests: int = 10
+    default_tokens_per_second: float = 50.0
+    active_request_weight: float = 10.0
+    tokens_per_second_weight: float = 1.0
+    ttft_weight: float = 1.0
+    failure_penalty: float = 5.0
+    failure_cooldown_s: float = 5.0
+    ewma_alpha: float = 0.2
+    redis_key_prefix: str = "balanced_smart_router"
+    redis_ttl_s: int = 3600
+
+
+@dataclass
+class DeploymentStats:
+    active: int = 0
+    selected: int = 0
+    successes: int = 0
+    failures: int = 0
+    ewma_tps: float = 0.0
+    ewma_ttft_s: float = 0.0
+    last_selected_at: float = 0.0
+    last_failure_at: float = 0.0
+
+
+class BalancedSmartRoutingHandler(CustomLogger):
+    """
+    Router strategy that combines bounded concurrency, observed throughput,
+    time-to-first-token, and recent failures.
+
+    The strategy acquires capacity before returning a deployment. Success and
+    failure callbacks release that capacity. When Redis is configured for the
+    router cache, acquire/release is atomic and shared across LiteLLM pods.
+    """
+
+    _ACQUIRE_SCRIPT = """
+local key = KEYS[1]
+local max_active = tonumber(ARGV[1])
+local now = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local active = tonumber(redis.call('HGET', key, 'active') or '0')
+if active >= max_active then
+  return 0
+end
+redis.call('HINCRBY', key, 'active', 1)
+redis.call('HINCRBY', key, 'selected', 1)
+redis.call('HSET', key, 'last_selected_at', now)
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+    _RELEASE_SUCCESS_SCRIPT = """
+local key = KEYS[1]
+local ttl = tonumber(ARGV[1])
+local active = tonumber(redis.call('HGET', key, 'active') or '0')
+if active > 0 then
+  redis.call('HINCRBY', key, 'active', -1)
+else
+  redis.call('HSET', key, 'active', 0)
+end
+redis.call('HINCRBY', key, 'successes', 1)
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+    _RELEASE_FAILURE_SCRIPT = """
+local key = KEYS[1]
+local ttl = tonumber(ARGV[1])
+local now = ARGV[2]
+local active = tonumber(redis.call('HGET', key, 'active') or '0')
+if active > 0 then
+  redis.call('HINCRBY', key, 'active', -1)
+else
+  redis.call('HSET', key, 'active', 0)
+end
+redis.call('HINCRBY', key, 'failures', 1)
+redis.call('HSET', key, 'last_failure_at', now)
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+    def __init__(self, router_cache: DualCache, routing_args: Optional[dict] = None):
+        self.router_cache = router_cache
+        allowed_args = {field.name for field in fields(BalancedSmartRoutingArgs)}
+        args = {
+            key: value
+            for key, value in dict(routing_args or {}).items()
+            if key in allowed_args
+        }
+        self.routing_args = BalancedSmartRoutingArgs(**args)
+
+    def get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: List[dict],
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[dict]:
+        deadline = time.time() + self.routing_args.max_queue_ttl_s
+        while True:
+            acquired = self._try_acquire_one(model_group, healthy_deployments)
+            if acquired is not None:
+                return acquired
+            if time.time() >= deadline:
+                return None
+            time.sleep(self.routing_args.queue_poll_s)
+
+    async def async_get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: List[dict],
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[dict]:
+        import asyncio
+
+        deadline = time.time() + self.routing_args.max_queue_ttl_s
+        while True:
+            acquired = await self._async_try_acquire_one(
+                model_group, healthy_deployments
+            )
+            if acquired is not None:
+                return acquired
+            if time.time() >= deadline:
+                return None
+            await asyncio.sleep(self.routing_args.queue_poll_s)
+
+    def log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self._release_success(kwargs, response_obj, start_time, end_time)
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        await self._async_release_success(kwargs, response_obj, start_time, end_time)
+
+    def log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        self._release_failure(kwargs)
+
+    async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
+        await self._async_release_failure(kwargs)
+
+    def _try_acquire_one(
+        self, model_group: str, healthy_deployments: List[dict]
+    ) -> Optional[dict]:
+        for deployment, deployment_id, _stats in self._rank_deployments(
+            model_group, healthy_deployments
+        ):
+            if self._acquire(deployment_id):
+                return deployment
+        return None
+
+    async def _async_try_acquire_one(
+        self, model_group: str, healthy_deployments: List[dict]
+    ) -> Optional[dict]:
+        ranked = await self._async_rank_deployments(model_group, healthy_deployments)
+        for deployment, deployment_id, _stats in ranked:
+            if await self._async_acquire(deployment_id):
+                return deployment
+        return None
+
+    def _rank_deployments(
+        self, model_group: str, healthy_deployments: List[dict]
+    ) -> List[Tuple[dict, str, DeploymentStats]]:
+        rows: List[Tuple[dict, str, DeploymentStats]] = []
+        for deployment in healthy_deployments:
+            deployment_id = self._deployment_id(model_group, deployment)
+            rows.append((deployment, deployment_id, self._get_stats(deployment_id)))
+        return self._sort_ranked_rows(rows)
+
+    async def _async_rank_deployments(
+        self, model_group: str, healthy_deployments: List[dict]
+    ) -> List[Tuple[dict, str, DeploymentStats]]:
+        rows: List[Tuple[dict, str, DeploymentStats]] = []
+        for deployment in healthy_deployments:
+            deployment_id = self._deployment_id(model_group, deployment)
+            rows.append(
+                (deployment, deployment_id, await self._async_get_stats(deployment_id))
+            )
+        return self._sort_ranked_rows(rows)
+
+    def _sort_ranked_rows(
+        self, rows: List[Tuple[dict, str, DeploymentStats]]
+    ) -> List[Tuple[dict, str, DeploymentStats]]:
+        now = time.time()
+        available = [
+            row
+            for row in rows
+            if now - row[2].last_failure_at >= self.routing_args.failure_cooldown_s
+        ]
+        rows_to_rank = available or rows
+        random.shuffle(rows_to_rank)
+        return sorted(rows_to_rank, key=lambda row: self._score(row[2], now))
+
+    def _score(self, stats: DeploymentStats, now: float) -> float:
+        concurrency_pressure = (
+            stats.active / max(1, self.routing_args.max_concurrent_requests)
+        ) * self.routing_args.active_request_weight
+
+        observed_tps = stats.ewma_tps or self.routing_args.default_tokens_per_second
+        tps_pressure = (
+            self.routing_args.default_tokens_per_second / max(0.001, observed_tps)
+        ) * self.routing_args.tokens_per_second_weight
+
+        ttft_pressure = stats.ewma_ttft_s * self.routing_args.ttft_weight
+        total = max(1, stats.successes + stats.failures)
+        failure_pressure = (
+            stats.failures / total
+        ) * self.routing_args.failure_penalty
+        cooldown_pressure = 0.0
+        if now - stats.last_failure_at < self.routing_args.failure_cooldown_s:
+            cooldown_pressure = self.routing_args.failure_penalty
+        return (
+            concurrency_pressure
+            + tps_pressure
+            + ttft_pressure
+            + failure_pressure
+            + cooldown_pressure
+        )
+
+    def _acquire(self, deployment_id: str) -> bool:
+        redis_client = self._redis_client()
+        if redis_client is not None:
+            result = redis_client.eval(
+                self._ACQUIRE_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.max_concurrent_requests,
+                time.time(),
+                self.routing_args.redis_ttl_s,
+            )
+            return int(result) == 1
+
+        stats = self._get_stats(deployment_id)
+        if stats.active >= self.routing_args.max_concurrent_requests:
+            return False
+        stats.active += 1
+        stats.selected += 1
+        stats.last_selected_at = time.time()
+        self._set_stats(deployment_id, stats)
+        return True
+
+    async def _async_acquire(self, deployment_id: str) -> bool:
+        redis_client = await self._async_redis_client()
+        if redis_client is not None:
+            result = await redis_client.eval(
+                self._ACQUIRE_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.max_concurrent_requests,
+                time.time(),
+                self.routing_args.redis_ttl_s,
+            )
+            return int(result) == 1
+
+        stats = await self._async_get_stats(deployment_id)
+        if stats.active >= self.routing_args.max_concurrent_requests:
+            return False
+        stats.active += 1
+        stats.selected += 1
+        stats.last_selected_at = time.time()
+        await self._async_set_stats(deployment_id, stats)
+        return True
+
+    def _release_success(self, kwargs, response_obj, start_time, end_time) -> None:
+        deployment_id = self._deployment_id_from_kwargs(kwargs)
+        if deployment_id is None:
+            return
+
+        redis_client = self._redis_client()
+        if redis_client is not None:
+            redis_client.eval(
+                self._RELEASE_SUCCESS_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.redis_ttl_s,
+            )
+            stats = self._get_stats(deployment_id)
+        else:
+            stats = self._get_stats(deployment_id)
+            stats.active = max(0, stats.active - 1)
+            stats.successes += 1
+
+        self._update_success_metrics(stats, response_obj, start_time, end_time)
+        self._set_stats(deployment_id, stats)
+
+    async def _async_release_success(
+        self, kwargs, response_obj, start_time, end_time
+    ) -> None:
+        deployment_id = self._deployment_id_from_kwargs(kwargs)
+        if deployment_id is None:
+            return
+
+        redis_client = await self._async_redis_client()
+        if redis_client is not None:
+            await redis_client.eval(
+                self._RELEASE_SUCCESS_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.redis_ttl_s,
+            )
+            stats = await self._async_get_stats(deployment_id)
+        else:
+            stats = await self._async_get_stats(deployment_id)
+            stats.active = max(0, stats.active - 1)
+            stats.successes += 1
+
+        self._update_success_metrics(stats, response_obj, start_time, end_time)
+        await self._async_set_stats(deployment_id, stats)
+
+    def _release_failure(self, kwargs) -> None:
+        deployment_id = self._deployment_id_from_kwargs(kwargs)
+        if deployment_id is None:
+            return
+        redis_client = self._redis_client()
+        if redis_client is not None:
+            redis_client.eval(
+                self._RELEASE_FAILURE_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.redis_ttl_s,
+                time.time(),
+            )
+            return
+
+        stats = self._get_stats(deployment_id)
+        stats.active = max(0, stats.active - 1)
+        stats.failures += 1
+        stats.last_failure_at = time.time()
+        self._set_stats(deployment_id, stats)
+
+    async def _async_release_failure(self, kwargs) -> None:
+        deployment_id = self._deployment_id_from_kwargs(kwargs)
+        if deployment_id is None:
+            return
+        redis_client = await self._async_redis_client()
+        if redis_client is not None:
+            await redis_client.eval(
+                self._RELEASE_FAILURE_SCRIPT,
+                1,
+                self._redis_key(deployment_id),
+                self.routing_args.redis_ttl_s,
+                time.time(),
+            )
+            return
+
+        stats = await self._async_get_stats(deployment_id)
+        stats.active = max(0, stats.active - 1)
+        stats.failures += 1
+        stats.last_failure_at = time.time()
+        await self._async_set_stats(deployment_id, stats)
+
+    def _update_success_metrics(
+        self, stats: DeploymentStats, response_obj, start_time, end_time
+    ) -> None:
+        duration_s = self._duration_seconds(start_time, end_time)
+        output_tokens = self._output_tokens(response_obj)
+        if output_tokens > 0 and duration_s > 0:
+            observed_tps = output_tokens / duration_s
+            stats.ewma_tps = self._ewma(stats.ewma_tps, observed_tps)
+        if duration_s > 0:
+            stats.ewma_ttft_s = self._ewma(stats.ewma_ttft_s, duration_s)
+
+    def _ewma(self, old: float, new: float) -> float:
+        if old <= 0:
+            return new
+        alpha = self.routing_args.ewma_alpha
+        return (alpha * new) + ((1 - alpha) * old)
+
+    def _get_stats(self, deployment_id: str) -> DeploymentStats:
+        redis_client = self._redis_client()
+        if redis_client is not None:
+            return self._stats_from_mapping(
+                redis_client.hgetall(self._redis_key(deployment_id)) or {}
+            )
+        raw = self.router_cache.get_cache(key=self._cache_key(deployment_id)) or {}
+        return self._stats_from_mapping(raw)
+
+    async def _async_get_stats(self, deployment_id: str) -> DeploymentStats:
+        redis_client = await self._async_redis_client()
+        if redis_client is not None:
+            return self._stats_from_mapping(
+                await redis_client.hgetall(self._redis_key(deployment_id)) or {}
+            )
+        raw = (
+            await self.router_cache.async_get_cache(key=self._cache_key(deployment_id))
+            or {}
+        )
+        return self._stats_from_mapping(raw)
+
+    def _set_stats(self, deployment_id: str, stats: DeploymentStats) -> None:
+        redis_client = self._redis_client()
+        if redis_client is not None:
+            redis_client.hset(self._redis_key(deployment_id), mapping=asdict(stats))
+            redis_client.expire(
+                self._redis_key(deployment_id), self.routing_args.redis_ttl_s
+            )
+            return
+        self.router_cache.set_cache(
+            key=self._cache_key(deployment_id), value=asdict(stats)
+        )
+
+    async def _async_set_stats(self, deployment_id: str, stats: DeploymentStats) -> None:
+        redis_client = await self._async_redis_client()
+        if redis_client is not None:
+            await redis_client.hset(
+                self._redis_key(deployment_id), mapping=asdict(stats)
+            )
+            await redis_client.expire(
+                self._redis_key(deployment_id), self.routing_args.redis_ttl_s
+            )
+            return
+        await self.router_cache.async_set_cache(
+            key=self._cache_key(deployment_id), value=asdict(stats)
+        )
+
+    def _stats_from_mapping(self, raw: Dict[Any, Any]) -> DeploymentStats:
+        normalized: Dict[str, Any] = {}
+        for key, value in raw.items():
+            if isinstance(key, bytes):
+                key = key.decode("utf-8")
+            if isinstance(value, bytes):
+                value = value.decode("utf-8")
+            normalized[str(key)] = value
+
+        return DeploymentStats(
+            active=max(0, int(float(normalized.get("active", 0) or 0))),
+            selected=max(0, int(float(normalized.get("selected", 0) or 0))),
+            successes=max(0, int(float(normalized.get("successes", 0) or 0))),
+            failures=max(0, int(float(normalized.get("failures", 0) or 0))),
+            ewma_tps=float(normalized.get("ewma_tps", 0) or 0),
+            ewma_ttft_s=float(normalized.get("ewma_ttft_s", 0) or 0),
+            last_selected_at=float(normalized.get("last_selected_at", 0) or 0),
+            last_failure_at=float(normalized.get("last_failure_at", 0) or 0),
+        )
+
+    def _deployment_id(self, model_group: str, deployment: dict) -> str:
+        model_info = deployment.get("model_info", {}) or {}
+        raw_id = (
+            model_info.get("balanced_smart_backend_id")
+            or model_info.get("id")
+            or deployment.get("model_name")
+            or model_group
+        )
+        return f"{model_group}:{raw_id}"
+
+    def _deployment_id_from_kwargs(self, kwargs) -> Optional[str]:
+        litellm_params = kwargs.get("litellm_params", {}) or {}
+        model_info = litellm_params.get("model_info", {}) or {}
+        metadata = litellm_params.get("metadata", {}) or {}
+        model_group = metadata.get("model_group") or litellm_params.get("model")
+        raw_id = model_info.get("balanced_smart_backend_id") or model_info.get("id")
+        if model_group is None or raw_id is None:
+            return None
+        return f"{model_group}:{raw_id}"
+
+    def _cache_key(self, deployment_id: str) -> str:
+        return f"{self.routing_args.redis_key_prefix}:{deployment_id}"
+
+    def _redis_key(self, deployment_id: str) -> str:
+        redis_cache = getattr(self.router_cache, "redis_cache", None)
+        key = self._cache_key(deployment_id)
+        if redis_cache is not None:
+            return redis_cache.check_and_fix_namespace(key)
+        return key
+
+    def _redis_client(self):
+        redis_cache = getattr(self.router_cache, "redis_cache", None)
+        return getattr(redis_cache, "redis_client", None)
+
+    async def _async_redis_client(self):
+        redis_cache = getattr(self.router_cache, "redis_cache", None)
+        if redis_cache is None:
+            return None
+        await redis_cache.init_async_client()
+        return getattr(redis_cache, "async_redis_conn", None)
+
+    def _duration_seconds(self, start_time, end_time) -> float:
+        if start_time is None or end_time is None:
+            return 0.0
+        delta = end_time - start_time
+        if hasattr(delta, "total_seconds"):
+            return max(0.0, delta.total_seconds())
+        return max(0.0, float(delta))
+
+    def _output_tokens(self, response_obj) -> int:
+        usage = getattr(response_obj, "usage", None)
+        if usage is None and isinstance(response_obj, dict):
+            usage = response_obj.get("usage")
+        if usage is None:
+            return 0
+        if isinstance(usage, dict):
+            return int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+        return int(
+            getattr(usage, "completion_tokens", None)
+            or getattr(usage, "output_tokens", None)
+            or 0
+        )

--- a/litellm/types/management_endpoints/router_settings_endpoints.py
+++ b/litellm/types/management_endpoints/router_settings_endpoints.py
@@ -90,6 +90,7 @@ ROUTING_STRATEGY_DESCRIPTIONS: Dict[str, str] = {
     "cost-based-routing": "Routes to the deployment with the lowest cost per token.",
     "usage-based-routing": "Routes to the deployment with the lowest TPM (Tokens Per Minute) usage. (deprecated)",
     "usage-based-routing-v2": "Improved version of usage-based routing with better tracking.",
+    "balanced-smart": "Routes by backend concurrency, observed throughput, latency, bounded queueing, and recent failures.",
 }
 
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -77,6 +77,7 @@ class RouterConfig(BaseModel):
         "least-busy",
         "usage-based-routing",
         "latency-based-routing",
+        "balanced-smart",
     ] = "simple-shuffle"
     routing_groups: Optional[List[RoutingGroup]] = None
 
@@ -757,6 +758,7 @@ class RoutingStrategy(enum.Enum):
     COST_BASED = "cost-based-routing"
     USAGE_BASED_ROUTING_V2 = "usage-based-routing-v2"
     USAGE_BASED_ROUTING = "usage-based-routing"
+    BALANCED_SMART = "balanced-smart"
     PROVIDER_BUDGET_LIMITING = "provider-budget-routing"
 
 

--- a/tests/test_litellm/router_strategy/test_balanced_smart_router.py
+++ b/tests/test_litellm/router_strategy/test_balanced_smart_router.py
@@ -1,0 +1,303 @@
+import os
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+from litellm import Router
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.balanced_smart import BalancedSmartRoutingHandler
+
+
+def _deployment(deployment_id: str, backend_id: str = None) -> dict:
+    model_info = {"id": deployment_id}
+    if backend_id is not None:
+        model_info["balanced_smart_backend_id"] = backend_id
+    return {
+        "model_name": "balanced-model",
+        "litellm_params": {
+            "model": f"openai/{deployment_id}",
+            "api_key": "sk-test",
+            "api_base": "https://example.invalid",
+        },
+        "model_info": model_info,
+    }
+
+
+def _router(routing_strategy_args=None) -> Router:
+    return Router(
+        model_list=[_deployment("a"), _deployment("b")],
+        routing_strategy="balanced-smart",
+        routing_strategy_args=routing_strategy_args or {},
+    )
+
+
+def _callback_kwargs(deployment_id: str, backend_id: str = None) -> dict:
+    model_info = {"id": deployment_id}
+    if backend_id is not None:
+        model_info["balanced_smart_backend_id"] = backend_id
+    return {
+        "litellm_params": {
+            "metadata": {"model_group": "balanced-model"},
+            "model_info": model_info,
+        }
+    }
+
+
+def test_router_accepts_balanced_smart_strategy():
+    router = _router()
+
+    strategy, selector = router._get_routing_context("balanced-model")
+
+    assert strategy == "balanced-smart"
+    assert selector is router.balanced_smart_logger
+    assert isinstance(selector, BalancedSmartRoutingHandler)
+
+
+@pytest.mark.asyncio
+async def test_async_router_dispatch_acquires_capacity():
+    router = _router({"max_concurrent_requests": 1, "max_queue_ttl_s": 0.01})
+
+    deployment = await router.async_get_available_deployment(
+        model="balanced-model",
+        request_kwargs={},
+    )
+
+    assert deployment is not None
+    stats = router.balanced_smart_logger._get_stats(
+        f"balanced-model:{deployment['model_info']['id']}"
+    )
+    assert stats.active == 1
+
+
+def test_max_concurrent_requests_spills_to_next_deployment():
+    router = _router({"max_concurrent_requests": 1, "max_queue_ttl_s": 0})
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    selector._acquire("balanced-model:a")
+
+    deployment = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a"), _deployment("b")],
+    )
+
+    assert deployment is not None
+    assert deployment["model_info"]["id"] == "b"
+
+
+def test_queue_ttl_expires_when_all_deployments_are_full():
+    router = _router(
+        {
+            "max_concurrent_requests": 1,
+            "max_queue_ttl_s": 0.01,
+            "queue_poll_s": 0.001,
+        }
+    )
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    selector._acquire("balanced-model:a")
+    selector._acquire("balanced-model:b")
+
+    start = time.time()
+    deployment = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a"), _deployment("b")],
+    )
+
+    assert deployment is None
+    assert time.time() - start < 0.5
+
+
+def test_tokens_per_second_and_ttft_affect_ranking():
+    router = _router(
+        {
+            "max_concurrent_requests": 1,
+            "active_request_weight": 0,
+            "tokens_per_second_weight": 1,
+            "ttft_weight": 1,
+        }
+    )
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    slow = selector._get_stats("balanced-model:a")
+    slow.ewma_tps = 10
+    slow.ewma_ttft_s = 1
+    selector._set_stats("balanced-model:a", slow)
+    fast = selector._get_stats("balanced-model:b")
+    fast.ewma_tps = 100
+    fast.ewma_ttft_s = 0.1
+    selector._set_stats("balanced-model:b", fast)
+
+    deployment = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a"), _deployment("b")],
+    )
+
+    assert deployment is not None
+    assert deployment["model_info"]["id"] == "b"
+
+
+def test_failure_cooldown_routes_away_from_recent_failure():
+    router = _router({"failure_cooldown_s": 60, "max_queue_ttl_s": 0})
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    failed = selector._get_stats("balanced-model:a")
+    failed.last_failure_at = time.time()
+    selector._set_stats("balanced-model:a", failed)
+
+    deployment = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a"), _deployment("b")],
+    )
+
+    assert deployment is not None
+    assert deployment["model_info"]["id"] == "b"
+
+
+def test_success_callback_releases_capacity_and_updates_metrics():
+    router = _router({"max_concurrent_requests": 1})
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    assert selector._acquire("balanced-model:a")
+
+    start_time = datetime.now(timezone.utc)
+    selector.log_success_event(
+        _callback_kwargs("a"),
+        {"usage": {"completion_tokens": 20}},
+        start_time,
+        start_time + timedelta(seconds=2),
+    )
+
+    stats = selector._get_stats("balanced-model:a")
+    assert stats.active == 0
+    assert stats.successes == 1
+    assert stats.ewma_tps == 10
+    assert stats.ewma_ttft_s == 2
+
+
+def test_failure_callback_releases_capacity_and_sets_cooldown():
+    router = _router({"max_concurrent_requests": 1})
+    selector = router.balanced_smart_logger
+    assert selector is not None
+    assert selector._acquire("balanced-model:a")
+
+    selector.log_failure_event(_callback_kwargs("a"), None, None, None)
+
+    stats = selector._get_stats("balanced-model:a")
+    assert stats.active == 0
+    assert stats.failures == 1
+    assert stats.last_failure_at > 0
+
+
+def test_balanced_smart_backend_id_shares_capacity_across_aliases():
+    router = Router(
+        model_list=[
+            _deployment("alias-a", backend_id="shared-backend"),
+            _deployment("alias-b", backend_id="shared-backend"),
+        ],
+        routing_strategy="balanced-smart",
+        routing_strategy_args={"max_concurrent_requests": 1, "max_queue_ttl_s": 0},
+    )
+    selector = router.balanced_smart_logger
+    assert selector is not None
+
+    first = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[
+            _deployment("alias-a", backend_id="shared-backend"),
+            _deployment("alias-b", backend_id="shared-backend"),
+        ],
+    )
+    second = selector.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[
+            _deployment("alias-a", backend_id="shared-backend"),
+            _deployment("alias-b", backend_id="shared-backend"),
+        ],
+    )
+
+    assert first is not None
+    assert second is None
+
+
+def test_redis_backed_capacity_is_shared_across_handler_instances():
+    class MiniRedis:
+        def __init__(self):
+            self.data = {}
+
+        def eval(self, script, numkeys, key, *args):
+            if "return 0" in script and "last_selected_at" in script:
+                max_active = int(args[0])
+                active = int(self.data.setdefault(key, {}).get("active", 0))
+                if active >= max_active:
+                    return 0
+                self.data[key]["active"] = active + 1
+                self.data[key]["selected"] = int(self.data[key].get("selected", 0)) + 1
+                self.data[key]["last_selected_at"] = args[1]
+                return 1
+            if "successes" in script:
+                current = int(self.data.setdefault(key, {}).get("active", 0))
+                self.data[key]["active"] = max(0, current - 1)
+                self.data[key]["successes"] = (
+                    int(self.data[key].get("successes", 0)) + 1
+                )
+                return 1
+            if "last_failure_at" in script:
+                current = int(self.data.setdefault(key, {}).get("active", 0))
+                self.data[key]["active"] = max(0, current - 1)
+                self.data[key]["failures"] = int(self.data[key].get("failures", 0)) + 1
+                self.data[key]["last_failure_at"] = args[1]
+                return 1
+            raise AssertionError("unexpected redis script")
+
+        def hgetall(self, key):
+            return dict(self.data.get(key, {}))
+
+        def hset(self, key, mapping):
+            self.data.setdefault(key, {}).update(mapping)
+
+        def expire(self, key, ttl):
+            return True
+
+    class FakeRedisCache:
+        def __init__(self):
+            self.redis_client = MiniRedis()
+
+        def check_and_fix_namespace(self, key: str) -> str:
+            return key
+
+    redis_cache = FakeRedisCache()
+    cache_a = DualCache()
+    cache_b = DualCache()
+    cache_a.redis_cache = redis_cache
+    cache_b.redis_cache = redis_cache
+    args = {"max_concurrent_requests": 1, "max_queue_ttl_s": 0}
+    handler_a = BalancedSmartRoutingHandler(router_cache=cache_a, routing_args=args)
+    handler_b = BalancedSmartRoutingHandler(router_cache=cache_b, routing_args=args)
+
+    first = handler_a.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a")],
+    )
+    second = handler_b.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a")],
+    )
+    start_time = datetime.now(timezone.utc)
+    handler_a.log_success_event(
+        _callback_kwargs("a"),
+        {"usage": {"completion_tokens": 1}},
+        start_time,
+        start_time + timedelta(seconds=1),
+    )
+    third = handler_b.get_available_deployments(
+        model_group="balanced-model",
+        healthy_deployments=[_deployment("a")],
+    )
+
+    assert first is not None
+    assert second is None
+    assert third is not None


### PR DESCRIPTION
## Summary
- add a built-in `balanced-smart` router strategy
- enforce per-backend max concurrent requests with bounded queue TTL
- route by active request pressure, observed tokens/sec, observed latency/TTFT proxy, and recent failures
- use Redis-backed atomic acquire/release when a router Redis cache is configured, so counters are shared across LiteLLM pods
- document Helm/proxy configuration and `model_info.balanced_smart_backend_id` for shared physical backend capacity pools

## Testing
- `PYTHONPATH=. /home/janis/PycharmProjects/litellm-router/.venv/bin/python -m py_compile litellm/router_strategy/balanced_smart.py tests/test_litellm/router_strategy/test_balanced_smart_router.py`
- `git diff --check`
- `PYTHONPATH=. /home/janis/PycharmProjects/litellm-router/.venv/bin/python -m pytest tests/test_litellm/router_strategy/test_balanced_smart_router.py tests/router_unit_tests/test_router_helper_utils.py::test_routing_strategy_init tests/router_unit_tests/test_router_helper_utils.py::test_routing_strategy_init_valid_string_strategies tests/router_unit_tests/test_router_helper_utils.py::test_routing_strategy_init_valid_enum_strategies tests/router_unit_tests/test_router_helper_utils.py::test_routing_strategy_init_invalid_strategy tests/test_litellm/router_strategy/test_router_routing_groups.py -q` (41 passed, 3 existing coroutine warnings)
- `helm template litellm deploy/charts/litellm-helm >/tmp/litellm-helm-render.yaml`
- `helm template litellm deploy/charts/litellm-helm -f <balanced-smart override values> >/tmp/litellm-helm-balanced-smart-render.yaml`

## Notes
- searched existing LiteLLM PRs/issues for this routing behavior and did not find a matching PR or issue