### PR TITLE
test(e2e): drop xfail markers for now-fixed team-budget-JSON and custom-pricing-leak bugs

### DIFF
--- a/tests/e2e/budgets/test_team_multi_window_budget_e2e.py
+++ b/tests/e2e/budgets/test_team_multi_window_budget_e2e.py
@@ -7,11 +7,10 @@ the tight window's cap is exceeded, then - once the 30s elapses and the reset jo
 and calls flow again. This exercises the reset_budget_windows TEAM branch (raw SQL over
 LiteLLM_TeamTable.budget_limits, the literal #25109 path), which had no live coverage.
 
-Fails at team creation today: /team/new writes the raw window list straight to the
-Json? column, where Prisma rejects it (500), unlike the key path and /team/update which
-json.dumps it first. Marked xfail(strict=True) so the suite stays green while the bug
-persists and flips to a failure the moment the write is fixed and the marker should be
-removed.
+This also guards the /team/new write path: it must json.dumps the window list into
+the Json? column. A raw list there made Prisma reject the create with a 500 (the key
+path and /team/update already json.dumps first); a regression would fail team creation
+here.
 """
 
 import time
@@ -33,12 +32,6 @@ def _call(client: BudgetClient, key: str):
     return client.chat(key, "claude-haiku-4-5", f"team-window {unique_marker()}", max_tokens=16)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="known proxy bug: /team/new writes budget_limits straight to the Json? "
-    "column and Prisma rejects it (500), unlike the key path and /team/update which "
-    "json.dumps first; remove this marker once that write is fixed",
-)
 def test_team_short_window_blocks_then_resets(client: BudgetClient, resources: ResourceManager) -> None:
     team_id = client.create_team(
         alias=f"e2e-team-window-{unique_marker()}",

--- a/tests/e2e/llm_translation/test_custom_pricing_e2e.py
+++ b/tests/e2e/llm_translation/test_custom_pricing_e2e.py
@@ -10,9 +10,8 @@ back here from the same config file. Three behaviors are checked independently:
 - reporting: /model/info surfaces those rates for the model
 - isolation: gemini-2.5-flash shares the same underlying gemini/gemini-2.5-flash
   but sets no override, so it must keep its own price; an override that leaks into
-  the shared cost map misprices it. This fails on a real proxy gap today, so it is
-  marked xfail(strict=True): the suite stays green while the leak persists and
-  flips to a failure the moment isolation is fixed and the marker should be removed.
+  the shared cost map misprices it. A regression that reintroduces that leak makes
+  the sibling's rate match the custom one and fails the isolation check.
 """
 
 import time
@@ -192,12 +191,6 @@ def test_model_info_reports_custom_pricing(client: PassthroughClient) -> None:
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="known proxy bug: a deployment's custom per-token pricing leaks into the "
-    "shared cost map for sibling deployments of the same underlying model; remove "
-    "this marker once isolation is fixed",
-)
 def test_custom_pricing_is_isolated_from_sibling_deployment(
     client: PassthroughClient,
 ) -> None:


### PR DESCRIPTION
## Relevant issues

Two e2e tests were `xfail(strict=True)` for known proxy bugs that are now fixed on `litellm_internal_staging`:
- `/team/new` wrote `budget_limits` as a raw list into the `Json?` column, which Prisma rejected with a 500 (the key path and `/team/update` json.dumps first). Related: #25109
- a deployment's custom per-token pricing leaked into the shared cost map for sibling deployments of the same underlying model

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Both fixes already shipped to `litellm_internal_staging`, so the two tests pass their assertions there. Because they were still marked `xfail(strict=True)`, the run reported the unexpected passes as failures:

```
[XPASS(strict)] known proxy bug: /team/new writes budget_limits straight to the Json? column ...
[XPASS(strict)] known proxy bug: a deployment's custom per-token pricing leaks into the shared cost map ...
FAILED budgets/test_team_multi_window_budget_e2e.py::test_team_short_window_blocks_then_resets
FAILED llm_translation/test_custom_pricing_e2e.py::test_custom_pricing_is_isolated_from_sibling_deployment
=================== 2 failed, 59 passed in 497.24s ===================
```

With the strict markers removed, both run as ordinary passing tests, taking the suite to all-green; their assertions are unchanged, so they now stand as regression guards for the two fixes

## Type

🧹 Refactoring
✅ Test

## Changes

Removed the `@pytest.mark.xfail(strict=True, ...)` decorator from `test_team_short_window_blocks_then_resets` and `test_custom_pricing_is_isolated_from_sibling_deployment`, as each marker's reason instructed once the underlying bug was fixed. Updated both docstrings to describe the regression each test now pins rather than the bug it used to tolerate. No assertion changed