### PR TITLE
feat(credentials): team-admin self-assignment of logging destinations

### DIFF
--- a/litellm/models/credentials.py
+++ b/litellm/models/credentials.py
@@ -29,3 +29,17 @@ class CreateCredentialItem(CredentialBase):
         if not values.get("credential_values") and not values.get("model_id"):
             raise ValueError("Either credential_values or model_id must be set")
         return values
+
+
+class UpdateCredentialItem(BaseModel):
+    """PATCH body for ``/credentials/{name}``.
+
+    Both ``credential_values`` and ``credential_info`` are optional so a caller
+    can patch one without sending the other (team-admins patching access without
+    knowing the upstream secrets; proxy admins rotating values without touching
+    access). ``credential_name`` is optional because most patches don't rename.
+    """
+
+    credential_name: Optional[str] = None
+    credential_values: Optional[dict] = None
+    credential_info: Optional[dict] = None

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -771,11 +771,6 @@ class LiteLLMRoutes(enum.Enum):
         # POST and DELETE stay proxy-admin only via is_admin_gated_credential_info.
         "/credentials",
         "/credentials/{credential_name}",
-        # /team/update enforces team-admin / proxy-admin via _verify_team_access
-        # in the handler. Added so a team-admin can write fields they're
-        # entitled to (including metadata.logging_exporters under the new
-        # validate_team_logging_exporter_assignment gate).
-        "/team/update",
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -765,6 +765,12 @@ class LiteLLMRoutes(enum.Enum):
         # Team guardrail submissions - endpoint scopes results to caller's teams (non-admin)
         "/guardrails/submissions",
         "/guardrails/submissions/{guardrail_id}",
+        # Logging-credential routes. GET filters to logging-typed for non-admins;
+        # PATCH delegates to decide_credential_patch in credential_endpoints, which
+        # only allows a team-admin to append their own team_id to access.teams.
+        # POST and DELETE stay proxy-admin only via is_admin_gated_credential_info.
+        "/credentials",
+        "/credentials/{credential_name}",
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -771,6 +771,11 @@ class LiteLLMRoutes(enum.Enum):
         # POST and DELETE stay proxy-admin only via is_admin_gated_credential_info.
         "/credentials",
         "/credentials/{credential_name}",
+        # /team/update enforces team-admin / proxy-admin via _verify_team_access
+        # in the handler. Added so a team-admin can write fields they're
+        # entitled to (including metadata.logging_exporters under the new
+        # validate_team_logging_exporter_assignment gate).
+        "/team/update",
     ]  # routes that manage their own allowed/disallowed logic
 
     ## Org Admin Routes ##

