### PR TITLE
perf(spend-logs): only strip NUL bytes in safe_dumps when present

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -24,7 +24,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             return "MaxDepthExceeded"
         # Base-case: if it is a primitive, simply return it.
         if isinstance(obj, str):
-            return strip_null_bytes(obj)
+            return obj.replace("\x00", "") if "\x00" in obj else obj
         if isinstance(obj, (int, float, bool, type(None))):
             return obj
         # Check for circular reference.
@@ -36,7 +36,8 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             result = {}
             for k, v in obj.items():
                 if isinstance(k, (str)):
-                    result[strip_null_bytes(k)] = _serialize(v, seen, depth + 1)
+                    clean_k = k.replace("\x00", "") if "\x00" in k else k
+                    result[clean_k] = _serialize(v, seen, depth + 1)
             seen.remove(id(obj))
             return result
         elif isinstance(obj, list):

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -174,6 +174,30 @@ def test_null_byte_stripped_in_fallback_str():
     assert json.loads(out)["obj"] == "objrepr"
 
 
+def test_clean_strings_are_not_run_through_replace():
+    """Regression for LIT-3910.
+
+    safe_dumps must not call ``str.replace`` on NUL-free strings. Running the
+    NUL strip unconditionally on every value and dict key (the v1.89.x behavior)
+    added per-request serialization overhead that scaled with payload size and
+    showed up under ``store_prompts_in_spend_logs``. Clean strings, which are the
+    overwhelming majority, must be returned untouched.
+    """
+
+    class ReplaceForbidden(str):
+        def replace(self, *args, **kwargs):
+            raise AssertionError("safe_dumps ran str.replace on a NUL-free string")
+
+    data = {
+        ReplaceForbidden("clean_key"): ReplaceForbidden("clean_value"),
+        "nested": [ReplaceForbidden("a"), {"deep": ReplaceForbidden("b")}],
+    }
+    result = json.loads(safe_dumps(data))
+    assert result["clean_key"] == "clean_value"
+    assert result["nested"][0] == "a"
+    assert result["nested"][1]["deep"] == "b"
+
+
 def test_pydantic_base_model():
     from pydantic import BaseModel
 


### PR DESCRIPTION
## Relevant issues

Relates to LIT-3910 (throughput regression v1.87.3 -> v1.89.2). This addresses the largest single contributor I could attribute to the per-request hot path; see "Context" below for why the original root cause on that ticket was incomplete

## Linear ticket

LIT-3910

## Context

The regression is cumulative across the auth, logging, spend-tracking and caching hot path, with no single commit responsible (a tag-by-tag sweep shows a gradual, noise-dominated decline rather than a step)

The single largest identifiable, cleanly-fixable piece is `safe_dumps`. PR #29515 made it call `strip_null_bytes` (a `str.replace`) on every string value and every dict key during recursive serialization, to keep NUL bytes out of Postgres text/jsonb columns (error 22P05). NUL bytes are vanishingly rare, so for the common case this is pure overhead that scales with payload size. With `store_prompts_in_spend_logs: true` the full prompt and response are serialized through `safe_dumps` on every request, so the cost lands directly in the per-request hot path. This is exercised heavily by the reporter's configuration (store prompts on, large payloads, high RPS)

## Fix

Guard the strip behind a cheap `"\x00" in obj` membership check, so NUL-free strings are returned untouched and only strings that actually contain a NUL pay for the replace. Behavior is unchanged: NUL bytes are still stripped from values, keys, nested structures, and the str() fallback

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Microbenchmark of `safe_dumps` on a realistic spend-log payload (chat history + response + metadata), comparing v1.87.3 (no NUL handling), #29515 as-merged, and this fix:

```
######## payload ~12 KB ########
v1.87.3(none)   safe_dumps:    42.24 us/call
#29515(merged)  safe_dumps:    49.52 us/call     (+17%)
FIXED           safe_dumps:    42.64 us/call     (restored)

######## payload ~75 KB ########
v1.87.3(none)   safe_dumps:   214.70 us/call
#29515(merged)  safe_dumps:   251.08 us/call     (+17%)
FIXED           safe_dumps:   211.77 us/call     (restored)
```

The +17% overhead #29515 added is removed entirely and scales away with payload size, while NUL stripping still works

Correctness verified end-to-end on a live proxy hitting real OpenAI with `store_prompts_in_spend_logs: true`. A request whose prompt contains literal NUL bytes is stored cleanly in Postgres (Postgres rejects literal NUL with 22P05, so a successful insert proves none leaked):

```
# send a completion whose prompt content contains a NUL byte twice
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d @request_with_nul.json
# HTTP 200 - assistant: Hi! How can I assist you today?

# inspect the stored spend log row
psql -c "select
    (proxy_server_request::text like '%LIT-3910%')   as has_content,
    (proxy_server_request::text like E'%uXXXX%')      as has_escaped_nul,
    substring(proxy_server_request::text from 'Say hi[^\"]{0,40}') as stored_snippet
  from \"LiteLLM_SpendLogs\" where request_id = 'chatcmpl-...';"

#  has_content | has_escaped_nul |               stored_snippet
# -------------+-----------------+---------------------------------------------
#  t           | f               | Say hi. Embedded NUL byte test for LIT-3910.
```

The original prompt was "Say hi.<NUL> Embedded NUL<NUL> byte test for LIT-3910."; the stored value has the NUL bytes stripped, no escaped-NUL sequence, and the row stored without 22P05

## Type

🐛 Bug Fix

## Changes

`litellm/litellm_core_utils/safe_json_dumps.py`: only run the NUL replace on strings (values and keys) that actually contain a NUL byte

`tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py`: add a regression test that fails if `safe_dumps` runs `str.replace` on a NUL-free string (a `str` subclass whose `replace` raises), pinning the efficiency property; existing NUL-stripping correctness tests continue to pass
