### PR TITLE
feat(guardrails): add headroom guardrail for message compression

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -125,9 +125,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
-        tools_to_check: List[ChatCompletionToolParam] = (
-            chat_completion_compatible_request.get("tools", [])
-        )
+        tools_to_check: List[ChatCompletionToolParam] = chat_completion_compatible_request.get("tools", [])
         task_mappings: List[Tuple[int, Optional[int]]] = []
 
         # Step 1: Extract all text content and images
@@ -175,16 +173,27 @@ class AnthropicMessagesHandler(BaseTranslation):
                     # Note: MCP servers are handled separately in the main transformation
                 data["tools"] = anthropic_tools
 
-            # Step 3: Map guardrail responses back to original message structure
-            await self._apply_guardrail_responses_to_input(
-                messages=messages,
-                responses=guardrailed_texts,
-                task_mappings=task_mappings,
-            )
+            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            if guardrailed_structured_messages is not None:
+                from litellm.litellm_core_utils.prompt_templates.factory import (
+                    anthropic_messages_pt,
+                )
 
-        verbose_proxy_logger.debug(
-            "Anthropic Messages: Processed input messages: %s", messages
-        )
+                model = str(data.get("model") or "")
+                data["messages"] = anthropic_messages_pt(
+                    messages=guardrailed_structured_messages,
+                    model=model,
+                    llm_provider="anthropic",
+                )
+            else:
+                # Step 3: Map guardrail responses back to original message structure
+                await self._apply_guardrail_responses_to_input(
+                    messages=messages,
+                    responses=guardrailed_texts,
+                    task_mappings=task_mappings,
+                )
+
+        verbose_proxy_logger.debug("Anthropic Messages: Processed input messages: %s", messages)
 
         return data
 
@@ -288,9 +297,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = (
-                    guardrail_response
-                )
+                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
 
     async def process_output_response(
         self,
@@ -369,9 +376,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 task_mappings=task_mappings,
             )
 
-        verbose_proxy_logger.debug(
-            "Anthropic Messages: Processed output response: %s", response
-        )
+        verbose_proxy_logger.debug("Anthropic Messages: Processed output response: %s", response)
 
         return response
 
@@ -391,20 +396,14 @@ class AnthropicMessagesHandler(BaseTranslation):
         has_ended = self._check_streaming_has_ended(responses_so_far)
         if has_ended:
             # build the model response from the responses_so_far
-            built_response = (
-                AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
-                    all_chunks=responses_so_far,
-                    litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
-                    model="",
-                )
+            built_response = AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
+                all_chunks=responses_so_far,
+                litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
+                model="",
             )
 
             # Check if model_response is valid and has choices before accessing
-            if (
-                built_response is not None
-                and hasattr(built_response, "choices")
-                and built_response.choices
-            ):
+            if built_response is not None and hasattr(built_response, "choices") and built_response.choices:
                 model_response = cast(ModelResponse, built_response)
                 first_choice = cast(Choices, model_response.choices[0])
                 tool_calls_list = cast(
@@ -418,16 +417,16 @@ class AnthropicMessagesHandler(BaseTranslation):
                 if tool_calls_list:
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
-                _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
-                    inputs=guardrail_inputs,
-                    request_data=request_data if request_data is not None else {},
-                    input_type="response",
-                    logging_obj=litellm_logging_obj,
+                _guardrailed_inputs = (
+                    await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
+                        inputs=guardrail_inputs,
+                        request_data=request_data if request_data is not None else {},
+                        input_type="response",
+                        logging_obj=litellm_logging_obj,
+                    )
                 )
             else:
-                verbose_proxy_logger.debug(
-                    "Skipping output guardrail - model response has no choices"
-                )
+                verbose_proxy_logger.debug("Skipping output guardrail - model response has no choices")
             return responses_so_far
 
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
@@ -454,9 +453,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 request_data[key] = response
 
         if "litellm_metadata" not in request_data:
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
+            user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
             if user_metadata:
                 request_data["litellm_metadata"] = user_metadata
         return request_data
