### PR TITLE
feat: package Rust OCR bridge in LiteLLM wheel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,6 +49,8 @@ build/
 *.egg-info/
 .DS_Store
 **/node_modules
+litellm-rust/target/
+litellm/rust_bridge/_native*.so
 *.log
 .env
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk add --no-cache \
     gcc \
     python3 \
     python3-dev \
+    rust \
     openssl \
     openssl-dev \
     nodejs \

--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -19,6 +19,7 @@ RUN for i in 1 2 3; do \
         python3 \
         python3-dev \
         gcc \
+        rust \
         bash \
         coreutils \
         curl \

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [lib]
-name = "litellm_python_bridge"
+name = "_native"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/litellm-rust/crates/python-bridge/build.rs
+++ b/litellm-rust/crates/python-bridge/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("macos") {
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+    }
+}

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -93,7 +93,7 @@ fn gil_stats(py: Python<'_>) -> PyResult<Py<PyAny>> {
 }
 
 #[pymodule]
-fn litellm_python_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _native(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(ocr, module)?)?;
     module.add_function(wrap_pyfunction!(gil_stats, module)?)?;
     Ok(())

--- a/litellm/ocr/rust_bridge.py
+++ b/litellm/ocr/rust_bridge.py
@@ -2,7 +2,7 @@
 Optional Rust-backed OCR path.
 
 Enable with ``litellm.use_litellm_rust()``; the sync ``litellm.ocr()`` entrypoint
-then routes supported Mistral calls through the compiled ``litellm_python_bridge``
+then routes supported Mistral calls through the compiled ``litellm.rust_bridge._native``
 extension, which performs the whole OCR call (URL, headers, HTTP, parse) in Rust.
 
 No module-level ``litellm`` imports keep this a leaf so ``litellm/ocr/main.py``
@@ -15,7 +15,7 @@ from typing import Final, Protocol, cast
 
 
 class RustOcr(Protocol):
