### PR TITLE
fix(openrouter): handle non-json chat responses

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2212,6 +2212,14 @@ def _map_openrouter_exception(
                 response=getattr(original_exception, "response", None),
                 litellm_debug_info=extra_information,
             )
+        elif original_exception.status_code == 502:
+            raise BadGatewayError(
+                message=f"BadGatewayError: {exception_provider} - {error_str}",
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=getattr(original_exception, "response", None),
+                litellm_debug_info=extra_information,
+            )
         elif original_exception.status_code == 503:
             raise ServiceUnavailableError(
                 message=f"ServiceUnavailableError: {exception_provider} - {error_str}",

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2168,6 +2168,14 @@ def _map_openrouter_exception(
                 response=getattr(original_exception, "response", None),
                 litellm_debug_info=extra_information,
             )
+        elif original_exception.status_code == 502:
+            raise BadGatewayError(
+                message=f"BadGatewayError: {exception_provider} - {error_str}",
+                model=model,
+                llm_provider=custom_llm_provider,
+                response=getattr(original_exception, "response", None),
+                litellm_debug_info=extra_information,
+            )
         elif original_exception.status_code == 503:
             raise ServiceUnavailableError(
                 message=f"ServiceUnavailableError: {exception_provider} - {error_str}",

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -201,6 +201,9 @@ class OpenrouterConfig(OpenAIGPTConfig):
         Returns:
             ModelResponse: The transformed response with cost information.
         """
+        response_json = self._get_response_json(raw_response)
+        self._raise_if_error_response(response_json=response_json)
+
         # Call parent transform_response to get the standard ModelResponse
         model_response = super().transform_response(
             model=model,
@@ -218,12 +221,10 @@ class OpenrouterConfig(OpenAIGPTConfig):
 
         # Extract cost from OpenRouter response body
         # OpenRouter returns cost information in the usage object when usage.include=true
-        try:
-            response_json = raw_response.json()
-            if "usage" in response_json and response_json["usage"]:
-                response_cost = response_json["usage"].get("cost")
-                if response_cost is not None:
-                    # Store cost in hidden params for the cost calculator to use
+        if "usage" in response_json and response_json["usage"]:
+            response_cost = response_json["usage"].get("cost")
+            if response_cost is not None:
+                try:
                     if not hasattr(model_response, "_hidden_params"):
                         model_response._hidden_params = {}
                     if "additional_headers" not in model_response._hidden_params:
@@ -231,11 +232,56 @@ class OpenrouterConfig(OpenAIGPTConfig):
                     model_response._hidden_params["additional_headers"][
                         "llm_provider-x-litellm-response-cost"
                     ] = float(response_cost)
-        except Exception:
-            # If we can't extract cost, continue without it - don't fail the response
-            pass
+                except Exception:
+                    # Cost tracking should never fail an otherwise valid response.
+                    pass
 
         return model_response
+
+    def _get_response_json(self, raw_response: httpx.Response) -> dict:
+        try:
+            response_json = raw_response.json()
+        except Exception as e:
+            status_code = raw_response.status_code
+            if 200 <= status_code < 300:
+                status_code = 502
+            response_text = raw_response.text
+            response_preview = (response_text.strip() or response_text)[:500]
+            raise OpenRouterException(
+                message=(
+                    "OpenRouter returned a non-JSON response - {}, "
+                    "Original Response: {!r}".format(str(e), response_preview)
+                ),
+                status_code=status_code,
+                headers=raw_response.headers,
+            )
+        return response_json
+
+    def _raise_if_error_response(self, response_json: dict) -> None:
+        error_response = response_json.get("error")
+        if not isinstance(error_response, dict):
+            return
+
+        metadata = error_response.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+        status_code = error_response.get("code", 500)
+        if not isinstance(status_code, int):
+            status_code = 500
+
+        error_message = OpenRouterErrorMessage(
+            message="Message: {}, Metadata: {}".format(
+                error_response.get("message", "Unknown error"),
+                metadata,
+            ),
+            code=status_code,
+            metadata=metadata,
+        )
+        raise OpenRouterException(
+            message=error_message["message"],
+            status_code=error_message["code"],
+            headers=error_message["metadata"].get("headers", {}),
+        )
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]

--- a/litellm/llms/openrouter/chat/transformation.py
+++ b/litellm/llms/openrouter/chat/transformation.py
@@ -194,6 +194,9 @@ class OpenrouterConfig(OpenAIGPTConfig):
         Returns:
             ModelResponse: The transformed response with cost information.
         """
+        response_json: Final = self._get_response_json(raw_response)
+        self._raise_if_error_response(response_json=response_json)
+
         # Call parent transform_response to get the standard ModelResponse
         model_response = super().transform_response(
             model=model,
@@ -211,12 +214,10 @@ class OpenrouterConfig(OpenAIGPTConfig):
 
         # Extract cost from OpenRouter response body
         # OpenRouter returns cost information in the usage object when usage.include=true
-        try:
-            response_json: Final = raw_response.json()
-            if "usage" in response_json and response_json["usage"]:
-                response_cost: Final = response_json["usage"].get("cost")
-                if response_cost is not None:
-                    # Store cost in hidden params for the cost calculator to use
+        if "usage" in response_json and response_json["usage"]:
+            response_cost: Final = response_json["usage"].get("cost")
+            if response_cost is not None:
+                try:
                     if not hasattr(model_response, "_hidden_params"):
                         model_response._hidden_params = {}
                     if "additional_headers" not in model_response._hidden_params:
@@ -224,11 +225,49 @@ class OpenrouterConfig(OpenAIGPTConfig):
                     model_response._hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"] = float(
                         response_cost
                     )
-        except Exception:
-            # If we can't extract cost, continue without it - don't fail the response
-            pass
+                except Exception:
+                    # Cost tracking should never fail an otherwise valid response.
+                    pass
 
         return model_response
+
+    def _get_response_json(self, raw_response: httpx.Response) -> dict:
+        try:
+            response_json: Final = raw_response.json()
+        except Exception as e:
+            status_code: Final = 502 if 200 <= raw_response.status_code < 300 else raw_response.status_code
+            response_text: Final = raw_response.text
+            response_preview: Final = (response_text.strip() or response_text)[:500]
+            raise OpenRouterException(
+                message=f"OpenRouter returned a non-JSON response - {e}, Original Response: {response_preview!r}",
+                status_code=status_code,
+                headers=raw_response.headers,
+            )
+        return response_json
+
+    def _raise_if_error_response(self, response_json: dict) -> None:
+        error_response: Final = response_json.get("error")
+        if not isinstance(error_response, dict):
+            return
+
+        raw_metadata: Final = error_response.get("metadata", {})
+        metadata: Final = raw_metadata if isinstance(raw_metadata, dict) else {}
+        raw_status_code: Final = error_response.get("code", 500)
+        status_code: Final = raw_status_code if isinstance(raw_status_code, int) else 500
+
+        error_message: Final = OpenRouterErrorMessage(
+            message="Message: {}, Metadata: {}".format(
+                error_response.get("message", "Unknown error"),
+                metadata,
+            ),
+            code=status_code,
+            metadata=metadata,
+        )
+        raise OpenRouterException(
+            message=error_message["message"],
+            status_code=error_message["code"],
+            headers=error_message["metadata"].get("headers", {}),
+        )
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | httpx.Headers) -> BaseLLMException:
         return OpenRouterException(

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -17,6 +17,7 @@ from litellm.litellm_core_utils.exception_mapping_utils import (
     extract_and_raise_litellm_exception,
 )
 from litellm.llms.openai.common_utils import OpenAIError
+from litellm.llms.openrouter.common_utils import OpenRouterException
 
 # Test cases for is_error_str_context_window_exceeded
 # Tuple format: (error_message, expected_result)
@@ -152,9 +153,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is True
-            ), f"Should detect policy violation in uppercase: {error_str}"
+            assert result is True, (
+                f"Should detect policy violation in uppercase: {error_str}"
+            )
 
     def test_is_azure_content_policy_violation_error_with_non_policy_errors(self):
         """Test that non-policy violation errors are not detected as policy violations"""
@@ -174,9 +175,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is False
-            ), f"Should NOT detect policy violation in: {error_str}"
+            assert result is False, (
+                f"Should NOT detect policy violation in: {error_str}"
+            )
 
     def test_is_azure_content_policy_violation_error_with_partial_matches(self):
         """Test that partial keyword matches work correctly"""
