### PR TITLE
fix(pass-through): stop pass-through route registry growing every reload (PERF-13)

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -2821,10 +2821,14 @@ async def initialize_pass_through_endpoints(
             config_file_path=config_file_path,
         )
 
-    # remove the ones that are not visited from the list
+    # Drop stale registry entries by their exact route key. registered_pass_through_endpoints
+    # holds route keys ("{id}:{type}:{path}:{methods}"), not endpoint ids, so remove_endpoint_routes
+    # (which matches on endpoint_id) never matched and left the registry growing every reload cycle.
+    # We pop the key directly and leave openai_routes alone: its append is path-deduped, and the path
+    # is still owned by the live endpoint that was just re-registered under a new id this same cycle.
     for endpoint_key in registered_pass_through_endpoints:
         if endpoint_key not in visited_endpoints:
-            InitPassThroughEndpointHelpers.remove_endpoint_routes(endpoint_key)
+            _registered_pass_through_routes.pop(endpoint_key, None)
 
 
 def _get_pass_through_endpoints_from_config() -> List[PassThroughGenericEndpoint]:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from contextlib import ExitStack
 from io import BytesIO
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,8 +19,11 @@ sys.path.insert(
 from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,
     HttpPassThroughEndpointHelpers,
+    InitPassThroughEndpointHelpers,
     LITELLM_PASS_THROUGH_CUSTOM_BODY_STATE_KEY,
+    _registered_pass_through_routes,
     create_pass_through_route,
+    initialize_pass_through_endpoints,
     pass_through_request,
     resolve_pass_through_request_timeout,
     resolve_llm_passthrough_timeout,
@@ -3313,3 +3317,117 @@ def test_get_response_headers_strips_server_and_date():
     assert lowered["content-type"] == "application/json"
     assert lowered["x-request-id"] == "req_abc"
     assert lowered["anthropic-ratelimit-requests-remaining"] == "100"
+
+
+class TestStaleRouteCleanupOnReload:
+    """Regression tests for the PERF-13 / issue #19921 reload leak.
+
+    ``initialize_pass_through_endpoints`` is re-run every 30s by the
+    ``add_deployment_job`` scheduler. Endpoints sourced from the DB/config
+    without a persisted ``id`` get a fresh UUID each cycle, so their route key
+    ("{id}:{type}:{path}:{methods}") changes every reload. The old cleanup
+    called ``remove_endpoint_routes(route_key)`` which matches on ``endpoint_id``
+    and therefore never matched a route key, so ``_registered_pass_through_routes``
+    grew without bound. That unbounded dict turned the O(n) per-cycle cleanup and
+    the per-request ``is_registered_pass_through_route`` scan into a CPU sink.
+    """
+
+    def setup_method(self):
+        _registered_pass_through_routes.clear()
+
+    def teardown_method(self):
+        _registered_pass_through_routes.clear()
+
+    @staticmethod
+    def _patches():
+        stack = ExitStack()
+        stack.enter_context(
+            patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.SafeRouteAdder.add_api_route_if_not_exists"
+            )
+        )
+        stack.enter_context(patch("litellm.proxy.proxy_server.premium_user", True))
+        mock_set_env = stack.enter_context(
+            patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.set_env_variables_in_header"
+            )
+        )
+        mock_set_env.return_value = {}
+        return stack
+
+    @staticmethod
+    def _paths_in_registry():
+        return sorted(v["path"] for v in _registered_pass_through_routes.values())
+
+    @pytest.mark.asyncio
+    async def test_registry_stays_bounded_across_reloads_for_idless_endpoint(self):
+        """A DB/config endpoint with no id must not grow the registry per reload.
+
+        Mutation check: with the old ``remove_endpoint_routes`` call this asserts
+        2 but the registry holds ``2 * num_cycles`` entries, so it fails.
+        """
+        num_cycles = 25
+        with self._patches():
+            for _ in range(num_cycles):
+                # Fresh dict each cycle mirrors the DB loader rebuilding objects;
+                # a reused dict would cache the minted id and hide the bug.
+                await initialize_pass_through_endpoints(
+                    [
+                        {
+                            "path": "/vertex-passthrough",
+                            "target": "http://example.com",
+                            "include_subpath": True,
+                        }
+                    ]
+                )
+
+        assert len(_registered_pass_through_routes) == 2
+        assert self._paths_in_registry() == [
+            "/vertex-passthrough",
+            "/vertex-passthrough",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_departed_endpoint_is_removed_on_next_reload(self):
+        """A route present in one cycle but absent the next is dropped.
+
+        Mutation check: the old cleanup leaves the departed ``/a`` key behind,
+        so the registry would hold both paths instead of only ``/b``.
+        """
+        with self._patches():
+            await initialize_pass_through_endpoints(
+                [{"path": "/a", "target": "http://example.com"}]
+            )
+            assert self._paths_in_registry() == ["/a"]
+
+            await initialize_pass_through_endpoints(
+                [{"path": "/b", "target": "http://example.com"}]
+            )
+
+        assert self._paths_in_registry() == ["/b"]
+
+    @pytest.mark.asyncio
+    async def test_live_route_survives_reload_and_stays_resolvable(self):
+        """The currently-registered route must remain after the stale-key sweep.
+
+        Guards against a cleanup that over-removes (e.g. stripping the shared
+        path of the freshly re-registered endpoint).
+        """
+        with self._patches():
+            for _ in range(3):
+                await initialize_pass_through_endpoints(
+                    [
+                        {
+                            "path": "/live-passthrough",
+                            "target": "http://example.com",
+                            "include_subpath": True,
+                        }
+                    ]
+                )
+
+        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+            "/live-passthrough"
+        )
+        assert InitPassThroughEndpointHelpers.is_registered_pass_through_route(
+            "/live-passthrough/some/subpath"
+        )


