### PR TITLE
fix(streaming): honor per-request stream_timeout as wall-clock cap for Vertex AI and Bedrock

### DIFF
--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -121,6 +121,7 @@ class CustomStreamWrapper:
         stream_options=None,
         make_call: Optional[Callable] = None,
         _response_headers: Optional[dict] = None,
+        max_streaming_duration: Optional[float] = None,
     ):
         self.model = model
         self.make_call = make_call
@@ -130,6 +131,7 @@ class CustomStreamWrapper:
         self.sent_first_chunk = False
         self.sent_last_chunk = False
         self._stream_created_time: float = time.time()
+        self._max_streaming_duration: Optional[float] = max_streaming_duration
 
         litellm_params: GenericLiteLLMParams = GenericLiteLLMParams(
             **self.logging_obj.model_call_details.get("litellm_params", {})
@@ -222,15 +224,29 @@ class CustomStreamWrapper:
         self._post_streaming_hooks: Optional[List] = None
 
     def _check_max_streaming_duration(self) -> None:
-        """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""
+        """Raise litellm.Timeout if the stream has exceeded its duration cap.
+
+        The cap is resolved in priority order:
+        1. ``max_streaming_duration`` passed to the constructor (set from the
+           Router's per-deployment / per-request ``stream_timeout``).
+        2. The global ``LITELLM_MAX_STREAMING_DURATION_SECONDS`` env-var
+           constant (applies when no per-request cap is configured).
+
+        This covers the case where a provider returns HTTP 200 and begins
+        streaming but then stalls mid-stream — the httpx read timeout is
+        satisfied by each chunk individually and would not fire, but this
+        wall-clock guard fires on the next ``__anext__`` call after the cap
+        is exceeded.
+        """
         from litellm.constants import LITELLM_MAX_STREAMING_DURATION_SECONDS
 
-        if LITELLM_MAX_STREAMING_DURATION_SECONDS is None:
+        cap = self._max_streaming_duration or LITELLM_MAX_STREAMING_DURATION_SECONDS
+        if cap is None:
             return
         elapsed = time.time() - self._stream_created_time
-        if elapsed > LITELLM_MAX_STREAMING_DURATION_SECONDS:
+        if elapsed > cap:
             raise litellm.Timeout(
-                message=f"Stream exceeded max streaming duration of {LITELLM_MAX_STREAMING_DURATION_SECONDS}s (elapsed {elapsed:.1f}s)",
+                message=f"Stream exceeded max streaming duration of {cap}s (elapsed {elapsed:.1f}s)",
                 model=self.model or "",
                 llm_provider=self.custom_llm_provider or "",
             )

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -157,6 +157,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             model=model,
             custom_llm_provider="bedrock",
             logging_obj=logging_obj,
+            max_streaming_duration=timeout if isinstance(timeout, float) else None,
         )
         return streaming_response
 

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1372,6 +1372,7 @@ class BedrockLLM(BaseAWSLLM):
             model=model,
             custom_llm_provider="bedrock",
             logging_obj=logging_obj,
+            max_streaming_duration=timeout if isinstance(timeout, float) else None,
         )
         return streaming_response
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3005,6 +3005,7 @@ class VertexLLM(VertexBase):
             model=model,
             custom_llm_provider="vertex_ai_beta",
             logging_obj=logging_obj,
+            max_streaming_duration=timeout if isinstance(timeout, float) else None,
         )
         return streaming_response
 
@@ -3297,6 +3298,7 @@ class VertexLLM(VertexBase):
                 model=model,
                 custom_llm_provider="vertex_ai_beta",
                 logging_obj=logging_obj,
+                max_streaming_duration=timeout if isinstance(timeout, float) else None,
             )
 
             return streaming_response

--- a/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
+++ b/tests/test_litellm/litellm_core_utils/test_max_streaming_duration.py
@@ -77,6 +77,66 @@ class TestCustomStreamWrapperMaxDuration:
                 await wrapper.__anext__()
 
 
+class TestCustomStreamWrapperPerRequestMaxDuration:
+    """Per-request max_streaming_duration passed to constructor takes priority over the
+    global LITELLM_MAX_STREAMING_DURATION_SECONDS env-var constant."""
+
+    def test_per_request_cap_raises_when_exceeded(self):
+        """Constructor max_streaming_duration fires independently of global constant."""
+        wrapper = CustomStreamWrapper(
+            completion_stream=None,
+            model="test-model",
+            logging_obj=MagicMock(),
+            custom_llm_provider="vertex_ai",
+            max_streaming_duration=5.0,
+        )
+        wrapper._stream_created_time = time.time() - 10  # simulate 10s elapsed
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", None):
+            with pytest.raises(litellm.Timeout, match="5.0s"):
+                wrapper._check_max_streaming_duration()
+
+    def test_per_request_cap_does_not_raise_when_under_limit(self):
+        """No error when elapsed time is within the per-request cap."""
+        wrapper = CustomStreamWrapper(
+            completion_stream=None,
+            model="test-model",
+            logging_obj=MagicMock(),
+            custom_llm_provider="bedrock",
+            max_streaming_duration=60.0,
+        )
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", None):
+            wrapper._check_max_streaming_duration()  # should not raise
+
+    def test_per_request_cap_wins_over_larger_global(self):
+        """Per-request cap (20s) fires before larger global cap (120s)."""
+        wrapper = CustomStreamWrapper(
+            completion_stream=None,
+            model="test-model",
+            logging_obj=MagicMock(),
+            custom_llm_provider="vertex_ai",
+            max_streaming_duration=20.0,
+        )
+        wrapper._stream_created_time = time.time() - 30  # 30s elapsed
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 120.0):
+            with pytest.raises(litellm.Timeout, match="20.0s"):
+                wrapper._check_max_streaming_duration()
+
+    def test_global_cap_applies_when_no_per_request_cap(self):
+        """Falls back to global constant when max_streaming_duration is None."""
+        wrapper = _make_custom_stream_wrapper()
+        wrapper._stream_created_time = time.time() - 30
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", 10.0):
+            with pytest.raises(litellm.Timeout, match="10.0s"):
+                wrapper._check_max_streaming_duration()
+
+    def test_no_cap_set_does_not_raise(self):
+        """Neither per-request nor global cap → no error regardless of elapsed time."""
+        wrapper = _make_custom_stream_wrapper()
+        wrapper._stream_created_time = time.time() - 9999
+        with patch("litellm.constants.LITELLM_MAX_STREAMING_DURATION_SECONDS", None):
+            wrapper._check_max_streaming_duration()  # should not raise
+
+
 # ---------------------------------------------------------------------------
 # BaseResponsesAPIStreamingIterator (responses)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`CustomStreamWrapper._check_max_streaming_duration()` only fires when `LITELLM_MAX_STREAMING_DURATION_SECONDS` is set as a global env-var. Per-deployment `stream_timeout` configured on the Router was silently ignored for mid-stream stall detection.

This matters because the httpx read timeout is satisfied by each arriving chunk individually — a provider that returns HTTP 200 and sends initial chunks, then stalls, would never trigger the read timeout but could hold the connection open indefinitely.

## Fix

- `CustomStreamWrapper` gains a `max_streaming_duration: Optional[float]` constructor param stored as `self._max_streaming_duration`
- `_check_max_streaming_duration()` resolves the cap in priority order: per-request value first, then the global `LITELLM_MAX_STREAMING_DURATION_SECONDS` env-var
- The three `async_streaming()` methods in Vertex AI, Bedrock Invoke, and Bedrock Converse handlers now pass `stream_timeout` from `litellm_params` through to `CustomStreamWrapper`

## Test

Added `tests/litellm_utils_tests/test_max_streaming_duration.py` covering:
- per-request cap fires before global env-var
- global env-var fires when no per-request cap is set
- no cap set → no timeout

Related: #23375, #23563

🤖 Generated with [Claude Code](https://claude.com/claude-code)