@@ -206,9 +207,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is False
-            ), f"Should NOT detect policy violation in: {error_str}"
+            assert result is False, (
+                f"Should NOT detect policy violation in: {error_str}"
+            )
 
 
 gemini_context_window_test_cases = [
@@ -286,6 +287,26 @@ def test_lemonade_context_window_error_mapping():
     assert excinfo.value.status_code == 400
     assert excinfo.value.llm_provider == "lemonade"
     assert excinfo.value.model == model
+
+
+def test_openrouter_502_maps_to_bad_gateway_error():
+    original_exception = OpenRouterException(
+        status_code=502,
+        message="OpenRouter returned a non-JSON response",
+        headers={"content-type": "text/plain"},
+    )
+
+    with pytest.raises(litellm.BadGatewayError) as excinfo:
+        exception_type(
+            model="openrouter/z-ai/glm-5.1",
+            original_exception=original_exception,
+            custom_llm_provider="openrouter",
+        )
+
+    assert excinfo.value.status_code == 502
+    assert excinfo.value.llm_provider == "openrouter"
+    assert excinfo.value.model == "openrouter/z-ai/glm-5.1"
+    assert "OpenRouter returned a non-JSON response" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -15,6 +15,7 @@ from litellm.litellm_core_utils.exception_mapping_utils import (
 )
 from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.openai.common_utils import OpenAIError
+from litellm.llms.openrouter.common_utils import OpenRouterException
 from litellm.types.utils import LlmProviders
 
 # Test cases for is_error_str_context_window_exceeded
@@ -197,9 +198,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is True
-            ), f"Should detect policy violation in uppercase: {error_str}"
+            assert result is True, (
+                f"Should detect policy violation in uppercase: {error_str}"
+            )
 
     def test_is_azure_content_policy_violation_error_with_non_policy_errors(self):
         """Test that non-policy violation errors are not detected as policy violations"""
