### PR TITLE
feat: add Rust realtime bridge entrypoint

### DIFF
--- a/litellm-rust/Cargo.lock
+++ b/litellm-rust/Cargo.lock
@@ -595,12 +595,14 @@ dependencies = [
 name = "litellm-python-bridge"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "litellm-core",
  "litellm-providers",
  "pyo3",
  "pyo3-async-runtimes",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/litellm-rust/Cargo.toml
+++ b/litellm-rust/Cargo.toml
@@ -20,6 +20,6 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "sync"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }

--- a/litellm-rust/crates/providers/src/realtime.rs
+++ b/litellm-rust/crates/providers/src/realtime.rs
@@ -8,6 +8,9 @@
 
 use std::time::Duration;
 
+use std::sync::Arc;
+
+use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use litellm_core::error::CoreError;
 use litellm_core::realtime::transformation::RealtimeProviderConfig;
@@ -16,8 +19,9 @@ use litellm_core::CoreResult;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
-use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue};
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
 use crate::openai::realtime::transformation::OPENAI_REALTIME_CONFIG;
 
@@ -28,6 +32,10 @@ const OPENAI_API_KEY_ENV: &str = "OPENAI_API_KEY";
 const DEFAULT_TIMEOUT_SECS: u64 = 60;
 
 const MISSING_KEY_MESSAGE: &str = "Missing OpenAI API Key - a realtime call is being made but no key was passed via params or the OPENAI_API_KEY environment variable";
+
+pub type UpstreamWs = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+type UpstreamTx = SplitSink<UpstreamWs, Message>;
+type UpstreamRx = SplitStream<UpstreamWs>;
 
 /// Resolve the OpenAI API key from the explicit param or the environment.
 ///
@@ -48,6 +56,79 @@ fn resolve_api_key(api_key: Option<&str>) -> CoreResult<String> {
 /// True for events that end a realtime turn: a completed response or an error.
 fn is_terminal_event(event: &RealtimeEvent) -> bool {
     event.event_type == "response.done" || event.event_type == "error"
+}
+
+/// Dial an arbitrary realtime WebSocket URL with caller-supplied headers.
+///
+/// Python owns URL/header construction for the proxy path so query params,
+/// OpenAI-Beta passthrough, and logging stay identical to the existing route.
+pub async fn dial_url(url: &str, headers: &[(String, String)]) -> CoreResult<UpstreamWs> {
+    let mut request = url
+        .into_client_request()
+        .map_err(|err| CoreError::Network(err.to_string()))?;
+    for (name, value) in headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|err| CoreError::Auth(format!("invalid header name '{name}': {err}")))?;
+        let header_value = HeaderValue::from_str(value)
+            .map_err(|err| CoreError::Auth(format!("invalid header value for '{name}': {err}")))?;
+        request.headers_mut().insert(header_name, header_value);
+    }
+    let (upstream, _response) = connect_async(request)
+        .await
+        .map_err(|err| CoreError::Network(err.to_string()))?;
+    Ok(upstream)
+}
+
+/// Long-lived handle to an upstream realtime WebSocket.
+///
+/// The split halves are protected independently so Python can await sends and
+/// receives concurrently from the existing bidirectional forwarding tasks.
+pub struct UpstreamHandle {
+    tx: Arc<tokio::sync::Mutex<UpstreamTx>>,
+    rx: Arc<tokio::sync::Mutex<UpstreamRx>>,
+}
+
+impl UpstreamHandle {
+    pub fn new(upstream: UpstreamWs) -> Self {
+        let (tx, rx) = upstream.split();
+        Self {
+            tx: Arc::new(tokio::sync::Mutex::new(tx)),
+            rx: Arc::new(tokio::sync::Mutex::new(rx)),
+        }
+    }
+
+    pub async fn send_text(&self, text: String) -> CoreResult<()> {
+        let mut tx = self.tx.lock().await;
+        tx.send(Message::Text(text))
+            .await
+            .map_err(|err| CoreError::Network(err.to_string()))
+    }
+
+    pub async fn recv_text(&self) -> CoreResult<Option<String>> {
+        let mut rx = self.rx.lock().await;
+        loop {
+            let Some(message) = rx.next().await else {
+                return Ok(None);
+            };
+            match message.map_err(|err| CoreError::Network(err.to_string()))? {
+                Message::Text(text) => return Ok(Some(text)),
+                Message::Close(_) => return Ok(None),
+                Message::Ping(_) | Message::Pong(_) | Message::Binary(_) | Message::Frame(_) => {
+                    continue
+                }
+            }
+        }
+    }
+
+    pub async fn close(&self) -> CoreResult<()> {
+        let mut tx = self.tx.lock().await;
+        match tx.close().await {
+            Ok(()) => Ok(()),
+            Err(tokio_tungstenite::tungstenite::Error::ConnectionClosed)
+            | Err(tokio_tungstenite::tungstenite::Error::AlreadyClosed) => Ok(()),
+            Err(err) => Err(CoreError::Network(err.to_string())),
+        }
+    }
 }
 
 /// Invoke the OpenAI realtime API end to end over a WebSocket.

