### PR TITLE
fix(proxy/client): redact api key from key/info client error messages

### DIFF
--- a/litellm/proxy/client/exceptions.py
+++ b/litellm/proxy/client/exceptions.py
@@ -2,18 +2,30 @@ from typing import Union
 
 import requests
 
+from litellm.litellm_core_utils.secret_redaction import redact_string
+
+
+def _redact_orig_exception(
+    orig_exception: Union[requests.exceptions.HTTPError, str],
+) -> Union[requests.exceptions.HTTPError, str]:
+    if isinstance(orig_exception, requests.exceptions.HTTPError):
+        return requests.exceptions.HTTPError(
+            redact_string(str(orig_exception)), response=orig_exception.response
+        )
+    return redact_string(str(orig_exception))
+
 
 class UnauthorizedError(Exception):
     """Exception raised when the API returns a 401 Unauthorized response."""
 
     def __init__(self, orig_exception: Union[requests.exceptions.HTTPError, str]):
-        self.orig_exception = orig_exception
-        super().__init__(str(orig_exception))
+        self.orig_exception = _redact_orig_exception(orig_exception)
+        super().__init__(str(self.orig_exception))
 
 
 class NotFoundError(Exception):
     """Exception raised when the API returns a 404 Not Found response or indicates a resource was not found."""
 
     def __init__(self, orig_exception: Union[requests.exceptions.HTTPError, str]):
-        self.orig_exception = orig_exception
-        super().__init__(str(orig_exception))
+        self.orig_exception = _redact_orig_exception(orig_exception)
+        super().__init__(str(self.orig_exception))

--- a/litellm/proxy/client/keys.py
+++ b/litellm/proxy/client/keys.py
@@ -2,6 +2,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import requests
 
+from litellm.litellm_core_utils.secret_redaction import redact_string
+
 from .exceptions import UnauthorizedError
 
 
@@ -314,6 +316,9 @@ class KeysManagementClient:
             response.raise_for_status()
             return response.json()
         except requests.exceptions.HTTPError as e:
+            redacted_message = redact_string(str(e))
             if e.response.status_code == 401:
-                raise UnauthorizedError(e)
-            raise
+                raise UnauthorizedError(redacted_message) from None
+            raise requests.exceptions.HTTPError(
+                redacted_message, response=e.response
+            ) from None

--- a/litellm/proxy/client/keys.py
+++ b/litellm/proxy/client/keys.py
@@ -318,7 +318,7 @@ class KeysManagementClient:
         except requests.exceptions.HTTPError as e:
             redacted_message = redact_string(str(e))
             if e.response.status_code == 401:
-                raise UnauthorizedError(redacted_message) from None
+                raise UnauthorizedError(e) from None
             raise requests.exceptions.HTTPError(
                 redacted_message, response=e.response
             ) from None

--- a/tests/test_litellm/proxy/client/test_keys.py
+++ b/tests/test_litellm/proxy/client/test_keys.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import traceback
 
 import pytest
 import requests
@@ -11,7 +12,7 @@ sys.path.insert(
 
 import responses
 
-from litellm.proxy.client.exceptions import UnauthorizedError
+from litellm.proxy.client.exceptions import NotFoundError, UnauthorizedError
 from litellm.proxy.client.keys import KeysManagementClient
 
 
@@ -420,3 +421,93 @@ def test_info_server_error(client):
     )
     with pytest.raises(requests.exceptions.HTTPError):
         client.info(key="test-key")
