### PR TITLE
test(pass-through): fix langfuse auth=true test broken by allowed_passthrough_routes gate

### DIFF
--- a/tests/local_testing/test_pass_through_endpoints.py
+++ b/tests/local_testing/test_pass_through_endpoints.py
@@ -402,7 +402,9 @@ async def test_aaapass_through_endpoint_pass_through_keys_langfuse(
 
         mock_api_key = "sk-my-test-key"
         cache_value = UserAPIKeyAuth(
-            token=hash_token(mock_api_key), rpm_limit=rpm_limit
+            token=hash_token(mock_api_key),
+            rpm_limit=rpm_limit,
+            metadata={"allowed_passthrough_routes": ["/api/public/ingestion"]},
         )
 
         _cohere_api_key = os.environ.get("COHERE_API_KEY")


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a test-only change, so the proof is the test going from red to green. Run isolated so the latent order-dependency doesn't mask it (under CI xdist worker isolation the failing case runs alone):

Before (on `litellm_internal_staging`):

```
$ python -m pytest "tests/local_testing/test_pass_through_endpoints.py::test_aaapass_through_endpoint_pass_through_keys_langfuse[True-0-429]" -p no:randomly -q
>           assert response.status_code == expected_error_code
E           assert 403 == 429
E            +  where 403 = <Response [403 Forbidden]>.status_code
RESPONSE RECEIVED - {"error":{"message":"Key/team not allowed to access passthrough route /api/public/ingestion. Configure `allowed_passthrough_routes` on the team or key.","type":"auth_error","param":"None","code":"403"}}
```

After (this branch):

```
$ python -m pytest "tests/local_testing/test_pass_through_endpoints.py::test_aaapass_through_endpoint_pass_through_keys_langfuse[True-0-429]" -p no:randomly -q
1 passed, 1 warning in 5.51s
```

The two `207` cases (`[True-2-207]`, `[False-0-207]`) forward to the live langfuse host; with the gate cleared they now reach forwarding and are served a `207` by the existing VCR cassette in CI. Locally without the cassette / credentials they surface a `401` from langfuse, which is unrelated to this change (the prior `403` came from the auth gate, before any forwarding)

## Type

✅ Test

## Changes

`tests/local_testing/test_pass_through_endpoints.py::test_aaapass_through_endpoint_pass_through_keys_langfuse[True-0-429]` started failing in CI with `assert 403 == 429`. This is an outdated test, not a product regression. #29256 (`fix(proxy): enforce allowed_passthrough_routes for auth=true pass-through`) intentionally made `auth=true` pass-through routes deny-by-default: a key/team must have `allowed_passthrough_routes` configured or auth returns `403`. That PR updated `tests/test_litellm/proxy/auth/test_route_checks.py` but missed this integration test

The test key (`sk-my-test-key`) has no `allowed_passthrough_routes`, so the `auth=true` parametrizations now hit the `403` gate in `user_api_key_auth` before reaching the rpm / forwarding logic they are meant to exercise. It also exposed a latent order-dependency: in a single sequential process the earlier `auth=false` parametrization registers the route first, so the gate did not re-fire and the test "passed"; under CI worker isolation it fails with `403`

The fix grants the test key `allowed_passthrough_routes: ["/api/public/ingestion"]` so it clears the gate and exercises the intended rpm / forwarding path