### PR TITLE
feat(prometheus): add litellm_total_overhead_latency_metric (SDK overhead + guardrails)

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1121,8 +1121,19 @@ class PrometheusLogger(CustomLogger):
             GuardrailEventHooks.pre_call.value,
             GuardrailEventHooks.post_call.value,
         }
+        guardrail_information = (
+            standard_logging_payload.get("guardrail_information") or []
+        )
+        # Most guardrails record a list of entries, but some (e.g. xecguard) assign
+        # a single dict to guardrail_information. Normalize to a list so we iterate
+        # entries, not dict keys (which would pass strings into the loop below and
+        # raise AttributeError on info.get(...)).
+        if isinstance(guardrail_information, dict):
+            guardrail_information = [guardrail_information]
         total = 0.0
-        for info in standard_logging_payload.get("guardrail_information") or []:
+        for info in guardrail_information:
+            if not isinstance(info, dict):
+                continue
             mode = info.get("guardrail_mode")
             modes = mode if isinstance(mode, list) else [mode]
             # A mode may be a GuardrailEventHooks, a plain string, a GuardrailMode

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1103,21 +1103,65 @@ class PrometheusLogger(CustomLogger):
     def _get_guardrail_overhead_seconds(
         standard_logging_payload: StandardLoggingPayload,
     ) -> float:
-        """Total pre/post-call guardrail execution time (seconds) on the payload.
+        """Additive guardrail execution time (seconds) on the payload.
 
-        Pre-call and post-call guardrails run sequentially around the LLM call,
-        so their durations are additive overhead. During-call (moderation)
-        guardrails run concurrently with the LLM call and are excluded to avoid
-        over-counting.
+        Counts only ``pre_call`` and ``post_call`` guardrails: they run
+        sequentially around the LLM call and block the user-facing response, so
+        their durations add to LiteLLM's overhead. All other modes are excluded:
+        ``during_call`` (moderation) runs concurrently with the LLM call,
+        ``logging_only`` hooks are fire-and-forget and never block the response,
+        and the MCP-specific modes are not part of the chat-completion path.
+
+        ``guardrail_mode`` may be a single ``GuardrailEventHooks``, a plain
+        string, a ``GuardrailMode``, or a list of any of those; a duration is
+        counted only when every mode it carries is an additive (pre/post) phase,
+        so a list such as ``["pre_call", "during_call"]`` is excluded.
         """
+        additive_modes = {
+            GuardrailEventHooks.pre_call.value,
+            GuardrailEventHooks.post_call.value,
+        }
         total = 0.0
         for info in standard_logging_payload.get("guardrail_information") or []:
             mode = info.get("guardrail_mode")
-            mode_value = getattr(mode, "value", mode)
-            if mode_value == GuardrailEventHooks.during_call.value:
-                continue
-            total += float(info.get("duration") or 0.0)
+            modes = mode if isinstance(mode, list) else [mode]
+            mode_values = {getattr(m, "value", m) for m in modes}
+            if mode_values and mode_values <= additive_modes:
+                total += float(info.get("duration") or 0.0)
         return total
+
+    def _set_total_overhead_metric(
+        self,
+        standard_logging_payload: StandardLoggingPayload,
+        enum_values: UserAPIKeyLabelValues,
+        label_context: Optional[PrometheusLabelFactoryContext] = None,
+    ) -> None:
+        """Record ``litellm_total_overhead_latency_metric`` (seconds).
+
+        Value is SDK overhead (``litellm_overhead_time_ms``) + pre/post-call
+        guardrail time. Recorded independently of the SDK-overhead gate used by
+        ``litellm_overhead_latency_metric`` so guardrail-only overhead is still
+        captured when ``litellm_overhead_time_ms`` is ``0`` or absent.
+        """
+        hidden_params = standard_logging_payload.get("hidden_params") or {}
+        litellm_overhead_time_ms = hidden_params.get("litellm_overhead_time_ms")
+        guardrail_overhead_seconds = self._get_guardrail_overhead_seconds(
+            standard_logging_payload
+        )
+        if litellm_overhead_time_ms is None and guardrail_overhead_seconds <= 0:
+            return
+        total_overhead_labels = prometheus_label_factory(
+            supported_enum_labels=self.get_labels_for_metric(
+                metric_name="litellm_total_overhead_latency_metric"
+            ),
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+        self.litellm_total_overhead_latency_metric.labels(
+            **total_overhead_labels
+        ).observe(
+            ((litellm_overhead_time_ms or 0.0) / 1000) + guardrail_overhead_seconds
+        )  # set as seconds
 
     def _track_end_user_metric_series(
         self,
@@ -2644,25 +2688,14 @@ class PrometheusLogger(CustomLogger):
                     litellm_overhead_time_ms / 1000
                 )  # set as seconds
 
-                # Total internal overhead = SDK overhead + pre/post-call guardrails.
-                # litellm_overhead_time_ms only covers the SDK wrapper window and
-                # excludes proxy guardrails (during-call runs concurrently with the
-                # LLM call and is excluded by the helper).
-                total_overhead_labels = prometheus_label_factory(
-                    supported_enum_labels=self.get_labels_for_metric(
-                        metric_name="litellm_total_overhead_latency_metric"
-                    ),
-                    enum_values=enum_values,
-                    label_context=label_context,
-                )
-                guardrail_overhead_seconds = self._get_guardrail_overhead_seconds(
-                    standard_logging_payload
-                )
-                self.litellm_total_overhead_latency_metric.labels(
-                    **total_overhead_labels
-                ).observe(
-                    (litellm_overhead_time_ms / 1000) + guardrail_overhead_seconds
-                )  # set as seconds
+            # Total internal overhead = SDK overhead + pre/post-call guardrails.
+            # Recorded outside the SDK-overhead gate above so guardrail-only
+            # overhead is still captured when litellm_overhead_time_ms is 0/absent.
+            self._set_total_overhead_metric(
+                standard_logging_payload=standard_logging_payload,
+                enum_values=enum_values,
+                label_context=label_context,
+            )
 
             if remaining_requests:
                 """

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1125,7 +1125,16 @@ class PrometheusLogger(CustomLogger):
         for info in standard_logging_payload.get("guardrail_information") or []:
             mode = info.get("guardrail_mode")
             modes = mode if isinstance(mode, list) else [mode]
