### PR TITLE
fix(otel): hashable scope for _emit_once when guardrail_mode is list

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -215,11 +215,9 @@ def _freeze_for_dedupe(value: object, _depth: int = 0) -> HashableScope:
             (_freeze_for_dedupe(key, _depth + 1), _freeze_for_dedupe(item, _depth + 1))
             for key, item in value.items()
         )
-    try:
-        hash(value)
-    except TypeError:
-        return repr(value)
-    return cast(HashableScope, value)
+    if isinstance(value, (str, int, float, bytes)) or value is None:
+        return value
+    return repr(value)
 
 
 @dataclass

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -189,13 +189,20 @@ def _normalize_team_metadata_keys(value: Any) -> List[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
-def _freeze_for_dedupe(value: object) -> object:
+_FREEZE_MAX_DEPTH = 16
+
+
+def _freeze_for_dedupe(value: object, _depth: int = 0) -> object:
+    if _depth >= _FREEZE_MAX_DEPTH:
+        return repr(value)
     if isinstance(value, (list, tuple)):
-        return tuple(_freeze_for_dedupe(item) for item in value)
+        return tuple(_freeze_for_dedupe(item, _depth + 1) for item in value)
     if isinstance(value, set):
-        return frozenset(_freeze_for_dedupe(item) for item in value)
+        return frozenset(_freeze_for_dedupe(item, _depth + 1) for item in value)
     if isinstance(value, dict):
-        return frozenset((key, _freeze_for_dedupe(item)) for key, item in value.items())
+        return frozenset(
+            (key, _freeze_for_dedupe(item, _depth + 1)) for key, item in value.items()
+        )
     try:
         hash(value)
     except TypeError:

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -191,8 +191,19 @@ def _normalize_team_metadata_keys(value: Any) -> List[str]:
 
 _FREEZE_MAX_DEPTH = 16
 
+HashableScope = Union[
+    str,
+    int,
+    float,
+    bool,
+    bytes,
+    None,
+    tuple["HashableScope", ...],
+    frozenset["HashableScope"],
+]
 
-def _freeze_for_dedupe(value: object, _depth: int = 0) -> object:
+
+def _freeze_for_dedupe(value: object, _depth: int = 0) -> HashableScope:
     if _depth >= _FREEZE_MAX_DEPTH:
         return repr(value)
     if isinstance(value, (list, tuple)):
@@ -201,13 +212,14 @@ def _freeze_for_dedupe(value: object, _depth: int = 0) -> object:
         return frozenset(_freeze_for_dedupe(item, _depth + 1) for item in value)
     if isinstance(value, dict):
         return frozenset(
-            (key, _freeze_for_dedupe(item, _depth + 1)) for key, item in value.items()
+            (_freeze_for_dedupe(key, _depth + 1), _freeze_for_dedupe(item, _depth + 1))
+            for key, item in value.items()
         )
     try:
         hash(value)
     except TypeError:
         return repr(value)
-    return value
+    return cast(HashableScope, value)
 
 
 @dataclass

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -189,6 +189,20 @@ def _normalize_team_metadata_keys(value: Any) -> List[str]:
     return [str(item).strip() for item in value if str(item).strip()]
 
 
+def _freeze_for_dedupe(value: object) -> object:
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_for_dedupe(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_freeze_for_dedupe(item) for item in value)
+    if isinstance(value, dict):
+        return frozenset((key, _freeze_for_dedupe(item)) for key, item in value.items())
+    try:
+        hash(value)
+    except TypeError:
+        return repr(value)
+    return value
+
+
 @dataclass
 class OpenTelemetryConfig:
     exporter: Union[str, SpanExporter] = "console"
@@ -1073,10 +1087,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
            can be re-read with mutated entries between calls, so dedupe
            must be at entry granularity. Scope: the entry's stable identity.
 
-        ``scope`` parts can be any hashable identity. The marker is stored
-        in ``kwargs["litellm_params"]["metadata"]["_otel_internal"]`` so it
-        is request-local (kwargs is shared across the sync/async callbacks
-        and lifecycle hooks for one request).
+        ``scope`` parts may include unhashable containers (list, dict, set);
+        they are normalized into a hashable shape via ``_freeze_for_dedupe``
+        before keying the marker dict. The marker is stored in
+        ``kwargs["litellm_params"]["metadata"]["_otel_internal"]`` so it is
+        request-local (kwargs is shared across the sync/async callbacks and
+        lifecycle hooks for one request).
         """
         litellm_params = kwargs.get("litellm_params")
         if not isinstance(litellm_params, dict):
@@ -1098,7 +1114,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (self.__class__.__name__, id(self), *scope)
+        dedupe_key = (
+            self.__class__.__name__,
+            id(self),
+            *(_freeze_for_dedupe(part) for part in scope),
+        )
         if spans_logged.get(dedupe_key) is True:
             return False
 

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -51,6 +51,7 @@ IGNORE_FUNCTIONS = [
     "_resolve",  # OCI: $ref resolver bounded by `resolving_stack` cycle guard.
     "resolve_oci_schema_anyof",  # OCI: bounded by JSON-schema tree depth (no cycles possible in well-formed input).
     "sanitize_oci_schema",  # OCI: bounded by JSON-schema tree depth.
+    "_freeze_for_dedupe",  # OTEL: max depth set (default 16, _FREEZE_MAX_DEPTH); fails closed by returning repr(value) at the cap.
 ]
 
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4735,6 +4735,19 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         )
         self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"a", "b"}))
 
+    def test_emit_once_handles_self_referential_scope_without_recursion_error(self):
+        """``_freeze_for_dedupe`` caps recursion at ``_FREEZE_MAX_DEPTH`` and
+        falls back to ``repr`` past the cap, so a self-referential container
+        in scope must not crash ``_emit_once``. ``guardrail_mode`` cannot
+        construct such input today, but the cap is the bound that justifies
+        recursion on the logging hot path."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        cyclic: list = []
+        cyclic.append(cyclic)
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
+
     def test_create_guardrail_span_does_not_raise_on_list_mode(self):
         """End-to-end regression for LIT-3428: ``_create_guardrail_span``
         must produce exactly one span (not raise ``TypeError``) when the

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4690,6 +4690,96 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         self.assertTrue(otel._emit_once(kwargs, "success"))
         self.assertFalse(otel._emit_once(kwargs, "success"))
 
+    def test_emit_once_accepts_list_valued_scope_part(self):
+        """Regression for LIT-3428 / LIT-3764: a list-valued ``guardrail_mode``
+        (the shape Presidio expands to with ``output_parse_pii: true``) must
+        not raise ``TypeError: unhashable type: 'list'`` when building the
+        dedupe key. Pre-fix, this call crashed inside ``dict.get``."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"])
+        )
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"]),
+            "Same list scope must dedupe to False on the second call",
+        )
+
+    def test_emit_once_distinct_list_scopes_dont_collide(self):
+        """Two different list-valued scopes on the same handler/kwargs must
+        each emit exactly once. Catches a regression where every list collapses
+        to the same key (e.g. ``str(list)`` collisions on near-identical input)."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call"]))
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"]),
+            "Distinct list scopes must produce distinct dedupe keys",
+        )
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call"]))
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"])
+        )
+
+    def test_emit_once_accepts_dict_and_set_scope_parts(self):
+        """``guardrail_mode`` can also arrive as a ``GuardrailMode`` TypedDict
+        (i.e. a plain dict at runtime). Sets are not produced today but flow
+        through the same normalization. Both must hash without raising."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        self.assertTrue(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]})
+        )
+        self.assertFalse(
+            otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]})
+        )
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"a", "b"}))
+
+    def test_create_guardrail_span_does_not_raise_on_list_mode(self):
+        """End-to-end regression for LIT-3428: ``_create_guardrail_span``
+        must produce exactly one span (not raise ``TypeError``) when the
+        guardrail entry's ``guardrail_mode`` is a list."""
+        span_exporter = InMemorySpanExporter()
+        tracer_provider = TracerProvider()
+        tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+        otel = OpenTelemetry(tracer_provider=tracer_provider)
+        otel.tracer = tracer_provider.get_tracer(__name__)
+
+        kwargs = {
+            "model": "gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "litellm_params": {"custom_llm_provider": "openai", "metadata": {}},
+            "standard_logging_object": {
+                "id": "test-id",
+                "call_type": "completion",
+                "metadata": {},
+                "hidden_params": {},
+                "guardrail_information": [
+                    {
+                        "guardrail_name": "presidio-pii",
+                        "guardrail_mode": ["pre_call", "post_call"],
+                        "guardrail_response": "ok",
+                        "start_time": 1.0,
+                        "end_time": 2.0,
+                    }
+                ],
+            },
+        }
+
+        otel._create_guardrail_span(kwargs=kwargs, context=None)
+        otel._create_guardrail_span(kwargs=kwargs, context=None)
+
+        guardrail_spans = [
+            s for s in span_exporter.get_finished_spans() if s.name == "guardrail"
+        ]
+        self.assertEqual(
+            len(guardrail_spans),
+            1,
+            "List-valued guardrail_mode must emit exactly one guardrail span "
+            "across repeated lifecycle entrypoints",
+        )
+
     def test_handle_success_emits_single_litellm_request_span_on_double_call(self):
         """Sync + async callback paths firing for the same kwargs must
         result in exactly one litellm_request span."""


