### PR TITLE
fix: close cached AsyncOpenAI clients on shutdown (Unclosed client session leak)

### DIFF
--- a/litellm/llms/custom_httpx/async_client_cleanup.py
+++ b/litellm/llms/custom_httpx/async_client_cleanup.py
@@ -50,19 +50,21 @@ async def close_litellm_async_clients():
         # Handle any other cached async client. Most expose aclose(), but some
         # SDK clients -- notably the openai SDK's AsyncOpenAI / AsyncAzureOpenAI,
         # which are cached here (set_cached_openai_client) and built on litellm's
-        # aiohttp transport -- name the async teardown close() instead. Accept
-        # either, guarding on iscoroutinefunction so sync close() methods
-        # (sync OpenAI / HTTPHandler) are left untouched.
+        # aiohttp transport -- name the async teardown close() instead. Try each
+        # candidate independently, guarding on iscoroutinefunction so sync
+        # teardowns (sync OpenAI / HTTPHandler) are left untouched. Checking them
+        # separately (rather than `aclose or close`) avoids picking a truthy but
+        # synchronous aclose() and then skipping a real async close() alongside it.
         else:
-            closer = getattr(handler, "aclose", None) or getattr(
-                handler, "close", None
-            )
-            if closer is not None and inspect.iscoroutinefunction(closer):
-                try:
-                    await closer()
-                except Exception:
-                    # Silently ignore errors during cleanup
-                    pass
+            for name in ("aclose", "close"):
+                closer = getattr(handler, name, None)
+                if closer is not None and inspect.iscoroutinefunction(closer):
+                    try:
+                        await closer()
+                    except Exception:
+                        # Silently ignore errors during cleanup
+                        pass
+                    break
 
     # Close the global base_llm_aiohttp_handler instance (issue #12443)
     # This is used by Gemini and other providers that use aiohttp

