### PR TITLE
fix(proxy): map non-standard SSE error codes (>=600) to 502 for failure handling

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -251,9 +251,28 @@ async def _parse_event_data_for_error(event_line: Union[str, bytes]) -> Optional
                         # Not a valid integer string, treat as if no valid code was found for this check
                         pass
 
-                # Ensure error_code is a valid HTTP status code
-                if error_code is not None and 100 <= error_code <= 599:
-                    return error_code
+                if error_code is not None:
+                    if 100 <= error_code <= 599:
+                        # Standard HTTP status code
+                        return error_code
+                    elif error_code >= 600:
+                        # Vendor-specific error codes outside the standard HTTP
+                        # range (e.g., ZAI/ZhipuAI 1302 rate limit, DashScope
+                        # throttling codes). Previously these were silently
+                        # dropped (returned None), causing the proxy to treat
+                        # the SSE chunk as normal content — the error was
+                        # forwarded to the client as a 200 response, and router
+                        # fallback/cooldown never triggered.
+                        #
+                        # Map to 502 (Bad Gateway) so that failure handling
+                        # (retry, fallback, cooldown) fires correctly. The
+                        # original vendor code is preserved in the warning log
+                        # for debugging.
+                        verbose_proxy_logger.warning(
+                            f"SSE error code {error_code} is outside standard HTTP range "
+                            f"(100-599); mapping to 502 for failure handling"
+                        )
+                        return 502
                 elif (
                     error_code_raw is not None
                 ):  # Log if original code was present but not valid

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1116,11 +1116,15 @@ class TestCommonRequestProcessingHelpers:
             (
                 'data: {"error": {"code": 99, "message": "too low"}}',
                 None,
-            ),  # Integer code too low
+            ),  # Integer code too low (< 100, likely invalid data)
             (
-                'data: {"error": {"code": 600, "message": "too high"}}',
-                None,
-            ),  # Integer code too high
+                'data: {"error": {"code": 600, "message": "vendor error"}}',
+                502,
+            ),  # Non-standard code >= 600 → mapped to 502 for failure handling
+            (
+                'data: {"error": {"code": 1302, "message": "rate limit"}}',
+                502,
+            ),  # Vendor-specific rate limit code (ZAI/ZhipuAI) → mapped to 502
             (
                 'data: {"id": "123", "content": "hello"}',
                 None,


### PR DESCRIPTION
## Summary

Fixes #31284

When a provider returns an SSE error chunk with a vendor-specific error code outside the standard HTTP range (100-599), `_parse_event_data_for_error()` silently drops it (returns `None`). This causes the proxy to treat error-bearing SSE chunks as normal content - the error is forwarded to the client as a `200` response, and router fallback/cooldown never triggers.

## Changes

- `_parse_event_data_for_error()`: Map error codes `>= 600` to `502` (was `None`)
- Updated test: `code: 600` now expects `502` (was `None`)
- Added test: `code: 1302` (ZAI rate limit) -> `502`
- `code: 99` (< 100) remains `None` (unchanged - likely corrupt data)

## Why 502?

- Cannot reliably classify vendor codes without a fragile provider mapping table
- 502 is semantically correct (upstream returned an error)
- 502 triggers the right retry/cooldown behavior in litellm
- Original vendor code is preserved in the warning log for debugging

## How to verify

```python
# Before fix: returns None (error silently ignored)
await _parse_event_data_for_error('data: {"error":{"code":1302,"message":"rate limit"}}')
# -> None

# After fix: returns 502 (triggers failure handling)
await _parse_event_data_for_error('data: {"error":{"code":1302,"message":"rate limit"}}')
# -> 502
```

All existing test cases pass + 2 new cases added (vendor codes 600 and 1302).

## Production evidence

This fix has been running in production on a v1.89.0 source-mount deployment with ZAI/ZhipuAI as the primary provider for 1+ days. Before the fix, ZAI 1302 (rate limit) errors appeared 855 times in anomaly logs with zero cooldown/fallback triggers. After the fix, rate-limit errors correctly trigger deployment cooldown, and subsequent requests are routed to fallback providers.