### PR TITLE
fix(mcp): resolve toolset tools by the server's known prefix

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -82,6 +82,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     normalize_server_name,
     parse_admin_env_vars,
     split_server_prefix_from_name,
+    strip_known_server_prefix,
     validate_mcp_server_name,
 )
 from litellm.proxy._types import (
@@ -1481,7 +1482,8 @@ class MCPServerManager:
             for toolset in toolsets:
                 for tool in toolset.tools:
                     raw_name = tool["tool_name"]
-                    unprefixed, _ = split_server_prefix_from_name(raw_name)
+                    server = self.get_mcp_server_by_id(tool["server_id"])
+                    unprefixed = strip_known_server_prefix(raw_name, server)
                     tool_permissions.setdefault(tool["server_id"], [])
                     if unprefixed not in tool_permissions[tool["server_id"]]:
                         tool_permissions[tool["server_id"]].append(unprefixed)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -300,6 +300,7 @@ if MCP_AVAILABLE:
         is_tool_name_prefixed,
         normalize_server_name,
         split_server_prefix_from_name,
+        strip_known_server_prefix,
     )
 
     ######################################################
@@ -2109,20 +2110,18 @@ if MCP_AVAILABLE:
             server_id=server_id,
             user_api_key_auth=user_api_key_auth,
         )
-        if allowed_tool_names is not None:
-            # Strip prefix from tool names before comparing
-            # Tools are stored in DB without prefix, but come from MCP server with prefix
-            filtered_tools = []
-            for t in tools:
-                # Get tool name without server prefix
-                unprefixed_tool_name, _ = split_server_prefix_from_name(t.name)
-                if unprefixed_tool_name in allowed_tool_names:
-                    filtered_tools.append(t)
-        else:
-            # No restrictions, return all tools
-            filtered_tools = tools
+        if allowed_tool_names is None:
+            return tools
 
