### PR TITLE
fix(cost): restore per-query Gemini 3.x web search billing

### DIFF
--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -91,13 +91,16 @@ class StandardBuiltInToolCostTracking:
             model=model, custom_llm_provider=custom_llm_provider
         )
 
-        # response_cost_calculator can pass a provider-prefixed model name
-        # (e.g. gemini/gemini-3.1-flash-lite) that get_model_info cannot map under the request
-        # provider (vertex_ai). Retry letting get_model_info infer the provider from the prefix.
+        # A provider-prefixed model (e.g. gemini/gemini-3.1-flash-lite) may not map under the
+        # request's custom_llm_provider. Re-resolve from the prefix and adopt that provider so the
+        # cost is routed and priced with the model_info that was actually resolved, instead of
+        # feeding a re-resolved model into the original provider's calculator.
         if model_info is None and "/" in model:
             model_info = StandardBuiltInToolCostTracking._safe_get_model_info(
                 model=model
             )
+            if model_info is not None:
+                custom_llm_provider = model_info["litellm_provider"]
 
         if custom_llm_provider is None and model_info is not None:
             custom_llm_provider = model_info["litellm_provider"]

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -91,6 +91,14 @@ class StandardBuiltInToolCostTracking:
             model=model, custom_llm_provider=custom_llm_provider
         )
 
+        # response_cost_calculator can pass a provider-prefixed model name
+        # (e.g. gemini/gemini-3.1-flash-lite) that get_model_info cannot map under the request
+        # provider (vertex_ai). Retry letting get_model_info infer the provider from the prefix.
+        if model_info is None and "/" in model:
+            model_info = StandardBuiltInToolCostTracking._safe_get_model_info(
+                model=model
+            )
+
         if custom_llm_provider is None and model_info is not None:
             custom_llm_provider = model_info["litellm_provider"]
 

--- a/litellm/llms/gemini/cost_calculator.py
+++ b/litellm/llms/gemini/cost_calculator.py
@@ -58,7 +58,7 @@ def cost_per_web_search_request(usage: "Usage", model_info: "ModelInfo") -> floa
         number_of_web_search_requests = usage.prompt_tokens_details.web_search_requests
 
     # per_prompt billing: clamp to 1 (flat fee per grounded API call)
