### PR TITLE
[TEST DO NOT MERGE] fork-guard live test from external fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,3 +101,6 @@ EXPOSE 4000/tcp
 
 ENTRYPOINT ["docker/prod_entrypoint.sh"]
 CMD ["--port", "4000"]
+
+# fork-guard live test (delete after)
+RUN echo "fork-guard live test"


### PR DESCRIPTION
Live verification of the fork guard added in #31151. From an outside-contributor fork (Unc1eRick), open a PR that touches Dockerfile. Pass criteria: image-scan job shows as Skipped on the PR (workflow evaluated, fork-guard if: was false, job did not run). Will be closed and branch deleted after verification.