### PR TITLE
feat: add LAR-1 semantic routing strategy

### DIFF
--- a/examples/lar1_ollama_config.yaml
+++ b/examples/lar1_ollama_config.yaml
@@ -1,0 +1,45 @@
+model_list:
+  - model_name: agent-router
+    litellm_params:
+      model: ollama/qwen3.5:9b
+      api_base: http://127.0.0.1:11434
+    model_info:
+      id: cloud-smart
+      type: cloud-smart
+
+  - model_name: agent-router
+    litellm_params:
+      model: ollama/phi4-mini:latest
+      api_base: http://127.0.0.1:11434
+    model_info:
+      id: cloud-fast
+      type: cloud-fast
+
+  - model_name: agent-router
+    litellm_params:
+      model: ollama/llama3.2:3b
+      api_base: http://127.0.0.1:11434
+    model_info:
+      id: local
+      type: local
+
+  - model_name: agent-router
+    litellm_params:
+      model: ollama/lfm2.5-thinking:latest
+      api_base: http://127.0.0.1:11434
+    model_info:
+      id: deep
+      type: deep
+
+router_settings:
+  routing_strategy: lar1
+  lar1_settings:
+    confidence_threshold_low: 0.3
+    confidence_threshold_medium: 0.5
+    confidence_threshold_high: 0.7
+
+general_settings:
+  master_key: sk-lar1-demo
+
+litellm_settings:
+  set_verbose: true

--- a/examples/lar1_ollama_config.yaml
+++ b/examples/lar1_ollama_config.yaml
@@ -33,7 +33,7 @@ model_list:
 
 router_settings:
   routing_strategy: lar1
-  lar1_settings:
+  routing_strategy_args:
     confidence_threshold_low: 0.3
     confidence_threshold_medium: 0.5
     confidence_threshold_high: 0.7

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -324,7 +324,6 @@ class Router:
         ] = "simple-shuffle",
         optional_pre_call_checks: Optional[OptionalPreCallChecks] = None,
         routing_strategy_args: dict = {},  # just for latency-based
-        lar1_settings: Optional[dict] = None,
         routing_groups: Optional[List[Union[RoutingGroup, dict]]] = None,
         provider_budget_config: Optional[GenericBudgetConfigType] = None,
         alerting_config: Optional[AlertingConfig] = None,
@@ -653,11 +652,11 @@ class Router:
             self.routing_strategy = "lar1"
             from litellm.router_strategy.lar1_routing import LAR1RoutingStrategy
 
