### PR TITLE
fix: normalize system role messages for Anthropic partner endpoints

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncIterator, Dict, List, Optional, Tuple
+from typing import Any, AsyncIterator, Optional
 
 import httpx
 
@@ -57,7 +57,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             # "metadata",
         ]
 
-    def _remove_scope_from_cache_control(self, anthropic_messages_request: Dict) -> None:
+    def _remove_scope_from_cache_control(self, anthropic_messages_request: dict) -> None:
         """
         Remove `scope` field from cache_control blocks.
 
@@ -111,9 +111,9 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
     def _normalize_system_role_messages(
         self,
-        messages: List[Dict],
-        anthropic_messages_optional_request_params: Dict,
-    ) -> Tuple[List[Dict], Dict]:
+        messages: list[dict],
+        anthropic_messages_optional_request_params: dict,
+    ) -> tuple[list[dict], dict]:
         """Move ``role: "system"`` entries from the messages array into the
         top-level ``system`` field.
 
@@ -121,32 +121,22 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         ``role: "system"`` inside messages — they only accept ``system`` as a
         top-level parameter.
         """
-        system_role_messages = [
-            m for m in messages if isinstance(m, dict) and m.get("role") == "system"
-        ]
+        system_role_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "system"]
         if not system_role_messages:
             return messages, anthropic_messages_optional_request_params
 
         # Remove system-role entries from messages
-        filtered_messages = [
-            m
-            for m in messages
-            if not (isinstance(m, dict) and m.get("role") == "system")
-        ]
+        filtered_messages = [m for m in messages if not (isinstance(m, dict) and m.get("role") == "system")]
 
         # Merge into top-level system
         existing_system = anthropic_messages_optional_request_params.get("system")
         system_blocks: list = []
 
         if existing_system is not None:
-            system_blocks.extend(
-                AnthropicMessagesConfig._as_system_content_blocks(existing_system)
-            )
+            system_blocks.extend(AnthropicMessagesConfig._as_system_content_blocks(existing_system))
 
         for msg in system_role_messages:
-            system_blocks.extend(
-                AnthropicMessagesConfig._as_system_content_blocks(msg.get("content"))
-            )
+            system_blocks.extend(AnthropicMessagesConfig._as_system_content_blocks(msg.get("content")))
 
         if system_blocks:
             anthropic_messages_optional_request_params["system"] = system_blocks
@@ -216,12 +206,12 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         self,
         headers: dict,
         model: str,
-        messages: List[Any],
+        messages: list[Any],
         optional_params: dict,
         litellm_params: dict,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
-    ) -> Tuple[dict, Optional[str]]:
+    ) -> tuple[dict, Optional[str]]:
         # Check for Anthropic OAuth token in Authorization header
         headers, api_key = optionally_handle_anthropic_oauth(headers=headers, api_key=api_key)
 
@@ -242,7 +232,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         return headers, api_base
 
     @staticmethod
-    def _translate_reasoning_effort_to_anthropic(model: str, optional_params: Dict) -> None:
+    def _translate_reasoning_effort_to_anthropic(model: str, optional_params: dict) -> None:
         """Map OpenAI-style ``reasoning_effort`` to native Anthropic params.
 
         Caller-supplied ``thinking`` / ``output_config`` win over the alias.
@@ -290,7 +280,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             optional_params["output_config"] = existing_output_config
 
     @staticmethod
-    def _translate_legacy_thinking_for_adaptive_model(model: str, optional_params: Dict) -> None:
+    def _translate_legacy_thinking_for_adaptive_model(model: str, optional_params: dict) -> None:
         """Translate legacy ``thinking.type=enabled`` to adaptive for 4.6/4.7.
         Caller-provided ``output_config.effort`` is never overridden.
         """
