### PR TITLE
fix(mcp): persist per-user OAuth client_id so tokens auto-refresh

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -951,6 +951,7 @@ async def store_user_oauth_credential(
     refresh_token: Optional[str] = None,
     expires_in: Optional[int] = None,
     scopes: Optional[List[str]] = None,
+    client_id: Optional[str] = None,
     skip_byok_guard: bool = False,
 ) -> None:
     """Persist an OAuth2 access token for a user+server pair.
@@ -958,6 +959,10 @@ async def store_user_oauth_credential(
     The payload is JSON-serialised and stored encrypted in the same
     ``credential_b64`` column used by BYOK.  A ``"type": "oauth2"`` key
     differentiates it from plain BYOK API keys.
+
+    ``client_id`` is persisted for servers that mint a per-user OAuth client via
+    dynamic client registration: that id has no static home on the server and is
+    required to refresh the token later.
     """
 
     expires_at: Optional[str] = None
@@ -977,6 +982,8 @@ async def store_user_oauth_credential(
         payload["expires_at"] = expires_at
     if scopes:
         payload["scopes"] = scopes
+    if client_id:
+        payload["client_id"] = client_id
 
     # Guard against silently overwriting a BYOK credential with an OAuth token.
     # Skip the guard when the caller knows the row is already an OAuth2 credential
@@ -1087,8 +1094,15 @@ async def refresh_user_oauth_token(
     refresh_token: Optional[str] = cred.get("refresh_token")
     token_url: Optional[str] = getattr(server, "token_url", None)
     server_id: str = getattr(server, "server_id", "")
-    client_id: Optional[str] = getattr(server, "client_id", None)
-    client_secret: Optional[str] = getattr(server, "client_secret", None)
+    # Prefer the per-user client_id stored at connect time (dynamic client
+    # registration mints one that has no static home on the server), falling
+    # back to the server config for statically-configured OAuth clients.
+    client_id: Optional[str] = cred.get("client_id") or getattr(
+        server, "client_id", None
+    )
+    client_secret: Optional[str] = cred.get("client_secret") or getattr(
+        server, "client_secret", None
+    )
 
     if not refresh_token:
         verbose_proxy_logger.debug(
@@ -1166,6 +1180,7 @@ async def refresh_user_oauth_token(
         refresh_token=new_refresh_token,
         expires_in=expires_in,
         scopes=scopes,
+        client_id=cred.get("client_id"),
         skip_byok_guard=True,  # Row is already OAuth2; skip the extra find_unique check
     )
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -270,6 +270,7 @@ async def _store_per_user_token_server_side(
     server: MCPServer,
     user_id: str,
     token_response: Dict[str, Any],
+    client_id: Optional[str] = None,
 ) -> None:
     """Persist the OAuth token server-side and warm the Redis cache.
 
@@ -317,6 +318,7 @@ async def _store_per_user_token_server_side(
             refresh_token=refresh_token,
             expires_in=expires_in,
             scopes=scopes,
+            client_id=client_id,
         )
         verbose_logger.info(
             "_store_per_user_token_server_side: stored token for user=%s server=%s",
@@ -491,6 +493,7 @@ async def exchange_token_with_server(
                     server=mcp_server,
                     user_id=user_id,
                     token_response=token_response,
+                    client_id=resolved_client_id,
                 )
             except Exception as exc:
                 verbose_logger.warning(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1424,6 +1424,7 @@ class MCPOAuthUserCredentialRequest(LiteLLMPydanticObjectBase):
     refresh_token: Optional[str] = None
     expires_in: Optional[int] = None  # seconds until expiry
     scopes: Optional[List[str]] = None
+    client_id: Optional[str] = None  # per-user id from dynamic client registration
 
 
 class MCPOAuthUserCredentialStatus(LiteLLMPydanticObjectBase):
@@ -1434,6 +1435,7 @@ class MCPOAuthUserCredentialStatus(LiteLLMPydanticObjectBase):
     expires_at: Optional[str] = None  # ISO-8601
     is_expired: bool = False
     connected_at: Optional[str] = None  # ISO-8601
+    has_refresh_token: bool = False
 
 
 class MCPUserCredentialListItem(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2024,6 +2024,7 @@ if MCP_AVAILABLE:
             refresh_token=payload.refresh_token,
             expires_in=payload.expires_in,
             scopes=payload.scopes,
+            client_id=payload.client_id,
         )
         # Read back the persisted record so the response reflects the stored
         # expires_at rather than recomputing it here (which could diverge by
@@ -2035,6 +2036,7 @@ if MCP_AVAILABLE:
             has_credential=True,
             expires_at=expires_at,
             is_expired=False,
+            has_refresh_token=bool(stored.get("refresh_token")) if stored else False,
         )
 
     @router.delete(
@@ -2115,6 +2117,7 @@ if MCP_AVAILABLE:
             expires_at=expires_at,
             is_expired=is_expired,
             connected_at=cred.get("connected_at"),
+            has_refresh_token=bool(cred.get("refresh_token")),
         )
 
     @router.get(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
@@ -11,6 +11,7 @@ keeps a plain-base64 fallback on read so existing rows continue to work.
 import base64
 import json
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -21,6 +22,7 @@ from litellm.proxy._experimental.mcp_server.db import (
     get_user_oauth_credential,
     is_oauth_credential_expired,
     list_user_oauth_credentials,
+    refresh_user_oauth_token,
     resolve_valid_user_oauth_token,
     rotate_mcp_user_credentials_master_key,
     rotate_mcp_user_env_vars_master_key,
@@ -577,6 +579,141 @@ async def test_resolve_returns_none_for_missing_credential(monkeypatch):
         is None
     )
     refresh.assert_not_called()
+
+
+# ── client_id persistence + refresh resolution ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_persists_client_id():
+    # A per-user client_id from dynamic client registration must round-trip so it
+    # is available at refresh time.
+    prisma = _make_prisma_with_existing(row=None)
+    await store_user_oauth_credential(
+        prisma, "alice", "srv-1", "at-1", refresh_token="rt-1", client_id="dcr-abc"
+    )
+
+    row = MagicMock()
+    row.credential_b64 = _stored_value(prisma)
+    row.server_id = "srv-1"
+    prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(return_value=row)
+
+    result = await get_user_oauth_credential(prisma, "alice", "srv-1")
+    assert result is not None
+    assert result["client_id"] == "dcr-abc"
+
+
+@pytest.mark.asyncio
+async def test_store_omits_client_id_when_absent():
+    # Statically-configured servers pass no client_id; the payload must not carry
+    # an empty key.
+    prisma = _make_prisma_with_existing(row=None)
+    await store_user_oauth_credential(prisma, "alice", "srv-1", "at-1")
+
+    row = MagicMock()
+    row.credential_b64 = _stored_value(prisma)
+    row.server_id = "srv-1"
+    prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(return_value=row)
+
+    result = await get_user_oauth_credential(prisma, "alice", "srv-1")
+    assert result is not None
+    assert "client_id" not in result
+
+
+def _mock_token_endpoint(monkeypatch, body):
+    """Patch db.get_async_httpx_client so refresh hits a fake token endpoint and
+    return the AsyncMock that captured the POST call."""
+    import litellm.proxy._experimental.mcp_server.db as db_mod
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock(return_value=None)
+    response.json = MagicMock(return_value=body)
+    post = AsyncMock(return_value=response)
+    client = MagicMock()
+    client.post = post
+    monkeypatch.setattr(db_mod, "get_async_httpx_client", lambda **_: client)
+    return post
+
+
+@pytest.mark.asyncio
+async def test_refresh_uses_stored_client_id_when_server_has_none(monkeypatch):
+    # Regression: a dynamically-registered server has no static client_id, so the
+    # refresh POST must carry the client_id stored with the credential. Before the
+    # fix, getattr(server, "client_id") was None and the POST omitted it, so the
+    # provider rejected the refresh.
+    prisma = _make_prisma_with_existing(row=None)
+    post = _mock_token_endpoint(
+        monkeypatch, {"access_token": "at-new", "expires_in": 3600}
+    )
+    server = SimpleNamespace(
+        token_url="https://provider.example/token",
+        server_id="srv-1",
+        client_id=None,
+        client_secret=None,
+    )
+    cred = {
+        "type": "oauth2",
+        "access_token": "at-old",
+        "refresh_token": "rt-1",
+        "client_id": "dcr-per-user-abc",
+    }
+
+    await refresh_user_oauth_token(prisma, "alice", server, cred)
+
+    sent = post.call_args.kwargs["data"]
+    assert sent["grant_type"] == "refresh_token"
+    assert sent["client_id"] == "dcr-per-user-abc"
+
+
+@pytest.mark.asyncio
+async def test_refresh_falls_back_to_server_client_id(monkeypatch):
+    # A statically-configured server keeps its client_id on the server object; the
+    # credential carries none, so refresh must fall back to the server value.
+    prisma = _make_prisma_with_existing(row=None)
+    post = _mock_token_endpoint(
+        monkeypatch, {"access_token": "at-new", "expires_in": 3600}
+    )
+    server = SimpleNamespace(
+        token_url="https://provider.example/token",
+        server_id="srv-1",
+        client_id="static-server-client",
+        client_secret=None,
+    )
+    cred = {"type": "oauth2", "access_token": "at-old", "refresh_token": "rt-1"}
+
+    await refresh_user_oauth_token(prisma, "alice", server, cred)
+
+    assert post.call_args.kwargs["data"]["client_id"] == "static-server-client"
+
+
+@pytest.mark.asyncio
+async def test_refresh_repersists_client_id(monkeypatch):
+    # The rotated row must keep the per-user client_id so the NEXT refresh still
+    # has it (otherwise the second refresh would lose it).
+    prisma = _make_prisma_with_existing(row=None)
+    _mock_token_endpoint(monkeypatch, {"access_token": "at-new", "expires_in": 3600})
+    server = SimpleNamespace(
+        token_url="https://provider.example/token",
+        server_id="srv-1",
+        client_id=None,
+        client_secret=None,
+    )
+    cred = {
+        "type": "oauth2",
+        "access_token": "at-old",
+        "refresh_token": "rt-1",
+        "client_id": "dcr-per-user-abc",
+    }
+
+    await refresh_user_oauth_token(prisma, "alice", server, cred)
+
+    row = MagicMock()
+    row.credential_b64 = _stored_value(prisma)
+    row.server_id = "srv-1"
+    prisma.db.litellm_mcpusercredentials.find_unique = AsyncMock(return_value=row)
+    persisted = await get_user_oauth_credential(prisma, "alice", "srv-1")
+    assert persisted is not None
+    assert persisted["client_id"] == "dcr-per-user-abc"
 
 
 # ── per-user env-var rotation ─────────────────────────────────────────────────

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2733,3 +2733,126 @@ async def test_token_exchange_passes_through_upstream_expires_in():
         {"access_token": "tok", "token_type": "Bearer", "expires_in": 43200}
     )
     assert body["expires_in"] == 43200
+
+
+@pytest.mark.asyncio
+async def test_exchange_persists_resolved_client_id_server_side():
+    """For a dynamically-registered server (no static client_id), the per-user
+    client_id from the exchange must be threaded into server-side storage so the
+    token can be refreshed later."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        exchange_token_with_server,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    # No static client_id: the id comes from the caller (dynamic registration).
+    server = MCPServer(
+        server_id="dcr-srv",
+        name="dcr",
+        server_name="dcr",
+        alias="dcr",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id=None,
+        client_secret=None,
+        authorization_url="https://provider.com/oauth/authorize",
+        token_url="https://provider.com/oauth/token",
+    )
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    fake_http_response = MagicMock()
+    fake_http_response.json.return_value = {
+        "access_token": "tok",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    fake_http_response.raise_for_status = MagicMock()
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock(return_value=fake_http_response)
+
+    store_side = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=fake_http_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._extract_user_id_from_request",
+            new=AsyncMock(return_value="alice"),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._store_per_user_token_server_side",
+            new=store_side,
+        ),
+    ):
+        await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="dcr-per-user-abc",
+            client_secret=None,
+            code_verifier="verifier",
+        )
+
+    assert store_side.await_args.kwargs["client_id"] == "dcr-per-user-abc"
+
+
+@pytest.mark.asyncio
+async def test_store_per_user_token_forwards_client_id_to_db():
+    """_store_per_user_token_server_side must pass client_id down to the DB
+    layer so it is persisted alongside the refresh token."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _store_per_user_token_server_side,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    server = MCPServer(
+        server_id="dcr-srv",
+        name="dcr",
+        server_name="dcr",
+        alias="dcr",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        token_url="https://provider.com/oauth/token",
+    )
+    store_db = AsyncMock(return_value=None)
+    cache = MagicMock()
+    cache.set = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "litellm.proxy.utils.get_prisma_client_or_throw",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.store_user_oauth_credential",
+            new=store_db,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.oauth2_token_cache.mcp_per_user_token_cache",
+            new=cache,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.oauth2_token_cache._compute_per_user_token_ttl",
+            return_value=60,
+        ),
+    ):
+        await _store_per_user_token_server_side(
+            server=server,
+            user_id="alice",
+            token_response={"access_token": "at", "expires_in": 3600},
+            client_id="dcr-per-user-abc",
+        )
+
+    assert store_db.await_args.kwargs["client_id"] == "dcr-per-user-abc"

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -3498,6 +3498,118 @@ async def test_store_mcp_oauth_user_credential_returns_status():
 
 
 @pytest.mark.asyncio
+async def test_store_mcp_oauth_user_credential_threads_client_id():
+    """The per-user client_id from dynamic client registration must reach
+    store_user_oauth_credential so it can be persisted for refresh."""
+    from litellm.proxy._types import MCPOAuthUserCredentialRequest
+
+    if not mgmt_endpoints.MCP_AVAILABLE:
+        pytest.skip("MCP module not installed")
+
+    from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+        store_mcp_oauth_user_credential,
+    )
+
+    server_id = "srv-1"
+    stored_payload = {
+        "type": "oauth2",
+        "access_token": "tok",
+        "refresh_token": "rt-1",
+        "connected_at": "2026-01-01T00:00:00+00:00",
+        "server_id": server_id,
+    }
+    store_mock = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=_make_prisma_client(),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_mcp_server",
+            new=AsyncMock(
+                return_value=generate_mock_mcp_server_db_record(server_id=server_id)
+            ),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints._user_has_admin_view",
+            return_value=True,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.store_user_oauth_credential",
+            new=store_mock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_user_oauth_credential",
+            new=AsyncMock(return_value=stored_payload),
+        ),
+    ):
+        result = await store_mcp_oauth_user_credential(
+            server_id=server_id,
+            payload=MCPOAuthUserCredentialRequest(
+                access_token="tok",
+                refresh_token="rt-1",
+                client_id="dcr-per-user-abc",
+            ),
+            user_api_key_dict=_make_user_auth("user-123"),
+        )
+
+    assert store_mock.await_args.kwargs["client_id"] == "dcr-per-user-abc"
+    # The echoed status reflects that a refresh token is stored.
+    assert result.has_refresh_token is True
+
+
+@pytest.mark.asyncio
+async def test_oauth_status_reports_has_refresh_token():
+    """The status endpoint surfaces whether a refresh token is stored, so a
+    client can tell auto-refresh is wired up without reading the token."""
+    from litellm.proxy._types import MCPOAuthUserCredentialStatus
+
+    if not mgmt_endpoints.MCP_AVAILABLE:
+        pytest.skip("MCP module not installed")
+
+    from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+        get_mcp_oauth_user_credential_status,
+    )
+
+    server_id = "srv-1"
+    with_refresh = {
+        "type": "oauth2",
+        "access_token": "tok",
+        "refresh_token": "rt-1",
+        "connected_at": "2026-01-01T00:00:00+00:00",
+    }
+    without_refresh = {
+        "type": "oauth2",
+        "access_token": "tok",
+        "connected_at": "2026-01-01T00:00:00+00:00",
+    }
+
+    async def _status_for(cred):
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+                return_value=_make_prisma_client(),
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.get_user_oauth_credential",
+                new=AsyncMock(return_value=cred),
+            ),
+        ):
+            return await get_mcp_oauth_user_credential_status(
+                server_id=server_id,
+                user_api_key_dict=_make_user_auth("user-123"),
+            )
+
+    with_result = await _status_for(with_refresh)
+    without_result = await _status_for(without_refresh)
+
+    assert isinstance(with_result, MCPOAuthUserCredentialStatus)
+    assert with_result.has_refresh_token is True
+    assert without_result.has_refresh_token is False
+
+
+@pytest.mark.asyncio
 async def test_delete_mcp_oauth_user_credential_only_deletes_oauth():
     """delete_mcp_oauth_user_credential only deletes OAuth2 credentials, not BYOK."""
     from litellm.proxy._types import MCPOAuthUserCredentialStatus


### PR DESCRIPTION
## Relevant issues

Relates to #31222 (per-user MCP OAuth credential management — the UI removal in #30178 that this PR's backend-only scope accounts for).
Companion PR: #31326 — use stored per-user OAuth token on tool calls.

## Type

🐛 Bug Fix

## Changes

Dynamically-registered MCP OAuth clients (e.g. Guru) mint a **per-user** `client_id` during browser-side dynamic client registration, use it for the token exchange, then discard it. At refresh time `refresh_user_oauth_token` read `server.client_id`, which is `None` for a registration-only server, so the refresh POST omitted `client_id` and the provider rejected it — the access token died after ~1h and the user had to re-authorize.

This persists `client_id` with the per-user credential across both store paths (the server-side `/token` store and the manual `oauth-user-credential` endpoint) and prefers it over the server config when refreshing (same fallback for `client_secret`). Also exposes `has_refresh_token` on the credential status so API clients can tell whether a credential will auto-refresh.

Backend-only: the original change also added a dashboard auto-refresh indicator, but the per-user MCP credential UI was removed upstream (#30178, tracked in #31222), so that hunk is intentionally omitted.

### Tests

- `test_db_credentials.py` — `client_id` persisted, and preferred over server config on refresh
- `test_discoverable_endpoints.py` — `client_id` threaded through token exchange → server-side store → DB layer
- `test_mcp_management_endpoints.py` — `client_id` reaches `store_user_oauth_credential`; `has_refresh_token` surfaced on status

All passing locally (`uv run pytest` on the three files above).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
