### PR TITLE
fix(proxy): dispatch prompt injection llm api check

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -376,6 +376,7 @@ class _CallbackCapabilities:
     has_iterator_override: bool = False
     has_streaming_chunk_override: bool = False
     has_guardrail: bool = False
+    has_during_call_hook: bool = False
     has_pre_call_override: bool = False
     # Tuple[(resolved_callback, "override" | "apply_guardrail"), ...]
     # Ordered the same as ``litellm.callbacks``; used to build the streaming
@@ -385,6 +386,14 @@ class _CallbackCapabilities:
     # avoids the per-request ``get_custom_logger_compatible_class`` walk for
     # every string entry in ``litellm.callbacks``.
     resolved_callbacks: Tuple[Any, ...] = field(default_factory=tuple)
+
+
+def _has_native_during_call_hook(callback: CustomLogger) -> bool:
+    base_hook = CustomLogger.async_moderation_hook
+    callback_hook = getattr(type(callback), "async_moderation_hook", base_hook)
+    return getattr(callback_hook, "__func__", callback_hook) is not getattr(
+        base_hook, "__func__", base_hook
+    )
 
 
 class ProxyLogging:
@@ -1685,6 +1694,7 @@ class ProxyLogging:
         has_iterator_override = False
         has_streaming_chunk_override = False
         has_guardrail = False
+        has_during_call_hook = False
         has_pre_call_override = False
         iterator_overrides: List[Tuple[Any, str]] = []  # (callback, kind)
         resolved_callbacks: List[Any] = []
@@ -1706,6 +1716,9 @@ class ProxyLogging:
                 continue
             if isinstance(resolved, CustomGuardrail):
                 has_guardrail = True
+                has_during_call_hook = True
+            elif _has_native_during_call_hook(resolved):
+                has_during_call_hook = True
             # Use the same leaf-class ``__dict__`` check as the other hook
             # capabilities: only callbacks that actually override the hook
             # contribute to the flag. Setting this for every ``CustomLogger``
@@ -1746,6 +1759,7 @@ class ProxyLogging:
             or any(kind == "apply_guardrail" for _, kind in iterator_overrides),
             has_streaming_chunk_override=has_streaming_chunk_override,
             has_guardrail=has_guardrail,
+            has_during_call_hook=has_during_call_hook,
             has_pre_call_override=has_pre_call_override,
             iterator_overrides=tuple(iterator_overrides),
             resolved_callbacks=tuple(resolved_callbacks),
@@ -1794,7 +1808,7 @@ class ProxyLogging:
 
     @staticmethod
     def has_during_call_guardrails() -> bool:
-        return ProxyLogging._callback_capabilities().has_guardrail
+        return ProxyLogging._callback_capabilities().has_during_call_hook
 
     async def during_call_hook(
         self,
@@ -1803,18 +1817,19 @@ class ProxyLogging:
         call_type: CallTypesLiteral,
     ):
         """
-        Runs the CustomGuardrail's async_moderation_hook() in parallel
+        Runs during-call async_moderation_hook() callbacks in parallel
         """
-        # Fast path: skip the entire guardrail scan when no CustomGuardrail
-        # callbacks are registered. Saves per-request iteration over
+        # Fast path: skip the entire guardrail scan when no during-call
+        # moderation callbacks are registered. Saves per-request iteration over
         # ``litellm.callbacks`` plus an ``asyncio.gather([])`` round trip on
-        # deployments with no guardrails configured.
-        if not ProxyLogging._callback_capabilities().has_guardrail:
+        # deployments with no during-call checks configured.
+        caps = ProxyLogging._callback_capabilities()
+        if not caps.has_during_call_hook:
             return data
         # Step 1: Collect all guardrail tasks to run in parallel
         guardrail_tasks = []
 
-        for callback in litellm.callbacks:
+        for callback in caps.resolved_callbacks:
             if isinstance(callback, CustomGuardrail):
                 ################################################################
                 # Check if guardrail should be run for GuardrailEventHooks.during_call hook
