### PR TITLE
fix(cost): preserve Anthropic server_tool_use web search usage in cost tracking

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -26,15 +26,15 @@ from litellm.types.utils import (
 
 
 class _AnthropicServerToolUseProbe(BaseModel):
-    web_search_requests: Optional[int] = None
+    web_search_requests: int | None = None
 
 
 class _AnthropicUsageProbe(BaseModel):
-    server_tool_use: Optional[_AnthropicServerToolUseProbe] = None
+    server_tool_use: _AnthropicServerToolUseProbe | None = None
 
 
 class _AnthropicResponseProbe(BaseModel):
-    usage: Optional[_AnthropicUsageProbe] = None
+    usage: _AnthropicUsageProbe | None = None
 
 
 class StandardBuiltInToolCostTracking:
@@ -325,7 +325,7 @@ class StandardBuiltInToolCostTracking:
         return None
 
     @staticmethod
-    def _anthropic_web_search_count(response_object: object) -> Optional[int]:
+    def _anthropic_web_search_count(response_object: object) -> int | None:
         """Read usage.server_tool_use.web_search_requests from a raw Anthropic
         /v1/messages response dict, returning None when absent."""
         if not isinstance(response_object, dict):
@@ -340,8 +340,8 @@ class StandardBuiltInToolCostTracking:
 
     @staticmethod
     def _usage_with_anthropic_web_search(
-        usage: Optional[Usage], response_object: object
-    ) -> Optional[Usage]:
+        usage: Usage | None, response_object: object
+    ) -> Usage | None:
         """Return a Usage carrying server_tool_use.web_search_requests sourced from a
         raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
         it. The original Usage is returned unchanged when it already exposes the field

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -4,8 +4,6 @@ Helper utilities for tracking the cost of built-in tools.
 
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from pydantic import BaseModel, ValidationError
-
 import litellm
 from litellm.constants import OPENAI_FILE_SEARCH_COST_PER_1K_CALLS
 from litellm.litellm_core_utils.llm_cost_calc.utils import _get_web_search_requests
@@ -23,18 +21,6 @@ from litellm.types.utils import (
     StandardBuiltInToolsParams,
     Usage,
 )
-
-
-class _AnthropicServerToolUseProbe(BaseModel):
-    web_search_requests: int | None = None
-
-
-class _AnthropicUsageProbe(BaseModel):
-    server_tool_use: _AnthropicServerToolUseProbe | None = None
-
-
-class _AnthropicResponseProbe(BaseModel):
-    usage: _AnthropicUsageProbe | None = None
 
 
 class StandardBuiltInToolCostTracking:
@@ -325,20 +311,6 @@ class StandardBuiltInToolCostTracking:
         return None
 
     @staticmethod
-    def _anthropic_web_search_count(response_object: object) -> int | None:
-        """Read usage.server_tool_use.web_search_requests from a raw Anthropic
-        /v1/messages response dict, returning None when absent."""
-        if not isinstance(response_object, dict):
-            return None
-        try:
-            probe = _AnthropicResponseProbe.model_validate(response_object)
-        except ValidationError:
-            return None
-        if probe.usage is None or probe.usage.server_tool_use is None:
-            return None
-        return probe.usage.server_tool_use.web_search_requests
-
-    @staticmethod
     def _usage_with_anthropic_web_search(
         usage: Usage | None, response_object: object
     ) -> Usage | None:
@@ -346,6 +318,10 @@ class StandardBuiltInToolCostTracking:
         raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
         it. The original Usage is returned unchanged when it already exposes the field
         or the response is not an Anthropic dict."""
+        from litellm.llms.anthropic.cost_calculation import (
+            get_anthropic_web_search_requests_from_response,
+        )
+
         if usage is None:
             return None
         if (
@@ -353,8 +329,8 @@ class StandardBuiltInToolCostTracking:
             is not None
         ):
             return usage
