### PR TITLE
fix(bedrock_mantle): correct responses routing for openai.gpt-5.x models

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -466,7 +466,7 @@ def get_format_from_file_id(file_id: Optional[str]) -> Optional[str]:
 
 def update_messages_with_model_file_ids(
     messages: List[AllMessageValues],
-    model_id: str,
+    model_id: Optional[str],
     model_file_id_mapping: Dict[str, Dict[str, str]],
 ) -> List[AllMessageValues]:
     """
@@ -519,7 +519,7 @@ def update_messages_with_model_file_ids(
                         if file_id:
                             provider_file_id = (
                                 model_file_id_mapping.get(file_id, {}).get(model_id)
-                                if model_file_id_mapping
+                                if model_file_id_mapping and model_id is not None
                                 else None
                             )
                             if (

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -904,9 +904,12 @@ class BedrockModelInfo(BaseLLMModelInfo):
             "mantle/": "mantle",
         }
 
-        # Check explicit routes first
+        # Check explicit routes first. Match each prefix only as a leading path
+        # segment so the `bedrock_mantle/` provider prefix is never mistaken for
+        # the `mantle/` invoke route (which would mangle
+        # `bedrock_mantle/openai.gpt-5.5` into `bedrock_openai.gpt-5.5`).
         for prefix, route_type in route_mappings.items():
-            if prefix in model:
+            if BedrockModelInfo._model_has_route_prefix(model, prefix):
                 return route_type
 
         # Check for nova spec prefixes (nova/ and nova-2/)
@@ -984,11 +987,23 @@ class BedrockModelInfo(BaseLLMModelInfo):
         return "agentcore/" in model
 
     @staticmethod
+    def _model_has_route_prefix(model: str, prefix: str) -> bool:
+        """Whether a route prefix (e.g. ``mantle/``) appears as a leading path segment.
+
+        A route token is only valid at the start of the model id or immediately
+        after a ``/``. A plain substring check matches the ``bedrock_mantle/``
+        provider prefix against the ``mantle/`` route, so the body model gets
+        mangled to ``bedrock_openai.gpt-5.5``; anchoring to a segment boundary
+        keeps the bare model id intact.
+        """
+        return model.startswith(prefix) or f"/{prefix}" in model
+
+    @staticmethod
     def _explicit_mantle_route(model: str) -> bool:
         """
         Check if the model is an explicit mantle route (bedrock-mantle endpoint).
         """
-        return "mantle/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "mantle/")
 
     @staticmethod
     def _explicit_converse_like_route(model: str) -> bool:

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -933,14 +933,14 @@ class BedrockModelInfo(BaseLLMModelInfo):
         """
         Check if the model is an explicit converse route.
         """
-        return "converse/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "converse/")
 
     @staticmethod
     def _explicit_claude_platform_route(model: str) -> bool:
         """
         Check if the model is an explicit Claude Platform on AWS route.
         """
-        return "claude_platform/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "claude_platform/")
 
     @staticmethod
     def get_claude_platform_model(model: str) -> str:
@@ -970,21 +970,21 @@ class BedrockModelInfo(BaseLLMModelInfo):
         """
         Check if the model is an explicit invoke route.
         """
-        return "invoke/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "invoke/")
 
     @staticmethod
     def _explicit_agent_route(model: str) -> bool:
         """
         Check if the model is an explicit agent route.
         """
-        return "agent/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "agent/")
 
     @staticmethod
     def _explicit_agentcore_route(model: str) -> bool:
         """
         Check if the model is an explicit agentcore route.
         """
-        return "agentcore/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "agentcore/")
 
     @staticmethod
     def _model_has_route_prefix(model: str, prefix: str) -> bool:
@@ -995,6 +995,10 @@ class BedrockModelInfo(BaseLLMModelInfo):
         provider prefix against the ``mantle/`` route, so the body model gets
         mangled to ``bedrock_openai.gpt-5.5``; anchoring to a segment boundary
         keeps the bare model id intact.
+
+        ``f"/{prefix}" in model`` matches the token as a segment at any path
+        depth, not just the second segment; that is intentional and acceptable
+        for these short, unambiguous route tokens.
         """
         return model.startswith(prefix) or f"/{prefix}" in model
 
