### PR TITLE
feat: add gonkabroker as an OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -176,5 +176,12 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "gonkabroker": {
+    "base_url": "https://proxy.gonkabroker.com/v1",
+    "api_key_env": "GONKABROKER_API_KEY",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1131,6 +1131,24 @@
         "interactions": true
       }
     },
+    "gonkabroker": {
+      "display_name": "Gonka Broker (`gonkabroker`)",
+      "url": "https://docs.litellm.ai/docs/providers/gonkabroker",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "vertex_ai": {
       "display_name": "Google - Vertex AI (`vertex_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/vertex",


### PR DESCRIPTION
## Relevant issues

None

## Linear ticket

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Gonka Broker is OpenAI-compatible and registers through the JSON-only path in `litellm/llms/openai_like/providers.json`, so there is no Python transformation class and no new code path that a unit test could meaningfully exercise; this matches how the existing OpenAI-compatible providers such as scaleway and aihubmix were added. Verification is the live proxy run below against the real Gonka Broker API

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:
- [ ] **CI run for the last commit**
       Link:
- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

config.yaml

```yaml
model_list:
  - model_name: gonkabroker-model
    litellm_params:
      model: gonkabroker/Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
      api_key: os.environ/GONKABROKER_API_KEY
```

Start the proxy with a real key in the environment

```bash
export GONKABROKER_API_KEY=gnk-prx-...   # a real Gonka Broker key
litellm --config config.yaml --port 4000
```

Live request through the proxy, hitting the real Gonka Broker API and spending real tokens

```bash
curl http://localhost:4000/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gonkabroker-model","messages":[{"role":"user","content":"Reply with exactly: GonkaBroker LiteLLM proof OK"}]}'
```

Response

```json
{"id":"devshard-10498-19","created":1782333245,"model":"gonkabroker-model","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"GonkaBroker LiteLLM proof OK","role":"assistant"}}],"usage":{"completion_tokens":10,"prompt_tokens":20,"total_tokens":30}}
```

## Type

🆕 New Feature

## Changes

Registers Gonka Broker as an OpenAI-compatible provider by adding an entry to `litellm/llms/openai_like/providers.json` and documenting it in `provider_endpoints_support.json` (required by the `check_provider_folders_documented` CI check). Gonka Broker is an OpenAI-compatible gateway to open-source models on the decentralized Gonka network, reachable at `https://proxy.gonkabroker.com/v1` with the key read from `GONKABROKER_API_KEY`. Models are addressed as `gonkabroker/<model-id>` and the always-current catalog is published at `https://proxy.gonkabroker.com/v1/models`. A companion documentation page is opened separately against BerriAI/litellm-docs