### PR TITLE
fix(hosted_vllm): accept messages-shaped embedding requests for multimodal models

### DIFF
--- a/litellm/llms/hosted_vllm/embedding/transformation.py
+++ b/litellm/llms/hosted_vllm/embedding/transformation.py
@@ -10,8 +10,10 @@ Docs: https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import httpx
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from litellm._logging import verbose_logger
+from litellm.exceptions import BadRequestError
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.secret_managers.main import get_secret_str
@@ -25,6 +27,54 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+class _ImageUrlField(BaseModel):
+    url: str | None = None
+
+
+class _ContentPart(BaseModel):
+    image_url: str | _ImageUrlField | None = None
+
+
+class _MessageWithImages(BaseModel):
+    content: str | list[_ContentPart] | None = None
+
+
+_MESSAGES_ADAPTER: TypeAdapter[list[_MessageWithImages]] = TypeAdapter(
+    list[_MessageWithImages]
+)
+
+
+def _reject_non_data_image_urls(messages: object, model: str) -> None:
+    """Reject any image URL vLLM would fetch server-side, to prevent SSRF.
+
+    Only base64 `data:` URLs are allowed; vLLM never makes an outbound request for
+    those. A remote `image_url` (http(s) or any other scheme) would let an
+    authenticated caller make the vLLM host fetch arbitrary internal endpoints, so
+    it is rejected before forwarding.
+    """
+    try:
+        parsed = _MESSAGES_ADAPTER.validate_python(messages)
+    except ValidationError:
+        return
+    for message in parsed:
+        if not isinstance(message.content, list):
+            continue
+        for part in message.content:
+            image_url = part.image_url
+            url = image_url.url if isinstance(image_url, _ImageUrlField) else image_url
+            if url is None or url.startswith("data:"):
+                continue
+            raise BadRequestError(
+                message=(
+                    "hosted_vllm embeddings: only base64 `data:` image URLs are "
+                    "supported in `messages`. A remote image URL was rejected to "
+                    "prevent server-side request forgery from the vLLM host."
+                ),
+                model=model,
+                llm_provider="hosted_vllm",
+            )
 
 
 class HostedVLLMEmbeddingError(BaseLLMException):
@@ -110,6 +160,8 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
         # vLLM's embeddings endpoint accepts a chat-style `messages` body for multimodal
         # (image) embeddings; forward it instead of `input` when present
         if "messages" in optional_params:
+            messages = optional_params["messages"]
+            _reject_non_data_image_urls(messages, model)
             if input:
                 verbose_logger.debug(
                     "hosted_vllm embeddings: both `messages` and `input` provided; "
@@ -120,7 +172,7 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
             }
             return {
                 "model": model,
-                "messages": optional_params["messages"],
+                "messages": messages,
                 **remaining_params,
             }
 

--- a/litellm/llms/hosted_vllm/embedding/transformation.py
+++ b/litellm/llms/hosted_vllm/embedding/transformation.py
@@ -102,13 +102,25 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
         """
         Transform embedding request to Hosted VLLM format (OpenAI-compatible).
         """
-        # Ensure input is a list
-        if isinstance(input, str):
-            input = [input]
-
         # Strip 'hosted_vllm/' prefix if present
         if model.startswith("hosted_vllm/"):
             model = model.replace("hosted_vllm/", "", 1)
