### PR TITLE
feat(mistral): support Mistral OCR 4 (mistral-ocr-4-0)

### DIFF
--- a/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/mistral/ocr/transformation.rs
@@ -15,6 +15,7 @@ const SUPPORTED_OCR_PARAMS: &[&str] = &[
     "extract_footer",
     "table_format",
     "confidence_scores_granularity",
+    "include_blocks",
     "id",
 ];
 
@@ -175,6 +176,7 @@ mod tests {
                 "extract_footer",
                 "table_format",
                 "confidence_scores_granularity",
+                "include_blocks",
                 "id",
             ]
         );

--- a/litellm/llms/mistral/ocr/transformation.py
+++ b/litellm/llms/mistral/ocr/transformation.py
@@ -42,6 +42,7 @@ class MistralOCRConfig(BaseOCRConfig):
         - extract_footer: Whether to extract document footer
         - table_format: Table output format ("markdown" or "html")
         - confidence_scores_granularity: Confidence score level ("word" or "page")
+        - include_blocks: Whether to return paragraph-level bounding boxes and typed content blocks (OCR 4)
         - id: Request identifier
         """
         return [
@@ -56,6 +57,7 @@ class MistralOCRConfig(BaseOCRConfig):
             "extract_footer",
             "table_format",
             "confidence_scores_granularity",
+            "include_blocks",
             "id",
         ]
 

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25550,8 +25550,18 @@
     },
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
-        "ocr_cost_per_page": 0.001,
-        "annotation_cost_per_page": 0.003,
+        "ocr_cost_per_page": 0.004,
+        "annotation_cost_per_page": 0.005,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://mistral.ai/pricing#api-pricing"
+    },
+    "mistral/mistral-ocr-4-0": {
+        "litellm_provider": "mistral",
+        "ocr_cost_per_page": 0.004,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25551,7 +25551,7 @@
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -25561,7 +25561,7 @@
     "mistral/mistral-ocr-4-0": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25551,7 +25551,7 @@
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.003,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -25561,7 +25561,7 @@
     "mistral/mistral-ocr-4-0": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.003,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25558,8 +25558,18 @@
     },
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
-        "ocr_cost_per_page": 0.001,
-        "annotation_cost_per_page": 0.003,
+        "ocr_cost_per_page": 0.004,
+        "annotation_cost_per_page": 0.005,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://mistral.ai/pricing#api-pricing"
+    },
+    "mistral/mistral-ocr-4-0": {
+        "litellm_provider": "mistral",
+        "ocr_cost_per_page": 0.004,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25559,7 +25559,7 @@
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.003,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -25569,7 +25569,7 @@
     "mistral/mistral-ocr-4-0": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.003,
+        "annotation_cost_per_page": 0.005,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25559,7 +25559,7 @@
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -25569,7 +25569,7 @@
     "mistral/mistral-ocr-4-0": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"

--- a/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
+++ b/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
@@ -1,0 +1,40 @@
+"""
+Cost tests for Mistral OCR models against the real litellm cost map
+(no monkeypatching of get_model_info). These regress the pricing entries
+for mistral-ocr-4-0 and mistral-ocr-latest, which now both resolve to
+OCR 4 at $4 / 1000 pages.
+"""
+
+import pytest
+
+import litellm
+from litellm.cost_calculator import completion_cost
+from litellm.llms.base_llm.ocr.transformation import OCRPage, OCRResponse, OCRUsageInfo
+
+OCR4_COST_PER_PAGE = 0.004
+
+
+def _ocr_response(model: str, pages_processed: int) -> OCRResponse:
+    return OCRResponse(
+        pages=[OCRPage(index=i, markdown=f"page {i}") for i in range(pages_processed)],
+        model=model,
+        usage_info=OCRUsageInfo(pages_processed=pages_processed),
+    )
+
+
+@pytest.mark.parametrize("model", ["mistral-ocr-4-0", "mistral-ocr-latest"])
+def test_model_info_ocr4_price(model: str) -> None:
+    info = litellm.get_model_info(model=f"mistral/{model}", custom_llm_provider="mistral")
+    assert info["ocr_cost_per_page"] == OCR4_COST_PER_PAGE
+
+
+@pytest.mark.parametrize("model", ["mistral-ocr-4-0", "mistral-ocr-latest"])
+@pytest.mark.parametrize("pages_processed", [1, 3, 10])
+def test_ocr4_cost_scales_with_pages(model: str, pages_processed: int) -> None:
+    cost = completion_cost(
+        completion_response=_ocr_response(model, pages_processed),
+        model=f"mistral/{model}",
+        custom_llm_provider="mistral",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(OCR4_COST_PER_PAGE * pages_processed)

--- a/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py
+++ b/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_transformation.py
@@ -5,6 +5,7 @@ Tests the supported OCR parameters and their mapping behaviour.
 No real API calls are made — all tests are fully mocked/local.
 """
 
