### PR TITLE
test(logging): regression coverage for streaming /v1/messages OpenAI Responses spend logs

### DIFF
--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -11,7 +11,9 @@ sys.path.insert(
 
 import time
 
+import litellm
 from litellm.constants import SENTRY_DENYLIST, SENTRY_PII_DENYLIST
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
 from litellm.litellm_core_utils.litellm_logging import set_callbacks
 from litellm.types.utils import ModelResponse, TextCompletionResponse
@@ -3406,6 +3408,116 @@ def test_handle_anthropic_messages_response_logging_degrades_on_unparseable_resp
     assert isinstance(result, ModelResponse)
     assert result.model == "openai/my-local"
     assert result.usage.prompt_tokens == 4  # type: ignore[attr-defined]
+
+
+class _SuccessCapturingLogger(CustomLogger):
+    """Records the success payload. Populated only in async_log_success_event, so it
+    stays None when the buggy no-op async_log_stream_event path runs for streaming."""
+
+    def __init__(self):
+        super().__init__()
+        self.success_payload = None
+        self.stream_event_calls = 0
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.success_payload = kwargs.get("standard_logging_object")
+
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
+        self.stream_event_calls += 1
+
+
+def _responses_completed_sse_bytes():
+    import json
+
+    event = {
+        "type": "response.completed",
+        "sequence_number": 1,
+        "response": _responses_api_response_with_text("hello world").model_dump(),
+    }
+    return f"data: {json.dumps(event)}\n\n".encode("utf-8")
+
+
+def _fake_streaming_responses_http_response():
+    sse = _responses_completed_sse_bytes()
+
+    async def aiter_bytes(*args, **kwargs):
+        yield sse
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.headers = {}
+    resp.aiter_bytes = aiter_bytes
+    return resp
+
+
+async def _drain_until_logged(logger, max_iter=30):
+    for _ in range(max_iter):
+        if logger.success_payload is not None:
+            break
+        await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging():
+    """Regression for #28595 / #28943. The existing tests above call
+    _handle_anthropic_messages_response_logging directly; they do not cover the
+    streaming wiring that originally broke. Drive a real streaming
+    anthropic_messages call routed to the OpenAI Responses backend (upstream SSE
+    mocked) and assert the success logger fires with real cost. On the broken
+    version the stream ran but only the no-op async_log_stream_event was called,
+    so success_payload stayed None and the SpendLogs row never landed."""
+    logger = _SuccessCapturingLogger()
+    litellm.callbacks = [logger]
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new=AsyncMock(return_value=_fake_streaming_responses_http_response()),
+    ):
+        stream = await litellm.anthropic_messages(
+            model="openai/gpt-4o",
+            api_key="sk-test-28595",
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=16,
+            stream=True,
+        )
+        async for _ in stream:  # logging fires on stream end; must drain fully
+            pass
+
+    await _drain_until_logged(logger)
+
+    assert logger.success_payload is not None, (
+        "async_log_success_event never fired for streaming /v1/messages -> openai "
+        "Responses bridge; the no-op stream path dropped the spend row"
+    )
+    assert logger.success_payload["response_cost"] > 0
+    assert logger.success_payload["call_type"] == "anthropic_messages"
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="live proof-of-fix for #28595; requires OPENAI_API_KEY",
+)
+@pytest.mark.asyncio
+async def test_streaming_anthropic_messages_openai_bridge_live():
+    """Live counterpart hitting real OpenAI; bills a few tokens and asserts the
+    streaming bridge produces a spend row with non-zero cost."""
+    logger = _SuccessCapturingLogger()
+    litellm.callbacks = [logger]
+
+    stream = await litellm.anthropic_messages(
+        model="openai/gpt-4o",
+        messages=[{"role": "user", "content": "ping"}],
+        max_tokens=16,
+        stream=True,
+    )
+    async for _ in stream:
+        pass
+
+    await _drain_until_logged(logger)
+
+    assert logger.success_payload is not None
+    assert logger.success_payload["response_cost"] > 0
+    assert logger.success_payload["call_type"] == "anthropic_messages"
 
 
 def test_failure_handler_records_recovered_partial_spend(logging_obj):

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3411,43 +3411,85 @@ def test_handle_anthropic_messages_response_logging_degrades_on_unparseable_resp
 
 
 class _SuccessCapturingLogger(CustomLogger):
-    """Records the success payload. Populated only in async_log_success_event, so it
-    stays None when the buggy no-op async_log_stream_event path runs for streaming."""
+    """Records the success payload. success_payload is populated only in
+    async_log_success_event, so it stays None when the buggy no-op
+    async_log_stream_event path runs for streaming."""
 
     def __init__(self):
         super().__init__()
         self.success_payload = None
+        self.success_calls = 0
         self.stream_event_calls = 0
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.success_calls += 1
         self.success_payload = kwargs.get("standard_logging_object")
 
     async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
         self.stream_event_calls += 1
 
 
