### PR TITLE
ci: harden cargo fetches during maturin builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,12 @@
+[http]
+# CI has seen transient crates.io failures from libcurl's HTTP/2 multiplexing
+# during `maturin` metadata resolution. Disable multiplexing and retry more
+# aggressively so editable `uv sync` builds are not failed by one flaky frame.
+multiplexing = false
+
+[net]
+retry = 5
+
 # PyO3 cdylib (`litellm-python-bridge`) links against the host interpreter's
 # symbols, which are not present at link time when building an extension module.
 # On macOS, tell the linker to resolve undefined `_Py*` symbols dynamically at

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,8 @@ jobs:
     working_directory: ~/project
     environment:
       UV_PYTHON: "3.11"
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_RETRY: "5"
     steps:
       - checkout
       - run:
@@ -243,7 +245,17 @@ jobs:
             if (-not (Select-String -Path $PROFILE -SimpleMatch $cargoBin -Quiet)) {
               Add-Content -Path $PROFILE -Value "`$env:Path = `"$cargoBin;`$env:Path`""
             }
-            uv sync --frozen --group dev --python 3.11
+            for ($attempt = 1; $attempt -le 5; $attempt++) {
+              Write-Host "uv sync attempt $attempt/5"
+              uv sync --frozen --group dev --python 3.11
+              if ($LASTEXITCODE -eq 0) {
+                break
+              }
+              if ($attempt -eq 5) {
+                exit $LASTEXITCODE
+              }
+              Start-Sleep -Seconds 15
+            }
       - run:
           name: Run Windows-specific test
           command: |
@@ -255,6 +267,7 @@ jobs:
           command: |
             $env:Path = "$HOME\.cargo\bin;$HOME\.local\bin;$env:Path"
             cargo --version
+            Get-ChildItem -Path "litellm\rust_bridge" -Filter "_native*" -File -ErrorAction SilentlyContinue | Remove-Item -Force
             uv build --wheel --out-dir dist
             uv run --no-sync python tests/windows_tests/check_windows_wheel_install.py
 

--- a/.github/scripts/uv_sync_with_retries.sh
+++ b/.github/scripts/uv_sync_with_retries.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+max_attempts="${UV_SYNC_MAX_ATTEMPTS:-5}"
+delay_seconds="${UV_SYNC_RETRY_DELAY_SECONDS:-15}"
+
+export CARGO_HTTP_MULTIPLEXING="${CARGO_HTTP_MULTIPLEXING:-false}"
+export CARGO_NET_RETRY="${CARGO_NET_RETRY:-5}"
+
+if [[ "$#" -eq 0 ]]; then
+  echo "usage: $0 <uv sync args...>" >&2
+  exit 2
+fi
+
+for attempt in $(seq 1 "${max_attempts}"); do
+  echo "uv sync attempt ${attempt}/${max_attempts}"
+  status=0
+  if uv sync "$@"; then
+    exit 0
+  else
+    status=$?
+  fi
+
+  if [[ "${attempt}" -eq "${max_attempts}" ]]; then
+    echo "uv sync failed after ${max_attempts} attempts" >&2
+    exit "${status}"
+  fi
+
+  echo "uv sync failed; retrying in ${delay_seconds}s..."
+  sleep "${delay_seconds}"
+done

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
       - name: Generate Prisma client
         env:

--- a/.github/workflows/check-ui-api-types.yml
+++ b/.github/workflows/check-ui-api-types.yml
@@ -46,7 +46,7 @@ jobs:
             ${{ runner.os }}-uv-
 
       - name: Install backend dependencies
-        run: uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+        run: .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
       - name: Generate Prisma client
         env:

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
       - name: Generate Prisma client
         env:

--- a/.github/workflows/test-mcp.yml
+++ b/.github/workflows/test-mcp.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock --check
-          uv sync --frozen --group proxy-dev --extra proxy --extra semantic-router
+          .github/scripts/uv_sync_with_retries.sh --frozen --group proxy-dev --extra proxy --extra semantic-router
 
       - name: Run MCP tests
         run: |

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
       - name: Generate Prisma client
         env:

--- a/.github/workflows/test-unit-proxy-legacy.yml
+++ b/.github/workflows/test-unit-proxy-legacy.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
 
       - name: Generate Prisma client
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,7 +234,7 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["maturin>=1.9.4,<2"]
+requires = ["maturin==1.9.4"]
 build-backend = "maturin"
 
 [tool.maturin]


### PR DESCRIPTION
## What changed
- Move Cargo config to repo-level `.cargo/config.toml` so `maturin` builds launched from the Python package root always see it.
- Disable Cargo HTTP multiplexing and set Cargo registry retries to 5 to harden against transient crates.io/libcurl HTTP/2 framing failures.
- Add a 5-attempt `uv sync` retry wrapper for the GitHub workflows that run the flaky dependency install path.
- Add the same 5-attempt retry behavior to the CircleCI Windows `uv sync` step.
- Clean stale editable-build `_native*` files before the CircleCI Windows `uv build` step, avoiding duplicate `_native.cp311-win_amd64.pyd` wheel entries.
- Pin the `maturin` build backend to `1.9.4` instead of resolving any `<2` version during build isolation.

## Why
`uv sync --frozen` now builds the main `litellm` package through `maturin`. A transient crates.io download failure during `cargo metadata` can fail the whole Python dependency install before tests start. On Windows, the follow-up wheel build can also see the editable-build `_native` artifact left by `uv sync`, causing maturin to reject the duplicate wheel path.

## Validation
- `.github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router`
- `cargo metadata --manifest-path litellm-rust/crates/python-bridge/Cargo.toml --locked --format-version 1`
- Fresh-cache registry path: `CARGO_HOME=$(mktemp -d) cargo fetch --manifest-path litellm-rust/crates/python-bridge/Cargo.toml --locked`
- `uv build --wheel --out-dir /tmp/litellm-wheel-clean-native`
- Verified wheel contains `litellm/rust_bridge/_native.cpython-312-darwin.so`
- Verified Windows MAX_PATH guard reports zero offenders on the rebuilt wheel
- `uv lock --check`
- `uv run ruff check pyproject.toml`
- `bash -n .github/scripts/uv_sync_with_retries.sh`
- Workflow/CircleCI YAML parsed with PyYAML