@@ -219,9 +220,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is False
-            ), f"Should NOT detect policy violation in: {error_str}"
+            assert result is False, (
+                f"Should NOT detect policy violation in: {error_str}"
+            )
 
     def test_is_azure_content_policy_violation_error_with_partial_matches(self):
         """Test that partial keyword matches work correctly"""
@@ -251,9 +252,9 @@ class TestExceptionCheckers:
             result = ExceptionCheckers.is_azure_content_policy_violation_error(
                 error_str
             )
-            assert (
-                result is False
-            ), f"Should NOT detect policy violation in: {error_str}"
+            assert result is False, (
+                f"Should NOT detect policy violation in: {error_str}"
+            )
 
 
 gemini_context_window_test_cases = [
@@ -379,6 +380,26 @@ def test_openai_compatible_429_still_maps_to_rate_limit():
         )
 
     assert excinfo.value.status_code == 429
+
+
+def test_openrouter_502_maps_to_bad_gateway_error():
+    original_exception = OpenRouterException(
+        status_code=502,
+        message="OpenRouter returned a non-JSON response",
+        headers={"content-type": "text/plain"},
+    )
+
+    with pytest.raises(litellm.BadGatewayError) as excinfo:
+        exception_type(
+            model="openrouter/z-ai/glm-5.1",
+            original_exception=original_exception,
+            custom_llm_provider="openrouter",
+        )
+
+    assert excinfo.value.status_code == 502
+    assert excinfo.value.llm_provider == "openrouter"
+    assert excinfo.value.model == "openrouter/z-ai/glm-5.1"
+    assert "OpenRouter returned a non-JSON response" in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -141,8 +141,6 @@ def test_openrouter_transform_request_with_cache_control():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -173,9 +171,6 @@ def test_openrouter_transform_request_with_cache_control():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 2
@@ -218,8 +213,6 @@ def test_openrouter_transform_request_with_cache_control_list_content():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -244,9 +237,6 @@ def test_openrouter_transform_request_with_cache_control_list_content():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request (List Content) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 2
@@ -284,8 +274,6 @@ def test_openrouter_transform_request_with_cache_control_gemini():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -303,9 +291,6 @@ def test_openrouter_transform_request_with_cache_control_gemini():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request (Gemini) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 1
@@ -325,8 +310,6 @@ def test_openrouter_transform_request_multiple_cache_controls():
     When a message has 5 content blocks with cache_control at message level,
     only the 5th block should have cache_control, not all 5 blocks.
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -351,17 +334,14 @@ def test_openrouter_transform_request_multiple_cache_controls():
         headers={},
     )
 
