### PR TITLE
fix: resolve reasoning_effort capability via base_model for Azure GPT-5

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -19,9 +19,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
     GPT5_SERIES_ROUTE = "gpt5_series/"
 
     @classmethod
-    def _supports_reasoning_effort_level(
-        cls, model: str, level: str, base_model: Optional[str] = None
-    ) -> bool:
+    def _supports_reasoning_effort_level(cls, model: str, level: str, base_model: Optional[str] = None) -> bool:
         """Override to handle gpt5_series/ prefix used for Azure routing.
 
         The parent class calls ``_supports_factory(model, custom_llm_provider=None)``
@@ -33,9 +31,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             model = "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
         elif not model.startswith("azure/"):
             model = "azure/" + model
-        return super()._supports_reasoning_effort_level(
-            model, level, base_model=base_model
-        )
+        return super()._supports_reasoning_effort_level(model, level, base_model=base_model)
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
@@ -103,9 +99,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
 
         # gpt-5.1/5.2/5.4 support reasoning_effort='none', but other gpt-5 models don't
         # See: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
-        supports_none = self._supports_reasoning_effort_level(
-            model, "none", base_model=base_model
-        )
+        supports_none = self._supports_reasoning_effort_level(model, "none", base_model=base_model)
 
         if effective_effort == "none" and not supports_none:
             if litellm.drop_params is True or (drop_params is not None and drop_params is True):

--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -1,6 +1,6 @@
 """Support for Azure OpenAI gpt-5 model family."""
 
-from typing import List
+from typing import List, Optional
 
 import litellm
 from litellm.exceptions import UnsupportedParamsError
@@ -19,7 +19,9 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
     GPT5_SERIES_ROUTE = "gpt5_series/"
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str) -> bool:
+    def _supports_reasoning_effort_level(
+        cls, model: str, level: str, base_model: Optional[str] = None
+    ) -> bool:
         """Override to handle gpt5_series/ prefix used for Azure routing.
 
         The parent class calls ``_supports_factory(model, custom_llm_provider=None)``
@@ -31,7 +33,9 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             model = "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
         elif not model.startswith("azure/"):
             model = "azure/" + model
-        return super()._supports_reasoning_effort_level(model, level)
+        return super()._supports_reasoning_effort_level(
+            model, level, base_model=base_model
+        )
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
@@ -92,13 +96,16 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         model: str,
         drop_params: bool,
         api_version: str = "",
+        base_model: Optional[str] = None,
     ) -> dict:
         reasoning_effort_value = non_default_params.get("reasoning_effort") or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(reasoning_effort_value)
 
         # gpt-5.1/5.2/5.4 support reasoning_effort='none', but other gpt-5 models don't
         # See: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
-        supports_none = self._supports_reasoning_effort_level(model, "none")
+        supports_none = self._supports_reasoning_effort_level(
+            model, "none", base_model=base_model
+        )
 
         if effective_effort == "none" and not supports_none:
             if litellm.drop_params is True or (drop_params is not None and drop_params is True):

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -115,9 +115,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
-    def _supports_reasoning_effort_level(
-        cls, model: str, level: str, base_model: Optional[str] = None
-    ) -> bool:
+    def _supports_reasoning_effort_level(cls, model: str, level: str, base_model: Optional[str] = None) -> bool:
         """Check if the model supports a specific reasoning_effort level.
 
         Looks up ``supports_{level}_reasoning_effort`` in the model map via

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -115,7 +115,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str) -> bool:
+    def _supports_reasoning_effort_level(
+        cls, model: str, level: str, base_model: Optional[str] = None
+    ) -> bool:
         """Check if the model supports a specific reasoning_effort level.
 
         Looks up ``supports_{level}_reasoning_effort`` in the model map via
@@ -126,6 +128,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             model=model,
             custom_llm_provider=None,
             key=f"supports_{level}_reasoning_effort",
