### PR TITLE
feat(proxy): add Melious OpenAI-like provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -880,6 +880,7 @@ openai_compatible_providers: List = [
     "docker_model_runner",
     "ragflow",
     "pinstripes",  # Pinstripes - JSON-configured provider
+    "melious",  # Melious - JSON-configured provider
     "darkbloom",
 ]
 openai_text_completion_compatible_providers: List = (

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -159,6 +159,17 @@
       "max_completion_tokens": "max_tokens"
     }
   },
+  "melious": {
+    "base_url": "https://api.melious.ai/v1",
+    "api_key_env": "MELIOUS_API_KEY",
+    "api_base_env": "MELIOUS_API_BASE",
+    "supported_endpoints": [
+      "/v1/chat/completions",
+      "/v1/embeddings",
+      "/v1/images/generations",
+      "/v1/audio/transcriptions"
+    ]
+  },
   "empiriolabs": {
     "base_url": "https://api.empiriolabs.ai/v1",
     "api_key_env": "EMPIRIOLABS_API_KEY",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -168,6 +168,7 @@
     },
     "supported_endpoints": [
       "/v1/chat/completions",
+      "/v1/messages",
       "/v1/embeddings",
       "/v1/images/generations",
       "/v1/audio/transcriptions"

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -163,6 +163,9 @@
     "base_url": "https://api.melious.ai/v1",
     "api_key_env": "MELIOUS_API_KEY",
     "api_base_env": "MELIOUS_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
     "supported_endpoints": [
       "/v1/chat/completions",
       "/v1/embeddings",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1395,6 +1395,23 @@
         "interactions": true
       }
     },
+    "melious": {
+      "display_name": "Melious (`melious`)",
+      "url": "https://docs.litellm.ai/docs/providers/melious",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": false,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": true,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "mistral": {
       "display_name": "Mistral AI API (`mistral`)",
       "url": "https://docs.litellm.ai/docs/providers/mistral",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3480,6 +3480,7 @@ class LlmProviders(str, Enum):
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"
     LIBERTAI = "libertai"
+    MELIOUS = "melious"
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
     LITELLM_AGENT = "litellm_agent"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1500,6 +1500,23 @@
         "interactions": true
       }
     },
+    "melious": {
+      "display_name": "Melious (`melious`)",
+      "url": "https://docs.litellm.ai/docs/providers/melious",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": false,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": true,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "mistral": {
       "display_name": "Mistral AI API (`mistral`)",
       "url": "https://docs.litellm.ai/docs/providers/mistral",


### PR DESCRIPTION
# Relevant issues
No issue opened but I want to add Melious as a new openai-like provider. Melious offers European AI model inference similar to OpenRouter.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests --> not applicable for openai-like
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

(https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:


## Type

🆕 New Feature


## Changes

Added Melious to the providers as a new openai-like provider. 