### PR TITLE
fix(guardrails): match policy-pipeline block response to direct guardrail attachment

### DIFF
--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -6,7 +6,7 @@ pass/fail actions (allow, block, next, modify_response) and data forwarding.
 """
 
 import time
-from typing import Any, List, Optional
+from typing import Any, List, Literal, Optional
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -64,7 +64,12 @@ class PipelineExecutor:
         for i, step in enumerate(steps):
             start_time = time.perf_counter()
 
-            outcome, modified_data, error_detail = await PipelineExecutor._run_step(
+            (
+                outcome,
+                modified_data,
+                error_detail,
+                original_exception,
+            ) = await PipelineExecutor._run_step(
                 step=step,
                 mode=mode,
                 data=working_data,
@@ -108,6 +113,7 @@ class PipelineExecutor:
                     terminal_action="block",
                     step_results=step_results,
                     error_message=error_detail,
+                    original_exception=original_exception,
                 )
 
             if action == "modify_response":
@@ -134,22 +140,30 @@ class PipelineExecutor:
         data: dict,
         user_api_key_dict: Any,
         call_type: str,
-    ) -> tuple:
+    ) -> tuple[
+        Literal["pass", "fail", "error"],
+        Optional[dict],
+        Optional[str],
+        Optional[Exception],
+    ]:
         """
         Run a single pipeline step's guardrail.
 
         Returns:
-            Tuple of (outcome, modified_data, error_detail) where:
+            Tuple of (outcome, modified_data, error_detail, original_exception):
             - outcome: "pass", "fail", or "error"
             - modified_data: dict if guardrail returned modified data, else None
             - error_detail: error message string if fail/error, else None
+            - original_exception: the exception the guardrail raised, so the
+              pipeline can re-raise it verbatim and match the direct-attachment
+              response/trace, else None
         """
-        callback = PipelineExecutor._find_guardrail_callback(step.guardrail)
+        callback = PipelineExecutor.find_guardrail_callback(step.guardrail)
         if callback is None:
             verbose_proxy_logger.warning(
                 f"Pipeline: guardrail '{step.guardrail}' not found in callbacks"
             )
-            return ("error", None, f"Guardrail '{step.guardrail}' not found")
+            return ("error", None, f"Guardrail '{step.guardrail}' not found", None)
 
         try:
             # Inject guardrail name into metadata so should_run_guardrail() allows it
@@ -182,26 +196,26 @@ class PipelineExecutor:
                     response=data.get("response"),  # type: ignore
                 )
             else:
-                return ("error", None, f"Unsupported pipeline mode: {mode}")
+                return ("error", None, f"Unsupported pipeline mode: {mode}", None)
 
             # Normal return means pass
             modified_data = None
             if response is not None and isinstance(response, dict):
                 modified_data = response
-            return ("pass", modified_data, None)
+            return ("pass", modified_data, None, None)
 
         except Exception as e:
             if CustomGuardrail._is_guardrail_intervention(e):
                 error_msg = _extract_error_message(e)
-                return ("fail", None, error_msg)
+                return ("fail", None, error_msg, e)
             else:
                 verbose_proxy_logger.error(
                     f"Pipeline: unexpected error from guardrail '{step.guardrail}': {e}"
                 )
-                return ("error", None, str(e))
+                return ("error", None, str(e), e)
 
     @staticmethod
-    def _find_guardrail_callback(guardrail_name: str) -> Optional[CustomGuardrail]:
+    def find_guardrail_callback(guardrail_name: str) -> Optional[CustomGuardrail]:
         """Look up an initialized guardrail callback by name from litellm.callbacks."""
         for callback in litellm.callbacks:
             if isinstance(callback, CustomGuardrail):

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -363,6 +363,16 @@ def _enrich_http_exception_with_guardrail_context(
         detail.setdefault("guardrail_mode", event_hook)
 
 
+def _exception_changes_request_flow(exc: BaseException) -> bool:
+    """
+    True for guardrail exceptions the proxy turns into an alternate request flow
+    (a reroute or a passthrough response) rather than a block. A pipeline step
+    configured to block must honor that block, so these are surfaced as the
+    generic pipeline block instead of being re-raised verbatim.
+    """
+    return isinstance(exc, (SensitiveDataRouteException, ModifyResponseException))
+
+
 @dataclass(frozen=True)
 class _CallbackCapabilities:
     """Cached per-hook capability flags derived from ``litellm.callbacks``.
