### PR TITLE
feat(guardrails): add headroom guardrail for message compression

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1093,6 +1093,46 @@ class CustomGuardrail(CustomLogger):
         return None
 
 
+def _sync_guardrail_info_to_logging_obj(
+    request_data: dict, logging_obj: object
+) -> None:
+    """Copy standard_logging_guardrail_information from request_data into logging_obj.
+
+    The @log_guardrail_information decorator writes guardrail info to
+    request_data["metadata"] or request_data["litellm_metadata"].  For
+    passthrough routes (/v1/messages, /v1/responses) the spend-log payload is
+    built from logging_obj.litellm_params["metadata"], which is a separate dict
+    that does not share identity with the one in request_data.  This helper
+    bridges that gap so guardrail_information is non-null in spend logs for all
+    routes, not just /v1/chat/completions.
+    """
+    if logging_obj is None:
+        return
+    slg_info = (
+        request_data.get("metadata") or request_data.get("litellm_metadata") or {}
+    ).get("standard_logging_guardrail_information")
+    if slg_info is None:
+        return
+    entries = slg_info if isinstance(slg_info, list) else [slg_info]
+    candidates = [
+        getattr(logging_obj, "litellm_params", None),
+        (getattr(logging_obj, "model_call_details", None) or {}).get("litellm_params"),
+    ]
+    for lp in candidates:
+        if not isinstance(lp, dict):
+            continue
+        if lp.get("metadata") is None:
+            lp["metadata"] = {}
+        meta = lp["metadata"]
+        existing = meta.get("standard_logging_guardrail_information")
+        if existing is None:
+            meta["standard_logging_guardrail_information"] = list(entries)
+        elif isinstance(existing, list):
+            for entry in entries:
+                if entry not in existing:
+                    existing.append(entry)
+
+
 def log_guardrail_information(func):
     """
     Decorator to add standard logging guardrail information to any function
@@ -1153,12 +1193,14 @@ def log_guardrail_information(func):
         if func.__name__ == "apply_guardrail" and "inputs" in kwargs:
             original_inputs = kwargs.get("inputs")
 
+        logging_obj = kwargs.get("logging_obj")
         entries_before = _count_recorded_guardrail_entries(request_data)
         try:
             response = await func(*args, **kwargs)
             if _count_recorded_guardrail_entries(request_data) > entries_before:
+                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 return response
-            return self._process_response(
+            result = self._process_response(
                 response=response,
                 request_data=request_data,
                 start_time=start_time.timestamp(),
@@ -1167,10 +1209,13 @@ def log_guardrail_information(func):
                 event_type=event_type,
                 original_inputs=original_inputs,
             )
+            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+            return result
         except Exception as e:
             if _count_recorded_guardrail_entries(request_data) > entries_before:
+                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 raise
-            return self._process_error(
+            result = self._process_error(
                 e=e,
                 request_data=request_data,
                 start_time=start_time.timestamp(),
@@ -1178,6 +1223,8 @@ def log_guardrail_information(func):
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
             )
+            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+            return result
 
     @functools.wraps(func)
     def sync_wrapper(*args, **kwargs):
@@ -1191,27 +1238,34 @@ def log_guardrail_information(func):
         if func.__name__ == "apply_guardrail" and "inputs" in kwargs:
             original_inputs = kwargs.get("inputs")
 
+        logging_obj = kwargs.get("logging_obj")
         entries_before = _count_recorded_guardrail_entries(request_data)
         try:
             response = func(*args, **kwargs)
             if _count_recorded_guardrail_entries(request_data) > entries_before:
+                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 return response
-            return self._process_response(
+            result = self._process_response(
                 response=response,
                 request_data=request_data,
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
                 original_inputs=original_inputs,
             )
+            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+            return result
         except Exception as e:
             if _count_recorded_guardrail_entries(request_data) > entries_before:
+                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 raise
-            return self._process_error(
+            result = self._process_error(
                 e=e,
                 request_data=request_data,
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
             )
+            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+            return result
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1108,23 +1108,26 @@ def _sync_guardrail_info_to_logging_obj(
     """
     if logging_obj is None:
         return
-    slg_info = (
+    meta_src = (
         request_data.get("metadata") or request_data.get("litellm_metadata") or {}
-    ).get("standard_logging_guardrail_information")
-    if slg_info is None:
+    )
+    slg_info = meta_src.get("standard_logging_guardrail_information")
+    if not slg_info:
         return
-    entries = slg_info if isinstance(slg_info, list) else [slg_info]
+    entries: list = slg_info if isinstance(slg_info, list) else [slg_info]
+    mcd = getattr(logging_obj, "model_call_details", None) or {}
     candidates = [
         getattr(logging_obj, "litellm_params", None),
-        (getattr(logging_obj, "model_call_details", None) or {}).get("litellm_params"),
+        mcd.get("litellm_params"),
     ]
     for lp in candidates:
         if not isinstance(lp, dict):
             continue
         if lp.get("metadata") is None:
             lp["metadata"] = {}