@@ -1870,6 +1885,18 @@ class ProxyLogging:
                             call_type=call_type,  # type: ignore
                         ),
                     )
+                guardrail_tasks.append(guardrail_task)
+            elif _has_native_during_call_hook(callback):
+                if call_type == CallTypes.call_mcp_tool.value:
+                    continue
+                guardrail_task = self._run_guardrail_task_with_enrichment(
+                    callback,
+                    callback.async_moderation_hook(
+                        data=data,
+                        user_api_key_dict=user_api_key_dict,  # type: ignore
+                        call_type=call_type,  # type: ignore
+                    ),
+                )
                 guardrail_tasks.append(guardrail_task)
 
         # Step 2: Run all guardrail tasks in parallel

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import litellm
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.proxy._types import LiteLLMPromptInjectionParams
+from litellm.proxy.hooks.prompt_injection_detection import (
+    _OPTIONAL_PromptInjectionDetection,
+)
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
 
@@ -31,8 +35,27 @@ def _make_guardrail(name="g1", should_run=True, response=None):
     return cb
 
 
+class _NativeDuringCallLogger(CustomLogger):
+    async def async_moderation_hook(self, data, user_api_key_dict, call_type):
+        return data
+
+
+def test_callback_capabilities_detect_native_during_call_hook(monkeypatch):
+    callback = _NativeDuringCallLogger()
+    monkeypatch.setattr(litellm, "callbacks", [callback])
+
+    caps = ProxyLogging._callback_capabilities()
+
+    assert caps.has_during_call_hook is True
+    assert caps.has_guardrail is False
+    assert caps.resolved_callbacks == (callback,)
+    assert ProxyLogging.has_during_call_guardrails() is True
+
+
 @pytest.mark.asyncio