-        web_search_requests = (
-            StandardBuiltInToolCostTracking._anthropic_web_search_count(response_object)
+        web_search_requests = get_anthropic_web_search_requests_from_response(
+            response_object
         )
         if web_search_requests is None:
             return usage
@@ -378,12 +354,12 @@ class StandardBuiltInToolCostTracking:
         - ResponsesAPIResponse (streaming + non-streaming)
         - Anthropic /v1/messages raw response dict
         """
+        from litellm.llms.anthropic.cost_calculation import (
+            get_anthropic_web_search_requests_from_response,
+        )
         from litellm.types.utils import PromptTokensDetailsWrapper
 
-        if (
-            StandardBuiltInToolCostTracking._anthropic_web_search_count(response_object)
-            is not None
-        ):
+        if get_anthropic_web_search_requests_from_response(response_object) is not None:
             return True
 
         if isinstance(response_object, ModelResponse):

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -4,6 +4,8 @@ Helper utilities for tracking the cost of built-in tools.
 
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
+from pydantic import BaseModel, ValidationError
+
 import litellm
 from litellm.constants import OPENAI_FILE_SEARCH_COST_PER_1K_CALLS
 from litellm.litellm_core_utils.llm_cost_calc.utils import _get_web_search_requests
@@ -17,9 +19,22 @@ from litellm.types.utils import (
     ModelInfo,
     ModelResponse,
     SearchContextCostPerQuery,
+    ServerToolUse,
     StandardBuiltInToolsParams,
     Usage,
 )
+
+
+class _AnthropicServerToolUseProbe(BaseModel):
+    web_search_requests: Optional[int] = None
+
+
+class _AnthropicUsageProbe(BaseModel):
+    server_tool_use: Optional[_AnthropicServerToolUseProbe] = None
+
+
+class _AnthropicResponseProbe(BaseModel):
+    usage: Optional[_AnthropicUsageProbe] = None
 
 
 class StandardBuiltInToolCostTracking:
@@ -58,6 +73,7 @@ class StandardBuiltInToolCostTracking:
                 custom_llm_provider=custom_llm_provider,
                 usage=usage,
                 standard_built_in_tools_params=standard_built_in_tools_params,
+                response_object=response_object,
             )
 
         # Handle file search
@@ -83,6 +99,7 @@ class StandardBuiltInToolCostTracking:
         custom_llm_provider: Optional[str],
         usage: Optional[Usage],
         standard_built_in_tools_params: StandardBuiltInToolsParams,
+        response_object: object = None,
     ) -> float:
         """Handle web search cost calculation."""
         from litellm.llms import get_cost_for_web_search_request
@@ -94,14 +111,20 @@ class StandardBuiltInToolCostTracking:
         if custom_llm_provider is None and model_info is not None:
             custom_llm_provider = model_info["litellm_provider"]
 
+        resolved_usage = (
+            StandardBuiltInToolCostTracking._usage_with_anthropic_web_search(
+                usage=usage, response_object=response_object
+            )
+        )
+
         if (
             model_info is not None
-            and usage is not None
+            and resolved_usage is not None
             and custom_llm_provider is not None
         ):
             result = get_cost_for_web_search_request(
                 custom_llm_provider=custom_llm_provider,
-                usage=usage,
+                usage=resolved_usage,
                 model_info=model_info,
             )
             if result is not None:
@@ -302,6 +325,48 @@ class StandardBuiltInToolCostTracking:
         return None
 
     @staticmethod
+    def _anthropic_web_search_count(response_object: object) -> Optional[int]:
+        """Read usage.server_tool_use.web_search_requests from a raw Anthropic
+        /v1/messages response dict, returning None when absent."""
+        if not isinstance(response_object, dict):
+            return None
+        try:
+            probe = _AnthropicResponseProbe.model_validate(response_object)
+        except ValidationError:
+            return None
+        if probe.usage is None or probe.usage.server_tool_use is None:
+            return None
+        return probe.usage.server_tool_use.web_search_requests
+
+    @staticmethod
+    def _usage_with_anthropic_web_search(
+        usage: Optional[Usage], response_object: object
+    ) -> Optional[Usage]:
+        """Return a Usage carrying server_tool_use.web_search_requests sourced from a
+        raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
+        it. The original Usage is returned unchanged when it already exposes the field
+        or the response is not an Anthropic dict."""
+        if usage is None:
+            return None
+        if (
+            _get_web_search_requests(getattr(usage, "server_tool_use", None))
+            is not None
+        ):
+            return usage
+        web_search_requests = (
+            StandardBuiltInToolCostTracking._anthropic_web_search_count(response_object)
+        )
+        if web_search_requests is None:
+            return usage
+        return usage.model_copy(
+            update={
+                "server_tool_use": ServerToolUse(
+                    web_search_requests=web_search_requests
+                )
+            }
+        )
+
+    @staticmethod
     def response_object_includes_web_search_call(
         response_object: Any, usage: Optional[Usage] = None
     ) -> bool:
@@ -311,8 +376,15 @@ class StandardBuiltInToolCostTracking:
         This covers:
         - Chat Completion Response (ModelResponse)
         - ResponsesAPIResponse (streaming + non-streaming)
+        - Anthropic /v1/messages raw response dict
         """
         from litellm.types.utils import PromptTokensDetailsWrapper
+
+        if (
+            StandardBuiltInToolCostTracking._anthropic_web_search_count(response_object)
+            is not None
+        ):
+            return True
 
         if isinstance(response_object, ModelResponse):
             # chat completions only include url_citation annotations when a web search call is made

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -316,15 +316,13 @@ class StandardBuiltInToolCostTracking:
     ) -> Usage | None:
         """Return a Usage carrying server_tool_use.web_search_requests sourced from a
         raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
-        it. The original Usage is returned unchanged when it already exposes the field
-        or the response is not an Anthropic dict."""
+        it (or was never supplied). The original Usage is returned unchanged when it
+        already exposes the field or the response is not an Anthropic dict."""
         from litellm.llms.anthropic.cost_calculation import (
             get_anthropic_web_search_requests_from_response,
         )
 
-        if usage is None:
-            return None
-        if (
+        if usage is not None and (
             _get_web_search_requests(getattr(usage, "server_tool_use", None))
             is not None
         ):
@@ -334,13 +332,10 @@ class StandardBuiltInToolCostTracking:
         )
         if web_search_requests is None:
             return usage
-        return usage.model_copy(
-            update={
-                "server_tool_use": ServerToolUse(
-                    web_search_requests=web_search_requests
-                )
-            }
-        )
+        server_tool_use = ServerToolUse(web_search_requests=web_search_requests)
+        if usage is None:
+            return Usage(server_tool_use=server_tool_use)
+        return usage.model_copy(update={"server_tool_use": server_tool_use})
 
     @staticmethod
     def response_object_includes_web_search_call(

--- a/litellm/llms/anthropic/cost_calculation.py
+++ b/litellm/llms/anthropic/cost_calculation.py
@@ -5,6 +5,8 @@ Helper util for handling anthropic-specific cost calculation
 
 from typing import TYPE_CHECKING, Optional, Tuple
 
+from pydantic import BaseModel, ValidationError
+
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     _get_token_base_cost,
     _get_web_search_requests,
@@ -109,6 +111,34 @@ def cost_per_token(
         pass
 
     return prompt_cost, completion_cost
+
+
+class _AnthropicServerToolUseProbe(BaseModel):
+    web_search_requests: int | None = None
+
+
+class _AnthropicUsageProbe(BaseModel):
+    server_tool_use: _AnthropicServerToolUseProbe | None = None
+
+
+class _AnthropicResponseProbe(BaseModel):
+    usage: _AnthropicUsageProbe | None = None
+
+
+def get_anthropic_web_search_requests_from_response(
+    response_object: object,
+) -> int | None:
+    """Read usage.server_tool_use.web_search_requests from a raw Anthropic
+    /v1/messages response dict, returning None when absent."""
+    if not isinstance(response_object, dict):
+        return None
+    try:
+        probe = _AnthropicResponseProbe.model_validate(response_object)
+    except ValidationError:
+        return None
+    if probe.usage is None or probe.usage.server_tool_use is None:
+        return None
+    return probe.usage.server_tool_use.web_search_requests
 
 
 def get_cost_for_anthropic_web_search(

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -625,6 +625,8 @@ class AnthropicResponseContentBlockRedactedThinking(BaseModel):
 
 
 class AnthropicResponseUsageBlock(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     input_tokens: int
     output_tokens: int
 

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -196,6 +196,76 @@ def test_anthropic_web_search_cost_from_raw_response_dict_when_usage_drops_serve
     assert getattr(usage, "server_tool_use", None) is None
 
 
+def test_anthropic_web_search_cost_from_raw_response_dict_when_usage_is_none():
+    """
+    Regression: when a caller hands the cost tracker a raw Anthropic dict without a
+    parallel Usage object, the web-search fee must still be priced per request from
+    usage.server_tool_use.web_search_requests on the dict instead of falling back to
+    the flat search_context_size_medium tier.
+    """
+    model = "claude-3-7-sonnet-20250219"
+    web_search_requests = 4
+    raw_response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "server_tool_use": {"web_search_requests": web_search_requests},
+        },
+    }
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=None,
+        response_object=raw_response,
+        custom_llm_provider="anthropic",
+        standard_built_in_tools_params=None,
+    )
+
+    per_query_cost = litellm.get_model_info(model)["search_context_cost_per_query"][
+        "search_context_size_medium"
+    ]
+    assert cost == per_query_cost * web_search_requests
+
+
+def test_anthropic_web_search_zero_requests_from_raw_response_charges_zero():
+    """
+    Regression: a raw Anthropic dict reporting zero web search requests must price
+    the call at zero rather than charging the default medium-tier fee.
+    """
+    model = "claude-3-7-sonnet-20250219"
+    raw_response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "server_tool_use": {"web_search_requests": 0},
+        },
+    }
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=None,
+        response_object=raw_response,
+        custom_llm_provider="anthropic",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == 0.0
+
+
 def test_anthropic_response_usage_block_preserves_server_tool_use():
     """
     Regression: AnthropicResponse.model_validate(...).model_dump() must keep

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -152,6 +152,78 @@ def test_get_cost_for_anthropic_web_search_with_server_tool_use_dict():
     )
 
 
