### PR TITLE
feat(mcp): include server alias and server_id in mcp_info response

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -79,6 +79,7 @@ if MCP_AVAILABLE:
     )
     from litellm.proxy._experimental.mcp_server.server import (
         ListMCPToolsRestAPIResponseObject,
+        MCPInfo,
         MCPServer,
         _tool_name_matches,
         execute_mcp_tool,
@@ -238,14 +239,24 @@ if MCP_AVAILABLE:
             )
             return {}
 
-    def _create_tool_response_objects(tools, server_mcp_info):
-        """Helper function to create tool response objects."""
+    def _create_tool_response_objects(tools, server: MCPServer):
+        """Helper function to create tool response objects.
+
+        Enriches the server's ``mcp_info`` with ``server_id`` and ``alias`` so
+        REST clients can map the internal ``server_name`` to the user-facing
+        alias without needing access to the ``mcp_routes``-gated server listing.
+        """
+        enriched_mcp_info: MCPInfo = {
+            **(server.mcp_info or {}),
+            "server_id": server.server_id,
+            "alias": server.alias,
+        }
         return [
             ListMCPToolsRestAPIResponseObject(
                 name=tool.name,
                 description=tool.description,
                 inputSchema=tool.inputSchema,
-                mcp_info=server_mcp_info,
+                mcp_info=enriched_mcp_info,
             )
             for tool in tools
         ]
@@ -405,7 +416,7 @@ if MCP_AVAILABLE:
         )
 
         if not apply_tool_filters:
-            return _create_tool_response_objects(tools, server.mcp_info)
+            return _create_tool_response_objects(tools, server)
 
         # Always apply allowed_tools/disallowed_tools so the blacklist is
         # enforced even when no allowlist is set (matches the SSE/HTTP path).
@@ -436,7 +447,7 @@ if MCP_AVAILABLE:
                     if _tool_name_matches(tool.name, allowed_tools_for_server)
                 ]
 
-        return _create_tool_response_objects(tools, server.mcp_info)
+        return _create_tool_response_objects(tools, server)
 
     async def _resolve_allowed_mcp_servers_for_tool_call(
         user_api_key_dict: UserAPIKeyAuth,
@@ -587,6 +598,8 @@ if MCP_AVAILABLE:
                     "mcp_info": {
                         "server_name": "zapier",
                         "logo_url": "https://www.zapier.com/logo.png",
+                        "server_id": "a1b2c3d4-...",
+                        "alias": "zapier_prod",
                     }
                 }
             ],

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1881,10 +1881,11 @@ def test_get_server_auth_header_no_auth_headers():
 
 
 def test_create_tool_response_objects():
-    """Test _create_tool_response_objects function."""
+    """Test _create_tool_response_objects enriches mcp_info with server_id and alias."""
     from litellm.proxy._experimental.mcp_server.rest_endpoints import (
         _create_tool_response_objects,
     )
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
     from mcp.types import Tool as MCPTool
 
     # Create mock tools
@@ -1901,20 +1902,32 @@ def test_create_tool_response_objects():
         ),
     ]
 
