### PR TITLE
fix(proxy): import installed callback modules before falling back to local files

### DIFF
--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -35,29 +35,36 @@ def get_instance_fn(value: str, config_file_path: Optional[str] = None) -> Any:
         instance_name = parts[-1]
 
         # If config_file_path is provided, use it to determine the module spec and load the module
-        if config_file_path is not None:
-            directory = os.path.dirname(config_file_path)
-            module_file_path = os.path.join(directory, *module_name.split("."))
-            module_file_path += ".py"
+        try:
+           # First try a normal Python import (site-packages, installed modules, etc.)
+           module = importlib.import_module(module_name)
 
-            # Check if the file exists before trying to load it
-            if not os.path.exists(module_file_path):
-                raise ImportError(f"Could not find module file {module_file_path}")
+        except ImportError:
+           # Fall back to loading a local callback relative to the config file
+           if config_file_path is None:
+              raise
 
-            spec = importlib.util.spec_from_file_location(module_name, module_file_path)  # type: ignore
-            if spec is None:
-                raise ImportError(
-                    f"Could not find a module specification for {module_file_path}"
-                )
-            module = importlib.util.module_from_spec(spec)  # type: ignore
-            if spec.loader is None:
-                raise ImportError(
-                    f"Could not find a module loader for {module_file_path}"
-                )
-            spec.loader.exec_module(module)  # type: ignore
-        else:
-            # Dynamically import the module
-            module = importlib.import_module(module_name)
+           directory = os.path.dirname(config_file_path)
+           module_file_path = os.path.join(directory, *module_name.split("."))
+           module_file_path += ".py"
+
+           if not os.path.exists(module_file_path):
+              raise ImportError(f"Could not find module file {module_file_path}")
+
+           spec = importlib.util.spec_from_file_location(module_name, module_file_path)
+           if spec is None:
+              raise ImportError(
+                 f"Could not find a module specification for {module_file_path}"
+           )
+
+           module = importlib.util.module_from_spec(spec)
+
+           if spec.loader is None:
+              raise ImportError(
+                 f"Could not find a module loader for {module_file_path}"
+           )
+
+           spec.loader.exec_module(module)
 
         # Get the instance from the module
         instance = getattr(module, instance_name)

--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -39,11 +39,19 @@ def get_instance_fn(value: str, config_file_path: Optional[str] = None) -> Any:
             # First try a normal Python import (site-packages, installed modules, etc.)
             module = importlib.import_module(module_name)
 
-        except ImportError:
-            # Fall back to loading a local callback relative to the config file
+        except ModuleNotFoundError as e:
+            # Only fall back to local file if the root module itself isn't found.
+            # If the module exists but has missing dependencies, let that error propagate.
             if config_file_path is None:
                 raise
 
+            # Check if the error is about the module we're trying to import or a dependency
+            # e.name will be set to the module that couldn't be found
+            if e.name and not module_name.startswith(e.name.split(".")[0]):
+                # The error is about a dependency, not our target module
+                raise
+
+            # Fall back to loading a local callback relative to the config file
             directory = os.path.dirname(config_file_path)
             module_file_path = os.path.join(directory, *module_name.split("."))
             module_file_path += ".py"

--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -36,35 +36,35 @@ def get_instance_fn(value: str, config_file_path: Optional[str] = None) -> Any:
 
         # If config_file_path is provided, use it to determine the module spec and load the module
         try:
-           # First try a normal Python import (site-packages, installed modules, etc.)
-           module = importlib.import_module(module_name)
+            # First try a normal Python import (site-packages, installed modules, etc.)
+            module = importlib.import_module(module_name)
 
         except ImportError:
-           # Fall back to loading a local callback relative to the config file
-           if config_file_path is None:
-              raise
+            # Fall back to loading a local callback relative to the config file
+            if config_file_path is None:
+                raise
 
-           directory = os.path.dirname(config_file_path)
-           module_file_path = os.path.join(directory, *module_name.split("."))
-           module_file_path += ".py"
+            directory = os.path.dirname(config_file_path)
+            module_file_path = os.path.join(directory, *module_name.split("."))
+            module_file_path += ".py"
 
-           if not os.path.exists(module_file_path):
-              raise ImportError(f"Could not find module file {module_file_path}")
+            if not os.path.exists(module_file_path):
+                raise ImportError(f"Could not find module file {module_file_path}")
 
-           spec = importlib.util.spec_from_file_location(module_name, module_file_path)
-           if spec is None:
-              raise ImportError(
-                 f"Could not find a module specification for {module_file_path}"
-           )
+            spec = importlib.util.spec_from_file_location(module_name, module_file_path)
+            if spec is None:
+                raise ImportError(
+                    f"Could not find a module specification for {module_file_path}"
+                )
 
-           module = importlib.util.module_from_spec(spec)
+            module = importlib.util.module_from_spec(spec)
 
-           if spec.loader is None:
-              raise ImportError(
-                 f"Could not find a module loader for {module_file_path}"
-           )
+            if spec.loader is None:
+                raise ImportError(
+                    f"Could not find a module loader for {module_file_path}"
+                )
 
-           spec.loader.exec_module(module)
+            spec.loader.exec_module(module)
 
         # Get the instance from the module
         instance = getattr(module, instance_name)


### PR DESCRIPTION
## Summary

This PR fixes callback loading in the LiteLLM Proxy by attempting a normal Python import before falling back to loading a callback module from a file relative to the config directory.

## Problem

When callbacks are configured in `config.yaml` like this:

```yaml
litellm_settings:
  callbacks:
    - some_package.some_module.SomeCallback
```

the current implementation always treats the callback as a local Python file whenever `config_file_path` is present.

For example, it attempts to load:

```
<config_directory>/some_package/some_module.py
```

instead of importing the installed package from Python's import system.

This prevents callbacks installed via `pip` from working with the LiteLLM Proxy, even though they are importable using Python.

## Current Behavior

```python
from some_package.some_module import SomeCallback
```

works correctly.

However, LiteLLM Proxy raises:

```
ImportError:
Could not find module file ...
```

because it never attempts a normal Python import.

## Proposed Solution

Attempt to import the module first using:

```python
importlib.import_module(module_name)
```

If that fails, preserve the existing behavior by loading the callback from a local file relative to the config directory.

## Benefits

- Supports callbacks installed through pip.
- Preserves support for project-local callback files.
- Fully backwards compatible.
- Aligns callback resolution with normal Python import semantics.

## Testing

Verified that:

- pip-installed callback modules import successfully.
- existing local callback loading continues to work as before.
- proxy starts normally after the change.