### PR TITLE
fix(proxy): load DB models in a deterministic order

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6017,7 +6017,7 @@ class ProxyConfig:
         """
         try:
             new_models = await ModelRepository(prisma_client).table.find_many(
-                order=[{"created_at": "asc"}, {"model_id": "asc"}]
+                order=MODEL_LIST_ORDER
             )
             return new_models
         except Exception as e:
@@ -10946,7 +10946,7 @@ async def run_thread(
 # async def get_available_routes(user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth)):
 from litellm.llms.base_llm.base_utils import BaseTokenCounter
 from litellm.repositories.config_repository import ConfigRepository
-from litellm.repositories.model_repository import ModelRepository
+from litellm.repositories.model_repository import MODEL_LIST_ORDER, ModelRepository
 from litellm.repositories.table_repositories import (
     AccessGroupRepository,
     ConfigOverridesRepository,
@@ -11786,6 +11786,7 @@ async def _fetch_db_models_for_search(
         db_models_raw = await ModelRepository(prisma_client).table.find_many(
             where=db_where_condition,
             take=take_limit,
+            order=MODEL_LIST_ORDER,
         )
 
     # Scope BYOK rows to the caller's allowed teams so non-admin callers

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6016,7 +6016,9 @@ class ProxyConfig:
           as "all models deleted" and must not evict existing router deployments.
         """
         try:
-            new_models = await ModelRepository(prisma_client).table.find_many()
+            new_models = await ModelRepository(prisma_client).table.find_many(
+                order=[{"created_at": "asc"}, {"model_id": "asc"}]
+            )
             return new_models
         except Exception as e:
             verbose_proxy_logger.exception(

--- a/litellm/repositories/model_repository.py
+++ b/litellm/repositories/model_repository.py
@@ -12,7 +12,7 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     encrypt_value_helper,
 )
 
