### PR TITLE
fix(google_genai): forward native generateContent top-level fields

### DIFF
--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -49,6 +49,7 @@ class GenerateContentSetupResult(BaseModel):
     custom_llm_provider: str
     generate_content_provider_config: Optional[BaseGoogleGenAIGenerateContentConfig]
     generate_content_config_dict: Dict[str, Any]
+    native_request_fields: dict[str, object]
     litellm_params: GenericLiteLLMParams
     litellm_logging_obj: LiteLLMLoggingObj
     litellm_call_id: Optional[str]
@@ -152,6 +153,7 @@ class GenerateContentHelper:
                 request_body={},  # Will be handled by adapter
                 generate_content_provider_config=None,  # type: ignore
                 generate_content_config_dict=dict(config or {}),
+                native_request_fields={},
                 litellm_params=litellm_params,
                 litellm_logging_obj=litellm_logging_obj,
                 litellm_call_id=litellm_call_id,
@@ -171,6 +173,12 @@ class GenerateContentHelper:
         system_instruction = kwargs.get("systemInstruction") or kwargs.get(
             "system_instruction"
         )
+        # Native top-level REST fields arrive as loose kwargs and are otherwise dropped.
+        native_request_fields: dict[str, object] = {
+            field: kwargs[field]
+            for field in generate_content_provider_config.get_generate_content_request_top_level_fields()
+            if field in kwargs
+        }
         request_body = (
             generate_content_provider_config.transform_generate_content_request(
                 model=model,
@@ -201,10 +209,27 @@ class GenerateContentHelper:
             request_body=request_body,
             generate_content_provider_config=generate_content_provider_config,
             generate_content_config_dict=generate_content_config_dict,
+            native_request_fields=native_request_fields,
             litellm_params=litellm_params,
             litellm_logging_obj=litellm_logging_obj,
             litellm_call_id=litellm_call_id,
         )
+
+
+def _merge_native_request_fields(
+    native_request_fields: dict[str, object],
+    extra_body: Optional[dict[str, object]],
+) -> Optional[dict[str, object]]:
+    """
+    Merge native top-level request fields into ``extra_body`` so the HTTP handler
+    forwards them verbatim onto the outgoing request body. An explicit ``extra_body``
+    value wins on conflict. Returns ``None`` only when there is genuinely nothing to
+    forward (no native fields and no caller-supplied ``extra_body``), preserving the
+    prior behavior without discarding an explicit ``extra_body={}``.
+    """
+    if not native_request_fields and extra_body is None:
+        return None
+    return {**native_request_fields, **(extra_body or {})}
 
 
 @client
@@ -350,7 +375,9 @@ def generate_content(
             litellm_params=setup_result.litellm_params,
             logging_obj=setup_result.litellm_logging_obj,
             extra_headers=extra_headers,
-            extra_body=extra_body,
+            extra_body=_merge_native_request_fields(
+                setup_result.native_request_fields, extra_body
+            ),
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
@@ -447,7 +474,9 @@ async def agenerate_content_stream(
             litellm_params=setup_result.litellm_params,
             logging_obj=setup_result.litellm_logging_obj,
             extra_headers=extra_headers,
-            extra_body=extra_body,
+            extra_body=_merge_native_request_fields(
+                setup_result.native_request_fields, extra_body
+            ),
             timeout=timeout or request_timeout,
             _is_async=True,
             client=kwargs.get("client"),
@@ -503,6 +532,11 @@ def generate_content_stream(
             **kwargs,
         )
 
+        # Extract systemInstruction from kwargs to pass to handler
+        system_instruction = kwargs.get("systemInstruction") or kwargs.get(
+            "system_instruction"
+        )
+
         # Check if we should use the adapter (when provider config is None)
         if setup_result.generate_content_provider_config is None:
             if "stream" in kwargs:
@@ -531,12 +565,15 @@ def generate_content_stream(
             litellm_params=setup_result.litellm_params,
             logging_obj=setup_result.litellm_logging_obj,
             extra_headers=extra_headers,
-            extra_body=extra_body,
+            extra_body=_merge_native_request_fields(
+                setup_result.native_request_fields, extra_body
+            ),
             timeout=timeout or request_timeout,
             _is_async=_is_async,
             client=kwargs.get("client"),
             stream=True,
             litellm_metadata=kwargs.get("litellm_metadata", {}),
+            system_instruction=system_instruction,
         )
 
     except Exception as e:

--- a/litellm/llms/base_llm/google_genai/transformation.py
+++ b/litellm/llms/base_llm/google_genai/transformation.py
@@ -62,6 +62,19 @@ class BaseGoogleGenAIGenerateContentConfig(ABC):
             "get_supported_generate_content_optional_params is not implemented"
         )
 
+    def get_generate_content_request_top_level_fields(self) -> tuple[str, ...]:
+        """
+        Native Google ``GenerateContentRequest`` fields that sit at the top level
+        (siblings of ``generationConfig``) rather than inside it. The proxy forwards
+        these verbatim from a native request so ``generateContent`` is a drop-in for
+        Google's REST API.
+
+        Excludes ``contents``, ``model`` and ``tools`` (dedicated params),
+        ``systemInstruction`` (dedicated extraction) and ``generationConfig`` (mapped
+        to ``config``).
+        """
+        return ("safetySettings", "toolConfig", "cachedContent", "labels")
+
     @abstractmethod
     def map_generate_content_optional_params(
         self,

--- a/tests/test_litellm/google_genai/test_google_genai_main.py
+++ b/tests/test_litellm/google_genai/test_google_genai_main.py
@@ -2,6 +2,7 @@
 """
 Test to verify the Google GenAI generate_content adapter functionality
 """
+
 import json
 import os
 import sys
@@ -42,4 +43,228 @@ async def test_agenerate_content_stream():
             stream=True,
         )
         mock_post.assert_called_once()
-        mock_post.call_args.kwargs["stream"] == True
+        assert mock_post.call_args.kwargs["stream"] is True
+
+
+def _mock_gemini_post_response():
+    """A minimal stand-in for a successful Gemini generateContent HTTP response."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.json.return_value = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "hi"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ]
+    }
+    return resp
+
+
+NATIVE_TOP_LEVEL_FIELD_CASES = [
+    (
+        "safetySettings",
+        [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}],
+    ),
+    ("toolConfig", {"functionCallingConfig": {"mode": "AUTO"}}),
+    ("cachedContent", "cachedContents/abc123"),
+    ("labels", {"team": "search"}),
+]
+
+
+@pytest.mark.parametrize("field_name, field_value", NATIVE_TOP_LEVEL_FIELD_CASES)
+def test_native_top_level_field_forwarded_to_request_body(field_name, field_value):
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/12671
+
+    Google's native generateContent body carries fields like safetySettings at the
+    top level (siblings of generationConfig). The proxy spreads them as loose kwargs
+    into generate_content. They must reach Google's request body at the top level and
+    must NOT be silently dropped nor nested under generationConfig.
+    """
+    from unittest.mock import patch
+
+    from litellm.google_genai.main import generate_content
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    with patch.object(
+        HTTPHandler, "post", return_value=_mock_gemini_post_response()
+    ) as mock_post:
+        generate_content(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            **{field_name: field_value},
+        )
+
+    assert mock_post.called, "expected the request to reach the HTTP client"
+    body = mock_post.call_args.kwargs["json"]
+    assert (
+        body[field_name] == field_value
+    ), f"{field_name} should be forwarded to Google at the top level"
+    assert field_name not in body.get("generationConfig", {}), (
+        f"{field_name} must be a top-level sibling of generationConfig, "
+        "not nested inside it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_safety_settings_forwarded_async():
+    """The async path (used by the proxy's :generateContent route) must also forward
+    native top-level fields."""
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.google_genai.main import agenerate_content
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+    ]
+
+    with patch.object(
+        AsyncHTTPHandler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=_mock_gemini_post_response(),
+    ) as mock_post:
+        await agenerate_content(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            safetySettings=safety_settings,
+        )
+
+    assert mock_post.called
+    body = mock_post.call_args.kwargs["json"]
+    assert body["safetySettings"] == safety_settings
+    assert "safetySettings" not in body.get("generationConfig", {})
+
+
+def test_native_fields_coexist_with_generation_config():
+    """Forwarding native top-level fields must not regress the already-working
+    generationConfig path; both must land in their correct positions."""
+    from unittest.mock import patch
+
+    from litellm.google_genai.main import generate_content
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+    ]
+
+    with patch.object(
+        HTTPHandler, "post", return_value=_mock_gemini_post_response()
+    ) as mock_post:
+        generate_content(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            safetySettings=safety_settings,
+            generationConfig={"temperature": 0, "responseMimeType": "application/json"},
+        )
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["safetySettings"] == safety_settings
+    generation_config = body["generationConfig"]
+    assert generation_config["temperature"] == 0
+    assert generation_config["responseMimeType"] == "application/json"
+
+
+def test_explicit_extra_body_overrides_native_top_level_field():
+    """An explicit extra_body value takes precedence over the same top-level field."""
+    from unittest.mock import patch
+
+    from litellm.google_genai.main import generate_content
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    native = [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}]
+    override = [
+        {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_ONLY_HIGH"}
+    ]
+
+    with patch.object(
+        HTTPHandler, "post", return_value=_mock_gemini_post_response()
+    ) as mock_post:
+        generate_content(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            safetySettings=native,
+            extra_body={"safetySettings": override},
+        )
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["safetySettings"] == override
+
+
+def test_native_fields_and_system_instruction_forwarded_on_sync_stream():
+    """The sync streaming path (generate_content_stream) must forward native top-level
+    fields AND systemInstruction. The PR changed the merge here and newly added the
+    systemInstruction kwarg; without coverage a regression on either ships green."""
+    from unittest.mock import patch
+
+    from litellm.google_genai.main import generate_content_stream
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+    ]
+    system_instruction = {"parts": [{"text": "Be terse"}]}
+
+    with patch.object(
+        HTTPHandler, "post", return_value=_mock_gemini_post_response()
+    ) as mock_post:
+        generate_content_stream(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            safetySettings=safety_settings,
+            systemInstruction=system_instruction,
+        )
+
+    assert mock_post.called
+    body = mock_post.call_args.kwargs["json"]
+    assert body["safetySettings"] == safety_settings
+    assert body["systemInstruction"] == system_instruction
+    assert "safetySettings" not in body.get("generationConfig", {})
+
+
+@pytest.mark.asyncio
+async def test_native_fields_forwarded_on_async_stream():
+    """The async streaming path (agenerate_content_stream) backs the proxy's
+    :streamGenerateContent route and must forward native top-level fields too."""
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.google_genai.main import agenerate_content_stream
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+    safety_settings = [
+        {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}
+    ]
+
+    with patch.object(
+        AsyncHTTPHandler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=_mock_gemini_post_response(),
+    ) as mock_post:
+        await agenerate_content_stream(
+            model="gemini/gemini-2.0-flash",
+            contents=[{"role": "user", "parts": [{"text": "Say hi"}]}],
+            custom_llm_provider="gemini",
+            api_key="test-key",
+            safetySettings=safety_settings,
+        )
+
+    assert mock_post.called
+    body = mock_post.call_args.kwargs["json"]
+    assert body["safetySettings"] == safety_settings
+    assert "safetySettings" not in body.get("generationConfig", {})


