### PR TITLE
fix: record TTFT for responses and agentic streaming

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
@@ -9,6 +9,7 @@ follow-up response is chained as Phase 2 of the same iterator.
 """
 
 import json
+from datetime import datetime
 from typing import Any, AsyncIterator, Dict, List, Optional, cast
 
 from litellm._logging import verbose_logger
@@ -174,15 +175,34 @@ class AgenticAnthropicStreamingIterator:
         self._stream_exhausted = False
         self._hook_processing_done = False
         self._follow_up_iterator: Optional[AsyncIterator] = None
+        self._completion_start_time_recorded = False
 
     def __aiter__(self):
         return self
+
+    def _mark_completion_start_time(self) -> None:
+        if self._completion_start_time_recorded:
+            return
+        self._completion_start_time_recorded = True
+        completion_start_time = datetime.now()
+        update_completion_start_time = getattr(
+            self._logging_obj, "_update_completion_start_time", None
+        )
+        if callable(update_completion_start_time):
+            update_completion_start_time(completion_start_time)
+            return
+
+        self._logging_obj.completion_start_time = completion_start_time
+        self._logging_obj.model_call_details["completion_start_time"] = (
+            completion_start_time
+        )
 
     async def __anext__(self) -> bytes:
         # Phase 1: yield from upstream, collect bytes
         if not self._stream_exhausted:
             try:
                 chunk = await self._inner.__anext__()
+                self._mark_completion_start_time()
                 self._collected_bytes.append(chunk)
                 return chunk
             except StopAsyncIteration:

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -78,6 +78,7 @@ class BaseResponsesAPIStreamingIterator:
         self._completed_response_cache_hit: Optional[bool] = None
         self._persist_completed_response_before_logging = True
         self._stream_created_time: float = time.time()
+        self._completion_start_time_recorded = False
 
         # track request context for hooks
         self.litellm_metadata = litellm_metadata
@@ -116,6 +117,23 @@ class BaseResponsesAPIStreamingIterator:
                 model=self.model or "",
                 llm_provider=self.custom_llm_provider or "",
             )
+
+    def _mark_completion_start_time(self) -> None:
+        if self._completion_start_time_recorded:
+            return
+        self._completion_start_time_recorded = True
+        completion_start_time = datetime.now()
+        update_completion_start_time = getattr(
+            self.logging_obj, "_update_completion_start_time", None
+        )
+        if callable(update_completion_start_time):
+            update_completion_start_time(completion_start_time)
+            return
+
+        self.logging_obj.completion_start_time = completion_start_time
+        self.logging_obj.model_call_details["completion_start_time"] = (
+            completion_start_time
+        )
 
     def _process_chunk(self, chunk) -> Optional[Any]:
         """Process a single chunk of data from the stream"""
@@ -280,6 +298,7 @@ class BaseResponsesAPIStreamingIterator:
                     else:
                         self._handle_logging_completed_response()
 
+                self._mark_completion_start_time()
                 return openai_responses_api_chunk
 
             return None

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -230,6 +230,42 @@ class TestBaseResponsesAPIStreamingIterator:
             # Verify no completed response was stored (since this is not a completed event)
             assert iterator.completed_response is None
 
+    def test_process_chunk_records_completion_start_time_once(self):
+        """Test _process_chunk records TTFT on the first emitted stream event."""
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+        mock_delta_event = Mock(spec=OutputTextDeltaEvent)
+        mock_delta_event.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+        mock_delta_event.delta = "Hello"
+        mock_config.transform_streaming_response.return_value = mock_delta_event
+
+        iterator = BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5.5",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            litellm_metadata={"model_info": {"id": "model_123"}},
+            custom_llm_provider="openai",
+        )
+
+        test_chunk_data = {
+            "type": "response.output_text.delta",
+            "delta": "Hello",
+            "item_id": "item_123",
+            "output_index": 0,
+            "content_index": 0,
+        }
+
+        iterator._process_chunk(json.dumps(test_chunk_data))
+        iterator._process_chunk(json.dumps(test_chunk_data))
+
+        mock_logging_obj._update_completion_start_time.assert_called_once()
+
     def test_process_chunk_handles_invalid_json(self):
         """
         Test that _process_chunk gracefully handles invalid JSON.

--- a/tests/pass_through_tests/test_anthropic_agentic_streaming_iterator.py
+++ b/tests/pass_through_tests/test_anthropic_agentic_streaming_iterator.py
@@ -1,0 +1,44 @@
+from unittest.mock import Mock
+
+import pytest
+
+from litellm.llms.anthropic.experimental_pass_through.messages.agentic_streaming_iterator import (
+    AgenticAnthropicStreamingIterator,
+)
+
+
+class AsyncBytesIterator:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = iter(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return next(self._chunks)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+@pytest.mark.asyncio
+async def test_agentic_streaming_iterator_records_completion_start_time_once():
+    logging_obj = Mock()
+    logging_obj.model_call_details = {}
+
+    iterator = AgenticAnthropicStreamingIterator(
+        completion_stream=AsyncBytesIterator([b"event: message_start\n\n", b"event: content_block_delta\n\n"]),
+        http_handler=Mock(),
+        model="claude-3-5-sonnet",
+        messages=[],
+        anthropic_messages_provider_config=Mock(),
+        anthropic_messages_optional_request_params={},
+        logging_obj=logging_obj,
+        custom_llm_provider="anthropic",
+        kwargs={},
+    )
+
+    assert await iterator.__anext__() == b"event: message_start\n\n"
+    assert await iterator.__anext__() == b"event: content_block_delta\n\n"
+
+    logging_obj._update_completion_start_time.assert_called_once()


### PR DESCRIPTION
## Summary

- Record `completion_start_time` when Responses API streaming emits its first parsed stream event.
- Record `completion_start_time` when the Anthropic Messages agentic streaming wrapper yields its first upstream byte chunk.
- Add targeted regression coverage for both paths.

## Why

Issue #31385 reports TTFT falling back to request `end_time` for streaming `/v1/responses`, and for `/v1/messages` when the Anthropic agentic-hook streaming path wraps the base iterator. In both paths, the stream can yield chunks without ever updating `LiteLLMLoggingObj.completion_start_time`, so logging falls back to total request duration.

This mirrors the existing base Anthropic Messages streaming behavior: mark the first chunk timestamp once, and leave final success logging unchanged.

## Validation

- `python3 -m py_compile litellm/responses/streaming_iterator.py litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py tests/pass_through_tests/test_anthropic_agentic_streaming_iterator.py`
- `uv run pytest tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py -k 'completion_start_time_once' -q`
- `uv run pytest tests/pass_through_tests/test_anthropic_agentic_streaming_iterator.py -q`
- `uv run ruff check litellm/responses/streaming_iterator.py litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py tests/pass_through_tests/test_anthropic_agentic_streaming_iterator.py`

Note: `ruff check` on the entire existing Responses streaming test file currently reports unrelated pre-existing unused imports/locals outside this change, so validation was scoped to targeted tests and changed source/new test files.

Fixes #31385