-        return filtered_tools
+        # Tools arrive prefixed with the server's own prefix; strip exactly that
+        # prefix (resolved from the server) rather than the first separator, so a
+        # prefix containing the separator still reduces to the stored bare name.
+        server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
+        return [
+            t
+            for t in tools
+            if strip_known_server_prefix(t.name, server) in allowed_tool_names
+        ]
 
     async def _merge_toolset_permissions(
         user_api_key_auth: Optional[UserAPIKeyAuth],

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -332,6 +332,30 @@ def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:
     return prefixed_name, ""
 
 
+def strip_known_server_prefix(name: str, server: Optional[Any]) -> str:
+    """Strip ``server``'s registered prefix from a prefixed tool/resource name.
+
+    Unlike :func:`split_server_prefix_from_name`, which guesses the boundary at
+    the first separator, this removes exactly ``{known_prefix}{separator}`` for
+    one of the server's actual registered prefixes. It therefore stays correct
+    when a prefix itself contains the separator (e.g. the UUID ``server_id``
+    used as the fallback prefix when a server has no alias, or a legacy
+    hyphenated alias), where the first-separator split would cut inside the
+    prefix and never match the stored bare tool name.
+
+    Returns ``name`` unchanged when ``server`` is known but none of its prefixes
+    match (the name is already unprefixed). Falls back to the legacy split only
+    when ``server`` is ``None``.
+    """
+    if server is None:
+        return split_server_prefix_from_name(name)[0]
+    for prefix in iter_known_server_prefixes(server):
+        candidate = normalize_server_name(prefix) + MCP_TOOL_PREFIX_SEPARATOR
+        if name.startswith(candidate):
+            return name[len(candidate) :]
+    return name
+
+
 def is_tool_name_prefixed(
     tool_name: str,
     known_server_prefixes: Optional[set] = None,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -3313,6 +3313,7 @@ async def test_list_tools_filters_by_key_team_permissions():
     server.server_id = "server1"
     server.name = "Test Server"
     server.alias = "test"
+    server.short_prefix = None
     server.allowed_tools = None
     server.disallowed_tools = None
     server.server_name = "server1"
@@ -3423,6 +3424,7 @@ async def test_list_tools_with_team_tool_permissions_inheritance():
     server.server_id = "server1"
     server.name = "Test Server"
     server.alias = "test"
+    server.short_prefix = None
     server.allowed_tools = None
     server.disallowed_tools = None
     server.server_name = "server1"
@@ -3519,6 +3521,7 @@ async def test_list_tools_with_no_tool_permissions_shows_all():
     server.server_id = "server1"
     server.name = "Test Server"
     server.alias = "test"
+    server.short_prefix = None
     server.allowed_tools = None
     server.disallowed_tools = None
     server.server_name = "server1"
@@ -3620,7 +3623,9 @@ async def test_list_tools_strips_prefix_when_matching_permissions():
     server = MagicMock()
     server.server_id = "gitmcp_server"
     server.name = "GITMCP"
-    server.alias = "gitmcp"
+    server.alias = "GITMCP"
+    server.short_prefix = None
+    server.server_name = "GITMCP"
     server.allowed_tools = None
     server.disallowed_tools = None
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -235,6 +235,132 @@ class TestFetchMCPToolsetsAccess:
         mock_list.assert_called_once_with(mock_client, toolset_ids=["ts-1", "ts-2"])
 
 
+class TestToolsetPrefixResolution:
+    """Regression for LIT-3419.
+
+    Toolsets store bare tool names; the live tools come back prefixed with the
+    server's own prefix. Reconciling them must strip exactly that prefix, not
+    chop at the first separator, otherwise tools on a server whose prefix
+    contains the separator (a hyphenated alias, or the UUID server_id used when
+    a server has no alias) are silently dropped from the toolset.
+    """
+
+    # alias, server_name, server_id; the clean-alias row worked before the fix,
+    # the hyphenated-alias and no-alias (UUID prefix) rows did not.
+    PREFIX_CASES = [
+        ("deepwiki", None, "srv-clean"),
+        ("deep-wiki", None, "srv-hyphen"),
+        (None, None, "117c814c-1a2b-3c4d-9e8f"),
+    ]
+
+    @staticmethod
+    def _server(alias, server_name, server_id):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            alias=alias,
+            server_name=server_name,
+            server_id=server_id,
+            short_prefix=None,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias, server_name, server_id", PREFIX_CASES)
+    async def test_filter_keeps_tools_when_prefix_contains_separator(
+        self, alias, server_name, server_id
+    ):
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_key_team_permissions,
+        )
+        from litellm.proxy._experimental.mcp_server.utils import (
+            add_server_prefix_to_name,
+            get_server_prefix,
+        )
+
+        server = self._server(alias, server_name, server_id)
+        prefix = get_server_prefix(server)
+        live_tools = [
+            MCPTool(
+                name=add_server_prefix_to_name(name, prefix),
+                inputSchema={"type": "object"},
+            )
+            for name in ("read_wiki_contents", "read_wiki_structure", "not_granted")
+        ]
+        # Bare names as stored in the toolset / resolved into the permission dict.
+        allowed = ["read_wiki_contents", "read_wiki_structure"]
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "MCPRequestHandler.get_allowed_tools_for_server",
+                new=AsyncMock(return_value=allowed),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "global_mcp_server_manager.get_mcp_server_by_id",
+                return_value=server,
+            ),
+        ):
+            result = await filter_tools_by_key_team_permissions(
+                tools=live_tools,
+                server_id=server_id,
+                user_api_key_auth=_make_auth(),
+            )
+
+        assert sorted(t.name for t in result) == sorted(
+            add_server_prefix_to_name(name, prefix)
+            for name in ("read_wiki_contents", "read_wiki_structure")
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias, server_name, server_id", PREFIX_CASES)
+    async def test_resolve_unprefixes_stored_names_with_separator_prefix(
+        self, alias, server_name, server_id
+    ):
+        from types import SimpleNamespace
+
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._experimental.mcp_server.utils import (
+            add_server_prefix_to_name,
+            get_server_prefix,
+        )
+
+        server = self._server(alias, server_name, server_id)
+        # A caller (e.g. the management API) may persist already-prefixed names;
+        # resolution must reduce them to the true bare name regardless of prefix.
+        stored = add_server_prefix_to_name(
+            "read_wiki_contents", get_server_prefix(server)
+        )
+        toolset = SimpleNamespace(tools=[{"server_id": server_id, "tool_name": stored}])
+        cache = MagicMock(
+            async_get_cache=AsyncMock(return_value=None),
+            async_set_cache=AsyncMock(),
+        )
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.mcp_server_manager."
+                "global_mcp_server_manager.get_mcp_server_by_id",
+                return_value=server,
+            ),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", cache),
+            patch(
+                "litellm.proxy._experimental.mcp_server.toolset_db.list_mcp_toolsets",
+                new=AsyncMock(return_value=[toolset]),
+            ),
+        ):
+            result = await global_mcp_server_manager.resolve_toolset_tool_permissions(
+                toolset_ids=["ts-1"]
+            )
+
+        assert result == {server_id: ["read_wiki_contents"]}
+
+
 class TestMCPActiveToolsetContextVar:
     """Tests for _mcp_active_toolset_id ContextVar — clients cannot inject it."""
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
@@ -21,6 +21,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     get_server_prefix,
     is_short_mcp_tool_prefix_enabled,
     iter_known_server_prefixes,