-        meta = lp["metadata"]
-        existing = meta.setdefault("standard_logging_guardrail_information", [])
+        existing = lp["metadata"].setdefault(
+            "standard_logging_guardrail_information", []
+        )
         for entry in entries:
             if entry not in existing:
                 existing.append(entry)

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1124,13 +1124,10 @@ def _sync_guardrail_info_to_logging_obj(
         if lp.get("metadata") is None:
             lp["metadata"] = {}
         meta = lp["metadata"]
-        existing = meta.get("standard_logging_guardrail_information")
-        if existing is None:
-            meta["standard_logging_guardrail_information"] = list(entries)
-        elif isinstance(existing, list):
-            for entry in entries:
-                if entry not in existing:
-                    existing.append(entry)
+        existing = meta.setdefault("standard_logging_guardrail_information", [])
+        for entry in entries:
+            if entry not in existing:
+                existing.append(entry)
 
 
 def log_guardrail_information(func):
@@ -1198,9 +1195,8 @@ def log_guardrail_information(func):
         try:
             response = await func(*args, **kwargs)
             if _count_recorded_guardrail_entries(request_data) > entries_before:
-                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 return response
-            result = self._process_response(
+            return self._process_response(
                 response=response,
                 request_data=request_data,
                 start_time=start_time.timestamp(),
@@ -1209,13 +1205,10 @@ def log_guardrail_information(func):
                 event_type=event_type,
                 original_inputs=original_inputs,
             )
-            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
-            return result
         except Exception as e:
             if _count_recorded_guardrail_entries(request_data) > entries_before:
-                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 raise
-            result = self._process_error(
+            return self._process_error(
                 e=e,
                 request_data=request_data,
                 start_time=start_time.timestamp(),
@@ -1223,8 +1216,8 @@ def log_guardrail_information(func):
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
             )
+        finally:
             _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
-            return result
 
     @functools.wraps(func)
     def sync_wrapper(*args, **kwargs):
@@ -1243,29 +1236,25 @@ def log_guardrail_information(func):
         try:
             response = func(*args, **kwargs)
             if _count_recorded_guardrail_entries(request_data) > entries_before:
-                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 return response
-            result = self._process_response(
+            return self._process_response(
                 response=response,
                 request_data=request_data,
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
                 original_inputs=original_inputs,
             )
-            _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
-            return result
         except Exception as e:
             if _count_recorded_guardrail_entries(request_data) > entries_before:
-                _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
                 raise
-            result = self._process_error(
+            return self._process_error(
                 e=e,
                 request_data=request_data,
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
             )
+        finally:
             _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
-            return result
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1093,6 +1093,18 @@ class CustomGuardrail(CustomLogger):
         return None
 
 
+def _append_slg_to_litellm_params(lp: object, entries: list) -> None:
+    """Merge guardrail entries into a single litellm_params dict."""
+    if not isinstance(lp, dict):
+        return
+    if lp.get("metadata") is None:
+        lp["metadata"] = {}
+    existing = lp["metadata"].setdefault("standard_logging_guardrail_information", [])
+    for entry in entries:
+        if entry not in existing:
+            existing.append(entry)
+
+
 def _sync_guardrail_info_to_logging_obj(
     request_data: dict, logging_obj: object
 ) -> None:
@@ -1116,21 +1128,8 @@ def _sync_guardrail_info_to_logging_obj(
         return
     entries: list = slg_info if isinstance(slg_info, list) else [slg_info]
     mcd = getattr(logging_obj, "model_call_details", None) or {}
-    candidates = [
-        getattr(logging_obj, "litellm_params", None),
-        mcd.get("litellm_params"),
-    ]
-    for lp in candidates:
-        if not isinstance(lp, dict):
-            continue
-        if lp.get("metadata") is None:
-            lp["metadata"] = {}
-        existing = lp["metadata"].setdefault(
-            "standard_logging_guardrail_information", []
-        )
-        for entry in entries:
-            if entry not in existing:
-                existing.append(entry)
+    _append_slg_to_litellm_params(getattr(logging_obj, "litellm_params", None), entries)
+    _append_slg_to_litellm_params(mcd.get("litellm_params"), entries)
 
 
 def log_guardrail_information(func):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5959,7 +5959,6 @@ def get_standard_logging_object_payload(
             ),
             standard_built_in_tools_params=standard_built_in_tools_params,
         )
-
         # emit_standard_logging_payload(payload) - Moved to success_handler to prevent double emitting
 
         return payload

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -125,9 +125,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
-        tools_to_check: List[ChatCompletionToolParam] = (
-            chat_completion_compatible_request.get("tools", [])
-        )
+        tools_to_check: List[ChatCompletionToolParam] = chat_completion_compatible_request.get("tools", [])
         task_mappings: List[Tuple[int, Optional[int]]] = []
 
         # Step 1: Extract all text content and images
@@ -175,16 +173,27 @@ class AnthropicMessagesHandler(BaseTranslation):
                     # Note: MCP servers are handled separately in the main transformation
                 data["tools"] = anthropic_tools
 
-            # Step 3: Map guardrail responses back to original message structure
-            await self._apply_guardrail_responses_to_input(
-                messages=messages,
-                responses=guardrailed_texts,
-                task_mappings=task_mappings,
-            )
+            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            if guardrailed_structured_messages is not None:
+                from litellm.litellm_core_utils.prompt_templates.factory import (
+                    anthropic_messages_pt,
+                )
 
-        verbose_proxy_logger.debug(
-            "Anthropic Messages: Processed input messages: %s", messages
-        )
+                model = str(data.get("model") or "")
+                data["messages"] = anthropic_messages_pt(
+                    messages=guardrailed_structured_messages,
+                    model=model,
+                    llm_provider="anthropic",
+                )
+            else:
+                # Step 3: Map guardrail responses back to original message structure
+                await self._apply_guardrail_responses_to_input(
+                    messages=messages,
+                    responses=guardrailed_texts,
+                    task_mappings=task_mappings,
+                )
+
+        verbose_proxy_logger.debug("Anthropic Messages: Processed input messages: %s", messages)
 
         return data
 
@@ -288,9 +297,7 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = (
-                    guardrail_response
-                )
+                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
 
     async def process_output_response(
         self,
@@ -369,9 +376,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 task_mappings=task_mappings,
             )
 
-        verbose_proxy_logger.debug(
-            "Anthropic Messages: Processed output response: %s", response
-        )
+        verbose_proxy_logger.debug("Anthropic Messages: Processed output response: %s", response)
 
         return response
 
@@ -391,20 +396,14 @@ class AnthropicMessagesHandler(BaseTranslation):
         has_ended = self._check_streaming_has_ended(responses_so_far)
         if has_ended:
             # build the model response from the responses_so_far
-            built_response = (
-                AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
-                    all_chunks=responses_so_far,
-                    litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
-                    model="",
-                )
+            built_response = AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
+                all_chunks=responses_so_far,
+                litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
+                model="",
             )
 
             # Check if model_response is valid and has choices before accessing
-            if (
-                built_response is not None
-                and hasattr(built_response, "choices")
-                and built_response.choices
-            ):
+            if built_response is not None and hasattr(built_response, "choices") and built_response.choices:
                 model_response = cast(ModelResponse, built_response)
                 first_choice = cast(Choices, model_response.choices[0])
                 tool_calls_list = cast(
@@ -418,16 +417,16 @@ class AnthropicMessagesHandler(BaseTranslation):
                 if tool_calls_list:
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
-                _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
-                    inputs=guardrail_inputs,
-                    request_data=request_data if request_data is not None else {},
-                    input_type="response",
-                    logging_obj=litellm_logging_obj,
+                _guardrailed_inputs = (
+                    await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
+                        inputs=guardrail_inputs,
+                        request_data=request_data if request_data is not None else {},
+                        input_type="response",
+                        logging_obj=litellm_logging_obj,
+                    )
                 )
             else:
-                verbose_proxy_logger.debug(
-                    "Skipping output guardrail - model response has no choices"
-                )
+                verbose_proxy_logger.debug("Skipping output guardrail - model response has no choices")
             return responses_so_far
 
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
@@ -454,9 +453,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 request_data[key] = response
 
         if "litellm_metadata" not in request_data:
-            user_metadata = self.transform_user_api_key_dict_to_metadata(
-                user_api_key_dict
-            )
+            user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
             if user_metadata:
                 request_data["litellm_metadata"] = user_metadata
         return request_data
@@ -604,9 +601,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                         if delta.get("type") == "text_delta":
                             text += delta.get("text", "")
                     except json.JSONDecodeError:
-                        verbose_proxy_logger.warning(
-                            f"Failed to parse JSON from SSE data: {data_line}"
-                        )
+                        verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error extracting text from SSE: {e}")
@@ -670,14 +665,10 @@ class AnthropicMessagesHandler(BaseTranslation):
                                 if stop_reason is not None:
                                     return True
                             except json.JSONDecodeError:
-                                verbose_proxy_logger.warning(
-                                    f"Failed to parse JSON from SSE data: {data_line}"
-                                )
+                                verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
 
                 except Exception as e:
-                    verbose_proxy_logger.error(
-                        f"Error checking streaming end in SSE: {e}"
-                    )
+                    verbose_proxy_logger.error(f"Error checking streaming end in SSE: {e}")
 
             # Handle already-parsed dict format
             elif isinstance(response, dict):
@@ -783,10 +774,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             if isinstance(content_block, dict):
                 if content_block.get("type") == "text":
                     cast(Dict[str, Any], content_block)["text"] = guardrail_response
-            elif (
-                hasattr(content_block, "type")
-                and getattr(content_block, "type", None) == "text"
-            ):
+            elif hasattr(content_block, "type") and getattr(content_block, "type", None) == "text":
                 # Update Pydantic object's text attribute
                 if hasattr(content_block, "text"):
                     content_block.text = guardrail_response

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -183,31 +183,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                 guardrailed_structured_messages is not None
                 and guardrailed_structured_messages is not original_structured_messages
             ):
-                from litellm.litellm_core_utils.prompt_templates.factory import (
-                    anthropic_messages_pt,
+                self._write_back_structured_messages(
+                    data, guardrailed_structured_messages
                 )
-
-                model = str(data.get("model") or "")
-                non_system = [
-                    m
-                    for m in guardrailed_structured_messages
-                    if m.get("role") != "system"
-                ]
-                converted = anthropic_messages_pt(
-                    messages=non_system,
-                    model=model,
-                    llm_provider="anthropic",
-                )
-                for msg in converted:
-                    content = msg.get("content")
-                    if isinstance(content, list):
-                        for block in content:
-                            if (
-                                isinstance(block, dict)
-                                and block.get("type") == "thinking"
-                            ):
-                                block.pop("cache_control", None)
-                data["messages"] = converted
             else:
                 # Step 3: Map guardrail responses back to original message structure
                 await self._apply_guardrail_responses_to_input(
@@ -221,6 +199,26 @@ class AnthropicMessagesHandler(BaseTranslation):
         )
 
         return data
+
+    @staticmethod
+    def _write_back_structured_messages(data: dict, structured_messages: list) -> None:
+        """Convert compressed structured_messages back to Anthropic format and write to data."""
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            anthropic_messages_pt,
+        )
+
+        model = str(data.get("model") or "")
+        non_system = [m for m in structured_messages if m.get("role") != "system"]
+        converted = anthropic_messages_pt(
+            messages=non_system, model=model, llm_provider="anthropic"
+        )
+        for msg in converted:
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "thinking":
+                        block.pop("cache_control", None)
+        data["messages"] = converted
 
     def extract_request_tool_names(self, data: dict) -> List[str]:
         """Extract tool names from Anthropic messages request (tools[].name)."""

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -188,8 +188,13 @@ class AnthropicMessagesHandler(BaseTranslation):
                 )
 
                 model = str(data.get("model") or "")
+                non_system = [
+                    m
+                    for m in guardrailed_structured_messages
+                    if m.get("role") != "system"
+                ]
                 data["messages"] = anthropic_messages_pt(
-                    messages=guardrailed_structured_messages,
+                    messages=non_system,
                     model=model,
                     llm_provider="anthropic",
                 )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -167,12 +167,6 @@ class AnthropicMessagesHandler(BaseTranslation):
                 slg_info = (
                     data.get("metadata") or data.get("litellm_metadata") or {}
                 ).get("standard_logging_guardrail_information")
-                print(
-                    f"[headroom-propagate] slg_info={slg_info is not None} "
-                    f"logging_obj_type={type(litellm_logging_obj).__name__} "
-                    f"has_model_call_details={hasattr(litellm_logging_obj, 'model_call_details')}",
-                    flush=True,
-                )
                 if slg_info is not None:
                     for _lp in [
                         getattr(litellm_logging_obj, "litellm_params", None),

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -163,6 +163,25 @@ class AnthropicMessagesHandler(BaseTranslation):
                 logging_obj=litellm_logging_obj,
             )
 
+            if litellm_logging_obj is not None:
+                slg_info = (data.get("metadata") or {}).get(
+                    "standard_logging_guardrail_information"
+                )
+                if slg_info is not None and litellm_logging_obj.metadata is not None:
+                    existing = litellm_logging_obj.metadata.get(
+                        "standard_logging_guardrail_information"
+                    )
+                    if existing is None:
+                        litellm_logging_obj.metadata[
+                            "standard_logging_guardrail_information"
+                        ] = slg_info
+                    elif isinstance(existing, list):
+                        for entry in (
+                            slg_info if isinstance(slg_info, list) else [slg_info]
+                        ):
+                            if entry not in existing:
+                                existing.append(entry)
+
             guardrailed_texts = guardrailed_inputs.get("texts", [])
             guardrailed_tools = guardrailed_inputs.get("tools")
             if guardrailed_tools is not None:

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -164,9 +164,9 @@ class AnthropicMessagesHandler(BaseTranslation):
             )
 
             if litellm_logging_obj is not None:
-                slg_info = (data.get("metadata") or {}).get(
-                    "standard_logging_guardrail_information"
-                )
+                slg_info = (
+                    data.get("metadata") or data.get("litellm_metadata") or {}
+                ).get("standard_logging_guardrail_information")
                 print(
                     f"[headroom-propagate] slg_info={slg_info is not None} "
                     f"logging_obj_type={type(litellm_logging_obj).__name__} "

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -167,20 +167,33 @@ class AnthropicMessagesHandler(BaseTranslation):
                 slg_info = (data.get("metadata") or {}).get(
                     "standard_logging_guardrail_information"
                 )
-                if slg_info is not None and litellm_logging_obj.metadata is not None:
-                    existing = litellm_logging_obj.metadata.get(
-                        "standard_logging_guardrail_information"
-                    )
-                    if existing is None:
-                        litellm_logging_obj.metadata[
+                if slg_info is not None:
+                    try:
+                        log_meta = litellm_logging_obj.model_call_details[
+                            "litellm_params"
+                        ].setdefault("metadata", {})
+                        if log_meta is None:
+                            litellm_logging_obj.model_call_details["litellm_params"][
+                                "metadata"
+                            ] = {}
+                            log_meta = litellm_logging_obj.model_call_details[
+                                "litellm_params"
+                            ]["metadata"]
+                        existing = log_meta.get(
                             "standard_logging_guardrail_information"
-                        ] = slg_info
-                    elif isinstance(existing, list):
-                        for entry in (
-                            slg_info if isinstance(slg_info, list) else [slg_info]
-                        ):
-                            if entry not in existing:
-                                existing.append(entry)
+                        )
+                        if existing is None:
+                            log_meta["standard_logging_guardrail_information"] = (
+                                slg_info
+                            )
+                        elif isinstance(existing, list):
+                            for entry in (
+                                slg_info if isinstance(slg_info, list) else [slg_info]
+                            ):
+                                if entry not in existing:
+                                    existing.append(entry)
+                    except (KeyError, AttributeError):
+                        pass
 
             guardrailed_texts = guardrailed_inputs.get("texts", [])
             guardrailed_tools = guardrailed_inputs.get("tools")

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -167,18 +167,21 @@ class AnthropicMessagesHandler(BaseTranslation):
                 slg_info = (data.get("metadata") or {}).get(
                     "standard_logging_guardrail_information"
                 )
+                print(
+                    f"[headroom-propagate] slg_info={slg_info is not None} "
+                    f"logging_obj_type={type(litellm_logging_obj).__name__} "
+                    f"has_model_call_details={hasattr(litellm_logging_obj, 'model_call_details')}",
+                    flush=True,
+                )
                 if slg_info is not None:
                     try:
-                        log_meta = litellm_logging_obj.model_call_details[
-                            "litellm_params"
-                        ].setdefault("metadata", {})
-                        if log_meta is None:
-                            litellm_logging_obj.model_call_details["litellm_params"][
-                                "metadata"
-                            ] = {}
-                            log_meta = litellm_logging_obj.model_call_details[
-                                "litellm_params"
-                            ]["metadata"]
+                        lp = litellm_logging_obj.litellm_params
+                        if not isinstance(lp, dict):
+                            lp = {}
+                            litellm_logging_obj.litellm_params = lp
+                        if lp.get("metadata") is None:
+                            lp["metadata"] = {}
+                        log_meta = lp["metadata"]
                         existing = log_meta.get(
                             "standard_logging_guardrail_information"
                         )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -125,7 +125,9 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         texts_to_check: List[str] = []
         images_to_check: List[str] = []
-        tools_to_check: List[ChatCompletionToolParam] = chat_completion_compatible_request.get("tools", [])
+        tools_to_check: List[ChatCompletionToolParam] = (
+            chat_completion_compatible_request.get("tools", [])
+        )
         task_mappings: List[Tuple[int, Optional[int]]] = []
 
         # Step 1: Extract all text content and images
@@ -173,7 +175,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                     # Note: MCP servers are handled separately in the main transformation
                 data["tools"] = anthropic_tools
 
-            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            guardrailed_structured_messages = guardrailed_inputs.get(
+                "structured_messages"
+            )
             if guardrailed_structured_messages is not None:
                 from litellm.litellm_core_utils.prompt_templates.factory import (
                     anthropic_messages_pt,
@@ -193,7 +197,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                     task_mappings=task_mappings,
                 )
 
-        verbose_proxy_logger.debug("Anthropic Messages: Processed input messages: %s", messages)
+        verbose_proxy_logger.debug(
+            "Anthropic Messages: Processed input messages: %s", messages
+        )
 
         return data
 
@@ -297,7 +303,9 @@ class AnthropicMessagesHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
+                messages[msg_idx]["content"][content_idx_optional]["text"] = (
+                    guardrail_response
+                )
 
     async def process_output_response(
         self,
@@ -376,7 +384,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                 task_mappings=task_mappings,
             )
 
-        verbose_proxy_logger.debug("Anthropic Messages: Processed output response: %s", response)
+        verbose_proxy_logger.debug(
+            "Anthropic Messages: Processed output response: %s", response
+        )
 
         return response
 
@@ -396,14 +406,20 @@ class AnthropicMessagesHandler(BaseTranslation):
         has_ended = self._check_streaming_has_ended(responses_so_far)
         if has_ended:
             # build the model response from the responses_so_far
-            built_response = AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
-                all_chunks=responses_so_far,
-                litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
-                model="",
+            built_response = (
+                AnthropicPassthroughLoggingHandler._build_complete_streaming_response(
+                    all_chunks=responses_so_far,
+                    litellm_logging_obj=cast("LiteLLMLoggingObj", litellm_logging_obj),
+                    model="",
+                )
             )
 
             # Check if model_response is valid and has choices before accessing
-            if built_response is not None and hasattr(built_response, "choices") and built_response.choices:
+            if (
+                built_response is not None
+                and hasattr(built_response, "choices")
+                and built_response.choices
+            ):
                 model_response = cast(ModelResponse, built_response)
                 first_choice = cast(Choices, model_response.choices[0])
                 tool_calls_list = cast(
@@ -417,16 +433,16 @@ class AnthropicMessagesHandler(BaseTranslation):
                 if tool_calls_list:
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
-                _guardrailed_inputs = (
-                    await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
-                        inputs=guardrail_inputs,
-                        request_data=request_data if request_data is not None else {},
-                        input_type="response",
-                        logging_obj=litellm_logging_obj,
-                    )
+                _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(  # allow rejecting the response, if invalid
+                    inputs=guardrail_inputs,
+                    request_data=request_data if request_data is not None else {},
+                    input_type="response",
+                    logging_obj=litellm_logging_obj,
                 )
             else:
-                verbose_proxy_logger.debug("Skipping output guardrail - model response has no choices")
+                verbose_proxy_logger.debug(
+                    "Skipping output guardrail - model response has no choices"
+                )
             return responses_so_far
 
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
@@ -453,7 +469,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                 request_data[key] = response
 
         if "litellm_metadata" not in request_data:
-            user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
+            user_metadata = self.transform_user_api_key_dict_to_metadata(
+                user_api_key_dict
+            )
             if user_metadata:
                 request_data["litellm_metadata"] = user_metadata
         return request_data
@@ -601,7 +619,9 @@ class AnthropicMessagesHandler(BaseTranslation):
                         if delta.get("type") == "text_delta":
                             text += delta.get("text", "")
                     except json.JSONDecodeError:
-                        verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
+                        verbose_proxy_logger.warning(
+                            f"Failed to parse JSON from SSE data: {data_line}"
+                        )
 
         except Exception as e:
             verbose_proxy_logger.error(f"Error extracting text from SSE: {e}")
@@ -665,10 +685,14 @@ class AnthropicMessagesHandler(BaseTranslation):
                                 if stop_reason is not None:
                                     return True
                             except json.JSONDecodeError:
-                                verbose_proxy_logger.warning(f"Failed to parse JSON from SSE data: {data_line}")
+                                verbose_proxy_logger.warning(
+                                    f"Failed to parse JSON from SSE data: {data_line}"
+                                )
 
                 except Exception as e:
-                    verbose_proxy_logger.error(f"Error checking streaming end in SSE: {e}")
+                    verbose_proxy_logger.error(
+                        f"Error checking streaming end in SSE: {e}"
+                    )
 
             # Handle already-parsed dict format
             elif isinstance(response, dict):
@@ -774,7 +798,10 @@ class AnthropicMessagesHandler(BaseTranslation):
             if isinstance(content_block, dict):
                 if content_block.get("type") == "text":
                     cast(Dict[str, Any], content_block)["text"] = guardrail_response
-            elif hasattr(content_block, "type") and getattr(content_block, "type", None) == "text":
+            elif (
+                hasattr(content_block, "type")
+                and getattr(content_block, "type", None) == "text"
+            ):
                 # Update Pydantic object's text attribute
                 if hasattr(content_block, "text"):
                     content_block.text = guardrail_response

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -163,43 +163,6 @@ class AnthropicMessagesHandler(BaseTranslation):
                 logging_obj=litellm_logging_obj,
             )
 
-            if litellm_logging_obj is not None:
-                slg_info = (
-                    data.get("metadata") or data.get("litellm_metadata") or {}
-                ).get("standard_logging_guardrail_information")
-                if slg_info is not None:
-                    for _lp in [
-                        getattr(litellm_logging_obj, "litellm_params", None),
-                        (litellm_logging_obj.model_call_details or {}).get(
-                            "litellm_params"
-                        )
-                        if hasattr(litellm_logging_obj, "model_call_details")
-                        else None,
-                    ]:
-                        if not isinstance(_lp, dict):
-                            continue
-                        try:
-                            if _lp.get("metadata") is None:
-                                _lp["metadata"] = {}
-                            log_meta = _lp["metadata"]
-                            existing = log_meta.get(
-                                "standard_logging_guardrail_information"
-                            )
-                            if existing is None:
-                                log_meta["standard_logging_guardrail_information"] = (
-                                    slg_info
-                                )
-                            elif isinstance(existing, list):
-                                for entry in (
-                                    slg_info
-                                    if isinstance(slg_info, list)
-                                    else [slg_info]
-                                ):
-                                    if entry not in existing:
-                                        existing.append(entry)
-                        except (KeyError, AttributeError):
-                            pass
-
             guardrailed_texts = guardrailed_inputs.get("texts", [])
             guardrailed_tools = guardrailed_inputs.get("tools")
             if guardrailed_tools is not None:

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -174,29 +174,37 @@ class AnthropicMessagesHandler(BaseTranslation):
                     flush=True,
                 )
                 if slg_info is not None:
-                    try:
-                        lp = litellm_logging_obj.litellm_params
-                        if not isinstance(lp, dict):
-                            lp = {}
-                            litellm_logging_obj.litellm_params = lp
-                        if lp.get("metadata") is None:
-                            lp["metadata"] = {}
-                        log_meta = lp["metadata"]
-                        existing = log_meta.get(
-                            "standard_logging_guardrail_information"
+                    for _lp in [
+                        getattr(litellm_logging_obj, "litellm_params", None),
+                        (litellm_logging_obj.model_call_details or {}).get(
+                            "litellm_params"
                         )
-                        if existing is None:
-                            log_meta["standard_logging_guardrail_information"] = (
-                                slg_info
+                        if hasattr(litellm_logging_obj, "model_call_details")
+                        else None,
+                    ]:
+                        if not isinstance(_lp, dict):
+                            continue
+                        try:
+                            if _lp.get("metadata") is None:
+                                _lp["metadata"] = {}
+                            log_meta = _lp["metadata"]
+                            existing = log_meta.get(
+                                "standard_logging_guardrail_information"
                             )
-                        elif isinstance(existing, list):
-                            for entry in (
-                                slg_info if isinstance(slg_info, list) else [slg_info]
-                            ):
-                                if entry not in existing:
-                                    existing.append(entry)
-                    except (KeyError, AttributeError):
-                        pass
+                            if existing is None:
+                                log_meta["standard_logging_guardrail_information"] = (
+                                    slg_info
+                                )
+                            elif isinstance(existing, list):
+                                for entry in (
+                                    slg_info
+                                    if isinstance(slg_info, list)
+                                    else [slg_info]
+                                ):
+                                    if entry not in existing:
+                                        existing.append(entry)
+                        except (KeyError, AttributeError):
+                            pass
 
             guardrailed_texts = guardrailed_inputs.get("texts", [])
             guardrailed_tools = guardrailed_inputs.get("tools")

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -149,6 +149,7 @@ class AnthropicMessagesHandler(BaseTranslation):
                 inputs["images"] = images_to_check
             if tools_to_check:
                 inputs["tools"] = tools_to_check
+            original_structured_messages = structured_messages
             if structured_messages:
                 inputs["structured_messages"] = structured_messages
             # Include model information if available
@@ -178,7 +179,10 @@ class AnthropicMessagesHandler(BaseTranslation):
             guardrailed_structured_messages = guardrailed_inputs.get(
                 "structured_messages"
             )
-            if guardrailed_structured_messages is not None:
+            if (
+                guardrailed_structured_messages is not None
+                and guardrailed_structured_messages is not original_structured_messages
+            ):
                 from litellm.litellm_core_utils.prompt_templates.factory import (
                     anthropic_messages_pt,
                 )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -193,11 +193,21 @@ class AnthropicMessagesHandler(BaseTranslation):
                     for m in guardrailed_structured_messages
                     if m.get("role") != "system"
                 ]
-                data["messages"] = anthropic_messages_pt(
+                converted = anthropic_messages_pt(
                     messages=non_system,
                     model=model,
                     llm_provider="anthropic",
                 )
+                for msg in converted:
+                    content = msg.get("content")
+                    if isinstance(content, list):
+                        for block in content:
+                            if (
+                                isinstance(block, dict)
+                                and block.get("type") == "thinking"
+                            ):
+                                block.pop("cache_control", None)
+                data["messages"] = converted
             else:
                 # Step 3: Map guardrail responses back to original message structure
                 await self._apply_guardrail_responses_to_input(

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -164,7 +164,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     )
 
         verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processed input messages: %s", messages
+            "OpenAI Chat Completions: Processed input messages: %s",
+            data.get("messages"),
         )
 
         return data

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -107,13 +107,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             structured_messages = self.get_structured_messages(data)
             if structured_messages:
                 if skip_system:
-                    structured_messages = openai_messages_without_system(
-                        structured_messages
-                    )
+                    structured_messages = openai_messages_without_system(structured_messages)
                 if skip_tool:
-                    structured_messages = openai_messages_without_tool(
-                        structured_messages
-                    )
+                    structured_messages = openai_messages_without_tool(structured_messages)
                 inputs["structured_messages"] = structured_messages
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
@@ -137,27 +133,27 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if guardrailed_tools is not None:
                 data["tools"] = guardrailed_tools
 
-            # Step 3: Map guardrail responses back to original message structure
-            if guardrailed_texts and texts_to_check:
-                await self._apply_guardrail_responses_to_input_texts(
-                    messages=messages,
-                    responses=guardrailed_texts,
-                    task_mappings=text_task_mappings,
-                )
+            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            if guardrailed_structured_messages is not None:
+                data["messages"] = guardrailed_structured_messages
+            else:
+                # Step 3: Map guardrail responses back to original message structure
+                if guardrailed_texts and texts_to_check:
+                    await self._apply_guardrail_responses_to_input_texts(
+                        messages=messages,
+                        responses=guardrailed_texts,
+                        task_mappings=text_task_mappings,
+                    )
 
-            # Step 4: Apply guardrailed tool calls back to messages
-            if guardrailed_tool_calls:
-                # Note: The guardrail may modify tool_calls_to_check in place
-                # or we may need to handle returned tool calls differently
-                await self._apply_guardrail_responses_to_input_tool_calls(
-                    messages=messages,
-                    tool_calls=guardrailed_tool_calls,  # type: ignore
-                    task_mappings=tool_call_task_mappings,
-                )
+                # Step 4: Apply guardrailed tool calls back to messages
+                if guardrailed_tool_calls:
+                    await self._apply_guardrail_responses_to_input_tool_calls(
+                        messages=messages,
+                        tool_calls=guardrailed_tool_calls,  # type: ignore
+                        task_mappings=tool_call_task_mappings,
+                    )
 
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processed input messages: %s", messages
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed input messages: %s", messages)
 
         return data
 
@@ -259,9 +255,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = (
-                    guardrail_response
-                )
+                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
 
     async def _apply_guardrail_responses_to_input_tool_calls(
         self,
@@ -281,9 +275,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
                 message_tool_calls = messages[msg_idx].get("tool_calls", None)
-                if message_tool_calls is not None and isinstance(
-                    message_tool_calls, list
-                ):
+                if message_tool_calls is not None and isinstance(message_tool_calls, list):
                     if tool_call_idx < len(message_tool_calls):
                         # Replace the tool call with the guardrailed version
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
@@ -315,9 +307,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 0: Check if response has any text content to process
         if not self._has_text_content(response):
-            verbose_proxy_logger.warning(
-                "OpenAI Chat Completions: No text content in response, skipping guardrail"
-            )
+            verbose_proxy_logger.warning("OpenAI Chat Completions: No text content in response, skipping guardrail")
             return response
 
         texts_to_check: List[str] = []
@@ -353,9 +343,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(
-                    user_api_key_dict
-                )
+                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -379,8 +367,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             returned_tool_calls = guardrailed_inputs.get("tool_calls")
             guardrailed_tool_calls: List[Dict[str, Any]] = (
                 cast(List[Dict[str, Any]], returned_tool_calls)
-                if isinstance(returned_tool_calls, list)
-                and len(returned_tool_calls) == len(tool_calls_to_check)
+                if isinstance(returned_tool_calls, list) and len(returned_tool_calls) == len(tool_calls_to_check)
                 else tool_calls_to_check
             )
 
@@ -400,9 +387,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     task_mappings=tool_call_task_mappings,
                 )
 
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processed output response: %s", response
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed output response: %s", response)
 
         return response
 
@@ -441,9 +426,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # convert to model response
             model_response = cast(
                 ModelResponse,
-                stream_chunk_builder(
-                    chunks=responses_so_far, logging_obj=litellm_logging_obj
-                ),
+                stream_chunk_builder(chunks=responses_so_far, logging_obj=litellm_logging_obj),
             )
             # run process_output_response
             await self.process_output_response(
@@ -496,9 +479,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(
-                    user_api_key_dict
-                )
+                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -506,11 +487,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if images_to_check:
                 inputs["images"] = images_to_check
             # Include model information from the first response if available
-            if (
-                responses_so_far
-                and hasattr(responses_so_far[0], "model")
-                and responses_so_far[0].model
-            ):
+            if responses_so_far and hasattr(responses_so_far[0], "model") and responses_so_far[0].model:
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -586,9 +563,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         return combined_texts
 
-    def _has_text_content(
-        self, response: Union["ModelResponse", "ModelResponseStream"]
-    ) -> bool:
+    def _has_text_content(self, response: Union["ModelResponse", "ModelResponseStream"]) -> bool:
         """
         Check if response has any text content or tool calls to process.
 
@@ -600,28 +575,20 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             for choice in response.choices:
                 if isinstance(choice, litellm.Choices):
                     # Check for text content
-                    if choice.message.content and isinstance(
-                        choice.message.content, str
-                    ):
+                    if choice.message.content and isinstance(choice.message.content, str):
                         return True
                     # Check for tool calls
-                    if choice.message.tool_calls and isinstance(
-                        choice.message.tool_calls, list
-                    ):
+                    if choice.message.tool_calls and isinstance(choice.message.tool_calls, list):
                         if len(choice.message.tool_calls) > 0:
                             return True
         elif isinstance(response, ModelResponseStream):
             for streaming_choice in response.choices:
                 if isinstance(streaming_choice, litellm.StreamingChoices):
                     # Check for text content
-                    if streaming_choice.delta.content and isinstance(
-                        streaming_choice.delta.content, str
-                    ):
+                    if streaming_choice.delta.content and isinstance(streaming_choice.delta.content, str):
                         return True
                     # Check for tool calls
-                    if streaming_choice.delta.tool_calls and isinstance(
-                        streaming_choice.delta.tool_calls, list
-                    ):
+                    if streaming_choice.delta.tool_calls and isinstance(streaming_choice.delta.tool_calls, list):
                         if len(streaming_choice.delta.tool_calls) > 0:
                             return True
         return False
@@ -641,9 +608,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize text/image/tool call extraction logic.
         """
-        verbose_proxy_logger.debug(
-            "OpenAI Chat Completions: Processing choice: %s", choice
-        )
+        verbose_proxy_logger.debug("OpenAI Chat Completions: Processing choice: %s", choice)
 
         # Determine content source and tool calls based on choice type
         content = None
@@ -690,9 +655,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     tool_calls_to_check.append(tool_call_dict)
                     tool_call_task_mappings.append((choice_idx, int(tool_call_idx)))
 
-    def _convert_tool_call_to_dict(
-        self, tool_call: Union[Dict[str, Any], Any]
-    ) -> Optional[Dict[str, Any]]:
+    def _convert_tool_call_to_dict(self, tool_call: Union[Dict[str, Any], Any]) -> Optional[Dict[str, Any]]:
         """
         Convert a tool call object to dictionary format.
 
@@ -746,9 +709,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                choice.message.content[content_idx_optional]["text"] = (
-                    guardrail_response  # type: ignore
-                )
+                choice.message.content[content_idx_optional]["text"] = guardrail_response  # type: ignore
 
     async def _apply_guardrail_responses_to_output_tool_calls(
         self,
@@ -771,9 +732,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls
 
-                if choice_tool_calls is not None and isinstance(
-                    choice_tool_calls, list
-                ):
+                if choice_tool_calls is not None and isinstance(choice_tool_calls, list):
                     if tool_call_idx < len(choice_tool_calls):
                         # Update the tool call with guardrailed version
                         existing_tool_call = choice_tool_calls[tool_call_idx]
@@ -781,9 +740,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         if "function" in guardrailed_tool_call:
                             func_dict = guardrailed_tool_call["function"]
                             if "arguments" in func_dict:
-                                existing_tool_call.function.arguments = func_dict[
-                                    "arguments"
-                                ]
+                                existing_tool_call.function.arguments = func_dict["arguments"]
                             if "name" in func_dict:
                                 existing_tool_call.function.name = func_dict["name"]
 

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -107,9 +107,13 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             structured_messages = self.get_structured_messages(data)
             if structured_messages:
                 if skip_system:
-                    structured_messages = openai_messages_without_system(structured_messages)
+                    structured_messages = openai_messages_without_system(
+                        structured_messages
+                    )
                 if skip_tool:
-                    structured_messages = openai_messages_without_tool(structured_messages)
+                    structured_messages = openai_messages_without_tool(
+                        structured_messages
+                    )
                 inputs["structured_messages"] = structured_messages
             # Pass tools (function definitions) to the guardrail
             tools = data.get("tools")
@@ -133,7 +137,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if guardrailed_tools is not None:
                 data["tools"] = guardrailed_tools
 
-            guardrailed_structured_messages = guardrailed_inputs.get("structured_messages")
+            guardrailed_structured_messages = guardrailed_inputs.get(
+                "structured_messages"
+            )
             if guardrailed_structured_messages is not None:
                 data["messages"] = guardrailed_structured_messages
             else:
@@ -153,7 +159,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         task_mappings=tool_call_task_mappings,
                     )
 
-        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed input messages: %s", messages)
+        verbose_proxy_logger.debug(
+            "OpenAI Chat Completions: Processed input messages: %s", messages
+        )
 
         return data
 
@@ -255,7 +263,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                messages[msg_idx]["content"][content_idx_optional]["text"] = guardrail_response
+                messages[msg_idx]["content"][content_idx_optional]["text"] = (
+                    guardrail_response
+                )
 
     async def _apply_guardrail_responses_to_input_tool_calls(
         self,
@@ -275,7 +285,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if task_idx < len(tool_calls):
                 guardrailed_tool_call = tool_calls[task_idx]
                 message_tool_calls = messages[msg_idx].get("tool_calls", None)
-                if message_tool_calls is not None and isinstance(message_tool_calls, list):
+                if message_tool_calls is not None and isinstance(
+                    message_tool_calls, list
+                ):
                     if tool_call_idx < len(message_tool_calls):
                         # Replace the tool call with the guardrailed version
                         message_tool_calls[tool_call_idx] = guardrailed_tool_call
@@ -307,7 +319,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         # Step 0: Check if response has any text content to process
         if not self._has_text_content(response):
-            verbose_proxy_logger.warning("OpenAI Chat Completions: No text content in response, skipping guardrail")
+            verbose_proxy_logger.warning(
+                "OpenAI Chat Completions: No text content in response, skipping guardrail"
+            )
             return response
 
         texts_to_check: List[str] = []
@@ -343,7 +357,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -367,7 +383,8 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             returned_tool_calls = guardrailed_inputs.get("tool_calls")
             guardrailed_tool_calls: List[Dict[str, Any]] = (
                 cast(List[Dict[str, Any]], returned_tool_calls)
-                if isinstance(returned_tool_calls, list) and len(returned_tool_calls) == len(tool_calls_to_check)
+                if isinstance(returned_tool_calls, list)
+                and len(returned_tool_calls) == len(tool_calls_to_check)
                 else tool_calls_to_check
             )
 
@@ -387,7 +404,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     task_mappings=tool_call_task_mappings,
                 )
 
-        verbose_proxy_logger.debug("OpenAI Chat Completions: Processed output response: %s", response)
+        verbose_proxy_logger.debug(
+            "OpenAI Chat Completions: Processed output response: %s", response
+        )
 
         return response
 
@@ -426,7 +445,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             # convert to model response
             model_response = cast(
                 ModelResponse,
-                stream_chunk_builder(chunks=responses_so_far, logging_obj=litellm_logging_obj),
+                stream_chunk_builder(
+                    chunks=responses_so_far, logging_obj=litellm_logging_obj
+                ),
             )
             # run process_output_response
             await self.process_output_response(
@@ -479,7 +500,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             # Add user API key metadata with prefixed keys
             if "litellm_metadata" not in request_data:
-                user_metadata = self.transform_user_api_key_dict_to_metadata(user_api_key_dict)
+                user_metadata = self.transform_user_api_key_dict_to_metadata(
+                    user_api_key_dict
+                )
                 if user_metadata:
                     request_data["litellm_metadata"] = user_metadata
 
@@ -487,7 +510,11 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if images_to_check:
                 inputs["images"] = images_to_check
             # Include model information from the first response if available
-            if responses_so_far and hasattr(responses_so_far[0], "model") and responses_so_far[0].model:
+            if (
+                responses_so_far
+                and hasattr(responses_so_far[0], "model")
+                and responses_so_far[0].model
+            ):
                 inputs["model"] = responses_so_far[0].model
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
@@ -563,7 +590,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         return combined_texts
 
-    def _has_text_content(self, response: Union["ModelResponse", "ModelResponseStream"]) -> bool:
+    def _has_text_content(
+        self, response: Union["ModelResponse", "ModelResponseStream"]
+    ) -> bool:
         """
         Check if response has any text content or tool calls to process.
 
@@ -575,20 +604,28 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             for choice in response.choices:
                 if isinstance(choice, litellm.Choices):
                     # Check for text content
-                    if choice.message.content and isinstance(choice.message.content, str):
+                    if choice.message.content and isinstance(
+                        choice.message.content, str
+                    ):
                         return True
                     # Check for tool calls
-                    if choice.message.tool_calls and isinstance(choice.message.tool_calls, list):
+                    if choice.message.tool_calls and isinstance(
+                        choice.message.tool_calls, list
+                    ):
                         if len(choice.message.tool_calls) > 0:
                             return True
         elif isinstance(response, ModelResponseStream):
             for streaming_choice in response.choices:
                 if isinstance(streaming_choice, litellm.StreamingChoices):
                     # Check for text content
-                    if streaming_choice.delta.content and isinstance(streaming_choice.delta.content, str):
+                    if streaming_choice.delta.content and isinstance(
+                        streaming_choice.delta.content, str
+                    ):
                         return True
                     # Check for tool calls
-                    if streaming_choice.delta.tool_calls and isinstance(streaming_choice.delta.tool_calls, list):
+                    if streaming_choice.delta.tool_calls and isinstance(
+                        streaming_choice.delta.tool_calls, list
+                    ):
                         if len(streaming_choice.delta.tool_calls) > 0:
                             return True
         return False
@@ -608,7 +645,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
         Override this method to customize text/image/tool call extraction logic.
         """
-        verbose_proxy_logger.debug("OpenAI Chat Completions: Processing choice: %s", choice)
+        verbose_proxy_logger.debug(
+            "OpenAI Chat Completions: Processing choice: %s", choice
+        )
 
         # Determine content source and tool calls based on choice type
         content = None
@@ -655,7 +694,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                     tool_calls_to_check.append(tool_call_dict)
                     tool_call_task_mappings.append((choice_idx, int(tool_call_idx)))
 
-    def _convert_tool_call_to_dict(self, tool_call: Union[Dict[str, Any], Any]) -> Optional[Dict[str, Any]]:
+    def _convert_tool_call_to_dict(
+        self, tool_call: Union[Dict[str, Any], Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Convert a tool call object to dictionary format.
 
@@ -709,7 +750,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
 
             elif isinstance(content, list) and content_idx_optional is not None:
                 # Replace specific text item in list content
-                choice.message.content[content_idx_optional]["text"] = guardrail_response  # type: ignore
+                choice.message.content[content_idx_optional]["text"] = (
+                    guardrail_response  # type: ignore
+                )
 
     async def _apply_guardrail_responses_to_output_tool_calls(
         self,
@@ -732,7 +775,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 choice = cast(Choices, response.choices[choice_idx])
                 choice_tool_calls = choice.message.tool_calls
 
-                if choice_tool_calls is not None and isinstance(choice_tool_calls, list):
+                if choice_tool_calls is not None and isinstance(
+                    choice_tool_calls, list
+                ):
                     if tool_call_idx < len(choice_tool_calls):
                         # Update the tool call with guardrailed version
                         existing_tool_call = choice_tool_calls[tool_call_idx]
@@ -740,7 +785,9 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                         if "function" in guardrailed_tool_call:
                             func_dict = guardrailed_tool_call["function"]
                             if "arguments" in func_dict:
-                                existing_tool_call.function.arguments = func_dict["arguments"]
+                                existing_tool_call.function.arguments = func_dict[
+                                    "arguments"
+                                ]
                             if "name" in func_dict:
                                 existing_tool_call.function.name = func_dict["name"]
 

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -124,6 +124,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if model:
                 inputs["model"] = model
 
+            original_structured_messages = inputs.get("structured_messages")
             guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs=inputs,
                 request_data=data,
@@ -140,7 +141,10 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             guardrailed_structured_messages = guardrailed_inputs.get(
                 "structured_messages"
             )
-            if guardrailed_structured_messages is not None:
+            if (
+                guardrailed_structured_messages is not None
+                and guardrailed_structured_messages is not original_structured_messages
+            ):
                 data["messages"] = guardrailed_structured_messages
             else:
                 # Step 3: Map guardrail responses back to original message structure

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
@@ -1,0 +1,48 @@
+from typing import TYPE_CHECKING, List, Union
+
+from litellm.types.guardrails import (
+    GuardrailEventHooks,
+    Mode,
+    SupportedGuardrailIntegrations,
+)
+
+from .headroom import HeadroomGuardrail
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def _coerce_event_hook(
+    mode: Union[str, List[str], Mode],
+) -> Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]:
+    if isinstance(mode, Mode):
+        return mode
+    if isinstance(mode, list):
+        return [GuardrailEventHooks(item) for item in mode]
+    return GuardrailEventHooks(mode)
+
+
+def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail") -> HeadroomGuardrail:
+    import litellm
+
+    _callback = HeadroomGuardrail(
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        model=litellm_params.model,
+        guardrail_name=guardrail["guardrail_name"],
+        event_hook=_coerce_event_hook(litellm_params.mode),
+        default_on=litellm_params.default_on or False,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(  # pyright: ignore[reportUnknownMemberType]
+        _callback
+    )
+    return _callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.HEADROOM.value: initialize_guardrail,
+}
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.HEADROOM.value: HeadroomGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, List, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from litellm.types.guardrails import (
     GuardrailEventHooks,
@@ -13,8 +15,8 @@ if TYPE_CHECKING:
 
 
 def _coerce_event_hook(
-    mode: Union[str, List[str], Mode],
-) -> Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]:
+    mode: str | list[str] | Mode,
+) -> GuardrailEventHooks | list[GuardrailEventHooks] | Mode:
     if isinstance(mode, Mode):
         return mode
     if isinstance(mode, list):
@@ -23,7 +25,7 @@ def _coerce_event_hook(
 
 
 def initialize_guardrail(
-    litellm_params: "LitellmParams", guardrail: "Guardrail"
+    litellm_params: LitellmParams, guardrail: Guardrail
 ) -> HeadroomGuardrail:
     import litellm
 

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py
@@ -22,7 +22,9 @@ def _coerce_event_hook(
     return GuardrailEventHooks(mode)
 
 
-def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail") -> HeadroomGuardrail:
+def initialize_guardrail(
+    litellm_params: "LitellmParams", guardrail: "Guardrail"
+) -> HeadroomGuardrail:
     import litellm
 
     _callback = HeadroomGuardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -7,7 +7,10 @@ from httpx import Response as HttpxResponse
 from typing_extensions import TypeGuard
 
 from litellm._logging import verbose_proxy_logger
-from litellm.integrations.custom_guardrail import CustomGuardrail, log_guardrail_information
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]
     httpxSpecialProvider,
@@ -38,10 +41,14 @@ class HeadroomGuardrail(CustomGuardrail):
         api_key: Optional[str] = None,
         model: Optional[str] = None,
         guardrail_name: Optional[str] = None,
-        event_hook: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]] = None,
+        event_hook: Optional[
+            Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]
+        ] = None,
         default_on: bool = False,
     ):
-        self.headroom_api_base = (api_base or get_secret_str("HEADROOM_API_BASE") or "").rstrip("/")
+        self.headroom_api_base = (
+            api_base or get_secret_str("HEADROOM_API_BASE") or ""
+        ).rstrip("/")
         if not self.headroom_api_base:
             raise ValueError(
                 "Headroom guardrail requires an API base URL. "
@@ -143,7 +150,9 @@ class HeadroomGuardrail(CustomGuardrail):
             return inputs
 
         if self._should_bypass(request_data):
-            verbose_proxy_logger.debug("Headroom: %s header set; skipping compression", BYPASS_HEADER)
+            verbose_proxy_logger.debug(
+                "Headroom: %s header set; skipping compression", BYPASS_HEADER
+            )
             return inputs
 
         structured_messages = inputs.get("structured_messages")

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -167,17 +167,26 @@ class HeadroomGuardrail(CustomGuardrail):
         input_type: Literal["request", "response"],
         logging_obj: LiteLLMLoggingObj | None = None,
     ) -> GenericGuardrailAPIInputs:
+        verbose_proxy_logger.info(
+            "Headroom guardrail apply_guardrail called: input_type=%s has_structured_messages=%s",
+            input_type,
+            inputs.get("structured_messages") is not None,
+        )
         if input_type != "request":
+            verbose_proxy_logger.info("Headroom: skipping (response type)")
             return inputs
 
         if self._should_bypass(request_data):
-            verbose_proxy_logger.debug(
+            verbose_proxy_logger.info(
                 "Headroom: %s header set; skipping compression", BYPASS_HEADER
             )
             return inputs
 
         structured_messages = inputs.get("structured_messages")
         if not _is_object_list(structured_messages) or not structured_messages:
+            verbose_proxy_logger.info(
+                "Headroom: no structured_messages in inputs; skipping compression"
+            )
             return inputs
 
         messages = [m for m in structured_messages if _is_str_object_dict(m)]

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -169,7 +169,10 @@ class HeadroomGuardrail(CustomGuardrail):
     ) -> GenericGuardrailAPIInputs:
         print(
             f"[headroom] apply_guardrail called: input_type={input_type} "
-            f"has_structured_messages={inputs.get('structured_messages') is not None}",
+            f"has_structured_messages={inputs.get('structured_messages') is not None} "
+            f"request_data_keys={list(request_data.keys())[:10]} "
+            f"has_metadata={'metadata' in request_data} "
+            f"has_litellm_metadata={'litellm_metadata' in request_data}",
             flush=True,
         )
         if input_type != "request":

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -74,7 +74,7 @@ class HeadroomGuardrail(CustomGuardrail):
         headers = psr.get("headers")
         if not _is_str_object_dict(headers):
             return False
-        value = headers.get(BYPASS_HEADER) or headers.get(BYPASS_HEADER.lower())
+        value = headers.get(BYPASS_HEADER)
         return str(value).lower() == "true"
 
     async def _call_compress(
@@ -121,13 +121,22 @@ class HeadroomGuardrail(CustomGuardrail):
                 },
             )
 
-        body: object = response.json()
+        try:
+            body: object = response.json()
+        except Exception:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned non-JSON response",
+                    "body": response.text[:500],
+                },
+            )
         if not _is_str_object_dict(body):
             raise HTTPException(
                 status_code=502,
                 detail={
                     "error": "Headroom compression service returned unexpected response shape",
-                    "body": response.text,
+                    "body": response.text[:500],
                 },
             )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Literal, Optional, Type, Union
+from typing import TYPE_CHECKING, Literal
 
 from fastapi import HTTPException
 from httpx import Response as HttpxResponse
@@ -37,13 +37,14 @@ def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isin
 class HeadroomGuardrail(CustomGuardrail):
     def __init__(
         self,
-        api_base: Optional[str] = None,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None,
-        guardrail_name: Optional[str] = None,
-        event_hook: Optional[
-            Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]
-        ] = None,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        guardrail_name: str | None = None,
+        event_hook: GuardrailEventHooks
+        | list[GuardrailEventHooks]
+        | Mode
+        | None = None,
         default_on: bool = False,
     ):
         self.headroom_api_base = (
@@ -77,9 +78,9 @@ class HeadroomGuardrail(CustomGuardrail):
 
     async def _call_compress(
         self,
-        messages: List[dict[str, object]],
-        model: Optional[str],
-    ) -> List[dict[str, object]]:
+        messages: list[dict[str, object]],
+        model: str | None,
+    ) -> list[dict[str, object]]:
         payload: dict[str, object] = {"messages": messages}
         if model:
             payload["model"] = model
@@ -88,7 +89,7 @@ class HeadroomGuardrail(CustomGuardrail):
         if self.headroom_api_key:
             request_headers["Authorization"] = f"Bearer {self.headroom_api_key}"
 
-        raw_response: Optional[HttpxResponse] = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
+        raw_response: HttpxResponse | None = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
             url=f"{self.headroom_api_base}/v1/compress",
             json=payload,
             headers=request_headers,
@@ -144,7 +145,7 @@ class HeadroomGuardrail(CustomGuardrail):
         inputs: GenericGuardrailAPIInputs,
         request_data: dict,
         input_type: Literal["request", "response"],
-        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+        logging_obj: LiteLLMLoggingObj | None = None,
     ) -> GenericGuardrailAPIInputs:
         if input_type != "request":
             return inputs
@@ -172,7 +173,7 @@ class HeadroomGuardrail(CustomGuardrail):
         return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
 
     @staticmethod
-    def get_config_model() -> Optional[Type["GuardrailConfigModel[object]"]]:
+    def get_config_model() -> type[GuardrailConfigModel[object]] | None:
         from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
             HeadroomGuardrailConfigModel,
         )

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -131,13 +131,23 @@ class HeadroomGuardrail(CustomGuardrail):
                 },
             )
 
+        filtered = [item for item in compressed_messages if _is_str_object_dict(item)]
+        if not filtered:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned empty message list",
+                    "body": response.text,
+                },
+            )
+
         verbose_proxy_logger.debug(
             "Headroom: compressed %s tokens -> %s tokens (ratio %.2f)",
             body.get("tokens_before", "?"),
             body.get("tokens_after", "?"),
             body.get("compression_ratio", 0),
         )
-        return [item for item in compressed_messages if _is_str_object_dict(item)]
+        return filtered
 
     @log_guardrail_information
     async def apply_guardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -167,26 +167,22 @@ class HeadroomGuardrail(CustomGuardrail):
         input_type: Literal["request", "response"],
         logging_obj: LiteLLMLoggingObj | None = None,
     ) -> GenericGuardrailAPIInputs:
-        verbose_proxy_logger.info(
-            "Headroom guardrail apply_guardrail called: input_type=%s has_structured_messages=%s",
-            input_type,
-            inputs.get("structured_messages") is not None,
+        print(
+            f"[headroom] apply_guardrail called: input_type={input_type} "
+            f"has_structured_messages={inputs.get('structured_messages') is not None}",
+            flush=True,
         )
         if input_type != "request":
-            verbose_proxy_logger.info("Headroom: skipping (response type)")
+            print("[headroom] skipping (response type)", flush=True)
             return inputs
 
         if self._should_bypass(request_data):
-            verbose_proxy_logger.info(
-                "Headroom: %s header set; skipping compression", BYPASS_HEADER
-            )
+            print(f"[headroom] {BYPASS_HEADER} set; skipping compression", flush=True)
             return inputs
 
         structured_messages = inputs.get("structured_messages")
         if not _is_object_list(structured_messages) or not structured_messages:
-            verbose_proxy_logger.info(
-                "Headroom: no structured_messages in inputs; skipping compression"
-            )
+            print("[headroom] no structured_messages in inputs; skipping", flush=True)
             return inputs
 
         messages = [m for m in structured_messages if _is_str_object_dict(m)]

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Literal, Optional, Type, Union
+
+from fastapi import HTTPException
+from httpx import Response as HttpxResponse
+from typing_extensions import TypeGuard
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]
+    httpxSpecialProvider,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.guardrails import GuardrailEventHooks, Mode
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
+
+BYPASS_HEADER = "x-headroom-bypass"
+
+
+def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, dict)
+
+
+def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, list)
+
+
+class HeadroomGuardrail(CustomGuardrail):
+    def __init__(
+        self,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        guardrail_name: Optional[str] = None,
+        event_hook: Optional[Union[GuardrailEventHooks, List[GuardrailEventHooks], Mode]] = None,
+        default_on: bool = False,
+    ):
+        self.headroom_api_base = (api_base or get_secret_str("HEADROOM_API_BASE") or "").rstrip("/")
+        if not self.headroom_api_base:
+            raise ValueError(
+                "Headroom guardrail requires an API base URL. "
+                "Set `api_base` in the guardrail config or HEADROOM_API_BASE env var."
+            )
+        self.headroom_api_key = api_key or get_secret_str("HEADROOM_API_KEY")
+        self.headroom_model = model
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback,
+        )
+        super().__init__(  # pyright: ignore[reportUnknownMemberType]
+            guardrail_name=guardrail_name,
+            event_hook=event_hook,
+            default_on=default_on,
+        )
+
+    def _should_bypass(self, request_data: dict) -> bool:
+        psr = request_data.get("proxy_server_request")
+        if not _is_str_object_dict(psr):
+            return False
+        headers = psr.get("headers")
+        if not _is_str_object_dict(headers):
+            return False
+        value = headers.get(BYPASS_HEADER) or headers.get(BYPASS_HEADER.lower())
+        return str(value).lower() == "true"
+
+    async def _call_compress(
+        self,
+        messages: List[dict[str, object]],
+        model: Optional[str],
+    ) -> List[dict[str, object]]:
+        payload: dict[str, object] = {"messages": messages}
+        if model:
+            payload["model"] = model
+
+        request_headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.headroom_api_key:
+            request_headers["Authorization"] = f"Bearer {self.headroom_api_key}"
+
+        raw_response: Optional[HttpxResponse] = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
+            url=f"{self.headroom_api_base}/v1/compress",
+            json=payload,
+            headers=request_headers,
+        )
+        if raw_response is None:
+            raise HTTPException(
+                status_code=502,
+                detail={"error": "Headroom compression service returned no response"},
+            )
+        response: HttpxResponse = raw_response
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned an error",
+                    "status_code": response.status_code,
+                    "body": response.text,
+                },
+            )
+
+        body: object = response.json()
+        if not _is_str_object_dict(body):
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service returned unexpected response shape",
+                    "body": response.text,
+                },
+            )
+
+        compressed_messages = body.get("messages")
+        if not _is_object_list(compressed_messages):
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service response missing 'messages'",
+                    "body": response.text,
+                },
+            )
+
+        verbose_proxy_logger.debug(
+            "Headroom: compressed %s tokens -> %s tokens (ratio %.2f)",
+            body.get("tokens_before", "?"),
+            body.get("tokens_after", "?"),
+            body.get("compression_ratio", 0),
+        )
+        return [item for item in compressed_messages if _is_str_object_dict(item)]
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> GenericGuardrailAPIInputs:
+        if input_type != "request":
+            return inputs
+
+        if self._should_bypass(request_data):
+            verbose_proxy_logger.debug("Headroom: %s header set; skipping compression", BYPASS_HEADER)
+            return inputs
+
+        structured_messages = inputs.get("structured_messages")
+        if not _is_object_list(structured_messages) or not structured_messages:
+            return inputs
+
+        messages = [m for m in structured_messages if _is_str_object_dict(m)]
+        if not messages:
+            return inputs
+
+        model = self.headroom_model or request_data.get("model")
+        compressed = await self._call_compress(
+            messages=messages,
+            model=model if isinstance(model, str) else None,
+        )
+
+        return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
+
+    @staticmethod
+    def get_config_model() -> Optional[Type["GuardrailConfigModel[object]"]]:
+        from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
+            HeadroomGuardrailConfigModel,
+        )
+
+        return HeadroomGuardrailConfigModel

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
+import httpx
 from fastapi import HTTPException
 from httpx import Response as HttpxResponse
 from typing_extensions import TypeGuard
@@ -89,11 +90,20 @@ class HeadroomGuardrail(CustomGuardrail):
         if self.headroom_api_key:
             request_headers["Authorization"] = f"Bearer {self.headroom_api_key}"
 
-        raw_response: HttpxResponse | None = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
-            url=f"{self.headroom_api_base}/v1/compress",
-            json=payload,
-            headers=request_headers,
-        )
+        try:
+            raw_response: HttpxResponse | None = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
+                url=f"{self.headroom_api_base}/v1/compress",
+                json=payload,
+                headers=request_headers,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError) as e:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "Headroom compression service unreachable",
+                    "detail": str(e),
+                },
+            ) from e
         if raw_response is None:
             raise HTTPException(
                 status_code=502,

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -7,7 +7,7 @@ from httpx import Response as HttpxResponse
 from typing_extensions import TypeGuard
 
 from litellm._logging import verbose_proxy_logger
-from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.integrations.custom_guardrail import CustomGuardrail, log_guardrail_information
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]
     httpxSpecialProvider,
@@ -131,6 +131,7 @@ class HeadroomGuardrail(CustomGuardrail):
         )
         return [item for item in compressed_messages if _is_str_object_dict(item)]
 
+    @log_guardrail_information
     async def apply_guardrail(
         self,
         inputs: GenericGuardrailAPIInputs,

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -167,25 +167,17 @@ class HeadroomGuardrail(CustomGuardrail):
         input_type: Literal["request", "response"],
         logging_obj: LiteLLMLoggingObj | None = None,
     ) -> GenericGuardrailAPIInputs:
-        print(
-            f"[headroom] apply_guardrail called: input_type={input_type} "
-            f"has_structured_messages={inputs.get('structured_messages') is not None} "
-            f"request_data_keys={list(request_data.keys())[:10]} "
-            f"has_metadata={'metadata' in request_data} "
-            f"has_litellm_metadata={'litellm_metadata' in request_data}",
-            flush=True,
-        )
         if input_type != "request":
-            print("[headroom] skipping (response type)", flush=True)
             return inputs
 
         if self._should_bypass(request_data):
-            print(f"[headroom] {BYPASS_HEADER} set; skipping compression", flush=True)
+            verbose_proxy_logger.debug(
+                "Headroom: %s header set; skipping compression", BYPASS_HEADER
+            )
             return inputs
 
         structured_messages = inputs.get("structured_messages")
         if not _is_object_list(structured_messages) or not structured_messages:
-            print("[headroom] no structured_messages in inputs; skipping", flush=True)
             return inputs
 
         messages = [m for m in structured_messages if _is_str_object_dict(m)]

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -53,6 +53,9 @@ from litellm.types.proxy.guardrails.guardrail_hooks.vigil_guard import (
 from litellm.types.proxy.guardrails.guardrail_hooks.cisco_ai_defense import (
     CiscoAIDefenseGuardrailConfigModel,
 )
+from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
+    HeadroomGuardrailConfigModel,
+)
 
 """
 Pydantic object defining how to set guardrails on litellm proxy
@@ -119,6 +122,7 @@ class SupportedGuardrailIntegrations(Enum):
     RUBRIK = "rubrik"
     VIGIL_GUARD = "vigil_guard"
     REPELLOAI = "repelloai"
+    HEADROOM = "headroom"
 
 
 class Role(Enum):
@@ -860,6 +864,7 @@ class LitellmParams(
     PresidioConfigModel,
     BedrockGuardrailConfigModel,
     LakeraV2GuardrailConfigModel,
+    HeadroomGuardrailConfigModel,
     RepelloAIGuardrailConfigModel,
     LassoGuardrailConfigModel,
     PillarGuardrailConfigModel,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/headroom.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/headroom.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from .base import GuardrailConfigModel
+
+
+class HeadroomGuardrailConfigModel(GuardrailConfigModel[BaseModel]):
+    api_base: Optional[str] = Field(
+        default=None,
+        description="Base URL for the headroom compression service (e.g. https://api.headroom.ai). Falls back to HEADROOM_API_BASE env var.",
+    )
+    api_key: Optional[str] = Field(
+        default=None,
+        description="API key for the headroom compression service. Falls back to HEADROOM_API_KEY env var.",
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="Model name forwarded to the headroom /v1/compress endpoint.",
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Headroom"

--- a/tests/test_litellm/integrations/test_guardrail_logging_sync.py
+++ b/tests/test_litellm/integrations/test_guardrail_logging_sync.py
@@ -1,0 +1,124 @@
+"""
+Regression test for _sync_guardrail_info_to_logging_obj.
+
+Ensures that when the @log_guardrail_information decorator writes guardrail info
+to request_data["litellm_metadata"] (as it does for /v1/messages passthrough
+routes that have no "metadata" key), the helper propagates it into
+logging_obj.litellm_params["metadata"] so merge_litellm_metadata surfaces it in
+spend logs.
+"""
+
+import pytest
+from litellm.integrations.custom_guardrail import _sync_guardrail_info_to_logging_obj
+
+
+def _make_slg_entry(name: str = "headroom-test") -> dict:
+    return {
+        "guardrail_name": name,
+        "guardrail_response": "mask",
+        "guardrail_status": "success",
+        "duration": 0.1,
+    }
+
+
+class _FakeLogging:
+    """Minimal stand-in for litellm.litellm_core_utils.litellm_logging.Logging."""
+
+    def __init__(self, lp_metadata: dict | None = None):
+        self.litellm_params: dict = {"metadata": lp_metadata or {}}
+        self.model_call_details: dict = {"litellm_params": self.litellm_params}
+
+
+def test_syncs_from_litellm_metadata_key():
+    """When guardrail info is in request_data["litellm_metadata"], it is copied."""
+    entry = _make_slg_entry()
+    request_data = {
+        "litellm_metadata": {"standard_logging_guardrail_information": [entry]}
+    }
+    logging_obj = _FakeLogging()
+
+    _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+
+    result = logging_obj.litellm_params["metadata"].get(
+        "standard_logging_guardrail_information"
+    )
+    assert result == [entry]
+
+
+def test_syncs_from_metadata_key():
+    """When guardrail info is in request_data["metadata"], it is also copied."""
+    entry = _make_slg_entry()
+    request_data = {"metadata": {"standard_logging_guardrail_information": [entry]}}
+    logging_obj = _FakeLogging()
+
+    _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+
+    result = logging_obj.litellm_params["metadata"].get(
+        "standard_logging_guardrail_information"
+    )
+    assert result == [entry]
+
+
+def test_metadata_wins_over_litellm_metadata():
+    """metadata key takes precedence over litellm_metadata when both are present."""
+    entry_meta = _make_slg_entry("from-metadata")
+    entry_lm = _make_slg_entry("from-litellm_metadata")
+    request_data = {
+        "metadata": {"standard_logging_guardrail_information": [entry_meta]},
+        "litellm_metadata": {"standard_logging_guardrail_information": [entry_lm]},
+    }
+    logging_obj = _FakeLogging()
+
+    _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+
+    result = logging_obj.litellm_params["metadata"].get(
+        "standard_logging_guardrail_information"
+    )
+    assert result == [entry_meta]
+
+
+def test_noop_when_no_guardrail_info():
+    """Does nothing when standard_logging_guardrail_information is absent."""
+    request_data = {"litellm_metadata": {"other_key": "value"}}
+    logging_obj = _FakeLogging()
+
+    _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+
+    assert (
+        logging_obj.litellm_params["metadata"].get(
+            "standard_logging_guardrail_information"
+        )
+        is None
+    )
+
+
+def test_noop_when_logging_obj_is_none():
+    """Does nothing when logging_obj is None."""
+    entry = _make_slg_entry()
+    request_data = {
+        "litellm_metadata": {"standard_logging_guardrail_information": [entry]}
+    }
+    _sync_guardrail_info_to_logging_obj(request_data, None)
+
+
+def test_writes_to_model_call_details_too():
+    """Also writes into model_call_details["litellm_params"]["metadata"]."""
+    entry = _make_slg_entry()
+    request_data = {
+        "litellm_metadata": {"standard_logging_guardrail_information": [entry]}
+    }
+
+    logging_obj = _FakeLogging()
+    # Simulate litellm_params reassignment (creating a new dict) — model_call_details
+    # then points to the OLD dict while litellm_params points to the new one.
+    old_lp = logging_obj.litellm_params
+    logging_obj.litellm_params = {**old_lp, "extra": "added"}
+    logging_obj.model_call_details["litellm_params"] = old_lp  # diverged
+
+    _sync_guardrail_info_to_logging_obj(request_data, logging_obj)
+
+    # Both dicts should have the info.
+    assert logging_obj.litellm_params["metadata"].get(
+        "standard_logging_guardrail_information"
+    ) == [entry]
+    assert old_lp["metadata"].get("standard_logging_guardrail_information") == [entry]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -73,7 +73,12 @@ async def test_apply_guardrail_compresses_and_returns_structured_messages(
     )
     mock_response = _make_compress_response(COMPRESSED_MESSAGES)
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={"model": "gpt-4o"},
@@ -93,7 +98,9 @@ async def test_apply_guardrail_bypass_header_skips_compression(
     )
     request_data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "true"}}}
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+    with patch.object(
+        guardrail.async_handler, "post", new_callable=AsyncMock
+    ) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data=request_data,
@@ -113,7 +120,9 @@ async def test_apply_guardrail_response_type_passthrough(
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+    with patch.object(
+        guardrail.async_handler, "post", new_callable=AsyncMock
+    ) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={},
@@ -130,7 +139,9 @@ async def test_apply_guardrail_empty_structured_messages_passthrough(
 ):
     inputs = GenericGuardrailAPIInputs(texts=["hello"])
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+    with patch.object(
+        guardrail.async_handler, "post", new_callable=AsyncMock
+    ) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={},
@@ -152,7 +163,12 @@ async def test_apply_guardrail_http_error_raises():
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await guardrail.apply_guardrail(
                 inputs=inputs,
@@ -176,7 +192,12 @@ async def test_apply_guardrail_missing_messages_key_raises():
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
         with pytest.raises(HTTPException) as exc_info:
             await guardrail.apply_guardrail(
                 inputs=inputs,
@@ -185,6 +206,41 @@ async def test_apply_guardrail_missing_messages_key_raises():
             )
 
     assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_compressed_messages_raises():
+    guardrail = _make_guardrail()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "messages": ["not-a-dict", 42, None],
+        "tokens_before": 1000,
+        "tokens_after": 0,
+        "compression_ratio": 0,
+    }
+    mock_response.text = "{}"
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert "empty message list" in str(exc_info.value.detail)
 
 
 def test_init_raises_without_api_base():
@@ -196,7 +252,9 @@ def test_bypass_header_case_insensitive():
     guardrail = _make_guardrail()
 
     for header_value in ("true", "True", "TRUE"):
-        data = {"proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}}
+        data = {
+            "proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}
+        }
         assert guardrail._should_bypass(data) is True
 
     data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "false"}}}
@@ -219,7 +277,12 @@ async def test_apply_guardrail_sends_model_from_config():
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
         await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={"model": "gpt-4o"},
@@ -241,7 +304,12 @@ async def test_apply_guardrail_sends_model_from_request_data_when_no_config_mode
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
         await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={"model": "gpt-4o"},

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1,0 +1,253 @@
+"""
+Unit tests for the Headroom guardrail.
+
+Tests cover:
+- apply_guardrail compresses messages via /v1/compress and returns them as structured_messages
+- x-headroom-bypass: true header causes guardrail to skip compression
+- missing or empty messages are passed through unchanged
+- response-type input is passed through unchanged
+- /v1/compress HTTP error raises HTTPException
+- /v1/compress returning malformed JSON raises HTTPException
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import HeadroomGuardrail
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+
+FAKE_API_BASE = "https://headroom.example.com"
+FAKE_API_KEY = "test-key"
+
+ORIGINAL_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "A" * 5000},
+]
+COMPRESSED_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "A" * 500},
+]
+
+
+def _make_guardrail(**kwargs) -> HeadroomGuardrail:
+    defaults = dict(
+        api_base=FAKE_API_BASE,
+        api_key=FAKE_API_KEY,
+        guardrail_name="headroom",
+        default_on=True,
+    )
+    defaults.update(kwargs)
+    return HeadroomGuardrail(**defaults)
+
+
+def _make_compress_response(messages: list, status: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status
+    mock.json.return_value = {
+        "messages": messages,
+        "tokens_before": 1000,
+        "tokens_after": 100,
+        "compression_ratio": 0.1,
+        "transforms_applied": ["router:smart_crusher:0.35"],
+    }
+    mock.text = ""
+    return mock
+
+
+@pytest.fixture
+def guardrail() -> HeadroomGuardrail:
+    return _make_guardrail()
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_compresses_and_returns_structured_messages(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    assert result.get("structured_messages") == COMPRESSED_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_bypass_header_skips_compression(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    request_data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "true"}}}
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+        mock_post.assert_not_called()
+
+    assert result.get("structured_messages") == ORIGINAL_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_response_type_passthrough(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["some response text"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={},
+            input_type="response",
+        )
+        mock_post.assert_not_called()
+
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_empty_structured_messages_passthrough(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(texts=["hello"])
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={},
+            input_type="request",
+        )
+        mock_post.assert_not_called()
+
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_http_error_raises():
+    guardrail = _make_guardrail()
+    mock_response = _make_compress_response([], status=500)
+    mock_response.text = "Internal Server Error"
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_missing_messages_key_raises():
+    guardrail = _make_guardrail()
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"tokens_before": 100, "tokens_after": 10}
+    mock_response.text = "{}"
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+
+
+def test_init_raises_without_api_base():
+    with pytest.raises(ValueError, match="API base URL"):
+        HeadroomGuardrail(api_base=None)
+
+
+def test_bypass_header_case_insensitive():
+    guardrail = _make_guardrail()
+
+    for header_value in ("true", "True", "TRUE"):
+        data = {"proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}}
+        assert guardrail._should_bypass(data) is True
+
+    data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "false"}}}
+    assert guardrail._should_bypass(data) is False
+
+    data = {"proxy_server_request": {"headers": {}}}
+    assert guardrail._should_bypass(data) is False
+
+    data = {}
+    assert guardrail._should_bypass(data) is False
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_model_from_config():
+    guardrail = _make_guardrail(model="gpt-4o-mini")
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    call_kwargs = mock_post.call_args
+    sent_payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert sent_payload.get("model") == "gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_model_from_request_data_when_no_config_model():
+    guardrail = _make_guardrail()
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock, return_value=mock_response) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    call_kwargs = mock_post.call_args
+    sent_payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
+    assert sent_payload.get("model") == "gpt-4o"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -10,15 +10,14 @@ Tests cover:
 - /v1/compress returning malformed JSON raises HTTPException
 """
 
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
 from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import HeadroomGuardrail
 from litellm.types.utils import GenericGuardrailAPIInputs
-
 
 FAKE_API_BASE = "https://headroom.example.com"
 FAKE_API_KEY = "test-key"
@@ -177,6 +176,32 @@ async def test_apply_guardrail_http_error_raises():
             )
 
     assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_transport_error_raises():