+import httpx
 import pytest
 
 from litellm.llms.mistral.ocr.transformation import MistralOCRConfig
@@ -40,9 +41,7 @@ class TestGetSupportedOcrParams:
             "bbox_annotation_format",
             "document_annotation_format",
         ]:
-            assert (
-                param in supported
-            ), f"Previously supported param '{param}' is missing"
+            assert param in supported, f"Previously supported param '{param}' is missing"
 
 
 class TestMapOcrParams:
@@ -93,12 +92,11 @@ class TestNewSupportedParams:
             "table_format",
             "confidence_scores_granularity",
             "document_annotation_prompt",
+            "include_blocks",
             "id",
         ],
     )
-    def test_new_param_in_supported_list(
-        self, config: MistralOCRConfig, param_name: str
-    ) -> None:
+    def test_new_param_in_supported_list(self, config: MistralOCRConfig, param_name: str) -> None:
         supported = config.get_supported_ocr_params(model=MODEL)
         assert param_name in supported
 
@@ -114,12 +112,11 @@ class TestNewParamsMapOcr:
             ("confidence_scores_granularity", "word"),
             ("confidence_scores_granularity", "page"),
             ("document_annotation_prompt", "Extract all invoice line items"),
+            ("include_blocks", True),
             ("id", "req-123"),
         ],
     )
-    def test_new_param_passed_through(
-        self, config: MistralOCRConfig, param_name: str, param_value: str
-    ) -> None:
+    def test_new_param_passed_through(self, config: MistralOCRConfig, param_name: str, param_value: str) -> None:
         result = config.map_ocr_params(
             non_default_params={param_name: param_value},
             optional_params={},
@@ -144,12 +141,11 @@ class TestTransformOcrRequest:
             ("document_annotation_prompt", "Extract all invoice line items"),
             ("id", "req-123"),
             ("extract_header", True),
+            ("include_blocks", True),
             ("pages", [0, 1]),
         ],
     )
-    def test_param_included_in_request_body(
-        self, config: MistralOCRConfig, param_name: str, param_value
-    ) -> None:
+    def test_param_included_in_request_body(self, config: MistralOCRConfig, param_name: str, param_value) -> None:
         result = config.transform_ocr_request(
             model=MODEL,
             document=self.SAMPLE_DOCUMENT,
@@ -176,3 +172,65 @@ class TestTransformOcrRequest:
         )
         for key, value in optional_params.items():
             assert result.data[key] == value
+
+
+class TestTransformOcrResponseOcr4Fields:
+    """OCR 4 adds blocks, confidence_scores, tables, hyperlinks, header and footer
+    to each page. These must survive transform_ocr_response so callers actually
+    receive the new structured output rather than having it silently dropped."""
+
+    def _response(self, page: dict) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "pages": [page],
+                "model": "mistral-ocr-4-0",
+                "usage_info": {"pages_processed": 1},
+            },
+        )
+
+    def test_blocks_and_confidence_scores_preserved(self, config: MistralOCRConfig) -> None:
+        page = {
+            "index": 0,
+            "markdown": "# Invoice",
+            "blocks": [
+                {
+                    "type": "title",
+                    "top_left_x": 10,
+                    "top_left_y": 20,
+                    "bottom_right_x": 300,
+                    "bottom_right_y": 60,
+                    "content": "Invoice",
+                }
+            ],
+            "confidence_scores": {"page": 0.98},
+        }
+
+        result = config.transform_ocr_response(
+            model="mistral-ocr-4-0",
+            raw_response=self._response(page),
+            logging_obj=None,
+        )
+
+        assert result.pages[0].blocks == page["blocks"]
+        assert result.pages[0].confidence_scores == page["confidence_scores"]
+
+    def test_ocr4_fields_survive_model_dump(self, config: MistralOCRConfig) -> None:
+        page = {
+            "index": 0,
+            "markdown": "table page",
+            "tables": [{"rows": 2, "cols": 3}],
+            "hyperlinks": ["https://example.com"],
+            "header": "Acme Corp",
+            "footer": "Page 1",
+        }
+
+        result = config.transform_ocr_response(
+            model="mistral-ocr-4-0",
+            raw_response=self._response(page),
+            logging_obj=None,
+        )
+
+        dumped_page = result.model_dump()["pages"][0]
+        for field in ("tables", "hyperlinks", "header", "footer"):
+            assert dumped_page[field] == page[field]


### PR DESCRIPTION
## Relevant issues

Model request from customer

## Linear ticket

LIT-3928

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Ran against the real Mistral API through a live LiteLLM proxy hitting `/v1/ocr`. `LITELLM_LOCAL_MODEL_COST_MAP=True` makes the proxy read the cost map from this branch (the remote `main` map does not have the entry until this merges, so without it the OCR cost falls back to 0)