--- a/litellm-rust/crates/python-bridge/Cargo.toml
+++ b/litellm-rust/crates/python-bridge/Cargo.toml
@@ -16,3 +16,5 @@ pyo3 = { workspace = true, features = ["extension-module"] }
 pyo3-async-runtimes.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
+tokio-tungstenite.workspace = true
+futures-util.workspace = true

--- a/litellm-rust/crates/python-bridge/src/lib.rs
+++ b/litellm-rust/crates/python-bridge/src/lib.rs
@@ -1,7 +1,8 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use litellm_core::error::CoreError;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict};
 use serde_json::{Map, Value};
@@ -181,10 +182,78 @@ fn gil_stats(py: Python<'_>) -> PyResult<Py<PyAny>> {
     Ok(stats.into_any().unbind())
 }
 
+fn core_error_to_runtime(err: CoreError) -> PyErr {
+    PyRuntimeError::new_err(err.to_string())
+}
+
+#[pyclass]
+struct RustRealtimeUpstream {
+    inner: Arc<litellm_providers::realtime::UpstreamHandle>,
+}
+
+#[pymethods]
+impl RustRealtimeUpstream {
+    fn send<'py>(&self, py: Python<'py>, text: String) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            inner.send_text(text).await.map_err(core_error_to_runtime)
+        })
+    }
+
+    fn recv<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            match inner.recv_text().await {
+                Ok(Some(text)) => Ok(text),
+                Ok(None) => Err(PyStopAsyncIteration::new_err("upstream closed")),
+                Err(err) => Err(core_error_to_runtime(err)),
+            }
+        })
+    }
+
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            inner.close().await.map_err(core_error_to_runtime)
+        })
+    }
+
+    fn __aiter__(slf: Py<Self>) -> Py<Self> {
+        slf
+    }
+
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        self.recv(py)
+    }
+}
+
+#[pyfunction]
+fn realtime_connect<'py>(
+    py: Python<'py>,
+    url: String,
+    headers: Bound<'py, PyDict>,
+) -> PyResult<Bound<'py, PyAny>> {
+    let headers_vec: Vec<(String, String)> = headers
+        .iter()
+        .map(|(key, value)| Ok((key.extract::<String>()?, value.extract::<String>()?)))
+        .collect::<PyResult<_>>()?;
+
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let upstream = litellm_providers::realtime::dial_url(&url, &headers_vec)
+            .await
+            .map_err(core_error_to_runtime)?;
+        Ok(RustRealtimeUpstream {
+            inner: Arc::new(litellm_providers::realtime::UpstreamHandle::new(upstream)),
+        })
+    })
+}
+
 #[pymodule]
 fn litellm_python_bridge(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(ocr, module)?)?;
     module.add_function(wrap_pyfunction!(aocr, module)?)?;
     module.add_function(wrap_pyfunction!(gil_stats, module)?)?;
