### PR TITLE
fix: safe_dumps false circular-reference on repeated sibling values

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -58,6 +58,7 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
             return result
         else:
             # Fall back to string conversion for non-serializable objects.
+            seen.remove(id(obj))
             try:
                 return strip_null_bytes(str(obj))
             except Exception:

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -80,6 +80,27 @@ def test_unserializable_object():
     assert result == "Unserializable Object"
 
 
+def test_repeated_unserializable_sibling_is_not_circular():
+    # The same non-serializable object appearing twice as siblings is not a
+    # circular reference and both occurrences must be serialized.
+    class Stringable:
+        def __str__(self):
+            return "value"
+
+    obj = Stringable()
+
+    assert json.loads(safe_dumps([obj, obj])) == ["value", "value"]
+    assert json.loads(safe_dumps({"a": obj, "b": obj})) == {
+        "a": "value",
+        "b": "value",
+    }
+
+    # A genuine self-cycle must still be reported.
+    cycle = {}
+    cycle["self"] = cycle
+    assert json.loads(safe_dumps(cycle))["self"] == "CircularReference Detected"
+
+
 def test_non_standard_dict_keys():
     try:
         # Test handling of dictionaries with non-standard keys


### PR DESCRIPTION
`safe_dumps`'s else-branch is missing the `seen.remove(...)` that the recursive branch performs after descending, so a value that legitimately appears in two sibling (non-nested) positions is falsely reported as a circular reference. The fix mirrors the `seen.remove` already present in the other branch. Verified both ways with a value reused across siblings.