### PR TITLE
feat: add Rust OCR providers

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -583,6 +583,7 @@ dependencies = [
 name = "litellm-providers"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "futures-util",
  "litellm-core",
  "reqwest",

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -23,3 +23,4 @@ thiserror = "2.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+base64 = "0.22"

--- a/litellm-rust/crates/providers/Cargo.toml
+++ b/litellm-rust/crates/providers/Cargo.toml
@@ -12,6 +12,7 @@ serde_json.workspace = true
 tokio.workspace = true
 tokio-tungstenite.workspace = true
 futures-util.workspace = true
+base64.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/litellm-rust/crates/providers/src/azure_ai/mod.rs
+++ b/litellm-rust/crates/providers/src/azure_ai/mod.rs
@@ -1,0 +1,1 @@
+pub mod ocr;

--- a/litellm-rust/crates/providers/src/azure_ai/ocr/mod.rs
+++ b/litellm-rust/crates/providers/src/azure_ai/ocr/mod.rs
@@ -1,0 +1,1 @@
+pub mod transformation;

--- a/litellm-rust/crates/providers/src/azure_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/providers/src/azure_ai/ocr/transformation.rs
@@ -1,0 +1,472 @@
+use std::collections::BTreeSet;
+
+use litellm_core::error::{json_type_name, CoreError, CoreResult};
+use litellm_core::ocr::transformation::OcrProviderConfig;
+use litellm_core::ocr::types::{OcrRequestData, OcrResponseData};
+use serde_json::{json, Map, Value};
+
+use crate::mistral::ocr::transformation::MISTRAL_OCR_CONFIG;
+
+const AZURE_AI_API_KEY_ENV: &str = "AZURE_AI_API_KEY";
+const AZURE_AI_API_BASE_ENV: &str = "AZURE_AI_API_BASE";
+const AZURE_DOCUMENT_INTELLIGENCE_API_KEY_ENV: &str = "AZURE_DOCUMENT_INTELLIGENCE_API_KEY";
+const AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT_ENV: &str = "AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT";
+const AZURE_DOCUMENT_INTELLIGENCE_API_VERSION: &str = "2024-11-30";
+const AZURE_DOCUMENT_INTELLIGENCE_DEFAULT_DPI: i64 = 96;
+
+const AZURE_DOCUMENT_INTELLIGENCE_SUPPORTED_OCR_PARAMS: &[&str] = &["pages"];
+
+pub struct AzureAiOcrConfig;
+pub struct AzureDocumentIntelligenceOcrConfig;
+
+pub const AZURE_AI_OCR_CONFIG: AzureAiOcrConfig = AzureAiOcrConfig;
+pub const AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG: AzureDocumentIntelligenceOcrConfig =
+    AzureDocumentIntelligenceOcrConfig;
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn resolve_value(
+    explicit: Option<&str>,
+    env_name: &str,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+    missing_message: &str,
+) -> CoreResult<String> {
+    non_empty(explicit)
+        .map(str::to_string)
+        .or_else(|| env_lookup(env_name).filter(|value| !value.trim().is_empty()))
+        .ok_or_else(|| CoreError::Auth(missing_message.to_string()))
+}
+
+pub fn resolve_azure_ai_api_key(
+    api_key: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    resolve_value(
+        api_key,
+        AZURE_AI_API_KEY_ENV,
+        env_lookup,
+        "Missing Azure AI API Key - A call is being made to Azure AI but no key is set either in the environment variables or via params",
+    )
+}
+
+pub fn resolve_azure_ai_api_base(
+    api_base: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    resolve_value(
+        api_base,
+        AZURE_AI_API_BASE_ENV,
+        env_lookup,
+        "Missing Azure AI API Base - Set AZURE_AI_API_BASE environment variable or pass api_base parameter",
+    )
+}
+
+pub fn complete_azure_ai_url(
+    api_base: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    let base = resolve_azure_ai_api_base(api_base, env_lookup)?;
+    Ok(format!(
+        "{}/providers/mistral/azure/ocr",
+        base.trim_end_matches('/')
+    ))
+}
+
+pub fn resolve_document_intelligence_api_key(
+    api_key: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    resolve_value(
+        api_key,
+        AZURE_DOCUMENT_INTELLIGENCE_API_KEY_ENV,
+        env_lookup,
+        "Missing Azure Document Intelligence API Key - Set AZURE_DOCUMENT_INTELLIGENCE_API_KEY environment variable or pass api_key parameter",
+    )
+}
+
+pub fn resolve_document_intelligence_endpoint(
+    api_base: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    resolve_value(
+        api_base,
+        AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT_ENV,
+        env_lookup,
+        "Missing Azure Document Intelligence Endpoint - Set AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT environment variable or pass api_base parameter",
+    )
+}
+
+fn encode_model_id(model: &str) -> String {
+    let model_id = model.rsplit('/').next().unwrap_or(model);
+    model_id
+        .bytes()
+        .flat_map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                vec![byte as char]
+            }
+            _ => format!("%{byte:02X}").chars().collect(),
+        })
+        .collect()
+}
+
+fn pages_token_is_valid(token: &str) -> bool {
+    let mut parts = token.split('-');
+    let Some(start) = parts.next() else {
+        return false;
+    };
+    if start.is_empty() || !start.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    match parts.next() {
+        None => true,
+        Some(end) => {
+            !end.is_empty() && end.chars().all(|ch| ch.is_ascii_digit()) && parts.next().is_none()
+        }
+    }
+}
+
+fn normalize_pages_param(pages: &Value) -> CoreResult<Option<String>> {
+    match pages {
+        Value::String(value) => {
+            let normalized = value
+                .split(',')
+                .map(str::trim)
+                .collect::<Vec<_>>()
+                .join(",");
+            if normalized.split(',').all(pages_token_is_valid) {
+                Ok(Some(normalized))
+            } else {
+                Err(CoreError::InvalidRequest(format!(
+                    "Invalid `pages` string for Azure Document Intelligence: {value:?}. Expected format like '1-3,5,7-9'."
+                )))
+            }
+        }
+        Value::Array(values) => {
+            if values.is_empty() {
+                return Ok(None);
+            }
+            if values.iter().all(Value::is_i64) {
+                let mut pages = BTreeSet::new();
+                for value in values {
+                    let page = value.as_i64().expect("checked is_i64");
+                    if page < 0 {
+                        return Err(CoreError::InvalidRequest(
+                            "`pages` integers must be >= 0 (Mistral 0-based indices)".to_string(),
+                        ));
+                    }
+                    pages.insert(page + 1);
+                }
+                return Ok(Some(
+                    pages
+                        .into_iter()
+                        .map(|page| page.to_string())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                ));
+            }
+            if values.iter().all(Value::is_string) {
+                let normalized = values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                if normalized.split(',').all(pages_token_is_valid) {
+                    return Ok(Some(normalized));
+                }
+                return Err(CoreError::InvalidRequest(format!(
+                    "Invalid `pages` list for Azure Document Intelligence: {values:?}. Expected tokens like '1' or '3-5'."
+                )));
+            }
+            Err(CoreError::InvalidRequest(
+                "`pages` must be a list[int] (0-based, Mistral-style) or a string like '1-3,5,7-9'."
+                    .to_string(),
+            ))
+        }
+        _ => Err(CoreError::InvalidRequest(
+            "`pages` must be a list[int] (0-based, Mistral-style) or a string like '1-3,5,7-9'."
+                .to_string(),
+        )),
+    }
+}
+
+pub fn complete_document_intelligence_url(
+    api_base: Option<&str>,
+    model: &str,
+    optional_params: &Map<String, Value>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    let endpoint = resolve_document_intelligence_endpoint(api_base, env_lookup)?;
+    let mut url = format!(
+        "{}/documentintelligence/documentModels/{}:analyze?api-version={}",
+        endpoint.trim_end_matches('/'),
+        encode_model_id(model),
+        AZURE_DOCUMENT_INTELLIGENCE_API_VERSION
+    );
+
+    if let Some(pages) = optional_params.get("pages") {
+        if let Some(normalized) = normalize_pages_param(pages)? {
+            url.push_str("&pages=");
+            url.push_str(&normalized);
+        }
+    }
+
+    Ok(url)
+}
+
+fn document_url_from_mistral_document(document: &Value) -> CoreResult<&str> {
+    let object = document.as_object().ok_or_else(|| CoreError::InvalidType {
+        expected: "object",
+        actual: json_type_name(document),
+    })?;
+    let doc_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(CoreError::MissingField("document.type"))?;
+    let field_name = match doc_type {
+        "document_url" => "document_url",
+        "image_url" => "image_url",
+        other => {
+            return Err(CoreError::InvalidRequest(format!(
+                "Invalid document type: {other}. Must be 'document_url' or 'image_url'"
+            )))
+        }
+    };
+    object
+        .get(field_name)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or(CoreError::MissingField(field_name))
+}
+
+fn extract_base64_from_data_uri(data_uri: &str) -> &str {
+    data_uri
+        .split_once(',')
+        .map(|(_, data)| data)
+        .unwrap_or(data_uri)
+}
+
+fn page_markdown(page: &Map<String, Value>) -> String {
+    page.get("lines")
+        .and_then(Value::as_array)
+        .map(|lines| {
+            lines
+                .iter()
+                .filter_map(|line| line.get("content").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default()
+}
+
+fn page_dimensions(page: &Map<String, Value>) -> Value {
+    let width = page.get("width").and_then(Value::as_f64).unwrap_or(8.5);
+    let height = page.get("height").and_then(Value::as_f64).unwrap_or(11.0);
+    let unit = page.get("unit").and_then(Value::as_str).unwrap_or("inch");
+    let (width, height) = if unit == "inch" {
+        (
+            (width * AZURE_DOCUMENT_INTELLIGENCE_DEFAULT_DPI as f64) as i64,
+            (height * AZURE_DOCUMENT_INTELLIGENCE_DEFAULT_DPI as f64) as i64,
+        )
+    } else {
+        (width as i64, height as i64)
+    };
+    json!({
+        "width": width,
+        "height": height,
+        "dpi": AZURE_DOCUMENT_INTELLIGENCE_DEFAULT_DPI,
+    })
+}
+
+impl OcrProviderConfig for AzureAiOcrConfig {
+    fn supported_ocr_params(&self) -> &'static [&'static str] {
+        MISTRAL_OCR_CONFIG.supported_ocr_params()
+    }
+
+    fn transform_ocr_request(
+        &self,
+        model: &str,
+        document: Value,
+        optional_params: Map<String, Value>,
+    ) -> CoreResult<OcrRequestData> {
+        MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
+    }
+
+    fn transform_ocr_response(
+        &self,
+        model: &str,
+        response_json: Value,
+    ) -> CoreResult<OcrResponseData> {
+        MISTRAL_OCR_CONFIG.transform_ocr_response(model, response_json)
+    }
+}
+
+impl OcrProviderConfig for AzureDocumentIntelligenceOcrConfig {
+    fn supported_ocr_params(&self) -> &'static [&'static str] {
+        AZURE_DOCUMENT_INTELLIGENCE_SUPPORTED_OCR_PARAMS
+    }
+
+    fn transform_ocr_request(
+        &self,
+        _model: &str,
+        document: Value,
+        _optional_params: Map<String, Value>,
+    ) -> CoreResult<OcrRequestData> {
+        let document_url = document_url_from_mistral_document(&document)?;
+        let mut data = Map::new();
+        if document_url.starts_with("data:") {
+            data.insert(
+                "base64Source".to_string(),
+                Value::String(extract_base64_from_data_uri(document_url).to_string()),
+            );
+        } else {
+            data.insert(
+                "urlSource".to_string(),
+                Value::String(document_url.to_string()),
+            );
+        }
+        Ok(OcrRequestData {
+            data: Value::Object(data),
+            files: None,
+        })
+    }
+
+    fn transform_ocr_response(
+        &self,
+        model: &str,
+        response_json: Value,
+    ) -> CoreResult<OcrResponseData> {
+        let response = response_json
+            .as_object()
+            .ok_or_else(|| CoreError::InvalidType {
+                expected: "object",
+                actual: json_type_name(&response_json),
+            })?;
+        let status = response
+            .get("status")
+            .and_then(Value::as_str)
+            .ok_or(CoreError::MissingField("status"))?;
+        if status != "succeeded" {
+            return Err(CoreError::InvalidResponse(format!(
+                "Azure Document Intelligence analysis failed with status: {status}"
+            )));
+        }
+
+        let azure_pages = response
+            .get("analyzeResult")
+            .and_then(|result| result.get("pages"))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let pages = azure_pages
+            .iter()
+            .filter_map(Value::as_object)
+            .map(|page| {
+                let page_number = page.get("pageNumber").and_then(Value::as_i64).unwrap_or(1);
+                json!({
+                    "index": page_number - 1,
+                    "markdown": page_markdown(page),
+                    "dimensions": page_dimensions(page),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Ok(OcrResponseData {
+            usage_info: Some(json!({
+                "pages_processed": pages.len(),
+                "doc_size_bytes": null,
+            })),
+            pages,
+            model: model.to_string(),
+            document_annotation: None,
+            object: "ocr".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn azure_ai_reuses_mistral_body_transform() {
+        let body = AZURE_AI_OCR_CONFIG
+            .transform_ocr_request(
+                "pixtral-12b-2409",
+                json!({"type": "document_url", "document_url": "data:application/pdf;base64,abc"}),
+                serde_json::Map::from_iter([("include_image_base64".to_string(), json!(true))]),
+            )
+            .expect("request transforms")
+            .data;
+
+        assert_eq!(body["model"], "pixtral-12b-2409");
+        assert_eq!(body["include_image_base64"], true);
+        assert_eq!(
+            body["document"]["document_url"],
+            "data:application/pdf;base64,abc"
+        );
+    }
+
+    #[test]
+    fn document_intelligence_url_normalizes_zero_based_pages() {
+        let params = serde_json::Map::from_iter([("pages".to_string(), json!([2, 0, 2]))]);
+        let url = complete_document_intelligence_url(
+            Some("https://example.cognitiveservices.azure.com/"),
+            "azure_ai/doc-intelligence/prebuilt-layout",
+            &params,
+            &|_| None,
+        )
+        .expect("url builds");
+
+        assert_eq!(
+            url,
+            "https://example.cognitiveservices.azure.com/documentintelligence/documentModels/prebuilt-layout:analyze?api-version=2024-11-30&pages=1,3"
+        );
+    }
+
+    #[test]
+    fn document_intelligence_request_uses_base64_source_for_data_uri() {
+        let body = AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG
+            .transform_ocr_request(
+                "prebuilt-read",
+                json!({"type": "document_url", "document_url": "data:application/pdf;base64,abc123"}),
+                Map::new(),
+            )
+            .expect("request transforms")
+            .data;
+
+        assert_eq!(body, json!({"base64Source": "abc123"}));
+    }
+
+    #[test]
+    fn document_intelligence_response_normalizes_pages() {
+        let response = AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG
+            .transform_ocr_response(
+                "prebuilt-layout",
+                json!({
+                    "status": "succeeded",
+                    "analyzeResult": {
+                        "pages": [{
+                            "pageNumber": 2,
+                            "width": 8.5,
+                            "height": 11,
+                            "unit": "inch",
+                            "lines": [{"content": "hello"}, {"content": "world"}]
+                        }]
+                    }
+                }),
+            )
+            .expect("response transforms");
+
+        assert_eq!(response.pages[0]["index"], 1);
+        assert_eq!(response.pages[0]["markdown"], "hello\nworld");
+        assert_eq!(response.pages[0]["dimensions"]["width"], 816);
+        assert_eq!(
+            response.usage_info,
+            Some(json!({"pages_processed": 1, "doc_size_bytes": null}))
+        );
+    }
+}

--- a/litellm-rust/crates/providers/src/lib.rs
+++ b/litellm-rust/crates/providers/src/lib.rs
@@ -1,4 +1,6 @@
+pub mod azure_ai;
 pub mod mistral;
 pub mod ocr;
 pub mod openai;
 pub mod realtime;
+pub mod vertex_ai;

--- a/litellm-rust/crates/providers/src/ocr.rs
+++ b/litellm-rust/crates/providers/src/ocr.rs
@@ -1,6 +1,6 @@
 //! End-to-end OCR orchestration.
 //!
-//! Owns the whole Mistral OCR call so the Python side stays a thin bridge:
+//! Owns supported OCR provider calls so the Python side stays a thin bridge:
 //! resolve the API key, build the URL + body via the pure transforms, POST it,
 //! and normalize the response. The HTTP client is built once and reused.
 
@@ -9,23 +9,21 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use litellm_core::error::CoreError;
-use litellm_core::ocr::transformation::OcrProviderConfig;
 use litellm_core::CoreResult;
 use litellm_core::LlmProvider;
 use serde_json::{Map, Value};
 
-use crate::mistral::ocr::transformation as mistral;
-use crate::mistral::ocr::transformation::MISTRAL_OCR_CONFIG;
+mod common_utils;
+
+use common_utils::{
+    convert_document_url_to_data_uri, has_authorization_header, has_header,
+    poll_document_intelligence, string_headers, truncate_error_body, OcrProviderDispatch,
+};
 
 /// OCR over large documents can take a while; bound it generously rather than
 /// hanging forever on an unresponsive upstream. The client-level limit is the
 /// outer ceiling; callers can tighten it per request via ``run_ocr``'s ``timeout``.
 const OCR_TIMEOUT_SECS: u64 = 600;
-
-/// Maximum upstream body characters retained in error messages. OCR responses
-/// can echo document contents and prompts; keep enough for debugging without
-/// forwarding sensitive payloads across the host boundary.
-const ERROR_BODY_MAX_CHARS: usize = 256;
 
 /// Process-wide async HTTP client (connection pool + TLS reused across calls).
 ///
@@ -43,45 +41,6 @@ fn http_client() -> &'static reqwest::Client {
     })
 }
 
-fn truncate_error_body(body: &str) -> String {
-    if body.chars().count() <= ERROR_BODY_MAX_CHARS {
-        return body.to_string();
-    }
-    let truncated: String = body.chars().take(ERROR_BODY_MAX_CHARS).collect();
-    format!("{truncated}... (truncated)")
-}
-
-fn ocr_config_for(provider: LlmProvider) -> Option<&'static dyn OcrProviderConfig> {
-    match provider {
-        LlmProvider::Mistral => Some(&MISTRAL_OCR_CONFIG),
-        _ => None,
-    }
-}
-
-fn string_headers(extra_headers: Option<Map<String, Value>>) -> CoreResult<Vec<(String, String)>> {
-    extra_headers
-        .unwrap_or_default()
-        .into_iter()
-        .map(|(key, value)| {
-            value
-                .as_str()
-                .map(|value| (key.clone(), value.to_string()))
-                .ok_or_else(|| {
-                    CoreError::InvalidRequest(format!(
-                        "OCR extra_headers.{key} must be a string, got {}",
-                        litellm_core::error::json_type_name(&value)
-                    ))
-                })
-        })
-        .collect()
-}
-
-fn has_authorization_header(headers: &[(String, String)]) -> bool {
-    headers
-        .iter()
-        .any(|(key, _)| key.eq_ignore_ascii_case("authorization"))
-}
-
 pub struct OcrRequest<'a> {
     pub model: &'a str,
     pub document: Value,
@@ -93,33 +52,54 @@ pub struct OcrRequest<'a> {
     pub timeout: Option<Duration>,
 }
 
-/// Perform a Mistral OCR call end to end and return the normalized response as
+/// Perform an OCR call end to end and return the normalized response as
 /// JSON (the shape the Python `OCRResponse` model expects).
 ///
 /// Async: intended to be awaited directly by the Python bridge's async entrypoint.
 pub async fn ocr(request: OcrRequest<'_>) -> CoreResult<Value> {
     let model = request.model;
     let provider = LlmProvider::from_str(request.custom_llm_provider)?;
-    let config =
-        ocr_config_for(provider).ok_or_else(|| CoreError::InvalidProvider(provider.to_string()))?;
-
-    // TODO: key and URL resolution are still Mistral-specific while Mistral is
-    // the only Rust OCR provider. Move these onto the trait when another OCR
-    // provider is added here.
-    let api_key = mistral::resolve_api_key(request.api_key, &|key| std::env::var(key).ok())?;
-    let url = mistral::complete_url(request.api_base);
-    let filtered_params = config.map_ocr_params(&request.optional_params);
-    let body = config
-        .transform_ocr_request(model, request.document, filtered_params)?
-        .data;
+    let dispatch = OcrProviderDispatch::for_provider_and_model(provider, model)
+        .ok_or_else(|| CoreError::InvalidProvider(provider.to_string()))?;
+    let config = dispatch.config();
+    let env_lookup = |key: &str| std::env::var(key).ok();
 
     let headers = string_headers(request.extra_headers)?;
+    let api_key = if dispatch.uses_subscription_key() {
+        (!has_header(&headers, "ocp-apim-subscription-key"))
+            .then(|| dispatch.resolve_api_key(request.api_key, &env_lookup))
+            .transpose()?
+    } else {
+        (!has_authorization_header(&headers))
+            .then(|| dispatch.resolve_api_key(request.api_key, &env_lookup))
+            .transpose()?
+    };
+    let url = dispatch.complete_url(
+        request.api_base,
+        model,
+        &request.optional_params,
+        &env_lookup,
+    )?;
+    let filtered_params = config.map_ocr_params(&request.optional_params);
+    let document = if dispatch.needs_data_uri_document() {
+        convert_document_url_to_data_uri(request.document).await?
+    } else {
+        request.document
+    };
+    let body = config
+        .transform_ocr_request(model, document, filtered_params)?
+        .data;
+
     let mut request_builder = http_client().post(&url).json(&body);
-    if !has_authorization_header(&headers) {
-        request_builder = request_builder.bearer_auth(&api_key);
+    if dispatch.uses_subscription_key() {
+        if let Some(api_key) = &api_key {
+            request_builder = request_builder.header("Ocp-Apim-Subscription-Key", api_key);
+        }
+    } else if let Some(api_key) = &api_key {
+        request_builder = request_builder.bearer_auth(api_key);
     }
-    for (key, value) in headers {
-        request_builder = request_builder.header(&key, value);
+    for (key, value) in &headers {
+        request_builder = request_builder.header(key, value);
     }
     if let Some(duration) = request.timeout {
         request_builder = request_builder.timeout(duration);
@@ -131,6 +111,25 @@ pub async fn ocr(request: OcrRequest<'_>) -> CoreResult<Value> {
         .map_err(|err| CoreError::Network(err.to_string()))?;
 
     let status = response.status();
+    if dispatch.polls_document_intelligence() && status.as_u16() == 202 {
+        let operation_url = response
+            .headers()
+            .get("operation-location")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                CoreError::InvalidResponse(
+                    "Azure Document Intelligence returned 202 but no Operation-Location header found"
+                        .to_string(),
+                )
+            })?;
+        let response_json =
+            poll_document_intelligence(&operation_url, &url, &headers, request.timeout).await?;
+        return Ok(config
+            .transform_ocr_response(model, response_json)?
+            .into_json());
+    }
+
     let text = response
         .text()
         .await
@@ -166,7 +165,7 @@ mod tests {
 
     #[test]
     fn truncate_error_body_caps_long_payloads() {
-        let body = "x".repeat(ERROR_BODY_MAX_CHARS + 50);
+        let body = "x".repeat(306);
         let truncated = truncate_error_body(&body);
 
         assert!(truncated.ends_with("... (truncated)"));
@@ -175,20 +174,41 @@ mod tests {
             .expect("truncated marker present")
             .chars()
             .count();
-        assert_eq!(prefix_chars, ERROR_BODY_MAX_CHARS);
+        assert_eq!(prefix_chars, 256);
     }
 
     #[test]
     fn truncate_error_body_does_not_split_multibyte_chars() {
-        let body = "é".repeat(ERROR_BODY_MAX_CHARS + 10);
+        let body = "é".repeat(266);
         let truncated = truncate_error_body(&body);
         assert!(truncated.is_char_boundary(truncated.len()));
     }
 
     #[test]
-    fn ocr_registry_supports_only_mistral() {
-        assert!(ocr_config_for(LlmProvider::Mistral).is_some());
-        assert!(ocr_config_for(LlmProvider::Openai).is_none());
+    fn ocr_dispatch_supports_migrated_providers() {
+        assert_eq!(
+            OcrProviderDispatch::for_provider_and_model(LlmProvider::Mistral, "mistral-ocr-latest"),
+            Some(OcrProviderDispatch::Mistral)
+        );
+        assert_eq!(
+            OcrProviderDispatch::for_provider_and_model(LlmProvider::AzureAi, "pixtral-12b-2409"),
+            Some(OcrProviderDispatch::AzureAi)
+        );
+        assert_eq!(
+            OcrProviderDispatch::for_provider_and_model(
+                LlmProvider::AzureAi,
+                "doc-intelligence/prebuilt-read"
+            ),
+            Some(OcrProviderDispatch::AzureDocumentIntelligence)
+        );
+        assert_eq!(
+            OcrProviderDispatch::for_provider_and_model(LlmProvider::VertexAi, "deepseek-ocr-maas"),
+            Some(OcrProviderDispatch::VertexAiDeepSeek)
+        );
+        assert_eq!(
+            OcrProviderDispatch::for_provider_and_model(LlmProvider::Openai, "gpt-4o"),
+            None
+        );
     }
 
     #[test]

--- a/litellm-rust/crates/providers/src/ocr/common_utils.rs
+++ b/litellm-rust/crates/providers/src/ocr/common_utils.rs
@@ -1,0 +1,326 @@
+use std::time::{Duration, Instant};
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use litellm_core::error::CoreError;
+use litellm_core::ocr::transformation::OcrProviderConfig;
+use litellm_core::{CoreResult, LlmProvider};
+use serde_json::{Map, Value};
+
+use crate::azure_ai::ocr::transformation as azure_ai;
+use crate::azure_ai::ocr::transformation::{
+    AZURE_AI_OCR_CONFIG, AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG,
+};
+use crate::mistral::ocr::transformation as mistral;
+use crate::mistral::ocr::transformation::MISTRAL_OCR_CONFIG;
+use crate::vertex_ai::ocr::transformation as vertex_ai;
+use crate::vertex_ai::ocr::transformation::{VERTEX_AI_DEEPSEEK_OCR_CONFIG, VERTEX_AI_OCR_CONFIG};
+
+use super::http_client;
+
+const ERROR_BODY_MAX_CHARS: usize = 256;
+const AZURE_DOCUMENT_INTELLIGENCE_POLL_TIMEOUT_SECS: u64 = 120;
+
+pub(super) fn truncate_error_body(body: &str) -> String {
+    if body.chars().count() <= ERROR_BODY_MAX_CHARS {
+        return body.to_string();
+    }
+    let truncated: String = body.chars().take(ERROR_BODY_MAX_CHARS).collect();
+    format!("{truncated}... (truncated)")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum OcrProviderDispatch {
+    Mistral,
+    AzureAi,
+    AzureDocumentIntelligence,
+    VertexAiMistral,
+    VertexAiDeepSeek,
+}
+
+impl OcrProviderDispatch {
+    pub(super) fn for_provider_and_model(provider: LlmProvider, model: &str) -> Option<Self> {
+        match provider {
+            LlmProvider::Mistral => Some(Self::Mistral),
+            LlmProvider::AzureAi if is_azure_document_intelligence_model(model) => {
+                Some(Self::AzureDocumentIntelligence)
+            }
+            LlmProvider::AzureAiDocIntelligence => Some(Self::AzureDocumentIntelligence),
+            LlmProvider::AzureAi => Some(Self::AzureAi),
+            LlmProvider::VertexAi if vertex_ai::is_deepseek_model(model) => {
+                Some(Self::VertexAiDeepSeek)
+            }
+            LlmProvider::VertexAi => Some(Self::VertexAiMistral),
+            _ => None,
+        }
+    }
+
+    pub(super) fn config(self) -> &'static dyn OcrProviderConfig {
+        match self {
+            Self::Mistral => &MISTRAL_OCR_CONFIG,
+            Self::AzureAi => &AZURE_AI_OCR_CONFIG,
+            Self::AzureDocumentIntelligence => &AZURE_DOCUMENT_INTELLIGENCE_OCR_CONFIG,
+            Self::VertexAiMistral => &VERTEX_AI_OCR_CONFIG,
+            Self::VertexAiDeepSeek => &VERTEX_AI_DEEPSEEK_OCR_CONFIG,
+        }
+    }
+
+    pub(super) fn complete_url(
+        self,
+        api_base: Option<&str>,
+        model: &str,
+        optional_params: &Map<String, Value>,
+        env_lookup: &dyn Fn(&str) -> Option<String>,
+    ) -> CoreResult<String> {
+        match self {
+            Self::Mistral => Ok(mistral::complete_url(api_base)),
+            Self::AzureAi => azure_ai::complete_azure_ai_url(api_base, env_lookup),
+            Self::AzureDocumentIntelligence => azure_ai::complete_document_intelligence_url(
+                api_base,
+                model,
+                optional_params,
+                env_lookup,
+            ),
+            Self::VertexAiMistral => {
+                vertex_ai::complete_vertex_mistral_url(api_base, model, optional_params, env_lookup)
+            }
+            Self::VertexAiDeepSeek => {
+                vertex_ai::complete_vertex_deepseek_url(api_base, optional_params, env_lookup)
+            }
+        }
+    }
+
+    pub(super) fn resolve_api_key(
+        self,
+        api_key: Option<&str>,
+        env_lookup: &dyn Fn(&str) -> Option<String>,
+    ) -> CoreResult<String> {
+        match self {
+            Self::Mistral => mistral::resolve_api_key(api_key, env_lookup),
+            Self::AzureAi => azure_ai::resolve_azure_ai_api_key(api_key, env_lookup),
+            Self::AzureDocumentIntelligence => {
+                azure_ai::resolve_document_intelligence_api_key(api_key, env_lookup)
+            }
+            Self::VertexAiMistral | Self::VertexAiDeepSeek => {
+                vertex_ai::resolve_vertex_api_key(api_key, env_lookup)
+            }
+        }
+    }
+
+    pub(super) fn needs_data_uri_document(self) -> bool {
+        matches!(self, Self::AzureAi | Self::VertexAiMistral)
+    }
+
+    pub(super) fn uses_subscription_key(self) -> bool {
+        matches!(self, Self::AzureDocumentIntelligence)
+    }
+
+    pub(super) fn polls_document_intelligence(self) -> bool {
+        matches!(self, Self::AzureDocumentIntelligence)
+    }
+}
+
+fn is_azure_document_intelligence_model(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    model.contains("doc-intelligence") || model.contains("documentintelligence")
+}
+
+pub(super) fn string_headers(
+    extra_headers: Option<Map<String, Value>>,
+) -> CoreResult<Vec<(String, String)>> {
+    extra_headers
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(key, value)| {
+            value
+                .as_str()
+                .map(|value| (key.clone(), value.to_string()))
+                .ok_or_else(|| {
+                    CoreError::InvalidRequest(format!(
+                        "OCR extra_headers.{key} must be a string, got {}",
+                        litellm_core::error::json_type_name(&value)
+                    ))
+                })
+        })
+        .collect()
+}
+
+pub(super) fn has_authorization_header(headers: &[(String, String)]) -> bool {
+    has_header(headers, "authorization")
+}
+
+pub(super) fn has_header(headers: &[(String, String)], name: &str) -> bool {
+    headers
+        .iter()
+        .any(|(key, _)| key.eq_ignore_ascii_case(name))
+}
+
+fn document_url_field(document: &Value) -> CoreResult<Option<(&str, &str)>> {
+    let Some(object) = document.as_object() else {
+        return Ok(None);
+    };
+    let Some(doc_type) = object.get("type").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    let field = match doc_type {
+        "document_url" => "document_url",
+        "image_url" => "image_url",
+        _ => return Ok(None),
+    };
+    let Some(url) = object.get(field).and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    Ok(Some((field, url)))
+}
+
+fn is_url_requiring_fetch(url: &str) -> bool {
+    !url.starts_with("data:") && (url.starts_with("http://") || url.starts_with("https://"))
+}
+
+pub(super) async fn convert_document_url_to_data_uri(document: Value) -> CoreResult<Value> {
+    let Some((field, url)) = document_url_field(&document)? else {
+        return Ok(document);
+    };
+    if !is_url_requiring_fetch(url) {
+        return Ok(document);
+    }
+
+    let response = http_client()
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| CoreError::Network(err.to_string()))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(CoreError::Http {
+            status: status.as_u16(),
+            body: truncate_error_body(&body),
+        });
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|err| CoreError::Network(err.to_string()))?;
+    let data_uri = format!(
+        "data:{content_type};base64,{}",
+        BASE64_STANDARD.encode(bytes)
+    );
+
+    let mut transformed = document
+        .as_object()
+        .cloned()
+        .ok_or_else(|| CoreError::InvalidRequest("OCR document must be an object".to_string()))?;
+    transformed.insert(field.to_string(), Value::String(data_uri));
+    Ok(Value::Object(transformed))
+}
+
+fn same_origin(left: &str, right: &str) -> bool {
+    let Ok(left) = reqwest::Url::parse(left) else {
+        return false;
+    };
+    let Ok(right) = reqwest::Url::parse(right) else {
+        return false;
+    };
+    left.scheme() == right.scheme()
+        && left.host_str() == right.host_str()
+        && left.port_or_known_default() == right.port_or_known_default()
+}
+
+fn retry_after_secs(response: &reqwest::Response) -> u64 {
+    response
+        .headers()
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(2)
+}
+
+fn operation_status(response_json: &Value) -> CoreResult<&str> {
+    let status = response_json
+        .get("status")
+        .and_then(Value::as_str)
+        .ok_or(CoreError::MissingField("status"))?;
+    match status {
+        "succeeded" => Ok("succeeded"),
+        "running" | "notStarted" => Ok("running"),
+        "failed" => {
+            let message = response_json
+                .get("error")
+                .and_then(|error| error.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("Unknown error");
+            Err(CoreError::InvalidResponse(format!(
+                "Azure Document Intelligence analysis failed: {message}"
+            )))
+        }
+        other => Err(CoreError::InvalidResponse(format!(
+            "Unknown operation status: {other}"
+        ))),
+    }
+}
+
+pub(super) async fn poll_document_intelligence(
+    operation_url: &str,
+    original_url: &str,
+    headers: &[(String, String)],
+    timeout: Option<Duration>,
+) -> CoreResult<Value> {
+    if !same_origin(operation_url, original_url) {
+        return Err(CoreError::InvalidResponse(
+            "Azure Document Intelligence: rejected cross-origin polling URL".to_string(),
+        ));
+    }
+
+    let start = Instant::now();
+    let timeout = timeout.unwrap_or(Duration::from_secs(
+        AZURE_DOCUMENT_INTELLIGENCE_POLL_TIMEOUT_SECS,
+    ));
+    loop {
+        if start.elapsed() > timeout {
+            return Err(CoreError::Network(format!(
+                "Azure Document Intelligence operation polling timed out after {} seconds",
+                timeout.as_secs()
+            )));
+        }
+
+        let mut request_builder = http_client().get(operation_url);
+        for (key, value) in headers {
+            if key.eq_ignore_ascii_case("ocp-apim-subscription-key") {
+                request_builder = request_builder.header(key, value);
+            }
+        }
+        let response = request_builder
+            .send()
+            .await
+            .map_err(|err| CoreError::Network(err.to_string()))?;
+        let retry_after = retry_after_secs(&response);
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .map_err(|err| CoreError::Network(err.to_string()))?;
+        if !status.is_success() {
+            return Err(CoreError::Http {
+                status: status.as_u16(),
+                body: truncate_error_body(&text),
+            });
+        }
+        let response_json: Value = serde_json::from_str(&text).map_err(|err| {
+            CoreError::InvalidResponse(format!("invalid Azure DI poll response JSON: {err}"))
+        })?;
+        if operation_status(&response_json)? == "succeeded" {
+            return Ok(response_json);
+        }
+        tokio::time::sleep(Duration::from_secs(retry_after)).await;
+    }
+}

--- a/litellm-rust/crates/providers/src/vertex_ai/mod.rs
+++ b/litellm-rust/crates/providers/src/vertex_ai/mod.rs
@@ -1,0 +1,1 @@
+pub mod ocr;

--- a/litellm-rust/crates/providers/src/vertex_ai/ocr/mod.rs
+++ b/litellm-rust/crates/providers/src/vertex_ai/ocr/mod.rs
@@ -1,0 +1,1 @@
+pub mod transformation;

--- a/litellm-rust/crates/providers/src/vertex_ai/ocr/transformation.rs
+++ b/litellm-rust/crates/providers/src/vertex_ai/ocr/transformation.rs
@@ -1,0 +1,396 @@
+use litellm_core::error::{json_type_name, CoreError, CoreResult};
+use litellm_core::ocr::transformation::OcrProviderConfig;
+use litellm_core::ocr::types::{OcrRequestData, OcrResponseData};
+use serde_json::{json, Map, Value};
+
+use crate::mistral::ocr::transformation::MISTRAL_OCR_CONFIG;
+
+const VERTEX_DEFAULT_LOCATION: &str = "us-central1";
+const VERTEX_DEFAULT_DEEPSEEK_API_BASE: &str = "https://aiplatform.googleapis.com";
+const VERTEX_AI_API_KEY_ENV: &str = "VERTEX_AI_API_KEY";
+const VERTEXAI_API_KEY_ENV: &str = "VERTEXAI_API_KEY";
+const VERTEXAI_PROJECT_ENV: &str = "VERTEXAI_PROJECT";
+const VERTEXAI_LOCATION_ENV: &str = "VERTEXAI_LOCATION";
+const VERTEX_LOCATION_ENV: &str = "VERTEX_LOCATION";
+
+#[rustfmt::skip]
+const DEEPSEEK_CHAT_COMPLETION_PARAMS: [&str; 6] = [
+    "stream",
+    "temperature",
+    "max_tokens",
+    "top_p",
+    "n",
+    "stop",
+];
+const DEEPSEEK_SUPPORTED_OCR_PARAMS: &[&str] = &DEEPSEEK_CHAT_COMPLETION_PARAMS;
+
+pub struct VertexAiOcrConfig;
+pub struct VertexAiDeepSeekOcrConfig;
+
+pub const VERTEX_AI_OCR_CONFIG: VertexAiOcrConfig = VertexAiOcrConfig;
+pub const VERTEX_AI_DEEPSEEK_OCR_CONFIG: VertexAiDeepSeekOcrConfig = VertexAiDeepSeekOcrConfig;
+
+fn string_param<'a>(params: &'a Map<String, Value>, keys: &[&str]) -> Option<&'a str> {
+    keys.iter()
+        .find_map(|key| params.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub fn is_deepseek_model(model: &str) -> bool {
+    model.to_ascii_lowercase().contains("deepseek")
+}
+
+pub fn resolve_vertex_api_key(
+    api_key: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    api_key
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(str::to_string)
+        .or_else(|| env_lookup(VERTEX_AI_API_KEY_ENV).filter(|key| !key.trim().is_empty()))
+        .or_else(|| env_lookup(VERTEXAI_API_KEY_ENV).filter(|key| !key.trim().is_empty()))
+        .ok_or_else(|| {
+            CoreError::Auth(
+                "Missing Vertex AI access token - pass api_key or provide Authorization via extra_headers"
+                    .to_string(),
+            )
+        })
+}
+
+fn vertex_project(
+    params: &Map<String, Value>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    string_param(params, &["vertex_project", "vertex_ai_project"])
+        .map(str::to_string)
+        .or_else(|| env_lookup(VERTEXAI_PROJECT_ENV).filter(|value| !value.trim().is_empty()))
+        .ok_or_else(|| {
+            CoreError::InvalidRequest(
+                "Missing vertex_project - Set VERTEXAI_PROJECT environment variable or pass vertex_project parameter"
+                    .to_string(),
+            )
+        })
+}
+
+fn vertex_location(
+    params: &Map<String, Value>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> String {
+    string_param(params, &["vertex_location", "vertex_ai_location"])
+        .map(str::to_string)
+        .or_else(|| env_lookup(VERTEXAI_LOCATION_ENV).filter(|value| !value.trim().is_empty()))
+        .or_else(|| env_lookup(VERTEX_LOCATION_ENV).filter(|value| !value.trim().is_empty()))
+        .unwrap_or_else(|| VERTEX_DEFAULT_LOCATION.to_string())
+}
+
+fn vertex_mistral_api_base(api_base: Option<&str>, location: &str) -> String {
+    api_base
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| format!("https://{location}-aiplatform.googleapis.com"))
+        .trim_end_matches('/')
+        .to_string()
+}
+
+pub fn complete_vertex_mistral_url(
+    api_base: Option<&str>,
+    model: &str,
+    optional_params: &Map<String, Value>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    let project = vertex_project(optional_params, env_lookup)?;
+    let location = vertex_location(optional_params, env_lookup);
+    let base = vertex_mistral_api_base(api_base, &location);
+    Ok(format!(
+        "{base}/v1/projects/{project}/locations/{location}/publishers/mistralai/models/{model}:rawPredict"
+    ))
+}
+
+pub fn complete_vertex_deepseek_url(
+    api_base: Option<&str>,
+    optional_params: &Map<String, Value>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> CoreResult<String> {
+    let project = vertex_project(optional_params, env_lookup)?;
+    let location = vertex_location(optional_params, env_lookup);
+    let base = api_base
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(VERTEX_DEFAULT_DEEPSEEK_API_BASE)
+        .trim_end_matches('/');
+    Ok(format!(
+        "{base}/v1/projects/{project}/locations/{location}/endpoints/openapi/chat/completions"
+    ))
+}
+
+fn document_content_item(document: &Value) -> CoreResult<Value> {
+    let object = document.as_object().ok_or_else(|| CoreError::InvalidType {
+        expected: "object",
+        actual: json_type_name(document),
+    })?;
+    let doc_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(CoreError::MissingField("document.type"))?;
+    let url_field = match doc_type {
+        "image_url" => "image_url",
+        "document_url" => "document_url",
+        other => {
+            return Err(CoreError::InvalidRequest(format!(
+                "Unsupported document type: {other}. Expected 'image_url' or 'document_url'"
+            )))
+        }
+    };
+    let url = object
+        .get(url_field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or(CoreError::MissingField(url_field))?;
+
+    Ok(json!({
+        "type": "image_url",
+        "image_url": url,
+    }))
+}
+
+fn deepseek_model_name(model: &str) -> String {
+    if model.starts_with("deepseek-ai/") {
+        model.to_string()
+    } else {
+        format!("deepseek-ai/{model}")
+    }
+}
+
+fn first_choice_content(response: &Value) -> CoreResult<Value> {
+    response
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("content"))
+        .cloned()
+        .filter(|content| match content {
+            Value::String(value) => !value.is_empty(),
+            Value::Object(_) => true,
+            _ => false,
+        })
+        .ok_or_else(|| {
+            CoreError::InvalidResponse("No content in chat completion response".to_string())
+        })
+}
+
+fn ocr_data_from_content(content: Value, usage: Option<Value>, model: &str) -> Value {
+    match content {
+        Value::String(content) => {
+            if content.trim_start().starts_with('{') {
+                serde_json::from_str(&content).unwrap_or_else(|_| {
+                    json!({
+                        "pages": [{"index": 0, "markdown": content}],
+                        "model": model,
+                        "usage_info": usage.unwrap_or_else(|| json!({})),
+                    })
+                })
+            } else {
+                json!({
+                    "pages": [{"index": 0, "markdown": content}],
+                    "model": model,
+                    "usage_info": usage.unwrap_or_else(|| json!({})),
+                })
+            }
+        }
+        Value::Object(_) => content,
+        other => json!({
+            "pages": [{"index": 0, "markdown": other.to_string()}],
+            "model": model,
+            "usage_info": usage.unwrap_or_else(|| json!({})),
+        }),
+    }
+}
+
+impl OcrProviderConfig for VertexAiOcrConfig {
+    fn supported_ocr_params(&self) -> &'static [&'static str] {
+        MISTRAL_OCR_CONFIG.supported_ocr_params()
+    }
+
+    fn transform_ocr_request(
+        &self,
+        model: &str,
+        document: Value,
+        optional_params: Map<String, Value>,
+    ) -> CoreResult<OcrRequestData> {
+        MISTRAL_OCR_CONFIG.transform_ocr_request(model, document, optional_params)
+    }
+
+    fn transform_ocr_response(
+        &self,
+        model: &str,
+        response_json: Value,
+    ) -> CoreResult<OcrResponseData> {
+        MISTRAL_OCR_CONFIG.transform_ocr_response(model, response_json)
+    }
+}
+
+impl OcrProviderConfig for VertexAiDeepSeekOcrConfig {
+    fn supported_ocr_params(&self) -> &'static [&'static str] {
+        DEEPSEEK_SUPPORTED_OCR_PARAMS
+    }
+
+    fn transform_ocr_request(
+        &self,
+        model: &str,
+        document: Value,
+        optional_params: Map<String, Value>,
+    ) -> CoreResult<OcrRequestData> {
+        let mut data = Map::new();
+        data.insert(
+            "model".to_string(),
+            Value::String(deepseek_model_name(model)),
+        );
+        data.insert(
+            "messages".to_string(),
+            json!([{"role": "user", "content": [document_content_item(&document)?]}]),
+        );
+        for (key, value) in optional_params {
+            if DEEPSEEK_SUPPORTED_OCR_PARAMS.contains(&key.as_str()) {
+                data.insert(key, value);
+            }
+        }
+        Ok(OcrRequestData {
+            data: Value::Object(data),
+            files: None,
+        })
+    }
+
+    fn transform_ocr_response(
+        &self,
+        model: &str,
+        response_json: Value,
+    ) -> CoreResult<OcrResponseData> {
+        let response = response_json
+            .as_object()
+            .ok_or_else(|| CoreError::InvalidType {
+                expected: "object",
+                actual: json_type_name(&response_json),
+            })?;
+        let usage = response.get("usage").cloned();
+        let content = first_choice_content(&response_json)?;
+        let mut ocr_data = ocr_data_from_content(content.clone(), usage.clone(), model);
+
+        if !ocr_data.get("pages").is_some_and(Value::is_array) {
+            ocr_data = json!({
+                "pages": [{
+                    "index": 0,
+                    "markdown": match content {
+                        Value::String(value) => value,
+                        other => other.to_string(),
+                    }
+                }],
+                "model": ocr_data.get("model").and_then(Value::as_str).unwrap_or(model),
+                "usage_info": ocr_data.get("usage_info").cloned().or(usage).unwrap_or_else(|| json!({})),
+            });
+        }
+
+        let object = ocr_data.as_object().ok_or_else(|| CoreError::InvalidType {
+            expected: "object",
+            actual: json_type_name(&ocr_data),
+        })?;
+        let pages = object
+            .get("pages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let usage_info = object
+            .get("usage_info")
+            .cloned()
+            .or_else(|| response.get("usage").cloned());
+        Ok(OcrResponseData {
+            pages,
+            model: object
+                .get("model")
+                .and_then(Value::as_str)
+                .unwrap_or(model)
+                .to_string(),
+            document_annotation: object.get("document_annotation").cloned(),
+            usage_info,
+            object: "ocr".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vertex_mistral_url_uses_project_location_and_model() {
+        let params = Map::from_iter([
+            ("vertex_project".to_string(), json!("proj-1")),
+            ("vertex_location".to_string(), json!("europe-west4")),
+        ]);
+
+        let url = complete_vertex_mistral_url(None, "mistral-ocr-maas", &params, &|_| None)
+            .expect("url builds");
+
+        assert_eq!(
+            url,
+            "https://europe-west4-aiplatform.googleapis.com/v1/projects/proj-1/locations/europe-west4/publishers/mistralai/models/mistral-ocr-maas:rawPredict"
+        );
+    }
+
+    #[test]
+    fn vertex_mistral_reuses_mistral_body_transform() {
+        let body = VERTEX_AI_OCR_CONFIG
+            .transform_ocr_request(
+                "mistral-ocr-maas",
+                json!({"type": "image_url", "image_url": "data:image/png;base64,abc"}),
+                Map::new(),
+            )
+            .expect("request transforms")
+            .data;
+
+        assert_eq!(body["model"], "mistral-ocr-maas");
+        assert_eq!(body["document"]["image_url"], "data:image/png;base64,abc");
+    }
+
+    #[test]
+    fn vertex_deepseek_request_uses_chat_completion_shape() {
+        let body = VERTEX_AI_DEEPSEEK_OCR_CONFIG
+            .transform_ocr_request(
+                "deepseek-ocr-maas",
+                json!({"type": "document_url", "document_url": "gs://bucket/doc.pdf"}),
+                Map::from_iter([("temperature".to_string(), json!(0.1))]),
+            )
+            .expect("request transforms")
+            .data;
+
+        assert_eq!(body["model"], "deepseek-ai/deepseek-ocr-maas");
+        assert_eq!(body["temperature"], 0.1);
+        assert_eq!(
+            body["messages"][0]["content"][0],
+            json!({"type": "image_url", "image_url": "gs://bucket/doc.pdf"})
+        );
+    }
+
+    #[test]
+    fn vertex_deepseek_response_wraps_markdown_content() {
+        let response = VERTEX_AI_DEEPSEEK_OCR_CONFIG
+            .transform_ocr_response(
+                "deepseek-ocr-maas",
+                json!({
+                    "choices": [{"message": {"content": "# OCR text"}}],
+                    "usage": {"prompt_tokens": 1}
+                }),
+            )
+            .expect("response transforms");
+
+        assert_eq!(
+            response.pages,
+            vec![json!({"index": 0, "markdown": "# OCR text"})]
+        );
+        assert_eq!(response.model, "deepseek-ocr-maas");
+        assert_eq!(response.usage_info, Some(json!({"prompt_tokens": 1})));
+    }
+}

--- a/litellm/ocr/main.py
+++ b/litellm/ocr/main.py
@@ -52,7 +52,17 @@ class _PreparedOCRRequest:
 @dataclass
 class _PreparedRustOCRCall:
     api_key: Optional[str]
+    api_base: Optional[str]
     headers: dict[str, object]
+    optional_params: dict[str, object]
+
+
+_RUST_OCR_PROVIDERS = {
+    "mistral",
+    "azure_ai",
+    "azure_ai/doc-intelligence",
+    "vertex_ai",
+}
 
 
 def _timeout_to_seconds(
@@ -172,6 +182,52 @@ def _prepare_ocr_request(
     )
 
 
+def _rust_ocr_supported(prepared_request: _PreparedOCRRequest) -> bool:
+    return prepared_request.custom_llm_provider in _RUST_OCR_PROVIDERS
+
+
+def _rust_bridge_optional_params(
+    prepared_request: _PreparedOCRRequest,
+    resolve_secret: Callable[[str], Optional[str]],
+) -> dict[str, object]:
+    optional_params = dict(prepared_request.optional_params)
+    if prepared_request.custom_llm_provider == "vertex_ai":
+        vertex_project = (
+            prepared_request.litellm_params.get("vertex_project")
+            or prepared_request.litellm_params.get("vertex_ai_project")
+            or litellm.vertex_project
+            or resolve_secret("VERTEXAI_PROJECT")
+        )
+        vertex_location = (
+            prepared_request.litellm_params.get("vertex_location")
+            or prepared_request.litellm_params.get("vertex_ai_location")
+            or litellm.vertex_location
+            or resolve_secret("VERTEXAI_LOCATION")
+            or resolve_secret("VERTEX_LOCATION")
+        )
+        if vertex_project is not None:
+            optional_params["vertex_project"] = vertex_project
+        if vertex_location is not None:
+            optional_params["vertex_location"] = vertex_location
+    return optional_params
+
+
+def _rust_bridge_api_base(
+    prepared_request: _PreparedOCRRequest,
+    resolve_secret: Callable[[str], Optional[str]],
+) -> Optional[str]:
+    if prepared_request.api_base is not None:
+        return prepared_request.api_base
+    if prepared_request.custom_llm_provider == "azure_ai":
+        if (
+            "doc-intelligence" in prepared_request.model
+            or "documentintelligence" in prepared_request.model
+        ):
+            return resolve_secret("AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT")
+        return resolve_secret("AZURE_AI_API_BASE")
+    return None
+
+
 def _prepare_rust_ocr_call(
     prepared_request: _PreparedOCRRequest,
     resolve_api_key: Callable[[str], Optional[str]],
@@ -194,6 +250,10 @@ def _prepare_rust_ocr_call(
         optional_params=prepared_request.optional_params,
         litellm_params=prepared_request.litellm_params,
     )
+    rust_api_base = _rust_bridge_api_base(prepared_request, resolve_api_key)
+    rust_optional_params = _rust_bridge_optional_params(
+        prepared_request, resolve_api_key
+    )
     prepared_request.litellm_logging_obj.pre_call(
         input="OCR document processing",
         api_key=resolved_api_key,
@@ -201,7 +261,7 @@ def _prepare_rust_ocr_call(
             "complete_input_dict": {
                 "model": prepared_request.model,
                 "document": prepared_request.document,
-                **prepared_request.optional_params,
+                **rust_optional_params,
             },
             "api_base": resolved_complete_url,
             "headers": resolved_headers,
@@ -209,7 +269,9 @@ def _prepare_rust_ocr_call(
     )
     return _PreparedRustOCRCall(
         api_key=resolved_api_key,
+        api_base=rust_api_base,
         headers=cast(dict[str, object], resolved_headers),
+        optional_params=rust_optional_params,
     )
 
 
@@ -235,10 +297,10 @@ def _run_rust_ocr(
             model=prepared_request.model,
             document=cast(dict[str, object], prepared_request.document),
             api_key=prepared.api_key,
-            api_base=prepared_request.api_base,
+            api_base=prepared.api_base,
             custom_llm_provider=prepared_request.custom_llm_provider,
             extra_headers=prepared.headers,
-            optional_params=prepared_request.optional_params,
+            optional_params=prepared.optional_params,
             timeout_seconds=_timeout_to_seconds(prepared_request.effective_timeout),
         )
     )
@@ -258,10 +320,10 @@ async def _run_rust_aocr(
             model=prepared_request.model,
             document=cast(dict[str, object], prepared_request.document),
             api_key=prepared.api_key,
-            api_base=prepared_request.api_base,
+            api_base=prepared.api_base,
             custom_llm_provider=prepared_request.custom_llm_provider,
             extra_headers=prepared.headers,
-            optional_params=prepared_request.optional_params,
+            optional_params=prepared.optional_params,
             timeout_seconds=_timeout_to_seconds(prepared_request.effective_timeout),
         )
     )
@@ -363,7 +425,7 @@ async def aocr(
             {"model": model, "custom_llm_provider": custom_llm_provider}
         )
 
-        if prepared.custom_llm_provider == "mistral" and rust_ocr_enabled():
+        if _rust_ocr_supported(prepared) and rust_ocr_enabled():
             rust_aocr = load_rust_aocr()
             if rust_aocr is None:
                 verbose_logger.debug(
@@ -640,8 +702,8 @@ def ocr(
             {"model": model, "custom_llm_provider": custom_llm_provider}
         )
 
-        # Optional Rust path: hand the whole Mistral OCR call to the Rust bridge.
-        if prepared.custom_llm_provider == "mistral" and rust_ocr_enabled():
+        # Optional Rust path: hand supported OCR calls to the Rust bridge.
+        if _rust_ocr_supported(prepared) and rust_ocr_enabled():
             rust_ocr = load_rust_ocr()
             if rust_ocr is None:
                 verbose_logger.debug(

--- a/litellm/ocr/rust_bridge.py
+++ b/litellm/ocr/rust_bridge.py
@@ -11,6 +11,7 @@ can import it statically without forming an import cycle.
 
 from __future__ import annotations
 
+import os
 from typing import Awaitable, Final, Protocol, cast
 
 
@@ -54,7 +55,17 @@ class _Unset:
 
 _UNSET: Final[_Unset] = _Unset()
 
-_rust_ocr_enabled = False
+
+def _env_enables_rust_ocr() -> bool:
+    return os.getenv("LITELLM_USE_RUST_OCR", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+_rust_ocr_enabled = _env_enables_rust_ocr()
 _rust_ocr_impl: RustOcr | None = None
 _rust_aocr_impl: RustAocr | None = None
 

--- a/tests/ocr_tests/test_ocr_rust_e2e.py
+++ b/tests/ocr_tests/test_ocr_rust_e2e.py
@@ -1,0 +1,188 @@
+"""
+Opt-in live E2E coverage for Rust-backed OCR providers.
+
+These tests are intentionally reusable across OCR providers. They validate the
+same Mistral-compatible response contract through:
+1. the Python SDK with ``litellm.use_litellm_rust(True)``; and
+2. a running LiteLLM proxy started with ``LITELLM_USE_RUST_OCR=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+import litellm
+from base_ocr_unit_tests import TEST_PDF_URL
+from litellm.ocr.rust_bridge import load_rust_aocr
+
+TEST_IMAGE_URL = (
+    "https://cdn.jsdelivr.net/gh/BerriAI/litellm"
+    "@d769e81c90d453240c61fc572cdb27fae06a89d0"
+    "/tests/image_gen_tests/test_image.png"
+)
+
+
+@dataclass(frozen=True)
+class RustOcrE2ECase:
+    name: str
+    model: str
+    document: dict[str, str]
+    required_env: tuple[str, ...]
+    optional_env: tuple[str, ...] = ()
+
+    def litellm_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {"model": self.model}
+        for env_name in self.required_env + self.optional_env:
+            value = os.getenv(env_name)
+            if value is not None:
+                kwargs.update(_env_to_litellm_kwargs(env_name, value))
+        return kwargs
+
+
+def _env_to_litellm_kwargs(env_name: str, value: str) -> dict[str, str]:
+    if env_name in {
+        "MISTRAL_API_KEY",
+        "AZURE_API_KEY",
+        "AZURE_DOCUMENT_INTELLIGENCE_API_KEY",
+    }:
+        return {"api_key": value}
+    if env_name in {"AZURE_API_BASE", "AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT"}:
+        return {"api_base": value}
+    if env_name in {"VERTEXAI_PROJECT", "VERTEX_AI_PROJECT"}:
+        return {"vertex_project": value}
+    if env_name in {"VERTEXAI_LOCATION", "VERTEX_LOCATION", "VERTEX_AI_LOCATION"}:
+        return {"vertex_location": value}
+    return {}
+
+
+RUST_OCR_E2E_CASES = [
+    RustOcrE2ECase(
+        name="mistral",
+        model="mistral/mistral-ocr-latest",
+        document={"type": "document_url", "document_url": TEST_PDF_URL},
+        required_env=("MISTRAL_API_KEY",),
+    ),
+    RustOcrE2ECase(
+        name="azure_ai",
+        model="azure_ai/mistral-document-ai-2505",
+        document={"type": "document_url", "document_url": TEST_PDF_URL},
+        required_env=("AZURE_API_KEY", "AZURE_API_BASE"),
+    ),
+    RustOcrE2ECase(
+        name="azure_document_intelligence",
+        model="azure_ai/doc-intelligence/prebuilt-layout",
+        document={"type": "document_url", "document_url": TEST_PDF_URL},
+        required_env=(
+            "AZURE_DOCUMENT_INTELLIGENCE_API_KEY",
+            "AZURE_DOCUMENT_INTELLIGENCE_ENDPOINT",
+        ),
+    ),
+    RustOcrE2ECase(
+        name="vertex_mistral",
+        model="vertex_ai/mistral-ocr-2505",
+        document={"type": "document_url", "document_url": TEST_PDF_URL},
+        required_env=("VERTEXAI_PROJECT",),
+        optional_env=("VERTEXAI_LOCATION", "VERTEX_LOCATION"),
+    ),
+    RustOcrE2ECase(
+        name="vertex_deepseek",
+        model="vertex_ai/deepseek-ocr-maas",
+        document={
+            "type": "image_url",
+            "image_url": os.getenv("RUST_OCR_IMAGE_URL", TEST_IMAGE_URL),
+        },
+        required_env=("VERTEXAI_PROJECT",),
+        optional_env=("VERTEXAI_LOCATION", "VERTEX_LOCATION"),
+    ),
+]
+
+
+def _skip_unless_live_rust_ocr_e2e(case: RustOcrE2ECase) -> None:
+    if os.getenv("LITELLM_RUN_LIVE_RUST_OCR_TESTS") != "1":
+        pytest.skip(
+            "Set LITELLM_RUN_LIVE_RUST_OCR_TESTS=1 to run live Rust OCR E2E tests"
+        )
+    missing = [env_name for env_name in case.required_env if not os.getenv(env_name)]
+    if missing:
+        pytest.skip(f"Missing required env vars for {case.name}: {', '.join(missing)}")
+    if case.name.startswith("vertex_") and not (
+        os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        or os.getenv("VERTEXAI_CREDENTIALS")
+        or os.getenv("VERTEX_AI_API_KEY")
+        or os.getenv("VERTEXAI_API_KEY")
+    ):
+        pytest.skip(
+            "Vertex OCR Rust E2E requires GOOGLE_APPLICATION_CREDENTIALS, VERTEXAI_CREDENTIALS, VERTEX_AI_API_KEY, or VERTEXAI_API_KEY"
+        )
+
+
+def _assert_ocr_response_shape(response: Any) -> None:
+    assert response.object == "ocr"
+    assert response.model
+    assert isinstance(response.pages, list)
+    assert len(response.pages) > 0
+    assert hasattr(response.pages[0], "index")
+    assert hasattr(response.pages[0], "markdown")
+
+
+def _assert_proxy_ocr_response_shape(response_json: dict[str, Any]) -> None:
+    assert response_json["object"] == "ocr"
+    assert response_json["model"]
+    assert isinstance(response_json["pages"], list)
+    assert len(response_json["pages"]) > 0
+    assert "index" in response_json["pages"][0]
+    assert "markdown" in response_json["pages"][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", RUST_OCR_E2E_CASES, ids=lambda case: case.name)
+async def test_rust_ocr_provider_live_sdk(case: RustOcrE2ECase) -> None:
+    _skip_unless_live_rust_ocr_e2e(case)
+    litellm.use_litellm_rust(True)
+    if load_rust_aocr() is None:
+        pytest.skip("compiled litellm_python_bridge.aocr is required for Rust OCR E2E")
+
+    try:
+        response = await litellm.aocr(document=case.document, **case.litellm_kwargs())
+        _assert_ocr_response_shape(response)
+    finally:
+        litellm.use_litellm_rust(False)
+
+
+@pytest.mark.parametrize("case", RUST_OCR_E2E_CASES, ids=lambda case: case.name)
+def test_rust_ocr_provider_live_proxy_gateway(case: RustOcrE2ECase) -> None:
+    _skip_unless_live_rust_ocr_e2e(case)
+    proxy_url = os.getenv("LITELLM_PROXY_URL")
+    if not proxy_url:
+        pytest.skip("Set LITELLM_PROXY_URL to run proxy OCR E2E")
+    if os.getenv("LITELLM_USE_RUST_OCR") != "1":
+        pytest.skip(
+            "Start the proxy with LITELLM_USE_RUST_OCR=1 for Rust OCR proxy E2E"
+        )
+
+    master_key = os.getenv("LITELLM_MASTER_KEY", "sk-1234")
+    body = {
+        **case.litellm_kwargs(),
+        "document": case.document,
+    }
+    with httpx.Client(timeout=float(os.getenv("E2E_REQUEST_TIMEOUT", "120"))) as client:
+        try:
+            health = client.get(f"{proxy_url.rstrip('/')}/health/liveliness")
+        except httpx.HTTPError as exc:
+            pytest.skip(f"No live proxy at {proxy_url}: {exc}")
+        if health.status_code >= 500:
+            pytest.skip(f"Proxy at {proxy_url} returned {health.status_code}")
+
+        response = client.post(
+            f"{proxy_url.rstrip('/')}/v1/ocr",
+            headers={"Authorization": f"Bearer {master_key}"},
+            json=body,
+        )
+
+    assert response.status_code == 200, response.text
+    _assert_proxy_ocr_response_shape(response.json())

--- a/tests/test_litellm/ocr/test_rust_bridge.py
+++ b/tests/test_litellm/ocr/test_rust_bridge.py
@@ -242,6 +242,11 @@ def test_use_litellm_rust_toggles_flag():
     assert rust_bridge.rust_ocr_enabled() is False
 
 
+def test_env_var_enables_rust_ocr(monkeypatch):
+    monkeypatch.setenv("LITELLM_USE_RUST_OCR", "1")
+    assert rust_bridge._env_enables_rust_ocr() is True
+
+
 def test_load_rust_ocr_returns_injected_impl():
     bridge = RecordingBridge()
     litellm.use_litellm_rust(True, ocr=bridge)
@@ -384,6 +389,74 @@ def test_run_rust_ocr_uses_provider_api_key_env_var():
     assert bridge.calls[0]["api_key"] == "sk-provider-env"
 
 
+def test_prepare_rust_ocr_call_forwards_vertex_routing_metadata():
+    bridge = RecordingBridge()
+
+    ocr_main._run_rust_ocr(
+        rust_ocr=bridge,
+        prepared_request=build_prepared_request(
+            custom_llm_provider="vertex_ai",
+            model="mistral-ocr-maas",
+            litellm_params={
+                "vertex_project": "project-1",
+                "vertex_location": "us-central1",
+                "vertex_credentials": "redacted",
+            },
+            optional_params={"include_image_base64": True},
+            timeout=None,
+        ),
+        resolve_api_key=lambda _name: None,
+    )
+
+    assert bridge.calls[0]["optional_params"] == {
+        "include_image_base64": True,
+        "vertex_project": "project-1",
+        "vertex_location": "us-central1",
+    }
+
+
+def test_prepare_rust_ocr_call_resolves_vertex_routing_metadata_from_secret_manager():
+    bridge = RecordingBridge()
+
+    def _resolver(name: str) -> str | None:
+        return {
+            "VERTEXAI_PROJECT": "project-from-secret",
+            "VERTEXAI_LOCATION": "us-east5",
+        }.get(name)
+
+    ocr_main._run_rust_ocr(
+        rust_ocr=bridge,
+        prepared_request=build_prepared_request(
+            custom_llm_provider="vertex_ai",
+            model="mistral-ocr-maas",
+            timeout=None,
+        ),
+        resolve_api_key=_resolver,
+    )
+
+    assert bridge.calls[0]["optional_params"]["vertex_project"] == "project-from-secret"
+    assert bridge.calls[0]["optional_params"]["vertex_location"] == "us-east5"
+
+
+def test_prepare_rust_ocr_call_resolves_azure_ai_api_base_from_secret_manager():
+    bridge = RecordingBridge()
+
+    ocr_main._run_rust_ocr(
+        rust_ocr=bridge,
+        prepared_request=build_prepared_request(
+            custom_llm_provider="azure_ai",
+            model="pixtral-12b-2409",
+            api_base=None,
+            timeout=None,
+        ),
+        resolve_api_key=lambda name: (
+            "https://azure.example.com" if name == "AZURE_AI_API_BASE" else None
+        ),
+    )
+
+    assert bridge.calls[0]["api_base"] == "https://azure.example.com"
+
+
 def test_run_rust_ocr_prefers_explicit_key_over_resolver():
     bridge = RecordingBridge()
     resolver_calls = []
@@ -456,6 +529,20 @@ def test_ocr_routes_to_rust_when_enabled(fake_bridge):
     }
     # Raw OCR params ride along in optional_params; Rust filters to supported keys.
     assert call["optional_params"].get("include_image_base64") is True
+
+
+def test_ocr_routes_azure_ai_to_rust_when_enabled(fake_bridge):
+    response = litellm.ocr(
+        model="azure_ai/pixtral-12b-2409",
+        document=DOCUMENT,
+        api_key="sk-test",
+        api_base="https://example.services.ai.azure.com",
+    )
+
+    assert isinstance(response, OCRResponse)
+    assert len(fake_bridge.calls) == 1
+    assert fake_bridge.calls[0]["model"] == "pixtral-12b-2409"
+    assert fake_bridge.calls[0]["custom_llm_provider"] == "azure_ai"
 
 
 def test_ocr_exception_type_uses_resolved_provider_context(


### PR DESCRIPTION
## Summary
- add Rust OCR transforms for Azure AI, Azure Document Intelligence, Vertex AI Mistral, and Vertex AI DeepSeek
- wire the opt-in Python Rust OCR bridge for all migrated OCR providers
- add a reusable opt-in live Rust OCR E2E suite for SDK and proxy gateway paths

## Rollout plan
1. Keep Rust OCR feature-flagged in this PR via `litellm.use_litellm_rust()` or `LITELLM_USE_RUST_OCR=1` when starting the gateway.
2. Run the new live E2E suite provider-by-provider with `LITELLM_RUN_LIVE_RUST_OCR_TESTS=1` and the provider credentials in env.
3. For gateway validation, start the LiteLLM proxy with `LITELLM_USE_RUST_OCR=1`, then run the same suite with `LITELLM_PROXY_URL` and `LITELLM_MASTER_KEY`.
4. Move traffic / make Rust OCR the default only after the provider E2Es pass.

## Tests
- `cd litellm-rust && cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
- `uv run pytest tests/test_litellm/ocr/test_rust_bridge.py -q`
- `uv run pytest tests/ocr_tests/test_ocr_rust_e2e.py -q` (skips unless live flags/credentials are set)
