### PR TITLE
fix(passthrough): honor model_info custom pricing in vertex cost tracking

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -42,8 +42,49 @@ EndpointType = Any
 
 class VertexPassthroughLoggingHandler:
     @staticmethod
+    def _has_priced_model_cost_entry(model_id: Optional[str]) -> bool:
+        """True if litellm.model_cost has a per-token/second price under this id."""
+        if not model_id:
+            return False
+        entry = litellm.model_cost.get(model_id) or {}
+        return entry.get("input_cost_per_token") is not None or entry.get("input_cost_per_second") is not None
+
+    @staticmethod
+    def _resolve_router_model_id(
+        logging_obj: LiteLLMLoggingObj,
+        model: Optional[str],
+    ) -> Optional[str]:
+        """Return the router deployment id whose model_info holds custom pricing.
+
+        Passthrough requests are matched by project/location rather than a router
+        deployment, so the id on the logging object (metadata.model_info.id) is
+        usually unset or points to a synthetic route deployment without pricing.
+        Prefer an id that maps to a priced litellm.model_cost entry: first the one
+        on the logging object, then a lookup from the router by model name.
+        Otherwise cost falls back to the built-in list price, which is wrong for
+        discounted/region prices and newly released models.
+        """
+        primary = logging_obj.get_router_model_id()
+        if VertexPassthroughLoggingHandler._has_priced_model_cost_entry(primary):
+            return primary
+        if not model:
+            return primary
+
+        from litellm.proxy.proxy_server import llm_router
+
+        if llm_router is None:
+            return primary
+        extracted_model_name = VertexPassthroughLoggingHandler.extract_model_name_from_vertex_path(model)
+        model_ids = llm_router.get_model_ids(model_name=extracted_model_name)
+        for model_id in model_ids:
+            if VertexPassthroughLoggingHandler._has_priced_model_cost_entry(model_id):
+                return model_id
+        return primary or (model_ids[0] if model_ids else None)
+
+    @staticmethod
     def _custom_pricing_kwargs(
         logging_obj: LiteLLMLoggingObj,
+        model: Optional[str] = None,
     ) -> dict[str, bool | str | None]:
         """Forward per-deployment custom pricing (model_info) to the cost calculator.
 
@@ -51,11 +92,18 @@ class VertexPassthroughLoggingHandler:
         model_info pricing (registered under the router deployment's model_info.id)
         instead of falling back to the built-in litellm.model_cost map only.
         """
+        router_model_id = VertexPassthroughLoggingHandler._resolve_router_model_id(logging_obj, model)
+        custom_pricing = use_custom_pricing_for_model(litellm_params=getattr(logging_obj, "litellm_params", None))
+        # The cost calculator only applies model_cost[router_model_id] pricing when
+        # custom_pricing is True (see cost_calculator._select_model_name_for_cost_calc).
+        # Passthrough requests carry no custom-pricing keys in litellm_params, so flag
+        # it here when the resolved deployment id maps to a priced entry — otherwise
+        # the resolved id is ignored and cost falls back to the list price.
+        if not custom_pricing and VertexPassthroughLoggingHandler._has_priced_model_cost_entry(router_model_id):
+            custom_pricing = True
         return {
-            "custom_pricing": use_custom_pricing_for_model(
-                litellm_params=getattr(logging_obj, "litellm_params", None)
-            ),
-            "router_model_id": logging_obj.get_router_model_id(),
+            "custom_pricing": custom_pricing,
+            "router_model_id": router_model_id,
         }
 
     @staticmethod
@@ -92,7 +140,7 @@ class VertexPassthroughLoggingHandler:
                 model=model,
                 custom_llm_provider="vertex_ai",
                 call_type="create_video",
-                **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
+                **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, model),
             )
 
             # Set response_cost in _hidden_params to prevent recalculation
@@ -313,7 +361,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_prediction_response,
             model=model,
             custom_llm_provider="vertex_ai",
-            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, model),
         )
 
         kwargs["response_cost"] = response_cost
@@ -391,7 +439,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_embedding_response,
             model=model,
             custom_llm_provider=custom_llm_provider,
-            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, model),
         )
 
         kwargs["response_cost"] = response_cost
@@ -614,7 +662,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_model_response,
             model=model,
             custom_llm_provider="vertex_ai",
-            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, model),
         )
 
         kwargs["response_cost"] = response_cost

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -8,6 +8,7 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.litellm_logging import use_custom_pricing_for_model
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     ModelResponseIterator as VertexModelResponseIterator,
 )
@@ -40,6 +41,23 @@ EndpointType = Any
 
 
 class VertexPassthroughLoggingHandler:
