### PR TITLE
fix(gemini/transformation): prevent in-place mutation of tool schemas…

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -638,6 +638,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         googleMaps: Optional[dict] = None
         google_maps_retrieval_config: Optional[dict] = None
         computerUse: Optional[dict] = None
+        value = deepcopy(value)
         # remove 'additionalProperties' from tools
         value = _remove_additional_properties(value)
         # remove 'strict' from tools

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -2097,3 +2097,48 @@ def test_multi_turn_function_calling_roles():
                 assert (
                     content["role"] == "user"
                 ), f"Content block {i} with function_response has role='{content['role']}', expected 'user'"
+
+
+def test_map_function_does_not_mutate_caller_tools():
+    """Regression test for issue #31343.
+
+    _map_function strips additionalProperties and strict from tool schemas because
+    Gemini does not accept them. Those fields must be removed from a local copy only;
+    the original list passed in by the caller must remain unchanged so that a
+    subsequent OpenAI fallback still receives a valid strict-mode schema.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "my_tool",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string", "description": "Input value."}
+                    },
+                    "required": ["value"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    original_additional_props = tools[0]["function"]["parameters"]["additionalProperties"]
+    original_strict = tools[0]["function"]["strict"]
+
+    VertexGeminiConfig()._map_function(value=tools, optional_params={})
+
+    assert tools[0]["function"]["parameters"]["additionalProperties"] == original_additional_props, (
+        "_map_function mutated the caller's tools list: additionalProperties was removed. "
+        "This breaks Gemini-to-OpenAI fallbacks because OpenAI requires additionalProperties=False."
+    )
+    assert tools[0]["function"]["strict"] == original_strict, (
+        "_map_function mutated the caller's tools list: strict was removed."
+    )
+


### PR DESCRIPTION
Relevant issues
Fixes #31343

Pre-Submission checklist
 My PR's scope is as isolated as possible; it only solves 1 specific problem
Type
Bug Fix

Description
When falling back from a Gemini model to an OpenAI model, if the request included tools/functions, the fallback failed with a BadRequestError from OpenAI indicating that additionalProperties was missing/invalid.

Root Cause
During the Gemini parameter mapping phase (_map_function in vertex_and_google_ai_studio_gemini.py), the tool schema is cleaned of additionalProperties and strict fields since Gemini does not support them. However, this cleanup was mutating the tool list/dictionary in-place. Because the router reuses the same parameter dictionary for fallbacks, the mutated tool schemas (now lacking additionalProperties and strict keys) were passed to the subsequent OpenAI model, which requires these fields for structured tool calls.

Solution
Deepcopy the value list inside _map_function before applying the in-place modifications (_remove_additional_properties and _remove_strict_from_schema), ensuring the router's original tools argument remains unmodified for subsequent fallback attempts.

Testing
Added a regression test test_map_function_does_not_mutate_caller_tools in test_vertex_ai_gemini_transformation.py to ensure _map_function does not mutate the input tools list.