### PR TITLE
fix(bedrock): duplicate toolResult for split concatenated tool calls

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -4237,6 +4237,58 @@ def _convert_to_bedrock_tool_call_result(
     return content_block
 
 
+def _bedrock_tool_call_split_count(arguments: Optional[str]) -> int:
+    """Number of Bedrock ``toolUse`` blocks a single OpenAI tool call expands into.
+
+    Mirrors the concatenated-JSON split in
+    ``_convert_to_bedrock_tool_call_invoke``: when a tool call's ``arguments``
+    string contains several JSON objects jammed together
+    (e.g. ``'{"cmd":"a"}{"cmd":"b"}'``) it is emitted as one ``toolUse`` per
+    object. Returns 1 for the normal single-object case.
+
+    Used so the matching ``toolResult`` can be duplicated for every split id,
+    so no ``toolUse`` is left without a result on the next turn.
+    See https://github.com/BerriAI/litellm/issues/26060
+    """
+    if not arguments or not arguments.strip():
+        return 1
+    try:
+        json.loads(arguments)
+        return 1
+    except json.JSONDecodeError:
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            split_concatenated_json_objects,
+        )
+
+        parsed_objects = split_concatenated_json_objects(arguments)
+        return len(parsed_objects) if parsed_objects else 1
+
+
+def _duplicate_bedrock_tool_result_for_splits(
+    tool_call_result: BedrockContentBlock, split_count: int
+) -> list[BedrockContentBlock]:
+    """Expand one ``toolResult`` into one per split id of a concatenated tool call.
+
+    ``_convert_to_bedrock_tool_call_invoke`` splits a single tool call into
+    ``split_count`` ``toolUse`` blocks with deterministic ids ``id``, ``id_1`` ..
+    ``id_{n-1}``. The app only returns one result (for the original ``id``), so we
+    reuse its content under each split id to keep every ``toolUse`` matched and
+    avoid Bedrock's "Expected toolResult blocks ... for the following Ids" error.
+    See https://github.com/BerriAI/litellm/issues/26060
+    """
+    if split_count <= 1 or "toolResult" not in tool_call_result:
+        return [tool_call_result]
+
+    base_tool_result = tool_call_result["toolResult"]
+    base_tool_use_id = base_tool_result["toolUseId"]
+    blocks: list[BedrockContentBlock] = [tool_call_result]
+    for idx in range(1, split_count):
+        duplicated_tool_result = copy.deepcopy(base_tool_result)
+        duplicated_tool_result["toolUseId"] = f"{base_tool_use_id}_{idx}"
+        blocks.append(BedrockContentBlock(toolResult=duplicated_tool_result))
+    return blocks
+
+
 def _deduplicate_bedrock_content_blocks(
     blocks: List[BedrockContentBlock],
     block_key: str,
@@ -4719,6 +4771,10 @@ class BedrockConverseMessagesProcessor:
             messages, model, llm_provider, user_continue_message
         )
 
+        # Maps an original tool_call_id to the number of bedrock toolUse blocks it
+        # was split into, so its toolResult can be duplicated to match (#26060).
+        tool_call_id_to_split_count: dict[str, int] = {}
+
         while msg_i < len(messages):
             user_content: List[BedrockContentBlock] = []
             init_msg_i = msg_i
@@ -4822,7 +4878,21 @@ class BedrockConverseMessagesProcessor:
             while msg_i < len(messages) and messages[msg_i]["role"] == "tool":
                 current_message = messages[msg_i]
                 tool_call_result = _convert_to_bedrock_tool_call_result(current_message)
-                tool_content.append(tool_call_result)
+                # The matching assistant turn split a concatenated-JSON tool call
+                # into N toolUse blocks with ids "<id>", "<id>_1", ... "<id>_N-1",
+                # but the model returns only one result (for the original id).
+                # Duplicate that result across every split id so no toolUse is left
+                # unmatched; otherwise Bedrock rejects the next turn with:
+                #   "Expected toolResult blocks ... for the following Ids: <id>_1"
+                # Fixes: https://github.com/BerriAI/litellm/issues/26060
+                _split_count = tool_call_id_to_split_count.get(
+                    str(current_message.get("tool_call_id", "")), 1
+                )
+                tool_content.extend(
+                    _duplicate_bedrock_tool_result_for_splits(
+                        tool_call_result, _split_count
+                    )
+                )
 
                 # Check if we need to add a separate cachePoint block
                 has_cache_control = False
@@ -4965,6 +5035,17 @@ class BedrockConverseMessagesProcessor:
                     assistant_content.extend(
                         _convert_to_bedrock_tool_call_invoke(_tool_calls)
                     )
