### PR TITLE
fix(mcp): correct misleading no-trusted-proxy warning for XFF access control

### DIFF
--- a/litellm/proxy/auth/ip_address_utils.py
+++ b/litellm/proxy/auth/ip_address_utils.py
@@ -152,12 +152,12 @@ class IPAddressUtils:
             if not _warned_xff_without_trusted_ranges:
                 verbose_proxy_logger.warning(
                     "use_x_forwarded_for is enabled but mcp_trusted_proxy_ranges "
-                    "is not configured. X-Forwarded-* headers will NOT be "
-                    "trusted, so MCP OAuth discovery URLs and access-control "
-                    "client IPs will use the proxy's literal request values. "
-                    "Set mcp_trusted_proxy_ranges in "
-                    "general_settings to your reverse-proxy CIDR(s) to allow "
-                    "X-Forwarded-* through."
+                    "is not configured, so X-Forwarded-* headers will NOT be trusted. "
+                    "MCP OAuth discovery URLs fall back to the proxy's literal request "
+                    "URL, and MCP access-control client-IP resolution fails closed "
+                    "(callers are treated as external). Set mcp_trusted_proxy_ranges in "
+                    "general_settings to your reverse-proxy CIDR(s) to trust "
+                    "X-Forwarded-*."
                 )
                 _warned_xff_without_trusted_ranges = True
             return False

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -98,10 +98,16 @@ class TestMCPClientIPExtraction:
             )
 
         warning = next(
-            record.getMessage()
-            for record in caplog.records
-            if "mcp_trusted_proxy_ranges" in record.getMessage()
+            (
+                record.getMessage()
+                for record in caplog.records
+                if "mcp_trusted_proxy_ranges" in record.getMessage()
+            ),
+            None,
         )
+        assert (
+            warning is not None
+        ), "Expected a warning containing 'mcp_trusted_proxy_ranges' but none was logged"
 
         assert "fails closed" in warning
         assert "treated as external" in warning

--- a/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
+++ b/tests/test_litellm/proxy/auth/test_mcp_ip_filtering.py
@@ -5,10 +5,13 @@ Tests that internal callers see all MCP servers while
 external callers only see servers with available_on_public_internet=True.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from fastapi import Request
 
+import litellm.proxy.auth.ip_address_utils as ip_mod
+from litellm._logging import verbose_proxy_logger
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
@@ -76,6 +79,38 @@ class TestMCPClientIPExtraction:
         # is classified as external and is_internal_ip("") is False.
         assert result == ""
         assert IPAddressUtils.is_internal_ip(result) is False
+
+    def test_no_trusted_ranges_warning_matches_fail_closed_behavior(self, caplog):
+        ip_mod._warned_xff_without_trusted_ranges = False
+
+        request = MagicMock(spec=Request)
+        request.client = MagicMock()
+        request.client.host = "203.0.113.5"
+        request.headers = {"x-forwarded-for": "1.2.3.4, 10.0.0.1"}
+        general_settings = {"use_x_forwarded_for": True}
+
+        with caplog.at_level(logging.WARNING, logger=verbose_proxy_logger.name):
+            assert (
+                IPAddressUtils.is_request_from_trusted_proxy(
+                    request, general_settings=general_settings
+                )
+                is False
+            )
+
+        warning = next(
+            record.getMessage()
+            for record in caplog.records
+            if "mcp_trusted_proxy_ranges" in record.getMessage()
+        )
+
+        assert "fails closed" in warning
+        assert "treated as external" in warning
+        assert "client IPs will use the proxy's literal request values" not in warning
+
+        assert (
+            IPAddressUtils.get_mcp_client_ip(request, general_settings=general_settings)
+            == ""
+        )
 
     def test_private_proxy_peer_does_not_grant_internal_access(self):
         # Regression: behind an internal reverse proxy with use_x_forwarded_for


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`IPAddressUtils.is_request_from_trusted_proxy` in `litellm/proxy/auth/ip_address_utils.py` logs a one-shot warning when `use_x_forwarded_for` is enabled but `mcp_trusted_proxy_ranges` is unset. The previous wording claimed that in this state both MCP OAuth discovery URLs and access-control client IPs "will use the proxy's literal request values," which is only half true and misleads operators about the security posture

