### PR TITLE
fix(vertex): preserve Gemini Embedding 2 usageMetadata for cost tracking

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -485,6 +485,7 @@ class PromptTokensDetailsResult(TypedDict):
     character_count: int
     image_count: int
     video_length_seconds: float
+    audio_length_seconds: float
 
 
 def _parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
@@ -535,6 +536,13 @@ def _parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
         )
         or 0.0
     )
+    audio_length_seconds = (
+        cast(
+            Optional[float],
+            getattr(usage.prompt_tokens_details, "audio_length_seconds", 0),
+        )
+        or 0.0
+    )
 
     return PromptTokensDetailsResult(
         cache_hit_tokens=cache_hit_tokens,
@@ -546,6 +554,7 @@ def _parse_prompt_tokens_details(usage: Usage) -> PromptTokensDetailsResult:
         character_count=character_count,
         image_count=image_count,
         video_length_seconds=float(video_length_seconds),
+        audio_length_seconds=float(audio_length_seconds),
     )
 
 
@@ -667,6 +676,14 @@ def _calculate_input_cost(
             prompt_tokens_details["video_length_seconds"],
         )
 
+    ### AUDIO LENGTH COST
+    if prompt_tokens_details["audio_length_seconds"]:
+        prompt_cost += calculate_cost_component(
+            model_info,
+            "input_cost_per_audio_per_second",
+            prompt_tokens_details["audio_length_seconds"],
+        )
+
     return prompt_cost
 
 
@@ -743,6 +760,7 @@ def generic_cost_per_token(
         character_count=0,
         image_count=0,
         video_length_seconds=0.0,
+        audio_length_seconds=0.0,
     )
     if usage.prompt_tokens_details:
         prompt_tokens_details = _parse_prompt_tokens_details(usage)

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
@@ -274,6 +274,7 @@ class GoogleBatchEmbeddings(VertexLLM):
                 model_response=model_response,
                 model=model,
                 response_json=_json_response,
+                resolved_files=resolved_files,
             )
         else:
             _predictions = VertexAIBatchEmbeddingsResponseObject(**_json_response)  # type: ignore
@@ -377,6 +378,7 @@ class GoogleBatchEmbeddings(VertexLLM):
                 model_response=model_response,
                 model=model,
                 response_json=_json_response,
