### PR TITLE
fix(mcp): degrade quietly when an upstream lacks resources/prompts

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -18,7 +18,13 @@ from typing import (
     Union,
 )
 import httpx
-from mcp import ClientSession, ReadResourceResult, Resource, StdioServerParameters
+from mcp import (
+    ClientSession,
+    McpError,
+    ReadResourceResult,
+    Resource,
+    StdioServerParameters,
+)
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 
@@ -32,6 +38,7 @@ except ImportError:
 from mcp.types import CallToolRequestParams as MCPCallToolRequestParams
 from mcp.types import CallToolResult as MCPCallToolResult
 from mcp.types import (
+    METHOD_NOT_FOUND,
     GetPromptRequestParams,
     GetPromptResult,
     Prompt,
@@ -75,6 +82,10 @@ def _first_non_cancelled_cause(exc: BaseException) -> Optional[BaseException]:
         elif not isinstance(current, asyncio.CancelledError):
             return current
     return None
+
+
+def _is_method_not_found(exc: BaseException) -> bool:
+    return isinstance(exc, McpError) and getattr(exc.error, "code", None) == METHOD_NOT_FOUND
 
 
 TSessionResult = TypeVar("TSessionResult")
@@ -389,8 +400,9 @@ class MCPClient:
             self._last_initialize_instructions = None
             transport_ctx, http_client = self._create_transport_context()
             return await self._execute_session_operation(transport_ctx, operation)
-        except Exception:
-            verbose_logger.warning("MCP client run_with_session failed for %s", self.server_url or "stdio")
+        except Exception as e:
+            if not _is_method_not_found(e):
+                verbose_logger.warning("MCP client run_with_session failed for %s", self.server_url or "stdio")
             raise
         finally:
             if http_client is not None:
@@ -604,6 +616,12 @@ class MCPClient:
             verbose_logger.warning("MCP client list_prompts was cancelled")
             raise
         except Exception as e:
+            if _is_method_not_found(e):
+                verbose_logger.debug(
+                    f"MCP server {self.server_url or 'stdio'} does not support "
+                    f"prompts/list (method not found); returning empty list"
+                )
+                return []
             error_type = type(e).__name__
             verbose_logger.error(
                 f"MCP client list_prompts failed - "
@@ -681,6 +699,12 @@ class MCPClient:
             verbose_logger.warning("MCP client list_resources was cancelled")
             raise
         except Exception as e:
+            if _is_method_not_found(e):
+                verbose_logger.debug(
+                    f"MCP server {self.server_url or 'stdio'} does not support "
+                    f"resources/list (method not found); returning empty list"
+                )
+                return []
             error_type = type(e).__name__
             verbose_logger.error(
                 f"MCP client list_resources failed - "

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from mcp import McpError
+from mcp.types import INTERNAL_ERROR, METHOD_NOT_FOUND, ErrorData
 
 # Add the parent directory to the path so we can import litellm
 sys.path.insert(0, "../../../")
@@ -626,6 +628,73 @@ async def test_get_prompt_does_not_log_arguments():
     logged = _all_logged_messages(mock_logger)
     assert "my_prompt" in logged
     assert secret not in logged
+
+
+class TestMethodNotFoundDegradesQuietly:
+    """An upstream that does not implement resources/prompts replies with the
+    JSON-RPC ``-32601`` (Method not found) error. LiteLLM must treat that as an
+    empty capability list and log it at DEBUG, not ERROR/WARNING, so a tools-only
+    server (issue #31179) does not flood the logs.
+    """
+
+    def _client_raising(self, mock_session_cls, operation_name, error):
+        client = MCPClient(server_url="http://example.com/mcp", transport_type="http")
+
+        init_result = MagicMock()
+        init_result.instructions = None
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock(return_value=init_result)
+        setattr(mock_session, operation_name, AsyncMock(side_effect=error))
+
+        session_ctx = MagicMock()
+        session_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+        session_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_session_cls.return_value = session_ctx
+
+        transport_ctx = MagicMock()
+        transport_ctx.__aenter__ = AsyncMock(return_value=(MagicMock(), MagicMock()))
+        transport_ctx.__aexit__ = AsyncMock(return_value=False)
+        client._create_transport_context = MagicMock(return_value=(transport_ctx, None))
+        return client
+
+    @pytest.mark.parametrize(
+        "list_method, operation_name",
+        [("list_resources", "list_resources"), ("list_prompts", "list_prompts")],
+    )
+    @pytest.mark.asyncio
+    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    async def test_method_not_found_returns_empty_at_debug(
+        self, mock_session_cls, list_method, operation_name
+    ):
+        error = McpError(ErrorData(code=METHOD_NOT_FOUND, message="Method not found"))
+        client = self._client_raising(mock_session_cls, operation_name, error)
+
+        with patch.object(mcp_client_module, "verbose_logger") as mock_logger:
+            result = await getattr(client, list_method)()
+
+        assert result == []
+        mock_logger.error.assert_not_called()
+        mock_logger.warning.assert_not_called()
+        assert mock_logger.debug.called
+
+    @pytest.mark.parametrize(
+        "list_method, operation_name",
+        [("list_resources", "list_resources"), ("list_prompts", "list_prompts")],
+    )
+    @pytest.mark.asyncio
+    @patch("litellm.experimental_mcp_client.client.ClientSession")
+    async def test_other_mcp_error_still_logs_error(
+        self, mock_session_cls, list_method, operation_name
+    ):
+        error = McpError(ErrorData(code=INTERNAL_ERROR, message="boom"))
+        client = self._client_raising(mock_session_cls, operation_name, error)
+
+        with patch.object(mcp_client_module, "verbose_logger") as mock_logger:
+            result = await getattr(client, list_method)()
+
+        assert result == []
+        mock_logger.error.assert_called()
+        mock_logger.warning.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Fixes #31179

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The bug lives in the MCP aggregation path, which never calls an LLM, so no provider API keys are needed; the only credential is the self-chosen proxy master key. Any upstream that implements tools but not resources/prompts reproduces it. Run these in order

1. Save a tools-only upstream MCP server as `mcp_tools_only_server.py`

```python
import contextlib
from collections.abc import AsyncIterator

import mcp.types as types
from mcp.server.lowlevel import Server
from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
from starlette.applications import Starlette
from starlette.routing import Mount
from starlette.types import Receive, Scope, Send

app = Server("tools-only-server")


@app.list_tools()
async def list_tools():
    return [
        types.Tool(
            name="echo",
            description="Echo back the provided text",
            inputSchema={
                "type": "object",
                "properties": {"text": {"type": "string"}},
                "required": ["text"],
            },
        )
    ]


@app.call_tool()
async def call_tool(name, arguments):
    return [types.TextContent(type="text", text=f"Echo: {arguments.get('text', '')}")]


session_manager = StreamableHTTPSessionManager(app=app, json_response=False, stateless=True)


async def handle_mcp(scope: Scope, receive: Receive, send: Send) -> None:
    await session_manager.handle_request(scope, receive, send)


@contextlib.asynccontextmanager
async def lifespan(_app: Starlette) -> AsyncIterator[None]:
    async with session_manager.run():
        yield


starlette_app = Starlette(routes=[Mount("/mcp", app=handle_mcp)], lifespan=lifespan)

if __name__ == "__main__":
    import uvicorn

    uvicorn.run(starlette_app, host="127.0.0.1", port=9000, log_level="warning")
```

2. Point the proxy at it with this `mcp_config.yaml`

```yaml
mcp_servers:
  toolsonly:
    url: "http://127.0.0.1:9000/mcp"
    transport: "http"
    auth_type: "none"

general_settings:
  master_key: sk-1234
```

3. Start both

```bash
python mcp_tools_only_server.py &
python litellm/proxy/proxy_cli.py --config mcp_config.yaml --detailed_debug 2>&1 | tee litellm.log
```

4. Trigger aggregation from a client

```bash
curl -s -X POST http://127.0.0.1:4000/mcp \
  -H "x-litellm-api-key: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
```

Before this change, `litellm.log` showed an ERROR plus a `run_with_session failed` WARNING for every resources/list and prompts/list call against this upstream even though tools were served fine and the response came back as an empty list. After this change the same run logs the condition once at DEBUG (`MCP server ... does not support resources/list (method not found); returning empty list`) and the ERROR/WARNING are gone, while genuine failures (auth, network, other JSON-RPC errors) still log at ERROR

## Type

🐛 Bug Fix

## Changes

The MCP protocol does not require a server to implement every capability family; a tools-only server answers resources/list and prompts/list with JSON-RPC `-32601` Method not found. `MCPClient.list_resources` and `list_prompts` already degraded to an empty list, but they logged the benign `-32601` at ERROR, and `run_with_session` logged an accompanying WARNING, so a perfectly healthy tools-only upstream flooded the logs on every aggregation

This adds a small `_is_method_not_found` helper that recognizes an `McpError` carrying `mcp.types.METHOD_NOT_FOUND`. The two list methods now log that specific case at DEBUG and return an empty list, and `run_with_session` skips its generic warning for it. Every other error keeps the existing ERROR logging and re-raise behavior, so real failures are still surfaced
