### PR TITLE
fix(ci): create releases with the LITELLM_RELEASE_APP token (workflows:write)

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -45,12 +45,25 @@ jobs:
             exit 1
           fi
 
+      # Creating a branch at a commit whose `.github/workflows/` tree has drifted
+      # from the default branch hits the same `workflows: write` guard as the
+      # release tag, which GITHUB_TOKEN cannot satisfy. Use the release-app token.
+      - name: Mint release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.LITELLM_RELEASE_APP_ID }}
+          private-key: ${{ secrets.LITELLM_RELEASE_APP_PRIVATE_KEY }}
+          owner: BerriAI
+          repositories: litellm
+
       - name: Create release branch
         env:
           TAG: ${{ inputs.tag }}
           COMMIT_HASH: ${{ inputs.commit_hash }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const tag = process.env.TAG;
             const commitHash = process.env.COMMIT_HASH;
@@ -70,6 +83,7 @@ jobs:
           COMMIT_HASH: ${{ inputs.commit_hash }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const tag = process.env.TAG;
             const commitHash = process.env.COMMIT_HASH;

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,14 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      # `generate_release_notes: true` makes createRelease enumerate the merged
-      # PRs (and any issues they reference) in the release range to build the
-      # notes. Reading those needs the scopes below. Without them the call 403s
-      # ("Resource not accessible by integration") partway through note
-      # generation — after getLatestRelease succeeds — so no draft, tag, or
-      # release is created and the dependent create-branch job is skipped.
-      pull-requests: read
-      issues: read
     steps:
       - name: Validate inputs
         env:
@@ -43,12 +35,29 @@ jobs:
             exit 1
           fi
 
+      # The default GITHUB_TOKEN cannot create a tag/release whose target
+      # commit's `.github/workflows/` tree has drifted from the default branch
+      # (older stable lines drift most) — GitHub then demands `workflows: write`,
+      # which is not grantable to GITHUB_TOKEN via `permissions:`. Mint the
+      # LITELLM_RELEASE_APP installation token (Contents + Workflows: write)
+      # instead. This is the same app project-releaser uses to dispatch this
+      # workflow, scoped to BerriAI/litellm.
+      - name: Mint release app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.LITELLM_RELEASE_APP_ID }}
+          private-key: ${{ secrets.LITELLM_RELEASE_APP_PRIVATE_KEY }}
+          owner: BerriAI
+          repositories: litellm
+
       - name: Create release
         env:
           TAG: ${{ inputs.tag }}
           COMMIT_HASH: ${{ inputs.commit_hash }}
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const tag = process.env.TAG;
             const commitHash = process.env.COMMIT_HASH;
@@ -171,6 +180,10 @@ jobs:
     needs: release
     permissions:
       contents: write
+    # Pass the release-app secrets through so the reusable workflow can mint the
+    # same installation token — branch creation hits the identical
+    # `workflows: write` guard as the release tag on drifted stable lines.
+    secrets: inherit
     uses: ./.github/workflows/create-release-branch.yml
     with:
       tag: ${{ inputs.tag }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # `generate_release_notes: true` makes createRelease enumerate the merged
+      # PRs (and any issues they reference) in the release range to build the
+      # notes. Reading those needs the scopes below. Without them the call 403s
+      # ("Resource not accessible by integration") partway through note
+      # generation — after getLatestRelease succeeds — so no draft, tag, or
+      # release is created and the dependent create-branch job is skipped.
+      pull-requests: read
+      issues: read
     steps:
       - name: Validate inputs
         env:
@@ -144,6 +152,17 @@ jobs:
               });
 
             } catch (error) {
+              // Surface enough context that a future failure isn't an opaque
+              // "Resource not accessible by integration" with no clue which
+              // call or permission was at fault.
+              core.error(`Release creation failed: ${error.status ?? '?'} ${error.message}`);
+              if (error.request) {
+                core.error(`Failed call: ${error.request.method} ${error.request.url}`);
+              }
+              const accepted = error.response?.headers?.['x-accepted-github-permissions'];
+              if (accepted) {
+                core.error(`Endpoint requires permissions: ${accepted}`);
+              }
               core.setFailed(error.message);
             }
 


### PR DESCRIPTION
## Problem

`create-release.yml` silently drops the GitHub release + tag for some shipped stable patches — worst on older lines. These shipped to GHCR but have **no GitHub tag**: `v1.84.10`, `v1.85.7`, `v1.87.5` (and historically `v1.84.2`, `v1.84.9`, `v1.85.6`). Runs failed with the opaque `Resource not accessible by integration`, and the catch block swallowed all detail.

## Root cause (proven)

Added error logging, re-ran a failing release with debug on, and read the `x-accepted-github-permissions` header on the 403:

```
GET  /repos/BerriAI/litellm/releases/latest   -> 200
POST /repos/BerriAI/litellm/releases          -> 403
Endpoint requires permissions: contents=write; contents=write,workflows=write
```

The job's `GITHUB_TOKEN` has `contents: write` but **not `workflows: write`**. GitHub requires `workflows: write` to create a tag/branch whose target commit's `.github/workflows/` tree has **drifted from the default branch** — and older stable lines have drifted most (49 workflow files differ for 1.84.x vs 34 for 1.89.x), so they fail deterministically. Crucially, **`workflows: write` is not grantable to `GITHUB_TOKEN` via the `permissions:` block** — it only exists on PATs and GitHub Apps. (An earlier attempt to add `pull-requests`/`issues` read scopes was a dead end, now reverted.)

## Fix

Mint the **`LITELLM_RELEASE_APP`** installation token — the same app `project-releaser`'s `release.yml` already uses to *dispatch* this workflow (`actions/create-github-app-token`, scoped to `BerriAI/litellm`) — and use it as `github-token` for:
- `createRelease` in `create-release.yml`
- both `createRef` calls in `create-release-branch.yml` (branch creation hits the identical guard; `secrets: inherit` passes the app secrets through to the reusable workflow)

Also keeps the error logging that surfaces `x-accepted-github-permissions`, so any future permission gap is self-diagnosing instead of opaque.

## Prerequisites for this to work
1. `LITELLM_RELEASE_APP_ID` + `LITELLM_RELEASE_APP_PRIVATE_KEY` must be readable by the **litellm** repo (org-level secret, or added to the repo). They currently live in `project-releaser`.
2. The app must have **Contents: write + Workflows: write** on `BerriAI/litellm`.

## Verification
Re-dispatch from this branch against a known-failing input (e.g. `tag=v1.84.10`, `commit_hash=2b7dad241bfde734c88ec7a0c95c7e29fba82108`) — green confirms the fix and backfills the tag. The remaining missing tags can then be re-dispatched the same way.