+    guardrail = _make_guardrail()
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=httpx.ConnectError("Connection refused"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert "unreachable" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
@@ -1,0 +1,124 @@
+"""
+Tests that when apply_guardrail returns structured_messages, both OpenAI and Anthropic
+translation handlers write them back to data["messages"] correctly.
+
+For OpenAI: structured_messages (OpenAI format) written directly to data["messages"].
+For Anthropic: structured_messages (OpenAI format) converted back to Anthropic format
+              via anthropic_messages_pt before writing to data["messages"].
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.llms.openai.chat.guardrail_translation.handler import (
+    OpenAIChatCompletionsHandler,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+
+ORIGINAL_MESSAGES = [
+    {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "A" * 5000},
+]
+COMPRESSED_MESSAGES = [
+    {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "A" * 200},
+]
+
+
+def _make_guardrail_returning_structured_messages(compressed: list) -> MagicMock:
+    guardrail = MagicMock()
+    guardrail.should_run_guardrail.return_value = True
+    guardrail.skip_system_message_in_guardrail = None
+    guardrail.skip_tool_message_in_guardrail = None
+    guardrail.experimental_use_latest_role_message_only = False
+
+    async def apply_guardrail(inputs, request_data, input_type, logging_obj=None):
+        result = dict(inputs)
+        result["structured_messages"] = compressed
+        return result
+
+    guardrail.apply_guardrail = apply_guardrail
+    return guardrail
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_writes_structured_messages_back():
+    handler = OpenAIChatCompletionsHandler()
+    guardrail = _make_guardrail_returning_structured_messages(COMPRESSED_MESSAGES)
+
+    data = {
+        "model": "gpt-4o",
+        "messages": ORIGINAL_MESSAGES,
+    }
+    result = await handler.process_input_messages(
+        data=data,
+        guardrail_to_apply=guardrail,
+    )
+
+    assert result["messages"] == COMPRESSED_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_openai_handler_uses_text_patchback_when_no_structured_messages():
+    handler = OpenAIChatCompletionsHandler()
+
+    guardrail = MagicMock()
+    guardrail.should_run_guardrail.return_value = True
+    guardrail.skip_system_message_in_guardrail = None
+    guardrail.skip_tool_message_in_guardrail = None
+    guardrail.experimental_use_latest_role_message_only = False
+
+    original_text = "hello world"
+    modified_text = "HELLO WORLD"
+    messages = [{"role": "user", "content": original_text}]
+
+    async def apply_guardrail(inputs, request_data, input_type, logging_obj=None):
+        return GenericGuardrailAPIInputs(texts=[modified_text])
+
+    guardrail.apply_guardrail = apply_guardrail
+
+    data = {"model": "gpt-4o", "messages": messages}
+    result = await handler.process_input_messages(
+        data=data,
+        guardrail_to_apply=guardrail,
+    )
+
+    assert result["messages"][0]["content"] == modified_text
+
+
+@pytest.mark.asyncio
+async def test_anthropic_handler_converts_structured_messages_to_anthropic_format():
+    from litellm.llms.anthropic.chat.guardrail_translation.handler import (
+        AnthropicMessagesHandler,
+    )
+
+    handler = AnthropicMessagesHandler()
+    guardrail = _make_guardrail_returning_structured_messages(COMPRESSED_MESSAGES)
+
+    anthropic_messages = [{"role": "user", "content": [{"type": "text", "text": "A" * 5000}]}]
+    data = {
+        "model": "claude-3-5-sonnet-20241022",
+        "messages": anthropic_messages,
+        "max_tokens": 1024,
+    }
+
+    converted_back = [{"role": "user", "content": [{"type": "text", "text": "A" * 200}]}]
+
+    with patch(
+        "litellm.litellm_core_utils.prompt_templates.factory.anthropic_messages_pt",
+        return_value=converted_back,
+    ) as mock_pt:
+        result = await handler.process_input_messages(
+            data=data,
+            guardrail_to_apply=guardrail,
+        )
+
+    mock_pt.assert_called_once_with(
+        messages=COMPRESSED_MESSAGES,
+        model="claude-3-5-sonnet-20241022",
+        llm_provider="anthropic",
+    )
+    assert result["messages"] == converted_back

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py
@@ -7,8 +7,7 @@ For Anthropic: structured_messages (OpenAI format) converted back to Anthropic f
               via anthropic_messages_pt before writing to data["messages"].
 """
 
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,13 +16,15 @@ from litellm.llms.openai.chat.guardrail_translation.handler import (
 )
 from litellm.types.utils import GenericGuardrailAPIInputs
 
-
 ORIGINAL_MESSAGES = [
     {"role": "system", "content": "Be concise."},
     {"role": "user", "content": "A" * 5000},
 ]
 COMPRESSED_MESSAGES = [
     {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "A" * 200},
+]
+COMPRESSED_MESSAGES_NON_SYSTEM = [
     {"role": "user", "content": "A" * 200},
 ]
 
@@ -98,14 +99,18 @@ async def test_anthropic_handler_converts_structured_messages_to_anthropic_forma
     handler = AnthropicMessagesHandler()
     guardrail = _make_guardrail_returning_structured_messages(COMPRESSED_MESSAGES)
 
-    anthropic_messages = [{"role": "user", "content": [{"type": "text", "text": "A" * 5000}]}]
+    anthropic_messages = [
+        {"role": "user", "content": [{"type": "text", "text": "A" * 5000}]}
+    ]
     data = {
         "model": "claude-3-5-sonnet-20241022",
         "messages": anthropic_messages,
         "max_tokens": 1024,
     }
 
-    converted_back = [{"role": "user", "content": [{"type": "text", "text": "A" * 200}]}]
+    converted_back = [
+        {"role": "user", "content": [{"type": "text", "text": "A" * 200}]}
+    ]
 
     with patch(
         "litellm.litellm_core_utils.prompt_templates.factory.anthropic_messages_pt",
@@ -117,7 +122,7 @@ async def test_anthropic_handler_converts_structured_messages_to_anthropic_forma
         )
 
     mock_pt.assert_called_once_with(
-        messages=COMPRESSED_MESSAGES,
+        messages=COMPRESSED_MESSAGES_NON_SYSTEM,
         model="claude-3-5-sonnet-20241022",
         llm_provider="anthropic",
     )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

End-to-end trace on a live proxy with real DB confirmed the full chain works:

```
[headroom] apply_guardrail called: input_type=request has_structured_messages=True
[headroom-propagate] slg_info=True logging_obj_type=Logging
[SLP] slg_in_metadata=True
[PAYLOAD] guardrail_information=True  ← written to DB
```

To test: run the proxy with a config that includes the headroom guardrail (with `default_on: true` or via key metadata), send a `/v1/messages` request, and verify `guardrail_information` is non-null in the spend log.

## Type

🆕 New Feature + 🐛 Bug Fixes

## Changes

**Core feature: headroom guardrail for message compression**

Adds a new `headroom` guardrail type that compresses request messages via `POST /v1/compress` on a configurable headroom service before they reach the LLM. Useful for reducing token costs on long-context conversations.

Config:
```yaml
guardrails:
  - guardrail_name: headroom-compression
    litellm_params:
      guardrail: headroom
      mode: pre_call
      api_base: https://your-headroom-service/
      default_on: true
```

Key behaviors:
- Runs on the unified guardrail path via `apply_guardrail`, works for both `/v1/chat/completions` and `/v1/messages`
- `x-headroom-bypass: true` request header skips compression
- Model forwarded to headroom can be set in config or falls back to the request model
- API key and base URL configurable via `api_key`/`api_base` in guardrail config or `HEADROOM_API_KEY`/`HEADROOM_API_BASE` env vars
- Raises 502 if compression service returns an empty message list or is unreachable
- Decorated with `@log_guardrail_information` so `guardrail_information` is populated in spend logs

**Bug fixes made during development:**

`structured_messages` write-back regression: the unified guardrail handler for both OpenAI and Anthropic paths was unconditionally writing back `structured_messages` even when the guardrail returned inputs unchanged. This clobbered `data["messages"]` with a filtered copy (e.g. skip-system filtered messages). Fixed with an identity check — only write back when the guardrail actually returned a new object.

`anthropic_messages_pt` crash on system messages with cache_control: `translate_anthropic_to_openai` preserves system messages with list content (cache_control blocks) as-is. `anthropic_messages_pt` rejects these. Fixed by stripping system messages before the reverse-translation call — they live in `data["system"]` in the Anthropic passthrough path, not `data["messages"]`.

`thinking.cache_control` rejected by Anthropic: the `prompt-caching-scope` beta adds `cache_control` to all content blocks including `thinking` blocks, which Anthropic rejects. Fixed by stripping `cache_control` from `thinking` type content blocks after the reverse-translation.

`guardrail_information` null in spend logs for `/v1/messages`: multiple root causes tracked down and fixed. The `@log_guardrail_information` decorator writes to `request_data["metadata"]` or `request_data["litellm_metadata"]` depending on which key is present. The spend log is built from `litellm_params["metadata"]` via `merge_litellm_metadata`. For `/v1/messages`, `data` only has `litellm_metadata` (no `metadata` key), and `Logging.litellm_params` gets reassigned during the request (creating a new dict that diverges from `model_call_details["litellm_params"]`). Fix: after `apply_guardrail` returns, explicitly copy the guardrail info from whichever metadata key it was written to, into both `logging_obj.litellm_params["metadata"]` and `logging_obj.model_call_details["litellm_params"]["metadata"]`.

New files:
- `litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py`
- `litellm/proxy/guardrails/guardrail_hooks/headroom/__init__.py`
- `litellm/types/proxy/guardrails/guardrail_hooks/headroom.py`
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py`
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_structured_messages_writeback.py`