### PR TITLE
ci: harden cargo fetches during maturin builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,12 @@
+[http]
+# CI has seen transient crates.io failures from libcurl's HTTP/2 multiplexing
+# during `maturin` metadata resolution. Disable multiplexing and retry more
+# aggressively so editable `uv sync` builds are not failed by one flaky frame.
+multiplexing = false
+
+[net]
+retry = 5
+
 # PyO3 cdylib (`litellm-python-bridge`) links against the host interpreter's
 # symbols, which are not present at link time when building an extension module.
 # On macOS, tell the linker to resolve undefined `_Py*` symbols dynamically at

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["maturin>=1.9.4,<2"]
+requires = ["maturin==1.9.4"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
## What changed
- Move Cargo config to repo-level `.cargo/config.toml` so `maturin` builds launched from the Python package root always see it.
- Disable Cargo HTTP multiplexing and raise Cargo registry retries to harden against transient crates.io/libcurl HTTP/2 framing failures.
- Pin the `maturin` build backend to `1.9.4` instead of resolving any `<2` version during build isolation.

## Why
`uv sync --frozen` now builds the main `litellm` package through `maturin`. A transient crates.io download failure during `cargo metadata` can fail the whole Python dependency install before tests start.

## Validation
- `uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router`
- `cargo metadata --manifest-path litellm-rust/crates/python-bridge/Cargo.toml --locked --format-version 1`
- Fresh-cache registry path: `CARGO_HOME=$(mktemp -d) cargo fetch --manifest-path litellm-rust/crates/python-bridge/Cargo.toml --locked`
- `uv lock --check`
- `uv run ruff check pyproject.toml`