-    server_mcp_info = {
-        "server_name": "zapier",
+    server = MCPServer(
+        server_id="a1b2c3d4",
+        name="zapier_internal",
+        alias="zapier",
+        transport="http",
+        mcp_info={
+            "server_name": "zapier_internal",
+            "logo_url": "https://zapier.com/logo.png",
+        },
+    )
+
+    result = _create_tool_response_objects(mock_tools, server)
+
+    expected_mcp_info = {
+        "server_name": "zapier_internal",
         "logo_url": "https://zapier.com/logo.png",
+        "server_id": "a1b2c3d4",
+        "alias": "zapier",
     }
-
-    result = _create_tool_response_objects(mock_tools, server_mcp_info)
-
     assert len(result) == 2
     assert result[0].name == "send_email"
     assert result[0].description == "Send an email"
-    assert result[0].mcp_info == server_mcp_info
+    assert result[0].mcp_info == expected_mcp_info
     assert result[1].name == "create_event"
     assert result[1].description == "Create a calendar event"
-    assert result[1].mcp_info == server_mcp_info
+    assert result[1].mcp_info == expected_mcp_info
 
 
 @pytest.mark.asyncio
@@ -1928,6 +1941,8 @@ async def test_get_tools_for_single_server():
     # Create a mock server (pin allowlist fields; MagicMock auto-attrs are truthy)
     mock_server = MagicMock()
     mock_server.mcp_info = {"server_name": "zapier"}
+    mock_server.server_id = "zapier_id"
+    mock_server.alias = "zapier_alias"
     mock_server.allowed_tools = None
     mock_server.disallowed_tools = None
 
@@ -1961,7 +1976,11 @@ async def test_get_tools_for_single_server():
         # Verify the result
         assert len(result) == 1
         assert result[0].name == "send_email"
-        assert result[0].mcp_info == {"server_name": "zapier"}
+        assert result[0].mcp_info == {
+            "server_name": "zapier",
+            "server_id": "zapier_id",
+            "alias": "zapier_alias",
+        }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1800,3 +1800,71 @@ class TestConnectionErrorMessage:
         message = rest_endpoints._connection_error_message(RuntimeError("weird"))
         assert "weird" not in message
         assert "proxy logs" in message.lower()
+
+
+class TestToolResponseMcpInfoEnrichment:
+    """The REST tools/list response must expose the user-facing alias and the
+    server_id alongside the internal server_name so clients (agent builder UIs)
+    can map the internal config key to a friendly name without needing the
+    mcp_routes-gated server listing.
+    """
+
+    def test_enriches_mcp_info_with_alias_and_server_id(self):
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        server = MCPServer(
+            server_id="a1b2c3d4",
+            name="mcpAtlassian",
+            alias="atlassian",
+            server_name="mcpAtlassian",
+            transport=MCPTransport.http,
+            mcp_info={"server_name": "mcpAtlassian"},
+        )
+        tools = [
+            MCPTool(
+                name="get_issue",
+                description="Fetch a Jira issue",
+                inputSchema={"type": "object"},
+            )
+        ]
+
+        result = rest_endpoints._create_tool_response_objects(tools, server)
+
+        assert result[0].mcp_info == {
+            "server_name": "mcpAtlassian",
+            "server_id": "a1b2c3d4",
+            "alias": "atlassian",
+        }
+
+    def test_alias_none_is_explicit_in_mcp_info(self):
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        server = MCPServer(
+            server_id="server-uuid",
+            name="no_alias_server",
+            alias=None,
+            server_name="no_alias_server",
+            transport=MCPTransport.http,
+            mcp_info={"server_name": "no_alias_server"},
+        )
+        tools = [
+            MCPTool(
+                name="ping",
+                description="Ping",
+                inputSchema={"type": "object"},
+            )
+        ]
+
+        result = rest_endpoints._create_tool_response_objects(tools, server)
+
+        assert result[0].mcp_info == {
+            "server_name": "no_alias_server",
+            "server_id": "server-uuid",
+            "alias": None,
+        }


### PR DESCRIPTION
## Add `alias` and `server_id` to `mcp_info` in `/mcp-rest/tools/list`

- Add `alias` and `server_id` fields to `mcp_info` object in `/mcp-rest/tools/list` endpoint
- Update `rest_endpoints.py` to surface `alias` from server config
- Add test coverage in `test_mcp_server.py` and `test_rest_endpoints.py`

Fixes #31015

## Relevant issues
Fixes #31015

## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a
      **Confidence Score of at least 4/5** before requesting a maintainer review

## Type
🆕 New Feature
✅ Test

## Changes

### Problem
The `/mcp-rest/tools/list` endpoint returned `mcp_info` without `alias` or
`server_id` fields, making it impossible for clients to identify which MCP
server a tool belongs to or route requests by alias.

**Before:**
```json
"mcp_info": {
  "server_name": "websearch",
  "description": "websearch"
}
```

**After:**
```json
"mcp_info": {
  "server_name": "websearch",
  "description": "websearch",
  "server_id": "c062766b-3cdf-4741-9962-8a3690dd7b7c",
  "alias": "websearch"
}
```

### What changed
- `rest_endpoints.py`: surface `alias` and `server_id` from server config
  into the `mcp_info` object returned per tool
- `alias` is `null` when not configured on the server (not omitted)
- `server_id` is always present

### Test coverage added
| Test | What it verifies |
|------|-----------------|
| `test_mcp_info_contains_server_id_and_alias_when_set` | Both fields present when alias configured |
| `test_mcp_info_alias_is_null_when_not_configured` | `alias` key exists but is