### PR TITLE
fix(auth): cache auth-path team object under canonical team_id key

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1991,13 +1991,16 @@ async def _user_api_key_auth_builder(
             else:
                 valid_token.team_object_permission = None
 
-            # Only cache when the key is a real team_id (non-team keys must not use key=None).
+            # Cache under the canonical "team_id:{id}" key so get_team_object and
+            # _update_team_cache serve this write from the L2 cache. The guard keeps a
+            # non-team (personal) key, whose team_id is None, from reaching the cache
+            # layer, which Redis rejects with a NoneType key error.
             if valid_token.team_id is not None and _team_obj is not None:
                 await user_api_key_cache.async_set_cache(
-                    key=valid_token.team_id,
+                    key=f"team_id:{valid_token.team_id}",
                     value=_team_obj,
                     model_type=LiteLLM_TeamTableCachedObj,
-                )  # save team table in cache - used for tpm/rpm limiting - tpm_rpm_limiter.py
+                )
 
             # Fetch project object if key belongs to a project
             _project_obj = None

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3989,3 +3989,98 @@ async def test_non_admin_cli_session_token_reaches_production_auth_path(monkeypa
     assert call_kwargs["valid_token_dict"]["is_session_token"] is True
     assert call_kwargs["valid_token_dict"]["user_role"] == LitellmUserRoles.INTERNAL_USER
     assert result.is_session_token is True
+
+
+@pytest.mark.asyncio
+async def test_auth_path_caches_team_object_under_canonical_team_id_key():
+    """Regression for LIT-4000: the auth builder must cache the team object under
+    the canonical ``team_id:{id}`` key that ``get_team_object`` and
+    ``_update_team_cache`` read, never under the raw ``team_id`` (and never under
+    a ``None`` key, which Redis rejects with a NoneType key error). A raw or None
+    key is silently dropped by Redis / never served back, so every request
+    re-hits Postgres for the team object instead of the L2 cache.
+
+    Drives the real builder for a team-scoped key against a real in-memory
+    ``UserApiKeyCache`` and reads the team object back. Mutating the cache key at
+    the write site to the raw ``valid_token.team_id`` (or ``None``) makes the
+    canonical-key read miss and fails this test.
+    """
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+    from litellm.proxy.auth.user_api_key_auth import _user_api_key_auth_builder
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+    from litellm.proxy.proxy_server import hash_token
+
+    team_id = "team-lit-4000"
+    api_key = "sk-lit-4000-team-key"
+    cache = UserApiKeyCache()
+
+    team_token = UserAPIKeyAuth(token=hash_token(api_key), team_id=team_id)
+    team_obj = LiteLLM_TeamTableCachedObj(team_id=team_id)
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+    attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": cache,
+        "proxy_logging_obj": proxy_logging_obj,
+        "master_key": "sk-test-master",
+        "general_settings": {"allow_requests_on_db_unavailable": False},
+        "llm_model_list": [],
+        "llm_router": None,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": MagicMock(),
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        request = Request(scope={"type": "http"})
+        request._url = URL(url="/chat/completions")
+        with (
+            patch(
+                "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+                AsyncMock(return_value=team_token),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                AsyncMock(return_value=team_obj),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._enforce_key_and_fallback_model_access",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth._return_user_api_key_auth_obj",
+                new_callable=AsyncMock,
+                return_value=team_token,
+            ),
+            patch(
+                "litellm.proxy.auth.auth_exception_handler.seed_request_identity",
+            ),
+        ):
+            await _user_api_key_auth_builder(
+                request=request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={},
+            )
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+    served = cache.get_cache(
+        key=f"team_id:{team_id}", model_type=LiteLLM_TeamTableCachedObj
+    )
+    assert served is not None and served.team_id == team_id
+    assert cache.get_cache(key=team_id) is None
+    assert cache.get_cache(key=None) is None


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4000

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

On the auth path, the team object was cached under the raw `valid_token.team_id`, while `get_team_object`, `_cache_team_object`, and `_update_team_cache` all read and write under `team_id:{id}`. That raw-key write was never served back, and on a non-team (personal) key whose `team_id` is None the original unguarded write passed a None key straight to the cache layer; the in-memory cache tolerates None keys but Redis rejects them with a NoneType key error, so with `enable_redis_auth_cache: true` the team object never reached the Redis L2 and every request fell back to Postgres.

Reproduced against a live proxy with `enable_redis_auth_cache: true` backed by real Postgres and Redis, calling a real Anthropic model with a team-scoped key.

Setup (same for before and after):

```
litellm_settings:
  enable_redis_auth_cache: true
  cache: true
  cache_params:
    type: redis
    host: 127.0.0.1
    port: 6779

# create a team with a fixed id and a team-scoped key, then call the model
curl -s -X POST $PROXY/team/new -H "Authorization: Bearer $MK" -d '{"team_id":"lit4000-team","team_alias":"lit4000"}'
KEY=$(curl -s -X POST $PROXY/key/generate -H "Authorization: Bearer $MK" -d '{"team_id":"lit4000-team","models":["haiku"]}' | jq -r .key)
redis-cli FLUSHALL
curl -s -X POST $PROXY/chat/completions -H "Authorization: Bearer $KEY" \
  -d '{"model":"haiku","messages":[{"role":"user","content":"say hi in one word"}],"max_tokens":10}'
# -> {"choices":[{"message":{"content":"Hi"}}], ...}
redis-cli KEYS '*' | grep lit4000-team | sort
```

Before the fix, the auth path writes the full team object under the bare `lit4000-team` key that `get_team_object` never reads, in addition to the canonical key:

```
{model_per_team:lit4000-team:haiku}:tokens
{team:lit4000-team}:tokens
lit4000-team
spend:team:lit4000-team
team_id:lit4000-team
```

```
redis-cli TYPE lit4000-team            -> string
redis-cli GET  lit4000-team            -> {"team_alias": "lit4000", "team_id": "lit4000-team", ...}
```

After the fix, the bare orphan key is gone and the team object is cached only under the canonical `team_id:lit4000-team` that the read path serves; the real LLM call still returns "Hi":

```
{model_per_team:lit4000-team:haiku}:tokens
{team:lit4000-team}:tokens
spend:team:lit4000-team
team_id:lit4000-team
```

To confirm the ticket's expected behavior end to end (the team object caches on the first lookup and subsequent requests are served from cache rather than hitting Postgres), I ran three successive requests with the same team-scoped key on a cold start (in-memory empty + `redis-cli FLUSHALL`) and traced auth with OpenTelemetry v2 (`LITELLM_OTEL_V2=true`, console exporter). The `auth` span carries a `postgres` child span per DB lookup, so a cache hit shows up as that span disappearing.

Note for anyone reproducing this: `import litellm` runs `load_dotenv()`, which walks up to the repo `.env`; if that file sets `OTEL_ENDPOINT`, the v2 config sends spans there instead of the console. Pre-set `OTEL_ENDPOINT="" OTEL_EXPORTER_OTLP_ENDPOINT="" OTEL_EXPORTER=console` before launch so `load_dotenv(override=False)` can't repopulate them.

```
REQUEST 1 (cold)  [INTERNAL] auth /chat/completions
   ├─ [CLIENT] postgres get_data            db.system=postgresql   <- key lookup
   ├─ [CLIENT] postgres _get_team_db_check  db.system=postgresql   <- team lookup
   └─ [CLIENT] redis async_get/set_cache    db.system=redis        <- L2 populate

REQUEST 2  [INTERNAL] auth /chat/completions
   └─ [CLIENT] redis async_set_cache        db.system=redis        <- no postgres

REQUEST 3  [INTERNAL] auth /chat/completions
   └─ [CLIENT] redis async_set_cache        db.system=redis        <- no postgres
```

```
request | postgres spans under auth | redis spans under auth
   1     |            2              |        9
   2     |            0              |        2
   3     |            0              |        2
```

Only the cold request hits Postgres for the key and team objects; every subsequent request resolves auth entirely from the L2 cache, with zero `postgres` spans under `auth`. The remaining `redis async_set_cache` spans on requests 2 and 3 are cache-refresh writes (last-active / spend), not auth reads. The same result holds in the Postgres `log_statement=all` query log (3 auth `SELECT`s on request 1, 0 after)

## Type

🐛 Bug Fix

## Changes

The write in `_user_api_key_auth_builder` now uses `f"team_id:{valid_token.team_id}"`, matching `get_team_object` / `_cache_team_object` / `_update_team_cache`, and keeps the existing guard that skips the write when `team_id` is None so a None key can never reach Redis.

Added a regression test that drives the real auth builder for a team-scoped key against an in-memory `UserApiKeyCache` and asserts the team object is served back under `team_id:{id}` and never under the raw `team_id` or a None key. Reverting the key to the raw `team_id` (or None) makes the canonical read miss and fails the test.

