### PR TITLE
fix(vertex): stop O(n^2) re-parse of accumulated Gemini stream JSON

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3601,16 +3601,22 @@ class ModelResponseIterator:
         chunk = litellm.CustomStreamWrapper._strip_sse_data_from_chunk(chunk) or ""
         message = chunk.replace("\n\n", "")
 
-        # Accumulate JSON data
         self.accumulated_json += message
 
-        # Try to parse the accumulated JSON
+        # json.loads on the whole buffer after every fragment is O(n^2) and
+        # holds the GIL, freezing the event loop for seconds on large responses
+        # (https://github.com/BerriAI/litellm/issues/26181). A complete Gemini
+        # chunk is a JSON object/array, so only attempt the parse once the
+        # buffer's last non-whitespace byte can close one.
+        stripped = self.accumulated_json.rstrip()
+        if not stripped or stripped[-1] not in "}]":
+            return None
+
         try:
             _data = json.loads(self.accumulated_json)
             self.accumulated_json = ""  # reset after successful parsing
             return self.chunk_parser(chunk=_data)
         except json.JSONDecodeError:
-            # If it's not valid JSON yet, continue to the next event
             return None
 
     def _common_chunk_parsing_logic(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2799,6 +2799,77 @@ def test_partial_json_chunk_on_first_chunk():
     ), "Should switch to accumulated_json mode"
 
 
+def test_accumulated_json_does_not_reparse_every_fragment():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/26181
+
+    handle_accumulated_json_chunk used to call json.loads on the entire
+    accumulated buffer after EVERY fragment. For a large response fragmented
+    across many chunks that is O(n^2) work in a single GIL-holding C call,
+    which freezes the asyncio event loop for seconds and kills liveness probes.
+
+    The buffer only becomes a complete JSON object on the final fragment, so a
+    correct implementation parses it ~once, not once per fragment. We assert the
+    full chunk still parses correctly AND that json.loads is not called on every
+    fragment (which is what made it quadratic).
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(),
+        sync_stream=True,
+        logging_obj=MagicMock(),
+    )
+    iterator.chunk_type = "accumulated_json"
+
+    text = "x" * 200_000  # no braces/brackets so only the final fragment closes
+    blob = json.dumps(
+        {"candidates": [{"content": {"role": "model", "parts": [{"text": text}]}}]}
+    )
+    fragments = [blob[i : i + 4096] for i in range(0, len(blob), 4096)]
+    assert len(fragments) > 10, "need a multi-fragment payload to exercise the bug"
+
+    parsed = None
+    with patch("json.loads", wraps=json.loads) as spy:
+        for fragment in fragments:
+            out = iterator.handle_accumulated_json_chunk(chunk=fragment)
+            if out is not None:
+                parsed = out
+        parse_calls = spy.call_count
+
+    assert parsed is not None, "the reassembled chunk must still parse"
+    assert parsed.choices[0].delta.content == text, "content must be preserved intact"
+
+    assert parse_calls <= 2, (
+        f"json.loads was called {parse_calls} times for {len(fragments)} "
+        "fragments; the O(n^2) per-fragment re-parse has regressed"
+    )
+
+
+def test_accumulated_json_partial_fragment_returns_none_without_parsing():
+    """A fragment that cannot complete the JSON must not trigger a json.loads
+    parse of the whole growing buffer (issue #26181)."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        ModelResponseIterator,
+    )
+
+    iterator = ModelResponseIterator(
+        streaming_response=MagicMock(),
+        sync_stream=True,
+        logging_obj=MagicMock(),
+    )
+    iterator.chunk_type = "accumulated_json"
+
+    with patch("json.loads", wraps=json.loads) as spy:
+        result = iterator.handle_accumulated_json_chunk(
+            chunk='{"candidates": [{"content": {"parts": [{"text": "partial'
+        )
+    assert result is None
+    assert spy.call_count == 0, "incomplete buffer should not be parsed"
+
+
 def test_google_ai_studio_presence_penalty_supported():
     """
     Test that presence_penalty is supported for Google AI Studio Gemini.


### PR DESCRIPTION
## Relevant issues

Fixes #26181

## Linear ticket

Resolves LIT-3503 (the large-streaming-payload half; the mid-stream 429 half is handled in a separate PR)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (got 5/5)

## Type

🐛 Bug Fix

## Changes

`ModelResponseIterator.handle_accumulated_json_chunk` reassembles a Gemini streaming chunk that arrived fragmented across SSE events. It appended each fragment to `self.accumulated_json` and then called `json.loads` on the whole buffer after every fragment. When a single value is split across many fragments that is O(n^2) total work, and each `json.loads` is one CPython C call that holds the GIL, so a large enough response blocks the asyncio event loop. In the default single-process uvicorn proxy that freezes every handler, the k8s liveness probe times out, and the pod is killed and restarted. This is the behavior the py-spy dumps in #26181 captured (MainThread pinned in `json.loads` called from `handle_accumulated_json_chunk`)

A complete Gemini stream value is a JSON object or array, so the buffer can only become parseable once its last non-whitespace byte can close one. The fix gates the `json.loads` attempt on that, so the common fragmented-response case parses roughly once instead of once per fragment. `json.loads` stays the correctness oracle (a premature attempt simply raises and keeps accumulating); the gate only decides when it is worth attempting, so output is unchanged

Scope is the Vertex/Gemini path that LIT-3503's evidence points at. The same copy-paste pattern exists in the Anthropic and SageMaker iterators and can follow in separate PRs

## Screenshots / Proof of Fix

Live proxy, one model pointing at a local mock that streams a 3 MB Gemini response fragmented into 64-byte SSE data lines (the accumulate-growth trigger). A background poller hits `/health/liveliness` every 100 ms for 30 s while one streaming request runs, so the worst single probe latency is how long the event loop was frozen

Same request, same assembled output (3,145,728 chars), only the proxy code differs:

Before (current `litellm_internal_staging`):

```
[unfixed] stream_wall_time=32.49s  probes=14 worst_liveness_probe_latency=12299 ms
[assembled] content_chars=3145728 all_x=True
```

After (this PR):

```
[fixed] stream_wall_time=3.49s  probes=281 worst_liveness_probe_latency=8 ms
[assembled] content_chars=3145728 all_x=True
```

The unfixed event loop is frozen for 12.3 s in a single stretch, so only 14 liveness probes get answered in 30 s and any probe with a sub-12 s timeout fails. With the fix the worst probe is 8 ms and the same content streams through correctly

Driving the exact production method directly (so the quadratic is unambiguous), event-loop-blocked time by payload size, 2 KB fragments:

```
# before
payload=2MB  event-loop-blocked=  221 ms
payload=4MB  event-loop-blocked= 1754 ms
payload=8MB  event-loop-blocked= 6859 ms     # doubling size ~4x's the freeze -> O(n^2)
# after
payload=2MB  event-loop-blocked=   20 ms
payload=4MB  event-loop-blocked=  105 ms
payload=8MB  event-loop-blocked=  325 ms
```

Tests (the regression test fails on current code and passes with the fix):

```
tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
  test_accumulated_json_does_not_reparse_every_fragment
  test_accumulated_json_partial_fragment_returns_none_without_parsing
127 passed
```