### PR TITLE
feat(mcp): add mcp_xff_num_trusted_hops to harden X-Forwarded-For client IP resolution

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2363,6 +2363,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     )
     mcp_xff_num_trusted_hops: Optional[int] = Field(
         None,
+        ge=1,
         description="Number of trusted reverse proxies/load balancers in front of the gateway that append to X-Forwarded-For. When set (and mcp_trusted_proxy_ranges validates the direct peer), the client IP for MCP access control is read this many entries from the right of the chain instead of the spoofable leftmost value, defeating append-style X-Forwarded-For forgery.",
     )
     trusted_proxy_ranges: Optional[List[str]] = Field(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2361,6 +2361,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="CIDR ranges of trusted reverse proxies. When set, X-Forwarded-For and X-Forwarded-* origin headers are only trusted from these IPs.",
     )
+    mcp_xff_num_trusted_hops: Optional[int] = Field(
+        None,
+        description="Number of trusted reverse proxies/load balancers in front of the gateway that append to X-Forwarded-For. When set (and mcp_trusted_proxy_ranges validates the direct peer), the client IP for MCP access control is read this many entries from the right of the chain instead of the spoofable leftmost value, defeating append-style X-Forwarded-For forgery.",
+    )
     trusted_proxy_ranges: Optional[List[str]] = Field(
         None,
         description="CIDR ranges of trusted reverse proxies allowed to provide identity headers for header-based auth paths such as enable_oauth2_proxy_auth and custom_ui_sso_sign_in_handler.",

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -45,9 +45,7 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning(
-                    "Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr
-                )
+                verbose_proxy_logger.warning("Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr)
         return networks if networks else IPAddressUtils._DEFAULT_INTERNAL_NETWORKS
 
     @staticmethod
@@ -65,9 +63,7 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning(
-                    "Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr
-                )
+                verbose_proxy_logger.warning("Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr)
         return networks
 
     @staticmethod
@@ -87,9 +83,7 @@ class IPAddressUtils:
     @staticmethod
     def is_internal_ip(
         client_ip: Optional[str],
-        internal_networks: Optional[
-            List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
-        ] = None,
+        internal_networks: Optional[List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]] = None,
     ) -> bool:
         """
         Check if a client IP is from an internal/private network.
@@ -210,7 +204,15 @@ class IPAddressUtils:
                 raw_num_trusted_hops,
             )
             return None
-        return num_hops if num_hops >= 1 else None
+        if num_hops < 1:
+            verbose_proxy_logger.warning(
+                "mcp_xff_num_trusted_hops=%s is below the minimum of 1; "
+                "hop-counting stays disabled and MCP client IP resolution "
+                "falls back to the legacy leftmost X-Forwarded-For value",
+                num_hops,
+            )
+            return None
+        return num_hops
 
     @staticmethod
     def get_mcp_client_ip(
@@ -250,27 +252,19 @@ class IPAddressUtils:
 
         # If XFF is enabled, validate the request comes from a trusted proxy
         if use_xff and "x-forwarded-for" in request.headers:
-            if not IPAddressUtils.is_request_from_trusted_proxy(
-                request, general_settings=general_settings
-            ):
+            if not IPAddressUtils.is_request_from_trusted_proxy(request, general_settings=general_settings):
                 direct_ip = request.client.host if request.client else None
                 if general_settings.get("mcp_trusted_proxy_ranges"):
                     # Direct connection isn't in any configured trusted CIDR.
-                    verbose_proxy_logger.warning(
-                        "XFF header from untrusted IP %s, ignoring", direct_ip
-                    )
+                    verbose_proxy_logger.warning("XFF header from untrusted IP %s, ignoring", direct_ip)
                     return direct_ip
                 # XFF enabled but no trusted proxy ranges configured: the direct
                 # peer is typically the reverse proxy's own (private) IP, so
                 # returning it would mis-classify external callers as internal.
                 # Fail closed for access control.
                 return ""
-            raw_num_trusted_hops: object = general_settings.get(
-                "mcp_xff_num_trusted_hops"
-            )
-            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(
-                raw_num_trusted_hops
-            )
+            raw_num_trusted_hops: object = general_settings.get("mcp_xff_num_trusted_hops")
+            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(raw_num_trusted_hops)
             if num_trusted_hops is not None:
                 client_ip = IPAddressUtils.extract_client_ip_from_xff_hops(
                     request.headers["x-forwarded-for"], num_trusted_hops

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -45,7 +45,9 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning("Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr)
+                verbose_proxy_logger.warning(
+                    "Invalid CIDR in mcp_internal_ip_ranges: %s, skipping", cidr
+                )
         return networks if networks else IPAddressUtils._DEFAULT_INTERNAL_NETWORKS
 
     @staticmethod
@@ -63,7 +65,9 @@ class IPAddressUtils:
             try:
                 networks.append(ipaddress.ip_network(cidr, strict=False))
             except ValueError:
-                verbose_proxy_logger.warning("Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr)
+                verbose_proxy_logger.warning(
+                    "Invalid CIDR in mcp_trusted_proxy_ranges: %s, skipping", cidr
+                )
         return networks
 
     @staticmethod
@@ -83,7 +87,9 @@ class IPAddressUtils:
     @staticmethod
     def is_internal_ip(
         client_ip: Optional[str],
-        internal_networks: Optional[List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]] = None,
+        internal_networks: Optional[
+            List[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
+        ] = None,
     ) -> bool:
         """
         Check if a client IP is from an internal/private network.
@@ -252,19 +258,27 @@ class IPAddressUtils:
 
         # If XFF is enabled, validate the request comes from a trusted proxy
         if use_xff and "x-forwarded-for" in request.headers:
-            if not IPAddressUtils.is_request_from_trusted_proxy(request, general_settings=general_settings):
+            if not IPAddressUtils.is_request_from_trusted_proxy(
+                request, general_settings=general_settings
+            ):
                 direct_ip = request.client.host if request.client else None
                 if general_settings.get("mcp_trusted_proxy_ranges"):
                     # Direct connection isn't in any configured trusted CIDR.
-                    verbose_proxy_logger.warning("XFF header from untrusted IP %s, ignoring", direct_ip)
+                    verbose_proxy_logger.warning(
+                        "XFF header from untrusted IP %s, ignoring", direct_ip
+                    )
                     return direct_ip
                 # XFF enabled but no trusted proxy ranges configured: the direct
                 # peer is typically the reverse proxy's own (private) IP, so
                 # returning it would mis-classify external callers as internal.
                 # Fail closed for access control.
                 return ""
-            raw_num_trusted_hops: object = general_settings.get("mcp_xff_num_trusted_hops")
-            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(raw_num_trusted_hops)
+            raw_num_trusted_hops: object = general_settings.get(
+                "mcp_xff_num_trusted_hops"
+            )
+            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(
+                raw_num_trusted_hops
+            )
             if num_trusted_hops is not None:
                 client_ip = IPAddressUtils.extract_client_ip_from_xff_hops(
                     request.headers["x-forwarded-for"], num_trusted_hops

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -9,6 +9,7 @@ import ipaddress
 from typing import Any, Dict, List, Optional, Union
 
 from fastapi import Request
+from pydantic import TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy.auth.auth_utils import _get_request_ip_address
@@ -16,6 +17,8 @@ from litellm.proxy.auth.auth_utils import _get_request_ip_address
 # One-shot warning so operators upgrading from the prior "always trust X-Forwarded-*"
 # behaviour see an actionable message in their logs the first time it triggers.
 _warned_xff_without_trusted_ranges = False
+
+_NUM_TRUSTED_HOPS_ADAPTER = TypeAdapter(int)
 
 
 class IPAddressUtils:
@@ -167,6 +170,49 @@ class IPAddressUtils:
         return IPAddressUtils.is_trusted_proxy(direct_ip, trusted_networks)
 
     @staticmethod
+    def extract_client_ip_from_xff_hops(
+        xff_header: str,
+        num_trusted_hops: int,
+    ) -> Optional[str]:
+        """
+        Resolve the originating client IP from an X-Forwarded-For chain by
+        counting ``num_trusted_hops`` entries from the right.
+
+        Each trusted proxy appends the address it received the connection from,
+        so the right end of the chain is written by infrastructure while the
+        left end is attacker-controllable. Selecting the Nth entry from the
+        right, where N is the number of trusted appending proxies in front of
+        the gateway, yields the real client IP and discards any values a client
+        prepended to spoof an allowed address.
+
+        Returns None when the chain has fewer than ``num_trusted_hops`` entries
+        or the selected entry is not a valid IP, so callers can fail closed.
+        """
+        entries = tuple(part.strip() for part in xff_header.split(",") if part.strip())
+        if num_trusted_hops < 1 or len(entries) < num_trusted_hops:
+            return None
+        candidate = entries[-num_trusted_hops]
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            return None
+        return candidate
+
+    @staticmethod
+    def _resolve_num_trusted_hops(raw_num_trusted_hops: object) -> Optional[int]:
+        if raw_num_trusted_hops is None:
+            return None
+        try:
+            num_hops = _NUM_TRUSTED_HOPS_ADAPTER.validate_python(raw_num_trusted_hops)
+        except ValidationError:
+            verbose_proxy_logger.warning(
+                "Invalid mcp_xff_num_trusted_hops value %r; ignoring",
+                raw_num_trusted_hops,
+            )
+            return None
+        return num_hops if num_hops >= 1 else None
+
+    @staticmethod
     def get_mcp_client_ip(
         request: Request,
         general_settings: Optional[Dict[str, Any]] = None,
@@ -177,6 +223,10 @@ class IPAddressUtils:
         Security: Only trusts X-Forwarded-For if:
         1. use_x_forwarded_for is enabled in settings
         2. The direct connection is from a trusted proxy (if mcp_trusted_proxy_ranges configured)
+
+        When ``mcp_xff_num_trusted_hops`` is set, the client IP is read that many
+        entries from the right of the chain instead of the spoofable leftmost
+        value, defeating append-style X-Forwarded-For forgery.
 
         Args:
             request: FastAPI request object
@@ -215,4 +265,23 @@ class IPAddressUtils:
                 # returning it would mis-classify external callers as internal.
                 # Fail closed for access control.
                 return ""
+            raw_num_trusted_hops: object = general_settings.get(
+                "mcp_xff_num_trusted_hops"
+            )
+            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(
+                raw_num_trusted_hops
+            )
+            if num_trusted_hops is not None:
+                client_ip = IPAddressUtils.extract_client_ip_from_xff_hops(
+                    request.headers["x-forwarded-for"], num_trusted_hops
+                )
+                if client_ip is None:
+                    verbose_proxy_logger.warning(
+                        "X-Forwarded-For chain has fewer than "
+                        "mcp_xff_num_trusted_hops=%s entries or an invalid "
+                        "address; failing closed",
+                        num_trusted_hops,
+                    )
+                    return ""
+                return client_ip
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -6,6 +6,7 @@ External callers (public IPs) only see servers with available_on_public_internet
 """
 
 import ipaddress
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 from fastapi import Request
@@ -19,6 +20,24 @@ from litellm.proxy.auth.auth_utils import _get_request_ip_address
 _warned_xff_without_trusted_ranges = False
 
 _NUM_TRUSTED_HOPS_ADAPTER = TypeAdapter(int)
+
+
+@dataclass(frozen=True, slots=True)
+class _HopCountUnset:
+    """mcp_xff_num_trusted_hops is absent: keep the legacy leftmost-XFF path."""
+
+
+@dataclass(frozen=True, slots=True)
+class _HopCountInvalid:
+    """mcp_xff_num_trusted_hops is present but unusable: fail closed, never legacy."""
+
+
+@dataclass(frozen=True, slots=True)
+class _HopCount:
+    value: int
+
+
+_HopCountSetting = Union[_HopCountUnset, _HopCountInvalid, _HopCount]
 
 
 class IPAddressUtils:
@@ -199,26 +218,29 @@ class IPAddressUtils:
         return candidate
 
     @staticmethod
-    def _resolve_num_trusted_hops(raw_num_trusted_hops: object) -> Optional[int]:
+    def _resolve_num_trusted_hops(raw_num_trusted_hops: object) -> _HopCountSetting:
         if raw_num_trusted_hops is None:
-            return None
+            return _HopCountUnset()
         try:
             num_hops = _NUM_TRUSTED_HOPS_ADAPTER.validate_python(raw_num_trusted_hops)
         except ValidationError:
             verbose_proxy_logger.warning(
-                "Invalid mcp_xff_num_trusted_hops value %r; ignoring",
+                "Invalid mcp_xff_num_trusted_hops value %r; failing closed for "
+                "MCP client IP resolution. Set it to a positive integer, or "
+                "remove the setting to restore the legacy X-Forwarded-For path",
                 raw_num_trusted_hops,
             )
-            return None
+            return _HopCountInvalid()
         if num_hops < 1:
             verbose_proxy_logger.warning(
-                "mcp_xff_num_trusted_hops=%s is below the minimum of 1; "
-                "hop-counting stays disabled and MCP client IP resolution "
-                "falls back to the legacy leftmost X-Forwarded-For value",
+                "mcp_xff_num_trusted_hops=%s is below the minimum of 1; failing "
+                "closed for MCP client IP resolution. Set it to a positive "
+                "integer, or remove the setting to restore the legacy "
+                "X-Forwarded-For path",
                 num_hops,
             )
-            return None
-        return num_hops
+            return _HopCountInvalid()
+        return _HopCount(num_hops)
 
     @staticmethod
     def get_mcp_client_ip(
@@ -234,7 +256,9 @@ class IPAddressUtils:
 
         When ``mcp_xff_num_trusted_hops`` is set, the client IP is read that many
         entries from the right of the chain instead of the spoofable leftmost
-        value, defeating append-style X-Forwarded-For forgery.
+        value, defeating append-style X-Forwarded-For forgery. A present-but-invalid
+        value (non-integer or below 1) fails closed rather than silently reverting
+        to the legacy path, so a config typo cannot quietly weaken access control.
 
         Args:
             request: FastAPI request object
@@ -273,23 +297,24 @@ class IPAddressUtils:
                 # returning it would mis-classify external callers as internal.
                 # Fail closed for access control.
                 return ""
-            raw_num_trusted_hops: object = general_settings.get(
-                "mcp_xff_num_trusted_hops"
-            )
-            num_trusted_hops = IPAddressUtils._resolve_num_trusted_hops(
-                raw_num_trusted_hops
-            )
-            if num_trusted_hops is not None:
-                client_ip = IPAddressUtils.extract_client_ip_from_xff_hops(
-                    request.headers["x-forwarded-for"], num_trusted_hops
-                )
-                if client_ip is None:
-                    verbose_proxy_logger.warning(
-                        "X-Forwarded-For chain has fewer than "
-                        "mcp_xff_num_trusted_hops=%s entries or an invalid "
-                        "address; failing closed",
-                        num_trusted_hops,
-                    )
+            match IPAddressUtils._resolve_num_trusted_hops(
+                general_settings.get("mcp_xff_num_trusted_hops")
+            ):
+                case _HopCountInvalid():
                     return ""
-                return client_ip
+                case _HopCount(value=num_trusted_hops):
+                    client_ip = IPAddressUtils.extract_client_ip_from_xff_hops(
+                        request.headers["x-forwarded-for"], num_trusted_hops
+                    )
+                    if client_ip is None:
+                        verbose_proxy_logger.warning(
+                            "X-Forwarded-For chain has fewer than "
+                            "mcp_xff_num_trusted_hops=%s entries or an invalid "
+                            "address; failing closed",
+                            num_trusted_hops,
+                        )
+                        return ""
+                    return client_ip
+                case _HopCountUnset():
+                    pass
         return _get_request_ip_address(request, use_x_forwarded_for=use_xff)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15385,6 +15385,7 @@ async def get_config_list(
         "maximum_spend_logs_retention_period": {"type": "String"},
         "mcp_internal_ip_ranges": {"type": "List"},
         "mcp_trusted_proxy_ranges": {"type": "List"},
+        "mcp_xff_num_trusted_hops": {"type": "Integer"},
         "always_include_stream_usage": {"type": "Boolean"},
         "forward_client_headers_to_llm_api": {"type": "Boolean"},
         "mcp_required_fields": {"type": "List"},

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -12,7 +12,12 @@ from fastapi import Request
 from pydantic import ValidationError
 
 from litellm.proxy._types import ConfigGeneralSettings
-from litellm.proxy.auth.ip_address_utils import IPAddressUtils
+from litellm.proxy.auth.ip_address_utils import (
+    IPAddressUtils,
+    _HopCount,
+    _HopCountInvalid,
+    _HopCountUnset,
+)
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
 
@@ -142,57 +147,89 @@ def _make_request(client_host, xff):
 class TestExtractClientIpFromXffHops:
     def test_single_hop_picks_rightmost(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops("10.0.0.99, 203.0.113.9", num_trusted_hops=1)
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "10.0.0.99, 203.0.113.9", num_trusted_hops=1
+            )
             == "203.0.113.9"
         )
 
     def test_two_hops_picks_second_from_right(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops("10.0.0.99, 203.0.113.9, 172.16.0.1", num_trusted_hops=2)
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "10.0.0.99, 203.0.113.9, 172.16.0.1", num_trusted_hops=2
+            )
             == "203.0.113.9"
         )
 
     def test_whitespace_and_empty_entries_are_ignored(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(" 1.1.1.1 ,  , 203.0.113.9 ", num_trusted_hops=1)
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                " 1.1.1.1 ,  , 203.0.113.9 ", num_trusted_hops=1
+            )
             == "203.0.113.9"
         )
 
     def test_chain_shorter_than_hops_returns_none(self):
-        assert IPAddressUtils.extract_client_ip_from_xff_hops("203.0.113.9", num_trusted_hops=2) is None
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "203.0.113.9", num_trusted_hops=2
+            )
+            is None
+        )
 
     def test_zero_or_negative_hops_returns_none(self):
-        assert IPAddressUtils.extract_client_ip_from_xff_hops("203.0.113.9", num_trusted_hops=0) is None
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "203.0.113.9", num_trusted_hops=0
+            )
+            is None
+        )
 
     def test_invalid_selected_entry_returns_none(self):
-        assert IPAddressUtils.extract_client_ip_from_xff_hops("not-an-ip, 10.0.0.1", num_trusted_hops=2) is None
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "not-an-ip, 10.0.0.1", num_trusted_hops=2
+            )
+            is None
+        )
 
 
 class TestResolveNumTrustedHops:
-    def test_unset_returns_none(self):
-        assert IPAddressUtils._resolve_num_trusted_hops(None) is None
+    def test_unset_is_unset(self):
+        assert IPAddressUtils._resolve_num_trusted_hops(None) == _HopCountUnset()
 
     def test_int_value(self):
-        assert IPAddressUtils._resolve_num_trusted_hops(2) == 2
+        assert IPAddressUtils._resolve_num_trusted_hops(2) == _HopCount(2)
 
     def test_numeric_string_is_coerced(self):
-        assert IPAddressUtils._resolve_num_trusted_hops("3") == 3
+        assert IPAddressUtils._resolve_num_trusted_hops("3") == _HopCount(3)
 
-    def test_zero_is_treated_as_disabled(self):
-        assert IPAddressUtils._resolve_num_trusted_hops(0) is None
+    def test_zero_is_invalid_not_disabled(self):
+        assert IPAddressUtils._resolve_num_trusted_hops(0) == _HopCountInvalid()
 
-    def test_invalid_value_is_ignored(self):
-        assert IPAddressUtils._resolve_num_trusted_hops("abc") is None
+    def test_non_numeric_value_is_invalid(self):
+        assert IPAddressUtils._resolve_num_trusted_hops("abc") == _HopCountInvalid()
 
     def test_below_minimum_warns_so_misconfig_is_visible(self):
-        with patch("litellm.proxy.auth.ip_address_utils.verbose_proxy_logger") as mock_logger:
-            assert IPAddressUtils._resolve_num_trusted_hops(0) is None
-            assert IPAddressUtils._resolve_num_trusted_hops(-3) is None
+        with patch(
+            "litellm.proxy.auth.ip_address_utils.verbose_proxy_logger"
+        ) as mock_logger:
+            assert IPAddressUtils._resolve_num_trusted_hops(0) == _HopCountInvalid()
+            assert IPAddressUtils._resolve_num_trusted_hops(-3) == _HopCountInvalid()
         assert mock_logger.warning.call_count == 2
 
+    def test_unset_does_not_warn(self):
+        with patch(
+            "litellm.proxy.auth.ip_address_utils.verbose_proxy_logger"
+        ) as mock_logger:
+            assert IPAddressUtils._resolve_num_trusted_hops(None) == _HopCountUnset()
+        mock_logger.warning.assert_not_called()
+
     def test_valid_value_does_not_warn(self):
-        with patch("litellm.proxy.auth.ip_address_utils.verbose_proxy_logger") as mock_logger:
-            assert IPAddressUtils._resolve_num_trusted_hops(2) == 2
+        with patch(
+            "litellm.proxy.auth.ip_address_utils.verbose_proxy_logger"
+        ) as mock_logger:
+            assert IPAddressUtils._resolve_num_trusted_hops(2) == _HopCount(2)
         mock_logger.warning.assert_not_called()
 
 
@@ -205,7 +242,10 @@ class TestConfigGeneralSettingsHopsValidation:
             ConfigGeneralSettings(mcp_xff_num_trusted_hops=bad_value)
 
     def test_valid_value_and_unset_are_accepted(self):
-        assert ConfigGeneralSettings(mcp_xff_num_trusted_hops=1).mcp_xff_num_trusted_hops == 1
+        assert (
+            ConfigGeneralSettings(mcp_xff_num_trusted_hops=1).mcp_xff_num_trusted_hops
+            == 1
+        )
         assert ConfigGeneralSettings().mcp_xff_num_trusted_hops is None
 
 
@@ -295,6 +335,22 @@ class TestXffTrustedHopsAccessControl:
 
         assert result == "10.0.0.99, 203.0.113.9"
 
+    @pytest.mark.parametrize("bad_value", [0, -1, "abc", 1.5])
+    def test_invalid_hops_config_fails_closed_not_legacy(self, bad_value):
+        request = _make_request("10.0.0.5", "10.0.0.99, 203.0.113.9")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                "mcp_xff_num_trusted_hops": bad_value,
+            },
+        )
+
+        assert result == ""
+        assert IPAddressUtils.is_internal_ip(result) is False
+
 
 class TestMCPServerIPFiltering:
     """Tests that external callers only see public MCP servers."""
@@ -316,7 +372,9 @@ class TestMCPServerIPFiltering:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        result = manager.filter_server_ids_by_ip(["pub", "priv"], client_ip="192.168.1.1")
+        result = manager.filter_server_ids_by_ip(
+            ["pub", "priv"], client_ip="192.168.1.1"
+        )
         assert result == ["pub", "priv"]
 
     @patch("litellm.public_mcp_servers", [])
@@ -339,7 +397,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="8.8.8.8")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["pub", "priv"], client_ip="8.8.8.8"
+        )
         assert allowed == ["pub"]
         assert blocked == 1
 
@@ -350,7 +410,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="192.168.1.1")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["pub", "priv"], client_ip="192.168.1.1"
+        )
         assert allowed == ["pub", "priv"]
         assert blocked == 0
 
@@ -360,7 +422,9 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv"], client_ip=None)
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["priv"], client_ip=None
+        )
         assert allowed == ["priv"]
         assert blocked == 0
 
@@ -371,6 +435,8 @@ class TestFilterServerIdsByIpWithInfo:
         priv2 = _make_server("priv2", available_on_public_internet=False)
         manager = _make_manager([priv1, priv2])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv1", "priv2"], client_ip="1.2.3.4")
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
+            ["priv1", "priv2"], client_ip="1.2.3.4"
+        )
         assert allowed == []
         assert blocked == 2

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -139,51 +139,30 @@ def _make_request(client_host, xff):
 class TestExtractClientIpFromXffHops:
     def test_single_hop_picks_rightmost(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                "10.0.0.99, 203.0.113.9", num_trusted_hops=1
-            )
+            IPAddressUtils.extract_client_ip_from_xff_hops("10.0.0.99, 203.0.113.9", num_trusted_hops=1)
             == "203.0.113.9"
         )
 
     def test_two_hops_picks_second_from_right(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                "10.0.0.99, 203.0.113.9, 172.16.0.1", num_trusted_hops=2
-            )
+            IPAddressUtils.extract_client_ip_from_xff_hops("10.0.0.99, 203.0.113.9, 172.16.0.1", num_trusted_hops=2)
             == "203.0.113.9"
         )
 
     def test_whitespace_and_empty_entries_are_ignored(self):
         assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                " 1.1.1.1 ,  , 203.0.113.9 ", num_trusted_hops=1
-            )
+            IPAddressUtils.extract_client_ip_from_xff_hops(" 1.1.1.1 ,  , 203.0.113.9 ", num_trusted_hops=1)
             == "203.0.113.9"
         )
 
     def test_chain_shorter_than_hops_returns_none(self):
-        assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                "203.0.113.9", num_trusted_hops=2
-            )
-            is None
-        )
+        assert IPAddressUtils.extract_client_ip_from_xff_hops("203.0.113.9", num_trusted_hops=2) is None
 
     def test_zero_or_negative_hops_returns_none(self):
-        assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                "203.0.113.9", num_trusted_hops=0
-            )
-            is None
-        )
+        assert IPAddressUtils.extract_client_ip_from_xff_hops("203.0.113.9", num_trusted_hops=0) is None
 
     def test_invalid_selected_entry_returns_none(self):
-        assert (
-            IPAddressUtils.extract_client_ip_from_xff_hops(
-                "not-an-ip, 10.0.0.1", num_trusted_hops=2
-            )
-            is None
-        )
+        assert IPAddressUtils.extract_client_ip_from_xff_hops("not-an-ip, 10.0.0.1", num_trusted_hops=2) is None
 
 
 class TestResolveNumTrustedHops:
@@ -201,6 +180,17 @@ class TestResolveNumTrustedHops:
 
     def test_invalid_value_is_ignored(self):
         assert IPAddressUtils._resolve_num_trusted_hops("abc") is None
+
+    def test_below_minimum_warns_so_misconfig_is_visible(self):
+        with patch("litellm.proxy.auth.ip_address_utils.verbose_proxy_logger") as mock_logger:
+            assert IPAddressUtils._resolve_num_trusted_hops(0) is None
+            assert IPAddressUtils._resolve_num_trusted_hops(-3) is None
+        assert mock_logger.warning.call_count == 2
+
+    def test_valid_value_does_not_warn(self):
+        with patch("litellm.proxy.auth.ip_address_utils.verbose_proxy_logger") as mock_logger:
+            assert IPAddressUtils._resolve_num_trusted_hops(2) == 2
+        mock_logger.warning.assert_not_called()
 
 
 class TestXffTrustedHopsAccessControl:
@@ -310,9 +300,7 @@ class TestMCPServerIPFiltering:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        result = manager.filter_server_ids_by_ip(
-            ["pub", "priv"], client_ip="192.168.1.1"
-        )
+        result = manager.filter_server_ids_by_ip(["pub", "priv"], client_ip="192.168.1.1")
         assert result == ["pub", "priv"]
 
     @patch("litellm.public_mcp_servers", [])
@@ -335,9 +323,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["pub", "priv"], client_ip="8.8.8.8"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="8.8.8.8")
         assert allowed == ["pub"]
         assert blocked == 1
 
@@ -348,9 +334,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([pub, priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["pub", "priv"], client_ip="192.168.1.1"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["pub", "priv"], client_ip="192.168.1.1")
         assert allowed == ["pub", "priv"]
         assert blocked == 0
 
@@ -360,9 +344,7 @@ class TestFilterServerIdsByIpWithInfo:
         priv = _make_server("priv", available_on_public_internet=False)
         manager = _make_manager([priv])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["priv"], client_ip=None
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv"], client_ip=None)
         assert allowed == ["priv"]
         assert blocked == 0
 
@@ -373,8 +355,6 @@ class TestFilterServerIdsByIpWithInfo:
         priv2 = _make_server("priv2", available_on_public_internet=False)
         manager = _make_manager([priv1, priv2])
 
-        allowed, blocked = manager.filter_server_ids_by_ip_with_info(
-            ["priv1", "priv2"], client_ip="1.2.3.4"
-        )
+        allowed, blocked = manager.filter_server_ids_by_ip_with_info(["priv1", "priv2"], client_ip="1.2.3.4")
         assert allowed == []
         assert blocked == 2

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -7,8 +7,11 @@ external callers only see servers with available_on_public_internet=True.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi import Request
+from pydantic import ValidationError
 
+from litellm.proxy._types import ConfigGeneralSettings
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
@@ -191,6 +194,19 @@ class TestResolveNumTrustedHops:
         with patch("litellm.proxy.auth.ip_address_utils.verbose_proxy_logger") as mock_logger:
             assert IPAddressUtils._resolve_num_trusted_hops(2) == 2
         mock_logger.warning.assert_not_called()
+
+
+class TestConfigGeneralSettingsHopsValidation:
+    """mcp_xff_num_trusted_hops must reject sub-minimum values at config-parse time."""
+
+    @pytest.mark.parametrize("bad_value", [0, -1])
+    def test_below_minimum_is_rejected(self, bad_value):
+        with pytest.raises(ValidationError):
+            ConfigGeneralSettings(mcp_xff_num_trusted_hops=bad_value)
+
+    def test_valid_value_and_unset_are_accepted(self):
+        assert ConfigGeneralSettings(mcp_xff_num_trusted_hops=1).mcp_xff_num_trusted_hops == 1
+        assert ConfigGeneralSettings().mcp_xff_num_trusted_hops is None
 
 
 class TestXffTrustedHopsAccessControl:

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -128,6 +128,168 @@ class TestMCPClientIPExtraction:
         assert result == "203.0.113.5"
 
 
+def _make_request(client_host, xff):
+    request = MagicMock(spec=Request)
+    request.client = MagicMock()
+    request.client.host = client_host
+    request.headers = {"x-forwarded-for": xff}
+    return request
+
+
+class TestExtractClientIpFromXffHops:
+    def test_single_hop_picks_rightmost(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "10.0.0.99, 203.0.113.9", num_trusted_hops=1
+            )
+            == "203.0.113.9"
+        )
+
+    def test_two_hops_picks_second_from_right(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "10.0.0.99, 203.0.113.9, 172.16.0.1", num_trusted_hops=2
+            )
+            == "203.0.113.9"
+        )
+
+    def test_whitespace_and_empty_entries_are_ignored(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                " 1.1.1.1 ,  , 203.0.113.9 ", num_trusted_hops=1
+            )
+            == "203.0.113.9"
+        )
+
+    def test_chain_shorter_than_hops_returns_none(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "203.0.113.9", num_trusted_hops=2
+            )
+            is None
+        )
+
+    def test_zero_or_negative_hops_returns_none(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "203.0.113.9", num_trusted_hops=0
+            )
+            is None
+        )
+
+    def test_invalid_selected_entry_returns_none(self):
+        assert (
+            IPAddressUtils.extract_client_ip_from_xff_hops(
+                "not-an-ip, 10.0.0.1", num_trusted_hops=2
+            )
+            is None
+        )
+
+
+class TestResolveNumTrustedHops:
+    def test_unset_returns_none(self):
+        assert IPAddressUtils._resolve_num_trusted_hops(None) is None
+
+    def test_int_value(self):
+        assert IPAddressUtils._resolve_num_trusted_hops(2) == 2
+
+    def test_numeric_string_is_coerced(self):
+        assert IPAddressUtils._resolve_num_trusted_hops("3") == 3
+
+    def test_zero_is_treated_as_disabled(self):
+        assert IPAddressUtils._resolve_num_trusted_hops(0) is None
+
+    def test_invalid_value_is_ignored(self):
+        assert IPAddressUtils._resolve_num_trusted_hops("abc") is None
+
+
+class TestXffTrustedHopsAccessControl:
+    def test_spoofed_internal_leftmost_is_defeated(self):
+        request = _make_request("10.0.0.5", "10.0.0.99, 203.0.113.9")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                "mcp_xff_num_trusted_hops": 1,
+            },
+        )
+
+        assert result == "203.0.113.9"
+        assert IPAddressUtils.is_internal_ip(result) is False
+
+    def test_genuine_internal_client_is_preserved(self):
+        request = _make_request("10.0.0.5", "10.0.0.50")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                "mcp_xff_num_trusted_hops": 1,
+            },
+        )
+
+        assert result == "10.0.0.50"
+        assert IPAddressUtils.is_internal_ip(result) is True
+
+    def test_two_hops_skips_proxy_appended_addresses(self):
+        request = _make_request("10.0.0.5", "10.0.0.99, 203.0.113.9, 172.16.0.1")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                "mcp_xff_num_trusted_hops": 2,
+            },
+        )
+
+        assert result == "203.0.113.9"
+
+    def test_short_chain_fails_closed(self):
+        request = _make_request("10.0.0.5", "203.0.113.9")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+                "mcp_xff_num_trusted_hops": 2,
+            },
+        )
+
+        assert result == ""
+        assert IPAddressUtils.is_internal_ip(result) is False
+
+    def test_hops_without_trusted_ranges_still_fails_closed(self):
+        request = _make_request("203.0.113.5", "10.0.0.99, 8.8.8.8")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_xff_num_trusted_hops": 1,
+            },
+        )
+
+        assert result == ""
+
+    def test_unset_hops_keeps_legacy_leftmost_behavior(self):
+        request = _make_request("10.0.0.5", "10.0.0.99, 203.0.113.9")
+
+        result = IPAddressUtils.get_mcp_client_ip(
+            request,
+            general_settings={
+                "use_x_forwarded_for": True,
+                "mcp_trusted_proxy_ranges": ["10.0.0.0/8"],
+            },
+        )
+
+        assert result == "10.0.0.99, 203.0.113.9"
+
+
 class TestMCPServerIPFiltering:
     """Tests that external callers only see public MCP servers."""
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22427,6 +22427,11 @@ export interface components {
              */
             mcp_trusted_proxy_ranges?: string[] | null;
             /**
+             * Mcp Xff Num Trusted Hops
+             * @description Number of trusted reverse proxies/load balancers in front of the gateway that append to X-Forwarded-For. When set (and mcp_trusted_proxy_ranges validates the direct peer), the client IP for MCP access control is read this many entries from the right of the chain instead of the spoofable leftmost value, defeating append-style X-Forwarded-For forgery.
+             */
+            mcp_xff_num_trusted_hops?: number | null;
+            /**
              * Otel
              * @description [BETA] OpenTelemetry support - this might change, use with caution.
              */


### PR DESCRIPTION
## Relevant issues

Hardening for the append-style X-Forwarded-For spoofing gap in MCP per-server IP access control, the same XFF trust model introduced with `mcp_trusted_proxy_ranges` (#28356)

## Linear ticket

Related to LIT-3964 (MCP internal/external classification via X-Forwarded-For)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

MCP per-server IP access control resolves the client IP from X-Forwarded-For and `is_internal_ip()` classifies it by reading the leftmost entry. Behind an append-style proxy or load balancer (AWS ALB, nginx with `$proxy_add_x_forwarded_for`, HAProxy, Envoy, Cloudflare), a client can prepend an arbitrary value, so the leftmost entry is attacker-controllable even when the direct peer is a trusted proxy. That lets an attacker spoof an internal IP and reach servers marked `available_on_public_internet=false`. This change reads the client IP `mcp_xff_num_trusted_hops` entries from the right of the chain instead, so prepended values are ignored.

No LLM call is involved because the change is purely in X-Forwarded-For parsing for MCP access control. The proof hits `GET /v1/mcp/network/client-ip`, which returns exactly the IP `get_mcp_client_ip()` resolves for access-control filtering.

Started a local proxy with `FORWARDED_ALLOW_IPS=10.255.255.255` so uvicorn does not rewrite `request.client.host` from the loopback curl peer; this mirrors a real deployment where the gateway's direct peer is the ingress (not loopback) and uvicorn leaves the header untouched.

Before, `general_settings` has `use_x_forwarded_for: true` and `mcp_trusted_proxy_ranges: ["127.0.0.0/8"]` and no hop count:

```
$ curl -s -H "Authorization: Bearer sk-1234" \
    -H "X-Forwarded-For: 10.0.0.99, 203.0.113.9" \
    http://localhost:4000/v1/mcp/network/client-ip
{"ip":"10.0.0.99, 203.0.113.9"}
```

The raw chain is returned and `is_internal_ip()` takes the leftmost `10.0.0.99`, so the caller is classified internal and the spoof succeeds.

After, the same config plus `mcp_xff_num_trusted_hops: 1`:

```
$ curl -s -H "Authorization: Bearer sk-1234" \
    -H "X-Forwarded-For: 10.0.0.99, 203.0.113.9" \
    http://localhost:4000/v1/mcp/network/client-ip
{"ip":"203.0.113.9"}

$ curl -s -H "Authorization: Bearer sk-1234" \
    -H "X-Forwarded-For: 10.0.0.50" \
    http://localhost:4000/v1/mcp/network/client-ip
{"ip":"10.0.0.50"}
```

The prepended `10.0.0.99` is ignored and the real client `203.0.113.9` is resolved (external, spoof defeated), while a genuine single-hop internal client `10.0.0.50` is preserved.

Fail-closed is also preserved: with `use_x_forwarded_for: true` and no `mcp_trusted_proxy_ranges`, the same spoofed header returns `{"ip":""}`, and with a chain shorter than the configured hop count the resolver returns `""` rather than guessing.

## Type

🆕 New Feature

🐛 Bug Fix

## Changes

Adds an optional `mcp_xff_num_trusted_hops` general setting modelled on Envoy's `xff_num_trusted_hops`. When set to N, `get_mcp_client_ip()` reads the client IP N entries from the right of the X-Forwarded-For chain, where N is the number of trusted appending proxies in front of the gateway, instead of letting the downstream classifier trust the spoofable leftmost value.

It composes with `mcp_trusted_proxy_ranges`, which still validates the direct peer, and only takes effect once that check passes. Without a validated direct peer the gateway keeps failing closed, so hop counting cannot be abused by a direct-to-pod attacker. The chain must contain at least N valid entries or resolution fails closed.

The setting defaults to unset, so existing deployments are unchanged. Values below 1 are rejected at config-parse time via a `ge=1` bound on the field. Any present-but-invalid value (0, negative, or non-numeric) that still reaches the runtime through raw config now fails closed (resolution returns `""`) and is logged as a warning, rather than silently reverting to the spoofable leftmost value. The three states are modelled as a tagged union so they stay distinct: unset keeps the legacy leftmost path, a valid count drives hop counting, and an invalid value fails closed. That way a typo cannot quietly weaken access control below the pre-feature baseline; it either fails to parse or fails closed. New unit tests cover the right-to-left selection, multi-hop chains, genuine internal clients, short-chain and invalid-entry fail-closed paths, the requirement that a trusted proxy range is configured, and that the legacy leftmost behavior is retained when the setting is absent.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive MCP client IP resolution used for internal-only server access; misconfiguration could block legitimate clients or weaken filtering if operators misunderstand hop count, though invalid values fail closed.
> 
> **Overview**
> Adds optional **`mcp_xff_num_trusted_hops`** to proxy general settings so MCP access control can derive the client IP from **X-Forwarded-For** by reading **N entries from the right** of the chain (after the existing trusted-proxy peer check), instead of trusting the spoofable leftmost value behind append-style load balancers.
> 
> **`get_mcp_client_ip()`** now branches on a three-state hop setting: unset keeps legacy leftmost behavior; a valid positive integer uses **`extract_client_ip_from_xff_hops`** and returns empty string when the chain is too short or invalid; present-but-invalid values **fail closed** (no silent fallback to legacy). Config parsing rejects values below 1 via **`ge=1`** on **`ConfigGeneralSettings`**, and the setting is exposed in the proxy config schema and dashboard OpenAPI types.
> 
> Unit tests cover hop extraction, misconfiguration warnings, spoof defeat, multi-hop chains, and legacy behavior when the setting is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a2a05af706bb352e65ea7dc8ab3a6cebba9d937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->