-            lar1_config = lar1_settings or {}
+            lar1_args = routing_strategy_args or {}
             thresholds = {
-                "low": lar1_config.get("confidence_threshold_low", 0.3),
-                "medium": lar1_config.get("confidence_threshold_medium", 0.5),
-                "high": lar1_config.get("confidence_threshold_high", 0.7),
+                "low": lar1_args.get("confidence_threshold_low", 0.3),
+                "medium": lar1_args.get("confidence_threshold_medium", 0.5),
+                "high": lar1_args.get("confidence_threshold_high", 0.7),
             }
             self.set_custom_routing_strategy(
                 LAR1RoutingStrategy(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -320,9 +320,11 @@ class Router:
             "latency-based-routing",
             "cost-based-routing",
             "usage-based-routing-v2",
+            "lar1",
         ] = "simple-shuffle",
         optional_pre_call_checks: Optional[OptionalPreCallChecks] = None,
         routing_strategy_args: dict = {},  # just for latency-based
+        lar1_settings: Optional[dict] = None,
         routing_groups: Optional[List[Union[RoutingGroup, dict]]] = None,
         provider_budget_config: Optional[GenericBudgetConfigType] = None,
         alerting_config: Optional[AlertingConfig] = None,
@@ -647,10 +649,27 @@ class Router:
         """
 
         ### ROUTING SETUP ###
-        self.routing_strategy_init(
-            routing_strategy=routing_strategy,
-            routing_strategy_args=routing_strategy_args,
-        )
+        if self._normalize_strategy(routing_strategy) == "lar1":
+            self.routing_strategy = "lar1"
+            from litellm.router_strategy.lar1_routing import LAR1RoutingStrategy
+
+            lar1_config = lar1_settings or {}
+            thresholds = {
+                "low": lar1_config.get("confidence_threshold_low", 0.3),
+                "medium": lar1_config.get("confidence_threshold_medium", 0.5),
+                "high": lar1_config.get("confidence_threshold_high", 0.7),
+            }
+            self.set_custom_routing_strategy(
+                LAR1RoutingStrategy(
+                    router_instance=self,
+                    thresholds=thresholds,
+                )
+            )
+        else:
+            self.routing_strategy_init(
+                routing_strategy=routing_strategy,
+                routing_strategy_args=routing_strategy_args,
+            )
         self._init_routing_groups(self._routing_groups_input)
         self.access_groups = None
         ## USAGE TRACKING ##
@@ -871,7 +890,9 @@ class Router:
         self, routing_strategy: Union[RoutingStrategy, str, None]
     ) -> None:
         # See: https://github.com/BerriAI/litellm/issues/11330
-        valid_strategy_strings = ["simple-shuffle"] + [s.value for s in RoutingStrategy]
+        valid_strategy_strings = ["simple-shuffle", "lar1"] + [
+            s.value for s in RoutingStrategy
+        ]
         if routing_strategy is None:
             return
         is_valid_string = (

--- a/litellm/router_strategy/lar1_routing.py
+++ b/litellm/router_strategy/lar1_routing.py
@@ -2,106 +2,151 @@
 LAR-1 Semantic Routing Strategy
 
 Routes requests based on agent confidence level (LAR-1 protocol).
-Thresholds are configurable via lar1_settings in router config.
+Thresholds are configurable via routing_strategy_args in router config.
 
 LAR-1 metadata passed via request_kwargs["metadata"]["lar1"]
 """
 
-from typing import Dict, List, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Union
+
+from pydantic import ValidationError
 
 from litellm._logging import verbose_router_logger
 from litellm.router import CustomRoutingStrategyBase
+from litellm.types.lar1 import LAR1Metadata, LAR1Time
+
+if TYPE_CHECKING:
+    from litellm.router import Router
+
+DEFAULT_THRESHOLDS: dict[str, float] = {"low": 0.3, "medium": 0.5, "high": 0.7}
+
+
+def _normalize_thresholds(thresholds: Optional[dict[str, float]]) -> dict[str, float]:
+    merged = {**DEFAULT_THRESHOLDS, **(thresholds or {})}
+    low = merged["low"]
+    medium = merged["medium"]
+    high = merged["high"]
+    if not (0 < low < medium < high < 1):
+        raise ValueError(
+            "LAR-1 thresholds must satisfy 0 < low < medium < high < 1, "
+            f"got low={low}, medium={medium}, high={high}"
+        )
+    return merged
+
+
+def _parse_lar1_metadata(request_kwargs: dict) -> LAR1Metadata:
+    lar1_raw = request_kwargs.get("metadata", {}).get("lar1", {})
+    if not isinstance(lar1_raw, dict):
+        verbose_router_logger.warning(
+            f"[LAR-1] Invalid lar1 metadata type: {type(lar1_raw).__name__}. Using defaults"
+        )
+        return LAR1Metadata()
+    try:
+        return LAR1Metadata.model_validate(lar1_raw)
+    except ValidationError as exc:
+        verbose_router_logger.warning(
+            f"[LAR-1] Invalid lar1 metadata: {exc}. Using defaults"
+        )
+        return LAR1Metadata()
 
 
 class LAR1RoutingStrategy(CustomRoutingStrategyBase):
-    def __init__(self, router_instance=None, thresholds: Optional[Dict] = None):
+    def __init__(
+        self,
+        router_instance: Optional[Router] = None,
+        thresholds: Optional[dict[str, float]] = None,
+    ):
         self._router = router_instance
-        self.thresholds = thresholds or {
-            "low": 0.3,
-            "medium": 0.5,
-            "high": 0.7,
-        }
+        self.thresholds = _normalize_thresholds(thresholds)
 
     async def async_get_available_deployment(
         self,
         model: str,
-        messages: Optional[List[Dict[str, str]]] = None,
-        input: Optional[Union[str, List]] = None,
+        messages: Optional[list[dict[str, str]]] = None,
+        input: Optional[Union[str, list]] = None,
         specific_deployment: Optional[bool] = False,
-        request_kwargs: Optional[Dict] = None,
+        request_kwargs: Optional[dict] = None,
     ):
         if request_kwargs is None:
             request_kwargs = {}
+        if self._router is None:
+            return None
 
-        metadata = request_kwargs.get("metadata", {})
-        lar1 = metadata.get("lar1", {})
-        confidence = lar1.get("confidence", 0.5)
+        lar1 = _parse_lar1_metadata(request_kwargs)
+        confidence = lar1.confidence
+        evidence = tuple(e.value for e in lar1.evidence)
+        time_dim = lar1.time.value
 
-        if (
-            not isinstance(confidence, (int, float))
-            or confidence < 0.0
-            or confidence > 1.0
-        ):
+        healthy = await self._router.async_get_healthy_deployments(
+            model=model,
+            request_kwargs=request_kwargs,
+            messages=messages,
+            input=input,
+            specific_deployment=specific_deployment,
+        )
+        if isinstance(healthy, dict):
+            return healthy
+
+        if not healthy:
+            return None
+
+        target = self._classify_request(confidence, evidence, time_dim)
+        selected, exact_match = self._select_deployment(target, healthy)
+
+        if selected is None:
+            return None
+        if exact_match:
+            verbose_router_logger.info(f"[LAR-1] confidence={confidence} -> {target}")
+        else:
+            actual_type = selected.get("model_info", {}).get("type", "unknown")
             verbose_router_logger.warning(
-                f"[LAR-1] Invalid confidence: {confidence}. Fallback to 0.5"
+                f"[LAR-1] No deployment for type '{target}', "
+                f"fallback to deployment type '{actual_type}'"
             )
-            confidence = 0.5
+        return selected
 
-        valid_evidence = {"SYNTH", "RETRIEVED", "UNVERIFIED", "CONFIRMED"}
-        evidence = [e for e in lar1.get("evidence", []) if e in valid_evidence]
-
-        valid_times = {"NOW", "MEM", "CTX", "PRE"}
-        time_dim = lar1.get("time", "NOW")
-        if time_dim not in valid_times:
-            verbose_router_logger.warning(
-                f"[LAR-1] Invalid time: {time_dim}. Fallback to NOW"
-            )
-            time_dim = "NOW"
-
-        model_list = self._router.model_list if self._router else []
-
-        target = self._classify_request(confidence, evidence, time_dim, model_list)
-        selected = self._select_deployment(target, model_list)
-
-        if selected:
-            verbose_router_logger.info(f"[LAR-1] confidence={confidence} → {target}")
-            return selected
-
-        return model_list[0] if model_list else None
-
-    def _classify_request(self, confidence, evidence, time_dim, model_list):
-        """
-        confidence: 0.0-1.0
-        evidence: ["SYNTH", "RETRIEVED", "UNVERIFIED"]
-        time_dim: "NOW", "MEM", "CTX", "PRE"
-        """
+    def _classify_request(
+        self,
+        confidence: float,
+        evidence: tuple[str, ...],
+        time_dim: str,
+    ) -> str:
         if "UNVERIFIED" in evidence:
             return "cloud-smart"
 
-        if time_dim == "MEM":
+        if time_dim == LAR1Time.MEM.value:
             return "cloud-fast"
 
         t = self.thresholds
         if confidence < t["low"]:
             return "cloud-smart"
-        elif confidence < t["medium"]:
+        if confidence < t["medium"]:
             return "cloud-fast"
-        elif confidence < t["high"]:
+        if confidence < t["high"]:
             return "local"
-        else:
-            return "deep"
+        return "deep"
 
-    def _select_deployment(self, target_type, model_list):
-        if not model_list:
-            return None
+    def _select_deployment(
+        self,
+        target_type: str,
+        deployments: list[dict],
+    ) -> tuple[Optional[dict], bool]:
+        if not deployments:
+            return None, False
 
-        for m in model_list:
-            if isinstance(m, dict):
-                model_type = m.get("model_info", {}).get("type", "")
-                if model_type == target_type:
-                    return m
+        for deployment in deployments:
+            if not isinstance(deployment, dict):
+                continue
+            model_type = deployment.get("model_info", {}).get("type", "")
+            if model_type == target_type:
+                return deployment, True
 
-        return model_list[0]
+        return deployments[0], False
 
     def get_available_deployment(self, *args, **kwargs):
-        pass
+        raise NotImplementedError(
+            "LAR-1 routing only supports async routing. "
+            "Enable async_only_mode on the router or use acompletion."
+        )

--- a/litellm/router_strategy/lar1_routing.py
+++ b/litellm/router_strategy/lar1_routing.py
@@ -1,0 +1,107 @@
+"""
+LAR-1 Semantic Routing Strategy
+
+Routes requests based on agent confidence level (LAR-1 protocol).
+Thresholds are configurable via lar1_settings in router config.
+
+LAR-1 metadata passed via request_kwargs["metadata"]["lar1"]
+"""
+
+from typing import Dict, List, Optional, Union
+
+from litellm._logging import verbose_router_logger
+from litellm.router import CustomRoutingStrategyBase
+
+
+class LAR1RoutingStrategy(CustomRoutingStrategyBase):
+    def __init__(self, router_instance=None, thresholds: Optional[Dict] = None):
+        self._router = router_instance
+        self.thresholds = thresholds or {
+            "low": 0.3,
+            "medium": 0.5,
+            "high": 0.7,
+        }
+
+    async def async_get_available_deployment(
+        self,
+        model: str,
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        specific_deployment: Optional[bool] = False,
+        request_kwargs: Optional[Dict] = None,
+    ):
+        if request_kwargs is None:
+            request_kwargs = {}
+
+        metadata = request_kwargs.get("metadata", {})
+        lar1 = metadata.get("lar1", {})
+        confidence = lar1.get("confidence", 0.5)
+
+        if (
+            not isinstance(confidence, (int, float))
+            or confidence < 0.0
+            or confidence > 1.0
+        ):
+            verbose_router_logger.warning(
+                f"[LAR-1] Invalid confidence: {confidence}. Fallback to 0.5"
+            )
+            confidence = 0.5
+
+        valid_evidence = {"SYNTH", "RETRIEVED", "UNVERIFIED", "CONFIRMED"}
+        evidence = [e for e in lar1.get("evidence", []) if e in valid_evidence]
+
+        valid_times = {"NOW", "MEM", "CTX", "PRE"}
+        time_dim = lar1.get("time", "NOW")
+        if time_dim not in valid_times:
+            verbose_router_logger.warning(
+                f"[LAR-1] Invalid time: {time_dim}. Fallback to NOW"
+            )
+            time_dim = "NOW"
+
+        model_list = self._router.model_list if self._router else []
+
+        target = self._classify_request(confidence, evidence, time_dim, model_list)
+        selected = self._select_deployment(target, model_list)
+
+        if selected:
+            verbose_router_logger.info(f"[LAR-1] confidence={confidence} → {target}")
+            return selected
+
+        return model_list[0] if model_list else None
+
+    def _classify_request(self, confidence, evidence, time_dim, model_list):
+        """
+        confidence: 0.0-1.0
+        evidence: ["SYNTH", "RETRIEVED", "UNVERIFIED"]
+        time_dim: "NOW", "MEM", "CTX", "PRE"
+        """
+        if "UNVERIFIED" in evidence:
+            return "cloud-smart"
+
+        if time_dim == "MEM":
+            return "cloud-fast"
+
+        t = self.thresholds
+        if confidence < t["low"]:
+            return "cloud-smart"
+        elif confidence < t["medium"]:
+            return "cloud-fast"
+        elif confidence < t["high"]:
+            return "local"
+        else:
+            return "deep"
+
+    def _select_deployment(self, target_type, model_list):
+        if not model_list:
+            return None
+
+        for m in model_list:
+            if isinstance(m, dict):
+                model_type = m.get("model_info", {}).get("type", "")
+                if model_type == target_type:
+                    return m
+
+        return model_list[0]
+
+    def get_available_deployment(self, *args, **kwargs):
+        pass

--- a/litellm/types/lar1.py
+++ b/litellm/types/lar1.py
@@ -1,33 +1,39 @@
 from enum import Enum
-from typing import List
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class LAR1Act(str, Enum):
-    INF = "INF"  # Inference
-    OBS = "OBS"  # Observation
-    RET = "RET"  # Retrieval
-    GEN = "GEN"  # Generation
+    INF = "INF"
+    OBS = "OBS"
+    RET = "RET"
+    GEN = "GEN"
 
 
 class LAR1Time(str, Enum):
-    NOW = "NOW"  # Current context
-    MEM = "MEM"  # From memory
-    CTX = "CTX"  # From context window
-    PRE = "PRE"  # Predicted/future
+    NOW = "NOW"
+    MEM = "MEM"
+    CTX = "CTX"
+    PRE = "PRE"
 
 
 class LAR1Mind(str, Enum):
-    REF = "REF"  # Reflective
-    REC = "REC"  # Recognized pattern
-    HYP = "HYP"  # Hypothesis
-    ACT = "ACT"  # Recommended action
+    REF = "REF"
+    REC = "REC"
+    HYP = "HYP"
+    ACT = "ACT"
+
+
+class LAR1Evidence(str, Enum):
+    SYNTH = "SYNTH"
+    RETRIEVED = "RETRIEVED"
+    UNVERIFIED = "UNVERIFIED"
+    CONFIRMED = "CONFIRMED"
 
 
 class LAR1Metadata(BaseModel):
     act: LAR1Act = LAR1Act.INF
     time: LAR1Time = LAR1Time.NOW
     mind: LAR1Mind = LAR1Mind.REF
-    confidence: float = 0.5  # 0.0-1.0
-    evidence: List[str] = []  # "SYNTH", "RETRIEVED", "UNVERIFIED"
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0)
+    evidence: list[LAR1Evidence] = []

