### PR TITLE
fix(exceptions): add typed ModelNotMappedError for unmapped models (#29146)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1366,6 +1366,7 @@ from .exceptions import (
     JSONSchemaValidationError,
     LITELLM_EXCEPTION_TYPES,
     MockException,
+    ModelNotMappedError,
 )
 from .budget_manager import BudgetManager
 from .proxy.proxy_cli import run_server

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -1069,6 +1069,21 @@ class LiteLLMUnknownProvider(BadRequestError):
         return self.message
 
 
+class ModelNotMappedError(BadRequestError, ValueError):
+    def __init__(self, model: str, custom_llm_provider: Optional[str] = None):
+        self.message = (
+            f"This model isn't mapped yet. model={model}, "
+            f"custom_llm_provider={custom_llm_provider}. Add it here - "
+            "https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+        )
+        super().__init__(
+            self.message, model=model, llm_provider=custom_llm_provider, response=None
+        )
+
+    def __str__(self):
+        return self.message
+
+
 class GuardrailRaisedException(Exception):
     def __init__(
         self,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -410,6 +410,7 @@ from .exceptions import (
     BudgetExceededError,
     ContentPolicyViolationError,
     ContextWindowExceededError,
+    ModelNotMappedError,
     NotFoundError,
     OpenAIError,
     PermissionDeniedError,
@@ -5487,10 +5488,8 @@ def get_max_tokens(model: str) -> Optional[int]:
         else:
             raise Exception()
         return None
-    except Exception:
-        raise Exception(
-            f"Model {model} isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
-        )
+    except Exception as e:
+        raise ModelNotMappedError(model=model) from e
 
 
 def _strip_stable_vertex_version(model_name) -> str:
@@ -5994,8 +5993,8 @@ def _get_model_info_helper(
                         _model_info = None
 
             if _model_info is None or key is None:
-                raise ValueError(
-                    "This model isn't mapped yet. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+                raise ModelNotMappedError(
+                    model=model, custom_llm_provider=custom_llm_provider
                 )
             _input_cost_per_token: Optional[float] = _model_info.get(
                 "input_cost_per_token"
@@ -6240,11 +6239,9 @@ def _get_model_info_helper(
             )
     except Exception as e:
         verbose_logger.debug(f"Error getting model info: {e}")
-        raise Exception(
-            "This model isn't mapped yet. model={}, custom_llm_provider={}. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.".format(
-                model, custom_llm_provider
-            )
-        )
+        raise ModelNotMappedError(
+            model=model, custom_llm_provider=custom_llm_provider
+        ) from e
 
 
 def _build_model_info(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4558,3 +4558,17 @@ def test_aws_bedrock_project_id_excluded_from_bedrock_optional_params():
     assert "aws_bedrock_project_id" not in result
     assert result["aws_region_name"] == "us-east-1"
 
+
+def test_get_model_info_unmapped_raises_model_not_mapped_error():
+    """get_model_info on an unmapped model raises the typed ModelNotMappedError,
+    which stays catchable as both BadRequestError and ValueError for backward
+    compatibility (regression for #29146)."""
+    with pytest.raises(litellm.ModelNotMappedError):
+        litellm.get_model_info("this-model-does-not-exist-xyz")
+
+    with pytest.raises(litellm.exceptions.BadRequestError):
+        litellm.get_model_info("this-model-does-not-exist-xyz")
+
+    with pytest.raises(ValueError):
+        litellm.get_model_info("this-model-does-not-exist-xyz")
+


### PR DESCRIPTION
## Relevant issues

Fixes #29146

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

This is a library-level exception type, so the realistic end-user view is a developer catching the error rather than a proxy endpoint, and the proof below is the runtime behavior a caller now sees

```bash
python -c "
import litellm
try:
    litellm.get_model_info('this-model-does-not-exist-xyz')
except litellm.ModelNotMappedError as e:
    print('type      :', type(e).__name__)
    print('is BadReq :', isinstance(e, litellm.exceptions.BadRequestError))
    print('is Value  :', isinstance(e, ValueError))
    print('message   :', str(e))
"
```

Output

```
type      : ModelNotMappedError
is BadReq : True
is Value  : True
message   : litellm.BadRequestError: This model isn't mapped yet. model=this-model-does-not-exist-xyz, custom_llm_provider=None. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
```

Before this change the same call raised a bare `Exception` (or, on one path, a plain `ValueError`) that callers had no way to catch precisely

## Type

🐛 Bug Fix

## Changes

Previously, asking litellm for an unmapped model raised an untyped error ("This model isn't mapped yet"), so callers could not distinguish that specific failure from any other generic exception. This adds a typed `litellm.ModelNotMappedError` that they can catch precisely

To stay backward compatible, `ModelNotMappedError` subclasses both `BadRequestError` and `ValueError`, so existing handlers that catch either (for example the `except Exception` paths in `router.py` and `token_counter.py`) keep working unchanged. The three generic raises in `litellm/utils.py` (in `get_max_tokens` and the two in `_get_model_info_helper`) now raise the typed error, and the new exception is exported from the top-level `litellm` namespace

Tests live in `tests/test_litellm/test_utils.py` and assert that `get_model_info` on an unmapped model raises `ModelNotMappedError` and that it stays catchable as both `BadRequestError` and `ValueError`