### PR DESCRIPTION
## Relevant issues

Fixes https://github.com/BerriAI/litellm/issues/28486

## Linear ticket

Resolves LIT-3428
Resolves LIT-3764

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link: https://github.com/BerriAI/litellm/actions?query=branch%3Alitellm_lit_3428_otel_emit_once_hashable
- [ ] **CI run for the last commit**
       Link: https://github.com/BerriAI/litellm/actions?query=branch%3Alitellm_lit_3428_otel_emit_once_hashable
- [ ] **Merge / cherry-pick CI run**
       Links: TBD

## Screenshots / Proof of Fix

Live proxy on this PR's worktree, real Anthropic API, OTEL callback on, custom guardrail with `mode: ["pre_call", "post_call"]` (the shape Presidio expands to when `output_parse_pii: true`). Same curl on the broken commit and the fixed commit; the only difference is whether `_freeze_for_dedupe` is applied inside `_emit_once`.

Repro config (custom guardrail records to `standard_logging_object` so `_create_guardrail_span` actually runs):

```yaml
model_list:
  - model_name: anthropic-haiku
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

guardrails:
  - guardrail_name: lit-3428-list-mode
    litellm_params:
      guardrail: lit_3428_repro_guardrail.Lit3428Guardrail
      default_on: true
      mode: ["pre_call", "post_call"]

general_settings:
  master_key: sk-1234

litellm_settings:
  callbacks: ["otel"]
  drop_params: true
  telemetry: false
```

