### PR TITLE
feat(prometheus): add requested_model label to spend and requests metrics

### DIFF
--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -409,6 +409,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_EMAIL.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
@@ -424,6 +425,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_EMAIL.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
     ]

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -607,6 +607,7 @@ def test_increment_top_level_request_and_spend_metrics(prometheus_logger):
         api_provider="openai",
         client_ip=None,
         user_agent=None,
+        requested_model=None,
     )
     prometheus_logger.litellm_requests_metric.labels().inc.assert_called_once()
 
@@ -626,6 +627,7 @@ def test_increment_top_level_request_and_spend_metrics(prometheus_logger):
         api_provider="openai",
         client_ip=None,
         user_agent=None,
+        requested_model=None,
     )
     prometheus_logger.litellm_spend_metric.labels().inc.assert_called_once_with(0.1)
 

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -148,6 +148,34 @@ def test_model_id_in_required_metrics():
         print(f"✅ {metric_name} contains model_id label")
 
 
+def test_requested_model_in_spend_and_requests_metrics():
+    """
+    Regression test for LIT-3796.
+
+    litellm_spend_metric and litellm_requests_metric must expose the
+    requested_model label so spend and request counts can be grouped by the
+    model alias the caller asked for, not just the backend deployment that
+    served the request. The sibling token metrics (input/output/total)
+    already carry this label; spend and requests were the odd ones out, even
+    though both are emitted side-by-side from the same call site.
+    """
+    requested_model_label = UserAPIKeyLabelNames.REQUESTED_MODEL.value
+
+    metrics_with_requested_model = [
+        "litellm_spend_metric",
+        "litellm_requests_metric",
+        "litellm_input_tokens_metric",
+        "litellm_output_tokens_metric",
+        "litellm_total_tokens_metric",
+    ]
+
+    for metric_name in metrics_with_requested_model:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert requested_model_label in labels, (
+            f"Metric {metric_name} should contain requested_model label"
+        )
+
+
 def test_route_normalization_for_responses_api():
     """
     Test that route normalization prevents high cardinality in Prometheus metrics


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3796

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Local proxy with two deployments behind one alias, real OpenAI traffic:

```yaml
model_list:
  - model_name: aliased-fast-model
    litellm_params: {model: openai/gpt-4o-mini, api_key: os.environ/OPENAI_API_KEY}
    model_info: {id: openai/gpt-4o-mini-deployment-A}
  - model_name: aliased-fast-model
    litellm_params: {model: openai/gpt-4o-mini, api_key: os.environ/OPENAI_API_KEY}
    model_info: {id: openai/gpt-4o-mini-deployment-B}
litellm_settings: {callbacks: ["prometheus"]}
general_settings: {master_key: sk-1234}
```

```bash
for i in 1 2 3 4 5; do
  curl -sS http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"aliased-fast-model","messages":[{"role":"user","content":"say hi in 1 word"}]}' > /dev/null
done
curl -sSL http://localhost:4000/metrics -H "Authorization: Bearer sk-1234" \
  | grep -E '^litellm_(spend|requests)_metric_total'
```

Before this PR (note: no `requested_model` label):

```
litellm_spend_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-A",...} 1.26e-05
litellm_spend_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-B",...} 3.15e-06
litellm_requests_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-A",...} 4.0
litellm_requests_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-B",...} 1.0
```

After this PR (note: `requested_model="aliased-fast-model"` now appears on every row, all other labels unchanged):

```
litellm_spend_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-A",requested_model="aliased-fast-model",...} 6.3e-06
litellm_spend_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-B",requested_model="aliased-fast-model",...} 9.45e-06
litellm_requests_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-A",requested_model="aliased-fast-model",...} 2.0
litellm_requests_metric_total{api_provider="openai",...,model="gpt-4o-mini",model_id="openai/gpt-4o-mini-deployment-B",requested_model="aliased-fast-model",...} 3.0
```

Adding a label is backward compatible for Prometheus and for any existing `sum()` or `sum by (existing_label)` queries; only queries that explicitly enumerate the full label set change shape

## Type

🐛 Bug Fix

## Changes

`litellm_spend_metric` and `litellm_requests_metric` both gained `UserAPIKeyLabelNames.REQUESTED_MODEL` in their labelnames list (`litellm/types/integrations/prometheus.py`). The value is already populated on `UserAPIKeyLabelValues.requested_model` upstream from `standard_logging_payload["model_group"]`, and the shared `_increment_top_level_request_and_spend_metrics` call site reads it through the existing helper, so no plumbing changes are needed. The sibling token metrics (`litellm_input_tokens_metric`, `litellm_output_tokens_metric`, `litellm_total_tokens_metric`) already carried the label; this makes the counter set consistent

Regression test `test_requested_model_in_spend_and_requests_metrics` in `tests/test_litellm/integrations/test_prometheus_labels.py` asserts the label is present on every metric in that family; reverting either source line makes the test fail with the exact missing-label assertion. One enterprise unit test (`test_increment_top_level_request_and_spend_metrics`) hard-coded the full kwargs of `labels(...)` and required the new `requested_model=None` entry to keep its `assert_called_once_with` aligned