+
+        # vLLM's embeddings endpoint accepts a chat-style `messages` body for multimodal
+        # (image) embeddings; forward it instead of `input` when present
+        if "messages" in optional_params:
+            remaining_params = {
+                k: v for k, v in optional_params.items() if k != "messages"
+            }
+            return {
+                "model": model,
+                "messages": optional_params["messages"],
+                **remaining_params,
+            }
+
+        # Ensure input is a list
+        if isinstance(input, str):
+            input = [input]
 
         return {
             "model": model,
@@ -150,6 +162,7 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
             "dimensions",
             "encoding_format",
             "user",
+            "messages",
         ]
 
     def map_openai_params(

--- a/litellm/llms/hosted_vllm/embedding/transformation.py
+++ b/litellm/llms/hosted_vllm/embedding/transformation.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import httpx
 
+from litellm._logging import verbose_logger
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.embedding.transformation import BaseEmbeddingConfig
 from litellm.secret_managers.main import get_secret_str
@@ -109,6 +110,11 @@ class HostedVLLMEmbeddingConfig(BaseEmbeddingConfig):
         # vLLM's embeddings endpoint accepts a chat-style `messages` body for multimodal
         # (image) embeddings; forward it instead of `input` when present
         if "messages" in optional_params:
+            if input:
+                verbose_logger.debug(
+                    "hosted_vllm embeddings: both `messages` and `input` provided; "
+                    "forwarding `messages` and ignoring `input`"
+                )
             remaining_params = {
                 k: v for k, v in optional_params.items() if k != "messages"
             }

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -5049,13 +5049,14 @@ class Router:
     def embedding(
         self,
         model: str,
-        input: Union[str, List],
+        input: Optional[Union[str, List]] = None,
         is_async: Optional[bool] = False,
         **kwargs,
     ) -> EmbeddingResponse:
         try:
             kwargs["model"] = model
-            kwargs["input"] = input
+            if input is not None:
+                kwargs["input"] = input
             kwargs["original_function"] = self._embedding
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = self.function_with_fallbacks(**kwargs)
@@ -5063,7 +5064,9 @@ class Router:
         except Exception as e:
             raise e
 
-    def _embedding(self, input: Union[str, List], model: str, **kwargs):
+    def _embedding(
+        self, model: str, input: Optional[Union[str, List]] = None, **kwargs
+    ):
         model_name = None
         try:
             verbose_router_logger.debug(
@@ -5100,10 +5103,10 @@ class Router:
             response = litellm.embedding(
                 **{
                     **data,
-                    "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
                     **kwargs,
+                    **({"input": input} if input is not None else {}),
                 }
             )
             self.success_calls[model_name] += 1
@@ -5122,13 +5125,14 @@ class Router:
     async def aembedding(
         self,
         model: str,
-        input: Union[str, List],
+        input: Optional[Union[str, List]] = None,
         is_async: Optional[bool] = True,
         **kwargs,
     ) -> EmbeddingResponse:
         try:
             kwargs["model"] = model
-            kwargs["input"] = input
+            if input is not None:
+                kwargs["input"] = input
             kwargs["original_function"] = self._aembedding
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
@@ -5144,7 +5148,9 @@ class Router:
             )
             raise e
 
-    async def _aembedding(self, input: Union[str, List], model: str, **kwargs):
+    async def _aembedding(
+        self, model: str, input: Optional[Union[str, List]] = None, **kwargs
+    ):
         model_name = None
         try:
             verbose_router_logger.debug(
@@ -5169,10 +5175,10 @@ class Router:
             response = litellm.aembedding(
                 **{
                     **data,
-                    "input": input,
                     "caching": self.cache_responses,
                     "client": model_client,
                     **kwargs,
+                    **({"input": input} if input is not None else {}),
                 }
             )
 

--- a/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
@@ -324,6 +324,115 @@ class TestHostedVLLMMultimodalEmbedding:
         assert result["messages"] == messages
         assert result["model"] == "Qwen3-VL-Embedding-8B-MLX-4bit"
 
+    def test_remote_http_image_url_in_messages_rejected(self):
+        """A remote http image_url must be rejected; vLLM would fetch it (SSRF)."""
+        from litellm.exceptions import BadRequestError
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "http://169.254.169.254/latest/meta-data/"
+                        },
+                    }
+                ],
+            }
+        ]
+        with pytest.raises(BadRequestError):
+            self.config.transform_embedding_request(
+                model=self.model,
+                input=[],
+                optional_params={"messages": messages},
+                headers={},
+            )
+
+    def test_public_https_image_url_in_messages_rejected(self):
+        """Even a public https image_url is rejected; only data: URLs are allowed."""
+        from litellm.exceptions import BadRequestError
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/cat.png"},
+                    }
+                ],
+            }
+        ]
+        with pytest.raises(BadRequestError):
+            self.config.transform_embedding_request(
+                model=self.model,
+                input=[],
+                optional_params={"messages": messages},
+                headers={},
+            )
+
+    def test_non_data_scheme_image_url_in_messages_rejected(self):
+        """A non-data scheme (e.g. file://) must be rejected."""
+        from litellm.exceptions import BadRequestError
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "file:///etc/passwd"}}
+                ],
+            }
+        ]
+        with pytest.raises(BadRequestError):
+            self.config.transform_embedding_request(
+                model=self.model,
+                input=[],
+                optional_params={"messages": messages},
+                headers={},
+            )
+
+    def test_string_form_remote_image_url_rejected(self):
+        """A remote URL given as the image_url string (not a dict) is also rejected."""
+        from litellm.exceptions import BadRequestError
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": "http://169.254.169.254/"}
+                ],
+            }
+        ]
+        with pytest.raises(BadRequestError):
+            self.config.transform_embedding_request(
+                model=self.model,
+                input=[],
+                optional_params={"messages": messages},
+                headers={},
+            )
+
+    def test_data_url_image_in_messages_allowed(self):
+        """data: URLs are never fetched server-side, so they are allowed and forwarded."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="},
+                    }
+                ],
+            }
+        ]
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=[],
+            optional_params={"messages": messages},
+            headers={},
+        )
+        assert result["messages"] == messages
+
     def test_messages_forwarded_alongside_other_optional_params(self):
         """messages must not collide with or duplicate other optional params."""
         messages = [{"role": "user", "content": "hi"}]

--- a/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
@@ -290,5 +290,141 @@ class TestHostedVLLMEmbeddingTransformation:
             assert sent_data["input"] == ["Hello world"]
 
 
+class TestHostedVLLMMultimodalEmbedding:
+    """Regression tests for issue #31178 - multimodal embedding (image inputs) via hosted_vllm proxy."""
+
+    def setup_method(self):
+        self.config = HostedVLLMEmbeddingConfig()
+        self.model = "hosted_vllm/Qwen3-VL-Embedding-8B-MLX-4bit"
+
+    def test_messages_in_optional_params_forwarded_as_messages(self):
+        """A messages-shaped request must be forwarded as `messages`, not `input`.
+
+        vLLM's embeddings endpoint expects chat-style `messages` for image embeddings.
+        """
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc="},
+                    }
+                ],
+            }
+        ]
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=[],
+            optional_params={"messages": messages},
+            headers={},
+        )
+
+        assert "input" not in result
+        assert result["messages"] == messages
+        assert result["model"] == "Qwen3-VL-Embedding-8B-MLX-4bit"
+
+    def test_messages_forwarded_alongside_other_optional_params(self):
+        """messages must not collide with or duplicate other optional params."""
+        messages = [{"role": "user", "content": "hi"}]
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=[],
+            optional_params={"messages": messages, "dimensions": 256},
+            headers={},
+        )
+
+        assert result["messages"] == messages
+        assert result["dimensions"] == 256
+        assert "input" not in result
+
+    def test_data_url_input_passed_through_unchanged(self):
+        """A data: URL in `input` must be forwarded as-is, not rewritten.
+
+        Backends differ: some (e.g. MLX-served Qwen3-VL) accept image data URLs directly
+        in `input`. The transform must not hijack the `input` field.
+        """
+        data_url = "data:image/png;base64,iVBORw0KGgo="
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=data_url,
+            optional_params={},
+            headers={},
+        )
+
+        assert "messages" not in result
+        assert result["input"] == [data_url]
+
+    def test_plain_text_input_unaffected(self):
+        """Plain text input is wrapped in a list and forwarded as `input`."""
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=["hello world"],
+            optional_params={},
+            headers={},
+        )
+
+        assert "messages" not in result
+        assert result["input"] == ["hello world"]
+
+    def test_messages_supported_param(self):
+        """messages must be in get_supported_openai_params so it survives optional-param filtering."""
+        assert "messages" in self.config.get_supported_openai_params(self.model)
+
+    def test_messages_mapped_through_map_openai_params(self):
+        """map_openai_params must pass messages into optional_params."""
+        messages = [{"role": "user", "content": "hi"}]
+        result = self.config.map_openai_params(
+            non_default_params={"messages": messages},
+            optional_params={},
+            model=self.model,
+            drop_params=False,
+        )
+        assert result["messages"] == messages
+
+    def test_router_aembedding_accepts_messages_without_input(self):
+        """Router.aembedding must not raise when called with messages and no input (failure mode 2)."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "qwen3-vl-embedding",
+                    "litellm_params": {
+                        "model": "hosted_vllm/Qwen3-VL-Embedding-8B-MLX-4bit",
+                        "api_base": "http://localhost:8001/v1",
+                    },
+                }
+            ]
+        )
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc="},
+                    }
+                ],
+            }
+        ]
+
+        fake_response = MagicMock()
+        fake_response.data = []
+        fake_response.model = "Qwen3-VL-Embedding-8B-MLX-4bit"
+        fake_response.usage = MagicMock(prompt_tokens=1, total_tokens=1)
+
+        with patch("litellm.aembedding", new=AsyncMock(return_value=fake_response)):
+            result = asyncio.run(
+                router.aembedding(model="qwen3-vl-embedding", messages=messages)
+            )
+
+        assert result is fake_response
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "-s"])

--- a/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/embedding/test_hosted_vllm_embedding_transformation.py
@@ -382,14 +382,23 @@ class TestHostedVLLMMultimodalEmbedding:
         )
         assert result["messages"] == messages
 
-    def test_router_aembedding_accepts_messages_without_input(self):
-        """Router.aembedding must not raise when called with messages and no input (failure mode 2)."""
-        import asyncio
-        from unittest.mock import AsyncMock, patch
+    def test_messages_takes_precedence_when_both_input_and_messages_provided(self):
+        """When both are supplied, messages wins and input is dropped (no raw input forwarded)."""
+        messages = [{"role": "user", "content": "hi"}]
+        result = self.config.transform_embedding_request(
+            model=self.model,
+            input=["should be ignored"],
+            optional_params={"messages": messages},
+            headers={},
+        )
 
+        assert result["messages"] == messages
+        assert "input" not in result
+
+    def _router(self):
         from litellm import Router
 
-        router = Router(
+        return Router(
             model_list=[
                 {
                     "model_name": "qwen3-vl-embedding",
@@ -401,7 +410,9 @@ class TestHostedVLLMMultimodalEmbedding:
             ]
         )
 
-        messages = [
+    @property
+    def _image_messages(self):
+        return [
             {
                 "role": "user",
                 "content": [
@@ -413,17 +424,70 @@ class TestHostedVLLMMultimodalEmbedding:
             }
         ]
 
+    def test_router_aembedding_accepts_messages_without_input(self):
+        """Router.aembedding must not raise when called with messages and no input (failure mode 2)."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
         fake_response = MagicMock()
