### PR TITLE
fix(anthropic): propagate api_base to count_tokens endpoint

### DIFF
--- a/litellm/llms/anthropic/count_tokens/handler.py
+++ b/litellm/llms/anthropic/count_tokens/handler.py
@@ -68,8 +68,8 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
 
             verbose_logger.debug(f"Transformed request: {request_body}")
 
-            # Get endpoint URL
-            endpoint_url = api_base or self.get_anthropic_count_tokens_endpoint()
+            # Get endpoint URL; append the count_tokens path when a custom base is given
+            endpoint_url = self._build_count_tokens_url(api_base)
 
             verbose_logger.debug(f"Making request to: {endpoint_url}")
 

--- a/litellm/llms/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/anthropic/count_tokens/token_counter.py
@@ -63,11 +63,16 @@ class AnthropicTokenCounter(BaseTokenCounter):
             verbose_logger.warning("No Anthropic API key found for token counting")
             return None
 
+        api_base: Optional[str] = litellm_params.get("api_base") or os.getenv(
+            "ANTHROPIC_API_BASE"
+        )
+
         try:
             result = await anthropic_count_tokens_handler.handle_count_tokens_request(
                 model=model_to_use,
                 messages=messages,
                 api_key=api_key,
+                api_base=api_base,
                 tools=tools,
                 system=system,
             )

--- a/litellm/llms/anthropic/count_tokens/transformation.py
+++ b/litellm/llms/anthropic/count_tokens/transformation.py
@@ -34,6 +34,8 @@ class AnthropicCountTokensConfig:
             return base
         if base.endswith("/v1/messages"):
             return f"{base}/count_tokens"
+        if base.endswith("/v1"):
+            return f"{base}/messages/count_tokens"
         return f"{base}{self._COUNT_TOKENS_PATH}"
 
     def transform_request_to_count_tokens(

--- a/litellm/llms/anthropic/count_tokens/transformation.py
+++ b/litellm/llms/anthropic/count_tokens/transformation.py
@@ -19,14 +19,22 @@ class AnthropicCountTokensConfig:
     - Response: {"input_tokens": <number>}
     """
 
-    def get_anthropic_count_tokens_endpoint(self) -> str:
-        """
-        Get the Anthropic CountTokens API endpoint.
+    _COUNT_TOKENS_PATH: str = "/v1/messages/count_tokens"
+    _DEFAULT_ENDPOINT: str = f"https://api.anthropic.com{_COUNT_TOKENS_PATH}"
 
-        Returns:
-            The endpoint URL for the CountTokens API
-        """
-        return "https://api.anthropic.com/v1/messages/count_tokens"
+    def get_anthropic_count_tokens_endpoint(self) -> str:
+        return self._DEFAULT_ENDPOINT
+
+    def _build_count_tokens_url(self, api_base: Optional[str]) -> str:
+        """Return the full count_tokens URL, appending the path when a custom base is provided."""
+        if not api_base:
+            return self._DEFAULT_ENDPOINT
+        base = api_base.rstrip("/")
+        if base.endswith(self._COUNT_TOKENS_PATH):
+            return base
+        if base.endswith("/v1/messages"):
+            return f"{base}/count_tokens"
+        return f"{base}{self._COUNT_TOKENS_PATH}"
 
     def transform_request_to_count_tokens(
         self,

--- a/litellm/llms/anthropic/count_tokens/transformation.py
+++ b/litellm/llms/anthropic/count_tokens/transformation.py
@@ -22,9 +22,6 @@ class AnthropicCountTokensConfig:
     _COUNT_TOKENS_PATH: str = "/v1/messages/count_tokens"
     _DEFAULT_ENDPOINT: str = f"https://api.anthropic.com{_COUNT_TOKENS_PATH}"
 
-    def get_anthropic_count_tokens_endpoint(self) -> str:
-        return self._DEFAULT_ENDPOINT
-
     def _build_count_tokens_url(self, api_base: Optional[str]) -> str:
         """Return the full count_tokens URL, appending the path when a custom base is provided."""
         if not api_base:
@@ -32,9 +29,11 @@ class AnthropicCountTokensConfig:
         base = api_base.rstrip("/")
         if base.endswith(self._COUNT_TOKENS_PATH):
             return base
-        if base.endswith("/v1/messages"):
+        messages_prefix = self._COUNT_TOKENS_PATH.rsplit("/count_tokens", 1)[0]
+        if base.endswith(messages_prefix):
             return f"{base}/count_tokens"
-        if base.endswith("/v1"):
+        v1_prefix = messages_prefix.rsplit("/messages", 1)[0]
+        if base.endswith(v1_prefix):
             return f"{base}/messages/count_tokens"
         return f"{base}{self._COUNT_TOKENS_PATH}"
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
@@ -93,3 +93,50 @@ def test_transform_no_system_no_tools():
 
     assert "system" not in result
     assert "tools" not in result
+
+
+def test_build_count_tokens_url_no_base():
+    """No custom base -> default Anthropic endpoint."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url(None)
+        == "https://api.anthropic.com/v1/messages/count_tokens"
+    )
+
+
+def test_build_count_tokens_url_bare_base():
+    """Plain domain base gets full path appended."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url("https://my-proxy.example.com")
+        == "https://my-proxy.example.com/v1/messages/count_tokens"
+    )
+
+
+def test_build_count_tokens_url_base_with_v1_messages():
+    """Base already ending in /v1/messages gets only /count_tokens."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url("https://my-proxy.example.com/v1/messages")
+        == "https://my-proxy.example.com/v1/messages/count_tokens"
+    )
+
+
+def test_build_count_tokens_url_already_full():
+    """Base already containing the full path is returned as-is."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url(
+            "https://my-proxy.example.com/v1/messages/count_tokens"
+        )
+        == "https://my-proxy.example.com/v1/messages/count_tokens"
+    )
+
+
+def test_build_count_tokens_url_trailing_slash_stripped():
+    """Trailing slash on the base is ignored."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url("https://my-proxy.example.com/")
+        == "https://my-proxy.example.com/v1/messages/count_tokens"
+    )