@@ -604,9 +601,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                         if delta.get("type") == "text_delta":
                             text += delta.get("text", "")
                     except json.JSONDecodeError:
-                        verbose_proxy_logger.warning(
-                            f"Failed to parse JSON from SSE data: {data_line}"
-                        )
+                        verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error extracting text from SSE: {e}")
@@ -670,14 +665,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                                 if stop_reason is not None:
                                     return True
                             except json.JSONDecodeError:
-                                verbose_proxy_logger.warning(
-                                    f"Failed to parse JSON from SSE data: {data_line}"
-                                )
+                                verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
 
                 except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"Error checking streaming end in SSE: {e}"
-                    )
+                    verbose_proxy_logger.error(f"Error checking streaming end in SSE: {e}")
 
             # Handle already-parsed dict format
             elif isinstance(response, dict):
@@ -783,10 +774,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             if isinstance(content_block, dict):
                 if content_block.get("type") == "text":
                     cast(Dict[str, Any], content_block)["text"] = guardrail_response
-            elif (
-                hasattr(content_block, "type")
-                and getattr(content_block, "type", None) == "text"
-            ):
+            elif hasattr(content_block, "type") and getattr(content_block, "type", None) == "text":
                 # Update Pydantic object's text attribute
                 if hasattr(content_block, "text"):
                     content_block.text = guardrail_response

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -107,13 +107,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             structured_messages = self.get_structured_messages(data)
             if structured_messages:
                 if skip_system:
-                    structured_messages = openai_messages_without_system(
-                        structured_messages
-                    )
+                    structured_messages = openai_messages_without_system(structured_messages)
                 if skip_tool:
-                    structured_messages = openai_messages_without_tool(
-                        structured_messages
-                    )
+                    structured_messages = openai_messages_without_tool(structured_messages)
                 inputs["structured_messages"] = structured_messages
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
@@ -137,27 +133,27 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if guardrailed_tools is not None:
                 data["tools"] = guardrailed_tools
 
-            # Step 3: Map guardrail responses back to original message structure
-            if guardrailed_texts and texts_to_check:
-                await self._apply_guardrail_responses_to_input_texts(
-                    messages=messages,
-                    responses=guardrailed_texts,
-                    task_mappings=text_task_mappings,
-                )
+            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            if guardrailed_structured_messages is not None:
+                data["messages"] = guardrailed_structured_messages
+            else:
+                # Step 3: Map guardrail responses back to original message structure
+                if guardrailed_texts and texts_to_check:
+                    await self._apply_guardrail_responses_to_input_texts(
+                        messages=messages,
+                        responses=guardrailed_texts,
+                        task_mappings=text_task_mappings,
+                    )
 
-            # Step 4: Apply guardrailed tool calls back to messages
-            if guardrailed_tool_calls:
-                # Note: The guardrail may modify tool_calls_to_check in place
-                # or we may need to handle returned tool calls differently
-                await self._apply_guardrail_responses_to_input_tool_calls(
-                    messages=messages,
-                    tool_calls=guardrailed_tool_calls,  # type: ignore
-                    task_mappings=tool_call_task_mappings,
-                )
+                # Step 4: Apply guardrailed tool calls back to messages
+                if guardrailed_tool_calls:
+                    await self._apply_guardrail_responses_to_input_tool_calls(
+                        messages=messages,
+                        tool_calls=guardrailed_tool_calls,  # type: ignore
+                        task_mappings=tool_call_task_mappings,
+                    )
 
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processed input messages: %s", messages
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed input messages: %s", messages)
 
         return data
 