@@ -324,11 +314,11 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
     def transform_anthropic_messages_request(
         self,
         model: str,
-        messages: List[Dict],
-        anthropic_messages_optional_request_params: Dict,
+        messages: list[dict],
+        anthropic_messages_optional_request_params: dict,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
-    ) -> Dict:
+    ) -> dict:
         """
         No transformation is needed for Anthropic messages
 
@@ -355,10 +345,8 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         # Normalize role: "system" entries from messages array into top-level system.
         # Some partner endpoints (Vertex AI, Bedrock) reject role: "system" in messages.
         if self.should_normalize_system_role_messages():
-            messages, anthropic_messages_optional_request_params = (
-                self._normalize_system_role_messages(
-                    messages, anthropic_messages_optional_request_params
-                )
+            messages, anthropic_messages_optional_request_params = self._normalize_system_role_messages(
+                messages, anthropic_messages_optional_request_params
             )
 
         system_param = anthropic_messages_optional_request_params.get("system")

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -100,7 +100,15 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
 
     @staticmethod
     def _as_system_content_blocks(value: Any) -> list:
-        """Convert system content to a list of content blocks."""
+        """Convert system content to a list of content blocks.
+
+        A bare ``dict`` (e.g. ``{"type": "text", "text": "..."}``) is treated as
+        a single content block shorthand and wrapped as-is — Anthropic's API
+        accepts this shape directly. Any other non-``None``/``str``/``list``/
+        ``dict`` value (e.g. an int) is also passed through unchanged; callers
+        are expected to have already validated ``content`` against the
+        Anthropic message schema upstream of this normalization step.
+        """
         if value is None:
             return []
         if isinstance(value, list):

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -87,6 +87,74 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
                     if isinstance(content, list):
                         _process_content_list(content)
 
+    def should_normalize_system_role_messages(self) -> bool:
+        """
+        Whether to normalize ``role: "system"`` entries from the messages array
+        into the top-level ``system`` field.
+
+        Anthropic's native Messages API accepts ``role: "system"`` inside messages,
+        but some partner endpoints (Vertex AI, Bedrock) reject it. Providers that
+        need this normalization override this to True.
+        """
+        return False
+
+    @staticmethod
+    def _as_system_content_blocks(value: Any) -> list:
+        """Convert system content to a list of content blocks."""
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return list(value)
+        if isinstance(value, str):
+            return [{"type": "text", "text": value}]
+        return [value]
+
+    def _normalize_system_role_messages(
+        self,
+        messages: List[Dict],
+        anthropic_messages_optional_request_params: Dict,
+    ) -> Tuple[List[Dict], Dict]:
+        """Move ``role: "system"`` entries from the messages array into the
+        top-level ``system`` field.
+
+        Some Anthropic partner endpoints (Vertex AI, Bedrock) reject
+        ``role: "system"`` inside messages — they only accept ``system`` as a
+        top-level parameter.
+        """
+        system_role_messages = [
+            m for m in messages if isinstance(m, dict) and m.get("role") == "system"
+        ]
+        if not system_role_messages:
+            return messages, anthropic_messages_optional_request_params
+
+        # Remove system-role entries from messages
+        filtered_messages = [
+            m
+            for m in messages
+            if not (isinstance(m, dict) and m.get("role") == "system")
+        ]
+
+        # Merge into top-level system
+        existing_system = anthropic_messages_optional_request_params.get("system")
+        system_blocks: list = []
+
+        if existing_system is not None:
+            system_blocks.extend(
+                AnthropicMessagesConfig._as_system_content_blocks(existing_system)
+            )
+
+        for msg in system_role_messages:
+            system_blocks.extend(
+                AnthropicMessagesConfig._as_system_content_blocks(msg.get("content"))
+            )
+
+        if system_blocks:
+            anthropic_messages_optional_request_params["system"] = system_blocks
+        else:
+            anthropic_messages_optional_request_params.pop("system", None)
+
+        return filtered_messages, anthropic_messages_optional_request_params
+
     def should_strip_billing_metadata(self) -> bool:
         """
         Whether to drop x-anthropic-billing-header system blocks before sending upstream.
@@ -283,6 +351,15 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             model=model,
             optional_params=anthropic_messages_optional_request_params,
         )