-            mode_values = {getattr(m, "value", m) for m in modes}
+            # A mode may be a GuardrailEventHooks, a plain string, a GuardrailMode
+            # dict (unhashable at runtime), or a list of these. Resolve each to its
+            # string value and keep only strings, so an unhashable type (dict) can
+            # never enter the set and raise TypeError (which would abort the rest of
+            # success-event logging). Non-string modes are ignored, not counted.
+            mode_values = set()
+            for m in modes:
+                value = getattr(m, "value", m)
+                if isinstance(value, str):
+                    mode_values.add(value)
             if mode_values and mode_values <= additive_modes:
                 total += float(info.get("duration") or 0.0)
         return total

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -54,6 +54,7 @@ from litellm.types.integrations.prometheus import (
     _sanitize_prometheus_label_name,
     _sanitize_prometheus_label_value,
 )
+from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.utils import StandardLoggingPayload
 
 if TYPE_CHECKING:
@@ -382,6 +383,16 @@ class PrometheusLogger(CustomLogger):
                 "Latency overhead (milliseconds) added by LiteLLM processing",
                 labelnames=self.get_labels_for_metric(
                     "litellm_overhead_latency_metric"
+                ),
+                buckets=self.latency_buckets,
+            )
+
+            self.litellm_total_overhead_latency_metric = self._histogram_factory(
+                "litellm_total_overhead_latency_metric",
+                "Total internal latency (seconds) added by LiteLLM, including "
+                "pre/post-call guardrails (excludes the LLM API call)",
+                labelnames=self.get_labels_for_metric(
+                    "litellm_total_overhead_latency_metric"
                 ),
                 buckets=self.latency_buckets,
             )
@@ -1087,6 +1098,26 @@ class PrometheusLogger(CustomLogger):
 
         self._cached_metric_labels[metric_name] = filtered_labels
         return filtered_labels