@@ -259,9 +255,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = (
-                    guardrail_response
-                )
+                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
 
     async def _apply_guardrail_responses_to_input_tool_calls(
         self,
@@ -281,9 +275,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
                 message_tool_calls = messages[msg_idx].get("tool_calls", None)
-                if message_tool_calls is not None and isinstance(
-                    message_tool_calls, list
-                ):
+                if message_tool_calls is not None and isinstance(message_tool_calls, list):
                     if tool_call_idx < len(message_tool_calls):
                         # Replace the tool call with the guardrailed version
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
@@ -315,9 +307,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 0: Check if response has any text content to process
         if not self._has_text_content(response):
-            verbose_proxy_logger.warning(
-                "OpenAI Chat Completions: No text content in response, skipping guardrail"
-            )
+            verbose_proxy_logger.warning("OpenAI Chat Completions: No text content in response, skipping guardrail")
             return response
 
         texts_to_check: List[str] = []
@@ -353,9 +343,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(
-                    user_api_key_dict
-                )
+                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -379,8 +367,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             returned_tool_calls = guardrailed_inputs.get("tool_calls")
             guardrailed_tool_calls: List[Dict[str, Any]] = (
                 cast(List[Dict[str, Any]], returned_tool_calls)
-                if isinstance(returned_tool_calls, list)
-                and len(returned_tool_calls) == len(tool_calls_to_check)
+                if isinstance(returned_tool_calls, list) and len(returned_tool_calls) == len(tool_calls_to_check)
                 else tool_calls_to_check
             )
 
@@ -400,9 +387,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     task_mappings=tool_call_task_mappings,
                 )
 
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processed output response: %s", response
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed output response: %s", response)
 
         return response
 