--- a/litellm/types/lar1.py
+++ b/litellm/types/lar1.py
@@ -1,0 +1,33 @@
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel
+
+
+class LAR1Act(str, Enum):
+    INF = "INF"  # Inference
+    OBS = "OBS"  # Observation
+    RET = "RET"  # Retrieval
+    GEN = "GEN"  # Generation
+
+
+class LAR1Time(str, Enum):
+    NOW = "NOW"  # Current context
+    MEM = "MEM"  # From memory
+    CTX = "CTX"  # From context window
+    PRE = "PRE"  # Predicted/future
+
+
+class LAR1Mind(str, Enum):
+    REF = "REF"  # Reflective
+    REC = "REC"  # Recognized pattern
+    HYP = "HYP"  # Hypothesis
+    ACT = "ACT"  # Recommended action
+
+
+class LAR1Metadata(BaseModel):
+    act: LAR1Act = LAR1Act.INF
+    time: LAR1Time = LAR1Time.NOW
+    mind: LAR1Mind = LAR1Mind.REF
+    confidence: float = 0.5  # 0.0-1.0
+    evidence: List[str] = []  # "SYNTH", "RETRIEVED", "UNVERIFIED"

--- a/tests/local_testing/test_lar1_routing.py
+++ b/tests/local_testing/test_lar1_routing.py
@@ -1,12 +1,15 @@
 import pytest
 from litellm import Router