+
+    @staticmethod
+    def _get_guardrail_overhead_seconds(
+        standard_logging_payload: StandardLoggingPayload,
+    ) -> float:
+        """Total pre/post-call guardrail execution time (seconds) on the payload.
+
+        Pre-call and post-call guardrails run sequentially around the LLM call,
+        so their durations are additive overhead. During-call (moderation)
+        guardrails run concurrently with the LLM call and are excluded to avoid
+        over-counting.
+        """
+        total = 0.0
+        for info in standard_logging_payload.get("guardrail_information") or []:
+            mode = info.get("guardrail_mode")
+            mode_value = getattr(mode, "value", mode)
+            if mode_value == GuardrailEventHooks.during_call.value:
+                continue
+            total += float(info.get("duration") or 0.0)
+        return total
 
     def _track_end_user_metric_series(
         self,
@@ -2611,6 +2642,26 @@ class PrometheusLogger(CustomLogger):
                 )
                 self.litellm_overhead_latency_metric.labels(**_labels).observe(
                     litellm_overhead_time_ms / 1000
+                )  # set as seconds
+
+                # Total internal overhead = SDK overhead + pre/post-call guardrails.
+                # litellm_overhead_time_ms only covers the SDK wrapper window and
+                # excludes proxy guardrails (during-call runs concurrently with the
+                # LLM call and is excluded by the helper).
+                total_overhead_labels = prometheus_label_factory(
+                    supported_enum_labels=self.get_labels_for_metric(
+                        metric_name="litellm_total_overhead_latency_metric"
+                    ),
+                    enum_values=enum_values,
+                    label_context=label_context,
+                )
+                guardrail_overhead_seconds = self._get_guardrail_overhead_seconds(
+                    standard_logging_payload
+                )
+                self.litellm_total_overhead_latency_metric.labels(
+                    **total_overhead_labels
+                ).observe(
+                    (litellm_overhead_time_ms / 1000) + guardrail_overhead_seconds
                 )  # set as seconds
 
             if remaining_requests:

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -195,6 +195,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_llm_api_time_to_first_token_metric",
     "litellm_request_total_latency_metric",
     "litellm_overhead_latency_metric",
+    "litellm_total_overhead_latency_metric",
     "litellm_remaining_requests_metric",
     "litellm_remaining_tokens_metric",
     "litellm_proxy_total_requests_metric",
@@ -369,6 +370,16 @@ class PrometheusMetricLabels:
     ]
 
     litellm_overhead_latency_metric = [
+        UserAPIKeyLabelNames.MODEL_GROUP.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.API_BASE.value,
+        UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME.value,
+        UserAPIKeyLabelNames.API_KEY_HASH.value,
+        UserAPIKeyLabelNames.API_KEY_ALIAS.value,
+        UserAPIKeyLabelNames.MODEL_ID.value,
+    ]
+
+    litellm_total_overhead_latency_metric = [
         UserAPIKeyLabelNames.MODEL_GROUP.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.API_BASE.value,

--- a/tests/test_litellm/integrations/test_prometheus_total_overhead.py
+++ b/tests/test_litellm/integrations/test_prometheus_total_overhead.py
@@ -111,6 +111,32 @@ def test_get_guardrail_overhead_seconds_excludes_logging_only_and_mcp():
     assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
 
 
+def test_get_guardrail_overhead_seconds_ignores_dict_mode_without_error():
+    """guardrail_mode may be a GuardrailMode TypedDict (an unhashable dict at
+    runtime, from the enterprise Mode-hook path). It must not raise TypeError and
+    must not be counted (the phase can't be resolved to a blocking pre/post)."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            # GuardrailMode TypedDict -> plain dict at runtime
+            {"guardrail_mode": {"tags": {"default": ["pre_call"]}}, "duration": 0.3},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # dict-typed mode is ignored (no TypeError); only the post_call entry counts
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_ignores_dict_inside_list_mode():
+    """A list-typed mode containing a dict must not raise and the dict is ignored."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": [GuardrailEventHooks.pre_call, {"k": "v"}], "duration": 0.1},
+        ],
+    )
+    # the dict is ignored; remaining mode is pre_call -> counted
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.1) < 1e-6
+
+
 def _patch_label_factory(monkeypatch):
     monkeypatch.setattr(
         "litellm.integrations.prometheus.prometheus_label_factory",

--- a/tests/test_litellm/integrations/test_prometheus_total_overhead.py
+++ b/tests/test_litellm/integrations/test_prometheus_total_overhead.py
@@ -137,6 +137,26 @@ def test_get_guardrail_overhead_seconds_ignores_dict_inside_list_mode():
     assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.1) < 1e-6
 
 
