### PR TITLE
chore: remove CI section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,17 @@
 ## Relevant issues
 
-<!-- e.g. "Fixes #000" -->
+<!-- e.g., "Fixes #000" -->
 
 ## Linear ticket
 
-<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g. "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->
+<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->
 
 ## Pre-Submission checklist
 
 **Please complete all items before asking a LiteLLM maintainer to review your PR**
 
 - [ ] I have added meaningful tests
-- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
+- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
 - [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
 - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
 
@@ -19,29 +19,13 @@
 
 If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).
 
-## CI (LiteLLM team)
-
-> **CI status guideline:**
->
-> - 50-55 passing tests: main is stable with minor issues.
-> - 45-49 passing tests: acceptable but needs attention
-> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.
-
-- [ ] **Branch creation CI run**  
-       Link:
-
-- [ ] **CI run for the last commit**  
-       Link:
-
-- [ ] **Merge / cherry-pick CI run**  
-       Links:
-
 ## Screenshots / Proof of Fix
 
-<!-- Include screenshots, screen recordings, or log output demonstrating that your changes work as expected.
-     For bug fixes: show reproduction before the fix and passing behavior after.
-     For new features: show the feature working end-to-end.
-     For UI changes: include before/after screenshots. -->
+<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
+     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
+     For bug fixes: show reproduction before the fix and passing behavior after
+     For new features: show the feature working end-to-end
+     For UI changes: include before/after screenshots -->
 
 ## Type
 


### PR DESCRIPTION
We now require all checks to pass