proxy config (`ocr_proxy_config.yaml`)

```yaml
model_list:
  - model_name: mistral-ocr-4-0
    litellm_params:
      model: mistral/mistral-ocr-4-0
      api_key: os.environ/MISTRAL_API_KEY
general_settings:
  master_key: sk-1234
```

```bash
export MISTRAL_API_KEY=...   # real key, costs ~$0.004/page
LITELLM_LOCAL_MODEL_COST_MAP=True litellm --config ocr_proxy_config.yaml --port 4000 --detailed_debug

curl -s http://localhost:4000/v1/ocr \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "mistral-ocr-4-0",
    "document": {"type": "document_url", "document_url": "https://arxiv.org/pdf/2201.04234"},
    "pages": [0],
    "include_blocks": true,
    "confidence_scores_granularity": "page"
  }'
```

Response (HTTP 200), trimmed to show the OCR 4 surface reaching the caller through LiteLLM

```
object: ocr | model: mistral-ocr-4-0 | usage_info.pages_processed: 1
page keys: ['blocks', 'confidence_scores', 'dimensions', 'footer', 'header', 'hyperlinks', 'images', 'index', 'markdown', 'tables']
blocks: 21 typed regions, first -> {"type": "header", "top_left_x": 135, "top_left_y": 31, "bottom_right_x": 378, "bottom_right_y": 47, "content": "Published as a conference paper at ICLR 2022"}
confidence_scores: {"average_page_confidence_score": 0.9793, "minimum_page_confidence_score": 0.2573, "word_confidence_scores": []}
```

`include_blocks: true` is forwarded (21 blocks returned) and the new per-page fields survive untouched. Cost tracking from the proxy log

```
cost_calculator OCR: model=mistral/mistral-ocr-4-0 pages_processed=1
litellm_logging.py:1603 - response_cost: 0.004
```

`0.004` for one page matches `ocr_cost_per_page`. `mistral-ocr-latest` resolves to OCR 4 server-side and tracks at the same price

## Type

🆕 New Feature

## Changes

Mistral launched OCR 4 (`mistral-ocr-4-0`) on 2026-06-23 at $4 / 1000 pages, and `mistral-ocr-latest` now points to it. This adds the model to LiteLLM

The cost map gains `mistral/mistral-ocr-4-0` at `ocr_cost_per_page = 0.004`, and `mistral/mistral-ocr-latest` is repriced from the old OCR 2 rate (`0.001`) to `0.004` so spend tracking stays correct now that `latest` resolves to OCR 4. `annotation_cost_per_page` is set to `0.005` to match Mistral's published $5 / 1000 rate for annotated pages (Document AI); both numbers are confirmed against the [pricing page](https://mistral.ai/pricing), the [OCR 4 announcement](https://mistral.ai/news/ocr-4/), and the [ocr-4-0 model card](https://docs.mistral.ai/models/model-cards/ocr-4-0). `ocr_cost()` bills off `ocr_cost_per_page`, so the annotation rate is documentation-only today. Both `model_prices_and_context_window.json` and the packaged `model_prices_and_context_window_backup.json` are updated

`include_blocks` is added to `MistralOCRConfig`'s supported params so callers can request OCR 4's paragraph-level bounding boxes and typed content blocks. OCR 4's other new per-page response fields (`blocks`, `confidence_scores`, `tables`, `hyperlinks`, `header`, `footer`) already reach the caller unchanged because `OCRPage` carries `model_config = {"extra": "allow"}`; a regression test pins that so the structured output cannot be silently dropped

Tests cover the new param surviving request transformation, the OCR 4 response fields surviving response transformation, and the per-page cost computing against the real cost map for both `mistral-ocr-4-0` and `mistral-ocr-latest`. No provider routing or transformation code path changes; `MistralOCRConfig` is model-agnostic and the new model flows through the existing `/v1/ocr` handler


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Repricing `mistral-ocr-latest` changes reported spend for existing OCR callers; otherwise the change is additive params and cost-map entries with regression tests.
> 
> **Overview**
> Adds **Mistral OCR 4** support by registering `mistral/mistral-ocr-4-0` in the model cost maps and repricing **`mistral-ocr-latest`** to OCR 4 rates (`ocr_cost_per_page` **0.004**, `annotation_cost_per_page` **0.005**).
> 
> Exposes OCR 4’s **`include_blocks`** request flag in **Python and Rust** Mistral OCR configs so paragraph-level blocks are forwarded instead of dropped on the Rust path. Tests cover param passthrough, OCR 4 per-page response fields (`blocks`, `confidence_scores`, `tables`, etc.), and per-page billing for `mistral-ocr-4-0` and `mistral-ocr-latest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9888e97f4bab9efa87efaef5c0fe87b9a087966c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->