### PR TITLE
fix(ui): parse routing_groups as JSON before saving router settings

### DIFF
--- a/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.test.tsx
@@ -134,6 +134,33 @@ describe("RouterSettings", () => {
     );
   });
 
+  it("should send routing_groups as a parsed list, not a stringified one", async () => {
+    vi.mocked(getCallbacksCall).mockResolvedValue({
+      router_settings: {
+        routing_strategy: "simple-shuffle",
+        routing_groups: [],
+      },
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<RouterSettings {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("strategy-select")).toBeInTheDocument();
+    });
+
+    const input = document.querySelector('input[name="routing_groups"]') as HTMLInputElement | null;
+    expect(input?.value).toBe("[]");
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    const payload = vi.mocked(setCallbacksCall).mock.calls[0][1] as {
+      router_settings: { routing_groups: unknown };
+    };
+    expect(payload.router_settings.routing_groups).toEqual([]);
+    expect(typeof payload.router_settings.routing_groups).not.toBe("string");
+  });
+
   it("should show a success notification after saving", async () => {
     const user = userEvent.setup();
     renderWithProviders(<RouterSettings {...defaultProps} />);

--- a/ui/litellm-dashboard/src/components/router_settings/index.tsx
+++ b/ui/litellm-dashboard/src/components/router_settings/index.tsx
@@ -90,7 +90,7 @@ const RouterSettings: React.FC<RouterSettingsProps> = ({ accessToken, userRole, 
     console.log("router_settings", router_settings);
 
     const numberKeys = new Set(["allowed_fails", "cooldown_time", "num_retries", "timeout", "retry_after"]);
-    const jsonKeys = new Set(["model_group_alias", "retry_policy"]);
+    const jsonKeys = new Set(["model_group_alias", "retry_policy", "routing_groups"]);
 
     const parseInputValue = (key: string, raw: string | undefined, fallback: unknown) => {
       if (raw === undefined) return fallback;


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Saving router settings from the dashboard while `routing_groups` is set in the form sends the value to the proxy. Steps to reproduce on a local proxy:

1. Start the proxy with a config that defines `routing_groups`, then open http://localhost:4000/ui/?page=router-settings
2. Leave `routing_groups` as-is (e.g. `[]` or a populated list) and click Save Changes
3. Inspect the `POST /config/update` (or equivalent settings update) request body

Before this fix the payload contained `"routing_groups": "[]"` (a stringified list); after the fix it contains `"routing_groups": []` (a real array), matching how `model_group_alias` and `retry_policy` already behave.

## Type

🐛 Bug Fix

## Changes

The router settings form renders every setting as a text input and serializes object/array values with `JSON.stringify`. On save, `handleSaveChanges` reads each input's string value back through `parseInputValue`. `routing_groups` was missing from `jsonKeys`, so its value was sent to the proxy as a stringified list instead of an array. This adds `routing_groups` to `jsonKeys` so it is `JSON.parse`d back into an array before the payload is built, mirroring the existing handling for `model_group_alias` and `retry_policy`.

Added a regression test that fails when `routing_groups` is not in `jsonKeys` (asserting the saved payload is the array `[]`, not the string `"[]"`) and passes with the fix in place
