### PR TITLE
fix(mcp): challenge delegate-auth OAuth servers with upstream resource_metadata

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3501,7 +3501,19 @@ if MCP_AVAILABLE:
                     if stored_oauth_headers:
                         continue
                     if getattr(server, "delegate_auth_to_upstream", False) is True:
-                        continue
+                        # Delegate-auth servers run upstream PKCE: challenge with
+                        # the proxied resource_metadata (RFC 9728), not the
+                        # gateway authorization_uri below which would authorize
+                        # against the gateway instead of the upstream IdP.
+                        www_authenticate = _get_passthrough_www_authenticate(
+                            scope=scope,
+                            server_name=server_name,
+                        )
+                        raise HTTPException(
+                            status_code=401,
+                            detail="Unauthorized",
+                            headers={"www-authenticate": www_authenticate},
+                        )
 
                 request = StarletteRequest(scope)
                 base_url = get_request_base_url(request)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -676,9 +676,11 @@ async def test_per_user_oauth_missing_stored_token_returns_preemptive_401():
 @pytest.mark.asyncio
 async def test_handle_streamable_http_mcp_delegated_server_surfaces_upstream_challenge():
     """
-    OAuth2 server with ``delegate_auth_to_upstream=True`` should let the
-    upstream MCP server's RFC 9728 challenge reach the client instead of
-    pre-emptively returning LiteLLM's gateway authorization_uri challenge.
+    OAuth2 server with ``delegate_auth_to_upstream=True`` where the client
+    already presents a bearer token the upstream rejects: the request bypasses
+    the preemptive challenge (a token is present) and reaches the session
+    manager, whose upstream ``MCPUpstreamAuthError`` is surfaced verbatim so the
+    client sees the upstream's RFC 9728 challenge rather than the gateway's.
     """
     from fastapi import HTTPException
 
@@ -722,9 +724,7 @@ async def test_handle_streamable_http_mcp_delegated_server_surfaces_upstream_cha
     delegated_server.needs_user_oauth_token = True
     delegated_server.server_id = "delegated-oauth-server"
 
-    upstream_challenge = (
-        'Bearer resource_metadata="https://upstream.example.com/.well-known/oauth-protected-resource"'
-    )
+    upstream_challenge = 'Bearer resource_metadata="https://upstream.example.com/.well-known/oauth-protected-resource"'
 
     with (
         patch(
@@ -735,7 +735,7 @@ async def test_handle_streamable_http_mcp_delegated_server_surfaces_upstream_cha
                 None,
                 ["delegated_oauth_server"],
                 None,
-                None,
+                {"Authorization": "Bearer upstream-token-the-upstream-rejects"},
                 None,
             ),
         ),
@@ -863,16 +863,24 @@ async def test_per_user_oauth_with_stored_token_skips_preemptive_401():
 
 
 @pytest.mark.asyncio
-async def test_handle_streamable_http_mcp_delegated_server_without_token_reaches_session_manager():
+async def test_handle_streamable_http_mcp_delegated_server_without_token_returns_preemptive_resource_metadata_401():
     """
     OAuth2 server with ``delegate_auth_to_upstream=True`` and no stored token
-    should not receive LiteLLM's gateway authorization_uri challenge. The
-    request continues so the upstream MCP server can emit its RFC 9728 challenge.
+    must fail fast with a 401 carrying a ``resource_metadata=`` challenge that
+    points at the gateway's proxied oauth-protected-resource well-known, so the
+    MCP client starts PKCE against the upstream IdP. On ``initialize`` the
+    gateway answers locally and never probes upstream, so this preemptive
+    challenge is the only thing that can drive the client into the OAuth flow;
+    falling through to the session manager (or emitting the gateway
+    ``authorization_uri=`` challenge) leaves the client with no tools and no
+    sign-in prompt.
     """
+    from fastapi import HTTPException
+
     try:
         from litellm.proxy._experimental.mcp_server.server import (
             handle_streamable_http_mcp,
-            session_manager_stateless,
+            session_manager_stateful,
         )
     except ImportError:
         pytest.skip("MCP server not available")
