### PR TITLE
fix(langfuse): preserve trace id from proxy metadata

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -1,7 +1,9 @@
 import base64
 import json  # <--- NEW
 import os
+import re
 from datetime import datetime
+from hashlib import sha256
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from litellm._logging import verbose_logger
@@ -25,6 +27,23 @@ else:
 
 LANGFUSE_CLOUD_EU_ENDPOINT = "https://cloud.langfuse.com/api/public/otel"
 LANGFUSE_CLOUD_US_ENDPOINT = "https://us.cloud.langfuse.com/api/public/otel"
+
+_OTEL_TRACE_ID_HEX = re.compile(r"[0-9a-f]{32}")
+
+
+def normalize_trace_id_for_otel(trace_id: str) -> str:
+    """Map an arbitrary trace id onto a valid 32-hex-char OTEL/Langfuse trace id.
+
+    Langfuse derives a trace's identity from the OTEL span-context trace id, which
+    must be 32 lowercase hex chars. An id that is already valid (case-insensitively,
+    or a dashed UUID) is reused directly so an explicit valid id is preserved; any
+    other string is hashed exactly as ``langfuse.create_trace_id(seed=...)`` does,
+    so a caller can reproduce the trace id from their external id.
+    """
+    canonical = trace_id.replace("-", "").lower()
+    if _OTEL_TRACE_ID_HEX.fullmatch(canonical):
+        return canonical
+    return sha256(trace_id.encode("utf-8")).digest()[:16].hex()
 
 
 class LangfuseOtelLogger(OpenTelemetry):

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -18,11 +18,14 @@ from litellm.types.integrations.langfuse_otel import (
 from litellm.types.utils import StandardCallbackDynamicParams
 
 if TYPE_CHECKING:
+    from opentelemetry.context import Context as _Context
     from opentelemetry.trace import Span as _Span
 
     Span = Union[_Span, Any]
+    Context = Union[_Context, Any]
 else:
     Span = Any
+    Context = Any
 
 
 LANGFUSE_CLOUD_EU_ENDPOINT = "https://cloud.langfuse.com/api/public/otel"
@@ -100,6 +103,61 @@ class LangfuseOtelLogger(OpenTelemetry):
             pass
 
         return metadata
+
+    @staticmethod
+    def _effective_langfuse_trace_id(kwargs) -> Optional[str]:
+        """Return the user-provided Langfuse trace id seed, if any.
+
+        ``existing_trace_id`` continues an existing trace and wins over
+        ``trace_id``, matching the vanilla Langfuse precedence.
+        """
+        metadata = LangfuseOtelLogger._extract_langfuse_metadata(kwargs)
+        raw = metadata.get("existing_trace_id") or metadata.get("trace_id")
+        return raw if isinstance(raw, str) and raw else None
+
+    @staticmethod
+    def _trace_id_parent_context(otel_trace_id_hex: str) -> "Context":
+        """Build an OTEL context whose non-recording parent carries
+        ``otel_trace_id_hex`` so a span started under it inherits that trace id.
+
+        Mirrors how the Langfuse SDK turns ``trace_context={"trace_id": ...}``
+        into a context: a non-recording parent with a synthetic span id and the
+        sampled flag set.
+        """
+        from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+        from opentelemetry.trace import (
+            NonRecordingSpan,
+            SpanContext,
+            TraceFlags,
+            set_span_in_context,
+        )
+
+        span_context = SpanContext(
+            trace_id=int(otel_trace_id_hex, 16),
+            span_id=RandomIdGenerator().generate_span_id(),
+            is_remote=False,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        return set_span_in_context(NonRecordingSpan(span_context))
+
+    def _get_span_context(self, kwargs, default_span: Optional[Span] = None):
+        """Honor an explicit Langfuse trace id from request metadata.
+
+        Any upstream parent (explicit parent span, traceparent header, or active
+        span) still wins, preserving distributed-tracing behavior. Only the
+        otherwise-random root span is anchored to the normalized trace id so the
+        Langfuse trace identity matches the caller's ``metadata.trace_id``.
+        """
+        ctx, parent_span = super()._get_span_context(kwargs, default_span=default_span)
+        if ctx is not None or parent_span is not None:
+            return ctx, parent_span
+
+        effective_trace_id = self._effective_langfuse_trace_id(kwargs)
+        if effective_trace_id is None:
+            return ctx, parent_span
+
+        otel_trace_id = normalize_trace_id_for_otel(effective_trace_id)
+        return self._trace_id_parent_context(otel_trace_id), None
 
     @staticmethod
     def _set_metadata_attributes(span: Span, metadata: dict):

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -1,8 +1,12 @@
 import json
 import os
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 
 from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
 from litellm.integrations.opentelemetry import OpenTelemetryConfig
@@ -239,6 +243,50 @@ class TestLangfuseOtelIntegration:
             assert (
                 actual == expected
             ), "Mismatch between expected and actual OTEL attribute mapping."
+
+    def test_openai_extra_body_trace_id_controls_langfuse_otel_trace_identity(self):
+        trace_id = "global_20260225143025_ord2468"
+        generation_name = "ishaan-test-generation"
+        exporter = InMemorySpanExporter()
+        logger = LangfuseOtelLogger(
+            config=OpenTelemetryConfig(exporter=exporter, skip_set_global=True),
+            callback_name="langfuse_otel",
+        )
+        metadata_from_openai_extra_body = {
+            "generation_name": generation_name,
+            "trace_id": trace_id,
+        }
+        kwargs = {
+            "litellm_params": {"metadata": metadata_from_openai_extra_body},
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "doubao",
+            "call_type": "acompletion",
+        }
+        response_obj = {
+            "id": "chatcmpl-test",
+            "choices": [
+                {"message": {"role": "assistant", "content": "ok"}},
+            ],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+        now = datetime.now()
+        with patch("litellm.integrations.arize._utils.set_attributes"):
+            logger.log_success_event(
+                kwargs=kwargs,
+                response_obj=response_obj,
+                start_time=now,
+                end_time=now,
+            )
+
+        generation_span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.attributes.get("langfuse.generation.name") == generation_name
+        )
+
+        assert generation_span.attributes.get("langfuse.trace.id") == trace_id
+        assert format(generation_span.context.trace_id, "032x") == trace_id
 
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -550,6 +550,63 @@ class TestLangfuseOtelIntegration:
             # Endpoint assertion removed as side effect is gone
 
 
+class TestNormalizeTraceIdForOtel:
+    """Unit tests for the trace-id normalization helper."""
+
+    def test_valid_lowercase_hex_passthrough(self):
+        from litellm.integrations.langfuse.langfuse_otel import (
+            normalize_trace_id_for_otel,
+        )
+
+        tid = "abcdef0123456789abcdef0123456789"
+        assert normalize_trace_id_for_otel(tid) == tid
+
+    def test_uppercase_hex_is_lowercased(self):
+        from litellm.integrations.langfuse.langfuse_otel import (
+            normalize_trace_id_for_otel,
+        )
+
+        assert (
+            normalize_trace_id_for_otel("ABCDEF0123456789ABCDEF0123456789")
+            == "abcdef0123456789abcdef0123456789"
+        )
+
+    def test_dashed_uuid_is_stripped_not_hashed(self):
+        from litellm.integrations.langfuse.langfuse_otel import (
+            normalize_trace_id_for_otel,
+        )
+
+        assert (
+            normalize_trace_id_for_otel("123e4567-e89b-12d3-a456-426614174000")
+            == "123e4567e89b12d3a456426614174000"
+        )
+
+    def test_external_id_hashed_like_langfuse_create_trace_id(self):
+        """Non-hex ids hash the ORIGINAL string (dashes and case preserved) so
+        the result is byte-for-byte ``langfuse.create_trace_id(seed=...)``."""
+        import hashlib
+
+        from litellm.integrations.langfuse.langfuse_otel import (
+            normalize_trace_id_for_otel,
+        )
+
+        for seed in ("global_20260225143025_ord2468", "Order-42", "ab-cd"):
+            assert (
+                normalize_trace_id_for_otel(seed)
+                == hashlib.sha256(seed.encode("utf-8")).digest()[:16].hex()
+            )
+
+    def test_output_is_always_32_lowercase_hex(self):
+        import re
+
+        from litellm.integrations.langfuse.langfuse_otel import (
+            normalize_trace_id_for_otel,
+        )
+
+        for seed in ("x", "global_seed", "ABCDEF0123456789ABCDEF0123456789", "1-2-3"):
+            assert re.fullmatch(r"[0-9a-f]{32}", normalize_trace_id_for_otel(seed))
+
+
 class TestLangfuseOtelResponsesAPI:
     """Test suite for Langfuse OTEL integration with ResponsesAPI"""
 

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -13,7 +13,7 @@ from litellm.integrations.opentelemetry import OpenTelemetryConfig
 from litellm.types.llms.openai import ResponsesAPIResponse
 
 
-def _export_langfuse_generation_span(metadata, *, generation_name="gen", model="doubao"):
+def _export_generation_span_for_kwargs(kwargs, *, generation_name):
     """Run a success event through a real (in-memory) Langfuse OTEL exporter and
     return the finished generation span, so trace-id tests assert against the
     actually-exported OTEL span context rather than a mock."""
@@ -22,14 +22,6 @@ def _export_langfuse_generation_span(metadata, *, generation_name="gen", model="
         config=OpenTelemetryConfig(exporter=exporter, skip_set_global=True),
         callback_name="langfuse_otel",
     )
-    kwargs = {
-        "litellm_params": {
-            "metadata": {"generation_name": generation_name, **metadata}
-        },
-        "messages": [{"role": "user", "content": "hi"}],
-        "model": model,
-        "call_type": "acompletion",
-    }
     response_obj = {
         "id": "chatcmpl-test",
         "choices": [{"message": {"role": "assistant", "content": "ok"}}],
@@ -45,6 +37,20 @@ def _export_langfuse_generation_span(metadata, *, generation_name="gen", model="
         for span in exporter.get_finished_spans()
         if span.attributes.get("langfuse.generation.name") == generation_name
     )
+
+
+def _export_langfuse_generation_span(
+    metadata, *, generation_name="gen", model="doubao"
+):
+    kwargs = {
+        "litellm_params": {
+            "metadata": {"generation_name": generation_name, **metadata}
+        },
+        "messages": [{"role": "user", "content": "hi"}],
+        "model": model,
+        "call_type": "acompletion",
+    }
+    return _export_generation_span_for_kwargs(kwargs, generation_name=generation_name)
 
 
 class TestLangfuseOtelIntegration:
@@ -286,9 +292,9 @@ class TestLangfuseOtelIntegration:
         import hashlib
 
         trace_id = "global_20260225143025_ord2468"
-        expected_otel_trace_id = hashlib.sha256(trace_id.encode("utf-8")).digest()[
-            :16
-        ].hex()
+        expected_otel_trace_id = (
+            hashlib.sha256(trace_id.encode("utf-8")).digest()[:16].hex()
+        )
         generation_name = "ishaan-test-generation"
         exporter = InMemorySpanExporter()
         logger = LangfuseOtelLogger(
@@ -329,7 +335,9 @@ class TestLangfuseOtelIntegration:
         )
 
         assert generation_span.attributes.get("langfuse.trace.id") == trace_id
-        assert format(generation_span.context.trace_id, "032x") == expected_otel_trace_id
+        assert (
+            format(generation_span.context.trace_id, "032x") == expected_otel_trace_id
+        )
 
     def test_valid_hex_trace_id_used_directly(self):
         """A ``metadata.trace_id`` that is already a valid 32-hex OTEL id must be
@@ -349,8 +357,7 @@ class TestLangfuseOtelIntegration:
             {"trace_id": "123e4567-e89b-12d3-a456-426614174000"}
         )
         assert (
-            format(span.context.trace_id, "032x")
-            == "123e4567e89b12d3a456426614174000"
+            format(span.context.trace_id, "032x") == "123e4567e89b12d3a456426614174000"
         )
 
     def test_existing_trace_id_takes_precedence_over_trace_id(self):
@@ -377,6 +384,58 @@ class TestLangfuseOtelIntegration:
         assert span.attributes.get("langfuse.generation.name") == "my-gen"
         assert span.name == "my-gen"
         assert format(span.context.trace_id, "032x") == expected
+
+    def test_traceparent_header_wins_over_metadata_trace_id(self):
+        """Distributed tracing must not regress: a traceparent header keeps
+        control of the trace identity even when metadata.trace_id is present."""
+        parent_trace_hex = "11111111111111111111111111111111"
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "generation_name": "gen",
+                    "trace_id": "global_20260225143025_ord2468",
+                },
+                "proxy_server_request": {
+                    "headers": {
+                        "traceparent": f"00-{parent_trace_hex}-2222222222222222-01"
+                    }
+                },
+            },
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "doubao",
+            "call_type": "acompletion",
+        }
+        span = _export_generation_span_for_kwargs(kwargs, generation_name="gen")
+        assert format(span.context.trace_id, "032x") == parent_trace_hex
+
+    def test_explicit_parent_span_wins_over_metadata_trace_id(self):
+        """An explicit proxy parent span keeps control of the trace identity even
+        when metadata.trace_id is present (the common proxy nesting case)."""
+        from opentelemetry.sdk.trace import TracerProvider
+
+        parent = TracerProvider().get_tracer("test").start_span("parent")
+        parent_trace_hex = format(parent.get_span_context().trace_id, "032x")
+        kwargs = {
+            "litellm_params": {
+                "metadata": {
+                    "generation_name": "gen",
+                    "trace_id": "global_20260225143025_ord2468",
+                    "litellm_parent_otel_span": parent,
+                },
+            },
+            "messages": [{"role": "user", "content": "hi"}],
+            "model": "doubao",
+            "call_type": "acompletion",
+        }
+        span = _export_generation_span_for_kwargs(kwargs, generation_name="gen")
+        assert format(span.context.trace_id, "032x") == parent_trace_hex
+
+    def test_no_trace_id_keeps_independent_random_root_spans(self):
+        """Without a metadata trace id the default behavior is unchanged: each
+        request gets its own random root trace, not a shared anchored one."""
+        first = _export_langfuse_generation_span({})
+        second = _export_langfuse_generation_span({})
+        assert first.context.trace_id != second.context.trace_id
 
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -353,6 +353,31 @@ class TestLangfuseOtelIntegration:
             == "123e4567e89b12d3a456426614174000"
         )
 
+    def test_existing_trace_id_takes_precedence_over_trace_id(self):
+        """``existing_trace_id`` continues an existing trace and must win over
+        ``trace_id`` for the OTEL trace identity, matching the vanilla Langfuse
+        precedence so trace continuation does not regress on the OTEL path."""
+        existing = "fedcba9876543210fedcba9876543210"
+        span = _export_langfuse_generation_span(
+            {"trace_id": "global_20260225143025_ord2468", "existing_trace_id": existing}
+        )
+        assert format(span.context.trace_id, "032x") == existing
+
+    def test_generation_name_preserved_with_custom_trace_id(self):
+        """Applying a custom trace context must not drop generation attributes:
+        the generation name still reaches the span (as both attribute and span
+        name) while the custom trace id drives the trace identity."""
+        import hashlib
+
+        trace_id = "order-42-trace"
+        expected = hashlib.sha256(trace_id.encode("utf-8")).digest()[:16].hex()
+        span = _export_langfuse_generation_span(
+            {"trace_id": trace_id}, generation_name="my-gen"
+        )
+        assert span.attributes.get("langfuse.generation.name") == "my-gen"
+        assert span.name == "my-gen"
+        assert format(span.context.trace_id, "032x") == expected
+
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""
         from litellm.types.integrations.langfuse_otel import LangfuseSpanAttributes

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -245,7 +245,16 @@ class TestLangfuseOtelIntegration:
             ), "Mismatch between expected and actual OTEL attribute mapping."
 
     def test_openai_extra_body_trace_id_controls_langfuse_otel_trace_identity(self):
+        """A non-hex ``metadata.trace_id`` from ``extra_body`` must drive the
+        exported OTEL span-context trace id (Langfuse derives a trace's identity
+        from it), deterministically hashed the same way ``langfuse.create_trace_id``
+        does so the caller can reproduce the id from their external id."""
+        import hashlib
+
         trace_id = "global_20260225143025_ord2468"
+        expected_otel_trace_id = hashlib.sha256(trace_id.encode("utf-8")).digest()[
+            :16
+        ].hex()
         generation_name = "ishaan-test-generation"
         exporter = InMemorySpanExporter()
         logger = LangfuseOtelLogger(
@@ -286,7 +295,7 @@ class TestLangfuseOtelIntegration:
         )
 
         assert generation_span.attributes.get("langfuse.trace.id") == trace_id
-        assert format(generation_span.context.trace_id, "032x") == trace_id
+        assert format(generation_span.context.trace_id, "032x") == expected_otel_trace_id
 
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -13,6 +13,40 @@ from litellm.integrations.opentelemetry import OpenTelemetryConfig
 from litellm.types.llms.openai import ResponsesAPIResponse
 
 
+def _export_langfuse_generation_span(metadata, *, generation_name="gen", model="doubao"):
+    """Run a success event through a real (in-memory) Langfuse OTEL exporter and
+    return the finished generation span, so trace-id tests assert against the
+    actually-exported OTEL span context rather than a mock."""
+    exporter = InMemorySpanExporter()
+    logger = LangfuseOtelLogger(
+        config=OpenTelemetryConfig(exporter=exporter, skip_set_global=True),
+        callback_name="langfuse_otel",
+    )
+    kwargs = {
+        "litellm_params": {
+            "metadata": {"generation_name": generation_name, **metadata}
+        },
+        "messages": [{"role": "user", "content": "hi"}],
+        "model": model,
+        "call_type": "acompletion",
+    }
+    response_obj = {
+        "id": "chatcmpl-test",
+        "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+    now = datetime.now()
+    with patch("litellm.integrations.arize._utils.set_attributes"):
+        logger.log_success_event(
+            kwargs=kwargs, response_obj=response_obj, start_time=now, end_time=now
+        )
+    return next(
+        span
+        for span in exporter.get_finished_spans()
+        if span.attributes.get("langfuse.generation.name") == generation_name
+    )
+
+
 class TestLangfuseOtelIntegration:
     def test_get_langfuse_otel_config_with_required_env_vars(self):
         """Test that config is created correctly with required environment variables."""
@@ -296,6 +330,28 @@ class TestLangfuseOtelIntegration:
 
         assert generation_span.attributes.get("langfuse.trace.id") == trace_id
         assert format(generation_span.context.trace_id, "032x") == expected_otel_trace_id
+
+    def test_valid_hex_trace_id_used_directly(self):
+        """A ``metadata.trace_id`` that is already a valid 32-hex OTEL id must be
+        used verbatim (lowercased) as the trace identity, never re-hashed, so an
+        explicit valid id is preserved end to end."""
+        for given, expected in (
+            ("abcdef0123456789abcdef0123456789", "abcdef0123456789abcdef0123456789"),
+            ("ABCDEF0123456789ABCDEF0123456789", "abcdef0123456789abcdef0123456789"),
+        ):
+            span = _export_langfuse_generation_span({"trace_id": given})
+            assert format(span.context.trace_id, "032x") == expected
+
+    def test_dashed_uuid_trace_id_normalized(self):
+        """A dashed UUID ``metadata.trace_id`` must map to its dash-stripped
+        32-hex form (LiteLLM's conventional trace id), not be sha256-hashed."""
+        span = _export_langfuse_generation_span(
+            {"trace_id": "123e4567-e89b-12d3-a456-426614174000"}
+        )
+        assert (
+            format(span.context.trace_id, "032x")
+            == "123e4567e89b12d3a456426614174000"
+        )
 
     def test_set_langfuse_specific_attributes_with_content(self):
         """Test that _set_langfuse_specific_attributes correctly sets observation.output with regular content response."""


### PR DESCRIPTION
## Relevant issues

Fixes #31378

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live run against a local proxy with `callbacks: ["langfuse_otel"]`, a real OpenAI model (`gpt-4.1-nano`), and a real Langfuse project (US cloud). Real calls, real spend, no mocks

The issue's exact request shape (`extra_body.metadata` from the OpenAI client arrives as top-level `metadata`):

```bash
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer sk-1234" \
  -d '{"model":"doubao","messages":[{"role":"user","content":"你好，你叫什么"}],
       "metadata":{"generation_name":"ishaan-test-generation","trace_id":"global_20260225143025_ord2468"}}'
# -> HTTP 200, real completion: "你好！我是ChatGPT ..."
```

The external id `global_20260225143025_ord2468` is not valid hex, so it is deterministically mapped the same way `langfuse.create_trace_id(seed=...)` does, which yields `69a93b3a2e46610a7677f4da579af29f`. Looking that up in Langfuse finds the trace:

```bash
curl -u "$LANGFUSE_PUBLIC_KEY:$LANGFUSE_SECRET_KEY" \
  https://us.cloud.langfuse.com/api/public/traces/69a93b3a2e46610a7677f4da579af29f
# -> HTTP 200
#    trace.id      = 69a93b3a2e46610a7677f4da579af29f
#    observations  = GENERATION "ishaan-test-generation" (model doubao) + SPAN
```

Before/after on the same fresh seed `bug-demo-no-fix-20260626-xyz` (which maps to `d4f0682860ac4c853056fbb25c25b8e1`) makes the breakage concrete. On the pre-fix code, looking the trace up by that deterministic id returns 404 because the span was exported under a random id (`20941361ec3c55ff412f075961c6221e`); a caller who sets `metadata.trace_id` and later looks it up by the Langfuse-derived id finds nothing. On the fixed code, the same request lands the trace under `d4f0682860ac4c853056fbb25c25b8e1` and the lookup returns 200 with the generation under it

```
pre-fix:  GET /api/public/traces/d4f0682860ac4c853056fbb25c25b8e1 -> 404  (trace under random id 20941361ec3c55ff412f075961c6221e)
fixed:    GET /api/public/traces/d4f0682860ac4c853056fbb25c25b8e1 -> 200  (trace.id == d4f0682860ac4c853056fbb25c25b8e1, GENERATION "fixed-demo")
```

Automated coverage backing this up: the focused regression suite in `tests/test_litellm/integrations/test_langfuse_otel.py` (33 passing, including the proxy-shaped repro, valid-hex passthrough, dashed-UUID normalization, `existing_trace_id` precedence, and traceparent / explicit-parent-span precedence guards), plus unit tests for the normalization helper. Mutation checks on the production code (truncated hash, dropped hex passthrough, ignored upstream parent, dropped `existing_trace_id` precedence) are all caught by the tests

## Type

🐛 Bug Fix

## Changes

Langfuse (the OpenTelemetry-based ingestion) derives a trace's identity from the OpenTelemetry span-context trace id, which must be 32 lowercase hex characters. `LangfuseOtelLogger` only ever wrote `metadata.trace_id` as a span attribute (`langfuse.trace.id`), which Langfuse does not use to set trace identity, so the exported generation span kept a randomly generated trace id and a `trace_id` passed through `extra_body.metadata` never controlled the Langfuse trace. `generation_name` appeared to work only because it also becomes the span name

This anchors the otherwise-random root span to the caller's trace id. `LangfuseOtelLogger` normalizes the provided id to a valid 32-hex trace id and starts the generation span under a non-recording parent context carrying it, mirroring how the Langfuse SDK builds context from `trace_context={"trace_id": ...}`. A value that is already a valid 32-hex id (case-insensitive) or a dashed UUID is used directly; any other string is hashed with `sha256(id).digest()[:16].hex()`, byte-for-byte identical to `langfuse.create_trace_id(seed=...)`, so a caller can reproduce the trace id from their external id. `existing_trace_id` keeps precedence over `trace_id`, matching the vanilla Langfuse integration

The change is isolated to the Langfuse OTEL integration. Any upstream parent (an explicit proxy parent span, a `traceparent` header, or an active span) still wins, so distributed tracing is unaffected, and behavior for non-Langfuse callbacks is unchanged
