### PR TITLE
fix(bedrock): surface web identity token aud/iss on InvalidIdentityToken

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1,3 +1,4 @@
+import base64
 import hashlib
 import json
 import os
@@ -19,7 +20,7 @@ from typing import (
 )
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from litellm._logging import verbose_logger
 from litellm.caching.caching import DualCache
@@ -54,6 +55,11 @@ class Boto3CredentialsInfo(BaseModel):
     credentials: Credentials
     aws_region_name: str
     aws_bedrock_runtime_endpoint: Optional[str]
+
+
+class _WebIdentityTokenClaims(BaseModel):
+    aud: Optional[Union[str, list[str]]] = None
+    iss: Optional[str] = None
 
 
 class AwsAuthError(Exception):
@@ -817,6 +823,25 @@ class BaseAWSLLM:
 
         return False
 
+    @staticmethod
+    def _unverified_web_identity_audience(oidc_token: str) -> Optional[str]:
+        """Return the public ``aud``/``iss`` claims of a web identity JWT
+        without verifying its signature, so a rejected-token error can name
+        the audience LiteLLM actually sent. The signature is never read, so no
+        secret is exposed."""
+        segments = oidc_token.split(".")
+        if len(segments) != 3:
+            return None
+        payload = segments[1]
+        try:
+            decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+            claims = _WebIdentityTokenClaims.model_validate_json(decoded)
+        except (ValueError, ValidationError):
+            return None
+        if claims.aud is None and claims.iss is None:
+            return None
+        return f"aud={claims.aud!r}, iss={claims.iss!r}"
+
     @tracer.wrap()
     def _auth_with_web_identity_token(
         self,
@@ -925,7 +950,21 @@ class BaseAWSLLM:
         if aws_external_id is not None:
             assume_role_params["ExternalId"] = aws_external_id
 
-        sts_response = sts_client.assume_role_with_web_identity(**assume_role_params)
+        try:
+            sts_response = sts_client.assume_role_with_web_identity(
+                **assume_role_params
+            )
+        except sts_client.exceptions.InvalidIdentityTokenException as e:
+            audience = (
+                self._unverified_web_identity_audience(oidc_token)
+                if isinstance(oidc_token, str)
+                else None
+            )
+            detail = f" Token {audience}" if audience else ""
+            raise AwsAuthError(
+                status_code=401,
+                message=f"AWS STS rejected the web identity token: {e}.{detail}",
+            ) from e
 
         iam_creds_dict = {
             "aws_access_key_id": sts_response["Credentials"]["AccessKeyId"],

--- a/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
+++ b/tests/test_litellm/llms/bedrock/test_web_identity_session_policy.py
@@ -29,6 +29,7 @@ claude_platform statement are present and cover every documented
 action.
 """
 
+import base64
 import json
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
@@ -155,6 +156,78 @@ class TestClaudePlatformActionsCovered:
             "session policy must not grant aws-external-anthropic:* — "
             "the ceiling should match the documented action set"
         )
+
+
+def _make_jwt(payload: dict) -> str:
+    def _segment(data: dict) -> str:
+        return base64.urlsafe_b64encode(json.dumps(data).encode()).rstrip(b"=").decode()
+
+    return f"{_segment({'alg': 'RS256', 'typ': 'JWT'})}.{_segment(payload)}.signature"
+
+
+class TestInvalidIdentityTokenSurfacesAudience:
+    """LIT-4026: when STS rejects the web identity token with
+    ``InvalidIdentityToken`` (the "Incorrect token audience" case), the raised
+    error must name the ``aud``/``iss`` the token actually carries so an
+    operator can diagnose the mismatch without enabling LITELLM_LOG=DEBUG on a
+    prod instance."""
+
+    _AUD = "https://guidepoint.litellm-prod.ai"
+    _ISS = "https://accounts.google.com"
+    _STS_MESSAGE = (
+        "An error occurred (InvalidIdentityToken) when calling the "
+        "AssumeRoleWithWebIdentity operation: Incorrect token audience"
+    )
+
+    def _raise_invalid_identity_token(self) -> Exception:
+        from litellm.llms.bedrock.base_aws_llm import AwsAuthError, BaseAWSLLM
+
+        token = _make_jwt({"aud": self._AUD, "iss": self._ISS, "sub": "svc-account"})
+
+        mock_sts = MagicMock()
+
+        class _InvalidIdentityTokenException(Exception):
+            pass
+
+        mock_sts.exceptions.InvalidIdentityTokenException = (
+            _InvalidIdentityTokenException
+        )
+        mock_sts.assume_role_with_web_identity.side_effect = (
+            _InvalidIdentityTokenException(self._STS_MESSAGE)
+        )
+
+        with (
+            patch("boto3.client", return_value=mock_sts),
+            patch(
+                "litellm.llms.bedrock.base_aws_llm.get_secret",
+                return_value=token,
+            ),
+            pytest.raises(AwsAuthError) as exc_info,
+        ):
+            BaseAWSLLM()._auth_with_web_identity_token(
+                aws_web_identity_token="oidc/google/" + self._AUD,
+                aws_role_name="arn:aws:iam::123456789012:role/litellm-bedrock-role",
+                aws_session_name="test-session",
+                aws_region_name="us-east-1",
+                aws_sts_endpoint=None,
+            )
+        return exc_info.value
+
+    def test_error_names_token_audience(self):
+        err = self._raise_invalid_identity_token()
+        assert self._AUD in str(err)
+
+    def test_error_names_token_issuer(self):
+        err = self._raise_invalid_identity_token()
+        assert self._ISS in str(err)
+
+    def test_error_preserves_original_sts_reason(self):
+        err = self._raise_invalid_identity_token()
+        assert "Incorrect token audience" in str(err)
+
+    def test_error_is_401(self):
+        err = self._raise_invalid_identity_token()
+        assert err.status_code == 401
 
 
 class TestPolicyTransportConditions:


### PR DESCRIPTION
## Relevant issues

Resolves LIT-4026

## Linear ticket

LIT-4026

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

A customer connecting Bedrock through an AWS IAM role with GCP OIDC (`AssumeRoleWithWebIdentity`) hit `InvalidIdentityToken: Incorrect token audience`. The whole investigation stalled on one question: what `aud` is LiteLLM actually putting in the token? The only way to find out was `LITELLM_LOG=DEBUG` on the prod instance, which degrades performance, so the answer stayed unknown for weeks.

This surfaces the token's `aud` and `iss` in the error itself, no debug logging required. The proof below runs a live proxy that makes a real `AssumeRoleWithWebIdentity` call against AWS STS (the call needs no AWS credentials; STS validates the token itself), so the same `InvalidIdentityTokenException` class and the same `base_aws_llm.py` code path as the customer's traceback are exercised end to end. The token here carries `aud=https://guidepoint.litellm-prod.ai`, the value the customer configured.

Config used (`aws_web_identity_token` resolves a JWT whose `aud` is `https://guidepoint.litellm-prod.ai`):

```yaml
model_list:
  - model_name: bedrock-claude
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-4-6-20250101-v1:0
      aws_web_identity_token: oidc/env/GUIDEPOINT_WEB_IDENTITY_TOKEN
      aws_role_name: arn:aws:iam::123456789012:role/litellm-bedrock-role
      aws_session_name: litellm-guidepoint
      aws_region_name: us-east-1
general_settings:
  master_key: sk-1234
```

Command (identical before and after):

```bash
curl -s -X POST http://127.0.0.1:4026/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"bedrock-claude","messages":[{"role":"user","content":"hi"}]}'
```

Before (opaque; raw botocore error, no audience anywhere, returned as a 500 `APIConnectionError`):

```
litellm.APIConnectionError: An error occurred (InvalidIdentityToken) when calling the
AssumeRoleWithWebIdentity operation: Couldn't retrieve verification key from your identity
provider,  please reference AssumeRoleWithWebIdentity documentation for requirements
  ...
  File ".../litellm/llms/bedrock/base_aws_llm.py", line 928, in _auth_with_web_identity_token
    sts_response = sts_client.assume_role_with_web_identity(**assume_role_params)
botocore.errorfactory.InvalidIdentityTokenException: ... Incorrect token audience
```

After (the STS reason is preserved and the token now names its own audience and issuer, as a 401 `AuthenticationError`):

```
litellm.AuthenticationError: BedrockException - AWS STS rejected the web identity token:
An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation:
Couldn't retrieve verification key from your identity provider,  please reference
AssumeRoleWithWebIdentity documentation for requirements.
Token aud='https://guidepoint.litellm-prod.ai', iss='https://accounts.google.com'.
Received Model Group=bedrock-claude
```

The crafted token here is not validly Google-signed, so AWS reports the verification-key subreason rather than the audience subreason; the exception class, the code path and the audience surfacing are exactly what the customer's "Incorrect token audience" case exercises. An operator now reads the `aud` straight off the failure and compares it to the IAM OIDC provider's `client_id_list` and the role trust policy condition, with no debug logging on prod.

## Type

🐛 Bug Fix

## Changes

`_auth_with_web_identity_token` wraps the `assume_role_with_web_identity` call and catches `InvalidIdentityTokenException`. On rejection it decodes the public `aud`/`iss` claims of the already-resolved JWT (base64url of the payload segment only; the signature is never read, so no secret is exposed) and raises an `AwsAuthError` that keeps the original STS reason and appends the token's audience and issuer. The decode is failure-path only, so there is no cost on the happy path; opaque or non-JWT tokens degrade gracefully to the original reason with no audience appended.

This is the single funnel for the bedrock OIDC auth flow: chat (converse and invoke), embeddings, image and rerank all reach it through `get_credentials`, so they are all covered.