--- a/litellm/llms/custom_httpx/async_client_cleanup.py
+++ b/litellm/llms/custom_httpx/async_client_cleanup.py
@@ -3,6 +3,7 @@ Utility functions for cleaning up async HTTP clients to prevent resource leaks.
 """
 
 import asyncio
+import inspect
 
 
 async def close_litellm_async_clients():
@@ -46,13 +47,22 @@ async def close_litellm_async_clients():
                     # Silently ignore errors during cleanup
                     pass
 
-        # Handle any other objects with aclose method
-        elif hasattr(handler, "aclose"):
-            try:
-                await handler.aclose()
-            except Exception:
-                # Silently ignore errors during cleanup
-                pass
+        # Handle any other cached async client. Most expose aclose(), but some
+        # SDK clients -- notably the openai SDK's AsyncOpenAI / AsyncAzureOpenAI,
+        # which are cached here (set_cached_openai_client) and built on litellm's
+        # aiohttp transport -- name the async teardown close() instead. Accept
+        # either, guarding on iscoroutinefunction so sync close() methods
+        # (sync OpenAI / HTTPHandler) are left untouched.
+        else:
+            closer = getattr(handler, "aclose", None) or getattr(
+                handler, "close", None
+            )
+            if closer is not None and inspect.iscoroutinefunction(closer):
+                try:
+                    await closer()
+                except Exception:
+                    # Silently ignore errors during cleanup
+                    pass
 
     # Close the global base_llm_aiohttp_handler instance (issue #12443)
     # This is used by Gemini and other providers that use aiohttp

--- a/tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py
+++ b/tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+Test for the AsyncOpenAI cleanup gap: close_litellm_async_clients() must close
+cached clients whose async teardown is named close() (the openai SDK's
+AsyncOpenAI / AsyncAzureOpenAI), not only those exposing aclose().
+
+Proposed path: tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py
+"""
+
+import pytest
+
+import litellm
+from litellm.llms.custom_httpx.async_client_cleanup import close_litellm_async_clients
+
+
+class _AsyncCloseOnlyClient:
+    """Mirrors openai.AsyncOpenAI: async close(), no aclose(), no .client."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _SyncClient:
+    """A sync client (close() is not a coroutine) -- must be left untouched."""
+
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_async_close_only_clients():
+    async_client = _AsyncCloseOnlyClient()
+    sync_client = _SyncClient()
+    litellm.in_memory_llm_clients_cache.set_cache(
+        key="test_async_close_only", value=async_client, ttl=60
+    )
+    litellm.in_memory_llm_clients_cache.set_cache(
+        key="test_sync_close", value=sync_client, ttl=60
+    )
+
+    await close_litellm_async_clients()
+
+    assert async_client.closed, "async close()-only client should be closed"
+    assert not sync_client.closed, "sync client should be left untouched"

--- a/tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py
+++ b/tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py
@@ -23,6 +23,36 @@ class _AsyncCloseOnlyClient:
         self.closed = True
 
 
+class _AsyncACloseOnlyClient:
+    """The pre-existing path: an async client whose teardown is aclose()."""
+
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _SyncCloseAsyncACloseClient:
+    """
+    The `or` short-circuit case: a sync aclose() alongside an async close().
+
+    `getattr(handler, "aclose") or getattr(handler, "close")` would pick the
+    truthy-but-synchronous aclose(), fail the iscoroutinefunction guard, and then
+    never reach the real async close() -- leaking the client. Each candidate must
+    be checked independently.
+    """
+
+    def __init__(self):
+        self.closed = False
+
+    def aclose(self):  # sync -- a decoy that must not satisfy cleanup
+        pass
+
+    async def close(self):
+        self.closed = True
+
+
 class _SyncClient:
     """A sync client (close() is not a coroutine) -- must be left untouched."""
 
@@ -48,3 +78,29 @@ async def test_cleanup_closes_async_close_only_clients():
 
     assert async_client.closed, "async close()-only client should be closed"
     assert not sync_client.closed, "sync client should be left untouched"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_closes_async_aclose_clients():
+    """Regression guard for the pre-existing aclose() path."""
+    aclose_client = _AsyncACloseOnlyClient()
+    litellm.in_memory_llm_clients_cache.set_cache(
+        key="test_async_aclose_only", value=aclose_client, ttl=60
+    )
+
+    await close_litellm_async_clients()
+
+    assert aclose_client.closed, "async aclose() client should be closed"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_prefers_async_close_over_sync_aclose():
+    """A sync aclose() must not shadow a real async close() (the `or` gap)."""
+    client = _SyncCloseAsyncACloseClient()
+    litellm.in_memory_llm_clients_cache.set_cache(
+        key="test_sync_aclose_async_close", value=client, ttl=60
+    )
+
+    await close_litellm_async_clients()
+
+    assert client.closed, "async close() should be called when aclose() is sync"


### PR DESCRIPTION
### Relevant issues

Fixes #31245

### Type

🐛 Bug Fix

### Changes

`close_litellm_async_clients()` closes litellm's own httpx/aiohttp handlers but
silently skips the cached `openai.AsyncOpenAI` clients. Those clients are cached
in `in_memory_llm_clients_cache` (`BaseOpenAILLM.set_cached_openai_client`) and
built on litellm's aiohttp transport (`OpenAIChatCompletion._get_async_http_client`
→ `AsyncHTTPHandler._create_async_transport`), so each owns an aiohttp
`ClientSession`.

The cleanup loop dispatched on three shapes only: `BaseLLMAIOHTTPHandler`,
objects with a `.client` attribute (`AsyncHTTPHandler`), and objects with
`.aclose()`. `AsyncOpenAI` matches none of these — its async teardown is named
`.close()`, not `.aclose()` — so every cached OpenAI/Azure-OpenAI client fell
through all branches and was never closed, surfacing as an `Unclosed client
session` error at loop teardown (one per distinct cached OpenAI client config).

This widens the final fallback branch to await whichever of `aclose()` /
`close()` a cached client exposes, guarded on `inspect.iscoroutinefunction` so
sync clients (`OpenAI`, `HTTPHandler`) are left untouched. The change is
additive — objects already handled by the `aclose()` branch keep working.

Distinct from #24230 (transport recycling) and #12443 / #13251 (Gemini/Vertex
handlers); this is specifically the cached `AsyncOpenAI` SDK client.

Minimal repro (no network):

```python
import asyncio, litellm
from openai import AsyncOpenAI

async def main():
    client = AsyncOpenAI(api_key="sk-fake")
    litellm.in_memory_llm_clients_cache.set_cache(key="repro", value=client, ttl=3600)
    await litellm.close_litellm_async_clients()
    print("closed by cleanup?", client.is_closed)   # -> False (leak) before this fix

asyncio.run(main())
```

### Testing

Adds `tests/test_litellm/llms/custom_httpx/test_openai_session_leak.py`: a cached
client whose async teardown is `close()` (no `aclose()`) is closed by
`close_litellm_async_clients()`, while a sync client is left untouched.

### Pre-Submission checklist

- [x] Added testing in the `tests/test_litellm/` directory
- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