### PR DESCRIPTION
## Relevant issues

Resolves #19921

## Linear ticket

Resolves PERF-13

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of 5/5

## Type

🐛 Bug Fix

## Changes

PERF-13 asked whether the 1.81.x performance regression in #19921 still exists and whether the upstream fix in #26082 is relevant. It still exists on `litellm_internal_staging` (1.91.0), and the pass-through registry leak that #26082 targets is the part that is still unfixed here, so this ports a minimal version of it.

### Root cause

The `add_deployment_job` scheduler re-runs `initialize_pass_through_endpoints` every 30s when `store_model_in_db` is on (proxy_server.py:8069). Each cycle re-registers every config and DB pass-through endpoint. An endpoint without a persisted `id` gets a fresh `uuid` every reload (pass_through_endpoints.py:2673), so its registry key, formatted as `"{id}:{type}:{path}:{methods}"`, changes each cycle and defeats the `if route_key in _registered_pass_through_routes` dedup.

The stale-route cleanup then called `remove_endpoint_routes(endpoint_key)` with that route key, but `remove_endpoint_routes` matches entries by `endpoint_id` (pass_through_endpoints.py:2522), so a route key never matched and nothing was ever deleted. `_registered_pass_through_routes` grew by one entry per route every 30s forever. That unbounded dict is what turns the per-cycle cleanup (O(n) keys, each calling an O(n) scan) and the per-request `is_registered_pass_through_route` scan in the auth path (route_checks.py:153) into a CPU sink, which matches the reported symptom of one core pinned at 100% and every management API and login getting slower over time.

This is the same root cause as #26082. The other reports in the thread (the `router_settings` per-request Router and Prometheus registry scan, and the slow spend-logs query) were separate issues already addressed by #20087, #20133, and #20720; this one was not.

### Fix

Pop the stale key from the registry directly in O(1). I deliberately did not also strip the path from `LiteLLMRoutes.openai_routes` the way #26082 does. That list is append-deduped by path (pass_through_endpoints.py:2698, 2737) so it does not grow unboundedly, and on a reload the path is still owned by the live endpoint that was just re-registered under a new id earlier in the same cycle, so removing it would drop a path the live endpoint still needs.

### Tests

Added `TestStaleRouteCleanupOnReload` to the mapped test file. The core test drives the real `initialize_pass_through_endpoints` across 25 reload cycles with an id-less endpoint and asserts the registry stays at 2 entries; with the old `remove_endpoint_routes` call it holds 50, so it fails on unfixed code (confirmed by stashing the production change). A second test asserts a departed endpoint is dropped on the next reload, and a third asserts the live route stays resolvable after repeated reloads.

## Screenshots / Proof of Fix

The registry size has no HTTP surface, so the leak metric comes from driving the exact reload function the 30s scheduler calls (`initialize_pass_through_endpoints`) with one id-less endpoint and printing `len(_registered_pass_through_routes)`.

Before (production fix reverted):

```
  after  1 reload cycle(s): _registered_pass_through_routes size = 2
  after  5 reload cycle(s): _registered_pass_through_routes size = 10
  after 10 reload cycle(s): _registered_pass_through_routes size = 20
  after 20 reload cycle(s): _registered_pass_through_routes size = 40
```

After (with the fix):

```
  after  1 reload cycle(s): _registered_pass_through_routes size = 2
  after  5 reload cycle(s): _registered_pass_through_routes size = 2
  after 10 reload cycle(s): _registered_pass_through_routes size = 2
  after 20 reload cycle(s): _registered_pass_through_routes size = 2
```

Live proxy on the fixed code, with two id-less pass-through endpoints in config (`/github-zen` and `/anthropic-passthrough`, `include_subpath: true`) and `store_model_in_db: true` so the 30s reload loop runs against real Postgres.

The reload loop fires every 30s and re-registers the endpoints (the leaky code path):

```
$ grep "adding exact pass through endpoint: /github-zen" litellm.log | grep -oE "^[0-9:]{8}" | sort -u
17:41:36
17:42:06
17:42:36
```

The id-less pass-through forwards real upstream traffic at startup and stays working across reload cycles:

```
$ curl -s http://127.0.0.1:4013/github-zen
Mind your words, they are important.

$ curl -s http://127.0.0.1:4013/github-zen        # after 2+ reload cycles
Accessible for all.
```

The id-less pass-through forwards a real Anthropic request (real provider, real cost):

```
$ curl -s -X POST http://127.0.0.1:4013/anthropic-passthrough/v1/messages \
    -H "content-type: application/json" -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -d '{"model":"claude-haiku-4-5-20251001","max_tokens":40,"messages":[{"role":"user","content":"Reply with exactly: passthrough works"}]}'
{"model":"claude-haiku-4-5-20251001", ... ,"content":[{"type":"text","text":"passthrough works"}], ... }
```
