### PR TITLE
test(pass-through): fix langfuse auth=true test broken by allowed_passthrough_routes gate

### DIFF
--- a/tests/local_testing/test_pass_through_endpoints.py
+++ b/tests/local_testing/test_pass_through_endpoints.py
@@ -402,7 +402,11 @@ async def test_aaapass_through_endpoint_pass_through_keys_langfuse(
 
         mock_api_key = "sk-my-test-key"
         cache_value = UserAPIKeyAuth(
-            token=hash_token(mock_api_key), rpm_limit=rpm_limit
+            token=hash_token(mock_api_key),
+            rpm_limit=rpm_limit,
+            # auth=true pass-through routes are gated by allowed_passthrough_routes;
+            # grant access so the request reaches the rpm/forwarding path under test.
+            metadata={"allowed_passthrough_routes": ["/api/public/ingestion"]},
         )
 
         _cohere_api_key = os.environ.get("COHERE_API_KEY")


### PR DESCRIPTION
Fixes the CI failure in `tests/local_testing/test_pass_through_endpoints.py::test_aaapass_through_endpoint_pass_through_keys_langfuse[True-0-429]` (`assert 403 == 429`).

## Root cause

This is an outdated test, not a product regression. #29256 (`fix(proxy): enforce allowed_passthrough_routes for auth=true pass-through`) intentionally made `auth=true` pass-through routes **deny-by-default**: a key/team must have `allowed_passthrough_routes` configured or auth returns `403`. That PR updated `tests/test_litellm/proxy/auth/test_route_checks.py` but missed this integration test.

The test key (`sk-my-test-key`) has no `allowed_passthrough_routes`, so the `auth=true` parametrizations now hit the 403 gate in `user_api_key_auth` **before** reaching the rpm / forwarding logic they are meant to exercise:

```
403: Key/team not allowed to access passthrough route /api/public/ingestion.
     Configure `allowed_passthrough_routes` on the team or key.
```

It also exposed a latent order-dependency: in a single sequential process the earlier `auth=false` parametrization registers the route first, so the gate did not re-fire and the test "passed". Under CI worker isolation it fails with 403.

## Fix

Grant the test key `allowed_passthrough_routes: ["/api/public/ingestion"]` so it clears the gate and exercises the intended path.

## Verification (local, isolated to avoid the order-dependency masking it)

| Case | before | after |
|---|---|---|
| `[True-0-429]` | 403 (gate) ❌ | 429 ✅ |
| `[True-2-207]` | 403 (gate) | past gate → 207 via VCR cassette in CI ✅ |
| `[False-0-207]` | unaffected (auth=false skips gate) | unchanged ✅ |

The two `207` cases forward to the live langfuse host and are served by the existing VCR cassette in CI (`[VCR HIT]`); they only show `401` when run locally without the cassette/credentials, which is unrelated to this change.