+    module.add_function(wrap_pyfunction!(realtime_connect, module)?)?;
+    module.add_class::<RustRealtimeUpstream>()?;
     Ok(())
 }

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -4,7 +4,7 @@ This file contains the calling OpenAI's `/v1/realtime` endpoint.
 This requires websockets, and is currently only supported on LiteLLM Proxy.
 """
 
-from typing import Any, Optional, cast
+from typing import Any, AsyncContextManager, Callable, Optional, cast
 
 from litellm._logging import _redact_string, verbose_logger
 from litellm.constants import REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES
@@ -17,6 +17,8 @@ from ....litellm_core_utils.realtime_streaming import (
 )
 from ....llms.custom_httpx.http_handler import get_shared_realtime_ssl_context
 from ..openai import OpenAIChatCompletion
+
+BackendConnect = Callable[..., AsyncContextManager[Any]]
 
 
 class OpenAIRealtime(OpenAIChatCompletion):
@@ -107,6 +109,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
         query_params: Optional[RealtimeQueryParams] = None,
         user_api_key_dict: Optional[Any] = None,
         litellm_metadata: Optional[dict] = None,
+        backend_connect: Optional[BackendConnect] = None,
         **kwargs: Any,
     ):
         import websockets
@@ -144,10 +147,14 @@ class OpenAIRealtime(OpenAIChatCompletion):
                 additional_args={
                     "api_base": url,
                     "headers": headers,
-                    "complete_input_dict": {"query_params": query_params},
+                    "complete_input_dict": {
+                        "query_params": query_params,
+                        "rust_bridge": backend_connect is not None,
+                    },
                 },
             )
-            async with websockets.connect(  # type: ignore
+            connector: BackendConnect = backend_connect or websockets.connect  # type: ignore[assignment]
+            async with connector(
                 url,
                 additional_headers=headers,  # type: ignore
                 max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,

--- a/litellm/ocr/rust_bridge.py
+++ b/litellm/ocr/rust_bridge.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import Awaitable, Final, Protocol, cast
 
+from litellm.realtime_api.rust_bridge import RustRealtimeConnect, set_rust_realtime
+
 
 class RustOcr(Protocol):
     """Signature of the compiled ``litellm_python_bridge.ocr`` entrypoint."""
@@ -64,11 +66,12 @@ def use_litellm_rust(
     *,
     ocr: RustOcr | None | _Unset = _UNSET,
     aocr: RustAocr | None | _Unset = _UNSET,
+    realtime: RustRealtimeConnect | None | _Unset = _UNSET,
 ) -> None:
-    """Route supported OCR calls through the Rust ``litellm_python_bridge`` extension.
+    """Route supported calls through the Rust ``litellm_python_bridge`` extension.
 
-    ``ocr`` and ``aocr`` inject bridge callables; when omitted the compiled
-    extension is loaded on demand and any previously injected bridge is
+    ``ocr``, ``aocr``, and ``realtime`` inject bridge callables; when omitted the
+    compiled extension is loaded on demand and any previous injection is
     preserved. Pass ``None`` explicitly to clear a prior injection.
     """
     global _rust_ocr_enabled, _rust_ocr_impl, _rust_aocr_impl
