### PR TITLE
fix(mcp): use stored per-user OAuth token on tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3676,12 +3676,15 @@ class MCPServerManager:
         oauth2_headers: Optional[Dict[str, str]],
         user_api_key_auth: Optional[UserAPIKeyAuth],
     ) -> Optional[Dict[str, str]]:
-        """Look up per-user OAuth headers when the client did not supply a token."""
-        if (
-            not mcp_server.needs_user_oauth_token
-            or oauth2_headers
-            or user_api_key_auth is None
-        ):
+        """Prefer the user's stored per-user OAuth token over the caller's Authorization.
+
+        On the standard auth path the caller's ``Authorization`` is the LiteLLM
+        admission key, not the upstream OAuth token, so forwarding it upstream
+        produces a 401. The stored token must win whenever it exists; the caller
+        header is only a fallback for the passthrough cold-start where the bearer
+        genuinely is the upstream token. Mirrors the list_tools path.
+        """
+        if not mcp_server.needs_user_oauth_token or user_api_key_auth is None:
             return oauth2_headers
 
         user_id = getattr(user_api_key_auth, "user_id", None)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -2970,14 +2970,17 @@ class TestMCPServerManager:
             object_permission_id="perm_no_mcp",
         )
 
-        with patch.object(
-            manager, "get_allow_all_keys_server_ids", return_value=["global-server"]
-        ), patch.object(
-            MCPRequestHandler,
-            "get_allowed_mcp_servers",
-            new_callable=AsyncMock,
-            return_value=["leaked-server"],
-        ) as mock_inner:
+        with (
+            patch.object(
+                manager, "get_allow_all_keys_server_ids", return_value=["global-server"]
+            ),
+            patch.object(
+                MCPRequestHandler,
+                "get_allowed_mcp_servers",
+                new_callable=AsyncMock,
+                return_value=["leaked-server"],
+            ) as mock_inner,
+        ):
             result = await manager.get_allowed_mcp_servers(user_api_key_auth)
 
         assert result == []
@@ -4734,6 +4737,92 @@ class TestCreateMcpClientV2Graft:
 
         assert isinstance(client._resolved_auth, NoOpAuth)
         assert client._get_auth_headers()["Authorization"] == "Bearer hook-jwt"
+
+
+class TestResolveOauth2HeadersForToolCall:
+    """The call_tool path must inject the user's stored OAuth token, not the
+    caller's Authorization header (which is the LiteLLM admission key on the
+    standard auth path and produces an upstream 401 if forwarded)."""
+
+    def _oauth_server(self) -> MCPServer:
+        return MCPServer(
+            server_id="oauth-server",
+            name="oauth-server",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stored_token_overrides_caller_authorization(self):
+        """Regression: with an Authorization header present (the LiteLLM key),
+        the stored per-user OAuth token must still be looked up and win."""
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        manager = MCPServerManager()
+        caller_headers = {"Authorization": "Bearer sk-litellm-admission-key"}
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server._get_user_oauth_extra_headers_from_db",
+            new=AsyncMock(
+                return_value={"Authorization": "Bearer upstream-oauth-token"}
+            ),
+        ):
+            resolved = await manager._resolve_oauth2_headers_for_tool_call(
+                mcp_server=self._oauth_server(),
+                oauth2_headers=caller_headers,
+                user_api_key_auth=UserAPIKeyAuth(user_id="user-1"),
+            )
+
+        assert resolved == {"Authorization": "Bearer upstream-oauth-token"}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_caller_headers_when_no_stored_token(self):
+        """Passthrough cold-start: no stored token, so the caller's bearer (the
+        upstream token) is preserved."""
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        manager = MCPServerManager()
+        caller_headers = {"Authorization": "Bearer upstream-passthrough-token"}
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server._get_user_oauth_extra_headers_from_db",
+            new=AsyncMock(return_value=None),
+        ):
+            resolved = await manager._resolve_oauth2_headers_for_tool_call(
+                mcp_server=self._oauth_server(),
+                oauth2_headers=caller_headers,
+                user_api_key_auth=UserAPIKeyAuth(user_id="user-1"),
+            )
+
+        assert resolved == caller_headers
+
+    @pytest.mark.asyncio
+    async def test_non_oauth_server_returns_caller_headers_unchanged(self):
+        """Non per-user-OAuth servers must not trigger a DB lookup."""
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        manager = MCPServerManager()
+        server = MCPServer(
+            server_id="bearer-server",
+            name="bearer-server",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.authorization,
+        )
+        caller_headers = {"Authorization": "Bearer something"}
+
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server._get_user_oauth_extra_headers_from_db",
+            new=AsyncMock(side_effect=AssertionError("DB lookup must not run")),
+        ):
+            resolved = await manager._resolve_oauth2_headers_for_tool_call(
+                mcp_server=server,
+                oauth2_headers=caller_headers,
+                user_api_key_auth=UserAPIKeyAuth(user_id="user-1"),
+            )
+
+        assert resolved == caller_headers
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

Relates to #31222 (per-user MCP OAuth credential management).
Companion PR: #31327 — persist per-user OAuth `client_id` so tokens auto-refresh.

## Type

🐛 Bug Fix

## Changes

`call_tool` resolved the per-user OAuth token only when the caller sent **no** `Authorization` header. On the standard auth path the caller's `Authorization` is always the LiteLLM admission key, so the stored-token lookup was skipped and the proxy key was forwarded upstream — every per-user OAuth MCP **tool call** returned `401`, while `list_tools` (which already prefers the stored token) kept working.

`_resolve_oauth2_headers_for_tool_call` now prefers the user's stored per-user OAuth token whenever one exists, and falls back to the caller's `Authorization` only for the passthrough cold-start (where the bearer genuinely is the upstream token). This mirrors the `list_tools` path.

### Tests

Adds `TestResolveOauth2HeadersForToolCall`:
- stored token overrides the caller's `Authorization` (the regression)
- fallback to caller header when no stored token (passthrough cold-start)
- non-OAuth servers don't trigger a DB lookup

```
uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py::TestResolveOauth2HeadersForToolCall
# 3 passed
```

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
