### PR TITLE
fix(streaming): record completion_start_time on first chunk in agentic and responses streaming iterators

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
@@ -9,6 +9,7 @@ follow-up response is chained as Phase 2 of the same iterator.
 """
 
 import json
+from datetime import datetime
 from typing import Any, AsyncIterator, Dict, List, Optional, cast
 
 from litellm._logging import verbose_logger
@@ -170,6 +171,7 @@ class AgenticAnthropicStreamingIterator:
         self._stream_exhausted = False
         self._hook_processing_done = False
         self._follow_up_iterator: Optional[AsyncIterator] = None
+        self._completion_start_time_set = False
 
     def __aiter__(self):
         return self
@@ -179,6 +181,15 @@ class AgenticAnthropicStreamingIterator:
         if not self._stream_exhausted:
             try:
                 chunk = await self._inner.__anext__()
+                if not self._completion_start_time_set:
+                    self._completion_start_time_set = True
+                    _now = datetime.now()
+                    if getattr(self._logging_obj, "completion_start_time", None) is None:
+                        self._logging_obj.completion_start_time = _now
+                    if hasattr(self._logging_obj, "model_call_details"):
+                        self._logging_obj.model_call_details.setdefault(
+                            "completion_start_time", _now
+                        )
                 self._collected_bytes.append(chunk)
                 return chunk
             except StopAsyncIteration:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
@@ -184,7 +184,10 @@ class AgenticAnthropicStreamingIterator:
                 if not self._completion_start_time_set:
                     self._completion_start_time_set = True
                     _now = datetime.now()
-                    if getattr(self._logging_obj, "completion_start_time", None) is None:
+                    if (
+                        getattr(self._logging_obj, "completion_start_time", None)
+                        is None
+                    ):
                         self._logging_obj.completion_start_time = _now
                     if hasattr(self._logging_obj, "model_call_details"):
                         self._logging_obj.model_call_details.setdefault(

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -612,7 +612,10 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                     if not self._completion_start_time_set:
                         self._completion_start_time_set = True
                         _now = datetime.now()
-                        if getattr(self.logging_obj, "completion_start_time", None) is None:
+                        if (
+                            getattr(self.logging_obj, "completion_start_time", None)
+                            is None
+                        ):
                             self.logging_obj.completion_start_time = _now
                         self.logging_obj.model_call_details.setdefault(
                             "completion_start_time", _now

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -78,6 +78,7 @@ class BaseResponsesAPIStreamingIterator:
         self._completed_response_cache_hit: Optional[bool] = None
         self._persist_completed_response_before_logging = True
         self._stream_created_time: float = time.time()
+        self._completion_start_time_set: bool = False
 
         # track request context for hooks
         self.litellm_metadata = litellm_metadata
@@ -608,6 +609,14 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                 if self.finished:
                     raise StopAsyncIteration
                 elif result is not None:
+                    if not self._completion_start_time_set:
+                        self._completion_start_time_set = True
+                        _now = datetime.now()
+                        if getattr(self.logging_obj, "completion_start_time", None) is None:
+                            self.logging_obj.completion_start_time = _now
+                        self.logging_obj.model_call_details.setdefault(
+                            "completion_start_time", _now
+                        )
                     # Await hook directly instead of run_async_function
                     # (which spawns a thread + event loop per call)
                     result = await self._call_post_streaming_deployment_hook(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_agentic_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_agentic_streaming_iterator.py
@@ -790,3 +790,93 @@ class TestAgenticStreamingIteratorErrorHandling:
 
         call_kwargs = mock_handler._call_agentic_completion_hooks.call_args
         assert call_kwargs.kwargs["stream"] is True
+
+
+class TestCompletionStartTimeStamping:
+    """completion_start_time must be stamped on the first yielded chunk (issue #31385)."""
+
+    def _make_logging_obj(self, *, already_set: bool = False):
+        mock = MagicMock()
+        mock.completion_start_time = MagicMock() if already_set else None
+        mock.model_call_details = {}
+        return mock
+
+    def _make_iterator(self, chunks, logging_obj):
+        mock_handler = MagicMock()
+        mock_handler._call_agentic_completion_hooks = AsyncMock(return_value=None)
+        return AgenticAnthropicStreamingIterator(
+            completion_stream=MockAsyncStream(chunks),
+            http_handler=mock_handler,
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "hi"}],
+            anthropic_messages_provider_config=MagicMock(),
+            anthropic_messages_optional_request_params={},
+            logging_obj=logging_obj,
+            custom_llm_provider="anthropic",
+            kwargs={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_stamps_completion_start_time_on_first_chunk(self):
+        """logging_obj.completion_start_time must be a datetime after the first chunk."""
+        from datetime import datetime
+
+        logging_obj = self._make_logging_obj()
+        chunks = _build_simple_text_stream()
+        iterator = self._make_iterator(chunks, logging_obj)
+
+        # Consume first chunk only
+        first = await iterator.__anext__()
+
+        assert first is not None
+        assert isinstance(
+            logging_obj.completion_start_time, datetime
+        ), "completion_start_time should be set to a datetime on first chunk"
+
+    @pytest.mark.asyncio
+    async def test_stamps_completion_start_time_in_model_call_details(self):
+        """model_call_details['completion_start_time'] must be populated after first chunk."""
+        from datetime import datetime
+
+        logging_obj = self._make_logging_obj()
+        chunks = _build_simple_text_stream()
+        iterator = self._make_iterator(chunks, logging_obj)
+
+        await iterator.__anext__()
+
+        assert "completion_start_time" in logging_obj.model_call_details
+        assert isinstance(
+            logging_obj.model_call_details["completion_start_time"], datetime
+        )
+
+    @pytest.mark.asyncio
+    async def test_stamps_only_once_across_all_chunks(self):
+        """completion_start_time must not be overwritten on subsequent chunks."""
+        logging_obj = self._make_logging_obj()
+        chunks = _build_simple_text_stream()
+        iterator = self._make_iterator(chunks, logging_obj)
+
+        await iterator.__anext__()
+        first_stamp = logging_obj.completion_start_time
+
+        # Drain remaining chunks
+        async for _ in iterator:
+            pass
+
+        assert logging_obj.completion_start_time is first_stamp, (
+            "completion_start_time must be set exactly once"
+        )
+
+    @pytest.mark.asyncio
+    async def test_does_not_overwrite_existing_completion_start_time(self):
+        """If completion_start_time is already set, the iterator must leave it unchanged."""
+        logging_obj = self._make_logging_obj(already_set=True)
+        original = logging_obj.completion_start_time
+        chunks = _build_simple_text_stream()
+        iterator = self._make_iterator(chunks, logging_obj)
+
+        await iterator.__anext__()
+
+        assert logging_obj.completion_start_time is original, (
+            "iterator must not overwrite a pre-existing completion_start_time"
+        )


### PR DESCRIPTION
Fixes #31385

## Problem
`AgenticAnthropicStreamingIterator` and `AsyncResponsesAPIStreamingIterator` never set `completion_start_time` on the logging object. As a fallback, `litellm_logging.py` substitutes `end_time` when `completion_start_time is None`, which makes TTFT equal to total latency.

## Fix
Stamp `completion_start_time` on the first non-None chunk in both iterators, matching the existing pattern in `BaseAnthropicMessagesStreamingIterator.async_sse_wrapper`.

## Files changed
- `litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py`
- `litellm/responses/streaming_iterator.py`