@@ -77,6 +80,10 @@ def use_litellm_rust(
         _rust_ocr_impl = ocr
     if not isinstance(aocr, _Unset):
         _rust_aocr_impl = aocr
+    if isinstance(realtime, _Unset):
+        set_rust_realtime(enabled)
+    else:
+        set_rust_realtime(enabled, connect=realtime)
 
 
 def rust_ocr_enabled() -> bool:

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -31,6 +31,12 @@ from ..llms.vertex_ai.realtime.transformation import VertexAIRealtimeConfig
 from ..llms.vertex_ai.vertex_llm_base import VertexBase
 from ..llms.xai.realtime.handler import XAIRealtime
 from ..utils import client as wrapper_client
+from .rust_bridge import (
+    load_rust_realtime,
+    rust_backend_connect_factory,
+    rust_realtime_enabled,
+    rust_supports_ssl_config,
+)
 
 azure_realtime = AzureOpenAIRealtime()
 openai_realtime = OpenAIRealtime()
@@ -38,6 +44,30 @@ bedrock_realtime = BedrockRealtime()
 xai_realtime = XAIRealtime()
 vertex_llm_base = VertexBase()
 base_llm_http_handler = BaseLLMHTTPHandler()
+
+
+def _maybe_rust_backend_connect(api_base: Optional[str]) -> Optional[Any]:
+    """Return a Rust-backed ``websockets.connect``-compatible factory."""
+    _ = api_base
+    if not rust_realtime_enabled():
+        return None
+    connect = load_rust_realtime()
+    if connect is None:
+        from litellm._logging import verbose_logger
+
+        verbose_logger.debug(
+            "Rust realtime bridge unavailable; falling back to Python path"
+        )
+        return None
+    if not rust_supports_ssl_config(get_shared_realtime_ssl_context()):
+        from litellm._logging import verbose_logger
+
+        verbose_logger.debug(
+            "Rust realtime path cannot honor disabled TLS verification; "
+            "falling back to Python path"
+        )
+        return None
+    return rust_backend_connect_factory(connect)
 
 
 def _build_litellm_metadata(kwargs: dict) -> dict:
@@ -415,6 +445,8 @@ async def _arealtime(
             or get_secret_str("OPENAI_API_KEY")
         )
 
+        backend_connect = _maybe_rust_backend_connect(api_base)
+
         await openai_realtime.async_realtime(
             model=model,
             websocket=websocket,
@@ -426,6 +458,7 @@ async def _arealtime(
             query_params=query_params,
             user_api_key_dict=kwargs.get("user_api_key_dict"),
             litellm_metadata=_build_litellm_metadata(kwargs),
+            backend_connect=backend_connect,
         )
     elif _custom_llm_provider == "bedrock":
         # Extract AWS parameters from kwargs

--- a/litellm/realtime_api/rust_bridge.py
+++ b/litellm/realtime_api/rust_bridge.py
@@ -1,0 +1,137 @@
+"""
+Optional Rust-backed realtime WebSocket upstream.
+
+Enable with ``litellm.use_litellm_rust(realtime=...)`` or
+``litellm.use_litellm_rust()``. The proxy realtime route keeps URL construction,
+OpenAI-Beta forwarding, pre-call logging, guardrails, and spend logging in
+Python, while the upstream WebSocket transport is supplied by the compiled
+``litellm_python_bridge`` extension.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Final,
+    Mapping,
+    Optional,
+    Protocol,
+    cast,
+    runtime_checkable,
+)
+
+
+@runtime_checkable
+class RustRealtimeUpstream(Protocol):
+    def send(self, text: str) -> Awaitable[None]: ...
+    def recv(self) -> Awaitable[str]: ...
+    def close(self) -> Awaitable[None]: ...
+
+
+class RustRealtimeConnect(Protocol):
+    def __call__(
+        self, url: str, headers: dict[str, str]
+    ) -> Awaitable[RustRealtimeUpstream]: ...
+
+
+class _Unset:
+    """Sentinel so ``realtime=None`` clears while omission preserves."""
+
+
+_UNSET: Final[_Unset] = _Unset()
+
+_rust_realtime_enabled = False
+_rust_realtime_impl: RustRealtimeConnect | None = None
+
+
+def set_rust_realtime(
+    enabled: bool, *, connect: RustRealtimeConnect | None | _Unset = _UNSET
+) -> None:
+    global _rust_realtime_enabled, _rust_realtime_impl
+    _rust_realtime_enabled = enabled
+    if not isinstance(connect, _Unset):
+        _rust_realtime_impl = connect
+
+
+def rust_realtime_enabled() -> bool:
+    return _rust_realtime_enabled
+
+
+def load_rust_realtime() -> RustRealtimeConnect | None:
+    if _rust_realtime_impl is not None:
+        return _rust_realtime_impl
+    try:
+        import litellm_python_bridge
+    except ImportError:
+        return None
+    return cast(
+        RustRealtimeConnect, getattr(litellm_python_bridge, "realtime_connect", None)
+    )
+
+
+class RustBackendWebsocket:
+    """Subset of ``websockets.ClientConnection`` used by ``RealTimeStreaming``."""
+
+    def __init__(self, upstream: RustRealtimeUpstream) -> None:
+        self._upstream = upstream
+        self._closed = False
+
+    async def send(self, message: str) -> None:
+        await self._upstream.send(message)
+
+    async def recv(self, *_args: Any, **_kwargs: Any) -> str:
+        try:
+            return await self._upstream.recv()
+        except StopAsyncIteration:
+            import websockets
+
+            raise websockets.exceptions.ConnectionClosedOK(None, None) from None
+
+    def __aiter__(self) -> "RustBackendWebsocket":
+        return self
+
+    async def __anext__(self) -> str:
+        return await self._upstream.recv()
+
+    async def close(self, *_args: Any, **_kwargs: Any) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._upstream.close()
+
+    async def __aenter__(self) -> "RustBackendWebsocket":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        await self.close()
+
+
+def rust_backend_connect_factory(connect: RustRealtimeConnect):
+    @asynccontextmanager
+    async def _connect(
+        url: str,
+        *,
+        additional_headers: Mapping[str, str],
+        max_size: Optional[int] = None,
+        ssl: Any = None,
+    ) -> AsyncIterator[RustBackendWebsocket]:
+        _ = max_size
+        if ssl is False:
+            raise NotImplementedError(
+                "Rust realtime path does not support disabling TLS verification"
+            )
+        upstream = await connect(url, dict(additional_headers))
+        backend = RustBackendWebsocket(upstream)
+        try:
+            yield backend
+        finally:
+            await backend.close()
+
+    return _connect
+
+
+def rust_supports_ssl_config(ssl_config: Any) -> bool:
+    return ssl_config is not False

--- a/tests/test_litellm/realtime_api/test_rust_bridge.py
+++ b/tests/test_litellm/realtime_api/test_rust_bridge.py
@@ -1,0 +1,284 @@
+"""Tests for the optional Rust-backed realtime path."""
+
+from __future__ import annotations
+
+import importlib
+import asyncio
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import litellm
+
+realtime_main = importlib.import_module("litellm.realtime_api.main")
+rust_bridge = importlib.import_module("litellm.realtime_api.rust_bridge")
+
+
+class RecordingUpstream:
+    def __init__(self, *, recv_frames: list[str] | None = None) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+        self._recv_frames = list(recv_frames or [])
+
+    def send(self, text: str):
+        async def _send() -> None:
+            self.sent.append(text)
+
+        return _send()
+
+    def recv(self):
+        async def _recv() -> str:
+            if not self._recv_frames:
+                raise StopAsyncIteration("upstream closed")
+            return self._recv_frames.pop(0)
+
+        return _recv()
+
+    def close(self):
+        async def _close() -> None:
+            self.closed = True
+
+        return _close()
+
+
+class RecordingConnect:
+    def __init__(self, *, recv_frames: list[str] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.upstream = RecordingUpstream(recv_frames=recv_frames)
+
+    def __call__(self, url: str, headers: dict[str, str]):
+        self.calls.append({"url": url, "headers": headers})
+
+        async def _connect() -> RecordingUpstream:
+            return self.upstream
+
+        return _connect()
+
+
+@pytest.fixture(autouse=True)
+def _reset_rust_flag():
+    rust_bridge.set_rust_realtime(False, connect=None)
+    yield
+    rust_bridge.set_rust_realtime(False, connect=None)
+
+
+def test_use_litellm_rust_toggles_realtime_flag():
+    assert rust_bridge.rust_realtime_enabled() is False
+    litellm.use_litellm_rust()
+    assert rust_bridge.rust_realtime_enabled() is True
+    litellm.use_litellm_rust(False)
+    assert rust_bridge.rust_realtime_enabled() is False
+
+
+def test_load_rust_realtime_returns_injected_impl():
+    bridge = RecordingConnect()
+    litellm.use_litellm_rust(True, realtime=bridge)
+    assert rust_bridge.load_rust_realtime() is bridge
+
+
+def test_toggle_without_realtime_arg_preserves_injected_impl():
+    bridge = RecordingConnect()
+    litellm.use_litellm_rust(True, realtime=bridge)
+
+    litellm.use_litellm_rust(False)
+    assert rust_bridge.load_rust_realtime() is bridge
+    litellm.use_litellm_rust(True)
+    assert rust_bridge.load_rust_realtime() is bridge
+
+
+def test_explicit_realtime_none_clears_injected_impl(monkeypatch):
+    monkeypatch.delitem(sys.modules, "litellm_python_bridge", raising=False)
+    bridge = RecordingConnect()
+    litellm.use_litellm_rust(True, realtime=bridge)
+
+    litellm.use_litellm_rust(True, realtime=None)
+
+    assert rust_bridge.load_rust_realtime() is None
+
+
+def test_load_rust_realtime_none_when_extension_absent(monkeypatch):
+    monkeypatch.delitem(sys.modules, "litellm_python_bridge", raising=False)
+    litellm.use_litellm_rust(True)
+    assert rust_bridge.load_rust_realtime() is None
+
+
+def test_load_rust_realtime_uses_compiled_extension(monkeypatch):
+    fake_module = types.ModuleType("litellm_python_bridge")
+    fake_module.realtime_connect = lambda url, headers: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "litellm_python_bridge", fake_module)
+
+    litellm.use_litellm_rust(True)
+    assert rust_bridge.load_rust_realtime() is fake_module.realtime_connect
+
+
+@pytest.mark.asyncio
+async def test_rust_backend_connect_factory_matches_websockets_shape():
+    bridge = RecordingConnect()
+    factory = rust_bridge.rust_backend_connect_factory(bridge)
+
+    async with factory(
+        "wss://api.openai.com/v1/realtime?model=gpt-realtime",
+        additional_headers={"Authorization": "Bearer sk-test"},
+        max_size=1234,
+        ssl=None,
+    ) as backend_ws:
+        assert isinstance(backend_ws, rust_bridge.RustBackendWebsocket)
+
+    assert bridge.calls == [
+        {
+            "url": "wss://api.openai.com/v1/realtime?model=gpt-realtime",
+            "headers": {"Authorization": "Bearer sk-test"},
+        }
+    ]
+    assert bridge.upstream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_rust_backend_websocket_recv_raises_connection_closed_ok():
+    import websockets
+
+    backend = rust_bridge.RustBackendWebsocket(RecordingUpstream())
+
+    with pytest.raises(websockets.exceptions.ConnectionClosed):
+        await backend.recv()
+
+
+def test_maybe_rust_backend_connect_returns_none_when_disabled():
+    assert realtime_main._maybe_rust_backend_connect(None) is None
+
+
+def test_maybe_rust_backend_connect_returns_factory_when_enabled():
+    bridge = RecordingConnect()
+    litellm.use_litellm_rust(True, realtime=bridge)
+    factory = realtime_main._maybe_rust_backend_connect(None)
+    assert factory is not None and callable(factory)
+
+
+def test_maybe_rust_backend_connect_falls_back_when_bridge_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "litellm_python_bridge", raising=False)
+    litellm.use_litellm_rust(True)
+    assert realtime_main._maybe_rust_backend_connect(None) is None
+
+
+def test_maybe_rust_backend_connect_falls_back_when_verify_off(monkeypatch):
+    bridge = RecordingConnect()
+    litellm.use_litellm_rust(True, realtime=bridge)
+    monkeypatch.setattr(
+        realtime_main,
+        "get_shared_realtime_ssl_context",
+        lambda: False,
+    )
+    assert realtime_main._maybe_rust_backend_connect(None) is None
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_passes_backend_connect_to_dial(monkeypatch):
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
+    from litellm.llms.openai.realtime.handler import OpenAIRealtime
+
+    handler = OpenAIRealtime()
+    captured: dict[str, Any] = {}
+
+    class FakeBackend:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+    def fake_connect(url: str, *, additional_headers, max_size, ssl):
+        captured.update(
+            {
+                "url": url,
+                "additional_headers": dict(additional_headers),
+                "max_size": max_size,
+                "ssl": ssl,
+            }
+        )
+        return FakeBackend()
+
+    class FakeClientWebsocket:
+        scope = {"headers": [(b"openai-beta", b"realtime=v1")]}
+
+        async def close(self, *args, **kwargs):
+            return None
+
+    async def fake_forward(self):
+        captured["streaming_started"] = True
+
+    monkeypatch.setattr(
+        "litellm.litellm_core_utils.realtime_streaming.RealTimeStreaming.bidirectional_forward",
+        fake_forward,
+    )
+
+    logging_obj = LiteLLMLogging(
+        model="gpt-realtime",
+        messages=[],
+        stream=False,
+        call_type="realtime",
+        start_time=datetime.now(),
+        litellm_call_id="test-call",
+        function_id="fn",
+    )
+    pre_call_payload: dict[str, Any] = {}
+    original_pre_call = logging_obj.pre_call
+
+    def capture_pre_call(*args: Any, **kwargs: Any):
+        pre_call_payload.update(kwargs)
+        return original_pre_call(*args, **kwargs)
+
+    monkeypatch.setattr(logging_obj, "pre_call", capture_pre_call)
+
+    await handler.async_realtime(
+        model="gpt-realtime",
+        websocket=FakeClientWebsocket(),
+        logging_obj=logging_obj,
+        api_base="https://api.openai.com/",
+        api_key="sk-test",
+        backend_connect=fake_connect,
+    )
+
+    assert captured["url"].startswith(
+        "wss://api.openai.com/v1/realtime?model=gpt-realtime"
+    )
+    assert captured["additional_headers"]["Authorization"] == "Bearer sk-test"
+    assert captured["additional_headers"]["OpenAI-Beta"] == "realtime=v1"
+    assert captured["streaming_started"] is True
+    complete_input = pre_call_payload["additional_args"]["complete_input_dict"]
+    assert complete_input["rust_bridge"] is True
+
+
+@pytest.mark.asyncio
+async def test_realtime_logging_flushes_through_rust_backend_adapter():
+    from litellm.litellm_core_utils.realtime_streaming import RealTimeStreaming
+
+    client_ws = MagicMock()
+    client_ws.send_text = AsyncMock()
+    backend_ws = rust_bridge.RustBackendWebsocket(
+        RecordingUpstream(
+            recv_frames=[
+                '{"type":"session.created","session":{"id":"sess_1"}}',
+                '{"type":"response.done","response":{"output":[]}}',
+            ]
+        )
+    )
+    logging_obj = MagicMock()
+    logging_obj.async_success_handler = AsyncMock()
+    logging_obj.success_handler = MagicMock()
+
+    streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
+    await streaming.backend_to_client_send_messages()
+    await asyncio.sleep(0)
+
+    assert client_ws.send_text.await_count == 2
+    logging_obj.async_success_handler.assert_awaited_once()
+    logged_events = logging_obj.async_success_handler.call_args.args[0]
+    assert [event["type"] for event in logged_events] == [
+        "session.created",
+        "response.done",
+    ]


### PR DESCRIPTION
## What changed

- Added an optional Rust-backed realtime WebSocket connector exposed as `litellm_python_bridge.realtime_connect`.
- Added `litellm.realtime_api.rust_bridge` so `litellm.use_litellm_rust()` can route OpenAI realtime upstream dialing through Rust while Python keeps URL/query construction, OpenAI-Beta forwarding, guardrails, and LiteLLM logging.
- Let `OpenAIRealtime.async_realtime()` accept a `websockets.connect`-compatible backend connector and added parity tests for enabled/disabled/missing-bridge fallback paths.

## Why

This mirrors the OCR rollout shape: Python remains the entrypoint and rollout/fallback owner, while Rust takes the realtime upstream WebSocket transport behind an opt-in flag. OpenAI is the first provider because the Rust realtime transform is currently passthrough and matches the Python OpenAI-compatible path.

## Evidence

Native bridge proof:

```text
rust_bridge_loaded=True
native_realtime_connect=realtime_connect
rust_route_selected=True
top_level_call=litellm._arealtime/openai_realtime.async_realtime
rust_connect_calls=1
upstream_url=wss://api.openai.com/v1/realtime?model=gpt-realtime
openai_beta_forwarded=True
logging_async_success_called=True
logged_event_types=['session.created', 'response.done']
```

## Validation

- `uv run ruff check litellm/ocr/rust_bridge.py litellm/realtime_api/main.py litellm/realtime_api/rust_bridge.py litellm/llms/openai/realtime/handler.py tests/test_litellm/realtime_api/test_rust_bridge.py`
- `uv run black --check litellm/ocr/rust_bridge.py litellm/realtime_api/main.py litellm/realtime_api/rust_bridge.py litellm/llms/openai/realtime/handler.py tests/test_litellm/realtime_api/test_rust_bridge.py`
- `uv run --extra proxy pytest tests/test_litellm/realtime_api/test_rust_bridge.py tests/test_litellm/llms/openai/realtime/test_openai_realtime_handler.py tests/test_litellm/ocr/test_rust_bridge.py -q` -> `44 passed`
- `cd litellm-rust && cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`
- `PYO3_PYTHON=.venv/bin/python RUSTFLAGS='-C link-arg=-undefined -C link-arg=dynamic_lookup' cargo build -p litellm-python-bridge`
- `git fetch upstream main && git rebase upstream/main` -> already up to date, no conflicts