### PR TITLE
fix(cost-map): retarget mistral-medium-latest to Medium 3.5 and add date-pinned aliases

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25770,7 +25770,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
-    "mistral/mistral-medium-latest": {
+    "mistral/mistral-medium-2508": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -25778,8 +25778,41 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
+        "source": "https://mistral.ai/news/mistral-medium-3",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "mistral/mistral-medium-2604": {
+        "input_cost_per_token": 1.5e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "mistral/mistral-medium-latest": {
+        "input_cost_per_token": 1.5e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -25810,6 +25843,7 @@
         "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25942,7 +25942,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
-    "mistral/mistral-medium-latest": {
+    "mistral/mistral-medium-2508": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -25950,8 +25950,41 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
+        "source": "https://mistral.ai/news/mistral-medium-3",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "mistral/mistral-medium-2604": {
+        "input_cost_per_token": 1.5e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "mistral/mistral-medium-latest": {
+        "input_cost_per_token": 1.5e-06,
+        "litellm_provider": "mistral",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 7.5e-06,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -25982,6 +26015,7 @@
         "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true

--- a/tests/test_litellm/test_mistral_medium_3_5_model_metadata.py
+++ b/tests/test_litellm/test_mistral_medium_3_5_model_metadata.py
@@ -27,6 +27,17 @@ def _load(path):
         return json.load(f)
 
 
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force get_model_info to resolve against the in-repo cost map instead of the
+    remote one fetched at import time, which still carries the pre-merge pricing."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
 @pytest.mark.parametrize("model", MEDIUM_3_5_MODELS)
 def test_medium_3_5_specs(model):
     info = _load(MAIN_PATH).get(model)
@@ -54,7 +65,7 @@ def test_medium_3_5_specs(model):
     assert provider == "mistral"
 
 
-def test_mistral_medium_latest_resolves_to_medium_3_5():
+def test_mistral_medium_latest_resolves_to_medium_3_5(local_model_cost_map):
     """LIT-3883: the -latest alias was retargeted to Medium 3.5; get_model_info must
     return the 3.5 pricing/context/reasoning, not the stale Medium 3.1 values."""
     info = litellm.get_model_info(model="mistral/mistral-medium-latest")

--- a/tests/test_litellm/test_mistral_medium_3_5_model_metadata.py
+++ b/tests/test_litellm/test_mistral_medium_3_5_model_metadata.py
@@ -3,19 +3,34 @@ from pathlib import Path
 
 import pytest
 
+import litellm
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
 
-@pytest.mark.parametrize("model", ["mistral/mistral-medium-3-5"])
-def test_mistral_medium_3_5_model_info(model):
-    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
-    with open(json_path) as f:
-        model_cost = json.load(f)
+MEDIUM_3_5_MODELS = (
+    "mistral/mistral-medium-3-5",
+    "mistral/mistral-medium-2604",
+    "mistral/mistral-medium-latest",
+)
 
-    info = model_cost.get(model)
-    assert (
-        info is not None
-    ), f"{model} not found in model_prices_and_context_window.json"
+SYNCED_MODELS = MEDIUM_3_5_MODELS + (
+    "mistral/mistral-medium-2508",
+    "mistral/mistral-medium-3-1-2508",
+)
+
+
+def _load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("model", MEDIUM_3_5_MODELS)
+def test_medium_3_5_specs(model):
+    info = _load(MAIN_PATH).get(model)
+    assert info is not None, f"{model} missing from model_prices_and_context_window.json"
 
     assert info["litellm_provider"] == "mistral"
     assert info["mode"] == "chat"
@@ -27,10 +42,11 @@ def test_mistral_medium_3_5_model_info(model):
     assert info["max_output_tokens"] == 262144
     assert info["max_tokens"] == 262144
 
+    assert info["supports_reasoning"] is True
+    assert info["supports_vision"] is True
     assert info["supports_function_calling"] is True
     assert info["supports_response_schema"] is True
     assert info["supports_tool_choice"] is True
-    assert info["supports_vision"] is True
     assert info["supports_assistant_prefill"] is True
 
     routed_model, provider, _, _ = get_llm_provider(model=model)
@@ -38,18 +54,32 @@ def test_mistral_medium_3_5_model_info(model):
     assert provider == "mistral"
 
 
-def test_mistral_medium_3_5_backup_matches_main():
-    """Ensure the bundled model cost map stays in sync with the canonical file."""
-    repo_root = Path(__file__).parents[2]
-    main_path = repo_root / "model_prices_and_context_window.json"
-    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+def test_mistral_medium_latest_resolves_to_medium_3_5():
+    """LIT-3883: the -latest alias was retargeted to Medium 3.5; get_model_info must
+    return the 3.5 pricing/context/reasoning, not the stale Medium 3.1 values."""
+    info = litellm.get_model_info(model="mistral/mistral-medium-latest")
 
-    with open(main_path) as f:
-        main_cost = json.load(f)
-    with open(backup_path) as f:
-        backup_cost = json.load(f)
+    assert info["input_cost_per_token"] == 1.5e-06
+    assert info["output_cost_per_token"] == 7.5e-06
+    assert info["max_input_tokens"] == 262144
+    assert info["supports_reasoning"] is True
 
-    for model in ("mistral/mistral-medium-3-5",):
-        assert backup_cost.get(model) == main_cost.get(
-            model
-        ), f"{model} differs between main and backup model cost maps"
+
+def test_mistral_medium_2508_keeps_medium_3_1_specs():
+    """The date-pinned 2508 alias is Medium 3.1 and must not inherit 3.5 pricing."""
+    info = _load(MAIN_PATH).get("mistral/mistral-medium-2508")
+    assert info is not None, "mistral/mistral-medium-2508 missing from cost map"
+
+    assert info["input_cost_per_token"] == 4e-07
+    assert info["output_cost_per_token"] == 2e-06
+    assert info["max_input_tokens"] == 131072
+    assert info.get("supports_reasoning") is not True
+
+
+@pytest.mark.parametrize("model", SYNCED_MODELS)
+def test_backup_matches_main(model):
+    """Ensure the bundled (backup) cost map stays in sync with the canonical file."""
+    main_cost = _load(MAIN_PATH)
+    backup_cost = _load(BACKUP_PATH)
+
+    assert backup_cost.get(model) == main_cost.get(model), f"{model} differs between main and backup model cost maps"


### PR DESCRIPTION
## Relevant issues

Supersedes the closed #30979. Surfaced via Pylon #5219.

## Linear ticket

LIT-3883: https://linear.app/litellm-ai/issue/LIT-3883

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

New cost-map entries read as $0.00 on a live proxy until they are merged to main, so the proxy was started against the local map (`LITELLM_LOCAL_MODEL_COST_MAP=True`) and a real Mistral call was billed end to end.

Start the proxy against the local cost map

```
LITELLM_LOCAL_MODEL_COST_MAP=True python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

1. Resolved metadata now reflects Medium 3.5 (`GET /model/info`)

```
curl -s http://localhost:4000/model/info -H "Authorization: Bearer sk-1234" \
 | jq '.data[] | select(.model_name=="mistral/mistral-medium-latest") | .model_info | {input_cost_per_token, output_cost_per_token, max_input_tokens, max_output_tokens, supports_reasoning, supports_vision}'
```

```json
{
  "input_cost_per_token": 0.0000015,
  "output_cost_per_token": 0.0000075,
  "max_input_tokens": 262144,
  "max_output_tokens": 262144,
  "supports_reasoning": true,
  "supports_vision": true
}
```

2. A real `mistral/mistral-medium-latest` completion is billed at the new rate (`POST /v1/chat/completions`)

```
curl -s -D - -o resp.json http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"mistral/mistral-medium-latest","messages":[{"role":"user","content":"Reply with exactly: pricing check ok"}],"max_tokens":16}'
```

```
x-litellm-response-cost: 7.05e-05
```

```json
{ "content": "pricing check ok",
  "usage": { "prompt_tokens": 22, "completion_tokens": 5, "total_tokens": 27 } }
```

3. The billed cost matches the new pricing to the cent, and the old stale map would have undercharged by 3.75x, exactly as LIT-3883 reported

```
new Medium 3.5 pricing: 22*1.5e-6 + 5*7.5e-6 = 7.050e-05  (matches x-litellm-response-cost)
old stale 3.1 pricing : 22*4e-7  + 5*2e-6   = 1.880e-05
undercharge factor before fix: 3.75x
```

## Type

🐛 Bug Fix

## Changes

Mistral retargeted the rolling `mistral-medium-latest` alias from Medium 3.1 to Medium 3.5, but the static cost map still carried Medium 3.1 specs, so the model hub showed the wrong pricing and context window and spend was undercharged by roughly 3.75x.

This updates `mistral/mistral-medium-latest` to the Medium 3.5 card ($1.50/$7.50 per 1M tokens, 256K context, reasoning and vision), adds the bare date-pinned aliases `mistral/mistral-medium-2604` (Medium 3.5) and `mistral/mistral-medium-2508` (Medium 3.1) that match Mistral's real API model ids, and adds `supports_reasoning` to `mistral/mistral-medium-3-5`. Every change is applied to both `model_prices_and_context_window.json` and the bundled `litellm/model_prices_and_context_window_backup.json` so the two never drift, which is what tripped the earlier attempt.

The regression tests lock the resolved `litellm.get_model_info("mistral/mistral-medium-latest")` values, assert the 2508 alias keeps its cheaper Medium 3.1 pricing, and check main/backup parity for all five touched models

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrects spend calculation for a widely used model alias (prior ~3.75x undercharge); changes are limited to static JSON metadata and regression tests, not runtime routing logic.
> 
> **Overview**
> Fixes **incorrect billing and hub metadata** for `mistral/mistral-medium-latest` by aligning the static cost map with Mistral’s retargeting of that alias to **Medium 3.5** (higher per-token rates, 262K context, reasoning/vision) instead of stale Medium 3.1 values.
> 
> Adds explicit entries for **`mistral/mistral-medium-2508`** (Medium 3.1 pricing/context) and **`mistral/mistral-medium-2604`** (Medium 3.5), sets **`supports_reasoning`** on the 3.5-related cards (including `mistral-medium-3-5`), and mirrors every change in **`litellm/model_prices_and_context_window_backup.json`** so main and backup stay identical.
> 
> Tests now assert 3.5 specs across the alias set, verify **`litellm.get_model_info("mistral/mistral-medium-latest")`** under the local cost map, lock 2508 to 3.1 pricing, and parametrize main/backup parity for all touched models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82ff21bbc4648bc77ee803a70d752ba783b364cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->