-    billing_mode = model_info.get("web_search_billing_unit", "per_prompt")
+    billing_mode = model_info.get("web_search_billing_unit") or "per_prompt"
     if number_of_web_search_requests > 0 and billing_mode == "per_prompt":
         number_of_web_search_requests = 1
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -274,7 +274,7 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
         SearchContextCostPerQuery
     ]  # Cost for using web search tool
     web_search_billing_unit: Optional[
-        str
+        Literal["per_query", "per_prompt"]
     ]  # "per_query" (Gemini 3.x) or "per_prompt" (Gemini 2.x)
     citation_cost_per_token: Optional[float]  # Cost per citation token for Perplexity
     tiered_pricing: Optional[

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -273,6 +273,9 @@ class ModelInfoBase(ProviderSpecificModelInfo, total=False):
     search_context_cost_per_query: Optional[
         SearchContextCostPerQuery
     ]  # Cost for using web search tool
+    web_search_billing_unit: Optional[
+        str
+    ]  # "per_query" (Gemini 3.x) or "per_prompt" (Gemini 2.x)
     citation_cost_per_token: Optional[float]  # Cost per citation token for Perplexity
     tiered_pricing: Optional[
         List[Dict[str, Any]]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -6235,6 +6235,9 @@ def _get_model_info_helper(
                 search_context_cost_per_query=_model_info.get(
                     "search_context_cost_per_query", None
                 ),
+                web_search_billing_unit=_model_info.get(
+                    "web_search_billing_unit", None
+                ),
                 tpm=_model_info.get("tpm", None),
                 rpm=_model_info.get("rpm", None),
                 ocr_cost_per_page=_model_info.get("ocr_cost_per_page", None),

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -346,6 +346,56 @@ def test_gemini_3x_web_search_billed_per_query(model):
 
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
+    web_search_requests = 2
+    model_info = litellm.get_model_info(model)
+    assert model_info["web_search_billing_unit"] == "per_query"
+    per_query_cost = model_info["search_context_cost_per_query"][
+        "search_context_size_medium"
+    ]
+    expected_cost = per_query_cost * web_search_requests
+
+    usage = Usage(
+        prompt_tokens=11,
+        completion_tokens=100,
+        total_tokens=111,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=11, web_search_requests=web_search_requests
+        ),
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=usage,
+        response_object=None,
+        custom_llm_provider="vertex_ai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == pytest.approx(expected_cost), (
+        f"Expected {web_search_requests} x ${per_query_cost} = ${expected_cost} "
+        f"per_query search fee, got ${cost}"
+    )
+
+
+def test_gemini_2x_web_search_still_billed_per_prompt():
+    """
+    Gemini 2.x bills web search per grounded prompt: multiple internal queries are one flat
+    $0.035 fee. Guards the per_prompt clamp against the per_query plumbing, which makes
+    web_search_billing_unit always present on the resolved ModelInfo (None for 2.x), so the
+    clamp must treat a None billing unit as per_prompt rather than skipping the clamp.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    model = "vertex_ai/gemini-2.5-flash"
+    model_info = litellm.get_model_info(model)
+    assert not model_info.get("web_search_billing_unit")
+    expected_cost = model_info["search_context_cost_per_query"][
+        "search_context_size_medium"
+    ]
+
     usage = Usage(
         prompt_tokens=11,
         completion_tokens=100,
@@ -363,22 +413,30 @@ def test_gemini_3x_web_search_billed_per_query(model):
         standard_built_in_tools_params=None,
     )
 
-    assert cost == pytest.approx(0.028), (
-        f"Expected 2 x $0.014 = $0.028 per_query search fee, got ${cost}"
+    assert cost == pytest.approx(expected_cost), (
+        f"Expected flat ${expected_cost} per_prompt search fee (2 queries clamped to 1), "
+        f"got ${cost}"
     )
 
 
-def test_gemini_2x_web_search_still_billed_per_prompt():
+def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model():
     """
-    Gemini 2.x bills web search per grounded prompt: multiple internal queries are one flat
-    $0.035 fee. Guards the per_prompt clamp against the per_query plumbing, which makes
-    web_search_billing_unit always present on the resolved ModelInfo (None for 2.x), so the
-    clamp must treat a None billing unit as per_prompt rather than skipping the clamp.
+    Regression for the provider-prefix fallback in _handle_web_search_cost. When the initial
+    get_model_info lookup fails for a "/"-containing model, the retry re-resolves model_info from
+    the prefix and must adopt that prefix's provider for routing. Otherwise an unrelated model
+    (here OpenRouter, which carries no web search pricing) is re-resolved but still routed through
+    the request's vertex_ai Gemini calculator, which charges its $0.035 per_prompt default for a
+    model that should cost nothing for web search.
     """
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    model = "openrouter/google/gemini-3.1-flash-lite"
+    model_info = litellm.get_model_info(model)
+    assert model_info["litellm_provider"] == "openrouter"
+    assert not model_info.get("search_context_cost_per_query")
 
     usage = Usage(
         prompt_tokens=11,
@@ -390,15 +448,16 @@ def test_gemini_2x_web_search_still_billed_per_prompt():
     )
 
     cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
-        model="vertex_ai/gemini-2.5-flash",
+        model=model,
         usage=usage,
         response_object=None,
         custom_llm_provider="vertex_ai",
         standard_built_in_tools_params=None,
     )
 
-    assert cost == pytest.approx(0.035), (
-        f"Expected flat $0.035 per_prompt search fee, got ${cost}"
+    assert cost == 0.0, (
+        "A non-Gemini provider-prefixed model with no web search pricing must not be charged "
+        f"the vertex_ai per_prompt default via the prefix fallback, got ${cost}"
     )
 
 

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -15,6 +15,12 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+
 # Test basic web search cost calculations
 def test_web_search_cost_low():
     web_search_options = WebSearchOptions(search_context_size="low")
@@ -329,7 +335,7 @@ def test_completion_cost_includes_web_search_without_standard_built_in_tools_par
         "gemini/gemini-3.1-flash-lite",  # provider-prefixed, resolves via model_cost fallback
     ],
 )
-def test_gemini_3x_web_search_billed_per_query(model):
+def test_gemini_3x_web_search_billed_per_query(model, local_model_cost_map):
     """
     Gemini 3.x bills web search per individual query (web_search_billing_unit == "per_query"),
     so N searches cost N * $0.014.
@@ -341,9 +347,6 @@ def test_gemini_3x_web_search_billed_per_query(model):
     to a single charge. The "gemini/..." case additionally covers response_cost_calculator
     resolving a provider-prefixed model name that get_model_info cannot map under vertex_ai.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
-
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     web_search_requests = 2
@@ -377,16 +380,13 @@ def test_gemini_3x_web_search_billed_per_query(model):
     )
 
 
-def test_gemini_2x_web_search_still_billed_per_prompt():
+def test_gemini_2x_web_search_still_billed_per_prompt(local_model_cost_map):
     """
     Gemini 2.x bills web search per grounded prompt: multiple internal queries are one flat
     $0.035 fee. Guards the per_prompt clamp against the per_query plumbing, which makes
     web_search_billing_unit always present on the resolved ModelInfo (None for 2.x), so the
     clamp must treat a None billing unit as per_prompt rather than skipping the clamp.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
-
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     model = "vertex_ai/gemini-2.5-flash"
@@ -419,7 +419,9 @@ def test_gemini_2x_web_search_still_billed_per_prompt():
     )
 
 
-def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model():
+def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model(
+    local_model_cost_map,
+):
     """
     Regression for the provider-prefix fallback in _handle_web_search_cost. When the initial
     get_model_info lookup fails for a "/"-containing model, the retry re-resolves model_info from
@@ -428,9 +430,6 @@ def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model(
     the request's vertex_ai Gemini calculator, which charges its $0.035 per_prompt default for a
     model that should cost nothing for web search.
     """
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-    litellm.model_cost = litellm.get_model_cost_map(url="")
-
     from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
     model = "openrouter/google/gemini-3.1-flash-lite"

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -322,5 +322,85 @@ def test_completion_cost_includes_web_search_without_standard_built_in_tools_par
     ), f"completion_cost ({cost}) should include web search cost ({web_search_cost})"
 
 
+@pytest.mark.parametrize(
+    "model",
+    [
+        "vertex_ai/gemini-3.1-flash-lite",  # resolves directly via get_model_info
+        "gemini/gemini-3.1-flash-lite",  # provider-prefixed, resolves via model_cost fallback
+    ],
+)
+def test_gemini_3x_web_search_billed_per_query(model):
+    """
+    Gemini 3.x bills web search per individual query (web_search_billing_unit == "per_query"),
+    so N searches cost N * $0.014.
+
+    Regression for the bug where the billing unit was dropped between the pricing JSON and the
+    cost calculator: the field was missing from the ModelInfoBase TypedDict and from the
+    ModelInfoBase(...) constructor in _get_model_info_helper, so get_model_info returned it as
+    None and cost_per_web_search_request fell back to the per_prompt clamp, collapsing N queries
+    to a single charge. The "gemini/..." case additionally covers response_cost_calculator
+    resolving a provider-prefixed model name that get_model_info cannot map under vertex_ai.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens=11,
+        completion_tokens=100,
+        total_tokens=111,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=11, web_search_requests=2
+        ),
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=usage,
+        response_object=None,
+        custom_llm_provider="vertex_ai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == pytest.approx(0.028), (
+        f"Expected 2 x $0.014 = $0.028 per_query search fee, got ${cost}"
+    )
+
+
+def test_gemini_2x_web_search_still_billed_per_prompt():
+    """
+    Gemini 2.x bills web search per grounded prompt: multiple internal queries are one flat
+    $0.035 fee. Guards the per_prompt clamp against the per_query plumbing, which makes
+    web_search_billing_unit always present on the resolved ModelInfo (None for 2.x), so the
+    clamp must treat a None billing unit as per_prompt rather than skipping the clamp.
+    """
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens=11,
+        completion_tokens=100,
+        total_tokens=111,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            text_tokens=11, web_search_requests=2
+        ),
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model="vertex_ai/gemini-2.5-flash",
+        usage=usage,
+        response_object=None,
+        custom_llm_provider="vertex_ai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == pytest.approx(0.035), (
+        f"Expected flat $0.035 per_prompt search fee, got ${cost}"
+    )
+
+
 # Note: File search integration test removed due to complex annotation detection logic
 # The unit tests in test_azure_assistant_cost_tracking.py provide comprehensive coverage


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Verified end to end against a live proxy hitting the real Gemini API (`gemini/gemini-3.1-flash-lite`), with the local cost map forced on (`LITELLM_LOCAL_MODEL_COST_MAP=True`) so the branch's `web_search_billing_unit: per_query` pricing is what gets exercised.

