### PR TITLE
fix(caching): guard against None async_redis_conn_pool in RedisCache.disconnect

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1270,7 +1270,8 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
-        await self.async_redis_conn_pool.disconnect(inuse_connections=True)
+        if self.async_redis_conn_pool is not None:
+            await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()
         except Exception as e:

--- a/tests/test_litellm/caching/test_redis_connection_pool.py
+++ b/tests/test_litellm/caching/test_redis_connection_pool.py
@@ -128,3 +128,29 @@ async def test_disconnect_idempotent():
 
     await cache.disconnect()
     await cache.disconnect()  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_disconnect_when_async_pool_is_none():
+    """Regression: disconnect() must not raise AttributeError when
+    async_redis_conn_pool is None (cluster-mode path sets it to None)."""
+    cache, mock_sync_client, _ = _make_redis_cache()
+    # Simulate cluster mode: connection pool is None after construction
+    cache.async_redis_conn_pool = None
+
+    # Should complete without raising AttributeError
+    await cache.disconnect()
+
+    # Sync client cleanup is still attempted
+    mock_sync_client.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_with_pool_calls_pool_disconnect():
+    """Happy path: when async_redis_conn_pool is present, disconnect()
+    forwards the call with inuse_connections=True."""
+    cache, mock_sync_client, mock_async_pool = _make_redis_cache()
+    await cache.disconnect()
+
+    mock_async_pool.disconnect.assert_awaited_once_with(inuse_connections=True)
+    mock_sync_client.close.assert_called_once()


### PR DESCRIPTION
Fixes #31206

## Problem

When `REDIS_CLUSTER_NODES` is set, `get_redis_connection_pool()` returns `None` because the cluster-mode path exits early:

```python
# litellm/_redis.py
if "startup_nodes" in redis_kwargs:
    return None  # cluster mode skips the connection pool
```

This causes `RedisCache.__init__` to store `self.async_redis_conn_pool = None`. At shutdown, `proxy_shutdown_event` calls `await litellm.cache.disconnect()` which calls `RedisCache.disconnect()`, which then crashes:

```
AttributeError: 'NoneType' object has no attribute 'disconnect'
  File "litellm/caching/redis_cache.py", line 1278, in disconnect
    await self.async_redis_conn_pool.disconnect(inuse_connections=True)
```

## Fix

Add a `None` guard before calling `.disconnect()` on the connection pool. The synchronous `self.redis_client.close()` is still attempted (it is already inside a try/except) so cluster-mode clients are still cleaned up gracefully on shutdown.

## Verification

The crash is reproducible by setting `REDIS_CLUSTER_NODES` and stopping LiteLLM (rolling update or graceful shutdown). After this fix, shutdown completes without the `AttributeError`.