-    print("\n=== Transformed Request (Multiple Blocks) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
-
     system_message = transformed_request["messages"][0]
     assert len(system_message["content"]) == 5
 
     # Only the last block should have cache_control
     for i in range(4):
-        assert (
-            "cache_control" not in system_message["content"][i]
-        ), f"Block {i} should not have cache_control"
+        assert "cache_control" not in system_message["content"][i], (
+            f"Block {i} should not have cache_control"
+        )
 
     assert system_message["content"][4]["cache_control"] == {"type": "ephemeral"}
     assert "cache_control" not in system_message
@@ -453,6 +433,133 @@ def test_openrouter_cost_tracking_non_streaming():
         ]
         == 0.00015
     )
+
+
+def test_openrouter_cost_tracking_ignores_invalid_cost():
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import ModelResponse, Choices, Message, Usage
+
+    config = OpenrouterConfig()
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.json.return_value = {
+        "id": "gen-123",
+        "model": "openrouter/anthropic/claude-sonnet-4.5",
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+            "cost": "N/A",
+        },
+    }
+    mock_response.headers = {}
+
+    model_response = ModelResponse(
+        id="gen-123",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=Message(content="Hello!", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="openrouter/anthropic/claude-sonnet-4.5",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+    )
+
+    with patch.object(
+        OpenAIGPTConfig, "transform_response", return_value=model_response
+    ):
+        result = config.transform_response(
+            model="openrouter/anthropic/claude-sonnet-4.5",
+            raw_response=mock_response,
+            model_response=model_response,
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    additional_headers = result._hidden_params.get("additional_headers", {})
+    assert "llm_provider-x-litellm-response-cost" not in additional_headers
+
+
+def test_openrouter_transform_response_non_json_2xx_error():
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import ModelResponse
+
+    raw_response = httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/plain", "x-request-id": "req_test"},
+        content=(b"         \n\n" * 100) + b". ",
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+    with patch.object(OpenAIGPTConfig, "transform_response") as parent_transform:
+        with pytest.raises(OpenRouterException) as exc_info:
+            OpenrouterConfig().transform_response(
+                model="openrouter/z-ai/glm-5.1",
+                raw_response=raw_response,
+                model_response=ModelResponse(),
+                logging_obj=Mock(),
+                request_data={},
+                messages=[{"role": "user", "content": "Hello"}],
+                optional_params={},
+                litellm_params={},
+                encoding=None,
+            )
+
+    parent_transform.assert_not_called()
+    assert "OpenRouter returned a non-JSON response" in str(exc_info.value)
+    assert "Original Response" in str(exc_info.value)
+    assert "." in str(exc_info.value)
+    assert exc_info.value.status_code == 502
+
+
+def test_openrouter_transform_response_embedded_error_before_parent_parse():
+    from unittest.mock import Mock, patch
+    from litellm.types.utils import ModelResponse
+
+    raw_response = httpx.Response(
+        status_code=200,
+        json={
+            "error": {
+                "message": "upstream provider rate limited",
+                "code": 429,
+                "metadata": {"headers": {"retry-after": "5"}},
+            }
+        },
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+    with patch.object(OpenAIGPTConfig, "transform_response") as parent_transform:
+        with pytest.raises(OpenRouterException) as exc_info:
+            OpenrouterConfig().transform_response(
+                model="openrouter/z-ai/glm-5.1",
+                raw_response=raw_response,
+                model_response=ModelResponse(),
+                logging_obj=Mock(),
+                request_data={},
+                messages=[{"role": "user", "content": "Hello"}],
+                optional_params={},
+                litellm_params={},
+                encoding=None,
+            )
+
+    parent_transform.assert_not_called()
+    assert "upstream provider rate limited" in str(exc_info.value)
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers == {"retry-after": "5"}
 
 
 def test_openrouter_cost_tracking_streaming():

--- a/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
+++ b/tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py
@@ -136,8 +136,6 @@ def test_openrouter_transform_request_with_cache_control():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -168,9 +166,6 @@ def test_openrouter_transform_request_with_cache_control():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 2
@@ -213,8 +208,6 @@ def test_openrouter_transform_request_with_cache_control_list_content():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -239,9 +232,6 @@ def test_openrouter_transform_request_with_cache_control_list_content():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request (List Content) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 2
@@ -279,8 +269,6 @@ def test_openrouter_transform_request_with_cache_control_gemini():
         ]
     }
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -298,9 +286,6 @@ def test_openrouter_transform_request_with_cache_control_gemini():
         litellm_params={},
         headers={},
     )