-def _responses_completed_sse_bytes():
+def _responses_stream_sse_bytes():
+    """A full Responses stream: an opened message item, two text deltas, then the
+    terminal response.completed carrying usage. Exercises mid-stream delta handling
+    in addition to end-of-stream success logging."""
     import json
 
-    event = {
-        "type": "response.completed",
-        "sequence_number": 1,
-        "response": _responses_api_response_with_text("hello world").model_dump(),
-    }
-    return f"data: {json.dumps(event)}\n\n".encode("utf-8")
+    events = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": "msg-1",
+                "type": "message",
+                "status": "in_progress",
+                "role": "assistant",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg-1",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "hello ",
+            "sequence_number": 2,
+        },
+        {
+            "type": "response.output_text.delta",
+            "item_id": "msg-1",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": "world",
+            "sequence_number": 3,
+        },
+        {
+            "type": "response.completed",
+            "sequence_number": 4,
+            "response": _responses_api_response_with_text("hello world").model_dump(),
+        },
+    ]
+    return [f"data: {json.dumps(e)}\n\n".encode("utf-8") for e in events]
 
 
 def _fake_streaming_responses_http_response():
-    sse = _responses_completed_sse_bytes()
+    sse_chunks = _responses_stream_sse_bytes()
 
     async def aiter_bytes(*args, **kwargs):
-        yield sse
+        for chunk in sse_chunks:
+            yield chunk
 
     resp = MagicMock()
     resp.status_code = 200
     resp.headers = {}
     resp.aiter_bytes = aiter_bytes
     return resp
+
+
+def _chunk_text(chunk):
+    if isinstance(chunk, (bytes, bytearray)):
+        return chunk.decode("utf-8", "ignore")
+    return str(chunk)
 
 
 async def _drain_until_logged(logger, max_iter=30):
@@ -3458,17 +3500,21 @@ async def _drain_until_logged(logger, max_iter=30):
 
 
 @pytest.mark.asyncio
-async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging():
+async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging(
+    monkeypatch,
+):
     """Regression for #28595 / #28943. The existing tests above call
     _handle_anthropic_messages_response_logging directly; they do not cover the
     streaming wiring that originally broke. Drive a real streaming
     anthropic_messages call routed to the OpenAI Responses backend (upstream SSE
-    mocked) and assert the success logger fires with real cost. On the broken
-    version the stream ran but only the no-op async_log_stream_event was called,
-    so success_payload stayed None and the SpendLogs row never landed."""
+    mocked) and assert the bridge surfaces delta chunks and fires success logging
+    exactly once with real cost. On the broken version the stream ran but only the
+    no-op async_log_stream_event was called, so success_payload stayed None and the
+    SpendLogs row never landed."""
     logger = _SuccessCapturingLogger()
-    litellm.callbacks = [logger]
+    monkeypatch.setattr(litellm, "callbacks", [logger])
 
+    chunks = []
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new=AsyncMock(return_value=_fake_streaming_responses_http_response()),
@@ -3480,15 +3526,20 @@ async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging(
             max_tokens=16,
             stream=True,
         )
-        async for _ in stream:  # logging fires on stream end; must drain fully
-            pass
+        async for chunk in stream:  # logging fires on stream end; must drain fully
+            chunks.append(chunk)
 
     await _drain_until_logged(logger)
 
+    assert chunks, "stream yielded no chunks"
+    assert any("content_block_delta" in _chunk_text(c) for c in chunks), (
+        "no delta chunks surfaced; the streaming text deltas were not forwarded"
+    )
     assert logger.success_payload is not None, (
         "async_log_success_event never fired for streaming /v1/messages -> openai "
         "Responses bridge; the no-op stream path dropped the spend row"
     )
+    assert logger.success_calls == 1, "bridge call must log success exactly once"
     assert logger.success_payload["response_cost"] > 0
     assert logger.success_payload["call_type"] == "anthropic_messages"
 
@@ -3498,24 +3549,27 @@ async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging(
     reason="live proof-of-fix for #28595; requires OPENAI_API_KEY",
 )
 @pytest.mark.asyncio
-async def test_streaming_anthropic_messages_openai_bridge_live():
+async def test_streaming_anthropic_messages_openai_bridge_live(monkeypatch):
     """Live counterpart hitting real OpenAI; bills a few tokens and asserts the
-    streaming bridge produces a spend row with non-zero cost."""
+    streaming bridge yields chunks and logs a spend row with non-zero cost once."""
     logger = _SuccessCapturingLogger()
-    litellm.callbacks = [logger]
+    monkeypatch.setattr(litellm, "callbacks", [logger])
 
+    chunks = []
     stream = await litellm.anthropic_messages(
         model="openai/gpt-4o",
         messages=[{"role": "user", "content": "ping"}],
         max_tokens=16,
         stream=True,
     )