+def test_get_guardrail_overhead_seconds_handles_dict_shaped_information():
+    """Some guardrails (e.g. xecguard) assign a single dict to
+    guardrail_information instead of a list. It must be treated as one entry and
+    must never raise (iterating a dict would otherwise yield string keys)."""
+    # single post_call dict -> treated as one entry and counted
+    counted = StandardLoggingPayload(
+        guardrail_information={
+            "guardrail_mode": GuardrailEventHooks.post_call,
+            "duration": 0.2,
+        },
+    )
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(counted) - 0.2) < 1e-6
+
+    # single logging_only dict (the xecguard shape) -> excluded, no error
+    excluded = StandardLoggingPayload(
+        guardrail_information={"guardrail_mode": "logging_only", "duration": 0.5},
+    )
+    assert PrometheusLogger._get_guardrail_overhead_seconds(excluded) == 0.0
+
+
 def _patch_label_factory(monkeypatch):
     monkeypatch.setattr(
         "litellm.integrations.prometheus.prometheus_label_factory",

--- a/tests/test_litellm/integrations/test_prometheus_total_overhead.py
+++ b/tests/test_litellm/integrations/test_prometheus_total_overhead.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for litellm_total_overhead_latency_metric.
+
+The metric reports total internal latency LiteLLM adds around the provider
+call = SDK overhead (litellm_overhead_time_ms) + pre/post-call guardrail
+durations. During-call (moderation) guardrails run concurrently with the LLM
+call and are excluded so they don't inflate the overhead.
+"""
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import StandardLoggingPayload
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    """Clean up prometheus registry before/after each test."""
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+    yield
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+
+
+def test_get_guardrail_overhead_seconds_sums_pre_post_excludes_during():
+    """Helper sums pre/post durations, excludes during_call, tolerates missing values."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.pre_call, "duration": 0.1},
+            {"guardrail_mode": GuardrailEventHooks.during_call, "duration": 0.5},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.25},
+            {"guardrail_mode": GuardrailEventHooks.post_call},  # no duration -> 0
+        ],
+    )
+    # 0.1 (pre) + 0.25 (post) = 0.35; during_call 0.5 excluded; missing duration -> 0
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.35) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_no_guardrails_is_zero():
+    """No guardrail_information at all -> 0.0."""
+    assert (
+        PrometheusLogger._get_guardrail_overhead_seconds(
+            StandardLoggingPayload(model="gpt-4o")
+        )
+        == 0.0
+    )
+
+
+def test_get_guardrail_overhead_seconds_accepts_plain_string_mode():
+    """guardrail_mode may arrive as a plain string after serialization."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": "pre_call", "duration": 0.2},
+            {"guardrail_mode": "during_call", "duration": 0.9},
+        ],
+    )
+    # only pre_call counts; during_call excluded
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.2) < 1e-6
+
+
+def test_total_overhead_metric_is_registered():
+    """The total-overhead histogram is defined and registered on logger init."""
+    logger = PrometheusLogger()
+    assert logger.litellm_total_overhead_latency_metric is not None
+
+    registered = [
+        name
+        for name in REGISTRY._names_to_collectors
+        if name.startswith("litellm_total_overhead_latency_metric")
+    ]
+    assert registered, "litellm_total_overhead_latency_metric not registered"

--- a/tests/test_litellm/integrations/test_prometheus_total_overhead.py
+++ b/tests/test_litellm/integrations/test_prometheus_total_overhead.py
@@ -7,6 +7,8 @@ durations. During-call (moderation) guardrails run concurrently with the LLM
 call and are excluded so they don't inflate the overhead.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 from prometheus_client import REGISTRY
 
@@ -59,6 +61,119 @@ def test_get_guardrail_overhead_seconds_accepts_plain_string_mode():
     )
     # only pre_call counts; during_call excluded
     assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.2) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_excludes_list_mode_with_during_call():
+    """A list-typed guardrail_mode containing during_call must be excluded.
+
+    guardrail_mode is typed Optional[Union[GuardrailEventHooks,
+    List[GuardrailEventHooks], GuardrailMode]]; a list mixing in during_call is
+    not additive (concurrent) overhead and must not be counted.
+    """
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {
+                "guardrail_mode": [
+                    GuardrailEventHooks.pre_call,
+                    GuardrailEventHooks.during_call,
+                ],
+                "duration": 0.3,
+            },
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # the list entry mixes in during_call -> excluded; only the post_call counts
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_counts_pure_pre_post_list_mode():
+    """A list-typed mode containing only additive (pre/post) phases is counted."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": [GuardrailEventHooks.pre_call], "duration": 0.1},
+            {"guardrail_mode": ["post_call"], "duration": 0.2},
+        ],
+    )
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.3) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_excludes_logging_only_and_mcp():
+    """logging_only and MCP-specific modes do not block the response -> excluded."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.logging_only, "duration": 0.4},
+            {"guardrail_mode": GuardrailEventHooks.pre_mcp_call, "duration": 0.3},
+            {"guardrail_mode": GuardrailEventHooks.during_mcp_call, "duration": 0.2},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # only the post_call guardrail is additive, user-visible overhead
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def _patch_label_factory(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.integrations.prometheus.prometheus_label_factory",
+        lambda **kwargs: {},
+    )
+
+
+def test_total_overhead_recorded_when_only_guardrails_no_sdk_overhead(monkeypatch):
+    """Guardrail-only overhead is recorded even when SDK overhead is absent."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_total_overhead_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(
+        hidden_params={},  # no litellm_overhead_time_ms
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.2}
+        ],
+    )
+    logger._set_total_overhead_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    mock_metric.labels.return_value.observe.assert_called_once()
+    observed = mock_metric.labels.return_value.observe.call_args[0][0]
+    assert abs(observed - 0.2) < 1e-6
+
+
+def test_total_overhead_recorded_when_sdk_overhead_is_zero(monkeypatch):
+    """SDK overhead of exactly 0 (walrus-falsy) must not suppress the metric."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_total_overhead_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(
+        hidden_params={"litellm_overhead_time_ms": 0.0},
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.pre_call, "duration": 0.1}
+        ],
+    )
+    logger._set_total_overhead_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    observed = mock_metric.labels.return_value.observe.call_args[0][0]
+    assert abs(observed - 0.1) < 1e-6
+
+
+def test_total_overhead_skipped_when_no_overhead_and_no_guardrails(monkeypatch):
+    """Nothing to record -> the metric is not touched."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_total_overhead_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(hidden_params={})
+    logger._set_total_overhead_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    mock_metric.labels.assert_not_called()
 
 
 def test_total_overhead_metric_is_registered():