@@ -1010,14 +1014,14 @@ class BedrockModelInfo(BaseLLMModelInfo):
         """
         Check if the model is an explicit converse like route.
         """
-        return "converse_like/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "converse_like/")
 
     @staticmethod
     def _explicit_async_invoke_route(model: str) -> bool:
         """
         Check if the model is an explicit async invoke route.
         """
-        return "async_invoke/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "async_invoke/")
 
     @staticmethod
     def _explicit_openai_route(model: str) -> bool:
@@ -1025,7 +1029,7 @@ class BedrockModelInfo(BaseLLMModelInfo):
         Check if the model is an explicit openai route.
         Used for Bedrock imported models that use OpenAI Chat Completions format.
         """
-        return "openai/" in model
+        return BedrockModelInfo._model_has_route_prefix(model, "openai/")
 
     @staticmethod
     def get_bedrock_provider_config_for_messages_api(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -633,6 +633,7 @@ async def acompletion(
 
     try:
         # Use a partial function to pass your keyword arguments
+        kwargs.pop("acompletion", None)
         func = partial(completion, **completion_kwargs, **kwargs)
 
         # Add the context to the function
@@ -5063,6 +5064,12 @@ def completion(  # type: ignore
     ######### unpacking kwargs #####################
     args = locals()
 
+    # Set by the responses->completion fallback so completion() does not bridge
+    # back to the Responses API: that round-trip mutually recurses forever for a
+    # model whose model_cost mode is "responses" but whose provider has no
+    # Responses API config (get_provider_responses_api_config -> None).
+    skip_responses_api_bridge = kwargs.pop("_skip_responses_api_bridge", False)
+
     skip_mcp_handler = kwargs.pop("_skip_mcp_handler", False)
     if not skip_mcp_handler and tools:
         from litellm.responses.mcp.chat_completions_handler import acompletion_with_mcp
@@ -5358,7 +5365,7 @@ def completion(  # type: ignore
 
         messages = update_messages_with_model_file_ids(
             messages=messages,
-            model_id=kwargs.get("model_info", {}).get("id", None),
+            model_id=(kwargs.get("model_info") or {}).get("id", None),
             model_file_id_mapping=cast(
                 Dict[str, Dict[str, str]],
                 kwargs.get("model_file_id_mapping") or {},
@@ -5559,7 +5566,10 @@ def completion(  # type: ignore
         # detection when the deployment name differs from the model name.
         _azure_detection_model = base_model or model
 
-        if responses_api_model_info.get("mode") == "responses":
+        if (
+            responses_api_model_info.get("mode") == "responses"
+            and not skip_responses_api_bridge
+        ):
             from litellm.completion_extras import responses_api_bridge
 
             optional_params, rs_val = (

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1849,7 +1849,10 @@ async def test_model_connection(
             "responses",
             "ocr",
         ]
-    ] = fastapi.Body("chat", description="The mode to test the model with"),
+    ] = fastapi.Body(
+        None,
+        description="The mode to test the model with. If not provided, auto-detected from model capabilities.",
+    ),
     litellm_params: Dict = fastapi.Body(
         None,
         description="Parameters for litellm.completion, litellm.embedding for the health check",

--- a/litellm/responses/litellm_completion_transformation/handler.py
+++ b/litellm/responses/litellm_completion_transformation/handler.py
@@ -61,6 +61,7 @@ class LiteLLMCompletionTransformationHandler:
         completion_args = {}
         completion_args.update(kwargs)
         completion_args.update(litellm_completion_request)
+        completion_args["_skip_responses_api_bridge"] = True
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper
@@ -111,6 +112,7 @@ class LiteLLMCompletionTransformationHandler:
         acompletion_args = {}
         acompletion_args.update(kwargs)
         acompletion_args.update(litellm_completion_request)
+        acompletion_args["_skip_responses_api_bridge"] = True
 
         litellm_completion_response: Union[
             ModelResponse, litellm.CustomStreamWrapper

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -263,3 +263,64 @@ def test_bundled_bedrock_opus_model_info_declares_output_config_effort_ceiling(
     model_info = GetModelCostMap.load_local_model_cost_map()[model]
 
     assert model_info["bedrock_output_config_effort_ceiling"] == expected_ceiling
+
+
+def test_route_prefix_matched_as_path_segment_not_substring():
+    """Route tokens like ``mantle/`` must match only at a path-segment boundary.
+
+    The ``bedrock_mantle/`` provider prefix contains the substring ``mantle/``;
+    a substring match misroutes ``bedrock_mantle/openai.gpt-5.5`` to the Claude
+    Mythos mantle config, whose request transform strips ``mantle/`` and mangles
+    the body model into ``bedrock_openai.gpt-5.5``. These assertions fail under
+    the old substring matching and pass once matching is anchored to ``startswith``
+    or a ``/`` boundary.
+    """
+    # The bedrock_mantle/ provider prefix must NOT be read as the mantle/ route.
+    assert (
+        BedrockModelInfo.get_bedrock_route("bedrock_mantle/openai.gpt-5.5") != "mantle"
+    )
+    assert (
+        BedrockModelInfo.get_bedrock_route("bedrock_mantle/openai.gpt-5.4") == "invoke"
+    )
+    assert (
+        BedrockModelInfo._explicit_mantle_route("bedrock_mantle/openai.gpt-5.5")
+        is False
+    )
+
+    # A genuine mantle route still resolves, via the startswith branch...
+    assert (
+        BedrockModelInfo.get_bedrock_route("mantle/anthropic.claude-mythos-preview")
+        == "mantle"
+    )
+    # ...and via the mid-path "/mantle/" branch (after the bedrock/ provider prefix).
+    assert (
+        BedrockModelInfo.get_bedrock_route(
+            "bedrock/mantle/anthropic.claude-mythos-preview"
+        )
+        == "mantle"
+    )
+
+
+def test_model_has_route_prefix_exercises_both_branches():
+    """``_model_has_route_prefix`` matches on ``startswith`` or a ``/`` boundary only."""
+    # startswith branch
+    assert (
+        BedrockModelInfo._model_has_route_prefix(
+            "mantle/anthropic.claude-mythos-preview", "mantle/"
+        )
+        is True
+    )
+    # f"/{prefix}" boundary branch
+    assert (
+        BedrockModelInfo._model_has_route_prefix(
+            "bedrock/mantle/anthropic.claude-mythos-preview", "mantle/"
+        )
+        is True
+    )
+    # neither branch: the token only appears glued to another segment
+    assert (
+        BedrockModelInfo._model_has_route_prefix(
+            "bedrock_mantle/openai.gpt-5.5", "mantle/"
+        )
+        is False
+    )

--- a/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
+++ b/tests/test_litellm/llms/bedrock/test_bedrock_common_utils.py
@@ -324,3 +324,62 @@ def test_model_has_route_prefix_exercises_both_branches():
         )
         is False
     )
+
+
+@pytest.mark.parametrize(
+    "route_method, token",
+    [
+        (BedrockModelInfo._explicit_converse_route, "converse"),
+        (BedrockModelInfo._explicit_converse_like_route, "converse_like"),
+        (BedrockModelInfo._explicit_invoke_route, "invoke"),
+        (BedrockModelInfo._explicit_async_invoke_route, "async_invoke"),
+        (BedrockModelInfo._explicit_agent_route, "agent"),
+        (BedrockModelInfo._explicit_agentcore_route, "agentcore"),
+        (BedrockModelInfo._explicit_claude_platform_route, "claude_platform"),
+        (BedrockModelInfo._explicit_openai_route, "openai"),
+    ],
+    ids=[
+        "converse",
+        "converse_like",
+        "invoke",
+        "async_invoke",
+        "agent",
+        "agentcore",
+        "claude_platform",
+        "openai",
+    ],
+)
+def test_explicit_route_helpers_match_token_only_as_path_segment(route_method, token):
+    """Each migrated ``_explicit_*_route`` matches its token only as a path segment.
+
+    A leading segment (start of the id or right after a ``/``) matches; the token
+    glued onto a preceding segment does not. Reverting any method to the old
+    ``"<token>/" in model`` substring check makes the non-segment case return True
+    and fails this test.
+    """
+    # leading-segment forms match
+    assert route_method(f"{token}/some-model") is True
+    assert route_method(f"bedrock/{token}/some-model") is True
+    # the token only as a non-segment substring must not match
+    assert route_method(f"x{token}/y") is False
+
+
+def test_explicit_invoke_route_does_not_match_async_invoke():
+    """``invoke/`` must not substring-match ``async_invoke/`` models.
+
+    This is the concrete improvement of the segment-boundary migration: the old
+    ``"invoke/" in model`` check wrongly classified async-invoke models as the
+    invoke route.
+    """
+    async_invoke_model = "async_invoke/twelvelabs.marengo-embed-2-7-v1:0"
+    assert BedrockModelInfo._explicit_invoke_route(async_invoke_model) is False
+    assert (
+        BedrockModelInfo._explicit_invoke_route(f"bedrock/{async_invoke_model}")
+        is False
+    )
+    # ...while async_invoke/ is still detected as its own route.
+    assert BedrockModelInfo._explicit_async_invoke_route(async_invoke_model) is True
+    assert (
+        BedrockModelInfo._explicit_async_invoke_route(f"bedrock/{async_invoke_model}")
+        is True
+    )

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_handler.py
@@ -1,0 +1,73 @@
+"""Regression tests for the responses -> completion fallback bridge guard.
+
+When the Responses API falls back to chat completions (no native responses
+config), it must tag the forwarded ``litellm.completion`` / ``litellm.acompletion``
+call with ``_skip_responses_api_bridge=True`` so ``completion()`` does not bridge
+the request straight back to the Responses API and mutually recurse forever.
+
+Both fallback paths are covered: the sync ``response_api_handler`` (``_is_async``
+False) and the async ``async_response_api_handler`` (``_is_async`` True). The
+module-level ``litellm.completion`` / ``litellm.acompletion`` are patched to
+capture the forwarded kwargs; if the flag-setting line is removed the captured
+kwargs lack the flag and these tests fail.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.responses.litellm_completion_transformation.handler import (
+    LiteLLMCompletionTransformationHandler,
+)
+
+
+class _StopForwarding(Exception):
+    """Raised by the mocked (a)completion once the forwarded kwargs are captured."""
+
+
+def test_sync_fallback_tags_skip_responses_api_bridge():
+    handler = LiteLLMCompletionTransformationHandler()
+    captured: dict = {}
+
+    def fake_completion(**kwargs):
+        captured.update(kwargs)
+        raise _StopForwarding()
+
+    with patch("litellm.completion", fake_completion):
+        with pytest.raises(_StopForwarding):
+            handler.response_api_handler(
+                model="gpt-4o",
+                input="hello",
+                responses_api_request={},
+                custom_llm_provider="openai",
+                _is_async=False,
+            )
+
+    assert captured.get("_skip_responses_api_bridge") is True
+
+
+@pytest.mark.asyncio
+async def test_async_fallback_tags_skip_responses_api_bridge():
+    handler = LiteLLMCompletionTransformationHandler()
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        raise _StopForwarding()
+
+    with patch("litellm.acompletion", fake_acompletion):
+        coro = handler.response_api_handler(
+            model="gpt-4o",
+            input="hello",
+            responses_api_request={},
+            custom_llm_provider="openai",
+            _is_async=True,
+        )
+        with pytest.raises(_StopForwarding):
+            await coro
+
+    assert captured.get("_skip_responses_api_bridge") is True

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21102,10 +21102,9 @@ export interface components {
             };
             /**
              * Mode
-             * @description The mode to test the model with
-             * @default chat
+             * @description The mode to test the model with. If not provided, auto-detected from model capabilities.
              */