-        fake_response.data = []
-        fake_response.model = "Qwen3-VL-Embedding-8B-MLX-4bit"
-        fake_response.usage = MagicMock(prompt_tokens=1, total_tokens=1)
 
         with patch("litellm.aembedding", new=AsyncMock(return_value=fake_response)):
             result = asyncio.run(
-                router.aembedding(model="qwen3-vl-embedding", messages=messages)
+                self._router().aembedding(
+                    model="qwen3-vl-embedding", messages=self._image_messages
+                )
             )
 
         assert result is fake_response
+
+    def test_router_aembedding_forwards_input_when_present(self):
+        """Router.aembedding must still forward `input` downstream when it is provided."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        fake_response = MagicMock()
+
+        with patch(
+            "litellm.aembedding", new=AsyncMock(return_value=fake_response)
+        ) as mock_aembedding:
+            result = asyncio.run(
+                self._router().aembedding(
+                    model="qwen3-vl-embedding", input=["hello world"]
+                )
+            )
+
+        assert result is fake_response
+        assert mock_aembedding.call_args.kwargs["input"] == ["hello world"]
+
+    def test_router_embedding_sync_accepts_messages_without_input(self):
+        """Router.embedding (sync) must not raise when called with messages and no input."""
+        from unittest.mock import patch
+
+        fake_response = MagicMock()
+
+        with patch("litellm.embedding", return_value=fake_response) as mock_embedding:
+            result = self._router().embedding(
+                model="qwen3-vl-embedding", messages=self._image_messages
+            )
+
+        assert result is fake_response
+        forwarded = mock_embedding.call_args.kwargs
+        assert "input" not in forwarded
+        assert forwarded["messages"] == self._image_messages
+
+    def test_router_embedding_sync_forwards_input_when_present(self):
+        """Router.embedding (sync) must still forward `input` downstream when it is provided."""
+        from unittest.mock import patch
+
+        fake_response = MagicMock()
+
+        with patch("litellm.embedding", return_value=fake_response) as mock_embedding:
+            result = self._router().embedding(
+                model="qwen3-vl-embedding", input=["hello world"]
+            )
+
+        assert result is fake_response
+        assert mock_embedding.call_args.kwargs["input"] == ["hello world"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/31178

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Tested against an OpenAI-compatible server hosting Qwen3-VL-Embedding-8B, configured as a `hosted_vllm` model

```yaml
model_list:
  - model_name: qwen3-vl-embedding
    litellm_params:
      model: hosted_vllm/Qwen3-VL-Embedding-8B-MLX-4bit
      api_base: http://<your-vllm-host>:8001/v1
      api_key: os.environ/HOSTED_VLLM_API_KEY
```

Before the fix, a `messages`-shaped embedding request died inside the Router with a 500

```bash
curl -s http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"qwen3-vl-embedding","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgo..."}}]}]}'
```

```json
{"error":{"message":"Router.aembedding() missing 1 required positional argument: 'input'","type":"None","param":"None","code":"500"}}
```

After the fix the Router accepts the request and forwards it to the upstream server instead of crashing (the MLX backend used here embeds images via `input` and does not implement vLLM's chat-style `messages` embeddings, so it returns its own response; a vLLM server that implements the messages variant returns embeddings)

Image embeddings work end to end through the proxy via an `input` data URL, which the transform passes through unchanged

```bash
curl -s http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"qwen3-vl-embedding","input":"data:image/png;base64,iVBORw0KGgo..."}'
```

```json
{"model":"qwen3-vl-embedding","data":[{"object":"embedding","index":0,"embedding":[0.047607421875,-0.00946044921875,-0.03662109375, ...]}]}
```

Plain text embeddings are unaffected

```bash
curl -s http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"qwen3-vl-embedding","input":"hello world"}'
```

```json
{"model":"qwen3-vl-embedding","data":[{"object":"embedding","index":0,"embedding":[0.035888671875,-0.00946044921875,-0.0274658203125, ...]}]}
```

A remote image URL inside `messages` is rejected before forwarding, so the vLLM host is never made to fetch a client-supplied URL

```bash
curl -s http://localhost:4000/v1/embeddings \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"qwen3-vl-embedding","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"http://169.254.169.254/latest/meta-data/"}}]}]}'
```

```json
{"error":{"message":"hosted_vllm embeddings: only base64 `data:` image URLs are supported in `messages`. A remote image URL was rejected to prevent server-side request forgery from the vLLM host.","code":"400"}}
```

## Type

🐛 Bug Fix

## Changes

`Router.embedding` and `Router.aembedding` required `input` as a positional argument, so a request carrying a chat-style `messages` body with no `input` raised `Router.aembedding() missing 1 required positional argument: 'input'` and never reached the upstream. Both methods now take `input` as optional and forward it downstream only when present, so a `messages`-shaped request flows through

vLLM's embeddings endpoint accepts a `messages` body for multimodal (image) embeddings, documented [here](https://docs.vllm.ai/en/latest/models/pooling_models/embed/). The hosted_vllm embedding transform now forwards `messages` to the upstream when present, and declares `messages` as a supported param so it survives optional-param filtering. Plain `input` requests, including image data URLs that some backends accept directly, are passed through unchanged

Image inputs inside `messages` are restricted to base64 `data:` URLs. A remote `image_url` (http(s) or any other scheme) is rejected with a 400 before forwarding, because vLLM would otherwise fetch it server-side and an authenticated caller could point it at internal services or cloud metadata. Allowing only `data:` URLs removes the server-side fetch entirely rather than validating a URL and forwarding it, which would still leave a DNS-rebinding window since vLLM re-resolves the host when it fetches

I deliberately did not auto-translate an `input` data URL into a `messages` body. Backends served behind hosted_vllm disagree on the shape: vLLM wants `messages` for images, while other OpenAI-compatible servers accept the image data URL directly in `input` and reject `messages`. Rewriting `input` globally would break the latter, so the transform leaves `input` untouched and lets callers send whichever shape their backend supports