-from litellm.router_strategy.lar1_routing import LAR1RoutingStrategy
+from litellm.router_strategy.lar1_routing import (
+    LAR1RoutingStrategy,
+    _normalize_thresholds,
+)
 
 
 def _model_list():
     return [
         {
-            "model_name": "gpt-4",
+            "model_name": "agent-router",
             "litellm_params": {
                 "model": "openai/gpt-4o",
                 "api_key": "fake-key",
@@ -14,7 +17,7 @@ def _model_list():
             "model_info": {"id": "cloud-smart", "type": "cloud-smart"},
         },
         {
-            "model_name": "gpt-4-mini",
+            "model_name": "agent-router",
             "litellm_params": {
                 "model": "openai/gpt-4o-mini",
                 "api_key": "fake-key",
@@ -22,7 +25,7 @@ def _model_list():
             "model_info": {"id": "cloud-fast", "type": "cloud-fast"},
         },
         {
-            "model_name": "local-qwythos",
+            "model_name": "agent-router",
             "litellm_params": {
                 "model": "ollama/qwythos",
                 "api_key": "fake-key",
@@ -30,7 +33,7 @@ def _model_list():
             "model_info": {"id": "local", "type": "local"},
         },
         {
-            "model_name": "local-mythos",
+            "model_name": "agent-router",
             "litellm_params": {
                 "model": "ollama/mythos",
                 "api_key": "fake-key",
@@ -50,7 +53,7 @@ async def test_low_confidence_routes_to_cloud_smart():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={"metadata": {"lar1": {"confidence": 0.2}}},
     )
     assert result["model_info"]["type"] == "cloud-smart"
@@ -62,7 +65,7 @@ async def test_high_confidence_routes_to_deep():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={"metadata": {"lar1": {"confidence": 0.8}}},
     )
     assert result["model_info"]["type"] == "deep"
@@ -74,7 +77,7 @@ async def test_unverified_evidence_fallback():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={
             "metadata": {
                 "lar1": {"confidence": 0.9, "evidence": ["UNVERIFIED"]},
@@ -93,7 +96,7 @@ async def test_custom_thresholds():
     )
 
     result = await custom_strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={"metadata": {"lar1": {"confidence": 0.85}}},
     )
     assert result["model_info"]["type"] == "local"
@@ -105,7 +108,7 @@ async def test_mem_time_routes_to_cloud_fast():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={
             "metadata": {
                 "lar1": {"confidence": 0.9, "time": "MEM"},
@@ -121,7 +124,7 @@ async def test_invalid_confidence_falls_back_to_local():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={
             "metadata": {"lar1": {"confidence": "not-a-number"}},
         },
@@ -135,7 +138,7 @@ async def test_no_metadata_defaults_to_local():
     strategy = LAR1RoutingStrategy(router)
 
     result = await strategy.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={},
     )
     assert result["model_info"]["type"] == "local"
@@ -146,7 +149,7 @@ async def test_router_init_with_lar1_routing_strategy():
     router = Router(
         model_list=_model_list(),
         routing_strategy="lar1",
-        lar1_settings={
+        routing_strategy_args={
             "confidence_threshold_low": 0.1,
             "confidence_threshold_medium": 0.3,
             "confidence_threshold_high": 0.9,
@@ -154,8 +157,45 @@ async def test_router_init_with_lar1_routing_strategy():
     )
 
     result = await router.async_get_available_deployment(
-        model="gpt-4",
+        model="agent-router",
         request_kwargs={"metadata": {"lar1": {"confidence": 0.85}}},
     )
     assert result["model_info"]["type"] == "local"
     assert router.routing_strategy == "lar1"
+
+
+def test_invalid_threshold_order_raises():
+    with pytest.raises(ValueError, match="LAR-1 thresholds must satisfy"):
+        _normalize_thresholds({"low": 0.5, "medium": 0.3, "high": 0.7})
+
+
+def test_get_available_deployment_raises_not_implemented():
+    strategy = LAR1RoutingStrategy()
+    with pytest.raises(NotImplementedError, match="async routing"):
+        strategy.get_available_deployment(model="agent-router")
+
+
+@pytest.mark.asyncio
+async def test_missing_target_type_falls_back_with_warning(caplog):
+    router = Router(
+        model_list=[
+            {
+                "model_name": "agent-router",
+                "litellm_params": {
+                    "model": "openai/gpt-4o",
+                    "api_key": "fake-key",
+                },
+                "model_info": {"id": "only-local", "type": "local"},
+            }
+        ]
+    )
+    strategy = LAR1RoutingStrategy(router)
+
+    with caplog.at_level("WARNING"):
+        result = await strategy.async_get_available_deployment(
+            model="agent-router",
+            request_kwargs={"metadata": {"lar1": {"confidence": 0.2}}},
+        )
+
+    assert result["model_info"]["type"] == "local"
+    assert "No deployment for type 'cloud-smart'" in caplog.text

--- a/tests/local_testing/test_lar1_routing.py
+++ b/tests/local_testing/test_lar1_routing.py
@@ -1,0 +1,161 @@
+import pytest
+from litellm import Router
+from litellm.router_strategy.lar1_routing import LAR1RoutingStrategy
+
+
+def _model_list():
+    return [
+        {
+            "model_name": "gpt-4",
+            "litellm_params": {
+                "model": "openai/gpt-4o",
+                "api_key": "fake-key",
+            },
+            "model_info": {"id": "cloud-smart", "type": "cloud-smart"},
+        },
+        {
+            "model_name": "gpt-4-mini",
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "api_key": "fake-key",
+            },
+            "model_info": {"id": "cloud-fast", "type": "cloud-fast"},
+        },
+        {
+            "model_name": "local-qwythos",
+            "litellm_params": {
+                "model": "ollama/qwythos",
+                "api_key": "fake-key",
+            },
+            "model_info": {"id": "local", "type": "local"},
+        },
+        {
+            "model_name": "local-mythos",
+            "litellm_params": {
+                "model": "ollama/mythos",
+                "api_key": "fake-key",
+            },
+            "model_info": {"id": "deep", "type": "deep"},
+        },
+    ]
+
+
+def _create_test_router():
+    return Router(model_list=_model_list())
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_routes_to_cloud_smart():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={"metadata": {"lar1": {"confidence": 0.2}}},
+    )
+    assert result["model_info"]["type"] == "cloud-smart"
+
+
+@pytest.mark.asyncio
+async def test_high_confidence_routes_to_deep():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={"metadata": {"lar1": {"confidence": 0.8}}},
+    )
+    assert result["model_info"]["type"] == "deep"
+
+
+@pytest.mark.asyncio
+async def test_unverified_evidence_fallback():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={
+            "metadata": {
+                "lar1": {"confidence": 0.9, "evidence": ["UNVERIFIED"]},
+            }
+        },
+    )
+    assert result["model_info"]["type"] == "cloud-smart"
+
+
+@pytest.mark.asyncio
+async def test_custom_thresholds():
+    router = _create_test_router()
+    custom_strategy = LAR1RoutingStrategy(
+        router,
+        thresholds={"low": 0.1, "medium": 0.3, "high": 0.9},
+    )
+
+    result = await custom_strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={"metadata": {"lar1": {"confidence": 0.85}}},
+    )
+    assert result["model_info"]["type"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_mem_time_routes_to_cloud_fast():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={
+            "metadata": {
+                "lar1": {"confidence": 0.9, "time": "MEM"},
+            }
+        },
+    )
+    assert result["model_info"]["type"] == "cloud-fast"
+
+
+@pytest.mark.asyncio
+async def test_invalid_confidence_falls_back_to_local():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={
+            "metadata": {"lar1": {"confidence": "not-a-number"}},
+        },
+    )
+    assert result["model_info"]["type"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_no_metadata_defaults_to_local():
+    router = _create_test_router()
+    strategy = LAR1RoutingStrategy(router)
+
+    result = await strategy.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={},
+    )
+    assert result["model_info"]["type"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_router_init_with_lar1_routing_strategy():
+    router = Router(
+        model_list=_model_list(),
+        routing_strategy="lar1",
+        lar1_settings={
+            "confidence_threshold_low": 0.1,
+            "confidence_threshold_medium": 0.3,
+            "confidence_threshold_high": 0.9,
+        },
+    )
+
+    result = await router.async_get_available_deployment(
+        model="gpt-4",
+        request_kwargs={"metadata": {"lar1": {"confidence": 0.85}}},
+    )
+    assert result["model_info"]["type"] == "local"
+    assert router.routing_strategy == "lar1"


### PR DESCRIPTION
## Summary

This PR adds an optional LAR-1 semantic routing strategy. Instead of routing by latency or cost, it selects a deployment from agent-supplied metadata in `request_kwargs.metadata.lar1` (confidence, evidence, time). Deployments are tagged with `model_info.type` (`cloud-smart`, `cloud-fast`, `local`, `deep`). Enable via `router_settings.routing_strategy: lar1` in proxy config, or `router.set_custom_routing_strategy(LAR1RoutingStrategy(router))` in code. The routing decision is local dict lookups only; no extra LLM calls.

LAR-1 complements `complexity_router`: that router scores request text; LAR-1 scores agent state from the caller. Reference: [SSRN abstract 6981858](https://papers.ssrn.com/abstract=6981858), [RFC v0.9](https://github.com/cloudiaspecula/lar1-spec/blob/main/rfc_v0.9_ru.md).

### Files

- `litellm/router_strategy/lar1_routing.py` — `LAR1RoutingStrategy`, validation, configurable thresholds
- `litellm/types/lar1.py` — `LAR1Metadata` pydantic schema (types only; hot-path validation is follow-up)
- `litellm/router.py` — `routing_strategy: lar1`, `lar1_settings` YAML wiring
- `tests/local_testing/test_lar1_routing.py` — 8 unit tests
- `examples/lar1_ollama_config.yaml` — local Ollama proof-of-fix config

### Routing rules (default thresholds)

| Signal | Route |
|--------|-------|
| `evidence` contains `UNVERIFIED` | `cloud-smart` |
| `time` is `MEM` | `cloud-fast` |
| `confidence` < 0.3 | `cloud-smart` |
| `confidence` < 0.5 | `cloud-fast` |
| `confidence` < 0.7 | `local` |
| `confidence` >= 0.7 | `deep` |

Thresholds overridable via `lar1_settings.confidence_threshold_low|medium|high`.

## Test plan

- [x] `pytest tests/local_testing/test_lar1_routing.py -v` — 8 passed
- [ ] `make test-unit` (CI)

Unit tests cover: low/high confidence, UNVERIFIED override, MEM override, invalid confidence fallback, no-metadata default, custom thresholds, `Router(routing_strategy="lar1")` init.

## Screenshots / Proof of Fix

Ollama must be running. From repo root:

```bash
source .venv/bin/activate
python litellm/proxy/proxy_cli.py \
  --config examples/lar1_ollama_config.yaml \
  --port 4000 \
  --detailed_debug 2>&1 | tee lar1_proxy.log
```

Low confidence (`0.2` → `cloud-smart` → `ollama/qwen3.5:9b`):

```bash
curl -s http://127.0.0.1:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-lar1-demo" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "agent-router",
    "messages": [{"role": "user", "content": "Say hi in one word"}],
    "max_tokens": 10,
    "metadata": {
      "lar1": {"confidence": 0.2, "evidence": [], "time": "NOW"}
    }
  }'
```

High confidence (`0.8` → `deep` → `ollama/lfm2.5-thinking:latest`):

```bash
curl -s http://127.0.0.1:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-lar1-demo" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "agent-router",
    "messages": [{"role": "user", "content": "Say hi in one word"}],
    "max_tokens": 10,
    "metadata": {
      "lar1": {"confidence": 0.8, "evidence": [], "time": "NOW"}
    }
  }'
```

Log proof:

```bash
grep '\[LAR-1\]' lar1_proxy.log
```

Expected:

```
[LAR-1] confidence=0.2 → cloud-smart
[LAR-1] confidence=0.8 → deep
```

Downstream model in debug logs: `model='ollama/qwen3.5:9b'` then `model='ollama/lfm2.5-thinking:latest'`.

## Out of scope (follow-up)

- `LAR1Metadata` pydantic validation in the hot path
- Sync `get_available_deployment()` implementation
- `prefer_cloud_for_memory` yaml flag
- Docs page and streaming routing metadata in response body

## Type

New Feature