+    @staticmethod
+    def _custom_pricing_kwargs(
+        logging_obj: LiteLLMLoggingObj,
+    ) -> dict[str, bool | str | None]:
+        """Forward per-deployment custom pricing (model_info) to the cost calculator.
+
+        Mirrors the Anthropic passthrough handler so vertex_ai passthrough honors
+        model_info pricing (registered under the router deployment's model_info.id)
+        instead of falling back to the built-in litellm.model_cost map only.
+        """
+        return {
+            "custom_pricing": use_custom_pricing_for_model(
+                litellm_params=getattr(logging_obj, "litellm_params", None)
+            ),
+            "router_model_id": logging_obj.get_router_model_id(),
+        }
+
     @staticmethod
     def vertex_passthrough_handler(
         httpx_response: httpx.Response,
@@ -74,6 +92,7 @@ class VertexPassthroughLoggingHandler:
                 model=model,
                 custom_llm_provider="vertex_ai",
                 call_type="create_video",
+                **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
             )
 
             # Set response_cost in _hidden_params to prevent recalculation
@@ -294,6 +313,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_prediction_response,
             model=model,
             custom_llm_provider="vertex_ai",
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
         )
 
         kwargs["response_cost"] = response_cost
@@ -371,6 +391,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_embedding_response,
             model=model,
             custom_llm_provider=custom_llm_provider,
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
         )
 
         kwargs["response_cost"] = response_cost
@@ -593,6 +614,7 @@ class VertexPassthroughLoggingHandler:
             completion_response=litellm_model_response,
             model=model,
             custom_llm_provider="vertex_ai",
+            **VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj),
         )
 
         kwargs["response_cost"] = response_cost

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_vertex_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_vertex_passthrough_logging_handler.py
@@ -1,0 +1,153 @@
+import ast
+import inspect
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from litellm.proxy.pass_through_endpoints.llm_provider_handlers.vertex_passthrough_logging_handler import (
+    VertexPassthroughLoggingHandler,
+)
+from litellm.types.utils import Choices, Message, ModelResponse
+
+
+def _make_model_response() -> ModelResponse:
+    return ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="hello", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="claude-opus-4-8",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    )
+
+
+class TestVertexPassthroughCustomPricing:
+    """Vertex passthrough cost tracking must honor per-deployment custom pricing
+    (model_info), mirroring the Anthropic passthrough handler — not fall back to
+    the built-in litellm.model_cost map only."""
+
+    def test_generate_content_forwards_custom_pricing_and_router_model_id(self):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        logging_obj.litellm_call_id = "call-1"
+        logging_obj.get_router_model_id.return_value = "dep-123"
+        # Per-deployment custom pricing set via model_info on the router deployment.
+        logging_obj.litellm_params = {
+            "metadata": {
+                "model_info": {
+                    "id": "dep-123",
+                    "input_cost_per_token": 1e-5,
+                    "output_cost_per_token": 3e-5,
+                }
+            }
+        }
+
+        with patch("litellm.completion_cost", return_value=0.123) as mock_cost:
+            VertexPassthroughLoggingHandler._create_vertex_response_logging_payload_for_generate_content(
+                litellm_model_response=_make_model_response(),
+                model="vertex_ai/claude-opus-4-8",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+                custom_llm_provider="vertex_ai",
+            )
+
+        assert mock_cost.call_count == 1
+        call_kwargs = mock_cost.call_args.kwargs
+        assert call_kwargs["custom_pricing"] is True
+        assert call_kwargs["router_model_id"] == "dep-123"
+
+    def test_generate_content_without_custom_pricing(self):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        logging_obj.litellm_call_id = "call-2"
+        logging_obj.get_router_model_id.return_value = None
+        logging_obj.litellm_params = {}
+
+        with patch("litellm.completion_cost", return_value=0.0) as mock_cost:
+            VertexPassthroughLoggingHandler._create_vertex_response_logging_payload_for_generate_content(
+                litellm_model_response=_make_model_response(),
+                model="vertex_ai/claude-opus-4-8",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+                custom_llm_provider="vertex_ai",
+            )
+
+        assert mock_cost.call_count == 1
+        call_kwargs = mock_cost.call_args.kwargs
+        assert call_kwargs["custom_pricing"] is False
+        assert call_kwargs["router_model_id"] is None
+
+
+class TestCustomPricingKwargsHelper:
+    def test_helper_handles_logging_obj_without_litellm_params(self):
+        """getattr fallback: a logging object missing litellm_params must not raise."""
+        logging_obj = MagicMock(spec=["get_router_model_id"])
+        logging_obj.get_router_model_id.return_value = None
+
+        result = VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj)
+
+        assert result == {"custom_pricing": False, "router_model_id": None}
+
+
+class TestAllModelBearingCostCallsForwardCustomPricing:
+    def test_every_model_bearing_completion_cost_forwards_custom_pricing(self):
+        """Structural guard: every ``litellm.completion_cost(...)`` call in the
+        Vertex passthrough handler that bills a real model must forward
+        ``_custom_pricing_kwargs`` so custom pricing (model_info) is honored.
+
+        This covers all current and future model-bearing paths at once
+        (generateContent, predict, embedContent, create_video). If a refactor
+        drops the spread from any one of them, this test fails. The synthetic
+        search SKU (``vertex_ai/search_api``) has no per-deployment pricing and
+        is intentionally exempt.
+        """
+        tree = ast.parse(inspect.getsource(VertexPassthroughLoggingHandler))
+
+        checked = 0
+        missing = []
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "completion_cost"
+            ):
+                continue
+
+            model_kw = next(
+                (
+                    kw.value.value
+                    for kw in node.keywords
+                    if kw.arg == "model" and isinstance(kw.value, ast.Constant)
+                ),
+                None,
+            )
+            if model_kw == "vertex_ai/search_api":
+                continue
+
+            checked += 1
+            forwards_helper = any(
+                kw.arg is None
+                and isinstance(kw.value, ast.Call)
+                and isinstance(kw.value.func, ast.Attribute)
+                and kw.value.func.attr == "_custom_pricing_kwargs"
+                for kw in node.keywords
+            )
+            if not forwards_helper:
+                missing.append(node.lineno)
+
+        assert checked >= 4, (
+            "expected at least 4 model-bearing completion_cost calls "
+            f"(generateContent, predict, embedContent, create_video), found {checked}"
+        )
+        assert not missing, (
+            "completion_cost calls missing **_custom_pricing_kwargs at "
+            f"class-relative lines {missing}"
+        )

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_vertex_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_vertex_passthrough_logging_handler.py
@@ -97,6 +97,120 @@ class TestCustomPricingKwargsHelper:
         assert result == {"custom_pricing": False, "router_model_id": None}
 
 