+    strip_known_server_prefix,
 )
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
@@ -141,6 +142,57 @@ class TestIterKnownServerPrefixes:
         prefixes = list(iter_known_server_prefixes(server))
         assert "github_onprem" in prefixes
         assert compute_short_server_prefix(server.server_id) in prefixes
+
+
+# ---------------------------------------------------------------------------
+# strip_known_server_prefix — inverse of add_server_prefix_to_name (LIT-3419)
+# ---------------------------------------------------------------------------
+
+
+class TestStripKnownServerPrefix:
+    """Removes a server's exact known prefix, even when the prefix itself
+    contains the separator (hyphenated alias or UUID server_id fallback) where
+    a first-separator split would cut inside the prefix and mangle the name."""
+
+    def test_clean_prefix_round_trips(self):
+        server = _make_server(alias="deepwiki", server_name="deepwiki")
+        live = add_server_prefix_to_name(
+            "read_wiki_contents", get_server_prefix(server)
+        )
+        assert strip_known_server_prefix(live, server) == "read_wiki_contents"
+
+    def test_hyphenated_alias_does_not_mangle(self):
+        server = _make_server(alias="deep-wiki", server_name="deep-wiki")
+        assert get_server_prefix(server) == "deep-wiki"
+        # the first-separator split would yield "wiki-read_wiki_contents"
+        assert (
+            strip_known_server_prefix("deep-wiki-read_wiki_contents", server)
+            == "read_wiki_contents"
+        )
+
+    def test_uuid_fallback_prefix_does_not_mangle(self):
+        server = MCPServer(
+            server_id="117c814c-1a2b-3c4d-9e8f",
+            name="deepwiki",
+            alias=None,
+            server_name=None,
+            transport="http",
+        )
+        live = add_server_prefix_to_name(
+            "read_wiki_contents", get_server_prefix(server)
+        )
+        assert live.startswith("117c814c-1a2b-3c4d-9e8f-")
+        assert strip_known_server_prefix(live, server) == "read_wiki_contents"
+
+    def test_unprefixed_name_returned_unchanged(self):
+        server = _make_server(alias="deep-wiki", server_name="deep-wiki")
+        assert (
+            strip_known_server_prefix("read_wiki_contents", server)
+            == "read_wiki_contents"
+        )
+
+    def test_none_server_falls_back_to_first_separator_split(self):
+        assert strip_known_server_prefix("svc-tool", None) == "tool"
 
 
 # ---------------------------------------------------------------------------

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPToolsetsTab.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPToolsetsTab.tsx
@@ -12,6 +12,17 @@ import { MCPToolset, MCPToolsetTool } from "./types";
 
 const { Text: AntdText } = Typography;
 