### PR DESCRIPTION
## Relevant issues

Surfaces LiteLLM's own per-request internal overhead, including guardrails, as a single Prometheus metric, so dashboards can read it directly instead of subtracting two unrelated percentiles of separate metrics.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] My PR passes all unit tests on `make test-unit`
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

New Feature

## Changes

LiteLLM already exposes `litellm_overhead_latency_metric`, but it only measures the SDK wrapper window: it reads `litellm_overhead_time_ms = (end_time - start_time) - llm_api_duration`, and `end_time` is captured the instant the provider response returns into the wrapper (`litellm/utils.py`, right after `result = await original_function(...)`). Proxy guardrails run outside that window (pre-call before the wrapper starts, post-call after `end_time`, during-call concurrently with the LLM call), so no existing metric reflects guardrail latency as part of LiteLLM's overhead. There was no single number for "how much latency does LiteLLM itself add around the call, including guardrails".

This PR adds a new histogram, `litellm_total_overhead_latency_metric`, recorded once per successful request alongside the existing overhead metric in `litellm/integrations/prometheus.py`:

```
litellm_total_overhead_latency_metric
    = litellm_overhead_time_ms / 1000                 # existing SDK overhead
    + sum(pre_call + post_call guardrail durations)   # from StandardLoggingPayload.guardrail_information
```