-    """Signature of the compiled ``litellm_python_bridge.ocr`` entrypoint."""
+    """Signature of the compiled Rust OCR entrypoint."""
 
     def __call__(
         self,
@@ -41,7 +41,7 @@ _rust_ocr_impl: RustOcr | None = None
 def use_litellm_rust(
     enabled: bool = True, *, ocr: RustOcr | None | _Unset = _UNSET
 ) -> None:
-    """Route supported OCR calls through the Rust ``litellm_python_bridge`` extension.
+    """Route supported OCR calls through the packaged Rust extension.
 
     ``ocr`` injects the bridge callable; when omitted the compiled extension is
     loaded on demand and any previously injected bridge is preserved. Pass
@@ -62,13 +62,14 @@ def load_rust_ocr() -> RustOcr | None:
     """Return the Rust OCR callable, or ``None`` when no bridge is available.
 
     Prefers an injected implementation, otherwise loads the compiled
-    ``litellm_python_bridge`` extension; a missing extension yields ``None`` so
+    ``litellm.rust_bridge._native`` extension; a missing extension yields ``None`` so
     the caller can fall back to the Python path instead of hard-failing.
     """
     if _rust_ocr_impl is not None:
         return _rust_ocr_impl
-    try:
-        import litellm_python_bridge
-    except ImportError:
+    from litellm.rust_bridge import get_native_bridge
+
+    native_bridge = get_native_bridge()
+    if native_bridge is None:
         return None
-    return cast(RustOcr, litellm_python_bridge.ocr)
+    return cast(RustOcr, native_bridge.ocr)

--- a/litellm/rust_bridge/__init__.py
+++ b/litellm/rust_bridge/__init__.py
@@ -1,0 +1,8 @@
+"""LiteLLM Rust bridge package."""
+
+from litellm.rust_bridge.loader import (
+    get_native_bridge,
+    native_bridge_available,
+)
+
+__all__ = ["get_native_bridge", "native_bridge_available"]

--- a/litellm/rust_bridge/loader.py
+++ b/litellm/rust_bridge/loader.py
@@ -1,0 +1,19 @@
+"""Loader for the packaged LiteLLM Rust extension."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+
+def get_native_bridge() -> ModuleType | None:
+    """Return the packaged Rust extension, or ``None`` when unavailable."""
+    try:
+        from litellm.rust_bridge import _native
+    except ImportError:
+        return None
+    return _native
+
+
+def native_bridge_available() -> bool:
+    """Whether the packaged Rust extension is importable."""
+    return get_native_bridge() is not None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,8 +235,23 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["uv_build==0.11.8"]
-build-backend = "uv_build"
+requires = ["maturin>=1.9.4,<2"]
+build-backend = "maturin"
+
+[tool.maturin]
+manifest-path = "litellm-rust/crates/python-bridge/Cargo.toml"
+module-name = "litellm.rust_bridge._native"
+python-source = "."
+bindings = "pyo3"
+exclude = [
+    "litellm/proxy/enterprise",
+    "**/__pycache__",
+    "**/__pycache__/**",
+    "**/.pytest_cache",
+    "**/.pytest_cache/**",
+    "**/.ruff_cache",
+    "**/.ruff_cache/**",
+]
 
 [tool.uv]
 constraint-dependencies = [
@@ -253,18 +268,6 @@ litellm-enterprise = { workspace = true }
 
 [tool.uv.workspace]
 members = ["enterprise", "litellm-proxy-extras"]
-
-[tool.uv.build-backend]
-module-root = ""
-source-exclude = [
-    "litellm/proxy/enterprise",
-    "**/__pycache__",
-    "**/__pycache__/**",
-    "**/.pytest_cache",
-    "**/.pytest_cache/**",
-    "**/.ruff_cache",
-    "**/.ruff_cache/**",
-]
 
 [tool.isort]
 profile = "black"
@@ -329,4 +332,3 @@ pytest_add_cli_args = [
 [tool.coverage.run]
 source = ["litellm"]
 relative_files = true
-

--- a/tests/test_litellm/ocr/test_rust_bridge.py
+++ b/tests/test_litellm/ocr/test_rust_bridge.py
@@ -1,7 +1,7 @@
 """Tests for the optional Rust-backed OCR path (``litellm/ocr/rust_bridge.py``)."""
 
 import importlib
-import sys
+import builtins
 import types
 
 import httpx
@@ -15,6 +15,7 @@ from litellm.llms.base_llm.ocr.transformation import OCRResponse
 # explicitly via importlib rather than attribute traversal.
 ocr_main = importlib.import_module("litellm.ocr.main")
 rust_bridge = importlib.import_module("litellm.ocr.rust_bridge")
+rust_bridge_loader = importlib.import_module("litellm.rust_bridge.loader")
 
 MODEL = "mistral/mistral-ocr-latest"
 DOCUMENT = {"type": "document_url", "document_url": "https://example.com/doc.pdf"}
@@ -106,6 +107,26 @@ def test_load_rust_ocr_returns_injected_impl():
     assert rust_bridge.load_rust_ocr() is bridge
 
 
+def test_native_bridge_loader_returns_none_when_extension_absent(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "litellm.rust_bridge" and "_native" in fromlist:
+            raise ImportError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert rust_bridge_loader.get_native_bridge() is None
+
+
+def test_native_bridge_available_reflects_loader(monkeypatch):
+    fake_module = types.ModuleType("litellm.rust_bridge._native")
+    monkeypatch.setattr(rust_bridge_loader, "get_native_bridge", lambda: fake_module)
+
+    assert rust_bridge_loader.native_bridge_available() is True
+
+
 def test_toggle_without_ocr_arg_preserves_injected_impl():
     """Regression: routine enable/disable calls must not clobber a prior injection.
 
@@ -122,7 +143,12 @@ def test_toggle_without_ocr_arg_preserves_injected_impl():
     assert rust_bridge.load_rust_ocr() is bridge
 
 
-def test_explicit_ocr_none_clears_injected_impl():
+def test_explicit_ocr_none_clears_injected_impl(monkeypatch):
+    monkeypatch.setattr(
+        importlib.import_module("litellm.rust_bridge"),
+        "get_native_bridge",
+        lambda: None,
+    )
     bridge = RecordingBridge()
     litellm.use_litellm_rust(True, ocr=bridge)
 
@@ -130,20 +156,29 @@ def test_explicit_ocr_none_clears_injected_impl():
     assert rust_bridge.load_rust_ocr() is None
 
 
-def test_load_rust_ocr_none_when_extension_absent():
+def test_load_rust_ocr_none_when_extension_absent(monkeypatch):
     """With no injected impl and no compiled wheel, the loader returns None so the
     caller degrades to the Python path instead of raising ImportError."""
+    monkeypatch.setattr(
+        importlib.import_module("litellm.rust_bridge"),
+        "get_native_bridge",
+        lambda: None,
+    )
     litellm.use_litellm_rust(True)  # no impl injected; extension isn't built in CI
     assert rust_bridge.load_rust_ocr() is None
 
 
 def test_load_rust_ocr_uses_compiled_extension(monkeypatch):
-    """With no injected impl but a compiled ``litellm_python_bridge`` importable,
+    """With no injected impl but a packaged ``litellm.rust_bridge._native`` importable,
     the loader returns the extension's ``ocr`` callable. The native wheel isn't
-    built in CI, so stand in a fake module via ``sys.modules``."""
-    fake_module = types.ModuleType("litellm_python_bridge")
+    built in CI, so stand in a fake module via the bridge loader."""
+    fake_module = types.ModuleType("litellm.rust_bridge._native")
     fake_module.ocr = lambda **kwargs: dict(FAKE_OCR_RESPONSE)  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "litellm_python_bridge", fake_module)