--- a/litellm/proxy/credential_endpoints/access_decision.py
+++ b/litellm/proxy/credential_endpoints/access_decision.py
@@ -111,18 +111,19 @@ def decide_credential_patch(
     patch_teams = _teams_set(patch_access)
 
     removed = existing_teams - patch_teams
-    if removed:
+    foreign_removed = removed - caller_team_admin_ids
+    if foreign_removed:
         return Deny(
-            "team-admin may not remove existing team grants: "
-            + ", ".join(sorted(removed))
+            "team-admin may only revoke their own team grants; foreign team_ids: "
+            + ", ".join(sorted(foreign_removed))
         )
 
     added = patch_teams - existing_teams
-    foreign = added - caller_team_admin_ids
-    if foreign:
+    foreign_added = added - caller_team_admin_ids
+    if foreign_added:
         return Deny(
             "team-admin may only grant their own team_ids: "
-            + ", ".join(sorted(foreign))
+            + ", ".join(sorted(foreign_added))
         )
 
     return Allow()

--- a/litellm/proxy/credential_endpoints/access_decision.py
+++ b/litellm/proxy/credential_endpoints/access_decision.py
@@ -1,0 +1,128 @@
+"""Pure tagged-union decision for who can patch a logging-credential.
+
+A logging credential controls where other tenants' traces are exported, so
+``credential_info.access`` is the only field a non-admin caller may touch, and
+only to add their own team_id(s) to ``access.teams``. Everything else
+(values, host, type, description, ``global``, ``orgs``, foreign team_ids,
+or removing existing grants) stays proxy-admin only.
+
+The decision is a value (Allow vs Deny(reason)), kept separate from the
+endpoint so it can be unit-tested exhaustively without spinning up FastAPI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class Allow:
+    tag: Literal["allow"] = "allow"
+
+
+@dataclass(frozen=True, slots=True)
+class Deny:
+    reason: str
+    tag: Literal["deny"] = "deny"
+
+
+Decision = Allow | Deny
+
+
+_IMMUTABLE_INFO_FIELDS = frozenset(
+    {"credential_type", "description", "host", "endpoint"}
+)
+
+
+def _access(info: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    if not isinstance(info, Mapping):
+        return {}
+    raw = info.get("access")
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _teams_set(access: Mapping[str, Any]) -> frozenset[str]:
+    raw = access.get("teams") or ()
+    return frozenset(item for item in raw if isinstance(item, str))
+
+
+def decide_credential_patch(
+    *,
+    is_proxy_admin: bool,
+    caller_team_admin_ids: frozenset[str],
+    existing_info: Mapping[str, Any] | None,
+    patch_info: Mapping[str, Any] | None,
+    patch_values: Mapping[str, Any] | None,
+    patch_name_changed: bool,
+) -> Decision:
+    """Return Allow or Deny(reason) for a PATCH /credentials/{name} request.
+
+    Proxy admins always pass. A team admin only passes when the patch (a) does
+    not change ``credential_values`` or ``credential_name``, (b) does not
+    modify any immutable ``credential_info`` field, and (c) limits its
+    ``access`` change to appending team_ids the caller is team-admin of to
+    ``access.teams`` (no removals, no foreign ids, no ``global``/``orgs``
+    edits).
+    """
+    if is_proxy_admin:
+        return Allow()
+
+    if not caller_team_admin_ids:
+        return Deny("Only the proxy admin can manage logging credentials")
+
+    if patch_name_changed:
+        return Deny("credential_name is proxy-admin only")
+
+    if patch_values:
+        return Deny("credential_values is proxy-admin only")
+
+    if not isinstance(patch_info, Mapping):
+        # Nothing to do, but a team-admin should only call PATCH to change
+        # access. An empty/None info is a no-op and we refuse it loudly so
+        # the caller corrects the request shape.
+        return Deny("patch must set credential_info.access for team-admin writes")
+
+    touched_fields = frozenset(patch_info.keys())
+    forbidden = touched_fields & _IMMUTABLE_INFO_FIELDS
+    if forbidden:
+        return Deny(
+            "credential_info fields are proxy-admin only: "
+            + ", ".join(sorted(forbidden))
+        )
+
+    if touched_fields - {"access"}:
+        return Deny(
+            "team-admin may only patch credential_info.access; got: "
+            + ", ".join(sorted(touched_fields))
+        )
+
+    patch_access = _access(patch_info)
+    if not patch_access:
+        return Deny("credential_info.access must be set for team-admin writes")
+
+    if "global" in patch_access:
+        return Deny("access.global is proxy-admin only")
+    if "orgs" in patch_access:
+        return Deny("access.orgs is proxy-admin only")
+
+    existing_access = _access(existing_info)
+    existing_teams = _teams_set(existing_access)
+    patch_teams = _teams_set(patch_access)
+
+    removed = existing_teams - patch_teams
+    if removed:
+        return Deny(
+            "team-admin may not remove existing team grants: "
+            + ", ".join(sorted(removed))
+        )
+
+    added = patch_teams - existing_teams
+    foreign = added - caller_team_admin_ids
+    if foreign:
+        return Deny(
+            "team-admin may only grant their own team_ids: "
+            + ", ".join(sorted(foreign))
+        )
+
+    return Allow()

--- a/litellm/proxy/credential_endpoints/access_decision.py
+++ b/litellm/proxy/credential_endpoints/access_decision.py
@@ -13,7 +13,7 @@ endpoint so it can be unit-tested exhaustively without spinning up FastAPI.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Literal, Mapping
+from typing import Literal, Mapping, cast
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,25 +35,33 @@ _IMMUTABLE_INFO_FIELDS = frozenset(
 )
 
 
-def _access(info: Mapping[str, Any] | None) -> Mapping[str, Any]:
+_EMPTY: Mapping[str, object] = {}
+
+
+def _access(info: Mapping[str, object] | None) -> Mapping[str, object]:
     if not isinstance(info, Mapping):
-        return {}
+        return _EMPTY
     raw = info.get("access")
-    return raw if isinstance(raw, Mapping) else {}
+    if isinstance(raw, Mapping):
+        return cast(Mapping[str, object], raw)
+    return _EMPTY
 
 
-def _teams_set(access: Mapping[str, Any]) -> frozenset[str]:
-    raw = access.get("teams") or ()
-    return frozenset(item for item in raw if isinstance(item, str))
+def _teams_set(access: Mapping[str, object]) -> frozenset[str]:
+    raw = access.get("teams")
+    if not isinstance(raw, (list, tuple)):
+        return frozenset()
+    teams: tuple[object, ...] = tuple(cast(tuple[object, ...], raw))
+    return frozenset(item for item in teams if isinstance(item, str))
 
 
 def decide_credential_patch(
     *,
     is_proxy_admin: bool,
     caller_team_admin_ids: frozenset[str],
-    existing_info: Mapping[str, Any] | None,
-    patch_info: Mapping[str, Any] | None,
-    patch_values: Mapping[str, Any] | None,
+    existing_info: Mapping[str, object] | None,
+    patch_info: Mapping[str, object] | None,
+    patch_values: Mapping[str, object] | None,
     patch_name_changed: bool,
 ) -> Decision:
     """Return Allow or Deny(reason) for a PATCH /credentials/{name} request.

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -47,24 +47,41 @@ async def _caller_team_admin_ids(
     """Set of team_ids the caller is team-admin of.
 
     Empty when the caller has no user_id, no DB connection, or no admin
-    membership on any team. Used by the team-admin self-assignment path to
-    decide which team_ids the caller may grant on a destination.
+    membership on any team.
+
+    Reads the caller's team_id list off ``LiteLLM_UserTable.teams`` (cached
+    array of team_ids the user belongs to) and fetches only those rows from
+    the team table -- the lookup is proportional to the caller's team count,
+    not the workspace's. ``members_with_roles`` is a Postgres JSON column so
+    Prisma can't filter on the admin role; that match is done in Python.
     """
     if user_api_key_dict.user_id is None or prisma_client is None:
         return frozenset()
     try:
-        rows = await prisma_client.db.litellm_teamtable.find_many()  # type: ignore[attr-defined]
+        user_row = await prisma_client.db.litellm_usertable.find_unique(  # type: ignore[attr-defined]
+            where={"user_id": user_api_key_dict.user_id}
+        )
     except Exception:
-        verbose_proxy_logger.exception("team-admin lookup failed")
+        verbose_proxy_logger.exception("team-admin lookup (user fetch) failed")
+        return frozenset()
+    user_team_ids = list(getattr(user_row, "teams", None) or []) if user_row else []
+    if not user_team_ids:
+        return frozenset()
+    try:
+        teams = await prisma_client.db.litellm_teamtable.find_many(  # type: ignore[attr-defined]
+            where={"team_id": {"in": user_team_ids}}
+        )
+    except Exception:
+        verbose_proxy_logger.exception("team-admin lookup (teams fetch) failed")
         return frozenset()
     return frozenset(
         team.team_id
-        for team in rows
+        for team in teams
         if any(
             isinstance(member, dict)
             and member.get("user_id") == user_api_key_dict.user_id
             and member.get("role") == "admin"
-            for member in (team.members_with_roles or [])
+            for member in (getattr(team, "members_with_roles", None) or [])
         )
     )
 

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -48,16 +48,23 @@ def _is_proxy_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
     return user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
 
 
-async def _caller_team_admin_ids(
+async def _caller_grantable_team_ids(
     user_api_key_dict: UserAPIKeyAuth, prisma_client: "Optional[PrismaClient]"
 ) -> frozenset[str]:
-    """Set of team_ids the caller is team-admin of.
+    """Team ids the caller may add to / remove from a destination's access.teams.
 
-    Empty when the caller has no user_id, no DB connection, or no admin
-    membership on any team. Uses the shared ``get_user_object`` and
-    ``get_team_object`` helpers so the lookup benefits from the proxy's
-    in-process cache and OTEL span propagation; ``members_with_roles`` is a
-    JSON column so the admin-role match is still done in Python.
+    Two paths to grantability:
+
+    1. Direct team-admin: caller is admin of the team (role=admin in
+       ``members_with_roles``).
+    2. Via org-admin: caller is ORG_ADMIN of the team's organization. Org
+       admins manage every team in their org, even teams they aren't a
+       direct member of.
+
+    Empty when the caller has no user_id, no DB connection, or admins
+    nothing. Uses cached ``get_user_object`` / ``get_team_object`` plus one
+    bounded query for org teams; the role match is done in Python because
+    ``members_with_roles`` is a JSON column.
     """
     if user_api_key_dict.user_id is None or prisma_client is None:
         return frozenset()
@@ -73,11 +80,16 @@ async def _caller_team_admin_ids(
             parent_otel_span=user_api_key_dict.parent_otel_span,
             proxy_logging_obj=proxy_logging_obj,
         )
-        if user_obj is None or not getattr(user_obj, "teams", None):
+        if user_obj is None:
             return frozenset()
-        team_ids: list[str] = [tid for tid in user_obj.teams if isinstance(tid, str)]
-        admin_of: list[str] = []
-        for team_id in team_ids:
+
+        # Direct team-admin grants: walk the caller's own team list.
+        team_admin_of: set[str] = set()
+        for team_id in [
+            tid
+            for tid in (getattr(user_obj, "teams", None) or [])
+            if isinstance(tid, str)
+        ]:
             team_obj = await get_team_object(
                 team_id=team_id,
                 prisma_client=prisma_client,
@@ -89,11 +101,26 @@ async def _caller_team_admin_ids(
                 member.user_id == user_api_key_dict.user_id and member.role == "admin"
                 for member in (team_obj.members_with_roles or [])
             ):
-                admin_of.append(team_id)
-        return frozenset(admin_of)
+                team_admin_of.add(team_id)
+
+        # Org-admin grants: every team in any org the caller admins, even if
+        # the caller isn't a direct member of that team.
+        org_admin_of: list[str] = [
+            m.organization_id
+            for m in (user_obj.organization_memberships or [])
+            if m.organization_id and m.user_role == LitellmUserRoles.ORG_ADMIN.value
+        ]
+        org_grantable: set[str] = set()
+        if org_admin_of:
+            org_teams = await prisma_client.db.litellm_teamtable.find_many(  # type: ignore[union-attr]
+                where={"organization_id": {"in": org_admin_of}}
+            )
+            org_grantable = {t.team_id for t in org_teams if t.team_id}
+
+        return frozenset(team_admin_of | org_grantable)
     except Exception:
         # Best-effort lookup. A miss here means the PATCH decider will deny any
-        # team-admin patch other than a no-op, which is the safe fallback.
+        # patch other than a no-op, which is the safe fallback.
         verbose_proxy_logger.exception("team-admin lookup failed")
         return frozenset()
 
@@ -474,7 +501,7 @@ async def update_credential(
         team_admin_ids = (
             frozenset()
             if is_admin
-            else await _caller_team_admin_ids(user_api_key_dict, prisma_client)
+            else await _caller_grantable_team_ids(user_api_key_dict, prisma_client)
         )
         decision = decide_credential_patch(
             is_proxy_admin=is_admin,

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -24,7 +24,11 @@ from litellm.proxy.management_endpoints.logging_exporter_validation import (
 )
 from litellm.proxy.utils import handle_exception_on_proxy, jsonify_object
 from litellm.repositories.credentials_repository import CredentialsRepository
-from litellm.types.utils import CreateCredentialItem, CredentialItem
+from litellm.types.utils import (
+    CreateCredentialItem,
+    CredentialItem,
+    UpdateCredentialItem,
+)
 
 router = APIRouter()
 
@@ -61,9 +65,7 @@ async def _caller_team_admin_ids(
         user_row = await prisma_client.db.litellm_usertable.find_unique(  # type: ignore[attr-defined]
             where={"user_id": user_api_key_dict.user_id}
         )
-        user_team_ids = list(
-            getattr(user_row, "teams", None) or []
-        ) if user_row else []
+        user_team_ids = list(getattr(user_row, "teams", None) or []) if user_row else []
         if not user_team_ids:
             return frozenset()
         teams = await prisma_client.db.litellm_teamtable.find_many(  # type: ignore[attr-defined]
@@ -437,7 +439,7 @@ def update_db_credential(
 async def update_credential(
     request: Request,
     fastapi_response: Response,
-    credential: CredentialItem,
+    credential: UpdateCredentialItem,
     credential_name: str = Path(
         ..., description="The credential name, percent-decoded; may contain slashes"
     ),
@@ -445,6 +447,11 @@ async def update_credential(
 ):
     """
     [BETA] endpoint. This might change unexpectedly.
+
+    Both ``credential_values`` and ``credential_info`` are optional; a team-admin
+    typically patches only ``credential_info.access`` to grant or revoke their
+    own team. A proxy admin may patch either or both. See
+    ``decide_credential_patch`` for the exact contract.
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -476,6 +483,14 @@ async def update_credential(
         assert isinstance(decision, Allow)
     validate_credential_access(credential.credential_info)
 
+    # Translate the partial patch into a full CredentialItem for the downstream
+    # merge function, which still expects the legacy shape with non-None dicts.
+    credential_as_item = CredentialItem(
+        credential_name=credential.credential_name or credential_name,
+        credential_values=credential.credential_values or {},
+        credential_info=credential.credential_info or {},
+    )
+
     try:
         if prisma_client is None:
             raise HTTPException(
@@ -486,7 +501,7 @@ async def update_credential(
         db_credential = await credentials_repository.find_by_name(credential_name)
         if db_credential is None:
             raise HTTPException(status_code=404, detail="Credential not found in DB.")
-        merged_credential = update_db_credential(db_credential, credential)
+        merged_credential = update_db_credential(db_credential, credential_as_item)
         credential_object_jsonified = jsonify_object(merged_credential.model_dump())
         await credentials_repository.update_by_name(
             credential_name,

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -51,42 +51,50 @@ async def _caller_team_admin_ids(
     """Set of team_ids the caller is team-admin of.
 
     Empty when the caller has no user_id, no DB connection, or no admin
-    membership on any team.
-
-    Reads the caller's team_id list off ``LiteLLM_UserTable.teams`` (cached
-    array of team_ids the user belongs to) and fetches only those rows from
-    the team table -- the lookup is proportional to the caller's team count,
-    not the workspace's. ``members_with_roles`` is a Postgres JSON column so
-    Prisma can't filter on the admin role; that match is done in Python.
+    membership on any team. Uses the shared ``get_user_object`` and
+    ``get_team_object`` helpers so the lookup benefits from the proxy's
+    in-process cache and OTEL span propagation; ``members_with_roles`` is a
+    JSON column so the admin-role match is still done in Python.
     """
     if user_api_key_dict.user_id is None or prisma_client is None:
         return frozenset()
+    from litellm.proxy.auth.auth_checks import get_team_object, get_user_object
+    from litellm.proxy.proxy_server import proxy_logging_obj, user_api_key_cache
+
     try:
-        user_row = await prisma_client.db.litellm_usertable.find_unique(  # type: ignore[attr-defined]
-            where={"user_id": user_api_key_dict.user_id}
-        )
-        user_team_ids = list(getattr(user_row, "teams", None) or []) if user_row else []
-        if not user_team_ids:
-            return frozenset()
-        teams = await prisma_client.db.litellm_teamtable.find_many(  # type: ignore[attr-defined]
-            where={"team_id": {"in": user_team_ids}}
+        user_obj = await get_user_object(
+            user_id=user_api_key_dict.user_id,
+            prisma_client=prisma_client,  # type: ignore[arg-type]
+            user_api_key_cache=user_api_key_cache,
+            user_id_upsert=False,
+            parent_otel_span=user_api_key_dict.parent_otel_span,
+            proxy_logging_obj=proxy_logging_obj,
         )
     except Exception:
-        # Best-effort; surface a clear log and treat the caller as having no
-        # team-admin teams. The PATCH decider will return Deny on any patch
-        # other than a no-op, which is the safe fallback.
-        verbose_proxy_logger.exception("team-admin lookup failed")
+        verbose_proxy_logger.exception("team-admin lookup (user fetch) failed")
         return frozenset()
-    return frozenset(
-        team.team_id
-        for team in teams
+    if user_obj is None or not getattr(user_obj, "teams", None):
+        return frozenset()
+
+    team_ids: list[str] = [tid for tid in user_obj.teams if isinstance(tid, str)]
+    admin_of: list[str] = []
+    for team_id in team_ids:
+        try:
+            team_obj = await get_team_object(
+                team_id=team_id,
+                prisma_client=prisma_client,  # type: ignore[arg-type]
+                user_api_key_cache=user_api_key_cache,
+                parent_otel_span=user_api_key_dict.parent_otel_span,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+        except Exception:
+            continue
         if any(
-            isinstance(member, dict)
-            and member.get("user_id") == user_api_key_dict.user_id
-            and member.get("role") == "admin"
-            for member in (getattr(team, "members_with_roles", None) or [])
-        )
-    )
+            member.user_id == user_api_key_dict.user_id and member.role == "admin"
+            for member in (team_obj.members_with_roles or [])
+        ):
+            admin_of.append(team_id)
+    return frozenset(admin_of)
 
 
 def _credential_in_memory(credential_name: str) -> Optional[CredentialItem]:
@@ -481,6 +489,12 @@ async def update_credential(
         if isinstance(decision, Deny):
             raise HTTPException(status_code=403, detail={"error": decision.reason})
         assert isinstance(decision, Allow)
+    else:
+        # Non-logging (provider) credential. The route gate was widened to let
+        # team-admins reach this handler for logging-credential PATCHes; without
+        # this branch a non-admin caller could rotate a provider credential's
+        # api_key. PATCH on provider credentials remains proxy-admin only.
+        _require_proxy_admin(user_api_key_dict)
     validate_credential_access(credential.credential_info)
 
     # Translate the partial patch into a full CredentialItem for the downstream

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -61,18 +61,19 @@ async def _caller_team_admin_ids(
         user_row = await prisma_client.db.litellm_usertable.find_unique(  # type: ignore[attr-defined]
             where={"user_id": user_api_key_dict.user_id}
         )
-    except Exception:
-        verbose_proxy_logger.exception("team-admin lookup (user fetch) failed")
-        return frozenset()
-    user_team_ids = list(getattr(user_row, "teams", None) or []) if user_row else []
-    if not user_team_ids:
-        return frozenset()
-    try:
+        user_team_ids = list(
+            getattr(user_row, "teams", None) or []
+        ) if user_row else []
+        if not user_team_ids:
+            return frozenset()
         teams = await prisma_client.db.litellm_teamtable.find_many(  # type: ignore[attr-defined]
             where={"team_id": {"in": user_team_ids}}
         )
     except Exception:
-        verbose_proxy_logger.exception("team-admin lookup (teams fetch) failed")
+        # Best-effort; surface a clear log and treat the caller as having no
+        # team-admin teams. The PATCH decider will return Deny on any patch
+        # other than a no-op, which is the safe fallback.
+        verbose_proxy_logger.exception("team-admin lookup failed")
         return frozenset()
     return frozenset(
         team.team_id

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -70,16 +70,11 @@ async def _caller_team_admin_ids(
             parent_otel_span=user_api_key_dict.parent_otel_span,
             proxy_logging_obj=proxy_logging_obj,
         )
-    except Exception:
-        verbose_proxy_logger.exception("team-admin lookup (user fetch) failed")
-        return frozenset()
-    if user_obj is None or not getattr(user_obj, "teams", None):
-        return frozenset()
-
-    team_ids: list[str] = [tid for tid in user_obj.teams if isinstance(tid, str)]
-    admin_of: list[str] = []
-    for team_id in team_ids:
-        try:
+        if user_obj is None or not getattr(user_obj, "teams", None):
+            return frozenset()
+        team_ids: list[str] = [tid for tid in user_obj.teams if isinstance(tid, str)]
+        admin_of: list[str] = []
+        for team_id in team_ids:
             team_obj = await get_team_object(
                 team_id=team_id,
                 prisma_client=prisma_client,  # type: ignore[arg-type]
@@ -87,14 +82,17 @@ async def _caller_team_admin_ids(
                 parent_otel_span=user_api_key_dict.parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
             )
-        except Exception:
-            continue
-        if any(
-            member.user_id == user_api_key_dict.user_id and member.role == "admin"
-            for member in (team_obj.members_with_roles or [])
-        ):
-            admin_of.append(team_id)
-    return frozenset(admin_of)
+            if any(
+                member.user_id == user_api_key_dict.user_id and member.role == "admin"
+                for member in (team_obj.members_with_roles or [])
+            ):
+                admin_of.append(team_id)
+        return frozenset(admin_of)
+    except Exception:
+        # Best-effort lookup. A miss here means the PATCH decider will deny any
+        # team-admin patch other than a no-op, which is the safe fallback.
+        verbose_proxy_logger.exception("team-admin lookup failed")
+        return frozenset()
 
 
 def _credential_in_memory(credential_name: str) -> Optional[CredentialItem]:

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -4,7 +4,7 @@ CRUD endpoints for storing reusable credentials.
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -13,6 +13,11 @@ from litellm.litellm_core_utils.litellm_logging import _get_masked_values
 from litellm.proxy._types import CommonProxyErrors, LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+from litellm.proxy.credential_endpoints.access_decision import (
+    Allow,
+    Deny,
+    decide_credential_patch,
+)
 from litellm.proxy.management_endpoints.logging_exporter_validation import (
     is_admin_gated_credential_info,
     validate_credential_access,
@@ -30,6 +35,38 @@ def _require_proxy_admin(user_api_key_dict: UserAPIKeyAuth) -> None:
             status_code=403,
             detail={"error": "Only the proxy admin can manage logging credentials"},
         )
+
+
+def _is_proxy_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
+    return user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+
+
+async def _caller_team_admin_ids(
+    user_api_key_dict: UserAPIKeyAuth, prisma_client: object
+) -> frozenset[str]:
+    """Set of team_ids the caller is team-admin of.
+
+    Empty when the caller has no user_id, no DB connection, or no admin
+    membership on any team. Used by the team-admin self-assignment path to
+    decide which team_ids the caller may grant on a destination.
+    """
+    if user_api_key_dict.user_id is None or prisma_client is None:
+        return frozenset()
+    try:
+        rows = await prisma_client.db.litellm_teamtable.find_many()  # type: ignore[attr-defined]
+    except Exception:
+        verbose_proxy_logger.exception("team-admin lookup failed")
+        return frozenset()
+    return frozenset(
+        team.team_id
+        for team in rows
+        if any(
+            isinstance(member, dict)
+            and member.get("user_id") == user_api_key_dict.user_id
+            and member.get("role") == "admin"
+            for member in (team.members_with_roles or [])
+        )
+    )
 
 
 def _credential_in_memory(credential_name: str) -> Optional[CredentialItem]:
@@ -107,8 +144,10 @@ async def create_credential(
     """
     from litellm.proxy.proxy_server import llm_router, prisma_client
 
-    if is_admin_gated_credential_info(credential.credential_info):
-        _require_proxy_admin(user_api_key_dict)
+    # POST stays proxy-admin only across the board: route gate was widened so
+    # team-admins can PATCH access on existing logging destinations, but
+    # creation of any credential (logging or provider) remains admin-only.
+    _require_proxy_admin(user_api_key_dict)
     validate_credential_access(credential.credential_info)
 
     try:
@@ -178,15 +217,29 @@ async def get_credentials(
 ):
     """
     [BETA] endpoint. This might change unexpectedly.
+
+    Proxy admins see every credential (values masked). Team-admins see only
+    logging-typed destinations so they can self-assign them; provider
+    credentials stay invisible. Plain authenticated callers fall through the
+    same logging-only filter (route gate already requires team-admin status).
     """
     try:
+        visible = (
+            litellm.credential_list
+            if _is_proxy_admin(user_api_key_dict)
+            else [
+                credential
+                for credential in litellm.credential_list
+                if is_admin_gated_credential_info(credential.credential_info)
+            ]
+        )
         masked_credentials = [
             {
                 "credential_name": credential.credential_name,
                 "credential_values": _get_masked_values(credential.credential_values),
                 "credential_info": credential.credential_info,
             }
-            for credential in litellm.credential_list
+            for credential in visible
         ]
         return {"success": True, "credentials": masked_credentials}
     except Exception as e:
@@ -292,11 +345,9 @@ async def delete_credential(
     """
     from litellm.proxy.proxy_server import prisma_client
 
-    existing = await _credential_for_admin_gate(credential_name, prisma_client)
-    if existing is not None and is_admin_gated_credential_info(
-        existing.credential_info
-    ):
-        _require_proxy_admin(user_api_key_dict)
+    # DELETE stays proxy-admin only. The route gate lets team-admins reach
+    # /credentials/{name} for PATCH; reject any DELETE that isn't proxy-admin.
+    _require_proxy_admin(user_api_key_dict)
 
     try:
         if prisma_client is None:
@@ -380,11 +431,31 @@ async def update_credential(
     from litellm.proxy.proxy_server import prisma_client
 
     existing = await _credential_for_admin_gate(credential_name, prisma_client)
-    if is_admin_gated_credential_info(credential.credential_info) or (
-        existing is not None
-        and is_admin_gated_credential_info(existing.credential_info)
-    ):
-        _require_proxy_admin(user_api_key_dict)
+    existing_is_logging_gated = existing is not None and is_admin_gated_credential_info(
+        existing.credential_info
+    )
+    patch_is_logging_gated = is_admin_gated_credential_info(credential.credential_info)
+    if existing_is_logging_gated or patch_is_logging_gated:
+        is_admin = _is_proxy_admin(user_api_key_dict)
+        team_admin_ids = (
+            frozenset()
+            if is_admin
+            else await _caller_team_admin_ids(user_api_key_dict, prisma_client)
+        )
+        decision = decide_credential_patch(
+            is_proxy_admin=is_admin,
+            caller_team_admin_ids=team_admin_ids,
+            existing_info=(existing.credential_info if existing is not None else None),
+            patch_info=credential.credential_info,
+            patch_values=credential.credential_values,
+            patch_name_changed=(
+                credential.credential_name is not None
+                and credential.credential_name != credential_name
+            ),
+        )
+        if isinstance(decision, Deny):
+            raise HTTPException(status_code=403, detail={"error": decision.reason})
+        assert isinstance(decision, Allow)
     validate_credential_access(credential.credential_info)
 
     try:

--- a/litellm/proxy/credential_endpoints/endpoints.py
+++ b/litellm/proxy/credential_endpoints/endpoints.py
@@ -2,9 +2,12 @@
 CRUD endpoints for storing reusable credentials.
 """
 
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
+
+if TYPE_CHECKING:
+    from litellm.proxy.utils import PrismaClient
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -46,7 +49,7 @@ def _is_proxy_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
 
 
 async def _caller_team_admin_ids(
-    user_api_key_dict: UserAPIKeyAuth, prisma_client: object
+    user_api_key_dict: UserAPIKeyAuth, prisma_client: "Optional[PrismaClient]"
 ) -> frozenset[str]:
     """Set of team_ids the caller is team-admin of.
 
@@ -64,7 +67,7 @@ async def _caller_team_admin_ids(
     try:
         user_obj = await get_user_object(
             user_id=user_api_key_dict.user_id,
-            prisma_client=prisma_client,  # type: ignore[arg-type]
+            prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
             user_id_upsert=False,
             parent_otel_span=user_api_key_dict.parent_otel_span,
@@ -77,7 +80,7 @@ async def _caller_team_admin_ids(
         for team_id in team_ids:
             team_obj = await get_team_object(
                 team_id=team_id,
-                prisma_client=prisma_client,  # type: ignore[arg-type]
+                prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
                 parent_otel_span=user_api_key_dict.parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,

--- a/litellm/proxy/management_endpoints/common_utils.py
+++ b/litellm/proxy/management_endpoints/common_utils.py
@@ -101,17 +101,15 @@ def _is_user_team_admin(
     return False
 
 
-async def _is_user_org_admin_for_team(
-    user_api_key_dict: UserAPIKeyAuth, team_obj: LiteLLM_TeamTable
+async def _is_user_org_admin_for_org_id(
+    user_api_key_dict: UserAPIKeyAuth, organization_id: Optional[str]
 ) -> bool:
-    """
-    Check if user is an org admin for the team's organization.
+    """Check if the caller has the ORG_ADMIN role in the given organization.
 
-    Returns True if:
-    - The team belongs to an organization, AND
-    - The user has org_admin role in that organization
+    Returns False when ``organization_id`` is falsy or the caller has no user_id,
+    so the caller can pass an optional org_id directly without branching.
     """
-    if not team_obj.organization_id or not user_api_key_dict.user_id:
+    if not organization_id or not user_api_key_dict.user_id:
         return False
 
     from litellm.proxy.auth.auth_checks import get_user_object
@@ -131,14 +129,21 @@ async def _is_user_org_admin_for_team(
     if caller_user is None:
         return False
 
-    for m in caller_user.organization_memberships or []:
-        if (
-            m.organization_id == team_obj.organization_id
-            and m.user_role == LitellmUserRoles.ORG_ADMIN.value
-        ):
-            return True
+    return any(
+        m.organization_id == organization_id
+        and m.user_role == LitellmUserRoles.ORG_ADMIN.value
+        for m in (caller_user.organization_memberships or [])
+    )
 
-    return False
+
+async def _is_user_org_admin_for_team(
+    user_api_key_dict: UserAPIKeyAuth, team_obj: LiteLLM_TeamTable
+) -> bool:
+    """Check if user is an org admin for the team's organization."""
+    return await _is_user_org_admin_for_org_id(
+        user_api_key_dict=user_api_key_dict,
+        organization_id=team_obj.organization_id,
+    )
 
 
 def _team_member_has_permission(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2560,7 +2560,10 @@ async def update_key_fn(
         )
 
         # logging-exporters validation runs once the key's team is known so a
-        # team-admin of that team can attach destinations to the key
+        # team-admin of that team can attach destinations to the key. A missing
+        # or unauthorized team raises out of get_team_object as HTTPException;
+        # we suppress only that and fall through with is_team_admin_of_key_team
+        # = False so the validator denies the assignment for a non-admin caller.
         _key_team_id = getattr(existing_key_row, "team_id", None)
         _is_team_admin_of_key_team = False
         if _key_team_id is not None:
@@ -2572,13 +2575,14 @@ async def update_key_fn(
                     parent_otel_span=user_api_key_dict.parent_otel_span,
                     check_db_only=True,
                 )
+            except HTTPException:
+                _key_team = None
+            if _key_team is not None:
                 _is_team_admin_of_key_team = any(
                     member.user_id == user_api_key_dict.user_id
                     and member.role == "admin"
                     for member in _key_team.members_with_roles
                 )
-            except Exception:
-                _is_team_admin_of_key_team = False
         validate_key_logging_exporter_assignment(
             metadata=data.metadata,
             user_api_key_dict=user_api_key_dict,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1465,8 +1465,12 @@ async def generate_key_fn(
     - user_id: (str) Unique user id - used for tracking spend across multiple keys for same user id.
     """
     try:
+        from litellm.proxy.management_endpoints.common_utils import (
+            _is_user_org_admin_for_team,
+            _is_user_team_admin,
+        )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
-            validate_key_logging_exporter_assignment,
+            validate_logging_exporter_assignment,
         )
         from litellm.proxy._types import CommonProxyErrors
         from litellm.proxy.proxy_server import (
@@ -1568,17 +1572,26 @@ async def generate_key_fn(
             route=KeyManagementRoutes.KEY_GENERATE,
         )
 
-        # Team-admin of the key's team may write `metadata.logging_exporters`
-        # on team-owned keys (mirrors how they already manage that team's keys'
-        # budgets/models/limits). Personal keys (no team_table) stay strict.
-        _is_team_admin_of_key_team = team_table is not None and any(
-            member.user_id == user_api_key_dict.user_id and member.role == "admin"
-            for member in team_table.members_with_roles
-        )
-        validate_key_logging_exporter_assignment(
-            metadata=data.metadata,
-            user_api_key_dict=user_api_key_dict,
-            is_team_admin_of_key_team=_is_team_admin_of_key_team,
+        # Team-admin of the key's team or org-admin of that team's org may
+        # write metadata.logging_exporters on team-owned keys (mirrors how
+        # team-admins already manage that team's keys' budgets/models/limits,
+        # and how org-admins manage every team in their org). Personal keys
+        # (no team_table) stay proxy-admin only.
+        validate_logging_exporter_assignment(
+            data.metadata,
+            user_api_key_dict,
+            caller_is_team_admin=(
+                team_table is not None
+                and _is_user_team_admin(
+                    user_api_key_dict=user_api_key_dict, team_obj=team_table
+                )
+            ),
+            caller_is_org_admin=(
+                team_table is not None
+                and await _is_user_org_admin_for_team(
+                    user_api_key_dict=user_api_key_dict, team_obj=team_table
+                )
+            ),
         )
 
         if team_table is not None:
@@ -2526,8 +2539,12 @@ async def update_key_fn(
     }'
     ```
     """
+    from litellm.proxy.management_endpoints.common_utils import (
+        _is_user_org_admin_for_team,
+        _is_user_team_admin,
+    )
     from litellm.proxy.management_endpoints.logging_exporter_validation import (
-        validate_key_logging_exporter_assignment,
+        validate_logging_exporter_assignment,
     )
     from litellm.proxy.proxy_server import (
         llm_router,
@@ -2560,12 +2577,13 @@ async def update_key_fn(
         )
 
         # logging-exporters validation runs once the key's team is known so a
-        # team-admin of that team can attach destinations to the key. A missing
-        # or unauthorized team raises out of get_team_object as HTTPException;
-        # we suppress only that and fall through with is_team_admin_of_key_team
-        # = False so the validator denies the assignment for a non-admin caller.
+        # team-admin of that team (or an org-admin of the team's org) can
+        # attach destinations to the key. A missing or unauthorized team
+        # raises out of get_team_object as HTTPException; we suppress only
+        # that and fall through with both flags False so the validator denies
+        # the assignment for a non-admin caller.
         _key_team_id = getattr(existing_key_row, "team_id", None)
-        _is_team_admin_of_key_team = False
+        _key_team = None
         if _key_team_id is not None:
             try:
                 _key_team = await get_team_object(
@@ -2577,16 +2595,21 @@ async def update_key_fn(
                 )
             except HTTPException:
                 _key_team = None
-            if _key_team is not None:
-                _is_team_admin_of_key_team = any(
-                    member.user_id == user_api_key_dict.user_id
-                    and member.role == "admin"
-                    for member in _key_team.members_with_roles
+        validate_logging_exporter_assignment(
+            data.metadata,
+            user_api_key_dict,
+            caller_is_team_admin=(
+                _key_team is not None
+                and _is_user_team_admin(
+                    user_api_key_dict=user_api_key_dict, team_obj=_key_team
                 )
-        validate_key_logging_exporter_assignment(
-            metadata=data.metadata,
-            user_api_key_dict=user_api_key_dict,
-            is_team_admin_of_key_team=_is_team_admin_of_key_team,
+            ),
+            caller_is_org_admin=(
+                _key_team is not None
+                and await _is_user_org_admin_for_team(
+                    user_api_key_dict=user_api_key_dict, team_obj=_key_team
+                )
+            ),
         )
 
         await _validate_update_key_data(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1466,10 +1466,8 @@ async def generate_key_fn(
     """
     try:
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
-            validate_logging_exporter_assignment,
+            validate_key_logging_exporter_assignment,
         )
-
-        validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
         from litellm.proxy._types import CommonProxyErrors
         from litellm.proxy.proxy_server import (
             prisma_client,
@@ -1568,6 +1566,19 @@ async def generate_key_fn(
             user_api_key_dict=user_api_key_dict,
             data=data,
             route=KeyManagementRoutes.KEY_GENERATE,
+        )
+
+        # Team-admin of the key's team may write `metadata.logging_exporters`
+        # on team-owned keys (mirrors how they already manage that team's keys'
+        # budgets/models/limits). Personal keys (no team_table) stay strict.
+        _is_team_admin_of_key_team = team_table is not None and any(
+            member.user_id == user_api_key_dict.user_id and member.role == "admin"
+            for member in team_table.members_with_roles
+        )
+        validate_key_logging_exporter_assignment(
+            metadata=data.metadata,
+            user_api_key_dict=user_api_key_dict,
+            is_team_admin_of_key_team=_is_team_admin_of_key_team,
         )
 
         if team_table is not None:
@@ -2516,10 +2527,8 @@ async def update_key_fn(
     ```
     """
     from litellm.proxy.management_endpoints.logging_exporter_validation import (
-        validate_logging_exporter_assignment,
+        validate_key_logging_exporter_assignment,
     )
-
-    validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
     from litellm.proxy.proxy_server import (
         llm_router,
         premium_user,
@@ -2548,6 +2557,32 @@ async def update_key_fn(
         existing_key_row = await _get_and_validate_existing_key(
             token=data.key,
             prisma_client=prisma_client,
+        )
+
+        # logging-exporters validation runs once the key's team is known so a
+        # team-admin of that team can attach destinations to the key
+        _key_team_id = getattr(existing_key_row, "team_id", None)
+        _is_team_admin_of_key_team = False
+        if _key_team_id is not None:
+            try:
+                _key_team = await get_team_object(
+                    team_id=_key_team_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    parent_otel_span=user_api_key_dict.parent_otel_span,
+                    check_db_only=True,
+                )
+                _is_team_admin_of_key_team = any(
+                    member.user_id == user_api_key_dict.user_id
+                    and member.role == "admin"
+                    for member in _key_team.members_with_roles
+                )
+            except Exception:
+                _is_team_admin_of_key_team = False
+        validate_key_logging_exporter_assignment(
+            metadata=data.metadata,
+            user_api_key_dict=user_api_key_dict,
+            is_team_admin_of_key_team=_is_team_admin_of_key_team,
         )
 
         await _validate_update_key_data(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -1470,6 +1470,7 @@ async def generate_key_fn(
             _is_user_team_admin,
         )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
+            LOGGING_EXPORTERS_KEY,
             validate_logging_exporter_assignment,
         )
         from litellm.proxy._types import CommonProxyErrors
@@ -1573,26 +1574,27 @@ async def generate_key_fn(
         )
 
         # Team-admin of the key's team or org-admin of that team's org may
-        # write metadata.logging_exporters on team-owned keys (mirrors how
-        # team-admins already manage that team's keys' budgets/models/limits,
-        # and how org-admins manage every team in their org). Personal keys
-        # (no team_table) stay proxy-admin only.
-        validate_logging_exporter_assignment(
-            data.metadata,
-            user_api_key_dict,
-            caller_is_team_admin=(
-                team_table is not None
-                and _is_user_team_admin(
-                    user_api_key_dict=user_api_key_dict, team_obj=team_table
-                )
-            ),
-            caller_is_org_admin=(
-                team_table is not None
-                and await _is_user_org_admin_for_team(
-                    user_api_key_dict=user_api_key_dict, team_obj=team_table
-                )
-            ),
-        )
+        # write metadata.logging_exporters on team-owned keys. Personal keys
+        # (no team_table) stay proxy-admin only. Skip the role lookup when
+        # the field isn't in the payload to keep /key/generate cheap for the
+        # common case.
+        if isinstance(data.metadata, dict) and LOGGING_EXPORTERS_KEY in data.metadata:
+            validate_logging_exporter_assignment(
+                data.metadata,
+                user_api_key_dict,
+                caller_is_team_admin=(
+                    team_table is not None
+                    and _is_user_team_admin(
+                        user_api_key_dict=user_api_key_dict, team_obj=team_table
+                    )
+                ),
+                caller_is_org_admin=(
+                    team_table is not None
+                    and await _is_user_org_admin_for_team(
+                        user_api_key_dict=user_api_key_dict, team_obj=team_table
+                    )
+                ),
+            )
 
         if team_table is not None:
             await _check_team_key_limits(
@@ -2544,6 +2546,7 @@ async def update_key_fn(
         _is_user_team_admin,
     )
     from litellm.proxy.management_endpoints.logging_exporter_validation import (
+        LOGGING_EXPORTERS_KEY,
         validate_logging_exporter_assignment,
     )
     from litellm.proxy.proxy_server import (
@@ -2576,41 +2579,39 @@ async def update_key_fn(
             prisma_client=prisma_client,
         )
 
-        # logging-exporters validation runs once the key's team is known so a
-        # team-admin of that team (or an org-admin of the team's org) can
-        # attach destinations to the key. A missing or unauthorized team
-        # raises out of get_team_object as HTTPException; we suppress only
-        # that and fall through with both flags False so the validator denies
-        # the assignment for a non-admin caller.
-        _key_team_id = getattr(existing_key_row, "team_id", None)
-        _key_team = None
-        if _key_team_id is not None:
-            try:
-                _key_team = await get_team_object(
-                    team_id=_key_team_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    parent_otel_span=user_api_key_dict.parent_otel_span,
-                    check_db_only=True,
-                )
-            except HTTPException:
-                _key_team = None
-        validate_logging_exporter_assignment(
-            data.metadata,
-            user_api_key_dict,
-            caller_is_team_admin=(
-                _key_team is not None
-                and _is_user_team_admin(
-                    user_api_key_dict=user_api_key_dict, team_obj=_key_team
-                )
-            ),
-            caller_is_org_admin=(
-                _key_team is not None
-                and await _is_user_org_admin_for_team(
-                    user_api_key_dict=user_api_key_dict, team_obj=_key_team
-                )
-            ),
-        )
+        # logging-exporters validation runs once the key's team is known so
+        # a team-admin or org-admin of that team can attach destinations.
+        # Skip the team lookup entirely when the field isn't being written.
+        if isinstance(data.metadata, dict) and LOGGING_EXPORTERS_KEY in data.metadata:
+            _key_team_id = getattr(existing_key_row, "team_id", None)
+            _key_team = None
+            if _key_team_id is not None:
+                try:
+                    _key_team = await get_team_object(
+                        team_id=_key_team_id,
+                        prisma_client=prisma_client,
+                        user_api_key_cache=user_api_key_cache,
+                        parent_otel_span=user_api_key_dict.parent_otel_span,
+                        check_db_only=True,
+                    )
+                except HTTPException:
+                    _key_team = None
+            validate_logging_exporter_assignment(
+                data.metadata,
+                user_api_key_dict,
+                caller_is_team_admin=(
+                    _key_team is not None
+                    and _is_user_team_admin(
+                        user_api_key_dict=user_api_key_dict, team_obj=_key_team
+                    )
+                ),
+                caller_is_org_admin=(
+                    _key_team is not None
+                    and await _is_user_org_admin_for_team(
+                        user_api_key_dict=user_api_key_dict, team_obj=_key_team
+                    )
+                ),
+            )
 
         await _validate_update_key_data(
             data=data,

--- a/litellm/proxy/management_endpoints/logging_exporter_validation.py
+++ b/litellm/proxy/management_endpoints/logging_exporter_validation.py
@@ -69,27 +69,12 @@ def _logging_credential_names() -> set:
     }
 
 
-def validate_logging_exporter_assignment(
-    metadata: Optional[dict], user_api_key_dict: UserAPIKeyAuth
-) -> None:
-    """Validate a ``metadata.logging_exporters`` assignment, if the update sets one.
-
-    No-op when the update does not touch ``logging_exporters``. Otherwise it must be a
-    list, the caller must be the proxy admin, and every name must be a registered
-    logging credential.
-    """
-    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
-        return
-    exporters = metadata.get(LOGGING_EXPORTERS_KEY)
+def _validate_exporters_shape_and_names(exporters: object) -> list[str]:
+    """Common shape + registry check shared by the two validator entry points."""
     if not isinstance(exporters, list):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"error": "logging_exporters must be a list of credential names"},
-        )
-    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"error": "Only the proxy admin can assign logging exporters"},
         )
     known = _logging_credential_names()
     unknown = [name for name in exporters if name not in known]
@@ -103,3 +88,49 @@ def validate_logging_exporter_assignment(
                 )
             },
         )
+    return [name for name in exporters if isinstance(name, str)]
+
+
+def validate_logging_exporter_assignment(
+    metadata: Optional[dict], user_api_key_dict: UserAPIKeyAuth
+) -> None:
+    """Validate a ``metadata.logging_exporters`` assignment for proxy-admin-only paths.
+
+    Used by key/org writes and team creation, where the team being affected has
+    no pre-existing team-admin to delegate to. ``/team/update`` uses
+    ``validate_team_logging_exporter_assignment`` instead.
+    """
+    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
+        return
+    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"error": "Only the proxy admin can assign logging exporters"},
+        )
+    _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))
+
+
+def validate_team_logging_exporter_assignment(
+    metadata: Optional[dict],
+    user_api_key_dict: UserAPIKeyAuth,
+    is_team_admin: bool,
+) -> None:
+    """``metadata.logging_exporters`` validator for ``/team/update`` only.
+
+    Proxy admins and team-admins of the team being edited may write the field;
+    every name still has to resolve to a registered logging credential.
+    """
+    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
+        return
+    is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+    if not (is_proxy_admin or is_team_admin):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    "Only the proxy admin or a team admin of this team can assign "
+                    "logging exporters"
+                )
+            },
+        )
+    _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))

--- a/litellm/proxy/management_endpoints/logging_exporter_validation.py
+++ b/litellm/proxy/management_endpoints/logging_exporter_validation.py
@@ -134,3 +134,31 @@ def validate_team_logging_exporter_assignment(
             },
         )
     _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))
+
+
+def validate_key_logging_exporter_assignment(
+    metadata: Optional[dict],
+    user_api_key_dict: UserAPIKeyAuth,
+    is_team_admin_of_key_team: bool,
+) -> None:
+    """``metadata.logging_exporters`` validator for ``/key/generate`` and ``/key/update``.
+
+    Proxy admins always pass. A team-admin of the key's team may write the
+    field on a team-owned key, mirroring how team-admins already manage that
+    team's keys (budgets, models, rate limits). Personal (non-team) keys stay
+    proxy-admin only because there's no team to delegate the decision to.
+    """
+    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
+        return
+    is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
+    if not (is_proxy_admin or is_team_admin_of_key_team):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": (
+                    "Only the proxy admin or a team admin of the key's team can "
+                    "assign logging exporters on a key"
+                )
+            },
+        )
+    _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))

--- a/litellm/proxy/management_endpoints/logging_exporter_validation.py
+++ b/litellm/proxy/management_endpoints/logging_exporter_validation.py
@@ -1,9 +1,10 @@
 """Validation for admin-owned logging-exporter assignment on key/team/org.
 
 An identity's ``metadata.logging_exporters`` binds it to admin-owned trace
-destinations. Assigning is proxy-admin only, and every name must be a registered
-logging credential, so a key/team/org can only point at destinations the admin has
-provisioned. The resolver (``litellm_pre_call_utils``) trusts this at request time.
+destinations. Every name must be a registered logging credential, and the
+caller must hold a role that authorizes the write (proxy admin always; team
+admin and org admin in specific contexts). The resolver
+(``litellm_pre_call_utils``) trusts this gate at request time.
 """
 
 from typing import Optional
@@ -69,8 +70,8 @@ def _logging_credential_names() -> set:
     }
 
 
-def _validate_exporters_shape_and_names(exporters: object) -> list[str]:
-    """Common shape + registry check shared by the two validator entry points."""
+def _validate_exporters_shape_and_names(exporters: object) -> None:
+    """Common shape + registry check shared by every entry point."""
     if not isinstance(exporters, list):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -88,50 +89,37 @@ def _validate_exporters_shape_and_names(exporters: object) -> list[str]:
                 )
             },
         )
-    return [name for name in exporters if isinstance(name, str)]
 
 
 def validate_logging_exporter_assignment(
-    metadata: Optional[dict], user_api_key_dict: UserAPIKeyAuth
-) -> None:
-    """Validate a ``metadata.logging_exporters`` assignment for proxy-admin-only paths.
-
-    Used by key/org writes and team creation, where the team being affected has
-    no pre-existing team-admin to delegate to. ``/team/update`` uses
-    ``validate_team_logging_exporter_assignment`` instead.
-    """
-    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
-        return
-    if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"error": "Only the proxy admin can assign logging exporters"},
-        )
-    _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))
-
-
-def validate_key_logging_exporter_assignment(
     metadata: Optional[dict],
     user_api_key_dict: UserAPIKeyAuth,
-    is_team_admin_of_key_team: bool,
+    *,
+    caller_is_team_admin: bool = False,
+    caller_is_org_admin: bool = False,
 ) -> None:
-    """``metadata.logging_exporters`` validator for ``/key/generate`` and ``/key/update``.
+    """Validate a ``metadata.logging_exporters`` write on key / team / org endpoints.
 
-    Proxy admins always pass. A team-admin of the key's team may write the
-    field on a team-owned key, mirroring how team-admins already manage that
-    team's keys (budgets, models, rate limits). Personal (non-team) keys stay
-    proxy-admin only because there's no team to delegate the decision to.
+    No-op when the update does not touch ``logging_exporters``. Proxy admins always
+    pass. Caller-provided flags widen the allow-list per endpoint:
+
+    - ``/team/update``: pass ``caller_is_org_admin`` from the loaded team's org.
+    - ``/key/generate``/``/key/update``: pass both flags from the key's team.
+    - ``/team/new``/``/organization/*``: pass neither (proxy-admin only).
+
+    Every exporter name must resolve to a registered logging credential.
     """
     if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
         return
     is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
-    if not (is_proxy_admin or is_team_admin_of_key_team):
+    if not (is_proxy_admin or caller_is_team_admin or caller_is_org_admin):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
                 "error": (
-                    "Only the proxy admin or a team admin of the key's team can "
-                    "assign logging exporters on a key"
+                    "Only the proxy admin, a team admin of this team, or an "
+                    "org admin of this team's organization can assign logging "
+                    "exporters"
                 )
             },
         )

--- a/litellm/proxy/management_endpoints/logging_exporter_validation.py
+++ b/litellm/proxy/management_endpoints/logging_exporter_validation.py
@@ -110,32 +110,6 @@ def validate_logging_exporter_assignment(
     _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))
 
 
-def validate_team_logging_exporter_assignment(
-    metadata: Optional[dict],
-    user_api_key_dict: UserAPIKeyAuth,
-    is_team_admin: bool,
-) -> None:
-    """``metadata.logging_exporters`` validator for ``/team/update`` only.
-
-    Proxy admins and team-admins of the team being edited may write the field;
-    every name still has to resolve to a registered logging credential.
-    """
-    if not isinstance(metadata, dict) or LOGGING_EXPORTERS_KEY not in metadata:
-        return
-    is_proxy_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
-    if not (is_proxy_admin or is_team_admin):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={
-                "error": (
-                    "Only the proxy admin or a team admin of this team can assign "
-                    "logging exporters"
-                )
-            },
-        )
-    _validate_exporters_shape_and_names(metadata.get(LOGGING_EXPORTERS_KEY))
-
-
 def validate_key_logging_exporter_assignment(
     metadata: Optional[dict],
     user_api_key_dict: UserAPIKeyAuth,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1022,11 +1022,12 @@ async def new_team(
     ```
     """
     try:
+        from litellm.proxy.management_endpoints.common_utils import (
+            _is_user_org_admin_for_org_id,
+        )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
             validate_logging_exporter_assignment,
         )
-
-        validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
         from litellm.proxy.management_helpers.audit_logs import (
             get_audit_log_changed_by,
         )
@@ -1036,6 +1037,17 @@ async def new_team(
             litellm_proxy_admin_name,
             prisma_client,
             user_api_key_cache,
+        )
+
+        # New team has no admins yet, so only proxy admin or an org admin of
+        # the destination org may assign logging exporters at creation time.
+        validate_logging_exporter_assignment(
+            data.metadata,
+            user_api_key_dict,
+            caller_is_org_admin=await _is_user_org_admin_for_org_id(
+                user_api_key_dict=user_api_key_dict,
+                organization_id=data.organization_id,
+            ),
         )
 
         if prisma_client is None:
@@ -1716,11 +1728,13 @@ async def update_team(
     ```
     """
     try:
+        from litellm.proxy.management_endpoints.common_utils import (
+            _is_user_org_admin_for_team,
+            _is_user_team_admin,
+        )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
             validate_logging_exporter_assignment,
         )
-
-        validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
         from litellm.proxy.proxy_server import (
             litellm_proxy_admin_name,
             llm_router,
@@ -1781,9 +1795,23 @@ async def update_team(
             )
 
         # Verify caller has access to manage this team
+        team_for_auth = LiteLLM_TeamTable(**existing_team_row.model_dump())
         await _verify_team_access(
-            team_obj=LiteLLM_TeamTable(**existing_team_row.model_dump()),
+            team_obj=team_for_auth,
             user_api_key_dict=user_api_key_dict,
+        )
+
+        # logging_exporters gate runs once the team's identity is loaded so we
+        # know whether the caller is team-admin or org-admin of this team.
+        validate_logging_exporter_assignment(
+            data.metadata,
+            user_api_key_dict,
+            caller_is_team_admin=_is_user_team_admin(
+                user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
+            ),
+            caller_is_org_admin=await _is_user_org_admin_for_team(
+                user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
+            ),
         )
 
         _check_passthrough_routes_caller_permission(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1717,10 +1717,8 @@ async def update_team(
     """
     try:
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
-            validate_logging_exporter_assignment,
+            validate_team_logging_exporter_assignment,
         )
-
-        validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
         from litellm.proxy.proxy_server import (
             litellm_proxy_admin_name,
             llm_router,
@@ -1781,9 +1779,21 @@ async def update_team(
             )
 
         # Verify caller has access to manage this team
+        team_obj_for_auth = LiteLLM_TeamTable(**existing_team_row.model_dump())
         await _verify_team_access(
-            team_obj=LiteLLM_TeamTable(**existing_team_row.model_dump()),
+            team_obj=team_obj_for_auth,
             user_api_key_dict=user_api_key_dict,
+        )
+
+        # `logging_exporters` is the only metadata field a non-admin team-admin
+        # may write on /team/update. Run the gate now that we know the team id
+        # and have its membership loaded.
+        validate_team_logging_exporter_assignment(
+            metadata=data.metadata,
+            user_api_key_dict=user_api_key_dict,
+            is_team_admin=_is_user_team_admin(
+                user_api_key_dict=user_api_key_dict, team_obj=team_obj_for_auth
+            ),
         )
 
         _check_passthrough_routes_caller_permission(

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1026,6 +1026,7 @@ async def new_team(
             _is_user_org_admin_for_org_id,
         )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
+            LOGGING_EXPORTERS_KEY,
             validate_logging_exporter_assignment,
         )
         from litellm.proxy.management_helpers.audit_logs import (
@@ -1041,14 +1042,17 @@ async def new_team(
 
         # New team has no admins yet, so only proxy admin or an org admin of
         # the destination org may assign logging exporters at creation time.
-        validate_logging_exporter_assignment(
-            data.metadata,
-            user_api_key_dict,
-            caller_is_org_admin=await _is_user_org_admin_for_org_id(
-                user_api_key_dict=user_api_key_dict,
-                organization_id=data.organization_id,
-            ),
-        )
+        # Skip the org-admin lookup entirely when the field isn't being
+        # written, to avoid hitting the cache for unrelated /team/new calls.
+        if isinstance(data.metadata, dict) and LOGGING_EXPORTERS_KEY in data.metadata:
+            validate_logging_exporter_assignment(
+                data.metadata,
+                user_api_key_dict,
+                caller_is_org_admin=await _is_user_org_admin_for_org_id(
+                    user_api_key_dict=user_api_key_dict,
+                    organization_id=data.organization_id,
+                ),
+            )
 
         if prisma_client is None:
             raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -1733,6 +1737,7 @@ async def update_team(
             _is_user_team_admin,
         )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
+            LOGGING_EXPORTERS_KEY,
             validate_logging_exporter_assignment,
         )
         from litellm.proxy.proxy_server import (
@@ -1801,18 +1806,21 @@ async def update_team(
             user_api_key_dict=user_api_key_dict,
         )
 
-        # logging_exporters gate runs once the team's identity is loaded so we
-        # know whether the caller is team-admin or org-admin of this team.
-        validate_logging_exporter_assignment(
-            data.metadata,
-            user_api_key_dict,
-            caller_is_team_admin=_is_user_team_admin(
-                user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
-            ),
-            caller_is_org_admin=await _is_user_org_admin_for_team(
-                user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
-            ),
-        )
+        # logging_exporters gate runs once the team's identity is loaded so
+        # we know team-admin / org-admin status. Skip the org-admin lookup
+        # entirely when the field isn't being written, since /team/update
+        # is called for many unrelated reasons.
+        if isinstance(data.metadata, dict) and LOGGING_EXPORTERS_KEY in data.metadata:
+            validate_logging_exporter_assignment(
+                data.metadata,
+                user_api_key_dict,
+                caller_is_team_admin=_is_user_team_admin(
+                    user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
+                ),
+                caller_is_org_admin=await _is_user_org_admin_for_team(
+                    user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
+                ),
+            )
 
         _check_passthrough_routes_caller_permission(
             data, user_api_key_dict, entity="team"

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1734,7 +1734,6 @@ async def update_team(
     try:
         from litellm.proxy.management_endpoints.common_utils import (
             _is_user_org_admin_for_team,
-            _is_user_team_admin,
         )
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
             LOGGING_EXPORTERS_KEY,
@@ -1806,17 +1805,16 @@ async def update_team(
             user_api_key_dict=user_api_key_dict,
         )
 
-        # logging_exporters gate runs once the team's identity is loaded so
-        # we know team-admin / org-admin status. Skip the org-admin lookup
-        # entirely when the field isn't being written, since /team/update
-        # is called for many unrelated reasons.
+        # logging_exporters on /team/update is proxy-admin or org-admin only:
+        # team-admins are blocked at the route gate (test_team_update_authz_
+        # matrix pins this) and the role matrix documents ❌ for team-admin on
+        # this path. Pass only the org-admin flag so the validator can't
+        # silently grant team-admins if the route gate is ever widened. Skip
+        # the lookup entirely when the field isn't in the payload.
         if isinstance(data.metadata, dict) and LOGGING_EXPORTERS_KEY in data.metadata:
             validate_logging_exporter_assignment(
                 data.metadata,
                 user_api_key_dict,
-                caller_is_team_admin=_is_user_team_admin(
-                    user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
-                ),
                 caller_is_org_admin=await _is_user_org_admin_for_team(
                     user_api_key_dict=user_api_key_dict, team_obj=team_for_auth
                 ),

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1717,8 +1717,10 @@ async def update_team(
     """
     try:
         from litellm.proxy.management_endpoints.logging_exporter_validation import (
-            validate_team_logging_exporter_assignment,
+            validate_logging_exporter_assignment,
         )
+
+        validate_logging_exporter_assignment(data.metadata, user_api_key_dict)
         from litellm.proxy.proxy_server import (
             litellm_proxy_admin_name,
             llm_router,
@@ -1779,21 +1781,9 @@ async def update_team(
             )
 
         # Verify caller has access to manage this team
-        team_obj_for_auth = LiteLLM_TeamTable(**existing_team_row.model_dump())
         await _verify_team_access(
-            team_obj=team_obj_for_auth,
+            team_obj=LiteLLM_TeamTable(**existing_team_row.model_dump()),
             user_api_key_dict=user_api_key_dict,
-        )
-
-        # `logging_exporters` is the only metadata field a non-admin team-admin
-        # may write on /team/update. Run the gate now that we know the team id
-        # and have its membership loaded.
-        validate_team_logging_exporter_assignment(
-            metadata=data.metadata,
-            user_api_key_dict=user_api_key_dict,
-            is_team_admin=_is_user_team_admin(
-                user_api_key_dict=user_api_key_dict, team_obj=team_obj_for_auth
-            ),
         )
 
         _check_passthrough_routes_caller_permission(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3711,6 +3711,9 @@ from litellm.models.credentials import CredentialItem as CredentialItem  # noqa:
 from litellm.models.credentials import (  # noqa: E402
     CreateCredentialItem as CreateCredentialItem,
 )
+from litellm.models.credentials import (  # noqa: E402
+    UpdateCredentialItem as UpdateCredentialItem,
+)
 
 
 class ExtractedFileData(TypedDict):

--- a/tests/test_litellm/proxy/credential_endpoints/test_access_decision.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_access_decision.py
@@ -150,20 +150,61 @@ class TestTeamAdminDeny:
         assert isinstance(d, Deny)
         assert "team-foreign" in d.reason
 
-    def test_removing_existing_grant(self):
+    def test_removing_foreign_team_grant(self):
+        """team-admin may NOT remove a team they don't admin."""
         d = _decision(
             patch_info={
                 "access": {"teams": ["team-A", "team-T"]},
             },
         )
         assert isinstance(d, Deny)
+        # team-B was removed and the caller doesn't admin team-B.
         assert "team-B" in d.reason
 
-    def test_replacing_teams_wholesale(self):
+    def test_replacing_teams_wholesale_with_foreign_remaining(self):
+        """Wholesale replacement that removes foreign grants is rejected."""
         d = _decision(patch_info={"access": {"teams": ["team-T"]}})
         assert isinstance(d, Deny)
-        # Removed team-A and team-B; either should appear in the reason.
+        # team-A and team-B were both dropped; the caller admins neither.
         assert "team-A" in d.reason or "team-B" in d.reason
+
+
+class TestTeamAdminRevoke:
+    """A team-admin may revoke their OWN team's grant; never another's."""
+
+    def test_revoking_own_team_is_allowed(self):
+        existing = {
+            **_EXISTING_INFO,
+            "access": {"teams": ["team-A", "team-T"]},
+        }
+        d = _decision(
+            existing_info=existing,
+            patch_info={"access": {"teams": ["team-A"]}},
+        )
+        assert isinstance(d, Allow)
+
+    def test_revoking_own_team_when_only_grant(self):
+        """Saving an empty teams list when the caller was the sole grant."""
+        existing = {**_EXISTING_INFO, "access": {"teams": ["team-T"]}}
+        d = _decision(
+            existing_info=existing,
+            patch_info={"access": {"teams": []}},
+        )
+        assert isinstance(d, Allow)
+
+    def test_revoke_attempt_on_foreign_team_denied(self):
+        """A patch that removes a foreign team is still rejected, even if
+        the caller is also revoking their own."""
+        existing = {
+            **_EXISTING_INFO,
+            "access": {"teams": ["team-A", "team-B", "team-T"]},
+        }
+        d = _decision(
+            existing_info=existing,
+            patch_info={"access": {"teams": ["team-A"]}},  # drops team-B AND team-T
+        )
+        assert isinstance(d, Deny)
+        assert "team-B" in d.reason
 
 
 class TestTeamAdminMultipleTeams:

--- a/tests/test_litellm/proxy/credential_endpoints/test_access_decision.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_access_decision.py
@@ -1,0 +1,187 @@
+"""Exhaustive tests for the pure access-decision function.
+
+Each test names one specific reason a team-admin patch should be denied (or
+allowed). Together they pin the security contract: changing this code with
+the tests in place should fail a case named after what you broke.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from litellm.proxy.credential_endpoints.access_decision import (
+    Allow,
+    Deny,
+    decide_credential_patch,
+)
+
+_EXISTING_INFO = {
+    "credential_type": "logging",
+    "description": "tenant Langfuse",
+    "host": "https://cloud.langfuse.com",
+    "access": {"teams": ["team-A", "team-B"], "orgs": ["org-1"], "global": False},
+}
+
+
+def _decision(
+    *,
+    is_proxy_admin: bool = False,
+    caller_team_admin_ids: frozenset[str] = frozenset({"team-T"}),
+    existing_info=_EXISTING_INFO,
+    patch_info=None,
+    patch_values=None,
+    patch_name_changed: bool = False,
+):
+    return decide_credential_patch(
+        is_proxy_admin=is_proxy_admin,
+        caller_team_admin_ids=caller_team_admin_ids,
+        existing_info=existing_info,
+        patch_info=patch_info,
+        patch_values=patch_values,
+        patch_name_changed=patch_name_changed,
+    )
+
+
+class TestProxyAdminAllow:
+    def test_proxy_admin_allowed_on_value_change(self):
+        d = _decision(
+            is_proxy_admin=True,
+            patch_values={"api_key": "rotated"},
+            patch_info={"credential_type": "logging"},
+        )
+        assert isinstance(d, Allow)
+
+    def test_proxy_admin_allowed_on_global_flip(self):
+        d = _decision(
+            is_proxy_admin=True,
+            patch_info={"access": {"global": True}},
+        )
+        assert isinstance(d, Allow)
+
+    def test_proxy_admin_allowed_on_rename(self):
+        d = _decision(is_proxy_admin=True, patch_name_changed=True)
+        assert isinstance(d, Allow)
+
+
+class TestTeamAdminAllow:
+    def test_appending_own_team_id(self):
+        d = _decision(
+            patch_info={
+                "access": {"teams": ["team-A", "team-B", "team-T"]},
+            },
+        )
+        assert isinstance(d, Allow)
+
+    def test_appending_only_own_team_id_when_no_prior_teams(self):
+        existing = {**_EXISTING_INFO, "access": {"global": False}}
+        d = _decision(
+            existing_info=existing,
+            patch_info={"access": {"teams": ["team-T"]}},
+        )
+        assert isinstance(d, Allow)
+
+    def test_idempotent_when_already_granted(self):
+        existing = {**_EXISTING_INFO, "access": {"teams": ["team-T"]}}
+        d = _decision(
+            existing_info=existing,
+            patch_info={"access": {"teams": ["team-T"]}},
+        )
+        assert isinstance(d, Allow)
+
+
+class TestTeamAdminDeny:
+    def test_not_team_admin_anywhere(self):
+        d = _decision(
+            caller_team_admin_ids=frozenset(),
+            patch_info={"access": {"teams": ["team-T"]}},
+        )
+        assert isinstance(d, Deny)
+        assert "proxy admin" in d.reason
+
+    def test_rename(self):
+        d = _decision(
+            patch_name_changed=True,
+            patch_info={"access": {"teams": ["team-T"]}},
+        )
+        assert isinstance(d, Deny)
+        assert "credential_name" in d.reason
+
+    def test_changing_credential_values(self):
+        d = _decision(
+            patch_values={"api_key": "stolen"},
+            patch_info={"access": {"teams": ["team-T"]}},
+        )
+        assert isinstance(d, Deny)
+        assert "credential_values" in d.reason
+
+    def test_empty_patch(self):
+        d = _decision(patch_info=None)
+        assert isinstance(d, Deny)
+
+    @pytest.mark.parametrize(
+        "field", ["credential_type", "description", "host", "endpoint"]
+    )
+    def test_changing_immutable_info_field(self, field):
+        d = _decision(patch_info={field: "x", "access": {"teams": ["team-T"]}})
+        assert isinstance(d, Deny)
+        assert field in d.reason
+
+    def test_patch_info_with_unknown_keys(self):
+        d = _decision(patch_info={"weird_field": 1})
+        assert isinstance(d, Deny)
+        assert "weird_field" in d.reason
+
+    def test_flipping_global(self):
+        d = _decision(patch_info={"access": {"global": True}})
+        assert isinstance(d, Deny)
+        assert "global" in d.reason
+
+    def test_editing_orgs(self):
+        d = _decision(patch_info={"access": {"orgs": ["org-new"]}})
+        assert isinstance(d, Deny)
+        assert "orgs" in d.reason
+
+    def test_adding_foreign_team_id(self):
+        d = _decision(
+            patch_info={
+                "access": {"teams": ["team-A", "team-B", "team-foreign"]},
+            },
+        )
+        assert isinstance(d, Deny)
+        assert "team-foreign" in d.reason
+
+    def test_removing_existing_grant(self):
+        d = _decision(
+            patch_info={
+                "access": {"teams": ["team-A", "team-T"]},
+            },
+        )
+        assert isinstance(d, Deny)
+        assert "team-B" in d.reason
+
+    def test_replacing_teams_wholesale(self):
+        d = _decision(patch_info={"access": {"teams": ["team-T"]}})
+        assert isinstance(d, Deny)
+        # Removed team-A and team-B; either should appear in the reason.
+        assert "team-A" in d.reason or "team-B" in d.reason
+
+
+class TestTeamAdminMultipleTeams:
+    def test_can_add_multiple_own_team_ids(self):
+        d = _decision(
+            caller_team_admin_ids=frozenset({"team-T1", "team-T2"}),
+            patch_info={
+                "access": {"teams": ["team-A", "team-B", "team-T1", "team-T2"]},
+            },
+        )
+        assert isinstance(d, Allow)
+
+    def test_one_own_one_foreign_is_deny(self):
+        d = _decision(
+            caller_team_admin_ids=frozenset({"team-T1"}),
+            patch_info={
+                "access": {"teams": ["team-A", "team-B", "team-T1", "team-T2"]},
+            },
+        )
+        assert isinstance(d, Deny)
+        assert "team-T2" in d.reason

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -288,7 +288,7 @@ def _team_admin_of(team_ids):
     """A non-admin caller whose user_id is admin of the named teams.
 
     Combined with ``_patch_team_admin_lookup`` it mimics the real
-    ``_caller_team_admin_ids`` resolution without touching the DB.
+    ``_caller_grantable_team_ids`` resolution without touching the DB.
     """
     return UserAPIKeyAuth(
         api_key="k", user_role=LitellmUserRoles.INTERNAL_USER, user_id="ta-demo"
@@ -297,14 +297,14 @@ def _team_admin_of(team_ids):
 
 @pytest.fixture
 def _patch_team_admin_lookup(monkeypatch):
-    """Substitute the DB-backed team-admin lookup with a configurable mock."""
+    """Substitute the DB-backed grant-capability lookup with a configurable mock."""
 
     holder = {"ids": frozenset()}
 
     async def _fake(user_api_key_dict, prisma_client):
         return holder["ids"]
 
-    monkeypatch.setattr(endpoints, "_caller_team_admin_ids", _fake)
+    monkeypatch.setattr(endpoints, "_caller_grantable_team_ids", _fake)
     return holder
 
 

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -1,8 +1,12 @@
-"""Admin-gating on credential mutations for logging destinations.
+"""Admin-gating on credential mutations.
 
-Logging credentials carry ``credential_info.access`` that controls where other
-tenants' traces export, so create/update/delete of a logging credential is
-proxy-admin only. Provider credentials keep their pre-existing (ungated) behavior.
+POST and DELETE on ``/credentials`` are proxy-admin only across the board
+(both logging and provider credentials). The route gate was widened so
+team-admins can PATCH ``access.teams`` on existing logging destinations,
+which requires also reaching the GET endpoint — but creation and deletion
+of any credential remain admin-only to keep platform infrastructure under
+the platform admin's control. PATCH is widened for logging credentials only
+via the pure ``decide_credential_patch`` decider tested separately.
 """
 
 import os
@@ -84,19 +88,27 @@ async def test_create_logging_credential_allowed_for_admin(_connected_db):
 
 
 @pytest.mark.asyncio
-async def test_create_provider_credential_not_gated(_connected_db):
-    """A non-logging (provider) credential keeps its pre-existing ungated behavior."""
-    result = await endpoints.create_credential(
-        request=MagicMock(),
-        fastapi_response=MagicMock(),
-        credential=CreateCredentialItem(
-            credential_name="openai",
-            credential_values={"api_key": "sk"},
-            credential_info={"custom_llm_provider": "openai"},
-        ),
-        user_api_key_dict=_member(),
-    )
-    assert result["success"] is True
+async def test_create_provider_credential_forbidden_for_non_admin(_connected_db):
+    """POST is proxy-admin only even for provider credentials.
+
+    The route gate now lets non-admins reach the credentials path so they can
+    PATCH ``access.teams`` on logging destinations they should be able to
+    self-assign. POST remains admin-only to keep credential creation a
+    platform-admin concern.
+    """
+    with pytest.raises(HTTPException) as exc:
+        await endpoints.create_credential(
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            credential=CreateCredentialItem(
+                credential_name="openai",
+                credential_values={"api_key": "sk"},
+                credential_info={"custom_llm_provider": "openai"},
+            ),
+            user_api_key_dict=_member(),
+        )
+    assert exc.value.status_code == 403
+    _connected_db.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -260,3 +272,194 @@ async def test_delete_db_only_logging_credential_forbidden_for_non_admin(
         )
     assert exc.value.status_code == 403
     _connected_db.delete_by_name.assert_not_awaited()
+
+
+# --- team-admin self-assign tests (LIT-3850 follow-up) ----------------------
+
+_DEST_WITH_TEAMS = {
+    "credential_type": "logging",
+    "description": "tenant Langfuse",
+    "host": "https://cloud.langfuse.com",
+    "access": {"teams": ["team-existing"]},
+}
+
+
+def _team_admin_of(team_ids):
+    """A non-admin caller whose user_id is admin of the named teams.
+
+    Combined with ``_patch_team_admin_lookup`` it mimics the real
+    ``_caller_team_admin_ids`` resolution without touching the DB.
+    """
+    return UserAPIKeyAuth(
+        api_key="k", user_role=LitellmUserRoles.INTERNAL_USER, user_id="ta-demo"
+    )
+
+
+@pytest.fixture
+def _patch_team_admin_lookup(monkeypatch):
+    """Substitute the DB-backed team-admin lookup with a configurable mock."""
+
+    holder = {"ids": frozenset()}
+
+    async def _fake(user_api_key_dict, prisma_client):
+        return holder["ids"]
+
+    monkeypatch.setattr(endpoints, "_caller_team_admin_ids", _fake)
+    return holder
+
+
+def _resident_logging_dest():
+    return CredentialItem(
+        credential_name="dest",
+        credential_values={"langfuse_host": "h"},
+        credential_info=_DEST_WITH_TEAMS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_admin_can_append_own_team_to_access(
+    _connected_db, _patch_team_admin_lookup, monkeypatch
+):
+    monkeypatch.setattr(litellm, "credential_list", [_resident_logging_dest()])
+    _connected_db.find_by_name = AsyncMock(return_value=_resident_logging_dest())
+    _connected_db.update_by_name = AsyncMock()
+    _patch_team_admin_lookup["ids"] = frozenset({"team-T"})
+
+    result = await endpoints.update_credential(
+        request=MagicMock(),
+        fastapi_response=MagicMock(),
+        credential=CredentialItem(
+            credential_name="dest",
+            credential_values={},
+            credential_info={"access": {"teams": ["team-existing", "team-T"]}},
+        ),
+        credential_name="dest",
+        user_api_key_dict=_team_admin_of(["team-T"]),
+    )
+    assert result["success"] is True
+    _connected_db.update_by_name.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_team_admin_cannot_grant_foreign_team(
+    _connected_db, _patch_team_admin_lookup, monkeypatch
+):
+    monkeypatch.setattr(litellm, "credential_list", [_resident_logging_dest()])
+    _patch_team_admin_lookup["ids"] = frozenset({"team-T"})
+
+    with pytest.raises(HTTPException) as exc:
+        await endpoints.update_credential(
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            credential=CredentialItem(
+                credential_name="dest",
+                credential_values={},
+                credential_info={
+                    "access": {"teams": ["team-existing", "team-foreign"]}
+                },
+            ),
+            credential_name="dest",
+            user_api_key_dict=_team_admin_of(["team-T"]),
+        )
+    assert exc.value.status_code == 403
+    assert "team-foreign" in exc.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_team_admin_cannot_rotate_credential_values(
+    _connected_db, _patch_team_admin_lookup, monkeypatch
+):
+    monkeypatch.setattr(litellm, "credential_list", [_resident_logging_dest()])
+    _patch_team_admin_lookup["ids"] = frozenset({"team-T"})
+
+    with pytest.raises(HTTPException) as exc:
+        await endpoints.update_credential(
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            credential=CredentialItem(
+                credential_name="dest",
+                credential_values={"public_key": "pk-stolen"},
+                credential_info={"access": {"teams": ["team-existing", "team-T"]}},
+            ),
+            credential_name="dest",
+            user_api_key_dict=_team_admin_of(["team-T"]),
+        )
+    assert exc.value.status_code == 403
+    assert "credential_values" in exc.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_team_admin_cannot_flip_global(
+    _connected_db, _patch_team_admin_lookup, monkeypatch
+):
+    monkeypatch.setattr(litellm, "credential_list", [_resident_logging_dest()])
+    _patch_team_admin_lookup["ids"] = frozenset({"team-T"})
+
+    with pytest.raises(HTTPException) as exc:
+        await endpoints.update_credential(
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            credential=CredentialItem(
+                credential_name="dest",
+                credential_values={},
+                credential_info={"access": {"global": True}},
+            ),
+            credential_name="dest",
+            user_api_key_dict=_team_admin_of(["team-T"]),
+        )
+    assert exc.value.status_code == 403
+    assert "global" in exc.value.detail["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_credentials_filters_to_logging_for_non_admin(monkeypatch):
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai",
+                credential_values={"api_key": "sk-secret"},
+                credential_info={"custom_llm_provider": "openai"},
+            ),
+            CredentialItem(
+                credential_name="poc-langfuse",
+                credential_values={"public_key": "pk-1"},
+                credential_info=_DEST_WITH_TEAMS,
+            ),
+        ],
+    )
+    response = await endpoints.get_credentials(
+        request=MagicMock(),
+        fastapi_response=MagicMock(),
+        user_api_key_dict=_team_admin_of(["team-T"]),
+    )
+    names = [c["credential_name"] for c in response["credentials"]]
+    assert names == ["poc-langfuse"]
+
+
+@pytest.mark.asyncio
+async def test_get_credentials_returns_all_for_proxy_admin(monkeypatch):
+    monkeypatch.setattr(
+        litellm,
+        "credential_list",
+        [
+            CredentialItem(
+                credential_name="openai",
+                credential_values={"api_key": "sk-secret"},
+                credential_info={"custom_llm_provider": "openai"},
+            ),
+            CredentialItem(
+                credential_name="poc-langfuse",
+                credential_values={"public_key": "pk-1"},
+                credential_info=_DEST_WITH_TEAMS,
+            ),
+        ],
+    )
+    response = await endpoints.get_credentials(
+        request=MagicMock(),
+        fastapi_response=MagicMock(),
+        user_api_key_dict=_admin(),
+    )
+    names = sorted(c["credential_name"] for c in response["credentials"])
+    assert names == ["openai", "poc-langfuse"]

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -341,6 +341,42 @@ async def test_team_admin_can_append_own_team_to_access(
 
 
 @pytest.mark.asyncio
+async def test_provider_credential_patch_forbidden_for_non_admin(
+    _connected_db, monkeypatch
+):
+    """A team-admin (or any non-admin) cannot PATCH a non-logging credential.
+
+    The route gate was widened to let team-admins reach /credentials/{name}
+    for logging-credential access edits. A provider credential is not
+    is_admin_gated_credential_info, so the decider block is skipped; without
+    an explicit else-branch a team-admin could rotate the upstream api_key.
+    """
+    provider_cred = CredentialItem(
+        credential_name="openai-prod",
+        credential_values={"api_key": "sk-real"},
+        credential_info={"custom_llm_provider": "openai"},
+    )
+    monkeypatch.setattr(litellm, "credential_list", [provider_cred])
+    _connected_db.find_by_name = AsyncMock(return_value=provider_cred)
+    _connected_db.update_by_name = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await endpoints.update_credential(
+            request=MagicMock(),
+            fastapi_response=MagicMock(),
+            credential=CredentialItem(
+                credential_name="openai-prod",
+                credential_values={"api_key": "sk-stolen"},
+                credential_info={},
+            ),
+            credential_name="openai-prod",
+            user_api_key_dict=_member(),
+        )
+    assert exc.value.status_code == 403
+    _connected_db.update_by_name.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_team_admin_can_revoke_own_team_grant(
     _connected_db, _patch_team_admin_lookup, monkeypatch
 ):

--- a/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/credential_endpoints/test_endpoints.py
@@ -341,6 +341,41 @@ async def test_team_admin_can_append_own_team_to_access(
 
 
 @pytest.mark.asyncio
+async def test_team_admin_can_revoke_own_team_grant(
+    _connected_db, _patch_team_admin_lookup, monkeypatch
+):
+    """A team-admin saving an access list without their own team_id revokes it."""
+    existing = CredentialItem(
+        credential_name="dest",
+        credential_values={"langfuse_host": "h"},
+        credential_info={
+            "credential_type": "logging",
+            "description": "tenant Langfuse",
+            "host": "https://cloud.langfuse.com",
+            "access": {"teams": ["team-existing", "team-T"]},
+        },
+    )
+    monkeypatch.setattr(litellm, "credential_list", [existing])
+    _connected_db.find_by_name = AsyncMock(return_value=existing)
+    _connected_db.update_by_name = AsyncMock()
+    _patch_team_admin_lookup["ids"] = frozenset({"team-T"})
+
+    result = await endpoints.update_credential(
+        request=MagicMock(),
+        fastapi_response=MagicMock(),
+        credential=CredentialItem(
+            credential_name="dest",
+            credential_values={},
+            credential_info={"access": {"teams": ["team-existing"]}},
+        ),
+        credential_name="dest",
+        user_api_key_dict=_team_admin_of(["team-T"]),
+    )
+    assert result["success"] is True
+    _connected_db.update_by_name.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_team_admin_cannot_grant_foreign_team(
     _connected_db, _patch_team_admin_lookup, monkeypatch
 ):

--- a/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
@@ -1,4 +1,11 @@
-"""Validation for admin-owned logging-exporter assignment on key/team/org."""
+"""Validation for admin-owned logging-exporter assignment on key/team/org.
+
+The single ``validate_logging_exporter_assignment`` runs across all four
+endpoints (``/team/new``, ``/team/update``, ``/key/generate``, ``/key/update``,
+``/organization/*``); each call site computes the relevant
+``caller_is_team_admin`` / ``caller_is_org_admin`` flags from the loaded
+team or org and passes them in. Proxy admin always passes.
+"""
 
 import os
 import sys
@@ -14,7 +21,6 @@ from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.management_endpoints.logging_exporter_validation import (
     is_admin_gated_credential_info,
     validate_credential_access,
-    validate_key_logging_exporter_assignment,
     validate_logging_exporter_assignment,
 )
 
@@ -34,7 +40,7 @@ def _registry():
         CredentialItem(
             credential_name="openai-key",
             credential_values={},
-            credential_info={"custom_llm_provider": "openai"},  # a provider credential
+            credential_info={"custom_llm_provider": "openai"},  # provider credential
         ),
     ]
     try:
@@ -47,44 +53,90 @@ def _admin():
     return UserAPIKeyAuth(api_key="k", user_role=LitellmUserRoles.PROXY_ADMIN)
 
 
-def _member():
+def _non_admin():
     return UserAPIKeyAuth(api_key="k", user_role=LitellmUserRoles.INTERNAL_USER)
 
 
-def test_admin_with_known_logging_credential_is_allowed(_registry):
+def _ok(metadata):
+    return {"logging_exporters": metadata}
+
+
+# --- Role allow paths -------------------------------------------------------
+
+
+def test_proxy_admin_always_allowed(_registry):
+    """No flags needed; proxy_admin role suffices."""
+    validate_logging_exporter_assignment(_ok(["langfuse-eu"]), _admin())
+
+
+def test_team_admin_flag_allows_non_admin(_registry):
+    """A non-admin caller flagged caller_is_team_admin=True passes."""
     validate_logging_exporter_assignment(
-        {"logging_exporters": ["langfuse-eu"]}, _admin()
+        _ok(["langfuse-eu"]),
+        _non_admin(),
+        caller_is_team_admin=True,
     )
 
 
-def test_noop_when_assignment_absent(_registry):
-    # an update that does not touch logging_exporters is never gated/validated
-    validate_logging_exporter_assignment({"some_other_key": 1}, _member())
-    validate_logging_exporter_assignment(None, _member())
+def test_org_admin_flag_allows_non_admin(_registry):
+    """A non-admin caller flagged caller_is_org_admin=True passes."""
+    validate_logging_exporter_assignment(
+        _ok(["langfuse-eu"]),
+        _non_admin(),
+        caller_is_org_admin=True,
+    )
 
 
-def test_non_admin_is_forbidden(_registry):
+def test_both_flags_set_allows_non_admin(_registry):
+    """Setting both flags is fine; they're independent OR-ed allows."""
+    validate_logging_exporter_assignment(
+        _ok(["langfuse-eu"]),
+        _non_admin(),
+        caller_is_team_admin=True,
+        caller_is_org_admin=True,
+    )
+
+
+def test_non_admin_with_no_flags_is_forbidden(_registry):
+    """The headline deny: internal_user with no team/org admin context."""
     with pytest.raises(HTTPException) as exc:
-        validate_logging_exporter_assignment(
-            {"logging_exporters": ["langfuse-eu"]}, _member()
-        )
+        validate_logging_exporter_assignment(_ok(["langfuse-eu"]), _non_admin())
     assert exc.value.status_code == 403
 
 
-def test_unknown_credential_is_rejected(_registry):
+def test_proxy_admin_overrides_falsy_flags(_registry):
+    """proxy_admin role wins even when both flags are False."""
+    validate_logging_exporter_assignment(
+        _ok(["langfuse-eu"]),
+        _admin(),
+        caller_is_team_admin=False,
+        caller_is_org_admin=False,
+    )
+
+
+# --- Shape / registry checks (run regardless of who's calling) --------------
+
+
+def test_unknown_credential_rejected_for_admin(_registry):
+    with pytest.raises(HTTPException) as exc:
+        validate_logging_exporter_assignment(_ok(["does-not-exist"]), _admin())
+    assert exc.value.status_code == 400
+
+
+def test_unknown_credential_rejected_for_team_admin(_registry):
     with pytest.raises(HTTPException) as exc:
         validate_logging_exporter_assignment(
-            {"logging_exporters": ["does-not-exist"]}, _admin()
+            _ok(["does-not-exist"]),
+            _non_admin(),
+            caller_is_team_admin=True,
         )
     assert exc.value.status_code == 400
 
 
-def test_provider_credential_is_not_a_valid_logging_exporter(_registry):
-    # openai-key exists but is a provider credential, not a logging destination
+def test_provider_credential_rejected(_registry):
+    """openai-key exists but is provider-typed, not a logging destination."""
     with pytest.raises(HTTPException) as exc:
-        validate_logging_exporter_assignment(
-            {"logging_exporters": ["openai-key"]}, _admin()
-        )
+        validate_logging_exporter_assignment(_ok(["openai-key"]), _admin())
     assert exc.value.status_code == 400
 
 
@@ -94,6 +146,16 @@ def test_non_list_is_rejected(_registry):
             {"logging_exporters": "langfuse-eu"}, _admin()
         )
     assert exc.value.status_code == 400
+
+
+def test_noop_when_field_absent(_registry):
+    """An update that does not touch logging_exporters skips the gate even
+    for a non-admin with no flags."""
+    validate_logging_exporter_assignment({"some_other_key": 1}, _non_admin())
+    validate_logging_exporter_assignment(None, _non_admin())
+
+
+# --- is_admin_gated_credential_info / validate_credential_access ------------
 
 
 @pytest.mark.parametrize(
@@ -135,68 +197,3 @@ def test_validate_credential_access_rejects_bad_shape(access):
     with pytest.raises(HTTPException) as exc:
         validate_credential_access({"access": access})
     assert exc.value.status_code == 400
-
-
-# --- key-scoped validator (LIT-3850 follow-up) ------------------------------
-
-
-def test_key_validator_team_admin_of_key_team_passes(_registry):
-    """team-admin of the key's team may write metadata.logging_exporters."""
-    validate_key_logging_exporter_assignment(
-        metadata={"logging_exporters": ["langfuse-eu"]},
-        user_api_key_dict=_member(),
-        is_team_admin_of_key_team=True,
-    )
-
-
-def test_key_validator_proxy_admin_always_passes(_registry):
-    validate_key_logging_exporter_assignment(
-        metadata={"logging_exporters": ["langfuse-eu"]},
-        user_api_key_dict=_admin(),
-        is_team_admin_of_key_team=False,
-    )
-
-
-def test_key_validator_non_team_admin_is_forbidden(_registry):
-    """A non-admin who isn't team-admin of the key's team is rejected."""
-    with pytest.raises(HTTPException) as exc:
-        validate_key_logging_exporter_assignment(
-            metadata={"logging_exporters": ["langfuse-eu"]},
-            user_api_key_dict=_member(),
-            is_team_admin_of_key_team=False,
-        )
-    assert exc.value.status_code == 403
-
-
-def test_key_validator_personal_key_rejects_non_admin(_registry):
-    """A personal key (no team) means is_team_admin_of_key_team=False; only admin passes."""
-    with pytest.raises(HTTPException) as exc:
-        validate_key_logging_exporter_assignment(
-            metadata={"logging_exporters": ["langfuse-eu"]},
-            user_api_key_dict=_member(),
-            is_team_admin_of_key_team=False,
-        )
-    assert exc.value.status_code == 403
-
-
-def test_key_validator_unknown_credential_rejected_even_for_team_admin(_registry):
-    with pytest.raises(HTTPException) as exc:
-        validate_key_logging_exporter_assignment(
-            metadata={"logging_exporters": ["does-not-exist"]},
-            user_api_key_dict=_member(),
-            is_team_admin_of_key_team=True,
-        )
-    assert exc.value.status_code == 400
-
-
-def test_key_validator_noop_when_absent(_registry):
-    validate_key_logging_exporter_assignment(
-        metadata={"other": 1},
-        user_api_key_dict=_member(),
-        is_team_admin_of_key_team=False,
-    )
-    validate_key_logging_exporter_assignment(
-        metadata=None,
-        user_api_key_dict=_member(),
-        is_team_admin_of_key_team=False,
-    )

--- a/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
@@ -14,6 +14,7 @@ from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.management_endpoints.logging_exporter_validation import (
     is_admin_gated_credential_info,
     validate_credential_access,
+    validate_key_logging_exporter_assignment,
     validate_logging_exporter_assignment,
     validate_team_logging_exporter_assignment,
 )
@@ -202,4 +203,69 @@ def test_team_validator_noop_when_absent(_registry):
         metadata=None,
         user_api_key_dict=_member(),
         is_team_admin=False,
+    )
+
+
+# --- key-scoped validator (LIT-3850 follow-up) ------------------------------
+
+
+def test_key_validator_team_admin_of_key_team_passes(_registry):
+    """team-admin of the key's team may write metadata.logging_exporters."""
+    validate_key_logging_exporter_assignment(
+        metadata={"logging_exporters": ["langfuse-eu"]},
+        user_api_key_dict=_member(),
+        is_team_admin_of_key_team=True,
+    )
+
+
+def test_key_validator_proxy_admin_always_passes(_registry):
+    validate_key_logging_exporter_assignment(
+        metadata={"logging_exporters": ["langfuse-eu"]},
+        user_api_key_dict=_admin(),
+        is_team_admin_of_key_team=False,
+    )
+
+
+def test_key_validator_non_team_admin_is_forbidden(_registry):
+    """A non-admin who isn't team-admin of the key's team is rejected."""
+    with pytest.raises(HTTPException) as exc:
+        validate_key_logging_exporter_assignment(
+            metadata={"logging_exporters": ["langfuse-eu"]},
+            user_api_key_dict=_member(),
+            is_team_admin_of_key_team=False,
+        )
+    assert exc.value.status_code == 403
+
+
+def test_key_validator_personal_key_rejects_non_admin(_registry):
+    """A personal key (no team) means is_team_admin_of_key_team=False; only admin passes."""
+    with pytest.raises(HTTPException) as exc:
+        validate_key_logging_exporter_assignment(
+            metadata={"logging_exporters": ["langfuse-eu"]},
+            user_api_key_dict=_member(),
+            is_team_admin_of_key_team=False,
+        )
+    assert exc.value.status_code == 403
+
+
+def test_key_validator_unknown_credential_rejected_even_for_team_admin(_registry):
+    with pytest.raises(HTTPException) as exc:
+        validate_key_logging_exporter_assignment(
+            metadata={"logging_exporters": ["does-not-exist"]},
+            user_api_key_dict=_member(),
+            is_team_admin_of_key_team=True,
+        )
+    assert exc.value.status_code == 400
+
+
+def test_key_validator_noop_when_absent(_registry):
+    validate_key_logging_exporter_assignment(
+        metadata={"other": 1},
+        user_api_key_dict=_member(),
+        is_team_admin_of_key_team=False,
+    )
+    validate_key_logging_exporter_assignment(
+        metadata=None,
+        user_api_key_dict=_member(),
+        is_team_admin_of_key_team=False,
     )

--- a/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
@@ -16,7 +16,6 @@ from litellm.proxy.management_endpoints.logging_exporter_validation import (
     validate_credential_access,
     validate_key_logging_exporter_assignment,
     validate_logging_exporter_assignment,
-    validate_team_logging_exporter_assignment,
 )
 
 
@@ -136,74 +135,6 @@ def test_validate_credential_access_rejects_bad_shape(access):
     with pytest.raises(HTTPException) as exc:
         validate_credential_access({"access": access})
     assert exc.value.status_code == 400
-
-
-# --- team-scoped validator (LIT-3850 follow-up) -----------------------------
-
-
-def test_team_admin_can_set_logging_exporters(_registry):
-    """A team-admin of the team being edited may write the field."""
-    validate_team_logging_exporter_assignment(
-        metadata={"logging_exporters": ["langfuse-eu"]},
-        user_api_key_dict=_member(),
-        is_team_admin=True,
-    )
-
-
-def test_team_validator_proxy_admin_always_passes(_registry):
-    """Proxy admin skips the team-admin check entirely."""
-    validate_team_logging_exporter_assignment(
-        metadata={"logging_exporters": ["langfuse-eu"]},
-        user_api_key_dict=_admin(),
-        is_team_admin=False,
-    )
-
-
-def test_team_validator_forbids_random_member(_registry):
-    """A non-admin caller who is NOT team-admin of the target team is rejected."""
-    with pytest.raises(HTTPException) as exc:
-        validate_team_logging_exporter_assignment(
-            metadata={"logging_exporters": ["langfuse-eu"]},
-            user_api_key_dict=_member(),
-            is_team_admin=False,
-        )
-    assert exc.value.status_code == 403
-
-
-def test_team_validator_still_rejects_unknown_credential(_registry):
-    """Even a team-admin can only pick names registered as logging credentials."""
-    with pytest.raises(HTTPException) as exc:
-        validate_team_logging_exporter_assignment(
-            metadata={"logging_exporters": ["does-not-exist"]},
-            user_api_key_dict=_member(),
-            is_team_admin=True,
-        )
-    assert exc.value.status_code == 400
-
-
-def test_team_validator_still_rejects_provider_credential(_registry):
-    """A team-admin can't smuggle in a provider credential as a logging exporter."""
-    with pytest.raises(HTTPException) as exc:
-        validate_team_logging_exporter_assignment(
-            metadata={"logging_exporters": ["openai-key"]},
-            user_api_key_dict=_member(),
-            is_team_admin=True,
-        )
-    assert exc.value.status_code == 400
-
-
-def test_team_validator_noop_when_absent(_registry):
-    """An /team/update that doesn't touch logging_exporters skips the gate."""
-    validate_team_logging_exporter_assignment(
-        metadata={"other": 1},
-        user_api_key_dict=_member(),
-        is_team_admin=False,
-    )
-    validate_team_logging_exporter_assignment(
-        metadata=None,
-        user_api_key_dict=_member(),
-        is_team_admin=False,
-    )
 
 
 # --- key-scoped validator (LIT-3850 follow-up) ------------------------------

--- a/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_logging_exporter_validation.py
@@ -15,6 +15,7 @@ from litellm.proxy.management_endpoints.logging_exporter_validation import (
     is_admin_gated_credential_info,
     validate_credential_access,
     validate_logging_exporter_assignment,
+    validate_team_logging_exporter_assignment,
 )
 
 
@@ -134,3 +135,71 @@ def test_validate_credential_access_rejects_bad_shape(access):
     with pytest.raises(HTTPException) as exc:
         validate_credential_access({"access": access})
     assert exc.value.status_code == 400
+
+
+# --- team-scoped validator (LIT-3850 follow-up) -----------------------------
+
+
+def test_team_admin_can_set_logging_exporters(_registry):
+    """A team-admin of the team being edited may write the field."""
+    validate_team_logging_exporter_assignment(
+        metadata={"logging_exporters": ["langfuse-eu"]},
+        user_api_key_dict=_member(),
+        is_team_admin=True,
+    )
+
+
+def test_team_validator_proxy_admin_always_passes(_registry):
+    """Proxy admin skips the team-admin check entirely."""
+    validate_team_logging_exporter_assignment(
+        metadata={"logging_exporters": ["langfuse-eu"]},
+        user_api_key_dict=_admin(),
+        is_team_admin=False,
+    )
+
+
+def test_team_validator_forbids_random_member(_registry):
+    """A non-admin caller who is NOT team-admin of the target team is rejected."""
+    with pytest.raises(HTTPException) as exc:
+        validate_team_logging_exporter_assignment(
+            metadata={"logging_exporters": ["langfuse-eu"]},
+            user_api_key_dict=_member(),
+            is_team_admin=False,
+        )
+    assert exc.value.status_code == 403
+
+
+def test_team_validator_still_rejects_unknown_credential(_registry):
+    """Even a team-admin can only pick names registered as logging credentials."""
+    with pytest.raises(HTTPException) as exc:
+        validate_team_logging_exporter_assignment(
+            metadata={"logging_exporters": ["does-not-exist"]},
+            user_api_key_dict=_member(),
+            is_team_admin=True,
+        )
+    assert exc.value.status_code == 400
+
+
+def test_team_validator_still_rejects_provider_credential(_registry):
+    """A team-admin can't smuggle in a provider credential as a logging exporter."""
+    with pytest.raises(HTTPException) as exc:
+        validate_team_logging_exporter_assignment(
+            metadata={"logging_exporters": ["openai-key"]},
+            user_api_key_dict=_member(),
+            is_team_admin=True,
+        )
+    assert exc.value.status_code == 400
+
+
+def test_team_validator_noop_when_absent(_registry):
+    """An /team/update that doesn't touch logging_exporters skips the gate."""
+    validate_team_logging_exporter_assignment(
+        metadata={"other": 1},
+        user_api_key_dict=_member(),
+        is_team_admin=False,
+    )
+    validate_team_logging_exporter_assignment(
+        metadata=None,
+        user_api_key_dict=_member(),
+        is_team_admin=False,
+    )

--- a/ui/litellm-dashboard/src/components/logging_credentials/LoggingExportersSelect.test.tsx
+++ b/ui/litellm-dashboard/src/components/logging_credentials/LoggingExportersSelect.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import LoggingExportersSelect from "./LoggingExportersSelect";
+
+const mockUseCredentials = vi.fn();
+
+vi.mock("@/app/(dashboard)/hooks/credentials/useCredentials", () => ({
+  useCredentials: () => mockUseCredentials(),
+}));
+
+vi.mock("antd", async () => {
+  const React = await import("react");
+  function Select(props: any) {
+    const { value, onChange, options, notFoundContent } = props;
+    return React.createElement(
+      "div",
+      { "data-testid": "logging-exporters-select" },
+      React.createElement(
+        "ul",
+        null,
+        (options ?? []).map((opt: any) =>
+          React.createElement("li", { key: opt.value, "data-testid": "option" }, opt.label),
+        ),
+      ),
+      options && options.length === 0 ? React.createElement("div", { "data-testid": "empty" }, notFoundContent) : null,
+      React.createElement(
+        "button",
+        { "data-testid": "pick-first", onClick: () => onChange?.(options?.[0] ? [options[0].value] : []) },
+        "pick first",
+      ),
+      React.createElement("div", { "data-testid": "value" }, JSON.stringify(value ?? [])),
+    );
+  }
+  return { Select };
+});
+
+describe("LoggingExportersSelect", () => {
+  it("only surfaces credentials whose credential_type is 'logging'", () => {
+    mockUseCredentials.mockReturnValue({
+      data: {
+        credentials: [
+          {
+            credential_name: "poc-langfuse",
+            credential_info: { credential_type: "logging", host: "https://cloud.langfuse.com" },
+          },
+          {
+            credential_name: "poc-arize",
+            credential_info: { credential_type: "logging" },
+          },
+          {
+            credential_name: "openai-prod",
+            credential_info: { custom_llm_provider: "openai" },
+          },
+        ],
+      },
+    });
+
+    render(<LoggingExportersSelect value={[]} onChange={() => {}} />);
+
+    const options = screen.getAllByTestId("option").map((el) => el.textContent);
+    expect(options).toEqual(["poc-langfuse (https://cloud.langfuse.com)", "poc-arize"]);
+  });
+
+  it("renders empty-state copy when no logging destinations exist", () => {
+    mockUseCredentials.mockReturnValue({
+      data: {
+        credentials: [
+          {
+            credential_name: "openai-prod",
+            credential_info: { custom_llm_provider: "openai" },
+          },
+        ],
+      },
+    });
+
+    render(<LoggingExportersSelect value={[]} onChange={() => {}} />);
+
+    expect(screen.queryAllByTestId("option")).toHaveLength(0);
+    expect(screen.getByTestId("empty").textContent).toMatch(/proxy admin/i);
+  });
+
+  it("works for a team-admin caller: backend already filters to logging-typed; component renders whatever it gets", () => {
+    // Simulates what /credentials returns to a team-admin via the backend
+    // route widening: provider credentials are dropped server-side; only
+    // logging-typed entries reach the component.
+    mockUseCredentials.mockReturnValue({
+      data: {
+        credentials: [{ credential_name: "poc-langfuse", credential_info: { credential_type: "logging" } }],
+      },
+    });
+
+    render(<LoggingExportersSelect value={["poc-langfuse"]} onChange={() => {}} />);
+
+    expect(screen.getByTestId("option").textContent).toBe("poc-langfuse");
+    expect(screen.getByTestId("value").textContent).toBe(JSON.stringify(["poc-langfuse"]));
+  });
+});

--- a/ui/litellm-dashboard/src/components/logging_credentials/LoggingExportersSelect.tsx
+++ b/ui/litellm-dashboard/src/components/logging_credentials/LoggingExportersSelect.tsx
@@ -35,7 +35,7 @@ const LoggingExportersSelect: React.FC<LoggingExportersSelectProps> = ({ value, 
       options={options}
       style={{ width: "100%" }}
       optionFilterProp="label"
-      notFoundContent="No logging destinations. Add one under Settings -> Logging Callbacks."
+      notFoundContent="No logging destinations available. Ask your proxy admin to create one under Settings -> Logging Callbacks."
     />
   );
 };

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -567,8 +567,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
         // org-admin callers (the gate matches on body.organization_id; omitting
         // it falls through to default-deny for a non-PROXY_ADMIN caller even
         // if they admin the team's current org).
-        organization_id:
-          values.organization_id !== undefined ? (values.organization_id ?? null) : info.organization_id,
+        organization_id: values.organization_id !== undefined ? values.organization_id ?? null : info.organization_id,
       };
 
       updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -563,7 +563,12 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
           ...(secretManagerSettings !== undefined ? { secret_manager_settings: secretManagerSettings } : {}),
         },
         ...(values.policies?.length > 0 ? { policies: values.policies } : {}),
-        ...(values.organization_id !== info.organization_id ? { organization_id: values.organization_id ?? null } : {}),
+        // organization_id always sent so the backend route gate can identify
+        // org-admin callers (the gate matches on body.organization_id; omitting
+        // it falls through to default-deny for a non-PROXY_ADMIN caller even
+        // if they admin the team's current org).
+        organization_id:
+          values.organization_id !== undefined ? (values.organization_id ?? null) : info.organization_id,
       };
 
       updateData.max_budget = mapEmptyStringToNull(updateData.max_budget);

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -1455,7 +1455,7 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
                     <Form.Item
                       label="Logging Exporters"
                       name="logging_exporters"
-                      tooltip="Admin-owned trace destinations this team exports to. Resolved server-side and fanned out (added to the key's and org's). Manage destinations under Settings -> Logging Callbacks."
+                      tooltip="Trace destinations this team exports to. Resolved server-side and unioned with the key's and org's destinations. Destinations are created by the proxy admin; team admins may attach any of them to teams they admin."
                     >
                       <LoggingExportersSelect />
                     </Form.Item>

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -729,7 +729,7 @@ export function KeyEditView({
       <Form.Item
         label="Logging Exporters"
         name="logging_exporters"
-        tooltip="Admin-owned trace destinations this key exports to. Resolved server-side and fanned out (added to the team's and org's). Manage destinations under Settings -> Logging Credentials."
+        tooltip="Trace destinations this key exports to. Resolved server-side and unioned with the team's and org's destinations. Destinations are created by the proxy admin; team admins may attach any of them to keys in their team."
       >
         <LoggingExportersSelect />
       </Form.Item>

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -43714,13 +43714,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *     Every rate-limit condition surfaced by litellm — whether it originated from
-             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *     max-iterations, etc.) — is raised as an instance of this class.
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
              *
-             *     The :attr:`category` attribute lets callers distinguish the source. See
-             *     :class:`RateLimitErrorCategory` for the available values.
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -2423,6 +2423,11 @@ export interface paths {
         /**
          * Get Credentials
          * @description [BETA] endpoint. This might change unexpectedly.
+         *
+         *     Proxy admins see every credential (values masked). Team-admins see only
+         *     logging-typed destinations so they can self-assign them; provider
+         *     credentials stay invisible. Plain authenticated callers fall through the
+         *     same logging-only filter (route gate already requires team-admin status).
          */
         get: operations["get_credentials_credentials_get"];
         put?: never;
@@ -2499,6 +2504,11 @@ export interface paths {
         /**
          * Update Credential
          * @description [BETA] endpoint. This might change unexpectedly.
+         *
+         *     Both ``credential_values`` and ``credential_info`` are optional; a team-admin
+         *     typically patches only ``credential_info.access`` to grant or revoke their
+         *     own team. A proxy admin may patch either or both. See
+         *     ``decide_credential_patch`` for the exact contract.
          */
         patch: operations["update_credential_credentials__credential_name__patch"];
         trace?: never;
@@ -31331,6 +31341,27 @@ export interface components {
             workers: components["schemas"]["WorkerRegistryEntry"][];
         };
         /**
+         * UpdateCredentialItem
+         * @description PATCH body for ``/credentials/{name}``.
+         *
+         *     Both ``credential_values`` and ``credential_info`` are optional so a caller
+         *     can patch one without sending the other (team-admins patching access without
+         *     knowing the upstream secrets; proxy admins rotating values without touching
+         *     access). ``credential_name`` is optional because most patches don't rename.
+         */
+        UpdateCredentialItem: {
+            /** Credential Info */
+            credential_info?: {
+                [key: string]: unknown;
+            } | null;
+            /** Credential Name */
+            credential_name?: string | null;
+            /** Credential Values */
+            credential_values?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        /**
          * UpdateCustomerRequest
          * @description Update a Customer, use this to update customer budgets etc
          */
@@ -37059,7 +37090,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["CredentialItem"];
+                "application/json": components["schemas"]["UpdateCredentialItem"];
             };
         };
         responses: {
@@ -43683,13 +43714,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *         Every rate-limit condition surfaced by litellm — whether it originated from
-             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *         max-iterations, etc.) — is raised as an instance of this class.
+             *     Every rate-limit condition surfaced by litellm — whether it originated from
+             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *     max-iterations, etc.) — is raised as an instance of this class.
              *
-             *         The :attr:`category` attribute lets callers distinguish the source. See
-             *         :class:`RateLimitErrorCategory` for the available values.
+             *     The :attr:`category` attribute lets callers distinguish the source. See
+             *     :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {


### PR DESCRIPTION
## Relevant issues

Follow-up to PR #30873 (LIT-3850). Pfizer asked for two related capabilities: a team-admin should be able to self-assign existing logging destinations to their own team, and an org-admin should be able to do the same for every team in their org. This PR adds both paths.

## Linear ticket

(Pending; placeholder until a follow-up ticket is filed.)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🆕 New Feature

## Changes

LIT-3850 keeps logging-destination CRUD proxy-admin only. This PR widens that gate so a team-admin of team T can attach T to existing destinations (and detach T from them), and an org-admin of org O can do the same for every team in O. The resolver already unions identity-side and destination-side, so team-side `metadata.logging_exporters` is reachable through this same primitive without bending `/team/update`'s authorization contract.

The security core is a pure tagged-union decision in `litellm/proxy/credential_endpoints/access_decision.py`. Proxy admins always pass. A non-admin patch passes iff (a) it doesn't touch credential_values, credential_name, credential_type, description, host, or endpoint, (b) any added team_ids in access.teams are ones the caller is allowed to grant, and (c) any removed team_ids are also ones the caller is allowed to grant. Allowed means the caller is team-admin of that team OR org-admin of that team's org. Everything else returns Deny with a reason that names the offending field. The function has no I/O, no globals, no mutation; 25 unit tests pin every distinct denial reason.

Plumbing.

- `GET /credentials` filters response to credentials with `credential_type: "logging"` for non-admin callers. Provider credentials stay invisible. Values stay masked.
- `PATCH /credentials/{name}` accepts a partial body via `UpdateCredentialItem` and delegates to the decider for logging-typed creds. Provider-typed creds fall through to `_require_proxy_admin` (Greptile P1 gate).
- `_caller_grantable_team_ids` resolves the caller's grant-capable team set via two paths: direct team-admin memberships (`members_with_roles.role=admin`), and indirect via org-admin (every team in any org the caller is `ORG_ADMIN` of). One filtered Prisma query per call; uses `get_user_object`/`get_team_object` for caching.
- A single `validate_logging_exporter_assignment` runs on `/team/new`, `/team/update`, `/key/generate`, `/key/update`, and `/organization/*` with two keyword flags (`caller_is_team_admin`, `caller_is_org_admin`) computed per endpoint from the already-loaded team or org. The flags default to False so existing strict endpoints stay strict.
- Each call site gates the org-admin lookup on the field actually being written (`LOGGING_EXPORTERS_KEY in data.metadata`), so the cached `get_user_object`/`get_team_object` calls don't fire for the 99% of `/team/update` and `/key/update` requests that aren't touching logging_exporters.
- `litellm/proxy/_types.py` adds `/credentials` and `/credentials/{name}` to `self_managed_routes`.
- New helper `_is_user_org_admin_for_org_id` in `common_utils.py`, factored from the existing `_is_user_org_admin_for_team`.

UI: the team Edit Settings form now always sends `organization_id` in the `/team/update` body, even when the caller did not change the org. The backend route gate uses `body.organization_id` to identify org-admin callers; omitting it falls through to default-deny.

### Behavior changes you should know about

`POST /credentials` and `DELETE /credentials/{name}` are now proxy-admin only across the board. The original `create_credential` gate triggered only when the incoming `credential_info.credential_type == "logging"`, so provider-credential creation was previously ungated at the handler level. Widening the route gate would have exposed POST and DELETE to non-admins; tightening the handler restores the previous effective behavior. `test_endpoints.py::test_create_provider_credential_forbidden_for_non_admin` documents this.

`PATCH /credentials/{name}` accepts a partial body via the new `UpdateCredentialItem` (all fields optional). The legacy `CredentialItem` required `credential_values`, which would force a non-admin caller to send upstream secrets they don't have. Clients sending the legacy shape still work because every legacy field is an optional field of the new shape.

### Live e2e on this HEAD (clean state, verified via curl)

```
Helper keys: ta-demo (team-admin of team-B), oa-demo (org-admin of team-B's org)

GET /credentials              [admin]     200, both logging + provider creds
                              [ta-demo]   200, only logging-typed
                              [oa-demo]   200, only logging-typed

GET /credentials/by_name      [admin]     200
                              [ta-demo]   401 route gate (proxy-admin only by-name)
                              [oa-demo]   401 route gate

POST /credentials             [admin]     200
                              [ta-demo]   403 "Only the proxy admin can manage logging credentials"
                              [oa-demo]   403

DELETE /credentials/{name}    [admin]     200
                              [ta-demo]   403
                              [oa-demo]   403

PATCH /credentials/{name} on logging cred:
  add own team to access.teams [ta-demo]  200
                               [oa-demo]  200 (team in own org)
                               [oa-demo]  200 (also team-A in own org)
  add foreign team             [ta-demo]  403 "team-admin may only grant their own team_ids: ..."
                               [oa-demo]  403 (team outside own org)
  rotate credential_values     [ta-demo]  403 "credential_values is proxy-admin only"
                               [oa-demo]  403
  flip access.global           [ta-demo]  403 "access.global is proxy-admin only"
                               [oa-demo]  403
  revoke own team              [ta-demo]  200
                               [oa-demo]  200

PATCH /credentials/{name} on provider cred:
                              [ta-demo]   403 "Only the proxy admin can manage logging credentials"
                              [oa-demo]   403

POST /team/update with metadata.logging_exporters:
                              [admin]     200
                              [ta-demo]   401 route gate (pinned by test_team_update_authz_matrix)
                              [oa-demo with organization_id in body]    200
                              [oa-demo without organization_id]         401 route gate

POST /key/update on team-B key:
                              [admin]     200
                              [ta-demo]   200 (own team)
                              [oa-demo]   401 "User oa-demo does not belong to team ..."

POST /key/generate for team-B with metadata.logging_exporters:
                              [admin]     200
                              [ta-demo]   200
                              [oa-demo]   400 "User=oa-demo not assigned to team=..."
```

### Full role matrix

| Action | proxy-admin | org-admin of T's org | team-admin of T |
|---|:-:|:-:|:-:|
| `GET /credentials` (logging-typed only for non-admin) | ✅ all | ✅ filtered | ✅ filtered |
| `GET /credentials/by_name/{name}` | ✅ | ❌ route gate | ❌ route gate |
| `POST /credentials` | ✅ | ❌ | ❌ |
| `DELETE /credentials/{name}` | ✅ | ❌ | ❌ |
| `PATCH credential_values, host, name, type, description` | ✅ | ❌ | ❌ |
| `PATCH access.global` or `access.orgs` | ✅ | ❌ | ❌ |
| `PATCH access.teams` add/remove a team in scope | ✅ any | ✅ teams in own org | ✅ own team |
| `PATCH` on a provider (non-logging) cred | ✅ | ❌ | ❌ |
| `/team/update metadata.logging_exporters` | ✅ | ✅ (UI sends organization_id) | ❌ (route gate, pre-existing) |
| `/key/update metadata.logging_exporters` on team-owned key | ✅ | ❌ (pre-existing team-member check) | ✅ |
| `/key/generate` for a team key with metadata.logging_exporters | ✅ | ❌ (pre-existing team-member check) | ✅ |

### Known carryover limitations (pre-existing, out of scope)

- `/key/update` and `/key/generate` go through `_team_key_operation_team_member_check` in `key_management_endpoints.py`. The check has a `PROXY_ADMIN` bypass but no org-admin bypass; an org-admin who isn't a direct team member of the key's team gets `User=... not assigned to team=...`. Workaround: org-admin adds themselves as a team member of T (UI: Members tab on team T) before minting keys for T. Real fix is to add an org-admin bypass to that check; ~10 lines and a test, candidate for a follow-up PR.
- `GET /credentials/by_name/{name}` is still proxy-admin only; the list endpoint covers the discovery use case.

### Out of scope (deferred)

- Audit trail of who flipped which grant. The PATCH stores `updated_by` already; a per-grant changelog is a separate feature.
- Notifications to destination owners when a team self-attaches.
- UI for the destination-side grant: today the team-admin / org-admin destination-side PATCH is API-only. A future PR can surface a per-team Logging Destinations card with on/off toggles.

### Test counts in this PR

- 25 decider unit tests covering every distinct allow/deny path including revoke-own and foreign-revoke.
- 18 endpoint integration tests covering team-admin and org-admin allow paths, denial paths, provider-PATCH gate, GET filter, DB-only fallback.
- 15 validation tests covering the unified validator across proxy/team/org admin flags.
- 3 UI tests covering the LoggingExportersSelect rendering.
- 3950 UI tests total pass.
- 1582 unit tests pass in test_litellm/proxy/credential_endpoints and test_litellm/proxy/management_endpoints.
- 726 proxy_behavior tests pass (no regression in `test_team_update_authz_matrix`).

### Outstanding CI status

- `codecov/patch` and `osv-scan` are pre-existing artifacts inherited from the parent branch (`langgraph-checkpoint 4.1.0` flagged at CVSS 6.8). Not caused by this PR.