-async def test_during_call_hook_no_guardrail_fast_path_returns_data(proxy_logging, make_user_api_key_auth, mock_callbacks_disabled):
+async def test_during_call_hook_no_guardrail_fast_path_returns_data(
+    proxy_logging, make_user_api_key_auth, mock_callbacks_disabled
+):
     data = {"messages": [{"role": "user"}], "model": "m", "temperature": 0.1}
     out = await proxy_logging.during_call_hook(
         data=data,
@@ -43,7 +66,9 @@ async def test_during_call_hook_no_guardrail_fast_path_returns_data(proxy_loggin
 
 
 @pytest.mark.asyncio
-async def test_during_call_hook_runs_guardrails_in_parallel(proxy_logging, make_user_api_key_auth, monkeypatch):
+async def test_during_call_hook_runs_guardrails_in_parallel(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
     g1 = _make_guardrail("a")
     g2 = _make_guardrail("b")
     monkeypatch.setattr(litellm, "callbacks", [g1, g2])
@@ -62,7 +87,72 @@ async def test_during_call_hook_runs_guardrails_in_parallel(proxy_logging, make_
 
 
 @pytest.mark.asyncio
-async def test_during_call_hook_guardrail_skipped_when_should_not_run(proxy_logging, make_user_api_key_auth, monkeypatch):
+async def test_during_call_hook_runs_prompt_injection_llm_api_check(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    prompt_injection_detection = _OPTIONAL_PromptInjectionDetection(
+        prompt_injection_params=LiteLLMPromptInjectionParams(
+            llm_api_check=True,
+            llm_api_name="prompt-check",
+            llm_api_system_prompt="Return SAFE or UNSAFE",
+            llm_api_fail_call_string="UNSAFE",
+        )
+    )
+    router = MagicMock()
+    router.model_names = ["prompt-check"]
+    router.acompletion = AsyncMock(return_value=None)
+    prompt_injection_detection.update_environment(router=router)
+    monkeypatch.setattr(litellm, "callbacks", [prompt_injection_detection])
+
+    data = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hello"}],
+        "temperature": 0.1,
+    }
+    out = await proxy_logging.during_call_hook(
+        data=data,
+        user_api_key_dict=make_user_api_key_auth(),
+        call_type="completion",
+    )
+
+    assert out is data
+    router.acompletion.assert_awaited_once()
+    assert router.acompletion.await_args.kwargs["model"] == "prompt-check"
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_skips_prompt_injection_for_mcp_calls(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    prompt_injection_detection = _OPTIONAL_PromptInjectionDetection(
+        prompt_injection_params=LiteLLMPromptInjectionParams(
+            llm_api_check=True,
+            llm_api_name="prompt-check",
+            llm_api_system_prompt="Return SAFE or UNSAFE",
+            llm_api_fail_call_string="UNSAFE",
+        )
+    )
+    router = MagicMock()
+    router.model_names = ["prompt-check"]
+    router.acompletion = AsyncMock(return_value=None)
+    prompt_injection_detection.update_environment(router=router)
+    monkeypatch.setattr(litellm, "callbacks", [prompt_injection_detection])
+
+    data = {"model": "m", "name": "tool", "arguments": {"query": "hello"}}
+    out = await proxy_logging.during_call_hook(
+        data=data,
+        user_api_key_dict=make_user_api_key_auth(),
+        call_type="call_mcp_tool",
+    )
+
+    assert out is data
+    router.acompletion.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_during_call_hook_guardrail_skipped_when_should_not_run(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
     g = _make_guardrail("g", should_run=False)
     monkeypatch.setattr(litellm, "callbacks", [g])
     await proxy_logging.during_call_hook(
@@ -74,7 +164,9 @@ async def test_during_call_hook_guardrail_skipped_when_should_not_run(proxy_logg
 
 
 @pytest.mark.asyncio
-async def test_during_call_hook_guardrail_error_raises(proxy_logging, make_user_api_key_auth, monkeypatch):
+async def test_during_call_hook_guardrail_error_raises(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
     g = _make_guardrail("bad")
     g.async_moderation_hook = AsyncMock(side_effect=RuntimeError("blocked"))
     monkeypatch.setattr(litellm, "callbacks", [g])


### PR DESCRIPTION
## Relevant issues

Fixes #19499

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

No real LLM APIs were called. Validation was done with mocked regression tests covering the dispatch path, MCP skip path, and native during-call capability detection.

`uv run pytest tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py -v`

Result: 7 passed, 1 warning

## Type

Bug Fix

Test

## Changes

This fixes the prompt injection `llm_api_check` during-call dispatch path.

`ProxyLogging` now tracks callbacks that define their own `async_moderation_hook`, not only `CustomGuardrail` instances, and the during-call hook runs those resolved callbacks in parallel with the existing guardrail path.

The native `CustomLogger` moderation hook path skips MCP tool calls, leaving MCP-specific during-call behavior to `CustomGuardrail` instances with explicit MCP event gating.

Mocked regression tests cover `_OPTIONAL_PromptInjectionDetection` with `llm_api_check=True`, verify the configured router model is called for completion requests, verify it is not called for MCP tool calls, and pin native `CustomLogger` capability detection.

## Why

`_OPTIONAL_PromptInjectionDetection` defines `async_moderation_hook`, where the `llm_api_check` logic lives, but it extends `CustomLogger`.

The during-call hook only considered `CustomGuardrail` callbacks runnable, so the prompt injection LLM API check path was unreachable even when configured.

The MCP skip avoids sending native `CustomLogger` moderation callbacks through an MCP call path where they cannot apply `CustomGuardrail.should_run_guardrail` MCP event gating.

## Tests run

`make format`

`uv run pytest tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py -v`

`uv run --no-sync black --check litellm/proxy/utils.py tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py`

`uv run --no-sync ruff check litellm/proxy/utils.py tests/test_litellm/proxy/utils/proxy_logging/test_during_call_hook.py`

`git diff --check`

`make lint` was attempted before this follow-up, but repo-wide Black check failed on unrelated enterprise files.

## Scope note

This only fixes `llm_api_check` dispatch for prompt injection detection.

It does not change prompt injection heuristics behavior or async performance.