+// Display-only. Toolsets persist {server_id, bare tool_name}; the gateway serves
+// each tool prefixed as "{server-prefix}-{tool}". Render that qualified form so
+// the same tool name on different servers stays distinguishable. This mirrors the
+// backend default MCP_TOOL_PREFIX_SEPARATOR; overriding that env var only changes
+// this cosmetic label, never what is stored or how tools are matched.
+const MCP_TOOL_PREFIX_SEPARATOR = "-";
+
+function displayToolName(serverPrefix: string | undefined, toolName: string): string {
+  return serverPrefix ? `${serverPrefix}${MCP_TOOL_PREFIX_SEPARATOR}${toolName}` : toolName;
+}
+
 interface MCPToolsetsTabProps {
   accessToken: string | null;
   userRole: string | null;
@@ -138,6 +149,10 @@ function CreateToolsetModal({ open, onClose, onSave, accessToken, initialToolset
   const [saving, setSaving] = useState(false);
   const [serverSearch, setServerSearch] = useState("");
   const { data: mcpServers = [] } = useMCPServers();
+  const serverPrefixById = React.useMemo(
+    () => new Map(mcpServers.map((s) => [s.server_id, s.alias || s.server_name || s.server_id])),
+    [mcpServers],
+  );
 
   React.useEffect(() => {
     if (open) {
@@ -254,7 +269,7 @@ function CreateToolsetModal({ open, onClose, onSave, accessToken, initialToolset
                 >
                   <div className="min-w-0 text-left">
                     <span className="text-xs font-medium text-purple-800 group-hover:text-red-600 truncate block">
-                      {tool.tool_name}
+                      {displayToolName(serverPrefixById.get(tool.server_id), tool.tool_name)}
                     </span>
                     <span className="text-[10px] text-purple-400 truncate block">{tool.server_id.slice(0, 8)}…</span>
                   </div>
@@ -282,8 +297,9 @@ function toolsetColumns(
   isAdmin: boolean,
   onEdit: (t: MCPToolset) => void,
   onDelete: (id: string) => void,
-  proxyBaseUrl: string,
+  serverPrefixById: Map<string, string>,
 ): ColumnDef<MCPToolset>[] {
+  const proxyBaseUrl = getProxyBaseUrl();
   return [
     {
       header: "Toolset ID",
@@ -334,7 +350,7 @@ function toolsetColumns(
                 key={i}
                 className="inline-flex items-center px-1.5 py-0.5 rounded bg-purple-50 border border-purple-200 text-purple-700 text-xs"
               >
-                {t.tool_name}
+                {displayToolName(serverPrefixById.get(t.server_id), t.tool_name)}
               </span>
             ))}
             {tools.length > 4 && <span className="text-xs text-gray-400 self-center">+{tools.length - 4} more</span>}
@@ -431,6 +447,7 @@ function ToolsetUsageGuide() {
 export function MCPToolsetsTab({ accessToken, userRole }: MCPToolsetsTabProps) {
   const queryClient = useQueryClient();
   const { data: toolsets = [], isLoading } = useMCPToolsets();
+  const { data: mcpServers = [] } = useMCPServers();
   const [createOpen, setCreateOpen] = useState(false);
   const [editToolset, setEditToolset] = useState<MCPToolset | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
@@ -466,8 +483,11 @@ export function MCPToolsetsTab({ accessToken, userRole }: MCPToolsetsTabProps) {
     }
   };
 
-  const proxyBaseUrl = getProxyBaseUrl();
-  const columns = toolsetColumns(isAdmin, setEditToolset, setDeleteId, proxyBaseUrl);
+  const serverPrefixById = React.useMemo(
+    () => new Map(mcpServers.map((s) => [s.server_id, s.alias || s.server_name || s.server_id])),
+    [mcpServers],
+  );
+  const columns = toolsetColumns(isAdmin, setEditToolset, setDeleteId, serverPrefixById);
 
   return (
     <div className="mt-4">


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves [LIT-3419](https://linear.app/litellm-ai/issue/LIT-3419)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Toolsets persist each tool as `{server_id, bare tool_name}`. At list time the bare name is reconciled against the live tool name, which the gateway serves prefixed as `{server-prefix}-{tool}`. The old reconciliation chopped the live name at the first `-`, so a server whose prefix contains a `-` had its tools silently dropped from the toolset. A server gets such a prefix when it has no alias and falls back to its UUID `server_id`, or when it carries a legacy hyphenated alias. Servers with a clean prefix (no separator) were unaffected, which is why some toolsets worked and others returned nothing.

Reproduced against a live proxy on `localhost:4099` backed by real Postgres, talking to the public DeepWiki MCP server. The server is registered with no alias, so its prefix is its hyphenated UUID.

Setup (identical for both runs):

```bash
# DeepWiki MCP server, no alias -> prefix is the hyphenated UUID server_id
SID=$(curl -s -X POST http://localhost:4099/v1/mcp/server \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"url":"https://mcp.deepwiki.com/mcp","transport":"http"}' | jq -r .server_id)
# -> 20976bf7-f206-4638-a499-94cc4c242346

# toolset stores BARE tool names
curl -s -X POST http://localhost:4099/v1/mcp/toolset \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"toolset_name\":\"wikiset\",\"tools\":[
        {\"server_id\":\"$SID\",\"tool_name\":\"read_wiki_contents\"},
        {\"server_id\":\"$SID\",\"tool_name\":\"read_wiki_structure\"}]}"
```

Listing tools through the toolset URL, before and after the change. The global `/mcp/` count stays at 3 in both runs, so the server and its tools are present throughout; only the toolset filter differs.

```bash
list() { curl -s "$1" -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'; }
list http://localhost:4099/mcp/                 # global, sanity
list http://localhost:4099/toolset/wikiset/mcp  # the toolset
```

Before (current `litellm_internal_staging`):

```
global tools available: 3            <- server present, tools served
/toolset/wikiset/mcp tools/list: {"result":{"tools":[]}}   <- dropped
```

After (this PR):

```
global tools available: 3
/toolset/wikiset/mcp tools/list:
   20976bf7-f206-4638-a499-94cc4c242346-read_wiki_structure
   20976bf7-f206-4638-a499-94cc4c242346-read_wiki_contents
```

The dashboard change is display only. On the MCP Toolsets tab the "Your Toolset" chips and the toolset list "Tools" column now render each tool as `{server-prefix}-{tool}` (for example `deepwiki-read_wiki_contents`) so the same tool name on different servers is distinguishable; the persisted record is unchanged. To see it, open `http://localhost:4000/ui/?page=mcp-servers`, go to the Toolsets tab, create or edit a toolset, and pick a couple of tools.

## Type

🐛 Bug Fix

## Changes

The reconciliation between a toolset's stored bare tool name and the live prefixed tool name used `split_server_prefix_from_name`, which removes everything up to the first `MCP_TOOL_PREFIX_SEPARATOR` with no knowledge of the server. When the server's prefix itself contains the separator the cut lands inside the prefix, so the stripped name never matches the stored bare name and the tool is filtered out.

The toolset already stores the `server_id`, so the prefix is knowable. This adds `strip_known_server_prefix(name, server)` in `utils.py`, which removes exactly `{known_prefix}{separator}` for one of the server's registered prefixes (via `iter_known_server_prefixes`) and leaves the name untouched when none match. `filter_tools_by_key_team_permissions` (the list/filter side) and `resolve_toolset_tool_permissions` (the stored-name side) both use it now, keyed by the `server_id` they already hold, so the two sides reduce to the same true bare name for hyphenated aliases, UUID prefixes, and the short-prefix mode alike. Storage format is unchanged and nothing is prefixed on write.

The same first-separator weakness exists in the server-level `allowed_tools` / display-override paths (`_tool_name_matches`, `apply_tool_overrides`); those are a separate feature gated on optional per-server config and are left for a follow-up to keep this change scoped to the toolset bug.

Tests extend `test_mcp_toolset_scope.py` with a parametrized regression over a clean alias, a hyphenated alias, and a no-alias UUID prefix, asserting the granted tools survive the filter and that resolution reduces an already-prefixed stored name back to bare. The clean-alias case passes on the old code; the hyphenated and UUID cases fail before this change and pass after.

A follow-up commit adds focused unit tests for `strip_known_server_prefix` in `test_short_mcp_tool_prefix.py`, exercising the clean, hyphenated-alias, and UUID server_id prefixes plus the unprefixed-passthrough and `server=None` fallback paths directly on the helper with real `MCPServer` objects
