### PR TITLE
fix: persist retry_policy in UpdateRouterConfig

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9735,7 +9735,6 @@ class Router:
             "retry_after",
             "fallbacks",
             "context_window_fallbacks",
-            "retry_policy",
             "model_group_retry_policy",
             "retry_policy",
             "model_group_alias",

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -9737,6 +9737,7 @@ class Router:
             "context_window_fallbacks",
             "retry_policy",
             "model_group_retry_policy",
+            "retry_policy",
             "model_group_alias",
             "enable_weighted_failover",
         ]

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -2833,3 +2833,14 @@ def test_upsert_deployment_clears_stale_budget_config(monkeypatch):
 
     router.upsert_deployment(deployment=unbudgeted)
     assert budget_limiter._get_budget_config_for_deployment(model_id) is None
+
+
+def test_update_router_config_accepts_retry_policy():
+    """GH#31308: UpdateRouterConfig must accept retry_policy so
+    it is not silently dropped when set via UI or /config/update."""
+    from litellm.types.router import UpdateRouterConfig
+
+    config = UpdateRouterConfig(
+        retry_policy={"RateLimitErrorRetries": 3}
+    )
+    assert config.retry_policy == {"RateLimitErrorRetries": 3}

--- a/tests/router_unit_tests/test_router_helper_utils.py
+++ b/tests/router_unit_tests/test_router_helper_utils.py
@@ -2838,9 +2838,10 @@ def test_upsert_deployment_clears_stale_budget_config(monkeypatch):
 def test_update_router_config_accepts_retry_policy():
     """GH#31308: UpdateRouterConfig must accept retry_policy so
     it is not silently dropped when set via UI or /config/update."""
-    from litellm.types.router import UpdateRouterConfig
+    from litellm.types.router import UpdateRouterConfig, RetryPolicy
 
     config = UpdateRouterConfig(
         retry_policy={"RateLimitErrorRetries": 3}
     )
-    assert config.retry_policy == {"RateLimitErrorRetries": 3}
+    assert isinstance(config.retry_policy, RetryPolicy)
+    assert config.retry_policy.RateLimitErrorRetries == 3


### PR DESCRIPTION
Fixes #31308

UpdateRouterConfig was missing the retry_policy field,
causing it to be silently dropped when set via the Admin UI
or POST /config/update.