### PR TITLE
fix: supports_native_streaming returns True for unknown/custom models

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2478,7 +2478,8 @@ def supports_native_streaming(model: str, custom_llm_provider: Optional[str]) ->
         verbose_logger.debug(
             f"Model not found or error in checking supports_native_streaming support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
         )
-        return False
+        return True  # unknown/custom models default to True, consistent with the
+        # .get("supports_native_streaming", True) default used when the model IS found
 
 
 def supports_response_schema(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -146,6 +146,22 @@ def test_supports_function_calling_unknown_github_alias_returns_false():
     )
 
 
+def test_supports_native_streaming_unknown_model_returns_true():
+    """Regression test for https://github.com/BerriAI/litellm/issues/21090
+
+    Custom/unknown models not in model_prices_and_context_window.json must return True
+    so that /v1/responses does not activate fake streaming, which silently drops
+    function_call_arguments.delta events.
+    """
+    assert (
+        litellm.utils.supports_native_streaming(
+            model="my-custom-vllm-model-not-in-registry",
+            custom_llm_provider=None,
+        )
+        is True
+    )
+
+
 def test_get_optional_params_image_gen():
     from litellm.llms.azure.image_generation import AzureGPTImageGenerationConfig
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -156,7 +156,7 @@ def test_supports_native_streaming_unknown_model_returns_true():
     assert (
         litellm.utils.supports_native_streaming(
             model="my-custom-vllm-model-not-in-registry",
-            custom_llm_provider=None,
+            custom_llm_provider="openai",
         )
         is True
     )


### PR DESCRIPTION
Fixes #21090

## What

In `supports_native_streaming()`, when `_get_model_info_helper()` raises `ValueError` (model not in `model_prices_and_context_window.json`), the `except` block was returning `False`.

This caused `OpenAIResponsesAPIConfig.should_fake_stream()` to activate fake streaming for all custom/unknown models on the `/v1/responses` path: LiteLLM strips `stream=true` from the backend request, receives a plain JSON response, and wraps it in `MockResponsesAPIStreamingIterator` — which can only emit text delta chunks, silently dropping all `function_call_arguments.delta` events.

## Fix

Return `True` instead of `False`, consistent with `.get("supports_native_streaming", True)` already used when the model IS found. The only 4 models with `supports_native_streaming: false` are registered in the DB and never reach the `except` block.