+
+        # Normalize role: "system" entries from messages array into top-level system.
+        # Some partner endpoints (Vertex AI, Bedrock) reject role: "system" in messages.
+        if self.should_normalize_system_role_messages():
+            messages, anthropic_messages_optional_request_params = (
+                self._normalize_system_role_messages(
+                    messages, anthropic_messages_optional_request_params
+                )
+            )
 
         system_param = anthropic_messages_optional_request_params.get("system")
         if self.should_strip_billing_metadata() and system_param is not None:

--- a/litellm/llms/azure_ai/anthropic/messages_transformation.py
+++ b/litellm/llms/azure_ai/anthropic/messages_transformation.py
@@ -21,6 +21,9 @@ class AzureAnthropicMessagesConfig(AnthropicMessagesConfig):
     and Azure endpoint format.
     """
 
+    def should_normalize_system_role_messages(self) -> bool:
+        return True
+
     def should_strip_billing_metadata(self) -> bool:
         return True
 

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -17,6 +17,9 @@ from ..output_params_utils import sanitize_vertex_anthropic_output_params
 
 
 class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, VertexBase):
+    def should_normalize_system_role_messages(self) -> bool:
+        return True
+
     def should_strip_billing_metadata(self) -> bool:
         return True
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_normalization.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_normalization.py
@@ -1,0 +1,201 @@
+"""Unit tests for system role message normalization in AnthropicMessagesConfig.
+
+Covers the should_normalize_system_role_messages() hook, _as_system_content_blocks(),
+and _normalize_system_role_messages() methods.
+"""
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+
+class TestAsSystemContentBlocks:
+    """Test the _as_system_content_blocks helper."""
+
+    def test_none_returns_empty_list(self):
+        result = AnthropicMessagesConfig._as_system_content_blocks(None)
+        assert result == []
+
+    def test_string_returns_text_block(self):
+        result = AnthropicMessagesConfig._as_system_content_blocks("hello")
+        assert result == [{"type": "text", "text": "hello"}]
+
+    def test_list_returns_copy(self):
+        original = [{"type": "text", "text": "block1"}, {"type": "text", "text": "block2"}]
+        result = AnthropicMessagesConfig._as_system_content_blocks(original)
+        assert result == original
+        assert result is not original
+
+    def test_dict_wraps_in_list(self):
+        block = {"type": "text", "text": "wrapped"}
+        result = AnthropicMessagesConfig._as_system_content_blocks(block)
+        assert result == [block]
+
+
+class TestNormalizeSystemRoleMessages:
+    """Test the _normalize_system_role_messages method."""
+
+    def _make_config(self):
+        return AnthropicMessagesConfig()
+
+    def test_no_system_role_messages_is_noop(self):
+        config = self._make_config()
+        messages = [{"role": "user", "content": "hello"}]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == messages
+        assert result_params == {}
+
+    def test_single_system_message_moved_to_top_level(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "user", "content": "hello"},
+        ]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hello"}]
+        assert result_params["system"] == [
+            {"type": "text", "text": "You are helpful"}
+        ]
+
+    def test_existing_system_merged_with_system_messages(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": "Extra instruction"},
+            {"role": "user", "content": "hello"},
+        ]
+        params = {"system": "Base instruction"}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hello"}]
+        assert result_params["system"] == [
+            {"type": "text", "text": "Base instruction"},
+            {"type": "text", "text": "Extra instruction"},
+        ]
+
+    def test_multiple_system_messages_all_moved(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": "First"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "Second"},
+        ]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hi"}]
+        assert result_params["system"] == [
+            {"type": "text", "text": "First"},
+            {"type": "text", "text": "Second"},
+        ]
+
+    def test_system_with_list_content_preserved(self):
+        config = self._make_config()
+        messages = [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "Block content"}],
+            },
+            {"role": "user", "content": "hello"},
+        ]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hello"}]
+        assert result_params["system"] == [
+            {"type": "text", "text": "Block content"}
+        ]
+
+    def test_existing_system_as_list_merged_correctly(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": "Extra"},
+            {"role": "user", "content": "hello"},
+        ]
+        params = {"system": [{"type": "text", "text": "Existing block"}]}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hello"}]
+        assert result_params["system"] == [
+            {"type": "text", "text": "Existing block"},
+            {"type": "text", "text": "Extra"},
+        ]
+
+    def test_empty_system_content_removes_system_param(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": None},
+            {"role": "user", "content": "hello"},
+        ]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [{"role": "user", "content": "hello"}]
+        assert "system" not in result_params
+
+    def test_non_dict_messages_preserved(self):
+        config = self._make_config()
+        messages = [
+            {"role": "system", "content": "sys"},
+            "not a dict",
+            {"role": "user", "content": "hello"},
+        ]
+        params = {}
+
+        result_messages, result_params = config._normalize_system_role_messages(
+            messages, params
+        )
+
+        assert result_messages == [
+            "not a dict",
+            {"role": "user", "content": "hello"},
+        ]
+        assert result_params["system"] == [{"type": "text", "text": "sys"}]
+
+
+class TestShouldNormalizeSystemRoleMessages:
+    """Test the opt-in flag defaults and overrides."""
+
+    def test_base_class_defaults_to_false(self):
+        config = AnthropicMessagesConfig()
+        assert config.should_normalize_system_role_messages() is False
+
+    def test_vertex_ai_overrides_to_true(self):
+        from litellm.llms.vertex_ai.vertex_ai_partner_models.anthropic.experimental_pass_through.transformation import (
+            VertexAIPartnerModelsAnthropicMessagesConfig,
+        )
+
+        config = VertexAIPartnerModelsAnthropicMessagesConfig()
+        assert config.should_normalize_system_role_messages() is True
+
+    def test_azure_ai_overrides_to_true(self):
+        from litellm.llms.azure_ai.anthropic.messages_transformation import (
+            AzureAnthropicMessagesConfig,
+        )
+
+        config = AzureAnthropicMessagesConfig()
+        assert config.should_normalize_system_role_messages() is True

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_normalization.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_system_role_normalization.py
@@ -43,9 +43,7 @@ class TestNormalizeSystemRoleMessages:
         messages = [{"role": "user", "content": "hello"}]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == messages
         assert result_params == {}
@@ -58,14 +56,10 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hello"}]
-        assert result_params["system"] == [
-            {"type": "text", "text": "You are helpful"}
-        ]
+        assert result_params["system"] == [{"type": "text", "text": "You are helpful"}]
 
     def test_existing_system_merged_with_system_messages(self):
         config = self._make_config()
@@ -75,9 +69,7 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {"system": "Base instruction"}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hello"}]
         assert result_params["system"] == [
@@ -94,9 +86,7 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hi"}]
         assert result_params["system"] == [
@@ -115,14 +105,10 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hello"}]
-        assert result_params["system"] == [
-            {"type": "text", "text": "Block content"}
-        ]
+        assert result_params["system"] == [{"type": "text", "text": "Block content"}]
 
     def test_existing_system_as_list_merged_correctly(self):
         config = self._make_config()
@@ -132,9 +118,7 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {"system": [{"type": "text", "text": "Existing block"}]}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hello"}]
         assert result_params["system"] == [
@@ -150,9 +134,7 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [{"role": "user", "content": "hello"}]
         assert "system" not in result_params
@@ -166,9 +148,7 @@ class TestNormalizeSystemRoleMessages:
         ]
         params = {}
 
-        result_messages, result_params = config._normalize_system_role_messages(
-            messages, params
-        )
+        result_messages, result_params = config._normalize_system_role_messages(messages, params)
 
         assert result_messages == [
             "not a dict",


### PR DESCRIPTION
- Anthropic's native Messages API now accepts `role: "system"` inside the messages array, but partner endpoints (Vertex AI, Bedrock, Azure AI Foundry) still reject it with 400 errors
- Add `should_normalize_system_role_messages()` opt-in flag to the shared `AnthropicMessagesConfig` base class
- When enabled, `role: "system"` entries are stripped from the messages array and merged into the top-level `system` field before the request is built
- Enabled for Vertex AI and Azure AI Foundry (Bedrock can opt in via the same flag when the Bedrock-specific PR is merged)
- Refs #29698