+
+
+LEAKY_KEY = "sk-1234567890abcdefghijklmnop"
+
+
+def _render_full_traceback(exc: BaseException) -> str:
+    return "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+
+@responses.activate
+def test_info_not_found_redacts_key_everywhere(client):
+    """A 404 must not echo the raw key embedded in the request URL.
+
+    Covers str(exc) and the rendered traceback, since the chain through
+    __cause__ / __context__ is what logging.exception() and the default
+    excepthook print.
+    """
+    responses.add(
+        responses.GET,
+        f"{client._base_url}/key/info?key={LEAKY_KEY}",
+        status=404,
+        json={"error": {"message": "Key not found", "code": "404"}},
+    )
+    with pytest.raises(requests.exceptions.HTTPError) as excinfo:
+        client.info(key=LEAKY_KEY)
+
+    exc = excinfo.value
+    assert LEAKY_KEY not in str(exc)
+    assert "REDACTED" in str(exc)
+    assert LEAKY_KEY not in _render_full_traceback(exc)
+    assert exc.__cause__ is None and exc.__suppress_context__
+    assert exc.response is not None
+    assert exc.response.status_code == 404
+    assert exc.request is not None
+    # Known residual: the live request URL still carries the key, since the
+    # response is preserved so callers keep status_code / text. str(exc) and the
+    # traceback are scrubbed; the URL-borne key is the root issue tracked in
+    # LIT-4013 (move the lookup key out of the query string server-side).
+    assert LEAKY_KEY in exc.response.request.url
+
+
+@responses.activate
+def test_info_unauthorized_redacts_key_everywhere(client):
+    """A 401 surfaced as UnauthorizedError must not echo the raw key in the
+    message, the retained original, or the rendered traceback chain."""
+    responses.add(
+        responses.GET,
+        f"{client._base_url}/key/info?key={LEAKY_KEY}",
+        status=401,
+        json={"error": "Unauthorized"},
+    )
+    with pytest.raises(UnauthorizedError) as excinfo:
+        client.info(key=LEAKY_KEY)
+
+    exc = excinfo.value
+    assert LEAKY_KEY not in str(exc)
+    assert "REDACTED" in str(exc)
+    assert LEAKY_KEY not in str(exc.orig_exception)
+    assert LEAKY_KEY not in _render_full_traceback(exc)
+    assert exc.__cause__ is None and exc.__suppress_context__
+
+
+def _http_error_with_key(prefix: str, status: int) -> requests.exceptions.HTTPError:
+    resp = requests.Response()
+    resp.status_code = status
+    return requests.exceptions.HTTPError(
+        f"{prefix} for url: http://x/key/info?key={LEAKY_KEY}", response=resp
+    )
+
+
+def test_unauthorized_error_redacts_wrapped_key():
+    """UnauthorizedError scrubs the key in str(exc) and in the retained
+    orig_exception, while preserving the response for structured access."""
+    wrapped = UnauthorizedError(
+        _http_error_with_key("401 Client Error: Unauthorized", 401)
+    )
+    assert LEAKY_KEY not in str(wrapped)
+    assert "REDACTED" in str(wrapped)
+    assert LEAKY_KEY not in str(wrapped.orig_exception)
+    assert wrapped.orig_exception.response.status_code == 401
+
+
+def test_not_found_error_redacts_wrapped_key():
+    """NotFoundError scrubs the key in str(exc) and in the retained
+    orig_exception, while preserving the response for structured access."""
+    wrapped = NotFoundError(_http_error_with_key("404 Client Error: Not Found", 404))
+    assert LEAKY_KEY not in str(wrapped)
+    assert "REDACTED" in str(wrapped)
+    assert LEAKY_KEY not in str(wrapped.orig_exception)
+    assert wrapped.orig_exception.response.status_code == 404

--- a/tests/test_litellm/proxy/client/test_keys.py
+++ b/tests/test_litellm/proxy/client/test_keys.py
@@ -481,6 +481,9 @@ def test_info_unauthorized_redacts_key_everywhere(client):
     assert LEAKY_KEY not in str(exc.orig_exception)
     assert LEAKY_KEY not in _render_full_traceback(exc)
     assert exc.__cause__ is None and exc.__suppress_context__
+    assert isinstance(exc.orig_exception, requests.exceptions.HTTPError)
+    assert exc.orig_exception.response is not None
+    assert exc.orig_exception.response.status_code == 401
 
 
 def _http_error_with_key(prefix: str, status: int) -> requests.exceptions.HTTPError:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4013

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (5/5 on the current commit)

## CI (LiteLLM team)

- [x] **Branch creation CI run**  
       Link: https://github.com/BerriAI/litellm/pull/31342/checks

- [x] **CI run for the last commit**  
       Link: https://github.com/BerriAI/litellm/pull/31342/checks

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

`KeysManagementClient.info()` builds `GET /key/info?key=<key>`, so the raw key sits in the request URL. When the proxy returns a non-2xx, `requests` raises `HTTPError`; its string form and its chained original both carry the URL, so any caller that logs the error or lets it propagate writes the full key to its logs

Repro consumer (mirrors how a caller surfaces the error):

```python
import logging, sys
from litellm.proxy.client.keys import KeysManagementClient

logging.basicConfig(level=logging.ERROR, format="%(levelname)s | %(message)s")
auth, lookup = sys.argv[1], (sys.argv[2] if len(sys.argv) > 2 else sys.argv[1])
client = KeysManagementClient(base_url="http://localhost:4000", api_key=auth)
try:
    client.info(key=lookup)
except Exception as e:
    logging.error(f"Error getting key info: {e}")     # str(e) surface
    # logging.exception(...) / uncaught -> traceback surface
```

Server side is already safe; the 404 body carries no key and the auth error masks it:

```
$ curl -sS "http://localhost:4000/key/info?key=sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz" -H "Authorization: Bearer sk-1234"
{"error":{"message":"Key not found in database","type":"not_found_error","param":"key","code":"404"}}

$ curl -sS "http://localhost:4000/key/info" -H "Authorization: Bearer sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz"
{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...wxyz, ...","code":"401"}}
```

BEFORE (unfixed client). The `str(e)` log leaks the key, on the 404 path (valid master auth, bad lookup key) and the 401 path (bad key as credential):

```
$ python repro.py sk-1234 sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
ERROR | Error getting key info: 404 Client Error: Not Found for url: http://localhost:4000/key/info?key=sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz

$ python repro.py sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
ERROR | Error getting key info: 401 Client Error: Unauthorized for url: http://localhost:4000/key/info?key=sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
```

and `logging.exception()` (or an uncaught error) leaks it through the rendered traceback:

```
$ python repro_traceback.py sk-1234 sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
Traceback (most recent call last):
  ...
  File ".../litellm/proxy/client/keys.py", line 314, in info
    response.raise_for_status()
  ...
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://localhost:4000/key/info?key=sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
```

AFTER (with this fix), both the message and the traceback scrub the query param to `?REDACTED`:

```
$ python repro.py sk-1234 sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
ERROR | Error getting key info: 404 Client Error: Not Found for url: http://localhost:4000/key/info?REDACTED

$ python repro_traceback.py sk-1234 sk-cdo1234567890ABCDEFghijKLMNOPqrstuvwxyz
Traceback (most recent call last):
  ...
  File ".../litellm/proxy/client/keys.py", line 322, in info
    raise requests.exceptions.HTTPError(
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: http://localhost:4000/key/info?REDACTED
```

The happy path is unaffected; a valid lookup still returns the key info:

```
$ # client.info(key=<valid key>) against the live proxy
OK info() returned: key_alias= repro-happy-path-key | spend= 0.0
```

Edge cases checked against the live proxy:

```
[SAFE] 404, valid auth + bad lookup, realistic key   -> ?REDACTED  (str + traceback)
[SAFE] 401, bad key as credential                    -> ?REDACTED  (str + traceback)
[SAFE] 64+ char key                                  -> ?REDACTED
[SAFE] orig_exception on the 401 path                -> redacted, response preserved
[SAFE] sibling list() with bad auth                  -> URL carries no raw key
[OK]   happy path, valid key lookup                  -> returns key info
```

Redaction stays on even when secret redaction is disabled, because the fix uses the always-on `redact_string` rather than the env-gated wrapper:

```
$ LITELLM_DISABLE_REDACT_SECRETS=true python repro.py sk-1234 sk-1a2b3c4d...
ERROR | Error getting key info: 404 Client Error: Not Found for url: http://localhost:4000/key/info?REDACTED
```

## Type

🐛 Bug Fix

## Changes

`KeysManagementClient.info` embeds the key in the request URL, and on failure the `requests` `HTTPError` string ("... for url: .../key/info?key=sk-...") flows to whatever logs the exception. The non-401 branch re-raised that error unchanged, and the 401 branch surfaced the same URL through `UnauthorizedError(str(orig_exception))`. Beyond `str(e)`, the original error stayed attached as the chained cause/context, so `logging.exception()` and an uncaught error printed the key in the rendered traceback too

This redacts both branches with the always-on `redact_string` helper from `litellm_core_utils/secret_redaction`. It is deliberately the always-on helper rather than the `redact_secrets` wrapper, since the latter is gated by `LITELLM_DISABLE_REDACT_SECRETS` and a key-leak fix should not be switchable off by a log-verbosity flag. `UnauthorizedError` and `NotFoundError` now scrub their message; `info()` raises the wrapped errors `from None` so the unredacted original is not re-attached as the chain, and it hands the already-redacted string to `UnauthorizedError` so the retained `orig_exception` carries no secret. The rebuilt `HTTPError` keeps the original `response`, so callers and the CLI still read `status_code` and `text`

Only `info()` is touched because it is the sole client method that puts the raw key in a URL; the sibling methods (`list`, `generate`, `delete`) build URLs that carry a hashed key and ids rather than the plaintext secret, so they are left as is

Redaction is shape and length based (it matches `?key=<value>` of 8+ chars and `sk-` tokens of 20+ chars), which covers real proxy keys and 64-char hashes. The `/key/info` route still accepts the key as a query param, so `GET /key/info?key=...` can land in proxy access logs and stays reachable via the preserved response object independently of this client fix; moving cross-key lookup to a header or body is a server-side change tracked in LIT-4013

Regression tests extend the mapped `tests/test_litellm/proxy/client/test_keys.py`; they assert the key is absent from `str(exc)`, from `orig_exception`, and from the rendered traceback, and they fail on the pre-fix code while passing once the key is scrubbed to `REDACTED`

One residual is intentional and pinned by a test: the preserved `response` keeps the raw key in `exc.response.request.url` (and `exc.request.url`), so the rendered string and traceback are scrubbed but the live request URL object is not; removing the key from the URL itself is the server-side root fix tracked in LIT-4013

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped client-side logging fix with no auth or server behavior changes; preserves `response` for structured error handling.
> 
> **Overview**
> **Prevents proxy API keys from leaking into logs** when `KeysManagementClient.info()` fails. That method puts the lookup key in the query string; `requests` error text and exception chains previously echoed the full URL.
> 
> `info()` now runs failures through always-on `redact_string`, raises redacted `UnauthorizedError` / `HTTPError` with `from None` so the unredacted original is not chained, and keeps the original `response` for status/body. **`UnauthorizedError` and `NotFoundError`** scrub `orig_exception` the same way via `_redact_orig_exception`.
> 
> Regression tests assert the key is absent from `str(exc)`, `orig_exception`, and rendered tracebacks. **`exc.response.request.url` may still contain the key** (documented residual; server-side LIT-4013).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366eb06684d80151b837704548d694dc48531c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->