+            base_model=base_model,
         )
 
     @classmethod

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2329,13 +2329,21 @@ def _supports_provider_info_factory(
     return None
 
 
-def _supports_factory(model: str, custom_llm_provider: Optional[str], key: str) -> bool:
+def _supports_factory(
+    model: str,
+    custom_llm_provider: Optional[str],
+    key: str,
+    base_model: Optional[str] = None,
+) -> bool:
     """
     Check if the given model supports function calling and return a boolean value.
 
     Parameters:
     model (str): The model name to be checked.
     custom_llm_provider (Optional[str]): The provider to be checked.
+    base_model (Optional[str]): If set, used as a fallback when the model
+        string itself is not found in the registry (e.g. custom Azure
+        deployment names).
 
     Returns:
     bool: True if the model supports function calling, False otherwise.

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2429,19 +2429,6 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: Optional[st
                 bare_entry = litellm.model_cost.get(bare_model_key) or {}
                 if bare_entry.get(key) is False:
                     return True
-        # GH#31243: when model is a custom deployment name (e.g.
-        # azure/gpt-5.1_2025-11-13_global) that is not a registry key,
-        # try the configured base_model as a fallback.
-        if base_model is not None and base_model != model:
-            try:
-                _m, _p, _, _ = litellm.get_llm_provider(
-                    model=base_model, custom_llm_provider=custom_llm_provider
-                )
-                _info = _get_model_info_helper(model=_m, custom_llm_provider=_p)
-                if _info.get(key, False) is True:
-                    return True
-            except Exception:
-                pass
 
         return False
     except Exception as e:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2379,15 +2379,12 @@ def _supports_factory(
         # azure/gpt-5.1_2025-11-13_global) that is not a registry key,
         # try the configured base_model as a fallback.
         if base_model is not None and base_model != model:
-            try:
-                _m, _p, _, _ = litellm.get_llm_provider(
-                    model=base_model, custom_llm_provider=custom_llm_provider
-                )
-                _info = _get_model_info_helper(model=_m, custom_llm_provider=_p)
-                if _info.get(key, False) is True:
-                    return True
-            except Exception:
-                pass
+            _m, _p, _, _ = litellm.get_llm_provider(
+                model=base_model, custom_llm_provider=custom_llm_provider
+            )
+            _info = _get_model_info_helper(model=_m, custom_llm_provider=_p)
+            if _info.get(key, False) is True:
+                return True
 
         return False
     except Exception as e:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2367,6 +2367,20 @@ def _supports_factory(model: str, custom_llm_provider: Optional[str], key: str) 
             if supported_by_provider is not None:
                 return supported_by_provider
 
+        # GH#31243: when model is a custom deployment name (e.g.
+        # azure/gpt-5.1_2025-11-13_global) that is not a registry key,
+        # try the configured base_model as a fallback.
+        if base_model is not None and base_model != model:
+            try:
+                _m, _p, _, _ = litellm.get_llm_provider(
+                    model=base_model, custom_llm_provider=custom_llm_provider
+                )
+                _info = _get_model_info_helper(model=_m, custom_llm_provider=_p)
+                if _info.get(key, False) is True:
+                    return True
+            except Exception:
+                pass
+
         return False
     except Exception as e:
         verbose_logger.debug(
@@ -2407,6 +2421,20 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: Optional[st
                 bare_entry = litellm.model_cost.get(bare_model_key) or {}
                 if bare_entry.get(key) is False:
                     return True
+        # GH#31243: when model is a custom deployment name (e.g.
+        # azure/gpt-5.1_2025-11-13_global) that is not a registry key,
+        # try the configured base_model as a fallback.
+        if base_model is not None and base_model != model:
+            try:
+                _m, _p, _, _ = litellm.get_llm_provider(
+                    model=base_model, custom_llm_provider=custom_llm_provider
+                )
+                _info = _get_model_info_helper(model=_m, custom_llm_provider=_p)
+                if _info.get(key, False) is True:
+                    return True
+            except Exception:
+                pass
+
         return False
     except Exception as e:
         verbose_logger.debug(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5479,6 +5479,7 @@
         "supports_vision": true
     },
     "azure/gpt-5.2": {
+        "supports_none_reasoning_effort": true,
         "cache_read_input_token_cost": 1.75e-07,
         "input_cost_per_token": 1.75e-06,
         "litellm_provider": "azure",
@@ -5772,6 +5773,7 @@
         "supports_web_search": true
     },
     "azure/gpt-5.4": {
+        "supports_none_reasoning_effort": true,
         "cache_read_input_token_cost": 2.5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 5e-07,
         "cache_read_input_token_cost_priority": 5e-07,
@@ -6709,6 +6711,7 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.5-2026-04-23": {
+        "supports_none_reasoning_effort": true,
         "cache_read_input_token_cost": 5e-07,
         "cache_read_input_token_cost_above_272k_tokens": 1e-06,
         "cache_read_input_token_cost_priority": 1e-06,
@@ -6903,6 +6906,7 @@
         "supports_web_search": true
     },
     "azure/gpt-5.4-mini": {
+        "supports_none_reasoning_effort": true,
         "cache_read_input_token_cost": 7.5e-08,
         "input_cost_per_token": 7.5e-07,
         "litellm_provider": "azure",

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -299,3 +299,27 @@ def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
     supported_params = config.get_supported_openai_params(model="gpt-5.1")
     assert "logprobs" not in supported_params
     assert "top_logprobs" not in supported_params
+
+
+def test_supports_none_reasoning_effort_via_base_model():
+    """GH#31243: capability check should fall back to base_model when
+    the deployment model name is not a registry key."""
+    from unittest.mock import patch
+
+    from litellm.utils import _supports_factory
+
+    with patch(
+        "litellm.utils._get_model_info_helper",
+        side_effect=lambda model, custom_llm_provider: (
+            {"supports_none_reasoning_effort": True}
+            if model == "gpt-5.1" and custom_llm_provider == "azure"
+            else {}
+        ),
+    ):
+        result = _supports_factory(
+            model="azure/gpt-5.1_2025-11-13_global",
+            custom_llm_provider="azure",
+            key="supports_none_reasoning_effort",
+            base_model="azure/gpt-5.1",
+        )
+        assert result is True


### PR DESCRIPTION
Fixes #31243

When an Azure GPT-5 deployment uses a custom model name (e.g.
azure/gpt-5.1_2025-11-13_global) with base_model set to the
canonical model, the capability check for
supports_none_reasoning_effort now falls back to base_model
if the deployment string is not a registry key.

Changes:
- _supports_factory accepts optional base_model parameter
- _supports_reasoning_effort_level passes base_model through
- AzureOpenAIGPT5Config.map_openai_params accepts and passes base_model
- get_optional_params passes base_model to map_openai_params