### PR TITLE
feat(aiml): add openai/gpt-image-2 image model

### DIFF
--- a/litellm/llms/aiml/image_generation/transformation.py
+++ b/litellm/llms/aiml/image_generation/transformation.py
@@ -37,9 +37,7 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         """
         return model.startswith(OPENAI_STYLE_IMAGE_MODEL_PREFIXES)
 
-    def get_supported_openai_params(
-        self, model: str
-    ) -> List[OpenAIImageGenerationOptionalParams]:
+    def get_supported_openai_params(self, model: str) -> List[OpenAIImageGenerationOptionalParams]:
         """
         https://api.aimlapi.com/v1/images/generations
         """
@@ -111,9 +109,7 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         """
         Get the complete url for the request
         """
-        complete_url: str = (
-            api_base or get_secret_str("AIML_API_BASE") or self.DEFAULT_BASE_URL
-        )
+        complete_url: str = api_base or get_secret_str("AIML_API_BASE") or self.DEFAULT_BASE_URL
 
         complete_url = complete_url.rstrip("/")
         # Strip /v1 suffix if present since IMAGE_GENERATION_ENDPOINT already includes v1
@@ -133,9 +129,7 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         api_base: Optional[str] = None,
     ) -> dict:
         final_api_key: Optional[str] = (
-            api_key
-            or get_secret_str("AIML_API_KEY")
-            or get_secret_str("AIMLAPI_KEY")  # Alternative name
+            api_key or get_secret_str("AIML_API_KEY") or get_secret_str("AIMLAPI_KEY")  # Alternative name
         )
         if not final_api_key:
             raise ValueError("AIML_API_KEY or AIMLAPI_KEY is not set")
@@ -160,12 +154,10 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         if self._is_openai_style_model(model):
             return {"model": model, "prompt": prompt, **optional_params}
 
-        aiml_image_generation_request_body: AimlImageGenerationRequestParams = (
-            AimlImageGenerationRequestParams(
-                prompt=prompt,
-                model=model,
-                **optional_params,
-            )
+        aiml_image_generation_request_body: AimlImageGenerationRequestParams = AimlImageGenerationRequestParams(
+            prompt=prompt,
+            model=model,
+            **optional_params,
         )
         return dict(aiml_image_generation_request_body)
 

--- a/litellm/llms/aiml/image_generation/transformation.py
+++ b/litellm/llms/aiml/image_generation/transformation.py
@@ -21,9 +21,21 @@ else:
     LiteLLMLoggingObj = Any
 
 
+OPENAI_STYLE_IMAGE_MODEL_PREFIXES: tuple[str, ...] = ("openai/",)
+
+
 class AimlImageGenerationConfig(BaseImageGenerationConfig):
     DEFAULT_BASE_URL: str = "https://api.aimlapi.com"
     IMAGE_GENERATION_ENDPOINT: str = "v1/images/generations"
+
+    @staticmethod
+    def _is_openai_style_model(model: str) -> bool:
+        """
+        OpenAI image models routed through AI/ML API (e.g. ``openai/gpt-image-2``)
+        use the upstream OpenAI request schema, not the flux-style schema used by
+        the rest of the AI/ML catalog.
+        """
+        return model.startswith(OPENAI_STYLE_IMAGE_MODEL_PREFIXES)
 
     def get_supported_openai_params(
         self, model: str
@@ -31,6 +43,17 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         """
         https://api.aimlapi.com/v1/images/generations
         """
+        if self._is_openai_style_model(model):
+            return [
+                "n",
+                "size",
+                "quality",
+                "response_format",
+                "output_format",
+                "background",
+                "moderation",
+                "output_compression",
+            ]
         return ["n", "response_format", "size"]
 
     def map_openai_params(
@@ -41,39 +64,38 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         drop_params: bool,
     ) -> dict:
         supported_params = self.get_supported_openai_params(model)
+        is_openai_style = self._is_openai_style_model(model)
 
         for k in non_default_params.keys():
-            if k not in optional_params.keys():
-                if k in supported_params:
-                    # Map OpenAI params to AI/ML params
-                    if k == "n":
-                        optional_params["num_images"] = non_default_params[k]
-                    elif k == "response_format":
-                        optional_params["output_format"] = non_default_params[k]
-                    elif k == "size":
-                        # Map OpenAI size format to AI/ML image_size
-                        size_value = non_default_params[k]
-                        if isinstance(size_value, str):
-                            # Handle standard OpenAI sizes like "1024x1024"
-                            if "x" in size_value:
-                                width, height = map(int, size_value.split("x"))
-                                optional_params["image_size"] = {
-                                    "width": width,
-                                    "height": height,
-                                }
-                            else:
-                                # Pass through predefined sizes
-                                optional_params["image_size"] = size_value
-                        else:
-                            optional_params["image_size"] = size_value
-                    else:
-                        optional_params[k] = non_default_params[k]
-                elif drop_params:
-                    pass
+            if k in optional_params.keys():
+                continue
+            if k not in supported_params:
+                if drop_params:
+                    continue
+                raise ValueError(
+                    f"Parameter {k} is not supported for model {model}. Supported parameters are {supported_params}. Set drop_params=True to drop unsupported parameters."
+                )
+
+            if is_openai_style:
+                optional_params[k] = non_default_params[k]
+                continue
+
+            if k == "n":
+                optional_params["num_images"] = non_default_params[k]
+            elif k == "response_format":
+                optional_params["output_format"] = non_default_params[k]
+            elif k == "size":
+                size_value = non_default_params[k]
+                if isinstance(size_value, str) and "x" in size_value:
+                    width, height = map(int, size_value.split("x"))
+                    optional_params["image_size"] = {
+                        "width": width,
+                        "height": height,
+                    }
                 else:
-                    raise ValueError(
-                        f"Parameter {k} is not supported for model {model}. Supported parameters are {supported_params}. Set drop_params=True to drop unsupported parameters."
-                    )
+                    optional_params["image_size"] = size_value
+            else:
+                optional_params[k] = non_default_params[k]
 
         return optional_params
 
@@ -131,10 +153,13 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         headers: dict,
     ) -> dict:
         """
