### PR TITLE
fix(repelloai): include conversation history in post_call scan

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
@@ -439,13 +439,10 @@ class RepelloAIGuardrail(CustomGuardrail):
         return data
 
     def _build_post_call_text(self, data: dict[str, object], response_text: str) -> str:
-        messages = build_inspection_messages(data)
-        if not messages:
+        history_parts = self._extract_prompt_message_text(data)
+        if not history_parts:
             return response_text
-        history = "\n".join(
-            f"{msg['role']}: {msg['content']}" for msg in messages
-        )
-        return history + "\n" + response_text
+        return "\n".join(history_parts) + "\n" + response_text
 
     async def async_post_call_success_hook(
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
@@ -438,6 +438,15 @@ class RepelloAIGuardrail(CustomGuardrail):
         )
         return data
 
+    def _build_post_call_text(self, data: dict[str, object], response_text: str) -> str:
+        # Prepend conversation history (all roles) so Argus can evaluate the
+        # response in context — e.g. detect system-prompt leakage or
+        # multi-turn policy violations.
+        history_parts = self._extract_prompt_message_text(data)
+        if history_parts:
+            return "\n".join(history_parts) + "\n" + response_text
+        return response_text
+
     async def async_post_call_success_hook(
         self,
         data: dict[str, object],
@@ -455,12 +464,14 @@ class RepelloAIGuardrail(CustomGuardrail):
         ):
             return response
 
-        text = self._extract_response_text(response)
-        if not text:
+        response_text = self._extract_response_text(response)
+        if not response_text:
             verbose_proxy_logger.warning(
                 "RepelloAI Argus: no inspectable response text - skipping."
             )
             return response