### PR DESCRIPTION
## Relevant issues

Fixes #12671

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Run a local proxy against real Gemini (with a `gemini/gemini-2.0-flash` model configured) and confirm the native top-level fields are now honored. The clearest signal is `safetySettings`: before this change the response came back with `"safetyRatings":null`, and the only way to make it stick was to wrap it in `extra_body`. After this change the native top-level field works on its own and the response carries populated `safetyRatings`

1. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. ```
   curl -L -X POST 'http://localhost:4000/v1beta/models/gemini-2.0-flash:generateContent' \
     -H 'content-type: application/json' -H 'authorization: Bearer sk-1234' \
     -d '{"contents":[{"parts":[{"text":"Say hi"}]}],
          "safetySettings":[{"category":"HARM_CATEGORY_HATE_SPEECH","threshold":"BLOCK_NONE"}]}'
   ```
3. Confirm the response now includes a populated `safetyRatings` array (it was `null` before)
4. As a non-regression check, the structured-output and `systemInstruction` examples from the issue still behave correctly

## Type

🐛 Bug Fix

## Changes

The proxy's native `generateContent` endpoint is meant to be a drop-in for Google's REST API, but it silently dropped most of the top-level fields Google's `GenerateContentRequest` carries as siblings of `generationConfig`: `safetySettings`, `toolConfig`, `cachedContent` and `labels`. They arrived in the request body, survived the proxy, were spread into `agenerate_content` as loose kwargs, and were then never read, so `safetySettings` in particular was ignored unless the caller wrapped it in `extra_body`. `generationConfig` and `systemInstruction` were already handled by earlier fixes; this completes the set

The provider config now exposes the native top-level field names through `get_generate_content_request_top_level_fields`, and `setup_generate_content_call` collects whichever of them are present and forwards them to Google verbatim by routing them through the existing `extra_body` merge in the shared HTTP handler. This keeps the change in one place and applies uniformly to the Gemini and Vertex configs as well as the sync, async and streaming paths. An explicit `extra_body` still wins on conflict. While wiring this up I also noticed the sync `generate_content_stream` path never forwarded `systemInstruction`, unlike the other three entry points, so it now does too

Tests live in `tests/test_litellm/google_genai/test_google_genai_main.py` and assert on the captured outgoing request body: each native top-level field lands at the top level and not nested under `generationConfig`, the async path behaves the same, the fields coexist with `generationConfig`, and an explicit `extra_body` override takes precedence. The sync and async streaming paths are covered too, including the `systemInstruction` forwarding added to `generate_content_stream`. With the source change reverted these tests fail because the fields are dropped