-        Transform the image generation request to the AI/ML flux image generation request body
+        Transform the image generation request to the AI/ML image generation request body
 
         https://api.aimlapi.com/v1/images/generations
         """
+        if self._is_openai_style_model(model):
+            return {"model": model, "prompt": prompt, **optional_params}
+
         aiml_image_generation_request_body: AimlImageGenerationRequestParams = (
             AimlImageGenerationRequestParams(
                 prompt=prompt,

--- a/litellm/llms/aiml/image_generation/transformation.py
+++ b/litellm/llms/aiml/image_generation/transformation.py
@@ -37,7 +37,9 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         """
         return model.startswith(OPENAI_STYLE_IMAGE_MODEL_PREFIXES)
 
-    def get_supported_openai_params(self, model: str) -> List[OpenAIImageGenerationOptionalParams]:
+    def get_supported_openai_params(
+        self, model: str
+    ) -> List[OpenAIImageGenerationOptionalParams]:
         """
         https://api.aimlapi.com/v1/images/generations
         """
@@ -109,7 +111,9 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         """
         Get the complete url for the request
         """
-        complete_url: str = api_base or get_secret_str("AIML_API_BASE") or self.DEFAULT_BASE_URL
+        complete_url: str = (
+            api_base or get_secret_str("AIML_API_BASE") or self.DEFAULT_BASE_URL
+        )
 
         complete_url = complete_url.rstrip("/")
         # Strip /v1 suffix if present since IMAGE_GENERATION_ENDPOINT already includes v1
@@ -129,7 +133,9 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         api_base: Optional[str] = None,
     ) -> dict:
         final_api_key: Optional[str] = (
-            api_key or get_secret_str("AIML_API_KEY") or get_secret_str("AIMLAPI_KEY")  # Alternative name
+            api_key
+            or get_secret_str("AIML_API_KEY")
+            or get_secret_str("AIMLAPI_KEY")  # Alternative name
         )
         if not final_api_key:
             raise ValueError("AIML_API_KEY or AIMLAPI_KEY is not set")
@@ -154,10 +160,12 @@ class AimlImageGenerationConfig(BaseImageGenerationConfig):
         if self._is_openai_style_model(model):
             return {"model": model, "prompt": prompt, **optional_params}
 
-        aiml_image_generation_request_body: AimlImageGenerationRequestParams = AimlImageGenerationRequestParams(
-            prompt=prompt,
-            model=model,
-            **optional_params,
+        aiml_image_generation_request_body: AimlImageGenerationRequestParams = (
+            AimlImageGenerationRequestParams(
+                prompt=prompt,
+                model=model,
+                **optional_params,
+            )
         )
         return dict(aiml_image_generation_request_body)
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -276,7 +276,7 @@
     "aiml/openai/gpt-image-2": {
         "litellm_provider": "aiml",
         "metadata": {
-            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output"
+            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output. output_cost_per_image is AI/ML's published medium-quality rate; like the other aiml image entries it is billed as a flat per-image price"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.054,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -282,8 +282,7 @@
         "output_cost_per_image": 0.054,
         "source": "https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2",
         "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
+            "/v1/images/generations"
         ],
         "supports_vision": true
     },

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -273,6 +273,20 @@
             "/v1/images/generations"
         ]
     },
