### PR TITLE
perf(caching): memoize _get_all_llm_api_params, rebuilt per request

### DIFF
--- a/litellm/litellm_core_utils/model_param_helper.py
+++ b/litellm/litellm_core_utils/model_param_helper.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Set
 
 from openai.types.chat.completion_create_params import (
@@ -54,9 +55,17 @@ class ModelParamHelper:
         return combined_kwargs
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def _get_all_llm_api_params() -> Set[str]:
         """
-        Gets the supported kwargs for each call type and combines them
+        Gets the supported kwargs for each call type and combines them.
+
+        The result is derived from static type annotations and fixed sets, so it
+        is constant for the process lifetime. It is computed once and cached
+        because it is rebuilt on every request through both the cache-key path
+        (``Cache.get_cache_key``) and the spend-logging path
+        (``_get_relevant_args_to_use_for_logging``). Callers treat the result as
+        read-only.
         """
         chat_completion_kwargs = (
             ModelParamHelper._get_litellm_supported_chat_completion_kwargs()

--- a/tests/test_litellm/litellm_core_utils/test_model_param_helper.py
+++ b/tests/test_litellm/litellm_core_utils/test_model_param_helper.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath("../../..")
+)  # Adds the parent directory to the system path
+
+from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
+
+
+def test_get_all_llm_api_params_is_correct():
+    """The cached result must equal a fresh, uncached computation."""
+    cached = ModelParamHelper._get_all_llm_api_params()
+    uncached = ModelParamHelper._get_all_llm_api_params.__wrapped__()
+    assert cached == uncached
+    assert {"model", "temperature", "stream"} <= cached
+    assert "metadata" not in cached  # excluded via _get_exclude_kwargs
+
+
+def test_get_all_llm_api_params_is_memoized():
+    """Regression: the param set is static and is rebuilt on every request via
+    the cache-key and spend-logging paths, so it must be memoized. Without the
+    cache each call returns a freshly built set (a different object)."""
+    first = ModelParamHelper._get_all_llm_api_params()
+    second = ModelParamHelper._get_all_llm_api_params()
+    assert first is second


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-4050 (found while investigating LIT-3910)

## Context

Pre-existing per-request inefficiency, not a regression in any particular release. `ModelParamHelper._get_all_llm_api_params()` introspects six sets of supported kwargs (chat, text, embedding, transcription, rerank, responses) from static OpenAI type annotations plus fixed sets, unions them, and subtracts an exclude set. The result is constant for the process lifetime, yet it was recomputed on every request through two near-universal paths:

- `Cache.get_cache_key()` runs on every request when caching is enabled
- `_get_relevant_args_to_use_for_logging()` -> `get_standard_logging_model_parameters()` runs on every request that builds a StandardLoggingPayload (spend logging and most callbacks)

## Fix

Memoize with `lru_cache(maxsize=1)`. The function takes no arguments and its result is process-static, and both callers treat the result as read-only (membership tests and `.difference()`, no mutation), so sharing one cached instance is safe.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Microbenchmark, cached vs the uncached underlying function (`__wrapped__`):

```
CACHED:   0.022 us/call
UNCACHED: 4.695 us/call
```

About 213x faster. Across the two per-request call sites that is roughly 9 us/req saved on every cached/logged request. Correctness verified in the same run: the cached result equals a fresh uncached computation, and repeated calls return the same object.

## Type

🚄 Infrastructure

## Changes

`litellm/litellm_core_utils/model_param_helper.py`: add `lru_cache(maxsize=1)` to `_get_all_llm_api_params`

`tests/test_litellm/litellm_core_utils/test_model_param_helper.py`: new mapped test file asserting the cached result equals the uncached computation and that the result is memoized (the memoization test fails if the cache is removed)
