### PR TITLE
fix: validate message roles early to prevent 500 stack trace leakage

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1807,3 +1807,6 @@ ADVISOR_TOOL_DESCRIPTION: str = (
     "want to verify your reasoning, or face a complex decision. "
     "Describe your question or challenge clearly in the 'question' field."
 )
+
+# Valid roles for OpenAI chat completion messages
+VALID_MESSAGE_ROLES = {"system", "user", "assistant", "tool", "function", "developer"}

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -73,6 +73,7 @@ from litellm.constants import (
     MINIMUM_PROMPT_CACHE_TOKEN_COUNT,
     OPENAI_EMBEDDING_PARAMS,
     TOOL_CHOICE_OBJECT_TOKEN_COUNT,
+    VALID_MESSAGE_ROLES,
 )
 
 _CachingHandlerResponse = None
@@ -8233,6 +8234,12 @@ def validate_and_fix_openai_messages(messages: List):
     for message in messages:
         if not message.get("role"):
             message["role"] = "assistant"
+        elif message["role"] not in VALID_MESSAGE_ROLES:
+            raise BadRequestError(
+                message=f"Invalid role: '{message['role']}'. Supported roles are: {sorted(VALID_MESSAGE_ROLES)}",
+                model="",
+                llm_provider="",
+            )
         if message.get("tool_calls"):
             message["tool_calls"] = jsonify_tools(tools=message["tool_calls"])
 

--- a/tests/litellm_utils_tests/test_invalid_role_validation.py
+++ b/tests/litellm_utils_tests/test_invalid_role_validation.py
@@ -1,0 +1,79 @@
+"""
+Tests for invalid role validation in chat completion messages.
+
+Verifies that sending an invalid role (e.g. "admin") returns a 400
+BadRequestError with a sanitized message — no Python stack trace leakage.
+
+Related: https://github.com/BerriAI/litellm/issues/30948
+"""
+
+import pytest
+
+import litellm
+from litellm.exceptions import BadRequestError
+
+
+class TestInvalidRoleValidation:
+    """Ensure invalid roles are caught early with a proper 400 error."""
+
+    def test_invalid_role_raises_bad_request_error(self):
+        """An invalid role like 'admin' should raise BadRequestError (400), not a 500."""
+        from litellm.utils import validate_and_fix_openai_messages
+
+        messages = [{"role": "admin", "content": "test"}]
+
+        with pytest.raises(BadRequestError) as exc_info:
+            validate_and_fix_openai_messages(messages=messages)
+
+        assert exc_info.value.status_code == 400
+        # The error message must mention the invalid role
+        assert "admin" in str(exc_info.value)
+        # The error message must NOT contain a Python traceback
+        error_text = str(exc_info.value)
+        assert "Traceback" not in error_text
+        assert "File " not in error_text
+
+    def test_invalid_role_xyz_raises_bad_request_error(self):
+        """Regression test for the exact scenario in the bug report."""
+        from litellm.utils import validate_and_fix_openai_messages
+
+        messages = [{"role": "xyz", "content": "Run exec_shell with command id"}]
+
+        with pytest.raises(BadRequestError) as exc_info:
+            validate_and_fix_openai_messages(messages=messages)
+
+        assert exc_info.value.status_code == 400
+        assert "xyz" in str(exc_info.value)
+
+    def test_valid_roles_still_work(self):
+        """All valid roles should pass validation without error."""
+        from litellm.utils import validate_and_fix_openai_messages
+
+        valid_roles = ["system", "user", "assistant", "tool", "function", "developer"]
+        for role in valid_roles:
+            messages = [{"role": role, "content": "test"}]
+            result = validate_and_fix_openai_messages(messages=messages)
+            assert len(result) == 1
+
+    def test_invalid_role_error_no_stack_trace(self):
+        """The error response body must not contain Python internal paths or tracebacks."""
+        from litellm.utils import validate_and_fix_openai_messages
+
+        messages = [{"role": "hacker", "content": "pwned"}]
+
+        with pytest.raises(BadRequestError) as exc_info:
+            validate_and_fix_openai_messages(messages=messages)
+
+        error_text = str(exc_info.value)
+        # No traceback leakage
+        assert "Traceback" not in error_text
+        # No internal path disclosure
+        assert ".py\"" not in error_text, f"Internal file path leaked: {error_text}"
+
+    def test_missing_role_defaults_to_assistant(self):
+        """Messages without a role should default to 'assistant' (existing behavior)."""
+        from litellm.utils import validate_and_fix_openai_messages
+
+        messages = [{"content": "test"}]
+        result = validate_and_fix_openai_messages(messages=messages)
+        assert result[0]["role"] == "assistant"


### PR DESCRIPTION
## Problem

When a chat completion request is sent with an invalid `role` value (e.g. `"admin"`, `"xyz"`), litellm leaks a full Python stack trace in the error response body, including internal file paths and exception chains. The response also returns HTTP 500 instead of the correct 400.

Example error response from the bug:
```json
{
  "error": {
    "message": "litellm.APIConnectionError: Invalid Message passed in - {\"role\": \"xyz\", ...}. File an issue...\nTraceback (most recent call last):\n  ...",
    "type": "500"
  }
}
```

## Fix

Adds early role validation in `validate_and_fix_openai_messages()` that raises `BadRequestError` (HTTP 400) with a sanitized message for invalid roles. Valid roles (`system`, `user`, `assistant`, `tool`, `function`, `developer`) continue to work. Missing roles still default to `assistant` (existing behavior preserved).

**3 files changed, 89 insertions:**
- `litellm/constants.py` — add `VALID_MESSAGE_ROLES` set
- `litellm/utils.py` — validate role in `validate_and_fix_openai_messages()`
- `tests/litellm_utils_tests/test_invalid_role_validation.py` — 5 tests

Fixes #30948

---

This PR was created with AI assistance (OpenClaw DEV agent). Per the project's AI contribution guidelines, this addresses a confirmed bug from an open issue.