+    "aiml/openai/gpt-image-2": {
+        "litellm_provider": "aiml",
+        "metadata": {
+            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output"
+        },
+        "mode": "image_generation",
+        "output_cost_per_image": 0.054,
+        "source": "https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
     "amazon.nova-canvas-v1:0": {
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -276,7 +276,7 @@
     "aiml/openai/gpt-image-2": {
         "litellm_provider": "aiml",
         "metadata": {
-            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output"
+            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output. output_cost_per_image is AI/ML's published medium-quality rate; like the other aiml image entries it is billed as a flat per-image price"
         },
         "mode": "image_generation",
         "output_cost_per_image": 0.054,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -282,8 +282,7 @@
         "output_cost_per_image": 0.054,
         "source": "https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2",
         "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
+            "/v1/images/generations"
         ],
         "supports_vision": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -273,6 +273,20 @@
             "/v1/images/generations"
         ]
     },
+    "aiml/openai/gpt-image-2": {
+        "litellm_provider": "aiml",
+        "metadata": {
+            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output"
+        },
+        "mode": "image_generation",
+        "output_cost_per_image": 0.054,
+        "source": "https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2",
+        "supported_endpoints": [
+            "/v1/images/generations",
+            "/v1/images/edits"
+        ],
+        "supports_vision": true
+    },
     "amazon.nova-canvas-v1:0": {
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -387,6 +387,62 @@ async def test_aiml_image_generation_with_dynamic_api_key():
 
 
 @pytest.mark.asyncio
+async def test_aiml_openai_gpt_image_2_request_uses_openai_param_shape():
+    """End-to-end check that ``aiml/openai/gpt-image-2`` keeps the upstream
+    OpenAI request shape (``size``/``n``/``response_format``) instead of
+    being remapped to the AI/ML flux schema (``image_size``/``num_images``/
+    ``output_format``), and hits the correct upstream model name.
+    """
+    from unittest.mock import MagicMock, patch
+    import json as _json
+
+    mock_aiml_response = {
+        "created": 1703658209,
+        "data": [{"url": "https://example.com/gpt-image-2.png"}],
+    }
+
+    captured = {}
+
+    def capture_post_call(*args, **kwargs):
+        captured["url"] = kwargs.get("url") or (args[0] if args else None)
+        captured["headers"] = kwargs.get("headers", {})
+        captured["json"] = kwargs.get("json", {})
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = mock_aiml_response
+        mock_response.text = _json.dumps(mock_aiml_response)
+        return mock_response
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post") as mock_post:
+        mock_post.side_effect = capture_post_call
+
+        await litellm.aimage_generation(
+            prompt="A T-Rex relaxing on a beach",
+            model="aiml/openai/gpt-image-2",
+            api_key="test-key-mocked-no-credits-needed",
+            size="1024x1536",
+            quality="high",
+            response_format="b64_json",
+            n=1,
+        )
+
+    assert captured["url"] is not None
+    assert "api.aimlapi.com" in captured["url"]
+    assert "/v1/images/generations" in captured["url"]
+
+    body = captured["json"]
+    assert body["model"] == "openai/gpt-image-2"
+    assert body["prompt"] == "A T-Rex relaxing on a beach"
+    assert body["size"] == "1024x1536"
+    assert body["quality"] == "high"
+    assert body["response_format"] == "b64_json"
+    assert body["n"] == 1
+    assert "image_size" not in body
+    assert "num_images" not in body
+    assert "output_format" not in body
+
+
+@pytest.mark.asyncio
 async def test_azure_image_generation_request_body():
     """Azure deployment URL selects the model; JSON body omits ``model`` (#26316)."""
     from litellm import aimage_generation

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -8,7 +8,9 @@ import traceback
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
+sys.path.insert(
+    0, os.path.abspath("../..")
+)  # Adds the parent directory to the system path
 
 from dotenv import load_dotenv
 from openai.types.image import Image
@@ -209,7 +211,9 @@ class TestAimlImageGeneration(BaseImageGenTest):
                 custom_logger = TestCustomLogger()
                 litellm.logging_callback_manager._reset_all_callbacks()
                 litellm.callbacks = [custom_logger]
-                base_image_generation_call_args = self.get_base_image_generation_call_args()
+                base_image_generation_call_args = (
+                    self.get_base_image_generation_call_args()
+                )
                 litellm.set_verbose = True
                 # Pass dummy api_key so validate_environment passes; HTTP is mocked
                 response = await litellm.aimage_generation(
@@ -226,7 +230,9 @@ class TestAimlImageGeneration(BaseImageGenTest):
                 # print("response_cost", response._hidden_params["response_cost"])
 
                 logged_standard_logging_payload = custom_logger.standard_logging_payload
-                print("logged_standard_logging_payload", logged_standard_logging_payload)
+                print(
+                    "logged_standard_logging_payload", logged_standard_logging_payload
+                )
                 assert logged_standard_logging_payload is not None
                 assert logged_standard_logging_payload["response_cost"] is not None
                 assert logged_standard_logging_payload["response_cost"] > 0
@@ -241,7 +247,9 @@ class TestAimlImageGeneration(BaseImageGenTest):
                     response_dict["usage"] = dict(response_dict["usage"])
                 print("response usage=", response_dict.get("usage"))
 
-                assert response.data is not None  # type guard for iteration (base fails here if None)
+                assert (
+                    response.data is not None
+                )  # type guard for iteration (base fails here if None)
                 for d in response.data:
                     assert isinstance(d, Image)
                     print("data in response.data", d)

--- a/tests/image_gen_tests/test_image_generation.py
+++ b/tests/image_gen_tests/test_image_generation.py
@@ -8,9 +8,7 @@ import traceback
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
 
 from dotenv import load_dotenv
 from openai.types.image import Image
@@ -211,9 +209,7 @@ class TestAimlImageGeneration(BaseImageGenTest):
                 custom_logger = TestCustomLogger()
                 litellm.logging_callback_manager._reset_all_callbacks()
                 litellm.callbacks = [custom_logger]
-                base_image_generation_call_args = (
-                    self.get_base_image_generation_call_args()
-                )
+                base_image_generation_call_args = self.get_base_image_generation_call_args()
                 litellm.set_verbose = True
                 # Pass dummy api_key so validate_environment passes; HTTP is mocked
                 response = await litellm.aimage_generation(
@@ -230,9 +226,7 @@ class TestAimlImageGeneration(BaseImageGenTest):
                 # print("response_cost", response._hidden_params["response_cost"])
 
                 logged_standard_logging_payload = custom_logger.standard_logging_payload
-                print(
-                    "logged_standard_logging_payload", logged_standard_logging_payload
-                )
+                print("logged_standard_logging_payload", logged_standard_logging_payload)
                 assert logged_standard_logging_payload is not None
                 assert logged_standard_logging_payload["response_cost"] is not None
                 assert logged_standard_logging_payload["response_cost"] > 0
@@ -247,9 +241,7 @@ class TestAimlImageGeneration(BaseImageGenTest):
                     response_dict["usage"] = dict(response_dict["usage"])
                 print("response usage=", response_dict.get("usage"))
 
-                assert (
-                    response.data is not None
-                )  # type guard for iteration (base fails here if None)
+                assert response.data is not None  # type guard for iteration (base fails here if None)
                 for d in response.data:
                     assert isinstance(d, Image)
                     print("data in response.data", d)

--- a/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
+++ b/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
@@ -1,0 +1,147 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+import litellm
+
+litellm.model_cost = litellm.get_model_cost_map(url="")
+
+from litellm.llms.aiml.image_generation.cost_calculator import (
+    cost_calculator as aiml_cost_calculator,
+)
+from litellm.llms.aiml.image_generation.transformation import (
+    AimlImageGenerationConfig,
+)
+from litellm.types.utils import ImageObject, ImageResponse
+
+
+def test_openai_style_model_supports_full_openai_param_surface():
+    params = AimlImageGenerationConfig().get_supported_openai_params(
+        "openai/gpt-image-2"
+    )
+    assert {
+        "n",
+        "size",
+        "quality",
+        "response_format",
+        "output_format",
+        "background",
+        "moderation",
+        "output_compression",
+    } == set(params)
+
+
+def test_flux_style_model_keeps_legacy_param_surface():
+    assert AimlImageGenerationConfig().get_supported_openai_params("flux-pro/v1.1") == [
+        "n",
+        "response_format",
+        "size",
+    ]
+
+
+def test_openai_style_request_passes_params_through_unchanged():
+    """gpt-image-2 must receive OpenAI-shaped fields (size string, n, response_format) verbatim;
+    the flux-style remapping to ``num_images``/``image_size``/``output_format`` would break the upstream call.
+    """
+    config = AimlImageGenerationConfig()
+    mapped = config.map_openai_params(
+        non_default_params={
+            "n": 1,
+            "size": "1024x1536",
+            "quality": "high",
+            "response_format": "b64_json",
+            "output_format": "png",
+        },
+        optional_params={},
+        model="openai/gpt-image-2",
+        drop_params=False,
+    )
+
+    body = config.transform_image_generation_request(
+        model="openai/gpt-image-2",
+        prompt="A cute baby sea otter",
+        optional_params=mapped,
+        litellm_params={},
+        headers={},
+    )
+
+    assert body == {
+        "model": "openai/gpt-image-2",
+        "prompt": "A cute baby sea otter",
+        "n": 1,
+        "size": "1024x1536",
+        "quality": "high",
+        "response_format": "b64_json",
+        "output_format": "png",
+    }
+
+
+def test_flux_style_request_still_remaps_to_legacy_fields():
+    config = AimlImageGenerationConfig()
+    mapped = config.map_openai_params(
+        non_default_params={
+            "n": 2,
+            "size": "1024x1024",
+            "response_format": "png",
+        },
+        optional_params={},
+        model="flux-pro/v1.1",
+        drop_params=False,
+    )
+
+    body = config.transform_image_generation_request(
+        model="flux-pro/v1.1",
+        prompt="hello",
+        optional_params=mapped,
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["model"] == "flux-pro/v1.1"
+    assert body["prompt"] == "hello"
+    assert body["num_images"] == 2
+    assert body["image_size"] == {"width": 1024, "height": 1024}
+    assert body["output_format"] == "png"
+    assert "n" not in body
+    assert "size" not in body
+    assert "response_format" not in body
+
+
+def test_openai_style_unsupported_param_raises_without_drop_params():
+    with pytest.raises(ValueError):
+        AimlImageGenerationConfig().map_openai_params(
+            non_default_params={"image_size": {"width": 1024, "height": 1024}},
+            optional_params={},
+            model="openai/gpt-image-2",
+            drop_params=False,
+        )
+
+
+def test_openai_style_unsupported_param_dropped_with_drop_params():
+    mapped = AimlImageGenerationConfig().map_openai_params(
+        non_default_params={"image_size": {"width": 1024, "height": 1024}},
+        optional_params={},
+        model="openai/gpt-image-2",
+        drop_params=True,
+    )
+    assert mapped == {}
+
+
+def test_cost_calculator_uses_aiml_pricing_for_gpt_image_2():
+    """Regression: pricing must come from the ``aiml/openai/gpt-image-2`` entry,
+    not the upstream OpenAI token-based entry.
+    """
+    response = ImageResponse(
+        data=[
+            ImageObject(b64_json=None, url="https://example.com/1.png"),
+            ImageObject(b64_json=None, url="https://example.com/2.png"),
+        ]
+    )
+    assert aiml_cost_calculator(
+        model="openai/gpt-image-2", image_response=response
+    ) == pytest.approx(0.054 * 2)

--- a/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
+++ b/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
@@ -21,7 +21,9 @@ from litellm.types.utils import ImageObject, ImageResponse
 
 
 def test_openai_style_model_supports_full_openai_param_surface():
-    params = AimlImageGenerationConfig().get_supported_openai_params("openai/gpt-image-2")
+    params = AimlImageGenerationConfig().get_supported_openai_params(
+        "openai/gpt-image-2"
+    )
     assert {
         "n",
         "size",
@@ -140,4 +142,6 @@ def test_cost_calculator_uses_aiml_pricing_for_gpt_image_2():
             ImageObject(b64_json=None, url="https://example.com/2.png"),
         ]
     )
-    assert aiml_cost_calculator(model="openai/gpt-image-2", image_response=response) == pytest.approx(0.054 * 2)
+    assert aiml_cost_calculator(
+        model="openai/gpt-image-2", image_response=response
+    ) == pytest.approx(0.054 * 2)

--- a/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
+++ b/tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py
@@ -21,9 +21,7 @@ from litellm.types.utils import ImageObject, ImageResponse
 
 
 def test_openai_style_model_supports_full_openai_param_surface():
-    params = AimlImageGenerationConfig().get_supported_openai_params(
-        "openai/gpt-image-2"
-    )
+    params = AimlImageGenerationConfig().get_supported_openai_params("openai/gpt-image-2")
     assert {
         "n",
         "size",
@@ -142,6 +140,4 @@ def test_cost_calculator_uses_aiml_pricing_for_gpt_image_2():
             ImageObject(b64_json=None, url="https://example.com/2.png"),
         ]
     )
-    assert aiml_cost_calculator(
-        model="openai/gpt-image-2", image_response=response
-    ) == pytest.approx(0.054 * 2)
+    assert aiml_cost_calculator(model="openai/gpt-image-2", image_response=response) == pytest.approx(0.054 * 2)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

## Linear ticket

Resolves LIT-3777

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit` (for the new + adjacent AIML image-gen suites)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

New Feature

## Changes

Adds the `aiml/openai/gpt-image-2` model and fixes the AI/ML API image generation transformer so OpenAI-style image models go through the correct upstream schema.

Two things were needed to make `aiml/openai/gpt-image-2` work end to end:

1. A cost-map entry (`aiml/openai/gpt-image-2`) with `mode=image_generation` so `get_model_info` resolves the model under the AI/ML provider and the existing `aiml_image_cost_calculator` finds an `output_cost_per_image`. The flat per-image rate of $0.054 matches the price AI/ML quotes in the public docs example for the default medium-quality 1536x1024 generation (https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2)

2. A model-aware request transformation in `AimlImageGenerationConfig`. The existing transformer was written for the flux/Imagen request schema and unconditionally remaps `n -> num_images`, `size -> image_size{width, height}`, and (incorrectly) `response_format -> output_format`. The `openai/gpt-image-2` endpoint on `api.aimlapi.com` instead expects the OpenAI shape (`n`, `size: "1024x1024"`, separate `response_format` for `url`/`b64_json` and `output_format` for `png`/`jpeg`/`webp`). Models whose name starts with `openai/` now pass their OpenAI-shaped params through unchanged; everything else keeps the existing flux-style remapping

Tests:

- `tests/test_litellm/llms/aiml/image_generation/test_aiml_image_generation_transformation.py` covers both branches of the new routing (param surface, request body, drop-params behavior) and locks in the `$0.054` per-image cost for `aiml/openai/gpt-image-2`
- `tests/image_gen_tests/test_image_generation.py::test_aiml_openai_gpt_image_2_request_uses_openai_param_shape` is an end-to-end check through `litellm.aimage_generation` that confirms the upstream POST body keeps `size`/`n`/`response_format` (and never grows `image_size`/`num_images`/`output_format`) and that the model identifier sent to AI/ML is `openai/gpt-image-2`

## Screenshots / Proof of Fix

To reproduce against a live proxy:

```
export AIML_API_KEY=...
export LITELLM_LOCAL_MODEL_COST_MAP=True
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

`LITELLM_LOCAL_MODEL_COST_MAP=True` is required until this PR merges. By default litellm pulls the cost map from `main` on GitHub, which does not carry the `aiml/openai/gpt-image-2` entry yet, so the spend logs as `$0.00`; forcing the bundled local map lets the new `$0.054` rate resolve

```
curl -sS http://localhost:4000/v1/images/generations \
  -H 'Content-Type: application/json' \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{
    "model": "aiml/openai/gpt-image-2",
    "prompt": "A T-Rex relaxing on a beach, lying on a sun lounger and wearing sunglasses.",
    "size": "1536x1024",
    "quality": "medium",
    "n": 1
  }'
```

This returns a `data[0].url` pointing at `cdn.aimlapi.com/...`, the upstream POST body to `api.aimlapi.com` stays OpenAI-shaped (`{"model": "openai/gpt-image-2", "n": 1, "quality": "medium", "size": "1536x1024"}`, never growing `num_images`/`image_size`/`output_format`), and `litellm.log` records a spend entry of `$0.054`

![aiml/openai/gpt-image-2 sample output](https://cdn.aimlapi.com/generations/openai-image-generation/1782429365899-985fd951-f65a-47ac-834b-787950a4746d.png)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [LIT-3777](https://linear.app/litellm-ai/issue/LIT-3777/add-gpt-image-2-model-to-aiml-api-provider)

<div><a href="https://cursor.com/agents/bc-4c6ad54e-3863-4bd2-bf8e-5a29ad8a5b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c6ad54e-3863-4bd2-bf8e-5a29ad8a5b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


