### PR TITLE
fix(audio): log audio filename on async transcription errors

### DIFF
--- a/litellm/llms/azure/audio_transcriptions.py
+++ b/litellm/llms/azure/audio_transcriptions.py
@@ -191,7 +191,7 @@ class AzureAudioTranscription(AzureChatCompletion):
         except Exception as e:
             ## LOGGING
             logging_obj.post_call(
-                input=input,
+                input=get_audio_file_name(audio_file),
                 api_key=api_key,
                 original_response=str(e),
             )

--- a/litellm/llms/openai/transcriptions/handler.py
+++ b/litellm/llms/openai/transcriptions/handler.py
@@ -226,7 +226,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         except Exception as e:
             ## LOGGING
             logging_obj.post_call(
-                input=input,
+                input=get_audio_file_name(audio_file),
                 api_key=api_key,
                 original_response=str(e),
             )

--- a/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
+++ b/tests/test_litellm/llms/azure/test_azure_exception_mapping.py
@@ -427,3 +427,36 @@ class TestAzureExceptionMapping:
         error = exc_info.value
         assert "encrypted_content_affinity" in error.message
         assert "enable_pre_call_checks" in error.message
+
+    @pytest.mark.asyncio
+    async def test_async_audio_transcription_error_path_logs_audio_filename(
+        self,
+    ):
+        from litellm.litellm_core_utils.audio_utils.utils import get_audio_file_name
+        from litellm.llms.azure.audio_transcriptions import AzureAudioTranscription
+        from litellm.utils import TranscriptionResponse
+
+        audio_file = ("test.wav", b"fake audio", "audio/wav")
+        expected_error = RuntimeError("azure upstream failure")
+        handler = AzureAudioTranscription()
+        handler.get_azure_openai_client = MagicMock(side_effect=expected_error)
+        logging_obj = MagicMock()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await handler.async_audio_transcriptions(
+                audio_file=audio_file,
+                model="whisper-1",
+                data={"model": "whisper-1", "file": audio_file},
+                model_response=TranscriptionResponse(),
+                timeout=1,
+                logging_obj=logging_obj,
+                api_key="test-api-key",
+                api_base="https://example.openai.azure.com",
+                litellm_params={},
+            )
+
+        assert exc_info.value is expected_error
+        logging_obj.post_call.assert_called_once()
+        kwargs = logging_obj.post_call.call_args.kwargs
+        assert kwargs["input"] == get_audio_file_name(audio_file)
+        assert kwargs["original_response"] == str(expected_error)

--- a/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py
@@ -104,3 +104,32 @@ class TestWhisperTransformResponse:
                     is_json=False,
                 )
             )
+
+
+@pytest.mark.asyncio
+async def test_async_transcription_error_path_logs_audio_filename():
+    from litellm.litellm_core_utils.audio_utils.utils import get_audio_file_name
+    from litellm.llms.openai.transcriptions.handler import OpenAIAudioTranscription
+    from litellm.utils import TranscriptionResponse
+
+    audio_file = ("test.wav", b"fake audio", "audio/wav")
+    expected_error = RuntimeError("upstream failure")
+    handler = OpenAIAudioTranscription()
+    handler._get_openai_client = MagicMock(side_effect=expected_error)
+    logging_obj = MagicMock()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await handler.async_audio_transcriptions(
+            audio_file=audio_file,
+            data={"model": "whisper-1", "file": audio_file},
+            model_response=TranscriptionResponse(),
+            timeout=1,
+            logging_obj=logging_obj,
+            api_key="test-api-key",
+        )
+
+    assert exc_info.value is expected_error
+    logging_obj.post_call.assert_called_once()
+    kwargs = logging_obj.post_call.call_args.kwargs
+    assert kwargs["input"] == get_audio_file_name(audio_file)
+    assert kwargs["original_response"] == str(expected_error)


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The async OpenAI and Azure transcription error paths now log the request audio filename, consistent with the success path in the same handlers. This value is internal logging metadata on the failure path, so it does not appear in the HTTP response; the regression tests assert the exact `logging_obj.post_call` argument instead

Focused regression tests:

```shell
python -m pytest \
  tests/test_litellm/llms/openai/transcriptions/test_whisper_transformation.py::test_async_transcription_error_path_logs_audio_filename \
  tests/test_litellm/llms/azure/test_azure_exception_mapping.py::TestAzureExceptionMapping::test_async_audio_transcription_error_path_logs_audio_filename \
  -q
```

Result:

```
2 passed
```

Both tests fail on the previous implementation because the error path logs Python's builtin `input` function instead of the audio file identifier

## Type

Bug Fix
Test

## Changes

The async transcription error handlers for OpenAI and Azure used `input=input` in `logging_obj.post_call`. In this scope `input` resolves to Python's builtin function, so failed async transcription calls logged `<built-in function input>` instead of the request audio file

This PR changes both error paths to use `get_audio_file_name(audio_file)`, matching the existing success-path logging in the same handlers

Regression tests cover both providers by forcing the async client setup to raise, then asserting that the original exception is still propagated and that the error-path logging input matches `get_audio_file_name(audio_file)`