+def test_anthropic_web_search_cost_from_raw_response_dict_when_usage_drops_server_tool_use():
+    """
+    Regression: on the Anthropic /v1/messages sync cost path the response is the raw
+    Anthropic dict while the reconstructed OpenAI-shape Usage drops server_tool_use.
+    The web-search fee must still be charged by reading the count off the raw dict,
+    and the passed-in Usage must not be mutated.
+    """
+    from litellm.types.utils import Usage
+
+    model = "claude-3-7-sonnet-20250219"
+    web_search_requests = 3
+    raw_response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "server_tool_use": {"web_search_requests": web_search_requests},
+        },
+    }
+    usage = Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150)
+    assert getattr(usage, "server_tool_use", None) is None
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=usage,
+        response_object=raw_response,
+        custom_llm_provider="anthropic",
+        standard_built_in_tools_params=None,
+    )
+
+    per_query_cost = litellm.get_model_info(model)["search_context_cost_per_query"][
+        "search_context_size_medium"
+    ]
+    assert cost == per_query_cost * web_search_requests
+    assert cost > 0.0
+    assert getattr(usage, "server_tool_use", None) is None
+
+
+def test_anthropic_response_usage_block_preserves_server_tool_use():
+    """
+    Regression: AnthropicResponse.model_validate(...).model_dump() must keep
+    server_tool_use so the /v1/messages logging fallback does not strip the
+    web-search usage before cost tracking sees it.
+    """
+    from litellm.types.llms.anthropic import AnthropicResponse
+
+    raw_response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-7-sonnet-20250219",
+        "content": [{"type": "text", "text": "hi"}],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "server_tool_use": {"web_search_requests": 2},
+        },
+    }
+
+    dumped_usage = AnthropicResponse.model_validate(raw_response).model_dump()["usage"]
+
+    assert dumped_usage["server_tool_use"] == {"web_search_requests": 2}
+
+
 @pytest.mark.parametrize(
     "model", ["gemini/gemini-2.0-flash-001", "gemini-2.0-flash-001"]
 )