+
+        text = self._build_post_call_text(data, response_text)
 
         repelloai_response = await self._call_analyze(
             text=text,
@@ -501,9 +512,14 @@ class RepelloAIGuardrail(CustomGuardrail):
         assembled = litellm_main.stream_chunk_builder(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
             chunks=chunks
         )
-        text = (
+        response_text = (
             self._extract_response_text(assembled)
             if isinstance(assembled, ModelResponse)
+            else None
+        )
+        text = (
+            self._build_post_call_text(request_data, response_text)
+            if response_text
             else None
         )
         if text:

--- a/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
@@ -439,13 +439,13 @@ class RepelloAIGuardrail(CustomGuardrail):
         return data
 
     def _build_post_call_text(self, data: dict[str, object], response_text: str) -> str:
-        # Prepend conversation history (all roles) so Argus can evaluate the
-        # response in context — e.g. detect system-prompt leakage or
-        # multi-turn policy violations.
-        history_parts = self._extract_prompt_message_text(data)
-        if history_parts:
-            return "\n".join(history_parts) + "\n" + response_text
-        return response_text
+        messages = build_inspection_messages(data)
+        if not messages:
+            return response_text
+        history = "\n".join(
+            f"{msg['role']}: {msg['content']}" for msg in messages
+        )
+        return history + "\n" + response_text
 
     async def async_post_call_success_hook(
         self,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_repelloai.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_repelloai.py
@@ -621,7 +621,7 @@ class TestRepelloAIPostCall:
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
         assert captured["url"] == ANALYZE_RESPONSE_URL
-        assert captured["json"]["scan_data"] == {"response": "the answer content"}
+        assert captured["json"]["scan_data"] == {"response": "user: q\nthe answer content"}
 
     @pytest.mark.asyncio
     async def test_text_completion_response_text_extracted_to_endpoint(
@@ -672,7 +672,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "first part and second part"
+        assert captured["json"]["scan_data"]["response"] == "user: q\nfirst part and second part"
 
     @pytest.mark.asyncio
     async def test_responses_api_dict_output_extracted_to_endpoint(self, monkeypatch):
@@ -699,7 +699,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "raw dict"
+        assert captured["json"]["scan_data"]["response"] == "user: q\nraw dict"
 
     @pytest.mark.asyncio
     async def test_responses_api_function_call_output_scanned(self, monkeypatch):
@@ -755,7 +755,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "first\nsecond"
+        assert captured["json"]["scan_data"]["response"] == "user: q\nfirst\nsecond"
 
     @pytest.mark.asyncio
     async def test_empty_choices_skips(self, monkeypatch):
@@ -1071,7 +1071,7 @@ class TestRepelloAIStreaming:
                 request_data=data,
             ):
                 pass
-        assert captured["json"]["scan_data"]["response"] == "unsafe answer"
+        assert captured["json"]["scan_data"]["response"] == "user: q\nunsafe answer"
 
     @pytest.mark.asyncio
     async def test_streaming_flagged_logs_warning(self, monkeypatch):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_repelloai.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_repelloai.py
@@ -621,7 +621,7 @@ class TestRepelloAIPostCall:
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
         assert captured["url"] == ANALYZE_RESPONSE_URL
-        assert captured["json"]["scan_data"] == {"response": "user: q\nthe answer content"}
+        assert captured["json"]["scan_data"] == {"response": "q\nthe answer content"}
 
     @pytest.mark.asyncio
     async def test_text_completion_response_text_extracted_to_endpoint(
@@ -672,7 +672,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "user: q\nfirst part and second part"
+        assert captured["json"]["scan_data"]["response"] == "q\nfirst part and second part"
 
     @pytest.mark.asyncio
     async def test_responses_api_dict_output_extracted_to_endpoint(self, monkeypatch):
@@ -699,7 +699,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "user: q\nraw dict"
+        assert captured["json"]["scan_data"]["response"] == "q\nraw dict"
 
     @pytest.mark.asyncio
     async def test_responses_api_function_call_output_scanned(self, monkeypatch):
@@ -755,7 +755,7 @@ class TestRepelloAIPostCall:
         await guardrail.async_post_call_success_hook(
             data=data, user_api_key_dict=UserAPIKeyAuth(), response=response
         )
-        assert captured["json"]["scan_data"]["response"] == "user: q\nfirst\nsecond"
+        assert captured["json"]["scan_data"]["response"] == "q\nfirst\nsecond"
 
     @pytest.mark.asyncio
     async def test_empty_choices_skips(self, monkeypatch):
@@ -1071,7 +1071,7 @@ class TestRepelloAIStreaming:
                 request_data=data,
             ):
                 pass
-        assert captured["json"]["scan_data"]["response"] == "user: q\nunsafe answer"
+        assert captured["json"]["scan_data"]["response"] == "q\nunsafe answer"
 
     @pytest.mark.asyncio
     async def test_streaming_flagged_logs_warning(self, monkeypatch):


### PR DESCRIPTION
## Summary
 #### Add conversation history to RepelloAI Argus post_call scan

Previously, the post_call hook sent only the LLM response text to Argus for scanning. This PR updates it to include the full conversation history (all roles) prepended to the response, matching the behaviour of other guardrail integrations and allowing Argus to evaluate responses in context. 

For example, detecting system prompt leakage or multi-turn policy violations that are only identifiable with prior context.
  
  - No interface changes; existing configs work without modification
  - No new parameters; behaviour is determined by existing messages in the request data

  This is a behavioural improvement to what text gets scanned, no API surface changes and no test additions required.

## Relevant issues

<!-- e.g. "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->
#### Output of make test-unit
```bash
============================================================================ test session starts ============================================================================
platform darwin -- Python 3.12.12, pytest-9.0.3, pluggy-1.6.0 -- /Users/lavish619/Documents/litellm/.venv/bin/python
codspeed: 4.3.0 (disabled, mode: walltime, callgraph: not supported, timer_resolution: 41.7ns)
cachedir: .pytest_cache
rootdir: /Users/lavish619/Documents/litellm
configfile: pyproject.toml
plugins: respx-0.22.0, logfire-4.6.0, mock-3.15.1, ddtrace-2.19.0, cov-5.0.0, codspeed-4.3.0, recording-0.13.4, xdist-3.8.0, timeout-2.4.0, retry-1.7.0, rerunfailures-15.1, asyncio-1.3.0, langsmith-0.8.18, requests-mock-1.12.1, postgresql-7.0.2, anyio-4.13.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=session, asyncio_default_test_loop_scope=function
collecting 0 items / 1 error                                                                                                                                                
================================================================================== ERRORS ===================================================================================
______________________________________________________ ERROR collecting tests/test_litellm/proxy/client/test_models.py ______________________________________________________
import file mismatch:
imported module 'test_models' has this __file__ attribute:
  /Users/lavish619/Documents/litellm/tests/test_litellm/models/test_models.py
which is not the same as the test file we want to collect:
  /Users/lavish619/Documents/litellm/tests/test_litellm/proxy/client/test_models.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
============================================================================= warnings summary ==============================================================================
.venv/lib/python3.12/site-packages/ddtrace/internal/module.py:295
.venv/lib/python3.12/site-packages/ddtrace/internal/module.py:295
.venv/lib/python3.12/site-packages/ddtrace/internal/module.py:295
.venv/lib/python3.12/site-packages/ddtrace/internal/module.py:295
  /Users/lavish619/Documents/litellm/.venv/lib/python3.12/site-packages/ddtrace/internal/module.py:295: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    self.loader.exec_module(module)

tests/test_litellm/integrations/arize/test_arize_utils.py:373
tests/test_litellm/integrations/arize/test_arize_utils.py:373
tests/test_litellm/integrations/arize/test_arize_utils.py:373
tests/test_litellm/integrations/arize/test_arize_utils.py:373
  /Users/lavish619/Documents/litellm/tests/test_litellm/integrations/arize/test_arize_utils.py:373: PytestCollectionWarning: cannot collect test class 'TestArizeLogger' because it has a __init__ constructor (from: tests/test_litellm/integrations/arize/test_arize_utils.py)
    class TestArizeLogger(CustomLogger):

tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:422
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:422
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:422
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:422
  /Users/lavish619/Documents/litellm/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:422: PytestCollectionWarning: cannot collect test class 'TestDataDogLLMObsLoggerForRedaction' because it has a __init__ constructor (from: tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py)
    class TestDataDogLLMObsLoggerForRedaction(DataDogLLMObsLogger):

tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:433
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:433
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:433
tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:433
  /Users/lavish619/Documents/litellm/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py:433: PytestCollectionWarning: cannot collect test class 'TestS3Logger' because it has a __init__ constructor (from: tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py)
    class TestS3Logger(CustomLogger):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== short test summary info ==========================================================================
ERROR tests/test_litellm/proxy/client/test_models.py - import file mismatch:
imported module 'test_models' has this __file__ attribute:
  /Users/lavish619/Documents/litellm/tests/test_litellm/models/test_models.py
which is not the same as the test file we want to collect:
  /Users/lavish619/Documents/litellm/tests/test_litellm/proxy/client/test_models.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
====================================================================== 16 warnings, 1 error in 42.64s =======================================================================
make: *** [test-unit] Error 2
```
## Type
🐛 Bug Fix

## Changes
