### PR TITLE
fix(guardrails): match tool blocklist case- and whitespace-insensitively

### DIFF
--- a/litellm/proxy/db/tool_registry_writer.py
+++ b/litellm/proxy/db/tool_registry_writer.py
@@ -7,7 +7,7 @@ Admins use the management endpoints to read and update input_policy / output_pol
 
 import uuid
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import ToolDiscoveryQueueItem
@@ -292,6 +292,15 @@ async def list_overrides_for_tool(
         return []
 
 
+def _canonical_tool_name(name: str) -> str:
+    """Canonical form for tool-name matching: case- and whitespace-insensitive.
+
+    Blocklist and policy lookups compare canonical names so a blocked tool
+    cannot be reached via case or surrounding-whitespace variants of its name.
+    """
+    return name.strip().lower()
+
+
 class ToolPolicyRegistry:
     """
     In-memory registry of tool policies synced from DB.
@@ -316,11 +325,17 @@ class ToolPolicyRegistry:
                 reason="sync_tool_policy_from_db_tools_lookup_failure",
             )
             self._tool_input_policies = {
-                row.tool_name: getattr(row, "input_policy", "untrusted") or "untrusted"
+                _canonical_tool_name(cast(str, row.tool_name)): getattr(
+                    row, "input_policy", "untrusted"
+                )
+                or "untrusted"
                 for row in tools
             }
             self._tool_output_policies = {
-                row.tool_name: getattr(row, "output_policy", "untrusted") or "untrusted"
+                _canonical_tool_name(cast(str, row.tool_name)): getattr(
+                    row, "output_policy", "untrusted"
+                )
+                or "untrusted"
                 for row in tools
             }
 
@@ -329,12 +344,14 @@ class ToolPolicyRegistry:
                 lambda: ObjectPermissionRepository(prisma_client).table.find_many(),
                 reason="sync_tool_policy_from_db_perms_lookup_failure",
             )
-            self._blocked_tools_by_op_id = {}
-            for row in perms:
-                op_id = getattr(row, "object_permission_id", None)
-                blocked = getattr(row, "blocked_tools", None) or []
-                if op_id:
-                    self._blocked_tools_by_op_id[op_id] = list(blocked)
+            self._blocked_tools_by_op_id = {
+                op_id: [
+                    _canonical_tool_name(t)
+                    for t in cast(List[str], getattr(row, "blocked_tools", None) or [])
+                ]
+                for row in perms
+                if (op_id := getattr(row, "object_permission_id", None))
+            }
 
             self._initialized = True
             verbose_proxy_logger.info(
@@ -349,10 +366,14 @@ class ToolPolicyRegistry:
             raise
 
     def get_input_policy(self, tool_name: str) -> str:
-        return self._tool_input_policies.get(tool_name, "untrusted")
+        return self._tool_input_policies.get(
+            _canonical_tool_name(tool_name), "untrusted"
+        )
 
     def get_output_policy(self, tool_name: str) -> str:
-        return self._tool_output_policies.get(tool_name, "untrusted")
+        return self._tool_output_policies.get(
+            _canonical_tool_name(tool_name), "untrusted"
+        )
 
     def get_effective_policies(
         self,
@@ -370,13 +391,16 @@ class ToolPolicyRegistry:
         for op_id in (object_permission_id, team_object_permission_id):
             if op_id and op_id.strip():
                 blocked.update(self._blocked_tools_by_op_id.get(op_id.strip(), []))
-        result: Dict[str, str] = {}
-        for name in tool_names:
-            if name in blocked:
-                result[name] = "blocked"
-            else:
-                result[name] = self._tool_input_policies.get(name, "untrusted")
-        return result
+        return {
+            name: (
+                "blocked"
+                if _canonical_tool_name(name) in blocked
+                else self._tool_input_policies.get(
+                    _canonical_tool_name(name), "untrusted"
+                )
+            )
+            for name in tool_names
+        }
 
 
 _tool_policy_registry: Optional[ToolPolicyRegistry] = None

--- a/litellm/proxy/db/tool_registry_writer.py
+++ b/litellm/proxy/db/tool_registry_writer.py
@@ -301,6 +301,37 @@ def _canonical_tool_name(name: str) -> str:
     return name.strip().lower()
 
 
+_INPUT_POLICY_RESTRICTIVENESS: dict[str, int] = {
+    "untrusted": 0,
+    "trusted": 1,
+    "blocked": 2,
+}
+_OUTPUT_POLICY_RESTRICTIVENESS: dict[str, int] = {"trusted": 0, "untrusted": 1}
+
+
+def _policies_by_canonical_name(
+    rows: list[Any], attr: str, restrictiveness: dict[str, int]
+) -> dict[str, str]:
+    """Map canonical tool name -> policy from DB rows.
+
+    Rows are sorted least- to most-restrictive so that when several rows
+    collapse to one canonical name (e.g. "exec_shell" and "Exec_Shell"), the
+    dict's last write keeps the strictest policy. Otherwise a looser variant
+    could silently override a block.
+    """
+    return {
+        _canonical_tool_name(cast(str, getattr(row, "tool_name", ""))): cast(
+            str, getattr(row, attr, "untrusted") or "untrusted"
+        )
+        for row in sorted(
+            rows,
+            key=lambda r: restrictiveness.get(
+                cast(str, getattr(r, attr, "untrusted") or "untrusted"), 0
+            ),
+        )
+    }
+
+
 class ToolPolicyRegistry:
     """
     In-memory registry of tool policies synced from DB.
@@ -324,20 +355,12 @@ class ToolPolicyRegistry:
                 lambda: ToolRepository(prisma_client).table.find_many(),
                 reason="sync_tool_policy_from_db_tools_lookup_failure",
             )