### PR DESCRIPTION
## Relevant issues

Anthropic `/v1/messages` responses report built-in web search usage under `usage.server_tool_use.web_search_requests`, but the spend record intermittently missed the web-search fee. On the sync cost path the response is the raw Anthropic dict while the reconstructed OpenAI-shape `Usage` drops `server_tool_use`, and separately `AnthropicResponse.model_validate(...).model_dump(...)` stripped the field before cost tracking ever saw it

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Fully end to end against a live proxy hitting the real Anthropic `/v1/messages` web search API, no mocks. The model actually runs server-side web searches (both responses carry real `web_search_result` citations to Wikipedia, CBS, and others) and Anthropic reports `usage.server_tool_use.web_search_requests`. The per-request spend is read straight off the `x-litellm-response-cost-original` response header, so the number shown is exactly what the proxy attributes to the call

Setup is identical for before and after. `claude-sonnet-4-5` is used because its cost map entry carries the web search per-query price (`search_context_size_medium = $0.01`):

```yaml
# config.yaml
model_list:
  - model_name: claude-sonnet-4-5-websearch
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-1234
```

```bash
export ANTHROPIC_API_KEY=sk-ant-...        # real key, billed for real searches
litellm --config config.yaml --port 4000
```

One non-streaming `/v1/messages` request whose prompt forces a `web_search` call, so Anthropic returns `usage.server_tool_use.web_search_requests`:

```bash
curl -sS -D - -o /tmp/body.json \
  -X POST http://localhost:4000/v1/messages \
  -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{
        "model": "claude-sonnet-4-5-websearch",
        "max_tokens": 1024,
        "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}],
        "messages": [{"role": "user", "content": "Use web_search to find who won the 2022 FIFA World Cup, then answer in one sentence. You must call web_search."}]
      }' | grep -i '^x-litellm-response-cost-original'

jq -r '.usage.server_tool_use, (.content[] | select(.type=="text").text)' /tmp/body.json
# {"web_search_requests": 1, "web_fetch_requests": 0}
# Argentina won the 2022 FIFA World Cup in Qatar, defeating France in the final
```