-    async for _ in stream:
-        pass
+    async for chunk in stream:
+        chunks.append(chunk)
 
     await _drain_until_logged(logger)
 
+    assert chunks, "stream yielded no chunks"
     assert logger.success_payload is not None
+    assert logger.success_calls == 1
     assert logger.success_payload["response_cost"] > 0
     assert logger.success_payload["call_type"] == "anthropic_messages"
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -3544,36 +3544,6 @@ async def test_streaming_anthropic_messages_openai_bridge_fires_success_logging(
     assert logger.success_payload["call_type"] == "anthropic_messages"
 
 
-@pytest.mark.skipif(
-    not os.getenv("OPENAI_API_KEY"),
-    reason="live proof-of-fix for #28595; requires OPENAI_API_KEY",
-)
-@pytest.mark.asyncio
-async def test_streaming_anthropic_messages_openai_bridge_live(monkeypatch):
-    """Live counterpart hitting real OpenAI; bills a few tokens and asserts the
-    streaming bridge yields chunks and logs a spend row with non-zero cost once."""
-    logger = _SuccessCapturingLogger()
-    monkeypatch.setattr(litellm, "callbacks", [logger])
-
-    chunks = []
-    stream = await litellm.anthropic_messages(
-        model="openai/gpt-4o",
-        messages=[{"role": "user", "content": "ping"}],
-        max_tokens=16,
-        stream=True,
-    )
-    async for chunk in stream:
-        chunks.append(chunk)
-
-    await _drain_until_logged(logger)
-
-    assert chunks, "stream yielded no chunks"
-    assert logger.success_payload is not None
-    assert logger.success_calls == 1
-    assert logger.success_payload["response_cost"] > 0
-    assert logger.success_payload["call_type"] == "anthropic_messages"
-
-
 def test_failure_handler_records_recovered_partial_spend(logging_obj):
     """A stream interrupted mid-flight still billed the provider for the chunks
     already delivered. When the router stashes that recovered usage as


### PR DESCRIPTION
## Relevant issues

Adds the missing regression coverage for #28595 (and the related #28943)

## Linear ticket

Resolves #4018

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

✅ Test

## Changes

The fix for #28595 (translate the Responses bridge result to a ModelResponse for spend logs) shipped in v1.90.0 and is correct, but the tests it added all call `_handle_anthropic_messages_response_logging` directly. Nothing exercises the streaming path that actually regressed: a streaming `POST /v1/messages` cross-routed to an OpenAI Responses backend returned 200 with a full body, but the success handler took the no-op `async_log_stream_event` branch, so `_PROXY_track_cost_callback` never fired and no `LiteLLM_SpendLogs` row landed. A refactor of `_get_assembled_streaming_response` or the success-handler routing could reintroduce that drop while every existing test stays green

This adds a deterministic end-to-end guard in the mapped test file. It drives `litellm.anthropic_messages(model="openai/gpt-4o", stream=True)` with the upstream Responses SSE mocked at the HTTP layer. The mocked stream emits an opened message item, two text deltas, then the terminal `response.completed`, so the test covers mid-stream delta forwarding as well as end-of-stream success logging. After draining the stream it asserts at least one `content_block_delta` surfaced, that `async_log_success_event` fired exactly once, and that the recorded payload has a non-zero `response_cost` with `call_type == "anthropic_messages"`. Checking cost and call_type (not just "a row exists") keeps the guard strong against a mutation that bills the row as `aresponses` or with zero cost. `litellm.callbacks` is set through the `monkeypatch` fixture so global logger state is restored after the test. The test is fully mocked and makes no network calls, so it stays within the isolation rules for `tests/test_litellm`

## Screenshots / Proof of Fix

The deterministic test was run against both the pre-fix and post-fix code to confirm it is a true fail-before / pass-after guard, not a tautology

Pre-fix (v1.89.4): the stream runs to completion (3 chunks) but only the no-op `async_log_stream_event` fires and no payload is recorded, so the test fails

```
1.89.4 -> chunks streamed: 3 | stream_event(no-op) calls: 1 | success_payload set: False
FAILED ... test_streaming_anthropic_messages_openai_bridge_fires_success_logging
  AssertionError: async_log_success_event never fired for streaming /v1/messages -> openai Responses bridge
```

Post-fix (current staging), the deterministic test plus the existing #28595 unit block pass

```
$ pytest test_litellm_logging.py -k "anthropic_messages_response_logging or anthropic_messages_openai_bridge"
.......  7 passed, 97 deselected
```

The live behavior was also verified by hand against a real proxy hitting OpenAI on `/v1/messages` with `stream: true`: pre-fix the streaming call returned 200 with a full body but wrote zero `LiteLLM_SpendLogs` rows, post-fix the same call wrote a row with non-zero cost
