### PR TITLE
fix(mcp): stop logging tool-call input in MCP client

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -563,7 +563,7 @@ class MCPClient:
         Call an MCP Tool.
         """
         verbose_logger.info(
-            f"MCP client calling tool '{call_tool_request_params.name}' with arguments: {call_tool_request_params.arguments}"
+            f"MCP client calling tool '{call_tool_request_params.name}'"
         )
 
         async def on_progress(
@@ -672,7 +672,7 @@ class MCPClient:
     ) -> GetPromptResult:
         """Fetch a prompt definition from the MCP server."""
         verbose_logger.info(
-            f"MCP client fetching prompt '{get_prompt_request_params.name}' with arguments: {get_prompt_request_params.arguments}"
+            f"MCP client fetching prompt '{get_prompt_request_params.name}'"
         )
 
         async def _get_prompt_operation(session: ClientSession):

--- a/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
+++ b/tests/test_litellm/experimental_mcp_client/test_mcp_client.py
@@ -582,5 +582,51 @@ class TestMCPClientResolvedAuth:
             await http_client.aclose()
 
 
+def _all_logged_messages(mock_logger):
+    return " ".join(
+        str(call.args[0])
+        for level in ("info", "debug", "warning", "error", "exception")
+        for call in getattr(mock_logger, level).call_args_list
+        if call.args
+    )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_does_not_log_arguments():
+    from mcp.types import CallToolRequestParams
+
+    secret = "ssn-123-45-6789"
+    client = MCPClient(server_url="http://test-server")
+    client.run_with_session = AsyncMock(return_value=MagicMock())
+    params = CallToolRequestParams(
+        name="search_tool", arguments={"input": secret, "model": "gpt-5-mini"}
+    )
+
+    with patch.object(mcp_client_module, "verbose_logger") as mock_logger:
+        await client.call_tool(params)
+
+    logged = _all_logged_messages(mock_logger)
+    assert "search_tool" in logged
+    assert secret not in logged
+    assert "gpt-5-mini" not in logged
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_does_not_log_arguments():
+    from mcp.types import GetPromptRequestParams
+
+    secret = "ssn-987-65-4321"
+    client = MCPClient(server_url="http://test-server")
+    client.run_with_session = AsyncMock(return_value=MagicMock())
+    params = GetPromptRequestParams(name="my_prompt", arguments={"input": secret})
+
+    with patch.object(mcp_client_module, "verbose_logger") as mock_logger:
+        await client.get_prompt(params)
+
+    logged = _all_logged_messages(mock_logger)
+    assert "my_prompt" in logged
+    assert secret not in logged
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-3811

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

The MCP client logged the tool input at INFO on every call, so the caller's `arguments` (the user query, model, instructions, etc.) showed up verbatim in the proxy logs and any downstream log aggregator. That is the line in the LIT-3811 screenshots

Proof against a live proxy running this branch's code, calling the public DeepWiki MCP server at production INFO level (no debug flags). Config used

```yaml
mcp_servers:
  deepwiki:
    transport: "http"
    url: "https://mcp.deepwiki.com/mcp"
    allow_all_keys: true
```

Same real tool call in both runs, with a sentinel string in the question so it is easy to grep

```
curl -s http://localhost:4001/mcp-rest/tools/call \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"server_id":"<deepwiki>","name":"ask_question","arguments":{"repoName":"BerriAI/litellm","question":"LIT3811SECRETPROBE what is litellm"}}'
```

Before the fix the INFO line carries the full arguments, and the input is grep-able in the logs

```
$ grep "MCP client calling tool" litellm.log
17:21:54 - LiteLLM:INFO: client.py:565 - MCP client calling tool 'ask_question' with arguments: {'repoName': 'BerriAI/litellm', 'question': 'LIT3811SECRETPROBE what is litellm'}

$ grep -c "LIT3811SECRETPROBE" litellm.log
1
```

After the fix the same line logs only the tool name, and the input no longer appears anywhere in the logs

```
$ grep "MCP client calling tool" litellm.log
17:22:34 - LiteLLM:INFO: client.py:565 - MCP client calling tool 'ask_question'

$ grep -c "LIT3811SECRETPROBE" litellm.log
0
```

## Type

Bug Fix

## Changes

The MCP client emitted the full tool `arguments` at INFO in `call_tool`, and the same for prompt `arguments` in `get_prompt`, so caller input flowed into the application logs on every call. Both lines now log only the tool or prompt name and drop the arguments. The name is a stable identifier and is not sensitive; the input is what must not be logged

Files: `litellm/experimental_mcp_client/client.py` (the two INFO log lines), plus regression tests in `tests/test_litellm/experimental_mcp_client/test_mcp_client.py` that drive `call_tool` / `get_prompt` with a sensitive `arguments` value and assert it never reaches the logger (they fail on the pre-fix code and pass on the fix)
