### PR TITLE
fix(caching): guard disconnect() against None async_redis_conn_pool in cluster mode

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1270,6 +1270,8 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
+        if self.async_redis_conn_pool is None:
+            return
         await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -1367,6 +1367,8 @@ class RedisCache(BaseCache):
         self.redis_client.flushall()
 
     async def disconnect(self):
+        if self.async_redis_conn_pool is None:
+            return
         await self.async_redis_conn_pool.disconnect(inuse_connections=True)
         try:
             self.redis_client.close()

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -56,6 +56,16 @@ class RedisClusterCache(RedisCache):
         async_redis_cluster_client = self.init_async_client()
         return await async_redis_cluster_client.mget_nonatomic(keys=keys)  # type: ignore
 
+    async def disconnect(self):
+        if self.redis_async_redis_cluster_client is not None:
+            await self.redis_async_redis_cluster_client.aclose()
+        try:
+            self.redis_client.close()
+        except Exception as e:
+            from litellm._logging import verbose_logger
+
+            verbose_logger.debug("Error closing sync Redis Cluster client: %s", e)
+
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -56,6 +56,16 @@ class RedisClusterCache(RedisCache):
         async_redis_cluster_client: Final = self.init_async_client()
         return await async_redis_cluster_client.mget_nonatomic(keys=keys)
 
+    async def disconnect(self):
+        if self.redis_async_redis_cluster_client is not None:
+            await self.redis_async_redis_cluster_client.aclose()
+        try:
+            self.redis_client.close()
+        except Exception as e:
+            from litellm._logging import verbose_logger
+
+            verbose_logger.debug("Error closing sync Redis Cluster client: %s", e)
+
     async def test_connection(self) -> dict:
         """
         Test the Redis Cluster connection.

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -853,3 +853,14 @@ def test_delete_cache_namespaces_key(namespace, expected, monkeypatch, redis_no_
     redis_cache.redis_client = mock_client
     redis_cache.delete_cache(key="k")
     mock_client.delete.assert_called_once_with(expected)
+
+@pytest.mark.asyncio
+async def test_disconnect_with_none_conn_pool():
+    """Regression test: disconnect() must not raise AttributeError when async_redis_conn_pool is None (cluster mode)."""
+    with patch("asyncio.get_running_loop", side_effect=RuntimeError):
+        cache = RedisCache(host="localhost", port=6379, password="x")
+
+    cache.async_redis_conn_pool = None
+
+    # Should return without raising
+    await cache.disconnect()

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -444,6 +444,17 @@ def test_delete_cache_namespaces_key(namespace, expected, monkeypatch, redis_no_
     redis_cache.delete_cache(key="k")
     mock_client.delete.assert_called_once_with(expected)
 
+@pytest.mark.asyncio
+async def test_disconnect_with_none_conn_pool():
+    """Regression test: disconnect() must not raise AttributeError when async_redis_conn_pool is None (cluster mode)."""
+    with patch("asyncio.get_running_loop", side_effect=RuntimeError):
+        cache = RedisCache(host="localhost", port=6379, password="x")
+
+    cache.async_redis_conn_pool = None
+
+    # Should return without raising
+    await cache.disconnect()
+
 
 def _closed_port() -> int:
     """A port with nothing listening, so Redis calls fail fast and deterministically."""


### PR DESCRIPTION
## Relevant issues

Fixes #31206

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduce before the fix:

```python
import asyncio
from unittest.mock import patch

async def repro():
    with patch("asyncio.get_running_loop", side_effect=RuntimeError):
        from litellm.caching.redis_cache import RedisCache
        cache = RedisCache(host="localhost", port=6379, password="x")
    cache.async_redis_conn_pool = None  # what get_redis_connection_pool returns for cluster
    await cache.disconnect()            # AttributeError: 'NoneType' object has no attribute 'disconnect'

asyncio.run(repro())
```

After the fix the call returns cleanly with no exception.

## Type

🐛 Bug Fix

## Changes

`get_redis_connection_pool()` returns `None` when `REDIS_CLUSTER_NODES` is set because the cluster client manages its own internal connection pool. `RedisCache.__init__` assigns that `None` directly to `self.async_redis_conn_pool`. `disconnect()` then called `self.async_redis_conn_pool.disconnect(...)` unconditionally, raising `AttributeError` and crashing proxy shutdown on every Redis Cluster deployment.

The fix is a single early-return guard at the top of `disconnect()`: if `async_redis_conn_pool` is `None` there is nothing to disconnect, so we return immediately. A regression test in `tests/test_litellm/caching/test_redis_cache.py` covers this path.