The method has two consumers that diverge in this exact configuration. `get_request_base_url` in `litellm/proxy/_experimental/mcp_server/oauth_utils.py` does fall back to the request's literal base URL for OAuth discovery and redirect_uri construction, so that half was accurate. `get_mcp_client_ip` in the same `ip_address_utils.py` file does the opposite: when XFF is enabled, an `x-forwarded-for` header is present, and `mcp_trusted_proxy_ranges` is unset, it does not return any literal request value. It fails closed and returns `""`, so the caller is treated as external and only sees servers with `available_on_public_internet=true`. The old message told operators their access-control client IPs would use literal request values, which would have led them to believe internal callers behind an untrusted proxy still resolve to their real IP when they actually get classified as external

This PR rewords the warning so it describes both behaviors accurately: OAuth discovery URLs fall back to the literal request URL, and access-control client-IP resolution fails closed with callers treated as external. No behavior changes; the message text is the only source change

The added regression test ties the message to the real behavior. It triggers the branch with `use_x_forwarded_for` on, an `x-forwarded-for` header present, and `mcp_trusted_proxy_ranges` unset, captures the warning via `caplog`, asserts the new fail-closed phrasing is present and the old misleading claim is gone, and asserts in the same scenario that `get_mcp_client_ip` returns `""`. Reverting the wording makes the assertions fail, and the coupled `get_mcp_client_ip` assert keeps the message honest about reality

## Screenshots / Proof of Fix

Ran a local proxy with `use_x_forwarded_for: true` and no `mcp_trusted_proxy_ranges`, then hit an MCP REST route that resolves the client IP with an `X-Forwarded-For` header. The corrected warning shows up in the proxy log

Start (config has `general_settings.use_x_forwarded_for: true`, an `mcp_servers` block, and crucially no `mcp_trusted_proxy_ranges`):

```
FORWARDED_ALLOW_IPS=10.255.255.255 python litellm/proxy/proxy_cli.py --config /tmp/xff_warn_config.yaml --detailed_debug 2>&1 | tee /tmp/xff_warn.log
```

Trigger:

```
$ curl -s -w "\nHTTP %{http_code}\n" -H 'x-forwarded-for: 1.2.3.4, 10.0.0.1' -H 'Authorization: Bearer sk-1234' http://localhost:4000/mcp-rest/tools/list
{"tools":[],"error":null,"message":"Successfully retrieved tools"}
HTTP 200
```

Corrected warning grep'd from the log:

```
$ grep -F "mcp_trusted_proxy_ranges" /tmp/xff_warn.log | grep -F "fails closed"
19:40:17 - LiteLLM Proxy:WARNING: ip_address_utils.py:153 - use_x_forwarded_for is enabled but mcp_trusted_proxy_ranges is not configured, so X-Forwarded-* headers will NOT be trusted. MCP OAuth discovery URLs fall back to the proxy's literal request URL, and MCP access-control client-IP resolution fails closed (callers are treated as external). Set mcp_trusted_proxy_ranges in general_settings to your reverse-proxy CIDR(s) to trust X-Forwarded-*.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log message and test-only change; MCP IP trust and access-control behavior are unchanged.
> 
> **Overview**
> Updates the one-shot proxy log warning when **`use_x_forwarded_for`** is on but **`mcp_trusted_proxy_ranges`** is unset. The old text implied MCP access-control client IPs would use the proxy’s literal request values; that was wrong for **`get_mcp_client_ip`**, which already **fails closed** (`""`, callers treated as external) while OAuth discovery can still fall back to the literal request URL.
> 
> The new wording states both outcomes explicitly and still points operators at **`mcp_trusted_proxy_ranges`**. **No runtime behavior changes.**
> 
> Adds **`test_no_trusted_ranges_warning_matches_fail_closed_behavior`**, which captures the warning via **`caplog`**, checks for the fail-closed phrasing and absence of the old line, and asserts **`get_mcp_client_ip`** returns **`""`** in the same setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d26ec1f33f4d93cf173e9e3fdc982f509c2a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