@@ -441,9 +426,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # convert to model response
             model_response = cast(
                 ModelResponse,
-                stream_chunk_builder(
-                    chunks=responses_so_far, logging_obj=litellm_logging_obj
-                ),
+                stream_chunk_builder(chunks=responses_so_far, logging_obj=litellm_logging_obj),
             )
             # run process_output_response
             await self.process_output_response(
@@ -496,9 +479,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(
-                    user_api_key_dict
-                )
+                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -506,11 +487,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if images_to_check:
                 inputs["images"] = images_to_check
             # Include model information from the first response if available
-            if (
-                responses_so_far
-                and hasattr(responses_so_far[0], "model")
-                and responses_so_far[0].model
-            ):
+            if responses_so_far and hasattr(responses_so_far[0], "model") and responses_so_far[0].model:
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -586,9 +563,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         return combined_texts
 
-    def _has_text_content(
-        self, response: Union["ModelResponse", "ModelResponseStream"]
-    ) -> bool:
+    def _has_text_content(self, response: Union["ModelResponse", "ModelResponseStream"]) -> bool:
         """
         Check if response has any text content or tool calls to process.
 
@@ -600,28 +575,20 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             for choice in response.choices:
                 if isinstance(choice, litellm.Choices):
                     # Check for text content
-                    if choice.message.content and isinstance(
-                        choice.message.content, str
-                    ):
+                    if choice.message.content and isinstance(choice.message.content, str):
                         return True
                     # Check for tool calls
-                    if choice.message.tool_calls and isinstance(
-                        choice.message.tool_calls, list
-                    ):
+                    if choice.message.tool_calls and isinstance(choice.message.tool_calls, list):
                         if len(choice.message.tool_calls) > 0:
                             return True
         elif isinstance(response, ModelResponseStream):
             for streaming_choice in response.choices:
                 if isinstance(streaming_choice, litellm.StreamingChoices):
                     # Check for text content
-                    if streaming_choice.delta.content and isinstance(
-                        streaming_choice.delta.content, str
-                    ):
+                    if streaming_choice.delta.content and isinstance(streaming_choice.delta.content, str):
                         return True
                     # Check for tool calls
-                    if streaming_choice.delta.tool_calls and isinstance(
-                        streaming_choice.delta.tool_calls, list
-                    ):
+                    if streaming_choice.delta.tool_calls and isinstance(streaming_choice.delta.tool_calls, list):
                         if len(streaming_choice.delta.tool_calls) > 0:
                             return True
         return False
@@ -641,9 +608,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize text/image/tool call extraction logic.
         """
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processing choice: %s", choice
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processing choice: %s", choice)
 
         # Determine content source and tool calls based on choice type
         content = None
@@ -690,9 +655,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     tool_calls_to_check.append(tool_call_dict)
                     tool_call_task_mappings.append((choice_idx, int(tool_call_idx)))
 
-    def _convert_tool_call_to_dict(
-        self, tool_call: Union[Dict[str, Any], Any]
-    ) -> Optional[Dict[str, Any]]:
+    def _convert_tool_call_to_dict(self, tool_call: Union[Dict[str, Any], Any]) -> Optional[Dict[str, Any]]:
         """
         Convert a tool call object to dictionary format.
 
@@ -746,9 +709,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                choice.message.content[content_idx_optional]["text"] = (
-                    guardrail_response  # type: ignore
-                )
+                choice.message.content[content_idx_optional]["text"] = guardrail_response  # type: ignore
 
     async def _apply_guardrail_responses_to_output_tool_calls(
         self,
@@ -771,9 +732,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls
 
-                if choice_tool_calls is not None and isinstance(
-                    choice_tool_calls, list
-                ):
+                if choice_tool_calls is not None and isinstance(choice_tool_calls, list):
                     if tool_call_idx < len(choice_tool_calls):
                         # Update the tool call with guardrailed version
                         existing_tool_call = choice_tool_calls[tool_call_idx]
@@ -781,9 +740,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         if "function" in guardrailed_tool_call:
                             func_dict = guardrailed_tool_call["function"]
                             if "arguments" in func_dict:
-                                existing_tool_call.function.arguments = func_dict[
-                                    "arguments"
-                                ]
+                                existing_tool_call.function.arguments = func_dict["arguments"]
                             if "name" in func_dict:
                                 existing_tool_call.function.name = func_dict["name"]
 

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, List, Union
+
+from litellm.types.guardrails import (
+    GuardrailEventHooks,
+    Mode,
+    SupportedGuardrailIntegrations,
+)
+
+from .headroom import HeadroomGuardrail
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def _coerce_event_hook(
+    mode: Union[str, List[str], Mode],
+) -> Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]:
+    if isinstance(mode, Mode):
+        return mode
+    if isinstance(mode, list):
+        return [GuardrailEventHooks(item) for item in mode]
+    return GuardrailEventHooks(mode)
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail") -> HeadroomGuardrail:
+    import litellm
+
+    _callback = HeadroomGuardrail(
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        model=litellm_params.model,
+        guardrail_name=guardrail["guardrail_name"],
+        event_hook=_coerce_event_hook(litellm_params.mode),
+        default_on=litellm_params.default_on or False,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(  # pyright: ignore[reportUnknownMemberType]
+        _callback
+    )
+    return _callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.HEADROOM.value: initialize_guardrail,
+}
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.HEADROOM.value: HeadroomGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Literal, Optional, Type, Union
+
+from fastapi import HTTPException
+from httpx import Response as HttpxResponse
+from typing_extensions import TypeGuard
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]
+    httpxSpecialProvider,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.guardrails import GuardrailEventHooks, Mode
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+BYPASS_HEADER = "x-headroom-bypass"
+
+
+def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, dict)
+
+
+def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, list)
+
+
+class HeadroomGuardrail(CustomGuardrail):
+    def __init__(
+        self,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        guardrail_name: Optional[str] = None,
+        event_hook: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]] = None,
+        default_on: bool = False,
+    ):
+        self.headroom_api_base = (api_base or get_secret_str("HEADROOM_API_BASE") or "").rstrip("/")
+        if not self.headroom_api_base:
+            raise ValueError(
+                "Headroom guardrail requires an API base URL. "
+                "Set `api_base` in the guardrail config or HEADROOM_API_BASE env var."
+            )
+        self.headroom_api_key = api_key or get_secret_str("HEADROOM_API_KEY")
+        self.headroom_model = model
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback,
+        )
+        super().__init__(  # pyright: ignore[reportUnknownMemberType]
+            guardrail_name=guardrail_name,
+            event_hook=event_hook,
+            default_on=default_on,
+        )
+
+    def _should_bypass(self, request_data: dict) -> bool:
+        psr = request_data.get("proxy_server_request")
+        if not _is_str_object_dict(psr):
+            return False
+        headers = psr.get("headers")
+        if not _is_str_object_dict(headers):
+            return False
+        value = headers.get(BYPASS_HEADER) or headers.get(BYPASS_HEADER.lower())
+        return str(value).lower() == "true"
+
+    async def _call_compress(
+        self,
+        messages: List[dict[str, object]],
+        model: Optional[str],
+    ) -> List[dict[str, object]]:
+        payload: dict[str, object] = {"messages": messages}
+        if model:
+            payload["model"] = model
+
+        request_headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.headroom_api_key:
+            request_headers["Authorization"] = f"Bearer {self.headroom_api_key}"
+
+        raw_response: Optional[HttpxResponse] = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
+            url=f"{self.headroom_api_base}/v1/compress",
+            json=payload,
+            headers=request_headers,
+        )
+        if raw_response is None:
+            raise HTTPException(
+                status_code=502,
+                detail={"error": "Headroom compression service returned no response"},
+            )
+        response: HttpxResponse = raw_response
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned an error",
+                    "status_code": response.status_code,
+                    "body": response.text,
+                },
+            )
+
+        body: object = response.json()
+        if not _is_str_object_dict(body):
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned unexpected response shape",
+                    "body": response.text,
+                },
+            )
+
+        compressed_messages = body.get("messages")
+        if not _is_object_list(compressed_messages):
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service response missing 'messages'",
+                    "body": response.text,
+                },
+            )
+
+        verbose_proxy_logger.debug(
+            "Headroom: compressed %s tokens -> %s tokens (ratio %.2f)",
+            body.get("tokens_before", "?"),
+            body.get("tokens_after", "?"),
+            body.get("compression_ratio", 0),
+        )
+        return [item for item in compressed_messages if _is_str_object_dict(item)]
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
+        if input_type != "request":
+            return inputs
+
+        if self._should_bypass(request_data):
+            verbose_proxy_logger.debug("Headroom: %s header set; skipping compression", BYPASS_HEADER)
+            return inputs
+
+        structured_messages = inputs.get("structured_messages")
+        if not _is_object_list(structured_messages) or not structured_messages:
+            return inputs
+
+        messages = [m for m in structured_messages if _is_str_object_dict(m)]
+        if not messages:
+            return inputs
+
+        model = self.headroom_model or request_data.get("model")
+        compressed = await self._call_compress(
+            messages=messages,
+            model=model if isinstance(model, str) else None,
+        )
+
+        return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
+
+    @staticmethod
+    def get_config_model() -> Optional[Type["GuardrailConfigModel[object]"]]:
+        from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
+            HeadroomGuardrailConfigModel,
+        )
+
+        return HeadroomGuardrailConfigModel

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -53,6 +53,9 @@ from litellm.types.proxy.guardrails.guardrail_hooks.vigil_guard import (
 from litellm.types.proxy.guardrails.guardrail_hooks.cisco_ai_defense import (
     CiscoAIDefenseGuardrailConfigModel,
 )
+from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
+    HeadroomGuardrailConfigModel,
+)
 
 """
 Pydantic object defining how to set guardrails on litellm proxy
@@ -119,6 +122,7 @@ class SupportedGuardrailIntegrations(Enum):
     RUBRIK = "rubrik"
     VIGIL_GUARD = "vigil_guard"
     REPELLOAI = "repelloai"
+    HEADROOM = "headroom"
 
 
 class Role(Enum):
@@ -860,6 +864,7 @@ class LitellmParams(
     PresidioConfigModel,
     BedrockGuardrailConfigModel,
     LakeraV2GuardrailConfigModel,
+    HeadroomGuardrailConfigModel,
     RepelloAIGuardrailConfigModel,
     LassoGuardrailConfigModel,
     PillarGuardrailConfigModel,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/headroom.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/headroom.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .base import GuardrailConfigModel
+
+
+class HeadroomGuardrailConfigModel(GuardrailConfigModel[BaseModel]):
+    api_base: Optional[str] = Field(
+        default=None,
+        description="Base URL for the headroom compression service (e.g. https://api.headroom.ai). Falls back to HEADROOM_API_BASE env var.",
+    )
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for the headroom compression service. Falls back to HEADROOM_API_KEY env var.",
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="Model name forwarded to the headroom /v1/compress endpoint.",
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Headroom"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1,0 +1,253 @@
+"""
+Unit tests for the Headroom guardrail.
+
+Tests cover:
+- apply_guardrail compresses messages via /v1/compress and returns them as structured_messages
+- x-headroom-bypass: true header causes guardrail to skip compression
+- missing or empty messages are passed through unchanged
+- response-type input is passed through unchanged
+- /v1/compress HTTP error raises HTTPException
+- /v1/compress returning malformed JSON raises HTTPException
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import HeadroomGuardrail
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+
+FAKE_API_BASE = "https://headroom.example.com"
+FAKE_API_KEY = "test-key"
+
+ORIGINAL_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "A" * 5000},
+]
+COMPRESSED_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "A" * 500},
+]
+
+
+def _make_guardrail(**kwargs) -> HeadroomGuardrail:
+    defaults = dict(
+        api_base=FAKE_API_BASE,
+        api_key=FAKE_API_KEY,
+        guardrail_name="headroom",
+        default_on=True,
+    )
+    defaults.update(kwargs)
+    return HeadroomGuardrail(**defaults)
+
+
+def _make_compress_response(messages: list, status: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status
+    mock.json.return_value = {
+        "messages": messages,
+        "tokens_before": 1000,
+        "tokens_after": 100,
+        "compression_ratio": 0.1,
+        "transforms_applied": ["router:smart_crusher:0.35"],
+    }
+    mock.text = ""
+    return mock
+
+
+@pytest.fixture
+def guardrail() -> HeadroomGuardrail:
+    return _make_guardrail()
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_compresses_and_returns_structured_messages(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    assert result.get("structured_messages") == COMPRESSED_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_bypass_header_skips_compression(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    request_data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "true"}}}
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+        mock_post.assert_not_called()
+
+    assert result.get("structured_messages") == ORIGINAL_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_type_passthrough(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["some response text"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={},
+            input_type="response",
+        )
+        mock_post.assert_not_called()
+
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_structured_messages_passthrough(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(texts=["hello"])
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={},
+            input_type="request",
+        )
+        mock_post.assert_not_called()
+
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_http_error_raises():
+    guardrail = _make_guardrail()
+    mock_response = _make_compress_response([], status=500)
+    mock_response.text = "Internal Server Error"
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_missing_messages_key_raises():
+    guardrail = _make_guardrail()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"tokens_before": 100, "tokens_after": 10}
+    mock_response.text = "{}"
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+
+
+def test_init_raises_without_api_base():
+    with pytest.raises(ValueError, match="API base URL"):
+        HeadroomGuardrail(api_base=None)
+
+
+def test_bypass_header_case_insensitive():
+    guardrail = _make_guardrail()
+
+    for header_value in ("true", "True", "TRUE"):
+        data = {"proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}}
+        assert guardrail._should_bypass(data) is True
+
+    data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "false"}}}
+    assert guardrail._should_bypass(data) is False
+
+    data = {"proxy_server_request": {"headers": {}}}
+    assert guardrail._should_bypass(data) is False
+
+    data = {}
+    assert guardrail._should_bypass(data) is False
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_model_from_config():
+    guardrail = _make_guardrail(model="gpt-4o-mini")
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    call_kwargs = mock_post.call_args
+    sent_payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert sent_payload.get("model") == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_model_from_request_data_when_no_config_model():
+    guardrail = _make_guardrail()
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    call_kwargs = mock_post.call_args
+    sent_payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert sent_payload.get("model") == "gpt-4o"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
@@ -1,0 +1,124 @@
+"""
+Tests that when apply_guardrail returns structured_messages, both OpenAI and Anthropic
+translation handlers write them back to data["messages"] correctly.
+
+For OpenAI: structured_messages (OpenAI format) written directly to data["messages"].
+For Anthropic: structured_messages (OpenAI format) converted back to Anthropic format
+              via anthropic_messages_pt before writing to data["messages"].
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.llms.openai.chat.guardrail_translation.handler import (
+    OpenAIChatCompletionsHandler,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+
+ORIGINAL_MESSAGES = [
+    {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "A" * 5000},
+]
+COMPRESSED_MESSAGES = [
+    {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "A" * 200},
+]
+
+
+def _make_guardrail_returning_structured_messages(compressed: list) -> MagicMock:
+    guardrail = MagicMock()
+    guardrail.should_run_guardrail.return_value = True
+    guardrail.skip_system_message_in_guardrail = None
+    guardrail.skip_tool_message_in_guardrail = None
+    guardrail.experimental_use_latest_role_message_only = False
+
+    async def apply_guardrail(inputs, request_data, input_type, logging_obj=None):
+        result = dict(inputs)
+        result["structured_messages"] = compressed
+        return result
+
+    guardrail.apply_guardrail = apply_guardrail
+    return guardrail
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_writes_structured_messages_back():
+    handler = OpenAIChatCompletionsHandler()
+    guardrail = _make_guardrail_returning_structured_messages(COMPRESSED_MESSAGES)
+
+    data = {
+        "model": "gpt-4o",
+        "messages": ORIGINAL_MESSAGES,
+    }
+    result = await handler.process_input_messages(
+        data=data,
+        guardrail_to_apply=guardrail,
+    )
+
+    assert result["messages"] == COMPRESSED_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_uses_text_patchback_when_no_structured_messages():
+    handler = OpenAIChatCompletionsHandler()
+
+    guardrail = MagicMock()
+    guardrail.should_run_guardrail.return_value = True
+    guardrail.skip_system_message_in_guardrail = None
+    guardrail.skip_tool_message_in_guardrail = None
+    guardrail.experimental_use_latest_role_message_only = False
+
+    original_text = "hello world"
+    modified_text = "HELLO WORLD"
+    messages = [{"role": "user", "content": original_text}]
+
+    async def apply_guardrail(inputs, request_data, input_type, logging_obj=None):
+        return GenericGuardrailAPIInputs(texts=[modified_text])
+
+    guardrail.apply_guardrail = apply_guardrail
+
+    data = {"model": "gpt-4o", "messages": messages}
+    result = await handler.process_input_messages(
+        data=data,
+        guardrail_to_apply=guardrail,
+    )
+
+    assert result["messages"][0]["content"] == modified_text
+
+
+@pytest.mark.asyncio
+async def test_anthropic_handler_converts_structured_messages_to_anthropic_format():
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+
+    handler = AnthropicMessagesHandler()
+    guardrail = _make_guardrail_returning_structured_messages(COMPRESSED_MESSAGES)
+
+    anthropic_messages = [{"role": "user", "content": [{"type": "text", "text": "A" * 5000}]}]
+    data = {
+        "model": "claude-3-5-sonnet-20241022",
+        "messages": anthropic_messages,
+        "max_tokens": 1024,
+    }
+
+    converted_back = [{"role": "user", "content": [{"type": "text", "text": "A" * 200}]}]
+
+    with patch(
+        "litellm.litellm_core_utils.prompt_templates.factory.anthropic_messages_pt",
+        return_value=converted_back,
+    ) as mock_pt:
+        result = await handler.process_input_messages(
+            data=data,
+            guardrail_to_apply=guardrail,
+        )
+
+    mock_pt.assert_called_once_with(
+        messages=COMPRESSED_MESSAGES,
+        model="claude-3-5-sonnet-20241022",
+        llm_provider="anthropic",
+    )
+    assert result["messages"] == converted_back


### PR DESCRIPTION
Adds a headroom guardrail that compresses request messages via POST /v1/compress before they reach the LLM. The guardrail implements apply_guardrail so it runs on the unified guardrail path; it receives pre-built structured_messages (OpenAI format) from the translation layer, calls the headroom compression service, and returns the compressed messages as structured_messages.

Set x-headroom-bypass: true on the request to skip compression.

Also adds structured_messages write-back support to the OpenAI and Anthropic translation handlers: when apply_guardrail returns structured_messages, those are written to data["messages"] directly (OpenAI) or reverse-translated via anthropic_messages_pt (Anthropic) instead of falling through to the existing text-patch path. This is a prerequisite for any guardrail that needs to replace the full message list rather than patch individual text spans.

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
