### PR TITLE
fix(model_prices): add supports_native_structured_output to claude-haiku-4-5 direct API entries

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -10280,7 +10280,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_native_structured_output": true
     },
     "claude-haiku-4-5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -10301,7 +10302,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_native_structured_output": true
     },
     "claude-3-7-sonnet-20250219": {
         "cache_creation_input_token_cost": 3.75e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -10280,7 +10280,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_native_structured_output": true
     },
     "claude-haiku-4-5": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -10301,7 +10302,8 @@
         "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_vision": true,
+        "supports_native_structured_output": true
     },
     "claude-3-7-sonnet-20250219": {
         "cache_creation_input_token_cost": 3.75e-06,


### PR DESCRIPTION
## Summary

Fixes #25308

### Root cause

`claude-haiku-4-5-20251001` and `claude-haiku-4-5` (the direct Anthropic API model IDs) were missing `supports_native_structured_output: true` in `model_prices_and_context_window.json`, even though the model supports it (all the Bedrock and regional cross-region variants already had the flag set correctly).

When a caller passes `response_format=SomePydanticModel` to `litellm.completion` with one of these model IDs, litellm falls back to synthesising a `json_tool_call` instead of forwarding the request natively. This causes issues when the call also has real tools — `_should_convert_tool_call_to_json_mode` only strips the synthetic wrapper when there is exactly one tool call, so legitimate `tool_calls` leak into the response alongside `json_tool_call`.

### Fix

Add `"supports_native_structured_output": true` to:
- `claude-haiku-4-5-20251001`
- `claude-haiku-4-5`

No code changes; the existing `supports_native_structured_output()` helper already routes through `model_prices_and_context_window.json`.

### Verification

After this change, `litellm.utils.supports_native_structured_output("claude-haiku-4-5-20251001")` returns `True`, and `response_format` is forwarded natively to the Anthropic API instead of being wrapped in a synthetic tool call.