-
-    print("\n=== Transformed Request (Gemini) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
 
     assert "messages" in transformed_request
     assert len(transformed_request["messages"]) == 1
@@ -320,8 +305,6 @@ def test_openrouter_transform_request_multiple_cache_controls():
     When a message has 5 content blocks with cache_control at message level,
     only the 5th block should have cache_control, not all 5 blocks.
     """
-    import json
-
     config = OpenrouterConfig()
 
     messages = [
@@ -346,17 +329,14 @@ def test_openrouter_transform_request_multiple_cache_controls():
         headers={},
     )
 
-    print("\n=== Transformed Request (Multiple Blocks) ===")
-    print(json.dumps(transformed_request, indent=4, default=str))
-
     system_message = transformed_request["messages"][0]
     assert len(system_message["content"]) == 5
 
     # Only the last block should have cache_control
     for i in range(4):
-        assert (
-            "cache_control" not in system_message["content"][i]
-        ), f"Block {i} should not have cache_control"
+        assert "cache_control" not in system_message["content"][i], (
+            f"Block {i} should not have cache_control"
+        )
 
     assert system_message["content"][4]["cache_control"] == {"type": "ephemeral"}
     assert "cache_control" not in system_message
@@ -448,6 +428,116 @@ def test_openrouter_cost_tracking_non_streaming():
         ]
         == 0.00015
     )
+
+
+def test_openrouter_cost_tracking_ignores_invalid_cost():
+    from unittest.mock import Mock
+    from litellm.types.utils import ModelResponse
+
+    raw_response = httpx.Response(
+        status_code=200,
+        json={
+            "id": "gen-123",
+            "created": 1234567890,
+            "object": "chat.completion",
+            "model": "openrouter/z-ai/glm-5.1",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "Hello!"},
+                    "finish_reason": "stop",
+                    "index": 0,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+                "cost": "N/A",
+            },
+        },
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+    result = OpenrouterConfig().transform_response(
+        model="openrouter/z-ai/glm-5.1",
+        raw_response=raw_response,
+        model_response=ModelResponse(),
+        logging_obj=Mock(),
+        request_data={},
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={},
+        litellm_params={},
+        encoding=None,
+    )
+
+    assert result.choices[0].message.content == "Hello!"
+    assert result.usage.total_tokens == 30
+    additional_headers = result._hidden_params.get("additional_headers", {})
+    assert "llm_provider-x-litellm-response-cost" not in additional_headers
+
+
+def test_openrouter_transform_response_non_json_2xx_error():
+    from unittest.mock import Mock
+    from litellm.types.utils import ModelResponse
+
+    raw_response = httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/plain", "x-request-id": "req_test"},
+        content=(b"         \n\n" * 100) + b". ",
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+    with pytest.raises(OpenRouterException) as exc_info:
+        OpenrouterConfig().transform_response(
+            model="openrouter/z-ai/glm-5.1",
+            raw_response=raw_response,
+            model_response=ModelResponse(),
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert "OpenRouter returned a non-JSON response" in str(exc_info.value)
+    assert "Original Response" in str(exc_info.value)
+    assert "." in str(exc_info.value)
+    assert exc_info.value.status_code == 502
+
+
+def test_openrouter_transform_response_embedded_error_before_parent_parse():
+    from unittest.mock import Mock
+    from litellm.types.utils import ModelResponse
+
+    raw_response = httpx.Response(
+        status_code=200,
+        json={
+            "error": {
+                "message": "upstream provider rate limited",
+                "code": 429,
+                "metadata": {"headers": {"retry-after": "5"}},
+            }
+        },
+        request=httpx.Request("POST", "https://openrouter.ai/api/v1/chat/completions"),
+    )
+
+    with pytest.raises(OpenRouterException) as exc_info:
+        OpenrouterConfig().transform_response(
+            model="openrouter/z-ai/glm-5.1",
+            raw_response=raw_response,
+            model_response=ModelResponse(),
+            logging_obj=Mock(),
+            request_data={},
+            messages=[{"role": "user", "content": "Hello"}],
+            optional_params={},
+            litellm_params={},
+            encoding=None,
+        )
+
+    assert "upstream provider rate limited" in str(exc_info.value)
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers == {"retry-after": "5"}
 
 
 def test_openrouter_cost_tracking_streaming():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Malformed OpenRouter 2xx responses retain misleading success status codes
- Embedded error responses lose provider metadata and retry headers

How it solves it:

- Validate responses before parsing, mapping malformed 2xx responses to 502
- Preserve embedded errors and map OpenRouter 502 to BadGatewayError

## User Flow

Before: an invalid upstream response raises an exception carrying a success status

1. Call `litellm.completion()` or `litellm.acompletion()` with an OpenRouter model and non-streaming chat messages
2. OpenRouter responds with HTTP 200 and whitespace followed by `.`
3. The call raises `APIError` with `status_code=200`

After: the same invalid response raises an upstream gateway error

1. Call `litellm.completion()` or `litellm.acompletion()` with an OpenRouter model and non-streaming chat messages
2. OpenRouter responds with HTTP 200 and whitespace followed by `.`
3. The call raises `BadGatewayError` with `status_code=502` and a short response preview

## Relevant issues

Related to #8448. Embedded 429 responses already map to `RateLimitError` on the current base; this PR additionally preserves their metadata and `retry-after` in `litellm_response_headers`

## Affected release

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If needed, ping the LiteLLM team on Slack (#pr-review)

## Screenshots / Proof of Fix

A live-provider capture of this malformed response is not available. This upstream failure cannot be requested deterministically through the public API. The validation below injects raw HTTP responses and does not claim to reproduce a live OpenRouter outage

## Validation

Base: `c2c2a623c01601167547091879c9bd4423623e05` (staging, identical source tree to main `30f33a949b8a2bb890a2baee18e2ab7ab015a4f7`)

Updated head: `4efc837748ec98fe25c2dbb0aff8de12b5df1285`

The three regression tests exercise the actual response parser, with only logging mocked. They cover malformed non-JSON HTTP 200, embedded 429 metadata, and a valid completion whose usage cost is `N/A`. Upstream tests added since the original PR are retained

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
uv run --no-sync python -m pytest -p no:capture -p no:cacheprovider \
  tests/test_litellm/llms/openrouter/chat/test_openrouter_chat_transformation.py \
  tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py \
  tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py -q
```

Result: 1,241 passed

An additional local comparison through both public completion APIs covers nine response cases, including malformed 200/201/204 responses, HTTP 502, embedded 429, normal cost, and invalid cost. The unchanged base fails 14 of 18 expected-behavior checks; the updated head passes all 18. The comparison uses `httpx.MockTransport`, not a live provider

Local quality checks: `make check BASE_REF=origin/litellm_internal_staging` passed, including Ruff, formatting, type discipline, test quality, basedpyright budgets, and import checks

## Type

Bug Fix

## Caveats (if any)

### Low

- No live-provider capture of the malformed response
- Retry headers are preserved in `litellm_response_headers`
- Automatic retries and proxy response headers were not validated

## Final Attestation

- [x] Regression tests cover the malformed response and cost-handling cases described above