+                resolved_files=resolved_files,
             )
         else:
             _predictions = VertexAIBatchEmbeddingsResponseObject(**_json_response)  # type: ignore

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -306,6 +306,7 @@ def transform_openai_input_gemini_embed_content(
 
 _IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg"})
 _VIDEO_TOKENS_PER_SECOND = 258.0
+_AUDIO_TOKENS_PER_SECOND = 32.0
 _usage_metadata_adapter = TypeAdapter(UsageMetadata)
 
 
@@ -398,13 +399,18 @@ def _usage_from_embed_content_response(
     video_length_seconds = (
         video_tokens / _VIDEO_TOKENS_PER_SECOND if video_tokens > 0 else 0.0
     )
-
-    has_billable_non_video = text_tokens > 0 or audio_tokens > 0 or image_count > 0
-    # generic_cost_per_token rewrites text_tokens to the full prompt when text and
-    # image_count are both zero; a 1-token floor keeps video billed per-second.
-    resolved_text_tokens = (
-        1 if video_length_seconds > 0 and not has_billable_non_video else text_tokens
+    audio_length_seconds = (
+        audio_tokens / _AUDIO_TOKENS_PER_SECOND if audio_tokens > 0 else 0.0
     )
+
+    # generic_cost_per_token rewrites text_tokens to the full prompt minus
+    # other modalities when both text_tokens and image_count are zero. For
+    # video, that misallocates video tokens to text; a 1-token floor sidesteps
+    # the rewrite and keeps billing on input_cost_per_video_per_second.
+    needs_video_text_floor = (
+        video_length_seconds > 0 and text_tokens == 0 and image_count == 0
+    )
+    resolved_text_tokens = 1 if needs_video_text_floor else text_tokens
 
     return Usage(
         prompt_tokens=prompt_tokens,
@@ -414,6 +420,7 @@ def _usage_from_embed_content_response(
             audio_tokens=audio_tokens,
             image_count=image_count,
             video_length_seconds=video_length_seconds,
+            audio_length_seconds=audio_length_seconds,
         ),
     )
 

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -4,6 +4,7 @@ Transformation logic from OpenAI /v1/embeddings format to Google AI Studio /batc
 Why separate file? Make it easy to see how transformation works
 """
 
+from collections.abc import Mapping
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from pydantic import TypeAdapter, ValidationError
@@ -317,7 +318,7 @@ def _parse_usage_metadata(raw_usage_metadata: object) -> Optional[UsageMetadata]
         return None
 
 
-def _flatten_input(input: GeminiEmbeddingInput) -> Tuple[str, ...]:
+def _flatten_input(input: GeminiEmbeddingInput) -> tuple[str, ...]:
     if isinstance(input, str):
         return (input,)
     return tuple(
@@ -327,7 +328,10 @@ def _flatten_input(input: GeminiEmbeddingInput) -> Tuple[str, ...]:
     )
 
 
-def _is_image_element(element: str) -> bool:
+def _is_image_element(
+    element: str,
+    resolved_files: Mapping[str, Mapping[str, str]],
+) -> bool:
     if element.startswith("data:") and ";base64," in element:
         try:
             mime_type, _ = _parse_data_url(element)
@@ -339,11 +343,21 @@ def _is_image_element(element: str) -> bool:
             return _infer_mime_type_from_gcs_url(element) in _IMAGE_MIME_TYPES
         except ValueError:
             return False
+    if _is_file_reference(element):
+        file_info = resolved_files.get(element)
+        return file_info is not None and file_info.get("mime_type") in _IMAGE_MIME_TYPES
     return False
 
 
-def _count_input_images(input: GeminiEmbeddingInput) -> int:
-    return sum(1 for element in _flatten_input(input) if _is_image_element(element))
+def _count_input_images(
+    input: GeminiEmbeddingInput,
+    resolved_files: Mapping[str, Mapping[str, str]],
+) -> int:
+    return sum(
+        1
+        for element in _flatten_input(input)
+        if _is_image_element(element, resolved_files)
+    )
 
 
 def _tokens_for_modality(details: Sequence[PromptTokensDetails], modality: str) -> int:
@@ -364,6 +378,7 @@ def _usage_from_embed_content_response(
     input: GeminiEmbeddingInput,
     model: str,
     raw_usage_metadata: object,
+    resolved_files: Mapping[str, Mapping[str, str]],
 ) -> Usage:
     usage_metadata = _parse_usage_metadata(raw_usage_metadata)
     if usage_metadata is None:
@@ -378,7 +393,7 @@ def _usage_from_embed_content_response(
     text_tokens = _tokens_for_modality(details, "TEXT")
     audio_tokens = _tokens_for_modality(details, "AUDIO")
     video_tokens = _tokens_for_modality(details, "VIDEO")
-    image_count = _count_input_images(input)
+    image_count = _count_input_images(input, resolved_files)
 
     video_length_seconds = (
         video_tokens / _VIDEO_TOKENS_PER_SECOND if video_tokens > 0 else 0.0
@@ -408,6 +423,7 @@ def process_embed_content_response(
     model_response: EmbeddingResponse,
     model: str,
     response_json: dict,
+    resolved_files: Mapping[str, Mapping[str, str]] | None = None,
 ) -> EmbeddingResponse:
     """
     Process Gemini embedContent response (single embedding for multimodal input).
@@ -417,6 +433,8 @@ def process_embed_content_response(
         model_response: EmbeddingResponse to populate
         model: Model name
         response_json: Raw JSON response from embedContent endpoint
+        resolved_files: Mapping of file references (files/abc) to {mime_type, uri},
+            used to bill resolved image references at the per-image rate
 
     Returns:
         EmbeddingResponse with single embedding
@@ -440,6 +458,7 @@ def process_embed_content_response(
         input=input,
         model=model,
         raw_usage_metadata=response_json.get("usageMetadata"),
+        resolved_files=resolved_files or {},
     )
 
     return model_response

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -139,7 +139,9 @@ def _is_multimodal_input(input: GeminiEmbeddingInput) -> bool:
 
     for element in input:
         if isinstance(element, list):
-            if any(_is_multimodal_element(sub) for sub in element if isinstance(sub, str)):
+            if any(
+                _is_multimodal_element(sub) for sub in element if isinstance(sub, str)
+            ):
                 return True
         elif isinstance(element, str) and _is_multimodal_element(element):
             return True
@@ -239,8 +241,13 @@ def transform_openai_input_gemini_content(
                 raise ValueError("Nested input list must not be empty")
             for sub in element:
                 if not isinstance(sub, str):
-                    raise ValueError(f"Elements inside a nested input list must be strings, got {type(sub)}")
-            parts = [_build_part_for_input(sub, resolved_files=resolved_files) for sub in element]
+                    raise ValueError(
+                        f"Elements inside a nested input list must be strings, got {type(sub)}"
+                    )
+            parts = [
+                _build_part_for_input(sub, resolved_files=resolved_files)
+                for sub in element
+            ]
         else:
             parts = [_build_part_for_input(element, resolved_files=resolved_files)]
         request = EmbedContentRequest(
@@ -313,7 +320,11 @@ def _parse_usage_metadata(raw_usage_metadata: object) -> Optional[UsageMetadata]
 def _flatten_input(input: GeminiEmbeddingInput) -> Tuple[str, ...]:
     if isinstance(input, str):
         return (input,)
-    return tuple(sub for element in input for sub in (element if isinstance(element, list) else [element]))
+    return tuple(
+        sub
+        for element in input
+        for sub in (element if isinstance(element, list) else [element])
+    )
 
 
 def _is_image_element(element: str) -> bool:
@@ -336,7 +347,9 @@ def _count_input_images(input: GeminiEmbeddingInput) -> int:
 
 
 def _tokens_for_modality(details: Sequence[PromptTokensDetails], modality: str) -> int:
-    return sum(detail["tokenCount"] for detail in details if detail["modality"] == modality)
+    return sum(
+        detail["tokenCount"] for detail in details if detail["modality"] == modality
+    )
 
 
 def _fallback_usage(input: GeminiEmbeddingInput, model: str) -> Usage:
@@ -359,18 +372,24 @@ def _usage_from_embed_content_response(
     prompt_tokens = usage_metadata.get("promptTokenCount", 0)
     total_tokens = usage_metadata.get("totalTokenCount") or prompt_tokens
 
-    details: Sequence[PromptTokensDetails] = usage_metadata.get("promptTokensDetails") or ()
+    details: Sequence[PromptTokensDetails] = (
+        usage_metadata.get("promptTokensDetails") or ()
+    )
     text_tokens = _tokens_for_modality(details, "TEXT")
     audio_tokens = _tokens_for_modality(details, "AUDIO")
     video_tokens = _tokens_for_modality(details, "VIDEO")
     image_count = _count_input_images(input)
 
-    video_length_seconds = video_tokens / _VIDEO_TOKENS_PER_SECOND if video_tokens > 0 else 0.0
+    video_length_seconds = (
+        video_tokens / _VIDEO_TOKENS_PER_SECOND if video_tokens > 0 else 0.0
+    )
 
     has_billable_non_video = text_tokens > 0 or audio_tokens > 0 or image_count > 0
     # generic_cost_per_token rewrites text_tokens to the full prompt when text and
     # image_count are both zero; a 1-token floor keeps video billed per-second.
-    resolved_text_tokens = 1 if video_length_seconds > 0 and not has_billable_non_video else text_tokens
+    resolved_text_tokens = (
+        1 if video_length_seconds > 0 and not has_billable_non_video else text_tokens
+    )
 
     return Usage(
         prompt_tokens=prompt_tokens,
@@ -403,7 +422,9 @@ def process_embed_content_response(
         EmbeddingResponse with single embedding
     """
     if "embedding" not in response_json:
-        raise ValueError(f"embedContent response missing 'embedding' field: {response_json}")
+        raise ValueError(
+            f"embedContent response missing 'embedding' field: {response_json}"
+        )
 
     embedding_data = response_json["embedding"]
 
@@ -448,17 +469,25 @@ def process_response(
         text_elements: List[str] = []
         for e in input_list:
             if isinstance(e, list):
-                text_elements.extend(sub for sub in e if isinstance(sub, str) and not _is_multimodal_element(sub))
+                text_elements.extend(
+                    sub
+                    for sub in e
+                    if isinstance(sub, str) and not _is_multimodal_element(sub)
+                )
             elif isinstance(e, str) and not _is_multimodal_element(e):
                 text_elements.append(e)
         if text_elements:
-            input_text = get_formatted_prompt(data={"input": text_elements}, call_type="embedding")
+            input_text = get_formatted_prompt(
+                data={"input": text_elements}, call_type="embedding"
+            )
             prompt_tokens = token_counter(model=model, text=input_text)
         else:
             prompt_tokens = 0
     else:
         input_text = get_formatted_prompt(data={"input": input}, call_type="embedding")
         prompt_tokens = token_counter(model=model, text=input_text)
-    model_response.usage = Usage(prompt_tokens=prompt_tokens, total_tokens=prompt_tokens)
+    model_response.usage = Usage(
+        prompt_tokens=prompt_tokens, total_tokens=prompt_tokens
+    )
 
     return model_response

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_transformation.py
@@ -4,7 +4,9 @@ Transformation logic from OpenAI /v1/embeddings format to Google AI Studio /batc
 Why separate file? Make it easy to see how transformation works
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from pydantic import TypeAdapter, ValidationError
 
 from litellm.types.llms.vertex_ai import (
     BlobType,
@@ -13,10 +15,17 @@ from litellm.types.llms.vertex_ai import (
     FileDataType,
     GeminiEmbeddingInput,
     PartType,
+    PromptTokensDetails,
+    UsageMetadata,
     VertexAIBatchEmbeddingsRequestBody,
     VertexAIBatchEmbeddingsResponseObject,
 )
-from litellm.types.utils import Embedding, EmbeddingResponse, Usage
+from litellm.types.utils import (
+    Embedding,
+    EmbeddingResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
 from litellm.utils import get_formatted_prompt, token_counter
 
 SUPPORTED_EMBEDDING_MIME_TYPES = {
@@ -130,9 +139,7 @@ def _is_multimodal_input(input: GeminiEmbeddingInput) -> bool:
 
     for element in input:
         if isinstance(element, list):
-            if any(
-                _is_multimodal_element(sub) for sub in element if isinstance(sub, str)
-            ):
+            if any(_is_multimodal_element(sub) for sub in element if isinstance(sub, str)):
                 return True
         elif isinstance(element, str) and _is_multimodal_element(element):
             return True
@@ -232,13 +239,8 @@ def transform_openai_input_gemini_content(
                 raise ValueError("Nested input list must not be empty")
             for sub in element:
                 if not isinstance(sub, str):
-                    raise ValueError(
-                        f"Elements inside a nested input list must be strings, got {type(sub)}"
-                    )
-            parts = [
-                _build_part_for_input(sub, resolved_files=resolved_files)
-                for sub in element
-            ]
+                    raise ValueError(f"Elements inside a nested input list must be strings, got {type(sub)}")
+            parts = [_build_part_for_input(sub, resolved_files=resolved_files) for sub in element]
         else:
             parts = [_build_part_for_input(element, resolved_files=resolved_files)]
         request = EmbedContentRequest(
@@ -294,6 +296,94 @@ def transform_openai_input_gemini_embed_content(
     return request_body
 
 
+_IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg"})
+_VIDEO_TOKENS_PER_SECOND = 258.0
+_usage_metadata_adapter = TypeAdapter(UsageMetadata)
+
+
+def _parse_usage_metadata(raw_usage_metadata: object) -> Optional[UsageMetadata]:
+    if not isinstance(raw_usage_metadata, dict):
+        return None
+    try:
+        return _usage_metadata_adapter.validate_python(raw_usage_metadata)
+    except ValidationError:
+        return None
+
+
+def _flatten_input(input: GeminiEmbeddingInput) -> Tuple[str, ...]:
+    if isinstance(input, str):
+        return (input,)
+    return tuple(sub for element in input for sub in (element if isinstance(element, list) else [element]))
+
+
+def _is_image_element(element: str) -> bool:
+    if element.startswith("data:") and ";base64," in element:
+        try:
+            mime_type, _ = _parse_data_url(element)
+        except ValueError:
+            return False
+        return mime_type in _IMAGE_MIME_TYPES
+    if _is_gcs_url(element):
+        try:
+            return _infer_mime_type_from_gcs_url(element) in _IMAGE_MIME_TYPES
+        except ValueError:
+            return False
+    return False
+
+
+def _count_input_images(input: GeminiEmbeddingInput) -> int:
+    return sum(1 for element in _flatten_input(input) if _is_image_element(element))
+
+
+def _tokens_for_modality(details: Sequence[PromptTokensDetails], modality: str) -> int:
+    return sum(detail["tokenCount"] for detail in details if detail["modality"] == modality)
+
+
+def _fallback_usage(input: GeminiEmbeddingInput, model: str) -> Usage:
+    if _is_multimodal_input(input):
+        return Usage(prompt_tokens=0, total_tokens=0)
+    input_text = get_formatted_prompt(data={"input": input}, call_type="embedding")
+    prompt_tokens = token_counter(model=model, text=input_text)
+    return Usage(prompt_tokens=prompt_tokens, total_tokens=prompt_tokens)
+
+
+def _usage_from_embed_content_response(
+    input: GeminiEmbeddingInput,
+    model: str,
+    raw_usage_metadata: object,
+) -> Usage:
+    usage_metadata = _parse_usage_metadata(raw_usage_metadata)
+    if usage_metadata is None:
+        return _fallback_usage(input, model)
+
+    prompt_tokens = usage_metadata.get("promptTokenCount", 0)
+    total_tokens = usage_metadata.get("totalTokenCount") or prompt_tokens
+
+    details: Sequence[PromptTokensDetails] = usage_metadata.get("promptTokensDetails") or ()
+    text_tokens = _tokens_for_modality(details, "TEXT")
+    audio_tokens = _tokens_for_modality(details, "AUDIO")
+    video_tokens = _tokens_for_modality(details, "VIDEO")
+    image_count = _count_input_images(input)
+
+    video_length_seconds = video_tokens / _VIDEO_TOKENS_PER_SECOND if video_tokens > 0 else 0.0
+
+    has_billable_non_video = text_tokens > 0 or audio_tokens > 0 or image_count > 0
+    # generic_cost_per_token rewrites text_tokens to the full prompt when text and
+    # image_count are both zero; a 1-token floor keeps video billed per-second.
+    resolved_text_tokens = 1 if video_length_seconds > 0 and not has_billable_non_video else text_tokens
+
+    return Usage(
+        prompt_tokens=prompt_tokens,
+        total_tokens=total_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=resolved_text_tokens,
+            audio_tokens=audio_tokens,
+            image_count=image_count,
+            video_length_seconds=video_length_seconds,
+        ),
+    )
+
+
 def process_embed_content_response(
     input: GeminiEmbeddingInput,
     model_response: EmbeddingResponse,
@@ -313,9 +403,7 @@ def process_embed_content_response(
         EmbeddingResponse with single embedding
     """
     if "embedding" not in response_json:
-        raise ValueError(
-            f"embedContent response missing 'embedding' field: {response_json}"
-        )
+        raise ValueError(f"embedContent response missing 'embedding' field: {response_json}")
 
     embedding_data = response_json["embedding"]
 
@@ -327,14 +415,10 @@ def process_embed_content_response(
 
     model_response.data = [openai_embedding]
     model_response.model = model
-
-    if _is_multimodal_input(input):
-        prompt_tokens = 0
-    else:
-        input_text = get_formatted_prompt(data={"input": input}, call_type="embedding")
-        prompt_tokens = token_counter(model=model, text=input_text)
-    model_response.usage = Usage(
-        prompt_tokens=prompt_tokens, total_tokens=prompt_tokens
+    model_response.usage = _usage_from_embed_content_response(
+        input=input,
+        model=model,
+        raw_usage_metadata=response_json.get("usageMetadata"),
     )
 
     return model_response
@@ -364,25 +448,17 @@ def process_response(
         text_elements: List[str] = []
         for e in input_list:
             if isinstance(e, list):
-                text_elements.extend(
-                    sub
-                    for sub in e
-                    if isinstance(sub, str) and not _is_multimodal_element(sub)
-                )
+                text_elements.extend(sub for sub in e if isinstance(sub, str) and not _is_multimodal_element(sub))
             elif isinstance(e, str) and not _is_multimodal_element(e):
                 text_elements.append(e)
         if text_elements:
-            input_text = get_formatted_prompt(
-                data={"input": text_elements}, call_type="embedding"
-            )
+            input_text = get_formatted_prompt(data={"input": text_elements}, call_type="embedding")
             prompt_tokens = token_counter(model=model, text=input_text)
         else:
             prompt_tokens = 0
     else:
         input_text = get_formatted_prompt(data={"input": input}, call_type="embedding")
         prompt_tokens = token_counter(model=model, text=input_text)
-    model_response.usage = Usage(
-        prompt_tokens=prompt_tokens, total_tokens=prompt_tokens
-    )
+    model_response.usage = Usage(prompt_tokens=prompt_tokens, total_tokens=prompt_tokens)
 
     return model_response

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -1539,6 +1539,9 @@ class PromptTokensDetailsWrapper(
     video_length_seconds: Optional[float] = None
     """Length of videos sent to the model. Used for Vertex AI multimodal embeddings."""
 
+    audio_length_seconds: Optional[float] = None
+    """Length of audio sent to the model. Used for multimodal embeddings priced per audio-second."""
+
     cache_creation_tokens: Optional[int] = None
     """Number of cache creation tokens sent to the model. Used for Anthropic prompt caching."""
 
@@ -1553,6 +1556,8 @@ class PromptTokensDetailsWrapper(
             del self.image_count
         if self.video_length_seconds is None:
             del self.video_length_seconds
+        if self.audio_length_seconds is None:
+            del self.audio_length_seconds
         if self.web_search_requests is None:
             del self.web_search_requests
         if self.cache_creation_tokens is None:

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -951,6 +951,7 @@ def test_cache_writing_cost_with_zero_creation_tokens_and_ephemeral_details():
         "character_count": 0,
         "image_count": 0,
         "video_length_seconds": 0.0,
+        "audio_length_seconds": 0.0,
     }
 
     model_info: ModelInfo = {}

--- a/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
@@ -74,7 +74,9 @@ class TestBuildPartForInput:
         assert part["file_data"]["file_uri"] == GCS_URL
 
     def test_file_reference_resolved(self):
-        resolved = {"files/abc": {"mime_type": "image/jpeg", "uri": "https://example.com/abc"}}
+        resolved = {
+            "files/abc": {"mime_type": "image/jpeg", "uri": "https://example.com/abc"}
+        }
         part = _build_part_for_input("files/abc", resolved_files=resolved)
         assert part["file_data"] is not None
         assert part["file_data"]["mime_type"] == "image/jpeg"
@@ -96,7 +98,9 @@ class TestTransformOpenaiInputGeminiContent:
 
     def test_multiple_texts(self):
         result = transform_openai_input_gemini_content(
-            input=["hello", "world"], model="gemini-embedding-2-preview", optional_params={}
+            input=["hello", "world"],
+            model="gemini-embedding-2-preview",
+            optional_params={},
         )
         assert len(result["requests"]) == 2
         assert result["requests"][0]["content"]["parts"][0]["text"] == "hello"
@@ -111,7 +115,10 @@ class TestTransformOpenaiInputGeminiContent:
         )
         assert len(result["requests"]) == 2
         # First request is text
-        assert result["requests"][0]["content"]["parts"][0]["text"] == "The food was delicious"
+        assert (
+            result["requests"][0]["content"]["parts"][0]["text"]
+            == "The food was delicious"
+        )
         # Second request is image
         assert result["requests"][1]["content"]["parts"][0]["inline_data"] is not None
 
@@ -210,7 +217,9 @@ class TestProcessResponse:
     """Test that process_response sets correct indices."""
 
     def test_single_embedding_index(self):
-        predictions: VertexAIBatchEmbeddingsResponseObject = {"embeddings": [{"values": [0.1, 0.2]}]}
+        predictions: VertexAIBatchEmbeddingsResponseObject = {
+            "embeddings": [{"values": [0.1, 0.2]}]
+        }
         model_response = EmbeddingResponse()
         result = process_response(
             input="hello",
@@ -261,7 +270,9 @@ class TestProcessResponse:
 
     def test_nested_input_token_counting(self):
         """Nested list: only plain-text sub-elements should be counted."""
-        predictions: VertexAIBatchEmbeddingsResponseObject = {"embeddings": [{"values": [0.1, 0.2]}]}
+        predictions: VertexAIBatchEmbeddingsResponseObject = {
+            "embeddings": [{"values": [0.1, 0.2]}]
+        }
         result = process_response(
             input=[["a red shoe", IMAGE_DATA_URI]],
             model_response=EmbeddingResponse(),
@@ -363,7 +374,9 @@ class TestProcessEmbedContentResponseUsage:
             response_json=response_json,
         )
         assert result.usage.prompt_tokens == 516
-        assert result.usage.prompt_tokens_details.video_length_seconds == pytest.approx(2.0)
+        assert result.usage.prompt_tokens_details.video_length_seconds == pytest.approx(
+            2.0
+        )
         assert result.usage.prompt_tokens_details.text_tokens == 1
 
     def test_missing_usage_metadata_does_not_estimate_from_base64(self):
@@ -386,3 +399,60 @@ class TestProcessEmbedContentResponseUsage:
             response_json=response_json,
         )
         assert result.usage.prompt_tokens > 0
+
+    def test_file_reference_image_billed_per_image_not_text(self):
+        """files/... image refs must bill per-image, not at the text token rate."""
+        response_json = {
+            "embedding": {"values": [0.1, 0.2, 0.3]},
+            "usageMetadata": {
+                "promptTokenCount": 258,
+                "totalTokenCount": 258,
+                "promptTokensDetails": [{"modality": "IMAGE", "tokenCount": 258}],
+            },
+        }
+        result = process_embed_content_response(
+            input=["files/img123"],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+            resolved_files={
+                "files/img123": {
+                    "mime_type": "image/png",
+                    "uri": "https://example.com/img123",
+                }
+            },
+        )
+        assert result.usage.prompt_tokens_details.image_count == 1
+        assert result.usage.prompt_tokens_details.text_tokens == 0
+
+        prompt_cost, _ = generic_cost_per_token(
+            model=self.MODEL,
+            usage=result.usage,
+            custom_llm_provider="vertex_ai",
+        )
+        assert prompt_cost == pytest.approx(0.00012)
+
+    def test_file_reference_non_image_not_counted_as_image(self):
+        """A files/... ref resolving to a non-image mime must not be image-counted."""
+        response_json = {
+            "embedding": {"values": [0.1, 0.2]},
+            "usageMetadata": {
+                "promptTokenCount": 64,
+                "totalTokenCount": 64,
+                "promptTokensDetails": [{"modality": "AUDIO", "tokenCount": 64}],
+            },
+        }
+        result = process_embed_content_response(
+            input=["files/clip1"],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+            resolved_files={
+                "files/clip1": {
+                    "mime_type": "audio/mpeg",
+                    "uri": "https://example.com/clip1",
+                }
+            },
+        )
+        assert result.usage.prompt_tokens_details.image_count == 0
+        assert result.usage.prompt_tokens_details.audio_tokens == 64

--- a/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
@@ -456,3 +456,48 @@ class TestProcessEmbedContentResponseUsage:
         )
         assert result.usage.prompt_tokens_details.image_count == 0
         assert result.usage.prompt_tokens_details.audio_tokens == 64
+        assert result.usage.prompt_tokens_details.audio_length_seconds == pytest.approx(
+            2.0
+        )
+
+        prompt_cost, _ = generic_cost_per_token(
+            model=self.MODEL,
+            usage=result.usage,
+            custom_llm_provider="vertex_ai",
+        )
+        assert prompt_cost == pytest.approx(2.0 * 0.00016)
+
+    def test_video_plus_audio_does_not_double_bill_text(self):
+        """Video+audio responses must not get video tokens reassigned to text."""
+        response_json = {
+            "embedding": {"values": [0.1]},
+            "usageMetadata": {
+                "promptTokenCount": 580,
+                "totalTokenCount": 580,
+                "promptTokensDetails": [
+                    {"modality": "VIDEO", "tokenCount": 516},
+                    {"modality": "AUDIO", "tokenCount": 64},
+                ],
+            },
+        }
+        result = process_embed_content_response(
+            input=["gs://bucket/clip.mp4"],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens_details.text_tokens == 1
+        assert result.usage.prompt_tokens_details.video_length_seconds == pytest.approx(
+            2.0
+        )
+        assert result.usage.prompt_tokens_details.audio_length_seconds == pytest.approx(
+            2.0
+        )
+
+        prompt_cost, _ = generic_cost_per_token(
+            model=self.MODEL,
+            usage=result.usage,
+            custom_llm_provider="vertex_ai",
+        )
+        # 1 floor text token at 2e-7 + 2s of video at 7.9e-4 + 2s of audio at 1.6e-4
+        assert prompt_cost == pytest.approx(1 * 2e-7 + 2 * 0.00079 + 2 * 0.00016)

--- a/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini_embeddings/test_batch_embed_content_transformation.py
@@ -10,9 +10,11 @@ Covers:
 
 import pytest
 
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.llms.vertex_ai.gemini_embeddings.batch_embed_content_transformation import (
     _build_part_for_input,
     _is_multimodal_input,
+    process_embed_content_response,
     process_response,
     transform_openai_input_gemini_content,
     transform_openai_input_gemini_embed_content,
@@ -208,9 +210,7 @@ class TestProcessResponse:
     """Test that process_response sets correct indices."""
 
     def test_single_embedding_index(self):
-        predictions: VertexAIBatchEmbeddingsResponseObject = {
-            "embeddings": [{"values": [0.1, 0.2]}]
-        }
+        predictions: VertexAIBatchEmbeddingsResponseObject = {"embeddings": [{"values": [0.1, 0.2]}]}
         model_response = EmbeddingResponse()
         result = process_response(
             input="hello",
@@ -261,9 +261,7 @@ class TestProcessResponse:
 
     def test_nested_input_token_counting(self):
         """Nested list: only plain-text sub-elements should be counted."""
-        predictions: VertexAIBatchEmbeddingsResponseObject = {
-            "embeddings": [{"values": [0.1, 0.2]}]
-        }
+        predictions: VertexAIBatchEmbeddingsResponseObject = {"embeddings": [{"values": [0.1, 0.2]}]}
         result = process_response(
             input=[["a red shoe", IMAGE_DATA_URI]],
             model_response=EmbeddingResponse(),
@@ -288,3 +286,103 @@ class TestProcessResponse:
                 model="gemini-embedding-2-preview",
                 optional_params={},
             )
+
+
+class TestProcessEmbedContentResponseUsage:
+    """Gemini Embedding 2 embedContent usageMetadata must drive spend.
+
+    Regression for multimodal calls recording prompt_tokens=0 / spend=$0.
+    """
+
+    MODEL = "gemini-embedding-2"
+
+    def test_multimodal_image_preserves_usage_metadata(self):
+        response_json = {
+            "embedding": {"values": [0.1, 0.2, 0.3]},
+            "usageMetadata": {
+                "promptTokenCount": 258,
+                "totalTokenCount": 258,
+                "promptTokensDetails": [{"modality": "IMAGE", "tokenCount": 258}],
+            },
+        }
+        result = process_embed_content_response(
+            input=[IMAGE_DATA_URI],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens == 258
+        assert result.usage.total_tokens == 258
+        assert result.usage.prompt_tokens_details.image_count == 1
+
+        prompt_cost, _ = generic_cost_per_token(
+            model=self.MODEL,
+            usage=result.usage,
+            custom_llm_provider="vertex_ai",
+        )
+        assert prompt_cost > 0
+
+    def test_text_modality_detail_populated(self):
+        response_json = {
+            "embedding": {"values": [0.1, 0.2]},
+            "usageMetadata": {
+                "promptTokenCount": 12,
+                "totalTokenCount": 12,
+                "promptTokensDetails": [{"modality": "TEXT", "tokenCount": 12}],
+            },
+        }
+        result = process_embed_content_response(
+            input="a short caption",
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens == 12
+        assert result.usage.prompt_tokens_details.text_tokens == 12
+
+        prompt_cost, _ = generic_cost_per_token(
+            model=self.MODEL,
+            usage=result.usage,
+            custom_llm_provider="vertex_ai",
+        )
+        assert prompt_cost > 0
+
+    def test_video_modality_derives_seconds_and_text_floor(self):
+        response_json = {
+            "embedding": {"values": [0.1]},
+            "usageMetadata": {
+                "promptTokenCount": 516,
+                "totalTokenCount": 516,
+                "promptTokensDetails": [{"modality": "VIDEO", "tokenCount": 516}],
+            },
+        }
+        result = process_embed_content_response(
+            input=["gs://bucket/clip.mp4"],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens == 516
+        assert result.usage.prompt_tokens_details.video_length_seconds == pytest.approx(2.0)
+        assert result.usage.prompt_tokens_details.text_tokens == 1
+
+    def test_missing_usage_metadata_does_not_estimate_from_base64(self):
+        response_json = {"embedding": {"values": [0.1, 0.2]}}
+        result = process_embed_content_response(
+            input=[IMAGE_DATA_URI],
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens == 0
+        assert result.usage.total_tokens == 0
+
+    def test_missing_usage_metadata_text_falls_back_to_token_counter(self):
+        response_json = {"embedding": {"values": [0.1, 0.2]}}
+        result = process_embed_content_response(
+            input="hello world this is plain text",
+            model_response=EmbeddingResponse(),
+            model=self.MODEL,
+            response_json=response_json,
+        )
+        assert result.usage.prompt_tokens > 0


### PR DESCRIPTION
## Relevant issues

Multimodal Gemini Embedding 2 (`embedContent`) calls returned successful embeddings but LiteLLM recorded `prompt_tokens=0` and spend `$0` whenever the Vertex response-cost header was absent. The `embedContent` response carries `usageMetadata` with per-modality token counts that we were discarding.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

PENDING a separate live-repro phase. Plan: run a local proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

then send a real multimodal Gemini Embedding 2 `embedContent` request through `/v1/embeddings` (image, audio or video input) hitting the real Vertex API, and confirm via `http://localhost:4000/ui/?page=logs` that the request records nonzero `prompt_tokens` and nonzero spend instead of `$0`

## Type

🐛 Bug Fix

## Changes

`process_embed_content_response` now derives `Usage` from the Gemini `embedContent` response's `usageMetadata` instead of always rebuilding it from the request. The raw metadata is validated with a `TypeAdapter(UsageMetadata)` so the parsing stays fully typed, `promptTokenCount` / `totalTokenCount` populate the token totals, and the `promptTokensDetails` modality breakdown plus the request's image inputs populate `PromptTokensDetailsWrapper` (text tokens, audio seconds, image count, video seconds) that `generic_cost_per_token` reads for `gemini-embedding-2` pricing.

Per-modality seconds are reverse-derived from the response's reported token counts using Google's documented tokenizer rates rather than re-parsing the media: video at 258 tokens/sec and audio at 32 tokens/sec (https://ai.google.dev/gemini-api/docs/tokens). Because these are the same rates Google uses to produce the reported token counts, dividing the reported VIDEO / AUDIO tokens by them recovers the exact billable second count; the per-second prices themselves stay in the cost map as `input_cost_per_video_per_second` and `input_cost_per_audio_per_second`. `generic_cost_per_token` gains an `audio_length_seconds` cost path so `gemini-embedding-2` audio (priced per second, not per token) no longer records `$0`.

A 1-token text floor is applied for video inputs whose only billable modality is video, matching `generic_cost_per_token`'s text-fallback trigger (`text_tokens == 0 and image_count == 0`); this keeps video tokens billed per-second instead of being reassigned to the text rate, and it holds even when audio is also present so video+audio is not double-billed.

When `usageMetadata` is absent the behavior stays conservative: text-only input still falls back to `token_counter`, and multimodal input keeps `prompt_tokens=0` rather than estimating tokens from the base64 payload.

Tests extend the mapped `test_batch_embed_content_transformation.py` and `test_llm_cost_calc_utils.py` with regressions that fail before this change: a multimodal image response with `usageMetadata` yields nonzero `prompt_tokens`, `image_count=1`, and nonzero cost through `generic_cost_per_token`; a text response populates `text_tokens`; a video response derives `video_length_seconds` with the 1-token floor; an audio response derives `audio_length_seconds` and bills per second; a video+audio response keeps `text_tokens=1` and does not reassign video tokens to text; a resolved `files/` image reference bills per image; and a response without `usageMetadata` does not estimate from base64

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes embedding usage and spend calculation for Vertex Gemini Embedding 2; incorrect mapping would misreport proxy logs and customer billing, though scope is limited to embedContent and cost detail fields.
> 
> **Overview**
> Fixes **$0 spend / zero `prompt_tokens`** on multimodal Gemini Embedding 2 `embedContent` when Vertex does not supply a response-cost header by building `Usage` from the API’s **`usageMetadata`** instead of zeroing multimodal calls or re-estimating from payloads.
> 
> **Vertex `embedContent` path:** `process_embed_content_response` now maps `promptTokenCount`, modality breakdowns, and request-side image detection (including resolved `files/…` refs) into `PromptTokensDetailsWrapper`. Video and audio billable duration is derived from reported VIDEO/AUDIO token counts (258 and 32 tokens/sec). A **1-token text floor** when only video (no text/images) prevents `generic_cost_per_token` from treating video tokens as text-priced input.
> 
> **Shared cost plumbing:** Adds **`audio_length_seconds`** on prompt token details and charges it via **`input_cost_per_audio_per_second`** in `_calculate_input_cost`. Handlers pass **`resolved_files`** into response processing for correct per-image counts.
> 
> Regression tests cover image/text/video/audio usage, file-reference image billing, video+audio without double text billing, and missing-metadata fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb6a09f7953df03068a709da94ed6e25e288bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->