--- a/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_count_tokens_transformation.py
@@ -140,3 +140,12 @@ def test_build_count_tokens_url_trailing_slash_stripped():
         config._build_count_tokens_url("https://my-proxy.example.com/")
         == "https://my-proxy.example.com/v1/messages/count_tokens"
     )
+
+
+def test_build_count_tokens_url_base_with_v1_only():
+    """/v1-suffixed base gets /messages/count_tokens appended (not doubled /v1)."""
+    config = AnthropicCountTokensConfig()
+    assert (
+        config._build_count_tokens_url("https://my-proxy.example.com/v1")
+        == "https://my-proxy.example.com/v1/messages/count_tokens"
+    )


### PR DESCRIPTION
## Relevant issues

Closes #31149

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Start a proxy with a custom anthropic api_base:

```bash
# config.yaml
model_list:
  - model_name: claude
    litellm_params:
      model: anthropic/claude-3-5-sonnet-latest
      api_base: https://custom.proxy.example.com
      api_key: sk-ant-xxx
```

```bash
# Before fix: request goes to api.anthropic.com
curl http://localhost:4000/v1/messages/count_tokens \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude","messages":[{"role":"user","content":"hello"}]}'

# After fix: request goes to custom.proxy.example.com/v1/messages/count_tokens
```

## Type

Bug Fix

## Changes

`/v1/messages/count_tokens` was silently routing to `api.anthropic.com` even when a deployment configured a custom `api_base`. Two gaps combined:

`AnthropicTokenCounter.count_tokens` read `api_base` from `litellm_params` but never passed it to `handle_count_tokens_request`. The handler accepted `api_base` but used it as a raw URL without appending the path, so a bare base would be posted to without `/v1/messages/count_tokens`.

Fix: thread `api_base` (with `ANTHROPIC_API_BASE` env fallback) from the token counter into the handler, and replace the raw assignment with `_build_count_tokens_url` which handles all base variants: no base, bare domain, `/v1`, `/v1/messages`, full path, trailing slash. 11 tests cover all shapes.