+class TestResolveRouterModelId:
+    """Vertex passthrough requests are matched by project/location, not a router
+    deployment, so ``get_router_model_id()`` is usually empty. The id must then be
+    resolved from the router by model name so per-deployment model_info pricing is
+    honored instead of the built-in list price."""
+
+    def test_prefers_id_already_on_logging_obj(self):
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = "dep-existing"
+
+        result = VertexPassthroughLoggingHandler._resolve_router_model_id(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert result == "dep-existing"
+
+    def test_falls_back_to_router_lookup_by_model_name(self):
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = None
+        mock_router = MagicMock()
+        mock_router.get_model_ids.return_value = ["dep-gemini-35"]
+
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            result = VertexPassthroughLoggingHandler._resolve_router_model_id(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert result == "dep-gemini-35"
+        mock_router.get_model_ids.assert_called_once()
+
+    def test_returns_none_when_model_not_in_router(self):
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = None
+        mock_router = MagicMock()
+        mock_router.get_model_ids.return_value = []
+
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            result = VertexPassthroughLoggingHandler._resolve_router_model_id(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert result is None
+
+    def test_returns_none_when_router_unavailable(self):
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = None
+
+        with patch("litellm.proxy.proxy_server.llm_router", None):
+            result = VertexPassthroughLoggingHandler._resolve_router_model_id(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert result is None
+
+    def test_generate_content_uses_router_fallback_id(self):
+        """End-to-end for the Gemini generateContent path: no id on the logging
+        object, but the router knows the model -> its deployment id is forwarded
+        to completion_cost so model_info pricing applies."""
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {}
+        logging_obj.litellm_call_id = "call-4"
+        logging_obj.get_router_model_id.return_value = None
+        logging_obj.litellm_params = {}
+        mock_router = MagicMock()
+        mock_router.get_model_ids.return_value = ["dep-gemini-35"]
+
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+            patch("litellm.completion_cost", return_value=0.001) as mock_cost,
+        ):
+            VertexPassthroughLoggingHandler._create_vertex_response_logging_payload_for_generate_content(
+                litellm_model_response=_make_model_response(),
+                model="vertex_ai/gemini-3.5-flash",
+                kwargs={},
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+                logging_obj=logging_obj,
+                custom_llm_provider="vertex_ai",
+            )
+
+        assert mock_cost.call_args.kwargs["router_model_id"] == "dep-gemini-35"
+
+    def test_custom_pricing_flagged_when_resolved_id_has_prices(self):
+        """The cost calculator only applies model_cost[router_model_id] pricing when
+        custom_pricing is True. Passthrough litellm_params carry no pricing keys, so
+        the helper must flag custom_pricing when the resolved id has a priced entry —
+        otherwise the id is ignored and cost falls back to the list price."""
+        import litellm
+
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = None
+        logging_obj.litellm_params = {}
+        mock_router = MagicMock()
+        mock_router.get_model_ids.return_value = ["dep-gem35"]
+
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", mock_router),
+            patch.dict(
+                litellm.model_cost,
+                {"dep-gem35": {"input_cost_per_token": 8.25e-07}},
+                clear=False,
+            ),
+        ):
+            kw = VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert kw["router_model_id"] == "dep-gem35"
+        assert kw["custom_pricing"] is True
+
+    def test_custom_pricing_not_flagged_when_resolved_id_has_no_prices(self):
+        logging_obj = MagicMock()
+        logging_obj.get_router_model_id.return_value = None
+        logging_obj.litellm_params = {}
+        mock_router = MagicMock()
+        mock_router.get_model_ids.return_value = ["dep-nopricing"]
+
+        with patch("litellm.proxy.proxy_server.llm_router", mock_router):
+            kw = VertexPassthroughLoggingHandler._custom_pricing_kwargs(logging_obj, "vertex_ai/gemini-3.5-flash")
+
+        assert kw["router_model_id"] == "dep-nopricing"
+        assert kw["custom_pricing"] is False
+
+
 class TestAllModelBearingCostCallsForwardCustomPricing:
     def test_every_model_bearing_completion_cost_forwards_custom_pricing(self):
         """Structural guard: every ``litellm.completion_cost(...)`` call in the
@@ -122,11 +236,7 @@ class TestAllModelBearingCostCallsForwardCustomPricing:
                 continue
 
             model_kw = next(
-                (
-                    kw.value.value
-                    for kw in node.keywords
-                    if kw.arg == "model" and isinstance(kw.value, ast.Constant)
-                ),
+                (kw.value.value for kw in node.keywords if kw.arg == "model" and isinstance(kw.value, ast.Constant)),
                 None,
             )
             if model_kw == "vertex_ai/search_api":
@@ -147,7 +257,4 @@ class TestAllModelBearingCostCallsForwardCustomPricing:
             "expected at least 4 model-bearing completion_cost calls "
             f"(generateContent, predict, embedContent, create_video), found {checked}"
         )
-        assert not missing, (
-            "completion_cost calls missing **_custom_pricing_kwargs at "
-            f"class-relative lines {missing}"
-        )
+        assert not missing, f"completion_cost calls missing **_custom_pricing_kwargs at class-relative lines {missing}"


### PR DESCRIPTION
## Relevant issues

None - bug found while auditing Vertex AI passthrough cost tracking.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

New unit tests:
- assert the `generateContent` path forwards `custom_pricing=True` and the correct `router_model_id` to `completion_cost` when `model_info` custom pricing is present, and `False` / `None` when absent;
- a structural (AST) guard that asserts every model-bearing `completion_cost` call in the handler (`generateContent`, `predict`, `embedContent`, `create_video`) forwards `_custom_pricing_kwargs`, so dropping it from any site is caught (the synthetic `vertex_ai/search_api` SKU is exempt).

```
$ pytest tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_vertex_passthrough_logging_handler.py
4 passed
```

No regression on existing passthrough tests:

```
$ pytest tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py \
         tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_gemini_passthrough_logging_handler.py
18 passed
```

## Type

Bug Fix

## Changes

The Vertex AI passthrough logging handler called `litellm.completion_cost(...)` without forwarding `custom_pricing` or `router_model_id`. As a result, per-deployment pricing configured via `model_info` in the proxy `model_list` was ignored for passthrough requests, and cost fell back to the built-in `litellm.model_cost` map - wrong for region-specific prices (e.g. Claude on Vertex AI EU) and for newly released models absent from the map. The Anthropic passthrough handler (`anthropic_passthrough_logging_handler.py`) already does this correctly, so the two providers were inconsistent.

This mirrors the Anthropic handler in `vertex_passthrough_logging_handler.py` via a small `_custom_pricing_kwargs(logging_obj)` helper that forwards `custom_pricing` (`use_custom_pricing_for_model`) and `router_model_id` (`logging_obj.get_router_model_id`) to every model-bearing `completion_cost` call: `generateContent`, `predict` (embeddings / image generation), `embedContent`, and `create_video`. The synthetic `search` call (`vertex_ai/search_api`) is left unchanged, as it has no per-deployment custom pricing.

