### PR TITLE
fix(bedrock_mantle): register xai.grok-4.3 for SigV4 Responses API routing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -42795,6 +42795,26 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/xai.grok-4.3": {
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 2.5e-06,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "use_openai_responses_path": true,
+        "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
+        "supported_modalities": ["text", "image"],
+        "supported_output_modalities": ["text"],
+        "supports_function_calling": true,
+        "supports_none_reasoning_effort": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "source": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html"
+    },
     "volcengine/doubao-seed-2-0-pro-260215": {
         "litellm_provider": "volcengine",
         "max_input_tokens": 256000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -43197,6 +43197,26 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "bedrock_mantle/xai.grok-4.3": {
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 2.5e-06,
+        "litellm_provider": "bedrock_mantle",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "use_openai_responses_path": true,
+        "supported_endpoints": ["/v1/chat/completions", "/v1/responses"],
+        "supported_modalities": ["text", "image"],
+        "supported_output_modalities": ["text"],
+        "supports_function_calling": true,
+        "supports_none_reasoning_effort": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "source": "https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-xai-grok-4-3.html"
+    },
     "volcengine/doubao-seed-2-0-pro-260215": {
         "litellm_provider": "volcengine",
         "max_input_tokens": 256000,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -714,6 +714,20 @@ class TestMantleSupportsResponses:
                 {"bedrock_mantle/google.gemma-3-27b-it": {"mode": "chat"}},
                 False,
             ),
+            # grok-4.3 on mantle openai/v1 responses path
+            (
+                "xai.grok-4.3",
+                {
+                    "bedrock_mantle/xai.grok-4.3": {
+                        "mode": "chat",
+                        "supported_endpoints": [
+                            "/v1/chat/completions",
+                            "/v1/responses",
+                        ],
+                    }
+                },
+                True,
+            ),
             # absent from model_cost -> no signal -> not supported
             ("somelab.unmapped", {}, False),
             (None, {}, False),
@@ -757,6 +771,10 @@ class TestBedrockMantlePerModelResponsesURL:
     )
     def test_gemma_4_uses_openai_responses_path(self, local_cost_map, model):
         url = self._url_for(model)
+        assert url == "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
+
+    def test_grok_4_3_uses_openai_responses_path(self, local_cost_map):
+        url = self._url_for("xai.grok-4.3")
         assert url == "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
 
 
@@ -1230,3 +1248,15 @@ class TestBedrockMantleResponsesPricing:
     def test_models_registered(self, local_cost_map):
         assert "bedrock_mantle/openai.gpt-5.5" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-5.4" in litellm.bedrock_mantle_models
+        assert "bedrock_mantle/xai.grok-4.3" in litellm.bedrock_mantle_models
+
+    def test_grok_4_3_pricing_and_capabilities(self, local_cost_map):
+        info = litellm.get_model_info("bedrock_mantle/xai.grok-4.3")
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == pytest.approx(1.25e-06)
+        assert info["output_cost_per_token"] == pytest.approx(2.5e-06)
+        assert info["max_input_tokens"] == 1000000
+        assert info["supports_none_reasoning_effort"] is True
+        from litellm.llms.bedrock_mantle.common_utils import mantle_base_segment
+
+        assert mantle_base_segment("xai.grok-4.3", litellm.model_cost) == "openai/v1"


### PR DESCRIPTION
## Summary

Register `bedrock_mantle/xai.grok-4.3` in the model cost map so Bedrock Mantle routes Responses API calls through `BedrockMantleResponsesAPIConfig` (SigV4-capable) instead of falling back to the bearer-only chat bridge.

Fixes #31196

## Motivation

`xai.grok-4.3` on Amazon Bedrock Mantle supports the native Responses API on the `/openai/v1` path with SigV4/IAM auth, but LiteLLM had no `model_cost` entry for this model. As a result, `mantle_supports_responses()` returned `False`, `get_provider_responses_api_config()` returned `None`, and requests were forced onto the chat-completions bridge that only supports bearer tokens.

## Changes

- Add `bedrock_mantle/xai.grok-4.3` to `model_prices_and_context_window.json` and the backup JSON with:
  - `use_openai_responses_path: true` (AWS `/openai/v1` wire path)
  - `supported_endpoints: ["/v1/chat/completions", "/v1/responses"]`
  - AWS pricing ($1.25/M input, $2.50/M output)
  - Reasoning/tool/vision capability flags from the AWS model card
- Add regression tests for Responses routing, pricing, registry membership, and `mantle_supports_responses`

## Tests

```bash
pytest tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py::TestBedrockMantlePerModelResponsesURL::test_grok_4_3_uses_openai_responses_path \
  tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py::TestBedrockMantleResponsesPricing::test_grok_4_3_pricing_and_capabilities \
  tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py::TestBedrockMantleResponsesPricing::test_models_registered -q
```

Result: **3 passed**

## Notes

- No routing/auth code changes needed — Bedrock Mantle onboarding is data-driven via `model_cost`.
- Tiered pricing above 200K tokens is not included (consistent with other `bedrock_mantle/*` entries today).