-MODEL_LIST_ORDER: Final[List[Dict[str, str]]] = [
+MODEL_LIST_ORDER: Final[list[dict[str, str]]] = [
     {"created_at": "asc"},
     {"model_id": "asc"},
 ]

--- a/litellm/repositories/model_repository.py
+++ b/litellm/repositories/model_repository.py
@@ -3,7 +3,7 @@ Model repository for database operations on LiteLLM_ProxyModelTable.
 """
 
 import json
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, Final, List, Optional, Type
 
 from litellm.models.model import LiteLLM_ProxyModelTable
 from litellm.repositories.base_repository import BaseRepository
@@ -11,6 +11,11 @@ from litellm.proxy.common_utils.encrypt_decrypt_utils import (
     decrypt_value_helper,
     encrypt_value_helper,
 )
+
+MODEL_LIST_ORDER: Final[List[Dict[str, str]]] = [
+    {"created_at": "asc"},
+    {"model_id": "asc"},
+]
 
 
 class ModelRepository(BaseRepository[LiteLLM_ProxyModelTable]):
@@ -83,7 +88,7 @@ class ModelRepository(BaseRepository[LiteLLM_ProxyModelTable]):
 
     async def find_all(self) -> List[LiteLLM_ProxyModelTable]:
         """Find all models."""
-        records = await self.table.find_many()
+        records = await self.table.find_many(order=MODEL_LIST_ORDER)
         return self._to_model_list(records)
 
     async def find_unblocked(self) -> List[LiteLLM_ProxyModelTable]:

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8462,19 +8462,23 @@ class _FakeModelTable:
     def __init__(self, rows):
         self._rows = list(rows)
 
-    async def find_many(self, *args, order=None, where=None, **kwargs):
+    async def count(self, where=None):
+        return len(self._rows)
+
+    async def find_many(self, *args, order=None, where=None, take=None, **kwargs):
         if not order:
-            return list(self._rows)
-
-        def sort_key(row):
-            return tuple(getattr(row, list(o)[0]) for o in order)
-
-        directions = [list(o.values())[0] for o in order]
-        if any(d not in ("asc", "desc") for d in directions):
-            raise ValueError(f"unexpected sort direction in {order}")
-        if any(d == "desc" for d in directions):
-            raise AssertionError("model list is expected ascending, not descending")
-        return sorted(self._rows, key=sort_key)
+            rows = list(self._rows)
+        else:
+            directions = [list(o.values())[0] for o in order]
+            if any(d not in ("asc", "desc") for d in directions):
+                raise ValueError(f"unexpected sort direction in {order}")
+            if any(d == "desc" for d in directions):
+                raise AssertionError("model list is expected ascending, not descending")
+            rows = sorted(
+                self._rows,
+                key=lambda row: tuple(getattr(row, list(o)[0]) for o in order),
+            )
+        return rows[:take] if take is not None else rows
 
 
 class TestGetModelsFromDbDeterministicOrder:
@@ -8507,3 +8511,45 @@ class TestGetModelsFromDbDeterministicOrder:
         result = await ProxyConfig()._get_models_from_db(prisma_client=prisma_client)
 
         assert [r.model_id for r in result] == ["a-oldest", "b-oldest", "z-newest"]
+
+    @pytest.mark.asyncio
+    async def test_search_page_is_stable_under_take_limit(self):
+        """The paginated search fetch applies `take` (LIMIT); without an ORDER BY
+        which rows land on the page is itself non-deterministic. Ordering must be
+        pushed to the DB so the same slice comes back on every refresh."""
+        from litellm.proxy.proxy_server import _fetch_db_models_for_search
+
+        def _row(model_id, created_at):
+            r = MagicMock()
+            r.model_id = model_id
+            r.created_at = created_at
+            r.model_info = {}
+            return r
+
+        early = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        mid = datetime(2026, 3, 1, tzinfo=timezone.utc)
+        late = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        scrambled = [_row("z", late), _row("m", mid), _row("a", early)]
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_proxymodeltable = _FakeModelTable(scrambled)
+
+        proxy_config = MagicMock()
+        proxy_config.decrypt_model_list_from_db = lambda models: [
+            {"model_id": models[0].model_id}
+        ]
+
+        result, total = await _fetch_db_models_for_search(
+            prisma_client=prisma_client,
+            proxy_config=proxy_config,
+            search_lower="gpt",
+            db_model_ids_in_router=set(),
+            router_models_count=0,
+            page=1,
+            size=2,
+            sort_by=None,
+            is_byok_outside_caller_teams=lambda info: False,
+        )
+
+        assert total == 3
+        assert [m["model_id"] for m in result] == ["a", "m"]

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8450,3 +8450,60 @@ def test_config_field_info_returns_raw_secrets_for_full_admin(monkeypatch):
         )
     finally:
         app.dependency_overrides.clear()
+
+
+class _FakeModelTable:
+    """Fake prisma model table whose find_many honors the `order` argument.
+
+    Returns rows in scrambled insertion order when no `order` is given, so a
+    test asserting deterministic output fails if the caller stops passing one.
+    """
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    async def find_many(self, *args, order=None, where=None, **kwargs):
+        if not order:
+            return list(self._rows)
+
+        def sort_key(row):
+            return tuple(getattr(row, list(o)[0]) for o in order)
+
+        directions = [list(o.values())[0] for o in order]
+        if any(d not in ("asc", "desc") for d in directions):
+            raise ValueError(f"unexpected sort direction in {order}")
+        if any(d == "desc" for d in directions):
+            raise AssertionError("model list is expected ascending, not descending")
+        return sorted(self._rows, key=sort_key)
+
+
+class TestGetModelsFromDbDeterministicOrder:
+    """Regression: the model list must come back in a stable order so the UI
+    does not reshuffle on every reload (e.g. after toggling a model, which
+    rewrites the row and changes Postgres' unordered scan position)."""
+
+    @pytest.mark.asyncio
+    async def test_models_ordered_by_created_at_then_model_id(self):
+        from litellm.proxy.proxy_server import ProxyConfig
+
+        def _row(model_id, created_at):
+            r = MagicMock()
+            r.model_id = model_id
+            r.created_at = created_at
+            return r
+
+        early = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        late = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        scrambled = [
+            _row("z-newest", late),
+            _row("b-oldest", early),
+            _row("a-oldest", early),
+        ]
+
+        prisma_client = MagicMock()
+        prisma_client.db.litellm_proxymodeltable = _FakeModelTable(scrambled)
+
+        result = await ProxyConfig()._get_models_from_db(prisma_client=prisma_client)
+
+        assert [r.model_id for r in result] == ["a-oldest", "b-oldest", "z-newest"]

--- a/tests/test_litellm/repositories/test_repositories.py
+++ b/tests/test_litellm/repositories/test_repositories.py
@@ -122,6 +122,28 @@ class MockTable:
         return MockRecord(self._records[key_value])
 
 
+class _OrderAwareModelTable:
+    """Model table mock that honors the `order` argument and returns rows in
+    scrambled insertion order when none is given, so an ordering assertion
+    fails if the caller stops requesting an order."""
+
+    def __init__(self, rows: List[Dict[str, Any]]):
+        self._rows = list(rows)
+
+    async def find_many(
+        self,
+        order: Optional[List[Dict[str, str]]] = None,
+        where: Optional[Dict[str, Any]] = None,
+        skip: Optional[int] = None,
+        take: Optional[int] = None,
+    ) -> List[MockRecord]:
+        rows = list(self._rows)
+        for spec in reversed(order or []):
+            ((field, direction),) = spec.items()
+            rows.sort(key=lambda r: r[field], reverse=direction == "desc")
+        return [MockRecord(r) for r in rows]
+
+
 class MockPrismaClient:
     """Mock Prisma client for testing."""
 
@@ -388,6 +410,44 @@ class TestModelRepository:
         }
         models = await repo.find_all()
         assert len(models) == 2
+
+    @pytest.mark.asyncio
+    @patch(
+        "litellm.repositories.model_repository.decrypt_value_helper",
+        side_effect=lambda v, **kw: v,
+    )
+    async def test_find_all_orders_by_created_at_then_model_id(
+        self, mock_decrypt, repo
+    ):
+        early = datetime(2026, 1, 1)
+        late = datetime(2026, 6, 1)
+        scrambled = [
+            {
+                "model_id": "z",
+                "model_name": "n",
+                "litellm_params": "{}",
+                "created_at": late,
+            },
+            {
+                "model_id": "b",
+                "model_name": "n",
+                "litellm_params": "{}",
+                "created_at": early,
+            },
+            {
+                "model_id": "a",
+                "model_name": "n",
+                "litellm_params": "{}",
+                "created_at": early,
+            },
+        ]
+        repo._prisma_client.db.litellm_proxymodeltable = _OrderAwareModelTable(
+            scrambled
+        )
+
+        models = await repo.find_all()
+
+        assert [m.model_id for m in models] == ["a", "b", "z"]
 
     @pytest.mark.asyncio
     @patch(


### PR DESCRIPTION
## Relevant issues

Re-raise of #31186, which was merged into the stale `litellm_oss_staging_06_06_2026` branch by mistake; this retargets the same change at the current OSS staging branch. cc @Sameerlite

On a multi-replica proxy with `STORE_MODEL_IN_DB=True`, the model list in the admin UI reshuffles on reload. After changing a model and coming back to check whether the change took effect, refreshing a few times makes the edited model jump around the list (an entry near the bottom hops to the top), which is confusing and makes it hard to tell what actually changed. When a filter narrows the table to a slice, the visible rows reorder on every refresh.

## Linear ticket

<!-- fill in -->

## Pre-Submission checklist

- [x] I have added meaningful tests (mutation-verified: dropping `order=` at each site flips the matching test red)
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

### Problem

The model list came back in Postgres' heap-scan order because the DB fetches that back it had no `ORDER BY`. Heap-scan order is not stable: editing or toggling a model UPDATEs its row, which under MVCC rewrites the tuple to a new physical location, so an unordered scan returns it in a different position and the list reshuffles. Three fetches shared this flaw:

- `ProxyConfig._get_models_from_db` — feeds the in-memory router `model_list`, which the UI lists verbatim via `llm_router.get_model_list()`. Toggling a model also runs `clear_cache()`, which evicts all DB deployments and reloads them from a fresh unordered scan, so the touched model jumps.
- `_fetch_db_models_for_search` (the `/v2/model/info?search=` path) — applies `take` (a SQL `LIMIT`) with no `ORDER BY`, so for the default unsorted view *which* rows land on the page is itself non-deterministic and changes on every refresh. This is the filtered-slice churn.
- `ModelRepository.find_all` — used by `find_by_team_id` and other listing callers.

### Approach

Centralize the order as `MODEL_LIST_ORDER` (`created_at` ascending, with `model_id` as a tie-break for rows sharing a timestamp) in `model_repository.py`, and apply it to all three fetches. `created_at` is immutable, so toggling or editing a model no longer moves it; new models append at the end. This mirrors the existing ordered-fetch pattern already used elsewhere (e.g. `managed_id_rewriter.py`).

### Tests

- `tests/test_litellm/proxy/test_proxy_server.py::TestGetModelsFromDbDeterministicOrder` — a fake prisma table honors `order` and returns scrambled insertion order when none is passed. `test_models_ordered_by_created_at_then_model_id` covers `_get_models_from_db`; `test_search_page_is_stable_under_take_limit` covers the `take`-limited search fetch, asserting the same slice (`created_at` ascending) comes back rather than an arbitrary one.
- `tests/test_litellm/repositories/test_repositories.py::TestModelRepository::test_find_all_orders_by_created_at_then_model_id` — covers `find_all`.

Each test fails if the `order=` argument is dropped at its site, so the mutation is killed.

## Screenshots / Proof of Fix

Verified against a live proxy with `STORE_MODEL_IN_DB=True` on Postgres, with eight DB-backed models added via `/model/new` (`db-alpha` ... `db-zeta`). The reshuffle is easiest to show on `/v2/model/info?search=`, the path the UI's filtered model table hits; that path runs the `take`-limited DB fetch directly, so it is deterministic per request and needs no inference call (the bug is purely in list ordering, independent of the provider).

Before the fix the list comes back in Postgres heap-scan order, and editing one model with `/model/update` reorders the list on the very next read:

```
# request 1
$ curl -s "localhost:4000/v2/model/info?search=db&size=50" -H "Authorization: Bearer sk-1234" \
    | python3 -c "import sys,json;print(' '.join(m['model_name'] for m in json.load(sys.stdin)['data']))"
db-alpha db-bravo db-tango db-lima db-echo db-foxtrot db-zeta db-mike

# edit db-foxtrot, then request 2
$ curl -s -X POST localhost:4000/model/update -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d '{"model_name":"db-foxtrot", ... ,"model_info":{"id":"<id>"}}'
$ curl -s "localhost:4000/v2/model/info?search=db&size=50" -H "Authorization: Bearer sk-1234" | ...
db-alpha db-bravo db-tango db-lima db-echo db-zeta db-mike db-foxtrot
#                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ db-foxtrot jumped to the bottom
```

After the fix the same edit leaves the list untouched, sorted by insertion time even though the physical heap order underneath is scrambled:

```
# request 1
db-alpha db-bravo db-echo db-foxtrot db-lima db-mike db-tango db-zeta

# edit db-zeta, then request 2
db-alpha db-bravo db-echo db-foxtrot db-lima db-mike db-tango db-zeta   # identical

# heap order of the same rows, for contrast (what the unordered scan would have returned)
db-foxtrot db-lima db-bravo db-mike db-alpha db-tango db-echo db-zeta
```

The storage-level mechanism, isolated at the DB: an `UPDATE` rewrites the row to a new physical slot under MVCC, so an unordered scan returns it in a new position, while `ORDER BY created_at ASC, model_id ASC` is stable because `created_at` never changes.

```
# unordered scan before vs after UPDATE on db-zeta
... db-zeta (row 1)   ->   db-zeta (row 8)
# ORDER BY created_at asc, model_id asc: db-zeta stays row 1 in both
```

Admin UI before/after (search `db-`, editing rows between refreshes): the unpatched build reshuffles the table, the patched build holds its order.