Launch:

```bash
export PYTHONPATH=<worktree-root>
export OTEL_EXPORTER=console
python litellm/proxy/proxy_cli.py \
  --config litellm/proxy/lit_3428_repro_config.yaml \
  --port 4000 --detailed_debug 2>&1 | tee litellm.log
```

Curl (identical on both runs):

```bash
curl -sS -o /tmp/resp.json -w "HTTP_STATUS=%{http_code}\n" \
  -X POST http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"anthropic-haiku","messages":[{"role":"user","content":"reply with just the word: OK"}]}'
```

### Before (origin/litellm_internal_staging, no fix)

```
HTTP_STATUS=200
```

The user sees a 200 because the crash happens inside the logging callback and is swallowed; the request itself succeeds. The damage is silent observability loss. Proxy log:

```
$ grep -c unhashable litellm.log
2
$ grep -c '"name": "guardrail"' litellm.log
0
```

Traceback in the log (each occurrence — sync + async success callbacks both fire):

```
File "litellm/integrations/opentelemetry.py", line 1214, in _handle_success
    self._create_guardrail_span(kwargs=kwargs, context=guardrail_ctx)
File "litellm/integrations/opentelemetry.py", line 1862, in _create_guardrail_span
    if not self._emit_once(
        kwargs,
        "guardrail",
        guardrail_information.get("guardrail_name"),
        start_time_float,
        guardrail_information.get("guardrail_mode"),
    ):
File "litellm/integrations/opentelemetry.py", line 1102, in _emit_once
    if spans_logged.get(dedupe_key) is True:
       ~~~~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: unhashable type: 'list'
```

On the blocking path (e.g. callbacks that mark guardrail-failure synchronously), the same error surfaces as HTTP 500; see GH #28486.

### After (this PR)

```
HTTP_STATUS=200
$ grep -c unhashable litellm.log
0
$ grep -c '"name": "guardrail"' litellm.log
2
```

One of the emitted guardrail spans (truncated to the relevant attributes):

```json
{
  "name": "guardrail",
  "attributes": {
    "openinference.span.kind": "GUARDRAIL",
    "guardrail_name": "lit-3428-list-mode",
    "guardrail_mode": "['pre_call', 'post_call']",
    "guardrail_response": "{\"checked\": true, \"stage\": \"pre_call\"}",
    "guardrail_status": "success"
  }
}
```

Regression check that the existing `mode: pre_call` (string) path is unaffected: the same curl with `mode: pre_call` returns 200, emits the guardrail span, no crash.