@@ -1356,7 +1366,7 @@ class ProxyLogging:
 
     @staticmethod
     def _handle_pipeline_result(
-        result: Any,
+        result: PipelineExecutionResult,
         data: dict,
         policy_name: str,
     ) -> dict:
@@ -1371,6 +1381,21 @@ class ProxyLogging:
             return data
 
         if result.terminal_action == "block":
+            original_exception = result.original_exception
+            if original_exception is not None and not _exception_changes_request_flow(
+                original_exception
+            ):
+                blocking_step = result.step_results[-1] if result.step_results else None
+                if blocking_step is not None:
+                    callback = PipelineExecutor.find_guardrail_callback(
+                        blocking_step.guardrail_name
+                    )
+                    if callback is not None:
+                        _enrich_http_exception_with_guardrail_context(
+                            original_exception, callback
+                        )
+                raise original_exception
+
             step_results_serializable = [
                 {
                     "guardrail": sr.guardrail_name,

--- a/litellm/types/proxy/policy_engine/pipeline_types.py
+++ b/litellm/types/proxy/policy_engine/pipeline_types.py
@@ -99,8 +99,11 @@ class PipelineStepResult(BaseModel):
 class PipelineExecutionResult(BaseModel):
     """Result of executing an entire pipeline."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     terminal_action: str  # block | allow | modify_response
     step_results: List[PipelineStepResult]
     modified_data: Optional[Dict[str, Any]] = None
     error_message: Optional[str] = None
     modify_response_message: Optional[str] = None
+    original_exception: Optional[Exception] = Field(default=None, exclude=True)

--- a/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
+++ b/tests/test_litellm/proxy/policy_engine/test_pipeline_executor.py
@@ -209,6 +209,75 @@ async def test_escalation_step1_fails_step2_blocks():
         litellm.callbacks = original_callbacks
 
 
+@pytest.mark.skipif(HTTPException is None, reason="fastapi not installed")
+@pytest.mark.asyncio
+async def test_block_carries_original_guardrail_exception():
+    """A blocking step must expose the guardrail's own raised exception on the
+    result so the caller can re-raise it verbatim, giving the policy path the
+    same response/trace as a direct guardrail attachment."""
+    guard = AlwaysFailGuardrail(guardrail_name="moderation-filter")
+
+    pipeline = GuardrailPipeline(
+        mode="pre_call",
+        steps=[
+            PipelineStep(
+                guardrail="moderation-filter", on_fail="block", on_pass="allow"
+            )
+        ],
+    )
+
+    original_callbacks = litellm.callbacks.copy()
+    litellm.callbacks = [guard]
+
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=pipeline.steps,
+            mode=pipeline.mode,
+            data={"messages": [{"role": "user", "content": "bad content"}]},
+            user_api_key_dict=MagicMock(),
+            call_type="completion",
+            policy_name="content-safety",
+        )
+
+        assert result.terminal_action == "block"
+        assert isinstance(result.original_exception, HTTPException)
+        assert result.original_exception.status_code == 400
+        assert result.original_exception.detail == "Content policy violation"
+    finally:
+        litellm.callbacks = original_callbacks
+
+
+@pytest.mark.asyncio
+async def test_unsupported_mode_yields_error_outcome_without_exception():
+    """An unexpected hook mode must surface as an error outcome (carrying no
+    original exception), not crash or run the guardrail."""
+    guard = AlwaysPassGuardrail(guardrail_name="filter")
+
+    original_callbacks = litellm.callbacks.copy()
+    litellm.callbacks = [guard]
+
+    try:
+        result = await PipelineExecutor.execute_steps(
+            steps=[PipelineStep(guardrail="filter", on_error="block", on_fail="block")],
+            mode="during_call",
+            data={"messages": [{"role": "user", "content": "hi"}]},
+            user_api_key_dict=MagicMock(),
+            call_type="completion",
+            policy_name="content-safety",
+        )
+
+        assert guard.calls == 0
+        assert result.terminal_action == "block"
+        assert result.step_results[0].outcome == "error"
+        assert (
+            "Unsupported pipeline mode: during_call"
+            in result.step_results[0].error_detail
+        )
+        assert result.original_exception is None
+    finally:
+        litellm.callbacks = original_callbacks
+
+
 @pytest.mark.asyncio
 async def test_passthrough_guardrail_failure_can_pipeline_block():
     """

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_guardrail_pipeline.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_guardrail_pipeline.py
@@ -17,6 +17,7 @@ import pytest
 from fastapi import HTTPException
 
 import litellm
+from litellm.exceptions import SensitiveDataRouteException
 from litellm.integrations.custom_guardrail import (
     CustomGuardrail,
     ModifyResponseException,
@@ -358,6 +359,7 @@ async def test_maybe_execute_pipelines_blocks_on_block_terminal_action_raises(
     fake_result = MagicMock()
     fake_result.terminal_action = "block"
     fake_result.step_results = []
+    fake_result.original_exception = None
     data = {"metadata": {"_guardrail_pipelines": [("policy-1", pipeline)]}, "messages": [], "model": "m"}
 
     async def fake_execute_steps(**kwargs):
@@ -376,6 +378,42 @@ async def test_maybe_execute_pipelines_blocks_on_block_terminal_action_raises(
         )
 
 
+@pytest.mark.asyncio
+async def test_maybe_execute_pipelines_reraises_original_guardrail_exception(
+    proxy_logging, make_user_api_key_auth, monkeypatch
+):
+    """A policy-wrapped guardrail block must surface the guardrail's own
+    exception verbatim, identical to the direct-attachment path."""
+    pipeline = MagicMock()
+    pipeline.mode = "pre_call"
+    pipeline.steps = []
+    original = HTTPException(
+        status_code=400,
+        detail={"error": "Violated OpenAI moderation policy", "moderation_result": {"x": 1}},
+    )
+    fake_result = MagicMock()
+    fake_result.terminal_action = "block"
+    fake_result.step_results = []
+    fake_result.original_exception = original
+    data = {"metadata": {"_guardrail_pipelines": [("policy-1", pipeline)]}, "messages": [], "model": "m"}
+
+    async def fake_execute_steps(**kwargs):
+        return fake_result
+
+    monkeypatch.setattr(
+        "litellm.proxy.policy_engine.pipeline_executor.PipelineExecutor.execute_steps",
+        fake_execute_steps,
+    )
+    with pytest.raises(HTTPException) as info:
+        await proxy_logging._maybe_execute_pipelines(
+            data=data,
+            user_api_key_dict=make_user_api_key_auth(),
+            call_type="completion",
+            event_hook="pre_call",
+        )
+    assert info.value is original
+
+
 # ---------------------------------------------------------------------------
 # _handle_pipeline_result
 # ---------------------------------------------------------------------------
@@ -390,10 +428,11 @@ def test_handle_pipeline_result_allow_with_modifications():
     assert out == {"a": 1, "b": 2, "c": 3}
 
 
-def test_handle_pipeline_result_block_raises_http_exception():
+def test_handle_pipeline_result_block_falls_back_to_generic_when_no_exception():
     result = MagicMock()
     result.terminal_action = "block"
     result.step_results = []
+    result.original_exception = None
     with pytest.raises(HTTPException) as info:
         ProxyLogging._handle_pipeline_result(result=result, data={"model": "m"}, policy_name="p")
     detail = info.value.detail
@@ -407,6 +446,94 @@ def test_handle_pipeline_result_block_raises_http_exception():
         "error_type": "guardrail_pipeline_error",
         "policy": "p",
     }
+
+
+def test_handle_pipeline_result_block_reraises_original_guardrail_exception():
+    """The policy path must re-raise the guardrail's own exception untouched,
+    not wrap it in a generic ``guardrail_pipeline_error``; this is what makes
+    the response and trace span identical to the direct-attachment path."""
+    original = HTTPException(
+        status_code=400,
+        detail={
+            "error": "Violated OpenAI moderation policy",
+            "moderation_result": {"violated_categories": ["harassment"]},
+        },
+    )
+    result = MagicMock()
+    result.terminal_action = "block"
+    result.step_results = []
+    result.original_exception = original
+    with pytest.raises(HTTPException) as info:
+        ProxyLogging._handle_pipeline_result(result=result, data={"model": "m"}, policy_name="p")
+    assert info.value is original
+    assert info.value.detail == {
+        "error": "Violated OpenAI moderation policy",
+        "moderation_result": {"violated_categories": ["harassment"]},
+    }
+
+
+def test_handle_pipeline_result_block_enriches_with_guardrail_name_and_mode():
+    """The re-raised exception must gain the blocking guardrail's name and mode,
+    matching the enrichment the direct-attachment path applies."""
+    cb = _make_guardrail()  # guardrail_name="g", event_hook=pre_call
+    original = HTTPException(status_code=400, detail={"error": "blocked"})
+    result = MagicMock()
+    result.terminal_action = "block"
+    result.step_results = [MagicMock(guardrail_name="g")]
+    result.original_exception = original
+
+    saved = litellm.callbacks
+    litellm.callbacks = [cb]
+    try:
+        with pytest.raises(HTTPException) as info:
+            ProxyLogging._handle_pipeline_result(
+                result=result, data={"model": "m"}, policy_name="p"
+            )
+    finally:
+        litellm.callbacks = saved
+
+    assert info.value is original
+    assert info.value.detail["guardrail_name"] == "g"
+    assert info.value.detail["guardrail_mode"] == GuardrailEventHooks.pre_call
+
+
+def test_handle_pipeline_result_block_does_not_reraise_sensitive_data_route():
+    """A step configured to block must enforce the block even when the guardrail
+    raised a reroute exception; re-raising it verbatim would route the request to
+    an alternate model instead of blocking, bypassing the configured policy."""
+    original = SensitiveDataRouteException(
+        route_to_model="on-prem-model",
+        session_id="sess-1",
+        guardrail_name="pii-router",
+    )
+    result = MagicMock()
+    result.terminal_action = "block"
+    result.step_results = [MagicMock(guardrail_name="pii-router")]
+    result.original_exception = original
+    with pytest.raises(HTTPException) as info:
+        ProxyLogging._handle_pipeline_result(result=result, data={"model": "m"}, policy_name="p")
+    assert info.value.status_code == 400
+    assert info.value.detail["error"]["type"] == "guardrail_pipeline_error"
+
+
+def test_handle_pipeline_result_block_does_not_reraise_modify_response():
+    """A step configured to block must enforce the block even when the guardrail
+    raised a passthrough/modify-response exception; re-raising it verbatim would
+    return the guardrail's synthetic response instead of blocking."""
+    original = ModifyResponseException(
+        message="redacted",
+        model="m",
+        request_data={"model": "m"},
+        guardrail_name="masker",
+    )
+    result = MagicMock()
+    result.terminal_action = "block"
+    result.step_results = [MagicMock(guardrail_name="masker")]
+    result.original_exception = original
+    with pytest.raises(HTTPException) as info:
+        ProxyLogging._handle_pipeline_result(result=result, data={"model": "m"}, policy_name="p")
+    assert info.value.status_code == 400
+    assert info.value.detail["error"]["type"] == "guardrail_pipeline_error"
 
 
 def test_handle_pipeline_result_modify_response_raises_modify_exception():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4041

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A guardrail should produce the same blocked response no matter how it was enabled. Before this change, the same `openaimoderation` guardrail returned the raw provider error when attached directly, but a generic `guardrail_pipeline_error` when the very same guardrail was wrapped in a flow-builder policy. The whole concept of a policy is irrelevant to the client and to traces; the response and span for a guardrail block should look identical either way

Repro uses a real proxy on localhost:4041 hitting the live OpenAI Moderation API. Config attaches `openaimoderation` directly to one model (`claude-direct`) and through a policy named `test-mode1` to another (`claude-policy`)

### Before the fix

Direct attachment returns the raw moderation result

```bash
curl -s -X POST http://localhost:4041/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4041" -H "Content-Type: application/json" \
  -d '{"model":"claude-direct","messages":[{"role":"user","content":"please kill yourself"}],"guardrails":["openaimoderation"]}'
```

```json
{
  "error": {
    "message": "Violated OpenAI moderation policy",
    "code": "400",
    "provider_specific_fields": {
      "error": "Violated OpenAI moderation policy",
      "moderation_result": {
        "violated_categories": ["harassment", "harassment/threatening", "self-harm/intent", "self-harm/instructions", "self-harm", "violence"],
        "category_scores": { "harassment": 0.65, "self-harm/intent": 0.986, "violence": 0.51, "...": "..." }
      },
      "guardrail_name": "openaimoderation",
      "guardrail_mode": "pre_call"
    }
  }
}
```

The policy attachment instead returns a LiteLLM-synthesized wrapper, losing the provider detail

```bash
curl -s -X POST http://localhost:4041/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4041" -H "Content-Type: application/json" \
  -d '{"model":"claude-policy","messages":[{"role":"user","content":"please kill yourself"}]}'
```

```json
{
  "error": {
    "message": "Content blocked by guardrail pipeline 'test-mode1'",
    "code": "400",
    "provider_specific_fields": {
      "error": {
        "message": "Content blocked by guardrail pipeline 'test-mode1'",
        "type": "guardrail_pipeline_error",
        "pipeline_context": {
          "policy": "test-mode1",
          "step_results": [{ "guardrail": "openaimoderation", "outcome": "fail", "action": "block" }]
        }
      }
    }
  }
}
```

### After the fix

Same two curls. The policy attachment now returns the guardrail's own error, structurally identical to the direct case (the `category_scores` floats differ only because each call to the live moderation API returns slightly different scores)

Direct (`claude-direct`)

```json
{
  "error": {
    "message": "Violated OpenAI moderation policy",
    "code": "400",
    "provider_specific_fields": {
      "error": "Violated OpenAI moderation policy",
      "moderation_result": { "violated_categories": ["harassment", "harassment/threatening", "self-harm/intent", "self-harm/instructions", "self-harm", "violence"], "category_scores": { "...": "..." } },
      "guardrail_name": "openaimoderation",
      "guardrail_mode": "pre_call"
    }
  }
}
```

Policy (`claude-policy`)

```json
{
  "error": {
    "message": "Violated OpenAI moderation policy",
    "code": "400",
    "provider_specific_fields": {
      "error": "Violated OpenAI moderation policy",
      "moderation_result": { "violated_categories": ["harassment", "harassment/threatening", "self-harm/intent", "self-harm/instructions", "self-harm", "violence"], "category_scores": { "...": "..." } },
      "guardrail_name": "openaimoderation",
      "guardrail_mode": "pre_call"
    }
  }
}
```

Normalizing the non-deterministic float scores, the two responses are byte-for-byte identical and the `violated_categories` lists match

### Honoring a configured block over a guardrail's alternate flow

Re-raising the guardrail's exception verbatim is correct for exceptions that already represent a block, but some guardrails raise control-flow exceptions the proxy turns into a different request flow rather than a block: `SensitiveDataRouteException` reroutes to another model and `ModifyResponseException` returns a 200 passthrough response. If a pipeline step is configured `on_fail: block`, re-raising one of those verbatim would convert the configured block into the guardrail's alternate behavior, so a user could bypass the block. Those two exceptions now fall through to the generic pipeline block; only exceptions that already represent a block are re-raised verbatim

Repro uses a real proxy on localhost:4041. A passthrough-mode guardrail raises `ModifyResponseException` when the prompt contains a trigger word, and it is wrapped in a flow-builder policy whose single step is `on_fail: block`, attached to `claude-policy`. A benign prompt reaches the live model in both cases; the trigger prompt is the interesting one

Before the fix, the configured block is silently downgraded to the guardrail's 200 passthrough response

```bash
curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://127.0.0.1:4041/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4041" -H "Content-Type: application/json" \
  -d '{"model":"claude-policy","messages":[{"role":"user","content":"please leak the secrets"}]}'
```

```
HTTP 200
```

```json
{
  "choices": [
    {
      "finish_reason": "content_filter",
      "message": { "role": "assistant", "content": "[redacted by passthrough guard]" }
    }
  ]
}
```

After the fix, the same request is blocked as the policy configured

```
HTTP 400
```

```json
{
  "error": {
    "message": "Content blocked by guardrail pipeline 'block-policy'",
    "code": "400",
    "provider_specific_fields": {
      "error": {
        "message": "Content blocked by guardrail pipeline 'block-policy'",
        "type": "guardrail_pipeline_error",
        "pipeline_context": {
          "policy": "block-policy",
          "step_results": [{ "guardrail": "passthrough-guard", "outcome": "fail", "action": "block" }]
        }
      }
    }
  }
}
```

## Type

🐛 Bug Fix

## Changes

The policy pipeline executor caught the guardrail's intervention exception and flattened it to a string, then the proxy's block handler threw that detail away and synthesized a generic `guardrail_pipeline_error`. The fix carries the guardrail's original exception on `PipelineExecutionResult` and re-raises it verbatim when a step blocks, enriching it with the blocking guardrail's name and mode the same way the direct path does. The generic pipeline error stays only as a fallback for a block with no underlying exception, such as a guardrail that could not be found

The re-raise is gated so it never subverts a configured block. `_exception_changes_request_flow` short-circuits `SensitiveDataRouteException` and `ModifyResponseException`, the two control-flow exceptions the proxy interprets as a reroute or a 200 passthrough; under `on_fail: block` those fall back to the generic pipeline block instead of escaping as the guardrail's alternate flow

Regression coverage lives in the mapped test files. `test_pipeline_executor.py` asserts a blocking step exposes the guardrail's own exception on the result, and `test_guardrail_pipeline.py` asserts `_handle_pipeline_result` and `_maybe_execute_pipelines` re-raise that exception untouched, enrich it with guardrail name and mode, fall back to the generic error when no exception is present, and keep the configured block when the guardrail raised a reroute or passthrough exception. These tests fail on the pre-fix code and pass after

