### PR TITLE
fix(proxy): honor budget_duration for global max_budget

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -26,6 +26,7 @@ from litellm.integrations.otel.model.config import is_otel_v2_enabled
 from litellm.integrations.otel.runtime import phase_span, seed_request_identity
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.litellm_core_utils.dot_notation_indexing import get_nested_value
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.proxy._types import *
 from litellm.proxy.auth.auth_checks import (
     ExperimentalUIJWTToken,
@@ -405,6 +406,27 @@ def update_valid_token_with_end_user_params(valid_token: UserAPIKeyAuth, end_use
 _global_spend_coordinator = EventDrivenCacheCoordinator(log_prefix="[GLOBAL SPEND]")
 
 
+def _global_budget_window_seconds() -> Optional[int]:
+    """Trailing window (in seconds) the global ``max_budget`` is enforced over.
+
+    Returns the configured ``litellm.budget_duration`` so that, for example,
+    ``budget_duration: 1d`` caps spend over the trailing day instead of the
+    fixed 30 days. Returns ``None`` (legacy fixed-30-day view) when no valid
+    duration is set.
+    """
+    if litellm.budget_duration is None:
+        return None
+    try:
+        return duration_in_seconds(duration=litellm.budget_duration)
+    except ValueError:
+        verbose_proxy_logger.warning(
+            "Invalid litellm.budget_duration=%r for global max_budget; "
+            "falling back to the trailing-30-day spend window.",
+            litellm.budget_duration,
+        )
+        return None
+
+
 async def _fetch_global_spend_with_event_coordination(
     cache_key: str,
     user_api_key_cache: UserApiKeyCache,
@@ -416,8 +438,17 @@ async def _fetch_global_spend_with_event_coordination(
     """
 
     async def _load_global_spend() -> Optional[float]:
-        sql_query = """SELECT SUM(spend) AS total_spend FROM "MonthlyGlobalSpend";"""
-        response = await prisma_client.db.query_raw(query=sql_query)
+        budget_window_seconds = _global_budget_window_seconds()
+        if budget_window_seconds is None:
+            sql_query = """SELECT SUM(spend) AS total_spend FROM "MonthlyGlobalSpend";"""
+            response = await prisma_client.db.query_raw(query=sql_query)
+        else:
+            sql_query = """
+                SELECT SUM("spend") AS total_spend
+                FROM "LiteLLM_SpendLogs"
+                WHERE "startTime" >= (NOW() - make_interval(secs => $1));
+            """
+            response = await prisma_client.db.query_raw(sql_query, budget_window_seconds)
         val = response[0]["total_spend"]
         return float(val) if val is not None else None
 

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -4084,3 +4084,75 @@ async def test_auth_path_caches_team_object_under_canonical_team_id_key():
     assert served is not None and served.team_id == team_id
     assert cache.get_cache(key=team_id) is None
     assert cache.get_cache(key=None) is None
+class _RecordingSpendDB:
+    """Captures the SQL and bound params the global-spend loader issues and
+    returns a fixed SUM, so a test can assert which window was queried."""
+
+    def __init__(self, total_spend):
+        self.total_spend = total_spend
+        self.calls = []
+
+    async def query_raw(self, query=None, *params):
+        self.calls.append((query, params))
+        return [{"total_spend": self.total_spend}]
+
+
+class _RecordingPrismaClient:
+    def __init__(self, total_spend):
+        self.db = _RecordingSpendDB(total_spend)
+
+
+@pytest.mark.asyncio
+async def test_global_spend_windowed_to_budget_duration(monkeypatch):
+    """Regression for #31292: the global ``max_budget`` is enforced over the
+    configured ``budget_duration`` window, not a hardcoded 30-day total.
+
+    With ``budget_duration='1d'`` the loader must sum ``LiteLLM_SpendLogs`` over
+    the trailing day (86400s as a bound param) and must NOT read the fixed
+    30-day ``MonthlyGlobalSpend`` view. Pre-fix this summed ``MonthlyGlobalSpend``
+    regardless of duration, so a trailing-30-day total above the daily cap would
+    429 even when no single day exceeded it."""
+    from litellm.proxy.auth import user_api_key_auth as uapi
+
+    monkeypatch.setattr(litellm, "budget_duration", "1d", raising=False)
+
+    prisma = _RecordingPrismaClient(total_spend=42.5)
+    cache = DualCache()
+
+    spend = await uapi._fetch_global_spend_with_event_coordination(
+        cache_key="test_global_spend_1d:spend",
+        user_api_key_cache=cache,
+        prisma_client=prisma,
+    )
+
+    assert spend == 42.5
+    assert len(prisma.db.calls) == 1
+    query, params = prisma.db.calls[0]
+    assert "MonthlyGlobalSpend" not in query
+    assert 'FROM "LiteLLM_SpendLogs"' in query
+    assert "make_interval" in query
+    assert params == (86400,)
+
+
+@pytest.mark.asyncio
+async def test_global_spend_falls_back_to_30day_view_without_duration(monkeypatch):
+    """When no ``budget_duration`` is configured the loader keeps the legacy
+    fixed-30-day ``MonthlyGlobalSpend`` view, preserving prior behaviour."""
+    from litellm.proxy.auth import user_api_key_auth as uapi
+
+    monkeypatch.setattr(litellm, "budget_duration", None, raising=False)
+
+    prisma = _RecordingPrismaClient(total_spend=10.0)
+    cache = DualCache()
+
+    spend = await uapi._fetch_global_spend_with_event_coordination(
+        cache_key="test_global_spend_legacy:spend",
+        user_api_key_cache=cache,
+        prisma_client=prisma,
+    )
+
+    assert spend == 10.0
+    assert len(prisma.db.calls) == 1
+    query, params = prisma.db.calls[0]
+    assert 'FROM "MonthlyGlobalSpend"' in query
+    assert params == ()


### PR DESCRIPTION
## Relevant issues

Fixes #31292

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

A global proxy budget configured with a duration

```yaml
litellm_settings:
  max_budget: 100
  budget_duration: 1d
```

was not acting as a daily cap. `budget_duration` is required to use the global `max_budget` and drives the reset wiring (`_add_proxy_budget_to_db` upserts the proxy-admin row with a `budget_reset_at`, and `ResetBudgetJob` zeroes that row on schedule), but enforcement never reads that resettable counter. The enforced baseline comes from `_load_global_spend` in `litellm/proxy/auth/user_api_key_auth.py`, which sums the `MonthlyGlobalSpend` view. That view is hardcoded to a trailing 30 days (`litellm/proxy/db/create_views.py`, `WHERE "startTime" >= (CURRENT_DATE - INTERVAL '30 days')`), so `1d`, `7d` and `30d` all collapse to the same 30-day cap. Once the rolling 30-day total crosses `max_budget` the proxy 429s every request and only recovers as old spend ages out of the window, never on the configured duration.

This windows the baseline query to the configured `budget_duration` instead of the fixed view. When a duration is set, `_load_global_spend` sums `LiteLLM_SpendLogs` over `NOW() - budget_duration` (via `make_interval`, passed as a bound parameter), so the global cap tracks the trailing duration and recovers as spend ages out of that window. `NOW()` is used rather than `CURRENT_DATE` so sub-day durations like `1h` are respected with full precision.

The change is deliberately narrow. The shared `MonthlyGlobalSpend` view is used by the admin spend dashboards and is left untouched. The `default_user_id` proxy-admin row is intentionally not used as the source here; as the issue notes, it tracks only the admin user's own spend rather than the proxy-wide total. Deployments that set `max_budget` without a `budget_duration` keep the existing trailing-30-day behavior, and an unparseable duration falls back to that path with a warning rather than failing requests.

## Testing

Added two regression tests in `tests/test_litellm/proxy/auth/test_user_api_key_auth.py` that exercise `_fetch_global_spend_with_event_coordination` against a recording fake DB:

- `test_global_spend_windowed_to_budget_duration`: with `budget_duration='1d'`, asserts the loader queries `LiteLLM_SpendLogs` with a `make_interval` window bound to `86400` seconds and does not touch `MonthlyGlobalSpend`
- `test_global_spend_falls_back_to_30day_view_without_duration`: with no duration, asserts the loader keeps the `MonthlyGlobalSpend` view

The first test fails on `main` (the loader summed `MonthlyGlobalSpend` regardless of duration) and passes with this change, so it pins the regression.

```
$ uv run --no-sync python -m pytest tests/test_litellm/proxy/auth/test_user_api_key_auth.py -q
100 passed

$ cd litellm && uv run --no-sync black --check proxy/auth/user_api_key_auth.py
$ uv run --no-sync ruff check proxy/auth/user_api_key_auth.py
All checks passed!
```

End-to-end reproduction for a reviewer with a Postgres-backed proxy: seed `LiteLLM_SpendLogs` with roughly $10/day across the last ~30 days (trailing-30-day total above `100`, no single day above it) under the config above, then send a request. On `main` this returns `429 budget_exceeded`; with this change the trailing-1-day total stays under the cap and the request succeeds, and the cap recovers once a day's spend ages out of the window.