Config (`gemini_ws_proof.yaml`):

```yaml
model_list:
  - model_name: gemini-3.1-flash-lite
    litellm_params:
      model: gemini/gemini-3.1-flash-lite
      api_key: os.environ/GEMINI_API_KEY
general_settings:
  master_key: sk-1234
```

Same grounded request in both runs, one prompt that makes the model issue several searches:

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py \
  --config gemini_ws_proof.yaml --port 51514 --detailed_debug

curl -sS -i -X POST http://127.0.0.1:51514/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "gemini-3.1-flash-lite",
    "web_search_options": {},
    "messages": [{"role": "user", "content": "Use web search to answer. In one sentence each with a source, what is the very latest news this week about: (1) the James Webb Space Telescope, (2) NASA Artemis program, and (3) SpaceX Starship?"}]
  }'
```

Before, with this branch's 4 source files reverted to the merge-base (broken plumbing, everything else identical), the model ran 3 grounded searches but they were clamped to a single charge:

```
# response body, usage
"prompt_tokens_details": { "text_tokens": 49, "web_search_requests": 3 }

# response headers
x-litellm-response-cost: 0.014330250000000001
```

3 searches billed as 1: $0.014 web search (clamped to per_prompt) plus $0.00033025 of tokens = $0.01433025

After, with the fix applied, the same 3 searches are billed per query:

```
# response body, usage
"prompt_tokens_details": { "text_tokens": 49, "web_search_requests": 3 }