-            self._tool_input_policies = {
-                _canonical_tool_name(cast(str, row.tool_name)): getattr(
-                    row, "input_policy", "untrusted"
-                )
-                or "untrusted"
-                for row in tools
-            }
-            self._tool_output_policies = {
-                _canonical_tool_name(cast(str, row.tool_name)): getattr(
-                    row, "output_policy", "untrusted"
-                )
-                or "untrusted"
-                for row in tools
-            }
+            self._tool_input_policies = _policies_by_canonical_name(
+                tools, "input_policy", _INPUT_POLICY_RESTRICTIVENESS
+            )
+            self._tool_output_policies = _policies_by_canonical_name(
+                tools, "output_policy", _OUTPUT_POLICY_RESTRICTIVENESS
+            )
 
             perms = await call_with_db_reconnect_retry(
                 prisma_client,
@@ -347,7 +370,7 @@ class ToolPolicyRegistry:
             self._blocked_tools_by_op_id = {
                 op_id: [
                     _canonical_tool_name(t)
-                    for t in cast(List[str], getattr(row, "blocked_tools", None) or [])
+                    for t in cast(list[str], getattr(row, "blocked_tools", None) or [])
                 ]
                 for row in perms
                 if (op_id := getattr(row, "object_permission_id", None))

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -322,6 +322,29 @@ async def test_tool_policy_registry_blocklist_matches_name_variants():
     assert result_key["Fetch_URL"] == "blocked"
     assert result_key["fetch_url "] == "blocked"
 
+
+@pytest.mark.asyncio
+async def test_tool_policy_registry_canonical_collision_keeps_most_restrictive():
+    """Follow-up to #30732: when two rows collapse to the same canonical name
+    (exec_shell blocked, Exec_Shell untrusted), the looser policy must not
+    override the block via last-write-wins in the synced dict."""
+    prisma = MagicMock()
+    prisma.db.litellm_tooltable.find_many = AsyncMock(
+        return_value=[
+            _mock_tool_row("exec_shell", input_policy="blocked"),
+            _mock_tool_row("Exec_Shell", input_policy="untrusted"),
+        ]
+    )
+    prisma.db.litellm_objectpermissiontable.find_many = AsyncMock(return_value=[])
+    registry = ToolPolicyRegistry()
+    await registry.sync_tool_policy_from_db(prisma)
+
+    assert registry.get_input_policy("exec_shell") == "blocked"
+    assert registry.get_input_policy("EXEC_SHELL") == "blocked"
+    result = registry.get_effective_policies(["exec_shell", "Exec_Shell"])
+    assert result["exec_shell"] == "blocked"
+    assert result["Exec_Shell"] == "blocked"
+
     # Direct policy lookups normalize too.
     assert registry.get_input_policy("Exec_Shell") == "blocked"
 

--- a/tests/test_litellm/proxy/db/test_tool_registry_writer.py
+++ b/tests/test_litellm/proxy/db/test_tool_registry_writer.py
@@ -294,6 +294,39 @@ async def test_tool_policy_registry_not_initialized_returns_untrusted():
 
 
 @pytest.mark.asyncio
+async def test_tool_policy_registry_blocklist_matches_name_variants():
+    """Regression for #30732: a blocked tool must not be reachable via case or
+    surrounding-whitespace variants of its name. The blocklist comparison used
+    exact string matching, so 'Exec_Shell' / 'exec_shell ' bypassed a block on
+    'exec_shell'."""
+    prisma = MagicMock()
+    prisma.db.litellm_tooltable.find_many = AsyncMock(
+        return_value=[_mock_tool_row("exec_shell", input_policy="blocked")]
+    )
+    prisma.db.litellm_objectpermissiontable.find_many = AsyncMock(
+        return_value=[_mock_perm_row("op-key-1", ["fetch_url"])]
+    )
+    registry = ToolPolicyRegistry()
+    await registry.sync_tool_policy_from_db(prisma)
+
+    variants = ["exec_shell", "Exec_Shell", "EXEC_SHELL", "exec_shell ", " exec_shell"]
+    result = registry.get_effective_policies(variants)
+    assert all(verdict == "blocked" for verdict in result.values())
+    # Result keys preserve the original (un-normalized) request names.
+    assert set(result.keys()) == set(variants)
+
+    # Per-key blocklist (object permission) must also catch variants.
+    result_key = registry.get_effective_policies(
+        ["Fetch_URL", "fetch_url "], object_permission_id="op-key-1"
+    )
+    assert result_key["Fetch_URL"] == "blocked"
+    assert result_key["fetch_url "] == "blocked"
+
+    # Direct policy lookups normalize too.
+    assert registry.get_input_policy("Exec_Shell") == "blocked"
+
+
+@pytest.mark.asyncio
 async def test_sync_tool_policy_from_db_retries_on_transport_error_first_read():
     """`ToolPolicyRegistry.sync_tool_policy_from_db` self-heals across one
     ClientNotConnectedError on the tools read — the perms read still fires
@@ -325,10 +358,7 @@ async def test_sync_tool_policy_from_db_retries_on_transport_error_first_read():
     assert len(invocations) == 2
     mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
     reconnect_kwargs = mock_prisma_client.attempt_db_reconnect.await_args.kwargs
-    assert (
-        reconnect_kwargs["reason"]
-        == "sync_tool_policy_from_db_tools_lookup_failure"
-    )
+    assert reconnect_kwargs["reason"] == "sync_tool_policy_from_db_tools_lookup_failure"
     assert registry.is_initialized()
 
 
@@ -361,7 +391,4 @@ async def test_sync_tool_policy_from_db_retries_on_transport_error_second_read()
     assert len(perms_invocations) == 2
     mock_prisma_client.attempt_db_reconnect.assert_awaited_once()
     reconnect_kwargs = mock_prisma_client.attempt_db_reconnect.await_args.kwargs
-    assert (
-        reconnect_kwargs["reason"]
-        == "sync_tool_policy_from_db_perms_lookup_failure"
-    )
+    assert reconnect_kwargs["reason"] == "sync_tool_policy_from_db_perms_lookup_failure"


### PR DESCRIPTION
## Relevant issues

Addresses the blocklist-bypass half of #30732

## Type

🐛 Bug Fix

## Changes

`ToolPolicyRegistry` matched tool names by exact string, so a tool blocked as `exec_shell` was still reachable through `Exec_Shell` or `exec_shell ` (case or surrounding-whitespace variants). Tool names are now canonicalized (strip + lowercase) at sync time and on every lookup (`get_input_policy`, `get_output_policy`, `get_effective_policies`), while `get_effective_policies` still returns the original request names as keys so callers are unaffected

Scope is intentionally limited to the blocklist-normalization half of #30732. The route-coverage gap (tool guardrails not applied on `/v1/responses` and `/v1/messages`) is left to a separate focused PR. Separator variants (`-` vs `_`) are out of scope here, since collapsing them could collide distinct tools

The issue author offered to send focused PRs for this; if that part is already in flight on their side, happy to close this in favor of theirs

## Testing

Added `test_tool_policy_registry_blocklist_matches_name_variants` in `tests/test_litellm/proxy/db/test_tool_registry_writer.py`, covering case and whitespace variants for both the global `input_policy` block and the per-key / team object-permission blocklist; it fails without the normalization. Locally the file passes pytest (16 tests), `ruff format --check` and `ruff check` are clean, and `basedpyright` on the file goes from 110 to 106 errors with no new violations
