### PR TITLE
fix(ci): grant create-release.yml the read scopes generate_release_notes needs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # `generate_release_notes: true` makes createRelease enumerate the merged
+      # PRs (and any issues they reference) in the release range to build the
+      # notes. Reading those needs the scopes below. Without them the call 403s
+      # ("Resource not accessible by integration") partway through note
+      # generation — after getLatestRelease succeeds — so no draft, tag, or
+      # release is created and the dependent create-branch job is skipped.
+      pull-requests: read
+      issues: read
     steps:
       - name: Validate inputs
         env:
@@ -144,6 +152,17 @@ jobs:
               });
 
             } catch (error) {
+              // Surface enough context that a future failure isn't an opaque
+              // "Resource not accessible by integration" with no clue which
+              // call or permission was at fault.
+              core.error(`Release creation failed: ${error.status ?? '?'} ${error.message}`);
+              if (error.request) {
+                core.error(`Failed call: ${error.request.method} ${error.request.url}`);
+              }
+              const accepted = error.response?.headers?.['x-accepted-github-permissions'];
+              if (accepted) {
+                core.error(`Endpoint requires permissions: ${accepted}`);
+              }
               core.setFailed(error.message);
             }
 


### PR DESCRIPTION
## Problem

`create-release.yml` has been **silently dropping the GitHub release + tag for some shipped stable patches**. The Docker images publish fine via project-releaser, but the GitHub release/tag never gets created, so there's no auto-generated changelog and the tag is missing. It's worst on the older lines — e.g. on GHCR these all shipped but have **no GitHub tag**: `v1.84.10`, `v1.85.7`, `v1.87.5` (and historically `v1.84.2`, `v1.84.9`, `v1.85.6`).

The runs fail with the opaque:

```
##[error]Resource not accessible by integration
```

…and because the catch block does `core.setFailed(error.message)`, that's *all* you ever see — no call, no resource, no permission.

## Root cause

Re-ran a failing release (`v1.84.10`) with debug logging on. The sequence:

```
GET  /repos/BerriAI/litellm/releases/latest   → 200
POST /repos/BerriAI/litellm/releases          → 403 in 3633ms   ← createRelease
   payload: { draft: true, generate_release_notes: true, ... }
```

The **3.6s before the 403** is the tell: a missing `contents: write` is rejected *instantly*. Taking 3.6s means GitHub accepted the request and ran server-side **release-notes generation**, then hit a permission wall inside it. `generate_release_notes: true` enumerates the merged PRs (and referenced issues) in the release range to build the notes — and the job only granted `contents: write`. When a range's notes need to read a PR/issue the token can't, the whole call 403s, no draft/tag is created, and the dependent `create-branch` job is skipped.

This is **deterministic per release range** (re-attempts of `v1.84.2`/`v1.84.9` failed every time), and content-dependent — which is why some patches sail through (their note ranges don't touch a restricted read) while others fail every time.

## Fix

- Add `pull-requests: read` and `issues: read` to the release job (what `generate_release_notes` needs).
- Stop swallowing the error — log the failing call and the `x-accepted-github-permissions` header so any *future* gap names the exact missing scope instead of an opaque message.

## Verification status

The evidence points strongly here, but this has **not yet been confirmed end-to-end** — the honest test is to dispatch this workflow **from this branch** against a known-failing input (e.g. `tag=v1.84.10`, `commit_hash=2b7dad241bfde734c88ec7a0c95c7e29fba82108`) and confirm it goes green + backfills the tag. Happy to run that, or a maintainer can. If it still 403s, the new logging will print the real required permission.

Note: this is **not** the flaky-retry issue it first looked like — it's a deterministic missing-permission, so retries are not the fix.