### PR TITLE
fix(proxy): remove select= kwarg from prisma find_many/find_unique calls

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -66,7 +66,6 @@ async def _get_internal_user_api_keys(
 
     key_records = await VerificationTokenRepository(prisma_client).table.find_many(
         where={"user_id": user_id},
-        select={"token": True},
     )
     user_api_keys.update(
         key_record.token

--- a/litellm/proxy/management_endpoints/tool_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tool_management_endpoints.py
@@ -396,7 +396,6 @@ async def _resolve_team_id_to_object_permission_id(
     team_id_clean = team_id.strip()
     row = await TeamRepository(prisma_client).table.find_unique(
         where={"team_id": team_id_clean},
-        select={"object_permission_id": True},
     )
     if row is None:
         return None
@@ -417,7 +416,6 @@ async def _resolve_team_id_to_object_permission_id(
         )
         row = await TeamRepository(prisma_client).table.find_unique(
             where={"team_id": team_id_clean},
-            select={"object_permission_id": True},
         )
         return getattr(row, "object_permission_id", None) if row else None
     return new_id

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -1076,3 +1076,40 @@ async def test_add_tag_to_deployment_model_not_found():
 
         assert exc_info.value.status_code == 500
         assert "not found in database" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_get_internal_user_api_keys_does_not_use_select_kwarg():
+    """Regression for #30972: find_many(..., select=...) raised TypeError on prisma-client-py.
+
+    _get_internal_user_api_keys must call find_many without a select= argument so
+    that the full row is returned and getattr(record, token, None) works.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.management_endpoints.tag_management_endpoints import (
+        _get_internal_user_api_keys,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    mock_key_record = MagicMock()
+    mock_key_record.token = "hashed-token-abc"
+
+    mock_table = MagicMock()
+    mock_table.find_many = AsyncMock(return_value=[mock_key_record])
+
+    mock_prisma = MagicMock()
+
+    # Use a simple mock to avoid UserAPIKeyAuth validation side effects
+    user_dict = MagicMock()
+    user_dict.api_key = None   # falsy so it won't be added to the set
+    user_dict.user_id = "user-123"
+
+    with patch(
+        "litellm.proxy.management_endpoints.tag_management_endpoints.VerificationTokenRepository"
+    ) as MockRepo:
+        MockRepo.return_value.table = mock_table
+        await _get_internal_user_api_keys(mock_prisma, user_dict)
+
+    call_kwargs = mock_table.find_many.call_args[1]
+    assert "select" not in call_kwargs, "select= kwarg is not supported by prisma-client-py"

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -448,7 +448,6 @@ async def test_internal_user_list_tags_only_returns_tags_used_by_their_keys():
             ]
             mock_db.litellm_verificationtoken.find_many.assert_awaited_once_with(
                 where={"user_id": "internal-user-123"},
-                select={"token": True},
             )
             mock_db.litellm_dailytagspend.group_by.assert_awaited_once_with(
                 by=["tag"],

--- a/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
@@ -157,10 +157,6 @@ async def test_resolve_team_id_does_not_use_select_kwarg():
     _resolve_team_id_to_object_permission_id must call find_unique without a select=
     argument so that the full row is returned and getattr(row, 'object_permission_id', None) works.
     """
-    import sys, os
-    sys.path.insert(0, os.path.abspath("../../.."))
-    from unittest.mock import AsyncMock, MagicMock, patch
-
     from litellm.proxy.management_endpoints.tool_management_endpoints import (
         _resolve_team_id_to_object_permission_id,
     )
@@ -182,3 +178,34 @@ async def test_resolve_team_id_does_not_use_select_kwarg():
     call_kwargs = mock_table.find_unique.call_args[1]
     assert "select" not in call_kwargs, "select= kwarg is not supported by prisma-client-py"
     assert result == "perm-uuid-123"
+
+
+@pytest.mark.asyncio
+async def test_resolve_team_id_race_condition_recovery_does_not_use_select_kwarg():
+    """Race-condition recovery path also must not pass select= to find_unique.
+
+    When the initial find_unique returns None (row not yet visible), the function
+    retries. Both the initial and recovery calls must be free of the select= kwarg.
+    """
+    from litellm.proxy.management_endpoints.tool_management_endpoints import (
+        _resolve_team_id_to_object_permission_id,
+    )
+
+    mock_row = MagicMock()
+    mock_row.object_permission_id = "perm-uuid-recovery"
+
+    mock_table = MagicMock()
+    # first call returns None (simulates race), second returns the row
+    mock_table.find_unique = AsyncMock(side_effect=[None, mock_row])
+
+    mock_prisma = MagicMock()
+
+    with patch(
+        "litellm.proxy.management_endpoints.tool_management_endpoints.TeamRepository"
+    ) as MockRepo:
+        MockRepo.return_value.table = mock_table
+        result = await _resolve_team_id_to_object_permission_id(mock_prisma, "team-abc")
+
+    assert result == "perm-uuid-recovery"
+    for call in mock_table.find_unique.call_args_list:
+        assert "select" not in call[1], "select= kwarg must not be passed on recovery path"

--- a/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
@@ -180,32 +180,3 @@ async def test_resolve_team_id_does_not_use_select_kwarg():
     assert result == "perm-uuid-123"
 
 
-@pytest.mark.asyncio
-async def test_resolve_team_id_race_condition_recovery_does_not_use_select_kwarg():
-    """Race-condition recovery path also must not pass select= to find_unique.
-
-    When the initial find_unique returns None (row not yet visible), the function
-    retries. Both the initial and recovery calls must be free of the select= kwarg.
-    """
-    from litellm.proxy.management_endpoints.tool_management_endpoints import (
-        _resolve_team_id_to_object_permission_id,
-    )
-
-    mock_row = MagicMock()
-    mock_row.object_permission_id = "perm-uuid-recovery"
-
-    mock_table = MagicMock()
-    # first call returns None (simulates race), second returns the row
-    mock_table.find_unique = AsyncMock(side_effect=[None, mock_row])
-
-    mock_prisma = MagicMock()
-
-    with patch(
-        "litellm.proxy.management_endpoints.tool_management_endpoints.TeamRepository"
-    ) as MockRepo:
-        MockRepo.return_value.table = mock_table
-        result = await _resolve_team_id_to_object_permission_id(mock_prisma, "team-abc")
-
-    assert result == "perm-uuid-recovery"
-    for call in mock_table.find_unique.call_args_list:
-        assert "select" not in call[1], "select= kwarg must not be passed on recovery path"

--- a/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
@@ -9,6 +9,7 @@ imports these inside function bodies to avoid circular imports.
 
 import os
 import sys
+import pytest
 from datetime import datetime, timezone
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -147,3 +148,37 @@ class TestToolManagementEndpoints:
             json={"tool_name": "my_tool", "input_policy": "invalid_value"},
         )
         assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_resolve_team_id_does_not_use_select_kwarg():
+    """Regression for #30972: find_unique(..., select=...) raised TypeError on prisma-client-py.
+
+    _resolve_team_id_to_object_permission_id must call find_unique without a select=
+    argument so that the full row is returned and getattr(row, 'object_permission_id', None) works.
+    """
+    import sys, os
+    sys.path.insert(0, os.path.abspath("../../.."))
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy.management_endpoints.tool_management_endpoints import (
+        _resolve_team_id_to_object_permission_id,
+    )
+
+    mock_row = MagicMock()
+    mock_row.object_permission_id = "perm-uuid-123"
+
+    mock_table = MagicMock()
+    mock_table.find_unique = AsyncMock(return_value=mock_row)
+
+    mock_prisma = MagicMock()
+
+    with patch(
+        "litellm.proxy.management_endpoints.tool_management_endpoints.TeamRepository"
+    ) as MockRepo:
+        MockRepo.return_value.table = mock_table
+        result = await _resolve_team_id_to_object_permission_id(mock_prisma, "team-abc")
+
+    call_kwargs = mock_table.find_unique.call_args[1]
+    assert "select" not in call_kwargs, "select= kwarg is not supported by prisma-client-py"
+    assert result == "perm-uuid-123"


### PR DESCRIPTION
## Relevant issues

Closes #30972

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Start the proxy with any DB backend, then:

```bash
curl -s http://localhost:4000/tag/list \
  -H "Authorization: Bearer $LITELLM_KEY" | python3 -m json.tool
```

Before fix (v1.89.2): `{"detail": "LiteLLM_VerificationTokenActions.find_many() got an unexpected keyword argument 'select'"}`

After fix: returns the tag list with HTTP 200.

For the tool policy path:
```bash
curl -s -X POST http://localhost:4000/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{"tool_name": "test-tool", "input_policy": "blocked"}'
```

Before fix: HTTP 500. After fix: HTTP 200.

## Type

Bug Fix

## Changes

prisma-client-py does not support a runtime `select=` keyword argument on `find_many` or `find_unique`. Passing it raises a `TypeError` (unexpected keyword argument), which the proxy surfaces as HTTP 500 on `/tag/list` and the tool policy endpoints (affects all callers of `_get_internal_user_api_keys` and `_resolve_team_id_to_object_permission_id`).

The three affected call sites all consume results via `getattr(record, field, None)`, so returning the full row is functionally equivalent. Removed `select=` from:

- `tag_management_endpoints._get_internal_user_api_keys`: `find_many` on `litellm_verificationtoken`
- `tool_management_endpoints._resolve_team_id_to_object_permission_id`: two `find_unique` calls on `litellm_teamtable`

Two regression tests verify the kwarg is absent from the actual calls made to the mock table.