+                    # Remember how many toolUse blocks each tool call split into so
+                    # the matching toolResult can be duplicated next turn (#26060).
+                    for _tool_call in _tool_calls:
+                        if "function" in _tool_call:
+                            _split_count = _bedrock_tool_call_split_count(
+                                _tool_call["function"].get("arguments", "")
+                            )
+                            if _split_count > 1:
+                                tool_call_id_to_split_count[str(_tool_call["id"])] = (
+                                    _split_count
+                                )
 
                 msg_i += 1
 
@@ -5157,6 +5238,10 @@ def _bedrock_converse_messages_pt(
         messages, model, llm_provider, user_continue_message
     )
 
+    # Maps an original tool_call_id to the number of bedrock toolUse blocks it
+    # was split into, so its toolResult can be duplicated to match (#26060).
+    tool_call_id_to_split_count: dict[str, int] = {}
+
     while msg_i < len(messages):
         user_content: List[BedrockContentBlock] = []
         init_msg_i = msg_i
@@ -5260,8 +5345,21 @@ def _bedrock_converse_messages_pt(
             tool_call_result = _convert_to_bedrock_tool_call_result(messages[msg_i])
             current_message = messages[msg_i]
 
-            # Add the tool result first
-            tool_content.append(tool_call_result)
+            # The matching assistant turn split a concatenated-JSON tool call into
+            # N toolUse blocks with ids "<id>", "<id>_1", ... "<id>_N-1", but the
+            # model returns only one result (for the original id). Duplicate that
+            # result across every split id so no toolUse is left unmatched;
+            # otherwise Bedrock rejects the next turn with:
+            #   "Expected toolResult blocks ... for the following Ids: <id>_1"
+            # Fixes: https://github.com/BerriAI/litellm/issues/26060
+            _split_count = tool_call_id_to_split_count.get(
+                str(current_message.get("tool_call_id", "")), 1
+            )
+            tool_content.extend(
+                _duplicate_bedrock_tool_result_for_splits(
+                    tool_call_result, _split_count
+                )
+            )
 
             # Check if we need to add a separate cachePoint block
             has_cache_control = False
@@ -5395,6 +5493,17 @@ def _bedrock_converse_messages_pt(
                 assistant_content.extend(
                     _convert_to_bedrock_tool_call_invoke(_tool_calls)
                 )
+                # Remember how many toolUse blocks each tool call split into so
+                # the matching toolResult can be duplicated next turn (#26060).
+                for _tool_call in _tool_calls:
+                    if "function" in _tool_call:
+                        _split_count = _bedrock_tool_call_split_count(
+                            _tool_call["function"].get("arguments", "")
+                        )
+                        if _split_count > 1:
+                            tool_call_id_to_split_count[str(_tool_call["id"])] = (
+                                _split_count
+                            )
 
             msg_i += 1
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2918,3 +2918,124 @@ def test_bedrock_converse_messages_pt_document_rejects_url_source():
         _bedrock_converse_messages_pt(
             messages, "anthropic.claude-sonnet-4-6", "bedrock"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/BerriAI/litellm/issues/26060
+# A concatenated-JSON tool call is split into N bedrock toolUse blocks, so its
+# single tool result must be duplicated into N matching toolResults. Otherwise
+# Bedrock 400s on the next turn:
+#   "Expected toolResult blocks ... for the following Ids: tooluse_<id>_1"
+# ---------------------------------------------------------------------------
+
+_CONCATENATED_ARGS = (
+    '{"command": ["ls"]}' '{"command": ["pwd"]}' '{"command": ["whoami"]}'
+)
+_SPLIT_TOOL_ID = "tooluse_ABC123"
+
+
+def _orphan_repro_messages():
+    return [
+        {"role": "user", "content": "run the commands"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": _SPLIT_TOOL_ID,
+                    "type": "function",
+                    "function": {"name": "shell", "arguments": _CONCATENATED_ARGS},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": _SPLIT_TOOL_ID, "content": "command output"},
+    ]
+
+
+def _tool_use_ids(blocks):
+    return [
+        block["toolUse"]["toolUseId"]
+        for message in blocks
+        if message["role"] == "assistant"
+        for block in message["content"]
+        if "toolUse" in block
+    ]
+
+
+def _tool_result_blocks(blocks):
+    return [
+        block["toolResult"]
+        for message in blocks
+        if message["role"] == "user"
+        for block in message["content"]
+        if "toolResult" in block
+    ]
+
+
+def test_bedrock_tool_call_split_count_helper():
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _bedrock_tool_call_split_count,
+    )
+
+    assert _bedrock_tool_call_split_count('{"a": 1}') == 1
+    assert _bedrock_tool_call_split_count(_CONCATENATED_ARGS) == 3
+    assert _bedrock_tool_call_split_count("") == 1
+    assert _bedrock_tool_call_split_count(None) == 1
+
+
+def test_bedrock_converse_split_tool_call_results_are_symmetric():
+    """#26060: 1 concatenated tool call -> 3 toolUse -> must yield 3 toolResults."""
+    result = _bedrock_converse_messages_pt(
+        messages=_orphan_repro_messages(),
+        model="us.anthropic.claude-opus-4-7",
+        llm_provider="bedrock",
+    )
+
+    tool_results = _tool_result_blocks(result)
+    tool_result_ids = [tr["toolUseId"] for tr in tool_results]
+    expected_ids = {_SPLIT_TOOL_ID, f"{_SPLIT_TOOL_ID}_1", f"{_SPLIT_TOOL_ID}_2"}
+
+    assert set(_tool_use_ids(result)) == expected_ids
+    # every toolUse now has a matching toolResult (no orphans)
+    assert set(tool_result_ids) == expected_ids
+    # duplicated results reuse the original (non-empty) content
+    contents = [tr["content"] for tr in tool_results]
+    assert contents[0]
+    assert all(c == contents[0] for c in contents)
+
+
+def test_bedrock_converse_single_tool_call_result_unchanged():
+    """A normal (non-concatenated) tool call still yields exactly one toolResult."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "tooluse_single",
+                    "type": "function",
+                    "function": {"name": "shell", "arguments": '{"command": ["ls"]}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "tooluse_single", "content": "ok"},
+    ]
+    result = _bedrock_converse_messages_pt(
+        messages=messages, model="us.anthropic.claude-opus-4-7", llm_provider="bedrock"
+    )
+    assert _tool_use_ids(result) == ["tooluse_single"]
+    assert [tr["toolUseId"] for tr in _tool_result_blocks(result)] == ["tooluse_single"]
+
+
+@pytest.mark.asyncio
+async def test_bedrock_converse_async_split_tool_call_results_are_symmetric():
+    """The #26060 fix must also hold for the async converter."""
+    result = await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+        messages=_orphan_repro_messages(),
+        model="us.anthropic.claude-opus-4-7",
+        llm_provider="bedrock",
+    )
+    expected_ids = {_SPLIT_TOOL_ID, f"{_SPLIT_TOOL_ID}_1", f"{_SPLIT_TOOL_ID}_2"}
+    assert set(_tool_use_ids(result)) == expected_ids
+    assert {tr["toolUseId"] for tr in _tool_result_blocks(result)} == expected_ids


### PR DESCRIPTION
  Fixes #26060
  
`_convert_to_bedrock_tool_call_invoke` splits a concatenated-JSON tool call
  into N `toolUse` blocks (`<id>`, `<id>_1`, `<id>_2`,...), but `_convert_to_bedrock_tool_call_result` only emitted
  one `toolResult`. The extra `toolUse` blocks were left unmatched, so Bedrock
  rejected every later turn with "Expected toolResult blocks ... for the
  following Ids".

  ## Relevant issues

  Fixes #26060

  ## Pre-Submission checklist
  
  - [x] I have added meaningful tests
  - [x] My PR passes all unit tests on `make test-unit`
  - [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
  - [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before 
  requesting a maintainer review
 
  ## Type

  🐛 Bug Fix
  
  ## Changes

  - `_convert_to_bedrock_tool_call_invoke` already splits a concatenated-JSON
    tool call (e.g. `'{"cmd":"a"}{"cmd":"b"}{"cmd":"c"}'`) into N `toolUse`
    blocks with ids `<id>`, `<id>_1`, …, but the result side only emitted one
    `toolResult` for the original id — orphaning the rest and breaking every
    subsequent turn with a 400.
  - Added `_bedrock_tool_call_split_count(...)` (reuses the existing
    `split_concatenated_json_objects` splitter, so the split rule stays in one
    place) and `_duplicate_bedrock_tool_result_for_splits(...)`.
  - In both `_bedrock_converse_messages_pt` (sync) and
    `_bedrock_converse_messages_pt_async`, the assistant turn records how many
    blocks each tool call split into, and the tool-result loop duplicates the
    result across every split id so each `toolUse` has a matching `toolResult`.
  - Added regression tests covering the split→symmetric case (sync + async),
    the split-count helper, and a guard that a normal single tool call is
    unchanged.
    
  ## Screenshots / Proof of Fix

  Without the fix (just the result-side change stashed), the new tests fail:

      3 failed — only 1 toolResult produced where 3 toolUse blocks exist

  With the fix, the full file passes:
  
      75 passed