### PR TITLE
fix(bedrock): route opus-4-6 to native output_config.format for structured outputs

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -11,7 +11,10 @@ from litellm.litellm_core_utils.prompt_templates.image_handling import (
     async_convert_url_to_base64,
     convert_url_to_base64,
 )
-from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+from litellm.llms.anthropic.chat.transformation import (
+    AnthropicConfig,
+    RESPONSE_FORMAT_TOOL_NAME,
+)
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
 )
@@ -34,6 +37,28 @@ if TYPE_CHECKING:
     LiteLLMLoggingObj = _LiteLLMLoggingObj
 else:
     LiteLLMLoggingObj = Any
+
+
+def _add_additional_properties_false(schema: dict) -> dict:
+    """Add ``additionalProperties: false`` to every object node in ``schema``.
+
+    AWS Bedrock Invoke rejects ``output_config.format`` schemas that contain
+    any object-type node without this field.  Walk the tree so nested objects
+    (array items, sub-keys) also satisfy the requirement.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    result = dict(schema)
+    if result.get("type") == "object":
+        result["additionalProperties"] = False
+        if "properties" in result:
+            result["properties"] = {
+                k: _add_additional_properties_false(v)
+                for k, v in result["properties"].items()
+            }
+    if "items" in result:
+        result["items"] = _add_additional_properties_false(result["items"])
+    return result
 
 
 class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
@@ -66,6 +91,20 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
     def get_supported_openai_params(self, model: str) -> List[str]:
         return AnthropicConfig.get_supported_openai_params(self, model)
 
+    # Bedrock-invoke models AWS hasn't shipped native output_config.format for yet.
+    # Remove from this set as AWS adds support — empirically verified Jun 2026.
+    _BEDROCK_INVOKE_NATIVE_OUTPUT_FORMAT_EXCLUSIONS = frozenset(
+        {
+            "opus-4-7", "opus_4_7", "opus-4.7", "opus_4.7",
+            "opus-4-8", "opus_4_8", "opus-4.8", "opus_4.8",
+        }
+    )
+
+    @classmethod
+    def _needs_tool_workaround(cls, model: str) -> bool:
+        m = model.lower()
+        return any(s in m for s in cls._BEDROCK_INVOKE_NATIVE_OUTPUT_FORMAT_EXCLUSIONS)
+
     def map_openai_params(
         self,
         non_default_params: dict,
@@ -73,13 +112,18 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        # Force tool-based structured outputs for Bedrock Invoke
-        # (similar to VertexAI fix in #19201)
-        # Bedrock Invoke doesn't support output_format parameter
-        original_model = model
-        if "response_format" in non_default_params:
-            # Use a model name that forces tool-based approach
-            model = "claude-3-sonnet-20240229"
+        # For models AWS doesn't accept native output_config.format on yet, force
+        # the tool path WITHOUT renaming the model: pop response_format before
+        # delegating so the parent maps everything else (incl. adaptive thinking)
+        # against the real model name, then inject the synthetic tool ourselves.
+        response_format = None
+        if "response_format" in non_default_params and self._needs_tool_workaround(
+            model
+        ):
+            response_format = non_default_params["response_format"]
+            non_default_params = {
+                k: v for k, v in non_default_params.items() if k != "response_format"
+            }
 
         # Clamp ``reasoning_effort`` to the Bedrock effort ceiling before the
         # parent mapping converts it to ``output_config.effort`` and the
@@ -89,7 +133,7 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
         # requests degrade ``xhigh`` -> ``max`` rather than 400-ing on
         # models like Opus 4.6 that don't natively advertise xhigh.
         self._clamp_adaptive_reasoning_effort_for_bedrock(
-            model=original_model, params=non_default_params
+            model=model, params=non_default_params
         )
 
         optional_params = AnthropicConfig.map_openai_params(
@@ -100,8 +144,21 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
             drop_params,
         )
 
-        # Restore original model name
-        model = original_model
+        if response_format is not None:
+            is_thinking = self.is_thinking_enabled(non_default_params)
+            tool = self.map_response_format_to_anthropic_tool(
+                response_format, optional_params, is_thinking
+            )
+            if tool is not None:
+                optional_params = self._add_tools_to_optional_params(
+                    optional_params, tools=[tool]
+                )
+                if not is_thinking:
+                    optional_params["tool_choice"] = {
+                        "name": RESPONSE_FORMAT_TOOL_NAME,
+                        "type": "tool",
+                    }
+                optional_params["json_mode"] = True
 
         return optional_params
 
@@ -221,15 +278,33 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
             anthropic_request
         )
         if output_format:
-            convert_bedrock_invoke_output_format_to_inline_schema(
-                output_format=output_format,
-                request_body=anthropic_request,
-            )
+            if self._needs_tool_workaround(model):
+                convert_bedrock_invoke_output_format_to_inline_schema(
+                    output_format=output_format,
+                    request_body=anthropic_request,
+                )
+            else:
+                schema = _add_additional_properties_false(
+                    output_format.get("schema", {})
+                )
+                anthropic_request.setdefault("output_config", {})["format"] = {
+                    "type": output_format.get("type", "json_schema"),
+                    "schema": schema,
+                }
         elif output_config_format:
-            convert_bedrock_invoke_output_format_to_inline_schema(
-                output_format=output_config_format,
-                request_body=anthropic_request,
-            )
+            if self._needs_tool_workaround(model):
+                convert_bedrock_invoke_output_format_to_inline_schema(
+                    output_format=output_config_format,
+                    request_body=anthropic_request,
+                )
+            else:
+                schema = _add_additional_properties_false(
+                    output_config_format.get("schema", {})
+                )
+                anthropic_request.setdefault("output_config", {})["format"] = {
+                    "type": output_config_format.get("type", "json_schema"),
+                    "schema": schema,
+                }
         if not (
             _supports_factory(
                 model=model,

--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -95,8 +95,14 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
     # Remove from this set as AWS adds support — empirically verified Jun 2026.
     _BEDROCK_INVOKE_NATIVE_OUTPUT_FORMAT_EXCLUSIONS = frozenset(
         {
-            "opus-4-7", "opus_4_7", "opus-4.7", "opus_4.7",
-            "opus-4-8", "opus_4_8", "opus-4.8", "opus_4.8",
+            "opus-4-7",
+            "opus_4_7",
+            "opus-4.7",
+            "opus_4.7",
+            "opus-4-8",
+            "opus_4_8",
+            "opus-4.8",
+            "opus_4.8",
         }
     )
 

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -51,6 +51,7 @@ IGNORE_FUNCTIONS = [
     "_resolve",  # OCI: $ref resolver bounded by `resolving_stack` cycle guard.
     "resolve_oci_schema_anyof",  # OCI: bounded by JSON-schema tree depth (no cycles possible in well-formed input).
     "sanitize_oci_schema",  # OCI: bounded by JSON-schema tree depth.
+    "_add_additional_properties_false",  # bounded by JSON-schema tree depth (no cycles possible in well-formed schema input).
 ]
 
 


### PR DESCRIPTION
## Problem

When using `response_format` with `bedrock/invoke/` models, `map_openai_params` unconditionally renamed the model to `claude-3-sonnet-20240229` before calling the parent. This forced **all** Bedrock Invoke models through the tool-based workaround path (`convert_bedrock_invoke_output_format_to_inline_schema`), which embeds the schema as a text block in the last user message. The model then returns the result wrapped in ` ```json\n{...}\n``` ` markdown — causing Pydantic parsing failures in downstream code.

Root cause chain:
1. `map_openai_params` renamed model to `claude-3-sonnet-20240229` for all `response_format` calls → forced tool workaround for everyone
2. Tool workaround wraps output in markdown → downstream `json.loads` / Pydantic fails
3. `claude-opus-4-6` (and earlier models) natively support `output_config.format` on Bedrock Invoke — no workaround needed

## Fix

- Add `_BEDROCK_INVOKE_NATIVE_OUTPUT_FORMAT_EXCLUSIONS` containing only `opus-4-7`/`opus-4-8` (not yet confirmed for native support)
- Add `_needs_tool_workaround()` routing method: excluded models get the tool path; all others (including `opus-4-6`) use the native `output_config.format` path
- Add `_add_additional_properties_false()` helper: AWS Bedrock Invoke requires `additionalProperties: false` on every object-type schema node; applied recursively (bounded by JSON-schema tree depth — no cycles possible in well-formed input; added to `recursive_detector.py` allowlist)
- Remove the model rename hack — the real model name is now preserved throughout

## Verification

Tested against AWS Bedrock Invoke via a live LiteLLM proxy (2026-06-24):

**Flat schema:**
```bash
curl http://<litellm-proxy>/chat/completions \
  -H "Authorization: Bearer <key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/invoke/us.anthropic.claude-opus-4-6-v1",
    "messages": [{"role": "user", "content": "Reply with a JSON object with a single field called answer with value hello"}],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "Answer",
        "schema": {
          "type": "object",
          "properties": {"answer": {"type": "string"}},
          "required": ["answer"]
        }
      }
    },
    "max_tokens": 100
  }'
# → content: '{"answer":"hello"}'  ✅ clean JSON, no markdown wrapper
```

**Nested schema (tests `additionalProperties` recursion):**
```bash
curl http://<litellm-proxy>/chat/completions \
  -H "Authorization: Bearer <key>" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/invoke/us.anthropic.claude-opus-4-6-v1",
    "messages": [{"role": "user", "content": "Return JSON with name=Alice and address.city=NYC"}],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "Person",
        "schema": {
          "type": "object",
          "properties": {
            "name": {"type": "string"},
            "address": {
              "type": "object",
              "properties": {"city": {"type": "string"}},
              "required": ["city"]
            }
          },
          "required": ["name", "address"]
        }
      }
    },
    "max_tokens": 100
  }'
# → content: '{"name":"Alice","address":{"city":"NYC"}}'  ✅ clean JSON
```

## Notes

- `opus-4-7` and `opus-4-8` remain in `_BEDROCK_INVOKE_NATIVE_OUTPUT_FORMAT_EXCLUSIONS` until their native support is confirmed with AWS
- The `structured-outputs-2025-11-13` beta header is **not** added — structured outputs graduated from beta; Bedrock Invoke rejects that header entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)