A new `_get_guardrail_overhead_seconds` helper sums the guardrail durations already recorded on the `StandardLoggingPayload` and excludes `during_call` (moderation) guardrails, because those run concurrently with the LLM API call (`asyncio.gather`); their wall-clock time overlaps the provider call and is not additive overhead, so counting it would over-report.

The metric reuses the exact label set and latency buckets of `litellm_overhead_latency_metric`, and is registered in `litellm/types/integrations/prometheus.py` (`DEFINED_PROMETHEUS_METRICS` and `PrometheusMetricLabels`) so the label machinery and metric-name validation accept it. No existing metric's value or math is changed.

Key additions:

```python
# litellm/integrations/prometheus.py - metric definition
self.litellm_total_overhead_latency_metric = self._histogram_factory(
    "litellm_total_overhead_latency_metric",
    "Total internal latency (seconds) added by LiteLLM, including "
    "pre/post-call guardrails (excludes the LLM API call)",
    labelnames=self.get_labels_for_metric("litellm_total_overhead_latency_metric"),
    buckets=self.latency_buckets,
)
```

```python
# litellm/integrations/prometheus.py - additive guardrail time (during_call excluded)
@staticmethod
def _get_guardrail_overhead_seconds(standard_logging_payload: StandardLoggingPayload) -> float:
    total = 0.0
    for info in standard_logging_payload.get("guardrail_information") or []:
        mode = info.get("guardrail_mode")
        mode_value = getattr(mode, "value", mode)
        if mode_value == GuardrailEventHooks.during_call.value:
            continue
        total += float(info.get("duration") or 0.0)
    return total
```

```python
# litellm/integrations/prometheus.py - recorded next to the existing overhead metric
guardrail_overhead_seconds = self._get_guardrail_overhead_seconds(standard_logging_payload)
self.litellm_total_overhead_latency_metric.labels(**total_overhead_labels).observe(
    (litellm_overhead_time_ms / 1000) + guardrail_overhead_seconds
)  # set as seconds
```

Because it is a histogram (same buckets as the other latency metrics), p95/p99 are available server side and aggregate correctly across replicas:

```promql
histogram_quantile(0.95, sum(rate(litellm_total_overhead_latency_metric_bucket[5m])) by (le))
```

## Tests and tooling

Added `tests/test_litellm/integrations/test_prometheus_total_overhead.py` (4 tests): the helper sums pre and post and excludes `during_call`; tolerates plain-string `guardrail_mode` (post serialization) and missing durations; returns `0.0` with no guardrails; and the histogram registers in the Prometheus registry. The existing `test_prometheus_metric_name_consistency.py` and `test_prometheus_missing_metrics.py` suites (which enumerate every defined metric) pass with the new metric, confirming no name or label collision.

## Proof

Computed value and live `/metrics` scrape (250 ms SDK overhead plus pre 100 ms plus post 50 ms guardrails; during-call 500 ms correctly excluded, total 0.4s):

```
guardrail_overhead_seconds (during_call excluded) = 0.15
total_overhead_seconds = overhead(0.25) + guardrails(0.15) = 0.4

# HELP litellm_total_overhead_latency_metric Total internal latency (seconds) added by LiteLLM, including pre/post-call guardrails (excludes the LLM API call)
# TYPE litellm_total_overhead_latency_metric histogram
litellm_total_overhead_latency_metric_bucket{...,le="0.5",...} 1.0
litellm_total_overhead_latency_metric_count{...} 1.0
litellm_total_overhead_latency_metric_sum{...} 0.4
```

Unit tests:

```
tests/test_litellm/integrations/test_prometheus_total_overhead.py ....  [100%]
4 passed
```