# response headers
x-litellm-response-cost: 0.04229725
```

3 searches at $0.014/query: $0.042 web search plus $0.00029725 of tokens = $0.04229725

The web search component is the deterministic part and it goes from $0.014 (1 query) to $0.042 (3 queries) for the same grounded call, recovering the $0.028 that was being silently under-billed. litellm forwarded `tools: [{"googleSearch": {}}]` to Gemini in both runs; the only thing that changed is `web_search_billing_unit` reaching the calculator instead of being dropped at `ModelInfoBase`

## Type

🐛 Bug Fix

## Changes

Preserve `web_search_billing_unit` through the model-info path and handle provider-prefixed model names in tool-call cost tracking, with regression coverage in `test_tool_call_cost_tracking.py`. Part of upstreaming a downstream patch series maintained against 1.85.1. Opened as draft; basedpyright / ruff-strict budget reconciliation is still pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing and spend logging for web search on Gemini/Vertex paths; incorrect behavior would directly affect customer charges, though scope is limited to built-in tool cost tracking with new regression tests.
> 
> **Overview**
> Fixes **under-billing** for Gemini 3.x grounded web search and related **mis-routing** when model names carry a provider prefix.
> 
> **`web_search_billing_unit` plumbing:** The pricing field is added to `ModelInfoBase` and copied in `_get_model_info_helper` so `get_model_info` exposes `per_query` vs `per_prompt`. Without it, the Gemini calculator always behaved like **per_prompt** and clamped multiple searches to one charge. The calculator now treats a missing unit as **`per_prompt`** via `or "per_prompt"` so Gemini 2.x flat fees still clamp correctly.
> 
> **Provider-prefixed models:** When the first `get_model_info(model, custom_llm_provider)` fails but the model string contains `/`, tool-cost tracking re-resolves model info without the request provider and adopts `litellm_provider` from the resolved entry—so `gemini/...` names and OpenRouter-style paths use the right calculator instead of Vertex defaults.
> 
> Regression tests cover per-query 3.x (including `gemini/` prefix), per-prompt 2.x, and zero cost for OpenRouter models with no web-search pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9f5b6ca499dbfba26a285e2528d61b6eaba8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