## Type

🐛 Bug Fix

## Changes

`_emit_once` keys `spans_logged` by `(class, id, *scope)`. `_create_guardrail_span` passes `guardrail_information["guardrail_mode"]` into that scope; its type is `Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], GuardrailMode]]` (`litellm/types/utils.py`), so a YAML `mode: [pre_call, post_call]` makes it a real list at runtime. Lists are not hashable, so `spans_logged.get(dedupe_key)` raises `TypeError: unhashable type: 'list'`.

The fix is a small recursive normalizer applied inside `_emit_once` before the dict lookup:

```python
def _freeze_for_dedupe(value: object) -> object:
    if isinstance(value, (list, tuple)):
        return tuple(_freeze_for_dedupe(item) for item in value)
    if isinstance(value, set):
        return frozenset(_freeze_for_dedupe(item) for item in value)
    if isinstance(value, dict):
        return frozenset((key, _freeze_for_dedupe(item)) for key, item in value.items())
    try:
        hash(value)
    except TypeError:
        return repr(value)
    return value
```

It is applied at the helper, not at the guardrail callsite, so all three `_emit_once` callsites (`"success"`, `"failure"`, and the guardrail one) are protected without per-site work. The helper assumes acyclic input; `guardrail_mode` values are built fresh from config (str enums, lists of str enums, TypedDict of str/list-of-str leaves), so a self-referential value cannot arise in practice.

The dedupe contract is preserved: distinct list scopes produce distinct keys (a fixed-string mutant fails the new test), and the existing string-scope behavior is byte-for-byte the same (the helper passes already-hashable scalars straight through).

Regression coverage in `TestOpenTelemetrySpanDedupe` (`tests/test_litellm/integrations/test_opentelemetry.py`):

- `test_emit_once_accepts_list_valued_scope_part` — the exact crash case
- `test_emit_once_distinct_list_scopes_dont_collide` — distinctness is preserved
- `test_emit_once_accepts_dict_and_set_scope_parts` — covers the `GuardrailMode` TypedDict shape and a future set-shaped scope
- `test_create_guardrail_span_does_not_raise_on_list_mode` — end-to-end through `_create_guardrail_span` confirming exactly one guardrail span emits across repeated lifecycle entrypoints

Each new test fails when the `_freeze_for_dedupe` application is reverted; mutation kill rate 4/4

### Scope

This is a surgical patch for v1 (`litellm/integrations/opentelemetry.py`), not an architectural change. The reason v1 needs a dedupe at all is that `_create_guardrail_span` is registered at three lifecycle hooks (`async_post_call_success_hook`, `_handle_success`, `_handle_failure`) and re-reads the guardrail entry list from `standard_logging_payload` each time; `_emit_once` is the workaround that collapses the three-way fan-out into one span. That fan-out is the structural reason a stray list-valued `guardrail_mode` could ever reach a dict key in the first place.

v2 (`litellm/integrations/otel/`) does not have this shape: it emits each guardrail span directly from the guardrail-recording code at the moment a guardrail finishes (`emit_guardrail_span` in `litellm/integrations/otel/logger.py`), so the emitter never sees the same entry twice and never needs to hash `guardrail_mode`. v2 also normalizes `guardrail_mode` to a display string at the front door via `_guardrail_mode_str` in `litellm/integrations/otel/model/payloads.py`, so the wider type can never crash a downstream callsite.

The right long-term move is to retire v1's three-hook registration in favor of v2's direct-emit pattern; that is out of scope here and tracked separately. This PR is the minimum patch that unblocks v1 customers hitting the crash today

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to v1 OTEL span dedupe on the logging callback path; behavior for hashable scopes is unchanged aside from fixing the list/dict/set crash.
> 
> **Overview**
> Fixes **`TypeError: unhashable type: 'list'`** when OpenTelemetry dedupes spans and **`guardrail_mode`** is a list (e.g. Presidio with `output_parse_pii: true` or YAML `mode: [pre_call, post_call]`).
> 
> Adds **`_freeze_for_dedupe`** to turn list/tuple, set, and dict scope parts into hashable keys (depth cap 16, **`repr`** fallback), and applies it inside **`_emit_once`** so all dedupe sites are covered without changing string-scope behavior. **Guardrail** span emission and dedupe are restored; regression tests cover list/dict/set scopes, distinct list keys, cyclic input, and end-to-end **`_create_guardrail_span`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1483a1bf210e2cf508fcd630f318181e15e6c635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->