+    monkeypatch.setattr(
+        importlib.import_module("litellm.rust_bridge"),
+        "get_native_bridge",
+        lambda: fake_module,
+    )
 
     litellm.use_litellm_rust(True)  # enabled, no impl injected -> import the extension
     assert rust_bridge.load_rust_ocr() is fake_module.ocr
@@ -317,6 +352,7 @@ def test_ocr_does_not_route_to_rust_when_disabled():
 def test_ocr_falls_back_to_python_when_bridge_unavailable(monkeypatch):
     """Rust enabled but no bridge available (no injected impl, no compiled wheel):
     ocr() must degrade to the Python HTTP handler instead of raising."""
+    monkeypatch.setattr(ocr_main, "load_rust_ocr", lambda: None)
     litellm.use_litellm_rust(True)  # enabled, but load_rust_ocr() returns None in CI
 
     captured = {}


### PR DESCRIPTION
## Summary

Synced directly on top of `litellm_internal_staging`

This makes the default `litellm` pip package build and ship the Rust OCR bridge inside the existing Python package instead of publishing a separate Rust wheel package

- switches the root package build backend to `maturin` and builds the PyO3 crate as `litellm.rust_bridge._native`
- adds a small `litellm.rust_bridge` loader package so Python code does not import a top-level native module
- updates the OCR Rust opt-in path to load the packaged native bridge and keep Python fallback behavior when unavailable
- adds Rust only to Docker builder stages; no runtime Rust dependency and no inline Dockerfile smoke-test bloat
- ports the old `uv_build` source excludes into `[tool.maturin]`, including `litellm/proxy/enterprise`
- ignores local Rust/native build artifacts so Docker context does not pick up generated outputs
- enforces typed Rust core translations by failing `cargo test` if `litellm-rust/crates/core/src` uses raw `serde_json::Value`, `serde_json::Map`, or `json!`
- replaces the remaining raw JSON OCR and realtime core payloads with typed Rust structs/enums, leaving JSON conversion at the gateway/bridge boundary

Related: #31263

## Validation

- `uv lock`
- `uv build --sdist --wheel`
- artifact inspection: generated wheel/sdist include the native bridge and `litellm/rust_bridge/loader.py`, and exclude `litellm/proxy/enterprise`
- `uv run black litellm/rust_bridge litellm/ocr/rust_bridge.py tests/test_litellm/ocr/test_rust_bridge.py`
- `uv run ruff check litellm/rust_bridge litellm/ocr/rust_bridge.py tests/test_litellm/ocr/test_rust_bridge.py`
- `uv run pytest tests/test_litellm/ocr/test_rust_bridge.py -q` (`18 passed`)
- `(cd litellm-rust && cargo fmt --check && cargo clippy --workspace --all-targets --locked -- -D warnings && cargo test --workspace --locked)`
- `cargo test --workspace --locked` includes `typed_core_boundary::core_translation_code_does_not_use_raw_json_values`
- `docker build -t litellm-rust-pip-binary-test .`
- `docker run --rm --entrypoint python litellm-rust-pip-binary-test -c "from litellm.rust_bridge import native_bridge_available; from litellm.ocr.rust_bridge import load_rust_ocr; import litellm.rust_bridge._native as native; assert native_bridge_available(); assert load_rust_ocr() is native.ocr; print('main docker rust bridge ok')"`
- `docker build -f docker/Dockerfile.non_root -t litellm-rust-pip-binary-non-root-test .`
- `docker run --rm --entrypoint python litellm-rust-pip-binary-non-root-test -c "from litellm.rust_bridge import native_bridge_available; from litellm.ocr.rust_bridge import load_rust_ocr; import litellm.rust_bridge._native as native; assert native_bridge_available(); assert load_rust_ocr() is native.ocr; print('non-root docker rust bridge ok')"`
- `git merge-tree $(git merge-base HEAD upstream/litellm_internal_staging) HEAD upstream/litellm_internal_staging` showed no conflicts

## Type

New Feature
Bug Fix
Test
