### PR TITLE
fix: creating litellm team with multiple budget limits

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2038,7 +2038,7 @@ async def update_team(
 
 def _initialize_budget_windows(
     budget_limits: Optional[Sequence[Union[BudgetLimitEntry, dict]]],
-) -> Optional[List[dict]]:
+) -> Optional[list[dict]]:
     """Stamp each budget window's reset_at and return plain dicts ready for JSON serialization. Returns None when there are no windows so callers can drop or skip the field."""
     if not budget_limits:
         return None

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -14,7 +14,7 @@ import json
 import math
 import traceback
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import fastapi
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -26,6 +26,7 @@ from litellm._uuid import uuid
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import (
     BlockTeamRequest,
+    BudgetLimitEntry,
     CommonProxyErrors,
     DeleteTeamRequest,
     LiteLLM_AuditLogs,
@@ -1247,18 +1248,9 @@ async def new_team(
                 budget_duration=complete_team_data.budget_duration,
             )
 
-        # If budget_limits is set, initialize reset_at for each window
-        if complete_team_data.budget_limits:
-            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
-
-            initialized_windows = []
-            for window in complete_team_data.budget_limits:
-                w = window if isinstance(window, dict) else window.model_dump()
-                w["reset_at"] = get_budget_reset_time(
-                    budget_duration=w["budget_duration"]
-                ).isoformat()
-                initialized_windows.append(w)
-            complete_team_data.budget_limits = initialized_windows  # type: ignore[assignment]
+        initialized_budget_limits = _initialize_budget_windows(
+            complete_team_data.budget_limits
+        )
 
         ## Add Team Member Budget Table
         members_with_roles: List[Member] = []
@@ -1267,6 +1259,13 @@ async def new_team(
             complete_team_data.members_with_roles = []
 
         complete_team_data_dict = complete_team_data.model_dump(exclude_none=True)
+
+        if initialized_budget_limits is not None:
+            complete_team_data_dict["budget_limits"] = json.dumps(
+                initialized_budget_limits
+            )
+        else:
+            complete_team_data_dict.pop("budget_limits", None)
 
         # Serialize router_settings to JSON (matching key creation pattern)
         router_settings_value = getattr(data, "router_settings", None)
@@ -2037,6 +2036,30 @@ async def update_team(
         raise handle_exception_on_proxy(e)
 
 
+def _initialize_budget_windows(
+    budget_limits: Optional[Sequence[Union[BudgetLimitEntry, dict]]],
+) -> Optional[List[dict]]:
+    """Stamp each budget window's reset_at and return plain dicts ready for JSON serialization. Returns None when there are no windows so callers can drop or skip the field."""
+    if not budget_limits:
+        return None
+
+    from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+    window_dicts = [
+        window if isinstance(window, dict) else window.model_dump()
+        for window in budget_limits
+    ]
+    return [
+        {
+            **w,
+            "reset_at": get_budget_reset_time(
+                budget_duration=w["budget_duration"]
+            ).isoformat(),
+        }
+        for w in window_dicts
+    ]
+
+
 def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
     """Set budget_reset_at in updated_kv if budget_duration is provided."""
     if data.budget_duration is not None:
@@ -2047,17 +2070,9 @@ def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
     elif "budget_duration" in updated_kv and updated_kv["budget_duration"] is None:
         updated_kv["budget_reset_at"] = None
 
-    if data.budget_limits is not None and len(data.budget_limits) > 0:
-        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
-
-        initialized_windows = []
-        for window in data.budget_limits:
-            w = window if isinstance(window, dict) else window.model_dump()
-            w["reset_at"] = get_budget_reset_time(
-                budget_duration=w["budget_duration"]
-            ).isoformat()
-            initialized_windows.append(w)
-        updated_kv["budget_limits"] = json.dumps(initialized_windows)
+    initialized_budget_limits = _initialize_budget_windows(data.budget_limits)
+    if initialized_budget_limits is not None:
+        updated_kv["budget_limits"] = json.dumps(initialized_budget_limits)
 
 
 async def handle_update_object_permission(

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -553,6 +553,135 @@ async def test_new_team_with_mcp_tool_permissions(mock_db_client, mock_admin_aut
 
 
 @pytest.mark.asyncio
+async def test_new_team_with_budget_limits_serializes_to_json_string(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Regression: /team/new must JSON-encode `budget_limits` before sending it to
+    Prisma. The team table column is `Json?`, and the Prisma Python client
+    rejects bare Python lists for that field with
+    "should be of any of the following types: NullableJsonNullValueInput, Json".
+    The update path already json.dumps the list; create previously left it as a
+    list, which broke create requests.
+    """
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.get_data = AsyncMock(return_value=None)
+    mock_db_client.update_data = AsyncMock(return_value=MagicMock())
+    mock_db_client.db = MagicMock()
+
+    mock_db_client.db.litellm_modeltable = MagicMock()
+    mock_db_client.db.litellm_modeltable.create = AsyncMock(
+        return_value=MagicMock(id="model123")
+    )
+
+    team_create_result = MagicMock(team_id="team-budget-windows")
+    team_create_result.model_dump.return_value = {"team_id": "team-budget-windows"}
+    mock_team_create = AsyncMock(return_value=team_create_result)
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.create = mock_team_create
+    mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(
+        return_value=team_create_result
+    )
+
+    mock_db_client.db.litellm_usertable = MagicMock()
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    from fastapi import Request
+
+    from litellm.proxy._types import BudgetLimitEntry, NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    team_request = NewTeamRequest(
+        team_alias="budget-windows-team",
+        budget_limits=[
+            BudgetLimitEntry(budget_duration="30d", max_budget=12.0),
+            BudgetLimitEntry(budget_duration="365d", max_budget=144.0),
+        ],
+    )
+
+    await new_team(
+        data=team_request,
+        http_request=MagicMock(spec=Request),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    assert mock_team_create.call_count == 1
+    team_data = mock_team_create.call_args.kwargs["data"]
+
+    assert isinstance(team_data["budget_limits"], str), (
+        "budget_limits must be a JSON string for Prisma's Json? column; "
+        f"got {type(team_data['budget_limits']).__name__}"
+    )
+
+    decoded = json.loads(team_data["budget_limits"])
+    assert [(w["budget_duration"], w["max_budget"]) for w in decoded] == [
+        ("30d", 12.0),
+        ("365d", 144.0),
+    ]
+    assert all(
+        isinstance(w.get("reset_at"), str) and w["reset_at"] for w in decoded
+    ), "each window must have reset_at initialized to a non-empty ISO timestamp"
+
+
+@pytest.mark.asyncio
+async def test_new_team_with_empty_budget_limits_drops_the_key(
+    mock_db_client, mock_admin_auth
+):
+    """
+    Regression: /team/new must not forward an empty `budget_limits` list to
+    Prisma. The team table column is `Json?` and the Prisma Python client
+    rejects bare Python lists with "should be of any of the following types:
+    NullableJsonNullValueInput, Json" -- the same error a non-empty list used to
+    raise. Treating an empty list as "no windows" (key absent) matches the
+    update path, which skips empty lists entirely.
+    """
+    mock_db_client.jsonify_team_object = lambda db_data: db_data
+    mock_db_client.get_data = AsyncMock(return_value=None)
+    mock_db_client.update_data = AsyncMock(return_value=MagicMock())
+    mock_db_client.db = MagicMock()
+
+    mock_db_client.db.litellm_modeltable = MagicMock()
+    mock_db_client.db.litellm_modeltable.create = AsyncMock(
+        return_value=MagicMock(id="model123")
+    )
+
+    team_create_result = MagicMock(team_id="team-empty-budget-limits")
+    team_create_result.model_dump.return_value = {
+        "team_id": "team-empty-budget-limits"
+    }
+    mock_team_create = AsyncMock(return_value=team_create_result)
+    mock_db_client.db.litellm_teamtable = MagicMock()
+    mock_db_client.db.litellm_teamtable.create = mock_team_create
+    mock_db_client.db.litellm_teamtable.count = AsyncMock(return_value=0)
+    mock_db_client.db.litellm_teamtable.update = AsyncMock(
+        return_value=team_create_result
+    )
+
+    mock_db_client.db.litellm_usertable = MagicMock()
+    mock_db_client.db.litellm_usertable.update = AsyncMock(return_value=MagicMock())
+
+    from fastapi import Request
+
+    from litellm.proxy._types import NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    await new_team(
+        data=NewTeamRequest(team_alias="empty-budget-limits", budget_limits=[]),
+        http_request=MagicMock(spec=Request),
+        user_api_key_dict=mock_admin_auth,
+    )
+
+    assert mock_team_create.call_count == 1
+    team_data = mock_team_create.call_args.kwargs["data"]
+
+    assert "budget_limits" not in team_data, (
+        "an empty budget_limits list must be dropped before reaching Prisma; "
+        f"got {team_data.get('budget_limits')!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_team_update_object_permissions_existing_permission(monkeypatch):
     """
     Test updating object permissions when a team already has an existing object_permission_id.


### PR DESCRIPTION
## Issue

When we create a LiteLLM Team with multiple budget_limits then we can either satisfy python validator or prisma validator. It's impossible to satisfy both. In case of PATCH endpoint, it already worked perfectly fine. I created common helper to make sure it works same way between create and update and tests to cover it.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The tests I attached didn't pass before my fix in the codebase.



<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
     For bug fixes: show reproduction before the fix and passing behavior after.
     For new features: show the feature working end-to-end.
     For UI changes: include before/after screenshots. -->

## Type

🐛 Bug Fix

## Changes