Output tokens differ slightly between the two calls since each is a fresh live generation, so each total is decomposed against that response's own `usage`. Input tokens are identical at 11850 and the only thing that changes is whether the one reported `web_search_request` is billed

### Before (on `litellm_internal_staging`, without this PR)

The search runs and `usage.server_tool_use.web_search_requests` is `1`, but the reconstructed `Usage` on the sync cost path drops `server_tool_use`, so the web search fee is computed as `$0` and the spend equals token cost only

```text
x-litellm-response-cost-original: 0.03735

usage: input_tokens=11850  output_tokens=120  server_tool_use.web_search_requests=1
token-only cost = 11850 * $3/M + 120 * $15/M = 0.03735
web search fee billed = 0.03735 - 0.03735 = $0.00   <- dropped
```

### After (with this PR)

Same request, same real search. The fallback recovers `web_search_requests` from the raw Anthropic response, so the $0.01 per-search fee is added on top of token cost

```text
x-litellm-response-cost-original: 0.047005

usage: input_tokens=11850  output_tokens=97  server_tool_use.web_search_requests=1
token-only cost = 11850 * $3/M + 97 * $15/M = 0.037005
web search fee billed = 0.047005 - 0.037005 = $0.01   <- now included
```

## Type

🐛 Bug Fix

## Changes

`AnthropicResponseUsageBlock` now sets `model_config = ConfigDict(extra="allow")` so that `AnthropicResponse.model_validate(...).model_dump(...)` keeps `server_tool_use` instead of silently dropping it on the logging fallback

`StandardBuiltInToolCostTracking` reads the web search count straight off the raw Anthropic response dict when the reconstructed `Usage` lacks `server_tool_use`. The raw dict is parsed by `get_anthropic_web_search_requests_from_response` in `litellm/llms/anthropic/cost_calculation.py`, a small typed Pydantic probe rather than ad-hoc dict access, so the Anthropic-specific parsing lives under `llms/` and no new `Any`/`Unknown` leaks into the type budget. Detection happens in `response_object_includes_web_search_call`, and `_usage_with_anthropic_web_search` synthesizes a `ServerToolUse` so the Anthropic web-search calculator sees the correct count without mutating the caller's `Usage`; it copies an existing `Usage` via `model_copy`, or builds a fresh one when the cost path is handed only the raw dict

The fallback only activates for a raw Anthropic `/v1/messages` dict that carries an integer `usage.server_tool_use.web_search_requests`. Every other response shape keeps its existing behavior, `Usage` objects that already expose `server_tool_use` are returned untouched, and a reported count of zero prices the call at `$0` rather than the default medium tier

Regression coverage lives in `tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py`. The tests fail before this change (fee computed as `0.0`, and `server_tool_use` stripped by `model_dump`) and pass after, asserting the exact per-query fee times the request count, that the passed-in `Usage` is not mutated, that a dict-only path with no parallel `Usage` is still priced per request, and that a zero count charges nothing


---

> [!NOTE]
> **Medium Risk**
> Changes only billing/cost attribution for Anthropic web search, but incorrect fees directly affect spend records; scope is narrow and covered by regression tests.
> 
> **Overview**
> Fixes **under-billing** on Anthropic `/v1/messages` when built-in web search runs: `usage.server_tool_use.web_search_requests` was dropped before built-in tool cost ran, so spend often omitted the per-search fee.
> 
> **`AnthropicResponseUsageBlock`** now allows extra fields (`extra="allow"`) so `AnthropicResponse.model_validate(...).model_dump()` keeps **`server_tool_use`** on the logging path instead of stripping it.
> 
> **Built-in web search cost tracking** now treats raw Anthropic response dicts as first-class: a typed helper reads `usage.server_tool_use.web_search_requests`, detection in `response_object_includes_web_search_call` recognizes those dicts, and `_handle_web_search_cost` builds a non-mutating `Usage` (via `model_copy`) when the OpenAI-shaped `Usage` lacks the field—so pricing uses **per-request count** (including **zero** requests → **$0**) rather than a default medium tier when `usage` is missing or incomplete.
> 
> Regression tests cover dict-only usage, dropped `server_tool_use` on an existing `Usage`, zero requests, and preserved fields after `model_dump`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d282dd23687ebba830af25850fb0dadbe9942b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
