### PR TITLE
fix(proxy): restore wildcard expansion in /v1/model/info

### DIFF
--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -1,6 +1,7 @@
 # What is this?
 ## Common checks for /v1/models and `/model/info`
-from typing import Dict, List, Optional, Set
+import copy
+from typing import Any, Dict, List, Optional, Set
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -339,6 +340,55 @@ def get_known_models_from_wildcard(
                 model = f"{wildcard_provider_prefix}/{model}"
         suffix_appended_wildcard_models.append(model)
     return suffix_appended_wildcard_models or []
+
+
+def expand_wildcard_deployments_for_model_info(
+    deployments: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Expand wildcard deployments into one row per known provider model.
+
+    PR #30025 changed /model/info to read from llm_router.model_list (correct,
+    so team-scoped rows are included). This function restores wildcard expansion
+    on top of that: a wildcard deployment like model_name="*" / litellm_params.model="openai/*"
+    becomes one entry per known openai model, matching /v1/models behaviour.
+    """
+    expanded: List[Dict[str, Any]] = []
+    for deployment in deployments:
+        model_name = deployment.get("model_name") or ""
+        litellm_params_dict = deployment.get("litellm_params") or {}
+        litellm_model = litellm_params_dict.get("model") or ""
+
+        # Determine the wildcard pattern to expand
+        if _check_wildcard_routing(model_name) and "/" in model_name:
+            wildcard_pattern = model_name
+        elif _check_wildcard_routing(litellm_model):
+            wildcard_pattern = litellm_model
+        elif _check_wildcard_routing(model_name):
+            wildcard_pattern = model_name
+        else:
+            expanded.append(deployment)
+            continue
+
+        litellm_params = (
+            LiteLLM_Params(**litellm_params_dict) if litellm_params_dict else None
+        )
+        expanded_names = get_known_models_from_wildcard(
+            wildcard_model=wildcard_pattern,
+            litellm_params=litellm_params,
+        )
+        if not expanded_names:
+            expanded.append(deployment)
+            continue
+
+        for name in expanded_names:
+            row = copy.deepcopy(deployment)
+            row["model_name"] = name
+            params = row.get("litellm_params")
+            if isinstance(params, dict):
+                params["model"] = name
+            expanded.append(row)
+
+    return expanded
 
 
 def _get_wildcard_models(

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -343,8 +343,8 @@ def get_known_models_from_wildcard(
 
 
 def expand_wildcard_deployments_for_model_info(
-    deployments: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
+    deployments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
     """Expand wildcard deployments into one row per known provider model.
 
     PR #30025 changed /model/info to read from llm_router.model_list (correct,
@@ -352,7 +352,7 @@ def expand_wildcard_deployments_for_model_info(
     on top of that: a wildcard deployment like model_name="*" / litellm_params.model="openai/*"
     becomes one entry per known openai model, matching /v1/models behaviour.
     """
-    expanded: List[Dict[str, Any]] = []
+    expanded: list[dict[str, Any]] = []
     for deployment in deployments:
         model_name = deployment.get("model_name") or ""
         litellm_params_dict = deployment.get("litellm_params") or {}

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -364,9 +364,12 @@ def expand_wildcard_deployments_for_model_info(
     """
     expanded: list[dict[str, Any]] = []
     for deployment in deployments:
-        model_name = deployment.get("model_name") or ""
-        litellm_params_dict = deployment.get("litellm_params") or {}
-        litellm_model = litellm_params_dict.get("model") or ""
+        model_name = str(deployment.get("model_name") or "")
+        raw_params = deployment.get("litellm_params")
+        litellm_params_dict: dict[str, Any] = (
+            raw_params if isinstance(raw_params, dict) else {}
+        )
+        litellm_model = str(litellm_params_dict.get("model") or "")
 
         # Determine the wildcard pattern to expand.
         # Branch order matters: only fall to litellm_model when model_name is
@@ -385,7 +388,9 @@ def expand_wildcard_deployments_for_model_info(
 
         try:
             litellm_params = (
-                LiteLLM_Params(**litellm_params_dict) if litellm_params_dict else None
+                LiteLLM_Params.model_validate(litellm_params_dict)
+                if litellm_params_dict
+                else None
             )
         except Exception:
             expanded.append(deployment)

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -282,8 +282,18 @@ def _hydrate_litellm_credential_name(
 def get_known_models_from_wildcard(
     wildcard_model: str, litellm_params: Optional[LiteLLM_Params] = None
 ) -> List[str]:
+    wildcard_model_to_expand = (
+        litellm_params.model
+        if wildcard_model == "*"
+        and litellm_params is not None
+        and _check_wildcard_routing(litellm_params.model)
+        and "/" in litellm_params.model
+        else wildcard_model
+    )
     try:
-        wildcard_provider_prefix, wildcard_suffix = wildcard_model.split("/", 1)
+        wildcard_provider_prefix, wildcard_suffix = wildcard_model_to_expand.split(
+            "/", 1
+        )
     except ValueError:  # safely fail
         return []
 

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -358,10 +358,14 @@ def expand_wildcard_deployments_for_model_info(
         litellm_params_dict = deployment.get("litellm_params") or {}
         litellm_model = litellm_params_dict.get("model") or ""
 
-        # Determine the wildcard pattern to expand
+        # Determine the wildcard pattern to expand.
+        # Branch order matters: only fall to litellm_model when model_name is
+        # also a wildcard, so a concrete model_name is never overwritten.
         if _check_wildcard_routing(model_name) and "/" in model_name:
             wildcard_pattern = model_name
-        elif _check_wildcard_routing(litellm_model):
+        elif _check_wildcard_routing(model_name) and _check_wildcard_routing(
+            litellm_model
+        ):
             wildcard_pattern = litellm_model
         elif _check_wildcard_routing(model_name):
             wildcard_pattern = model_name
@@ -369,9 +373,13 @@ def expand_wildcard_deployments_for_model_info(
             expanded.append(deployment)
             continue
 
-        litellm_params = (
-            LiteLLM_Params(**litellm_params_dict) if litellm_params_dict else None
-        )
+        try:
+            litellm_params = (
+                LiteLLM_Params(**litellm_params_dict) if litellm_params_dict else None
+            )
+        except Exception:
+            expanded.append(deployment)
+            continue
         expanded_names = get_known_models_from_wildcard(
             wildcard_model=wildcard_pattern,
             litellm_params=litellm_params,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -269,6 +269,7 @@ from litellm.proxy.auth.auth_utils import (
 from litellm.proxy.auth.handle_jwt import JWTHandler
 from litellm.proxy.auth.litellm_license import LicenseCheck
 from litellm.proxy.auth.model_checks import (
+    expand_wildcard_deployments_for_model_info,
     get_all_fallbacks,
     get_complete_model_list,
     get_key_models,
@@ -673,21 +674,7 @@ _description = (
 
 
 def cleanup_router_config_variables():
-    global \
-        master_key, \
-        user_config_file_path, \
-        otel_logging, \
-        user_custom_auth, \
-        user_custom_auth_path, \
-        user_custom_key_generate, \
-        user_custom_key_update, \
-        user_custom_sso, \
-        user_custom_ui_sso_sign_in_handler, \
-        use_background_health_checks, \
-        use_shared_health_check, \
-        health_check_interval, \
-        health_check_concurrency, \
-        prisma_client
+    global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_key_update, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, use_shared_health_check, health_check_interval, health_check_concurrency, prisma_client
 
     # Set all variables to None
     master_key = None
@@ -707,12 +694,7 @@ def cleanup_router_config_variables():
 
 
 async def proxy_shutdown_event():
-    global \
-        prisma_client, \
-        master_key, \
-        user_custom_auth, \
-        user_custom_key_generate, \
-        user_custom_key_update
+    global prisma_client, master_key, user_custom_auth, user_custom_key_generate, user_custom_key_update
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
@@ -782,22 +764,7 @@ async def _initialize_shared_aiohttp_session():
 
 @asynccontextmanager
 async def proxy_startup_event(app: FastAPI):
-    global \
-        prisma_client, \
-        master_key, \
-        use_background_health_checks, \
-        llm_router, \
-        llm_model_list, \
-        general_settings, \
-        proxy_budget_rescheduler_min_time, \
-        proxy_budget_rescheduler_max_time, \
-        litellm_proxy_admin_name, \
-        db_writer_client, \
-        store_model_in_db, \
-        premium_user, \
-        _license_check, \
-        proxy_batch_polling_interval, \
-        shared_aiohttp_session
+    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval, shared_aiohttp_session
     import json
 
     init_verbose_loggers()
@@ -1978,9 +1945,9 @@ redis_usage_cache: Optional[RedisCache] = (
     None  # redis cache used for tracking spend, tpm/rpm limits
 )
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[
-    str
-] = []  # Models that should use native provider background mode instead of polling
+native_background_mode: List[str] = (
+    []
+)  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -3287,9 +3254,13 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if llm_router.health_check_ignore_transient_errors and exception_status in (
-                429,
-                408,
+            if (
+                llm_router.health_check_ignore_transient_errors
+                and exception_status
+                in (
+                    429,
+                    408,
+                )
             ):
                 continue
 
@@ -4195,35 +4166,7 @@ class ProxyConfig:
         """
         Load config values into proxy global state
         """
-        global \
-            master_key, \
-            user_config_file_path, \
-            otel_logging, \
-            user_custom_auth, \
-            user_custom_auth_path, \
-            user_custom_key_generate, \
-            user_custom_key_update, \
-            user_custom_sso, \
-            user_custom_ui_sso_sign_in_handler, \
-            use_background_health_checks, \
-            use_shared_health_check, \
-            health_check_interval, \
-            health_check_concurrency, \
-            use_queue, \
-            proxy_budget_rescheduler_max_time, \
-            proxy_budget_rescheduler_min_time, \
-            ui_access_mode, \
-            litellm_master_key_hash, \
-            proxy_batch_write_at, \
-            disable_spend_logs, \
-            prompt_injection_detection_obj, \
-            redis_usage_cache, \
-            store_model_in_db, \
-            premium_user, \
-            open_telemetry_logger, \
-            health_check_details, \
-            proxy_batch_polling_interval, \
-            config_passthrough_endpoints
+        global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_key_update, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, use_shared_health_check, health_check_interval, health_check_concurrency, use_queue, proxy_budget_rescheduler_max_time, proxy_budget_rescheduler_min_time, ui_access_mode, litellm_master_key_hash, proxy_batch_write_at, disable_spend_logs, prompt_injection_detection_obj, redis_usage_cache, store_model_in_db, premium_user, open_telemetry_logger, health_check_details, proxy_batch_polling_interval, config_passthrough_endpoints
 
         config: dict = await self.get_config(config_file_path=config_file_path)
 
@@ -4500,10 +4443,7 @@ class ProxyConfig:
                     pass
                 elif key == "responses":
                     # Initialize global polling via cache settings
-                    global \
-                        polling_via_cache_enabled, \
-                        native_background_mode, \
-                        polling_cache_ttl
+                    global polling_via_cache_enabled, native_background_mode, polling_cache_ttl
                     background_mode = value.get("background_mode", {})
                     polling_via_cache_enabled = background_mode.get(
                         "polling_via_cache", False
@@ -5138,7 +5078,8 @@ class ProxyConfig:
                 ### LOAD FROM GOOGLE KMS ###
                 load_google_kms(use_google_kms=True)
             elif (
-                key_management_system == KeyManagementSystem.AWS_SECRET_MANAGER.value  # noqa: F405
+                key_management_system
+                == KeyManagementSystem.AWS_SECRET_MANAGER.value  # noqa: F405
             ):
                 from litellm.secret_managers.aws_secret_manager_v2 import (
                     AWSSecretsManagerV2,
@@ -6689,10 +6630,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[
-                Guardrail
-            ] = await GuardrailRegistry.get_all_guardrails_from_db(
-                prisma_client=prisma_client
+            guardrails_in_db: List[Guardrail] = (
+                await GuardrailRegistry.get_all_guardrails_from_db(
+                    prisma_client=prisma_client
+                )
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -7004,23 +6945,7 @@ async def initialize(
     use_queue=False,
     config=None,
 ):
-    global \
-        user_model, \
-        user_api_base, \
-        user_debug, \
-        user_detailed_debug, \
-        user_user_max_tokens, \
-        user_request_timeout, \
-        user_temperature, \
-        user_telemetry, \
-        user_headers, \
-        experimental, \
-        llm_model_list, \
-        llm_router, \
-        general_settings, \
-        master_key, \
-        user_custom_auth, \
-        prisma_client
+    global user_model, user_api_base, user_debug, user_detailed_debug, user_user_max_tokens, user_request_timeout, user_temperature, user_telemetry, user_headers, experimental, llm_model_list, llm_router, general_settings, master_key, user_custom_auth, prisma_client
     from litellm.proxy.common_utils.banner import show_banner
 
     show_banner()
@@ -8832,13 +8757,7 @@ async def model_list(
                     Hiding is presentation-only: a hidden model can still be
                     called directly.
     """
-    global \
-        llm_model_list, \
-        general_settings, \
-        llm_router, \
-        prisma_client, \
-        user_api_key_cache, \
-        proxy_logging_obj
+    global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
 
     settings = cast(dict[str, object], general_settings)  # any-ok: legacy settings
 
@@ -9015,13 +8934,7 @@ async def model_info(
     scoping, health filtering, paused deployments) drives both endpoints; the
     listing's public id must resolve to the same internal deployment here.
     """
-    global \
-        llm_model_list, \
-        general_settings, \
-        llm_router, \
-        prisma_client, \
-        user_api_key_cache, \
-        proxy_logging_obj
+    global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
 
     settings = cast(dict[str, object], general_settings)  # any-ok: legacy settings
 
@@ -9172,9 +9085,9 @@ async def chat_completion(
             hasattr(user_api_key_dict, "organization_alias")
             and user_api_key_dict.organization_alias is not None
         ):
-            data["metadata"]["user_api_key_org_alias"] = (
-                user_api_key_dict.organization_alias
-            )
+            data["metadata"][
+                "user_api_key_org_alias"
+            ] = user_api_key_dict.organization_alias
         if (
             hasattr(user_api_key_dict, "agent_id")
             and user_api_key_dict.agent_id is not None
@@ -9356,9 +9269,9 @@ async def completion(
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -9572,12 +9485,9 @@ async def embeddings(
                     litellm_params = deployment.get("litellm_params", {}) or {}
                     litellm_model = litellm_params.get("model", "")
                     # Check if this provider supports token arrays
-                    supports_token_arrays = (
-                        litellm_model in litellm.open_ai_embedding_models
-                        or any(
-                            litellm_model.startswith(provider)
-                            for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
-                        )
+                    supports_token_arrays = litellm_model in litellm.open_ai_embedding_models or any(
+                        litellm_model.startswith(provider)
+                        for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
                     )
                     if not supports_token_arrays:
                         # non-openai/azure embedding model called with token input - decode tokens
@@ -9610,9 +9520,9 @@ async def embeddings(
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"]["user_api_key_org_alias"] = (
-                    user_api_key_dict.organization_alias
-                )
+                data["metadata"][
+                    "user_api_key_org_alias"
+                ] = user_api_key_dict.organization_alias
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -12570,12 +12480,7 @@ async def model_info_v2(
     }
     ```
     """
-    global \
-        llm_model_list, \
-        general_settings, \
-        user_config_file_path, \
-        proxy_config, \
-        llm_router
+    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router
 
     # Return empty data array when no models are configured (graceful handling for fresh installs)
     if llm_router is None or not llm_router.model_list:
@@ -13331,13 +13236,7 @@ async def model_info_v1(
 
     ```
     """
-    global \
-        llm_model_list, \
-        general_settings, \
-        user_config_file_path, \
-        proxy_config, \
-        llm_router, \
-        user_model
+    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router, user_model
 
     # Unit tests call this handler directly; FastAPI normally resolves Query defaults.
     if not isinstance(include_team_models, bool):
@@ -13429,6 +13328,8 @@ async def model_info_v1(
     all_models: List[dict] = copy.deepcopy(llm_router.model_list)
     alias_models = copy.deepcopy(llm_router.get_model_list_from_model_alias())
     all_models.extend(alias_models)
+
+    all_models = expand_wildcard_deployments_for_model_info(all_models)
 
     allowed_model_names = _get_v1_model_info_allowed_model_names(
         user_api_key_dict=user_api_key_dict,
@@ -13679,12 +13580,7 @@ async def model_group_info(
             }
     ```
     """
-    global \
-        llm_model_list, \
-        general_settings, \
-        user_config_file_path, \
-        proxy_config, \
-        llm_router
+    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router
 
     # Return empty data array when no models are configured (graceful handling for fresh installs)
     if llm_model_list is None or llm_router is None or not llm_model_list:
@@ -15076,14 +14972,7 @@ async def update_config(
     untouched — this endpoint never persists pre-existing YAML values to DB as
     a side effect of an unrelated update.
     """
-    global \
-        llm_router, \
-        llm_model_list, \
-        general_settings, \
-        proxy_config, \
-        proxy_logging_obj, \
-        master_key, \
-        prisma_client
+    global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key, prisma_client
     try:
         if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
             raise HTTPException(
@@ -15595,9 +15484,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[
-                                idx
-                            ].field_description = sub_field_info.description
+                            nested_fields[idx].field_description = (
+                                sub_field_info.description
+                            )
                         idx += 1
 
                     _stored_in_db = None
@@ -15785,9 +15674,9 @@ async def delete_callback(
 
         # Remove callback from success_callback list
         success_callbacks.remove(callback_name)
-        config.setdefault("litellm_settings", {})["success_callback"] = (
-            success_callbacks
-        )
+        config.setdefault("litellm_settings", {})[
+            "success_callback"
+        ] = success_callbacks
 
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)
@@ -15831,13 +15720,7 @@ async def get_config():
     # return the callbacks and the env variables for the callback
 
     """
-    global \
-        llm_router, \
-        llm_model_list, \
-        general_settings, \
-        proxy_config, \
-        proxy_logging_obj, \
-        master_key
+    global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key
     try:
         all_available_callbacks = AllCallbacks()
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -674,7 +674,21 @@ _description = (
 
 
 def cleanup_router_config_variables():
-    global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_key_update, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, use_shared_health_check, health_check_interval, health_check_concurrency, prisma_client
+    global \
+        master_key, \
+        user_config_file_path, \
+        otel_logging, \
+        user_custom_auth, \
+        user_custom_auth_path, \
+        user_custom_key_generate, \
+        user_custom_key_update, \
+        user_custom_sso, \
+        user_custom_ui_sso_sign_in_handler, \
+        use_background_health_checks, \
+        use_shared_health_check, \
+        health_check_interval, \
+        health_check_concurrency, \
+        prisma_client
 
     # Set all variables to None
     master_key = None
@@ -694,7 +708,12 @@ def cleanup_router_config_variables():
 
 
 async def proxy_shutdown_event():
-    global prisma_client, master_key, user_custom_auth, user_custom_key_generate, user_custom_key_update
+    global \
+        prisma_client, \
+        master_key, \
+        user_custom_auth, \
+        user_custom_key_generate, \
+        user_custom_key_update
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
@@ -764,7 +783,22 @@ async def _initialize_shared_aiohttp_session():
 
 @asynccontextmanager
 async def proxy_startup_event(app: FastAPI):
-    global prisma_client, master_key, use_background_health_checks, llm_router, llm_model_list, general_settings, proxy_budget_rescheduler_min_time, proxy_budget_rescheduler_max_time, litellm_proxy_admin_name, db_writer_client, store_model_in_db, premium_user, _license_check, proxy_batch_polling_interval, shared_aiohttp_session
+    global \
+        prisma_client, \
+        master_key, \
+        use_background_health_checks, \
+        llm_router, \
+        llm_model_list, \
+        general_settings, \
+        proxy_budget_rescheduler_min_time, \
+        proxy_budget_rescheduler_max_time, \
+        litellm_proxy_admin_name, \
+        db_writer_client, \
+        store_model_in_db, \
+        premium_user, \
+        _license_check, \
+        proxy_batch_polling_interval, \
+        shared_aiohttp_session
     import json
 
     init_verbose_loggers()
@@ -1945,9 +1979,9 @@ redis_usage_cache: Optional[RedisCache] = (
     None  # redis cache used for tracking spend, tpm/rpm limits
 )
 polling_via_cache_enabled: Union[Literal["all"], List[str], bool] = False
-native_background_mode: List[str] = (
-    []
-)  # Models that should use native provider background mode instead of polling
+native_background_mode: List[
+    str
+] = []  # Models that should use native provider background mode instead of polling
 polling_cache_ttl: int = 3600  # Default 1 hour TTL for polling cache
 user_custom_auth = None
 user_custom_key_generate = None
@@ -3254,13 +3288,9 @@ def _write_health_state_to_router_cache(
 
             exception_status = getattr(original_exception, "status_code", 500)
 
-            if (
-                llm_router.health_check_ignore_transient_errors
-                and exception_status
-                in (
-                    429,
-                    408,
-                )
+            if llm_router.health_check_ignore_transient_errors and exception_status in (
+                429,
+                408,
             ):
                 continue
 
@@ -4166,7 +4196,35 @@ class ProxyConfig:
         """
         Load config values into proxy global state
         """
-        global master_key, user_config_file_path, otel_logging, user_custom_auth, user_custom_auth_path, user_custom_key_generate, user_custom_key_update, user_custom_sso, user_custom_ui_sso_sign_in_handler, use_background_health_checks, use_shared_health_check, health_check_interval, health_check_concurrency, use_queue, proxy_budget_rescheduler_max_time, proxy_budget_rescheduler_min_time, ui_access_mode, litellm_master_key_hash, proxy_batch_write_at, disable_spend_logs, prompt_injection_detection_obj, redis_usage_cache, store_model_in_db, premium_user, open_telemetry_logger, health_check_details, proxy_batch_polling_interval, config_passthrough_endpoints
+        global \
+            master_key, \
+            user_config_file_path, \
+            otel_logging, \
+            user_custom_auth, \
+            user_custom_auth_path, \
+            user_custom_key_generate, \
+            user_custom_key_update, \
+            user_custom_sso, \
+            user_custom_ui_sso_sign_in_handler, \
+            use_background_health_checks, \
+            use_shared_health_check, \
+            health_check_interval, \
+            health_check_concurrency, \
+            use_queue, \
+            proxy_budget_rescheduler_max_time, \
+            proxy_budget_rescheduler_min_time, \
+            ui_access_mode, \
+            litellm_master_key_hash, \
+            proxy_batch_write_at, \
+            disable_spend_logs, \
+            prompt_injection_detection_obj, \
+            redis_usage_cache, \
+            store_model_in_db, \
+            premium_user, \
+            open_telemetry_logger, \
+            health_check_details, \
+            proxy_batch_polling_interval, \
+            config_passthrough_endpoints
 
         config: dict = await self.get_config(config_file_path=config_file_path)
 
@@ -4443,7 +4501,10 @@ class ProxyConfig:
                     pass
                 elif key == "responses":
                     # Initialize global polling via cache settings
-                    global polling_via_cache_enabled, native_background_mode, polling_cache_ttl
+                    global \
+                        polling_via_cache_enabled, \
+                        native_background_mode, \
+                        polling_cache_ttl
                     background_mode = value.get("background_mode", {})
                     polling_via_cache_enabled = background_mode.get(
                         "polling_via_cache", False
@@ -5078,8 +5139,7 @@ class ProxyConfig:
                 ### LOAD FROM GOOGLE KMS ###
                 load_google_kms(use_google_kms=True)
             elif (
-                key_management_system
-                == KeyManagementSystem.AWS_SECRET_MANAGER.value  # noqa: F405
+                key_management_system == KeyManagementSystem.AWS_SECRET_MANAGER.value  # noqa: F405
             ):
                 from litellm.secret_managers.aws_secret_manager_v2 import (
                     AWSSecretsManagerV2,
@@ -6630,10 +6690,10 @@ class ProxyConfig:
         )
 
         try:
-            guardrails_in_db: List[Guardrail] = (
-                await GuardrailRegistry.get_all_guardrails_from_db(
-                    prisma_client=prisma_client
-                )
+            guardrails_in_db: List[
+                Guardrail
+            ] = await GuardrailRegistry.get_all_guardrails_from_db(
+                prisma_client=prisma_client
             )
             verbose_proxy_logger.debug(
                 "guardrails from the DB %s", str(guardrails_in_db)
@@ -6945,7 +7005,23 @@ async def initialize(
     use_queue=False,
     config=None,
 ):
-    global user_model, user_api_base, user_debug, user_detailed_debug, user_user_max_tokens, user_request_timeout, user_temperature, user_telemetry, user_headers, experimental, llm_model_list, llm_router, general_settings, master_key, user_custom_auth, prisma_client
+    global \
+        user_model, \
+        user_api_base, \
+        user_debug, \
+        user_detailed_debug, \
+        user_user_max_tokens, \
+        user_request_timeout, \
+        user_temperature, \
+        user_telemetry, \
+        user_headers, \
+        experimental, \
+        llm_model_list, \
+        llm_router, \
+        general_settings, \
+        master_key, \
+        user_custom_auth, \
+        prisma_client
     from litellm.proxy.common_utils.banner import show_banner
 
     show_banner()
@@ -8757,7 +8833,13 @@ async def model_list(
                     Hiding is presentation-only: a hidden model can still be
                     called directly.
     """
-    global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
+    global \
+        llm_model_list, \
+        general_settings, \
+        llm_router, \
+        prisma_client, \
+        user_api_key_cache, \
+        proxy_logging_obj
 
     settings = cast(dict[str, object], general_settings)  # any-ok: legacy settings
 
@@ -8934,7 +9016,13 @@ async def model_info(
     scoping, health filtering, paused deployments) drives both endpoints; the
     listing's public id must resolve to the same internal deployment here.
     """
-    global llm_model_list, general_settings, llm_router, prisma_client, user_api_key_cache, proxy_logging_obj
+    global \
+        llm_model_list, \
+        general_settings, \
+        llm_router, \
+        prisma_client, \
+        user_api_key_cache, \
+        proxy_logging_obj
 
     settings = cast(dict[str, object], general_settings)  # any-ok: legacy settings
 
@@ -9085,9 +9173,9 @@ async def chat_completion(
             hasattr(user_api_key_dict, "organization_alias")
             and user_api_key_dict.organization_alias is not None
         ):
-            data["metadata"][
-                "user_api_key_org_alias"
-            ] = user_api_key_dict.organization_alias
+            data["metadata"]["user_api_key_org_alias"] = (
+                user_api_key_dict.organization_alias
+            )
         if (
             hasattr(user_api_key_dict, "agent_id")
             and user_api_key_dict.agent_id is not None
@@ -9269,9 +9357,9 @@ async def completion(
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"][
-                    "user_api_key_org_alias"
-                ] = user_api_key_dict.organization_alias
+                data["metadata"]["user_api_key_org_alias"] = (
+                    user_api_key_dict.organization_alias
+                )
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -9485,9 +9573,12 @@ async def embeddings(
                     litellm_params = deployment.get("litellm_params", {}) or {}
                     litellm_model = litellm_params.get("model", "")
                     # Check if this provider supports token arrays
-                    supports_token_arrays = litellm_model in litellm.open_ai_embedding_models or any(
-                        litellm_model.startswith(provider)
-                        for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
+                    supports_token_arrays = (
+                        litellm_model in litellm.open_ai_embedding_models
+                        or any(
+                            litellm_model.startswith(provider)
+                            for provider in LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS
+                        )
                     )
                     if not supports_token_arrays:
                         # non-openai/azure embedding model called with token input - decode tokens
@@ -9520,9 +9611,9 @@ async def embeddings(
                 hasattr(user_api_key_dict, "organization_alias")
                 and user_api_key_dict.organization_alias is not None
             ):
-                data["metadata"][
-                    "user_api_key_org_alias"
-                ] = user_api_key_dict.organization_alias
+                data["metadata"]["user_api_key_org_alias"] = (
+                    user_api_key_dict.organization_alias
+                )
             if (
                 hasattr(user_api_key_dict, "agent_id")
                 and user_api_key_dict.agent_id is not None
@@ -12480,7 +12571,12 @@ async def model_info_v2(
     }
     ```
     """
-    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router
+    global \
+        llm_model_list, \
+        general_settings, \
+        user_config_file_path, \
+        proxy_config, \
+        llm_router
 
     # Return empty data array when no models are configured (graceful handling for fresh installs)
     if llm_router is None or not llm_router.model_list:
@@ -13236,7 +13332,13 @@ async def model_info_v1(
 
     ```
     """
-    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router, user_model
+    global \
+        llm_model_list, \
+        general_settings, \
+        user_config_file_path, \
+        proxy_config, \
+        llm_router, \
+        user_model
 
     # Unit tests call this handler directly; FastAPI normally resolves Query defaults.
     if not isinstance(include_team_models, bool):
@@ -13580,7 +13682,12 @@ async def model_group_info(
             }
     ```
     """
-    global llm_model_list, general_settings, user_config_file_path, proxy_config, llm_router
+    global \
+        llm_model_list, \
+        general_settings, \
+        user_config_file_path, \
+        proxy_config, \
+        llm_router
 
     # Return empty data array when no models are configured (graceful handling for fresh installs)
     if llm_model_list is None or llm_router is None or not llm_model_list:
@@ -14972,7 +15079,14 @@ async def update_config(
     untouched — this endpoint never persists pre-existing YAML values to DB as
     a side effect of an unrelated update.
     """
-    global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key, prisma_client
+    global \
+        llm_router, \
+        llm_model_list, \
+        general_settings, \
+        proxy_config, \
+        proxy_logging_obj, \
+        master_key, \
+        prisma_client
     try:
         if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
             raise HTTPException(
@@ -15484,9 +15598,9 @@ async def get_config_list(
                             hasattr(sub_field_info, "description")
                             and sub_field_info.description is not None
                         ):
-                            nested_fields[idx].field_description = (
-                                sub_field_info.description
-                            )
+                            nested_fields[
+                                idx
+                            ].field_description = sub_field_info.description
                         idx += 1
 
                     _stored_in_db = None
@@ -15674,9 +15788,9 @@ async def delete_callback(
 
         # Remove callback from success_callback list
         success_callbacks.remove(callback_name)
-        config.setdefault("litellm_settings", {})[
-            "success_callback"
-        ] = success_callbacks
+        config.setdefault("litellm_settings", {})["success_callback"] = (
+            success_callbacks
+        )
 
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)
@@ -15720,7 +15834,13 @@ async def get_config():
     # return the callbacks and the env variables for the callback
 
     """
-    global llm_router, llm_model_list, general_settings, proxy_config, proxy_logging_obj, master_key
+    global \
+        llm_router, \
+        llm_model_list, \
+        general_settings, \
+        proxy_config, \
+        proxy_logging_obj, \
+        master_key
     try:
         all_available_callbacks = AllCallbacks()
 

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -617,3 +617,34 @@ def test_get_team_models_all_team_models_expands_with_access_groups():
     assert "model-b" in result
     assert "group-1" in result
     assert "group-2" in result
+
+
+def test_expand_wildcard_deployments_non_wildcard_passthrough():
+    """Non-wildcard deployments must be returned unchanged."""
+    from litellm.proxy.auth.model_checks import expand_wildcard_deployments_for_model_info
+
+    deployment = {"model_name": "gpt-4o", "litellm_params": {"model": "gpt-4o"}}
+    result = expand_wildcard_deployments_for_model_info([deployment])
+    assert result == [deployment]
+
+
+def test_expand_wildcard_deployments_openai_wildcard():
+    """openai/* should expand into ≥1 known openai model entries."""
+    from unittest.mock import patch
+
+    from litellm.proxy.auth.model_checks import expand_wildcard_deployments_for_model_info
+
+    fake_models = ["openai/gpt-4o", "openai/gpt-4o-mini"]
+    deployment = {
+        "model_name": "openai/*",
+        "litellm_params": {"model": "openai/*"},
+    }
+    with patch(
+        "litellm.proxy.auth.model_checks.get_known_models_from_wildcard",
+        return_value=fake_models,
+    ):
+        result = expand_wildcard_deployments_for_model_info([deployment])
+
+    assert len(result) == 2
+    assert all(r["model_name"] in fake_models for r in result)
+    assert all(r["litellm_params"]["model"] in fake_models for r in result)

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -552,7 +552,8 @@ def test_get_key_models_all_team_models_recursive_team():
     from litellm.proxy._types import SpecialModelNames
 
     user_api_key_dict = type(
-        "obj", (object,),
+        "obj",
+        (object,),
         {
             "models": [SpecialModelNames.all_team_models.value],
             "team_id": "team-1",
@@ -621,7 +622,9 @@ def test_get_team_models_all_team_models_expands_with_access_groups():
 
 def test_expand_wildcard_deployments_non_wildcard_passthrough():
     """Non-wildcard deployments must be returned unchanged."""
-    from litellm.proxy.auth.model_checks import expand_wildcard_deployments_for_model_info
+    from litellm.proxy.auth.model_checks import (
+        expand_wildcard_deployments_for_model_info,
+    )
 
     deployment = {"model_name": "gpt-4o", "litellm_params": {"model": "gpt-4o"}}
     result = expand_wildcard_deployments_for_model_info([deployment])
@@ -632,7 +635,9 @@ def test_expand_wildcard_deployments_openai_wildcard():
     """openai/* should expand into ≥1 known openai model entries."""
     from unittest.mock import patch
 
-    from litellm.proxy.auth.model_checks import expand_wildcard_deployments_for_model_info
+    from litellm.proxy.auth.model_checks import (
+        expand_wildcard_deployments_for_model_info,
+    )
 
     fake_models = ["openai/gpt-4o", "openai/gpt-4o-mini"]
     deployment = {
@@ -648,3 +653,36 @@ def test_expand_wildcard_deployments_openai_wildcard():
     assert len(result) == 2
     assert all(r["model_name"] in fake_models for r in result)
     assert all(r["litellm_params"]["model"] in fake_models for r in result)
+
+
+def test_expand_wildcard_concrete_model_name_with_wildcard_litellm_params():
+    """Concrete model_name must not be overwritten when only litellm_params.model is wildcard."""
+    from litellm.proxy.auth.model_checks import (
+        expand_wildcard_deployments_for_model_info,
+    )
+
+    deployment = {
+        "model_name": "my-custom-alias",
+        "litellm_params": {"model": "openai/*"},
+    }
+    result = expand_wildcard_deployments_for_model_info([deployment])
+    # model_name is not a wildcard, so the deployment passes through unchanged
+    assert result == [deployment]
+
+
+def test_expand_wildcard_invalid_litellm_params_passthrough():
+    """Deployments with invalid litellm_params must pass through unchanged (no 500)."""
+    from litellm.proxy.auth.model_checks import (
+        expand_wildcard_deployments_for_model_info,
+    )
+
+    deployment = {
+        "model_name": "openai/*",
+        "litellm_params": {
+            "model": "openai/*",
+            "max_retries": "not-an-int-field-that-breaks",
+        },
+    }
+    # Even if LiteLLM_Params construction fails the deployment should survive
+    result = expand_wildcard_deployments_for_model_info([deployment])
+    assert result == [deployment]

--- a/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_model_info.py
@@ -128,6 +128,44 @@ def test_v1_model_info_no_model_list_error(client, auth_as, null_router, path):
     assert "LLM Model List not loaded" in response.text
 
 
+def test_v1_model_info_star_wildcard_filter_keeps_provider_expansion(monkeypatch):
+    from litellm.proxy._types import SpecialModelNames, UserAPIKeyAuth
+    from litellm.proxy.auth import model_checks
+
+    def fake_get_provider_models(provider, litellm_params=None):
+        if provider == "openai":
+            return ["gpt-4o"]
+        return []
+
+    deployment = {
+        "model_name": "*",
+        "litellm_params": {"model": "openai/*"},
+    }
+    router = MagicMock()
+    router.get_model_access_groups = MagicMock(return_value={})
+    router.get_model_names = MagicMock(return_value=["*"])
+    router.get_model_list = MagicMock(return_value=[deployment])
+    monkeypatch.setattr(model_checks, "get_provider_models", fake_get_provider_models)
+
+    expanded_deployments = proxy_server.expand_wildcard_deployments_for_model_info(
+        [deployment]
+    )
+    allowed_model_names = proxy_server._get_v1_model_info_allowed_model_names(
+        user_api_key_dict=UserAPIKeyAuth(
+            api_key="sk-test",
+            models=[SpecialModelNames.all_proxy_models.value],
+        ),
+        llm_router=router,
+    )
+
+    result = proxy_server._filter_v1_model_info_deployments(
+        all_models=expanded_deployments,
+        allowed_model_names=allowed_model_names,
+    )
+
+    assert [model["model_name"] for model in result] == ["openai/gpt-4o"]
+
+
 # ---------------------------------------------------------------------------
 # GET /model/info — team BYOK scoping (issue #30983)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `expand_wildcard_deployments_for_model_info()` to `model_checks.py` that fans out wildcard deployments (e.g. `openai/*`, `*`) into one row per known provider model, restoring the behaviour users expected.
- The expansion is applied only to the **`/v1/model/info`** endpoint (`model_info_v1`). `/v2/model/info` is unchanged.

<img width="1099" height="662" alt="image" src="https://github.com/user-attachments/assets/5e38d36e-a476-416b-8cd7-35892aa7c052" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches model listing and permission filtering for a widely used admin/API endpoint; logic is defensive but expansion can increase response size for broad wildcards.
> 
> **Overview**
> Restores **wildcard fan-out** on **`/v1/model/info`** after deployments started coming from `llm_router.model_list` (which fixed team-scoped rows but dropped per-model expansion).
> 
> Adds **`expand_wildcard_deployments_for_model_info()`**, which duplicates wildcard deployment dicts into one row per known provider model (via **`get_known_models_from_wildcard`**), aligned with **`/v1/models`**. **`/v2/model/info`** is unchanged.
> 
> Expansion picks the wildcard from `model_name` vs `litellm_params.model` so a **concrete alias** is not replaced when only the backend model is wildcarded; invalid **`LiteLLM_Params`** or empty expansions **pass through** unchanged to avoid errors.
> 
> Unit tests cover passthrough, `openai/*` expansion, alias preservation, and bad params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00185b0597bea7962c3bfcdaa67c924bfa123ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->