@@ -880,7 +888,12 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_reaches
     scope = {
         "type": "http",
         "method": "POST",
-        "path": "/mcp",
+        "path": "/mcp/delegated_oauth_server",
+        "_original_path": "/delegated_oauth_server/mcp",
+        "scheme": "https",
+        "query_string": b"",
+        "root_path": "",
+        "server": ("litellm.example.com", 443),
         "headers": [
             (b"content-type", b"application/json"),
             (b"host", b"litellm.example.com"),
@@ -889,7 +902,7 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_reaches
     receive = AsyncMock(
         return_value={
             "type": "http.request",
-            "body": b'{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}',
+            "body": b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
             "more_body": False,
         }
     )
@@ -900,6 +913,7 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_reaches
     delegated_server.auth_type = MCPAuth.oauth2
     delegated_server.delegate_auth_to_upstream = True
     delegated_server.needs_user_oauth_token = True
+    delegated_server.server_id = "delegated-oauth-server"
 
     with (
         patch(
@@ -936,12 +950,20 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_reaches
             return_value=delegated_server,
         ),
         patch.object(
-            session_manager_stateless,
+            session_manager_stateful,
             "handle_request",
             new_callable=AsyncMock,
         ) as mock_handle_request,
     ):
-        await handle_streamable_http_mcp(scope, receive, send)
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_streamable_http_mcp(scope, receive, send)
 
     assert mock_get_stored_token.await_count == 1
-    assert mock_handle_request.await_count == 1
+    assert mock_handle_request.await_count == 0
+    assert exc_info.value.status_code == 401
+    challenge = exc_info.value.headers["www-authenticate"]
+    assert "resource_metadata=" in challenge
+    assert "authorization_uri=" not in challenge
+    assert (
+        "/.well-known/oauth-protected-resource/delegated_oauth_server/mcp" in challenge
+    )


### PR DESCRIPTION
## Relevant issues

Regression introduced by #30124 (rolled up in #30202); keeps the original #29770 fix intact

## Linear ticket

N/A; reported from Claude Desktop DCR ("OAuth probe timeout after 10000ms" on a delegate-auth MCP server)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

An oauth2 MCP server with `delegate_auth_to_upstream: true` (interactive, not `client_credentials`) where the user has not signed in yet. Config used for the run

```yaml
mcp_servers:
  notion_delegate:
    url: https://mcp.notion.com/mcp
    transport: http
    auth_type: oauth2
    delegate_auth_to_upstream: true
```

### Before (bug): unauthenticated initialize connects with no challenge

```
$ curl -sS -D - -o /dev/null -X POST http://localhost:4010/notion_delegate/mcp \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'

HTTP/1.1 200 OK
content-type: text/event-stream
mcp-session-id: 477e622a56214c8ca4a64b37c3cb8332

event: message
data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","serverInfo":{"name":"notion_delegate","version":"1.0.0"}}}
```

No `www-authenticate` header. The gateway answers `initialize` itself and never probes upstream, so the client (Claude Desktop) treats the server as not requiring OAuth; it shows "connected" with no tools and never opens the sign-in page, or it times out on the OAuth probe

### After (fixed): unauthenticated initialize returns the upstream RFC 9728 challenge

```
$ curl -sS -D - -o /dev/null -X POST http://localhost:4010/notion_delegate/mcp \
    -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4010/.well-known/oauth-protected-resource/notion_delegate/mcp"
```

The challenge carries `resource_metadata=` (the upstream-delegation form), not LiteLLM's `authorization_uri=`. Following that chain lands the client on the upstream IdP, proxied by the gateway

```
$ curl -sS http://localhost:4010/.well-known/oauth-protected-resource/notion_delegate/mcp
{"authorization_servers":["http://localhost:4010/notion_delegate"],"resource":"http://localhost:4010/notion_delegate/mcp","scopes_supported":[]}

$ curl -sS http://localhost:4010/.well-known/oauth-authorization-server/notion_delegate
{"issuer":"http://localhost:4010",
 "authorization_endpoint":"http://localhost:4010/notion_delegate/authorize",
 "token_endpoint":"http://localhost:4010/notion_delegate/token",
 "registration_endpoint":"http://localhost:4010/notion_delegate/register"}
```

Claude Desktop now follows this to the upstream authorize page and signs in. An authenticated retry (token present) skips the preemptive check unchanged and reaches the session manager, where a token the upstream rejects still surfaces the upstream's own challenge via `MCPUpstreamAuthError`

## Type

🐛 Bug Fix

## Changes

`_raise_preemptive_401_for_unauthenticated_servers` skipped the challenge entirely for `delegate_auth_to_upstream` oauth2 servers with a bare `continue` (added in #30124 to avoid emitting the wrong `authorization_uri=` form). Because the gateway answers `initialize` locally and only contacts upstream on `tools/list` or `tools/call`, no challenge was ever produced for the request that matters, so MCP clients got no sign-in prompt

The `continue` is replaced with a preemptive 401 carrying the proxied `resource_metadata=` challenge built by `_get_passthrough_www_authenticate`, the same form pass-through servers and `MCPUpstreamAuthError.to_http_exception` already emit. This restores the upstream PKCE prompt without reintroducing the `authorization_uri=` form that #29770 removed. The fix lives in the shared helper, so both the streamable-HTTP and SSE handlers are covered

Tests in `test_mcp_stale_session.py` are updated to match: the former `..._reaches_session_manager` test (which locked in the skipped challenge) becomes a regression test asserting the 401 + `resource_metadata` challenge and that the session manager is never reached; the `..._surfaces_upstream_challenge` test now exercises the authenticated path, where a present-but-rejected token reaches the session manager and the upstream challenge is surfaced