-            mode: ("chat" | "completion" | "embedding" | "audio_speech" | "audio_transcription" | "image_generation" | "video_generation" | "batch" | "rerank" | "realtime" | "responses" | "ocr") | null;
+            mode?: ("chat" | "completion" | "embedding" | "audio_speech" | "audio_transcription" | "image_generation" | "video_generation" | "batch" | "rerank" | "realtime" | "responses" | "ocr") | null;
             /**
              * Model Info
              * @description Model info for the health check


### PR DESCRIPTION
## Relevant issues

One of the issues https://github.com/BerriAI/litellm/issues/30954 among others

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] My PR passes all unit tests on `make test-unit`
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

Bug Fix

## Changes

Fixes the dashboard "Test Connection" for `bedrock_mantle/openai.gpt-5.4` and `bedrock_mantle/openai.gpt-5.5`, which was failing first with "maximum recursion depth exceeded" and then with "model does not exist"

Route detection in the bedrock provider (`litellm/llms/bedrock/common_utils.py`) matched route tokens by plain substring, so the `bedrock_mantle/` provider prefix was mistaken for the `mantle/` invoke route. That route runs `model.replace("mantle/", "")`, which rewrote `bedrock_mantle/openai.gpt-5.5` into `bedrock_openai.gpt-5.5` and triggered the upstream "model does not exist". 

A new `_model_has_route_prefix` helper now matches route tokens only at a path-segment boundary, and every explicit route check (`mantle/`, `converse/`, `converse_like/`, `invoke/`, `async_invoke/`, `agent/`, `agentcore/`, `claude_platform/`, `openai/`) uses it, so the bare model name reaches the endpoint intact and the genuine routes still resolve

A responses-mode model whose provider has no Responses API config bounced forever between the Responses API and chat completions: the responses to completion fallback calls `completion()`, and `completion()` bridges back to responses whenever the model_cost mode is "responses". The fallback now tags its call with an internal `_skip_responses_api_bridge` flag so `completion()` does not bridge back, which breaks the loop (`litellm/main.py`, `litellm/responses/litellm_completion_transformation/handler.py`)

The Test Connection endpoint hardcoded the test mode to "chat", which disabled mode auto-detection for responses-only models (`litellm/proxy/health_endpoints/_health_endpoints.py`); the default is now None so the mode is detected from the model's capabilities

`acompletion()` drops a duplicate `acompletion` kwarg before building the partial (it raised "got multiple values for keyword argument 'acompletion'") and treats `model_info=None` as an empty dict to avoid a NoneType crash (`litellm/main.py`)

## Tests and tooling

Added regression tests under `tests/test_litellm/` covering the path-segment route matching (so `bedrock_mantle/...` no longer resolves to the `mantle/` route while genuine `mantle/...` and `bedrock/mantle/...` still do) and the `_skip_responses_api_bridge` guard on both the sync and async fallback paths; each test fails if the corresponding fix line is reverted

Aligned `update_messages_with_model_file_ids` `model_id` to `Optional[str]` so the `model_info=None` guard does not introduce a new `reportArgumentType` error, keeping the basedpyright budget unchanged

Regenerated the dashboard OpenAPI types (`ui/litellm-dashboard/src/lib/http/schema.d.ts`) so the now-optional `mode` field on `test_model_connection` stays in sync with the proxy spec

## Screenshots of the fix
Test Connection
<img width="3014" height="1812" alt="Screenshot 2026-06-24 at 12 49 31 AM" src="https://github.com/user-attachments/assets/c6c40caa-ea9b-4754-83bd-1e33ff28cff3" />

GPT 5.5 on Bedrock Mantle
<img width="3008" height="1820" alt="Screenshot 2026-06-24 at 12 58 08 AM (1)" src="https://github.com/user-attachments/assets/9c5068c1-a10d-4755-8aaf-11f903594c6b" />

GPT 5.4 on Bedrock Mantle
<img width="3008" height="1790" alt="Screenshot 2026-06-24 at 12 57 06 AM (1)" src="https://github.com/user-attachments/assets/5a822499-f69f-4df6-a142-943dc9d15a94" />
