### PR TITLE
feat(guardrails): make the Generic Guardrail resilient to built-in tools and errors (adopted from #31286)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/__init__.py
@@ -21,6 +21,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
         unreachable_fallback=getattr(
             litellm_params, "unreachable_fallback", "fail_closed"
         ),
+        fail_on_error=getattr(litellm_params, "fail_on_error", True),
         extra_headers=getattr(litellm_params, "extra_headers", None),
         guardrail_name=guardrail.get("guardrail_name", ""),
         event_hook=litellm_params.mode,

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -187,6 +187,7 @@ class GenericGuardrailAPI(CustomGuardrail):
         api_key: Optional[str] = None,
         additional_provider_specific_params: Optional[Dict[str, Any]] = None,
         unreachable_fallback: Literal["fail_closed", "fail_open"] = "fail_closed",
+        fail_on_error: Optional[bool] = True,
         extra_headers: Optional[list] = None,
         **kwargs,
     ):
@@ -222,6 +223,8 @@ class GenericGuardrailAPI(CustomGuardrail):
         self.unreachable_fallback: Literal["fail_closed", "fail_open"] = (
             unreachable_fallback
         )
+
+        self.fail_on_error: bool = True if fail_on_error is None else fail_on_error
 
         # Set supported event hooks
         if "supported_event_hooks" not in kwargs:
@@ -351,7 +354,8 @@ class GenericGuardrailAPI(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         is_unreachable: bool = True,
     ) -> GenericGuardrailAPIInputs:
-        if is_unreachable and self.unreachable_fallback == "fail_open":
+        unreachable_fail_open = is_unreachable and self.unreachable_fallback == "fail_open"
+        if unreachable_fail_open or not self.fail_on_error:
             http_status_code = getattr(
                 getattr(error, "response", None), "status_code", None
             )
@@ -432,26 +436,26 @@ class GenericGuardrailAPI(CustomGuardrail):
             extra_allowlist=extra_allowlist,
         )
 
-        # Create request payload
-        guardrail_request = GenericGuardrailAPIRequest(
-            litellm_call_id=logging_obj.litellm_call_id if logging_obj else None,
-            litellm_trace_id=logging_obj.litellm_trace_id if logging_obj else None,
-            texts=texts,
-            request_data=user_metadata,
-            request_headers=inbound_headers,
-            litellm_version=litellm_version,
-            images=images,
-            tools=tools,
-            structured_messages=structured_messages,
-            tool_calls=tool_calls,
-            additional_provider_specific_params=additional_params,
-            input_type=input_type,
-            model=model,
-        )
-
-        headers = self._build_request_headers()
-
         try:
+            # Create request payload
+            guardrail_request = GenericGuardrailAPIRequest(
+                litellm_call_id=logging_obj.litellm_call_id if logging_obj else None,
+                litellm_trace_id=logging_obj.litellm_trace_id if logging_obj else None,
+                texts=texts,
+                request_data=user_metadata,
+                request_headers=inbound_headers,
+                litellm_version=litellm_version,
+                images=images,
+                tools=tools,
+                structured_messages=structured_messages,
+                tool_calls=tool_calls,
+                additional_provider_specific_params=additional_params,
+                input_type=input_type,
+                model=model,
+            )
+
+            headers = self._build_request_headers()
+
             # Make the API request
             # Use mode="json" to ensure all iterables are converted to lists
             response = await self.async_handler.post(

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -27,6 +27,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.generic_guardrail_api import
     GenericGuardrailAPIMetadata,
     GenericGuardrailAPIRequest,
     GenericGuardrailAPIResponse,
+    GuardrailToolParam,
 )
 from litellm.types.utils import GenericGuardrailAPIInputs
 
@@ -448,7 +449,11 @@ class GenericGuardrailAPI(CustomGuardrail):
                 request_headers=inbound_headers,
                 litellm_version=litellm_version,
                 images=images,
-                tools=tools,
+                tools=(
+                    [GuardrailToolParam.model_validate(t) for t in tools]
+                    if tools
+                    else None
+                ),
                 structured_messages=structured_messages,
                 tool_calls=tool_calls,
                 additional_provider_specific_params=additional_params,

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -303,7 +303,7 @@ class GenericGuardrailAPI(CustomGuardrail):
             f" http_status_code={http_status_code}" if http_status_code else ""
         )
         verbose_proxy_logger.critical(
-            "Generic Guardrail API unreachable (fail-open). Proceeding without guardrail.%s "
+            "Generic Guardrail API error (fail-open). Proceeding without guardrail.%s "
             "guardrail_name=%s api_base=%s input_type=%s litellm_call_id=%s litellm_trace_id=%s",
             status_suffix,
             getattr(self, "guardrail_name", None),

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -354,7 +354,9 @@ class GenericGuardrailAPI(CustomGuardrail):
         logging_obj: Optional["LiteLLMLoggingObj"],
         is_unreachable: bool = True,
     ) -> GenericGuardrailAPIInputs:
-        unreachable_fail_open = is_unreachable and self.unreachable_fallback == "fail_open"
+        unreachable_fail_open = (
+            is_unreachable and self.unreachable_fallback == "fail_open"
+        )
         if unreachable_fail_open or not self.fail_on_error:
             http_status_code = getattr(
                 getattr(error, "response", None), "status_code", None

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -750,7 +750,12 @@ class BaseLitellmParams(
     )
     fail_on_error: Optional[bool] = Field(
         default=True,
-        description="Whether to fail the request if Model Armor encounters an error",
+        description=(
+            "Whether to fail the request if the guardrail encounters an error. "
+            "Implemented by guardrail='model_armor' and 'generic_guardrail_api'. "
+            "True (default) raises the error. False logs a critical error and lets the request proceed, "
+            "so only a valid guardrail response can block or modify it."
+        ),
     )
 
     additional_provider_specific_params: Optional[Dict[str, Any]] = Field(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -6,7 +6,6 @@ from typing_extensions import TYPE_CHECKING, TypedDict
 from litellm.types.llms.openai import (
     AllMessageValues,
     ChatCompletionToolCallChunk,
-    ChatCompletionToolParam,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 from litellm.types.utils import ChatCompletionMessageToolCall
@@ -110,7 +109,7 @@ class GenericGuardrailAPIResponse:
 
     texts: Optional[List[str]]
     images: Optional[List[str]]
-    tools: Optional[List[ChatCompletionToolParam]]
+    tools: Optional[List[GuardrailToolParam]]
     action: str
     blocked_reason: Optional[str]
 
@@ -120,7 +119,7 @@ class GenericGuardrailAPIResponse:
         texts: Optional[List[str]] = None,
         blocked_reason: Optional[str] = None,
         images: Optional[List[str]] = None,
-        tools: Optional[List[ChatCompletionToolParam]] = None,
+        tools: Optional[List[GuardrailToolParam]] = None,
     ):
         self.action = action
         self.blocked_reason = blocked_reason

--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TYPE_CHECKING, TypedDict
 
 from litellm.types.llms.openai import (
@@ -10,6 +10,18 @@ from litellm.types.llms.openai import (
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 from litellm.types.utils import ChatCompletionMessageToolCall
+
+
+class GuardrailToolParam(BaseModel):
+    """A tool forwarded verbatim to the guardrail for inspection.
+
+    Built-in tools (code_interpreter, file_search, ...) have no ``function`` block
+    and stash their config in tool-specific keys, so only ``type`` is required and
+    ``extra="allow"`` preserves the rest instead of stripping it.
+    """
+
+    model_config = ConfigDict(extra="allow")
+    type: str
 
 
 class GenericGuardrailAPIMetadata(TypedDict, total=False):
@@ -65,7 +77,7 @@ class GenericGuardrailAPIRequest(BaseModel):
     )
     structured_messages: Optional[List[AllMessageValues]] = None
     images: Optional[List[str]] = None
-    tools: Optional[List[ChatCompletionToolParam]] = None
+    tools: Optional[List[GuardrailToolParam]] = None
     texts: Optional[List[str]] = None
     request_data: GenericGuardrailAPIMetadata
     request_headers: Optional[Dict[str, str]] = Field(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/generic_guardrail_api.py
@@ -51,6 +51,16 @@ class GenericGuardrailAPIOptionalParams(BaseModel):
         ),
     )
 
+    fail_on_error: Optional[bool] = Field(
+        default=True,
+        description=(
+            "Behavior on any guardrail error, not just unreachability. "
+            "True (default) raises and blocks the request on error. "
+            "False logs a critical error and allows the request to proceed, so only a valid "
+            "guardrail response can block or modify it; broader than unreachable_fallback."
+        ),
+    )
+
 
 class GenericGuardrailAPIConfigModel(
     GuardrailConfigModel[GenericGuardrailAPIOptionalParams],

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -1021,3 +1021,44 @@ class TestMultimodalSupport:
             call_args = mock_post.call_args
             json_payload = call_args.kwargs["json"]
             assert isinstance(json_payload["structured_messages"], list)
+
+
+class TestToolSupport:
+    """Test tool handling in guardrail requests"""
+
+    @pytest.mark.asyncio
+    async def test_builtin_tools_without_function_block_do_not_crash(
+        self, generic_guardrail
+    ):
+        """Built-in tools (code_interpreter, file_search) have no `function` block.
+
+        Regression for a 500 where serializing them raised a Pydantic
+        ValidationError because the tool schema required `function`. The full
+        tool, including built-in tool config, must reach the guardrail intact.
+        """
+        tools = [
+            {"type": "function", "function": {"name": "get_weather", "parameters": {}}},
+            {"type": "code_interpreter"},
+            {
+                "type": "file_search",
+                "vector_store_ids": ["vs_1"],
+                "max_num_results": 5,
+            },
+        ]
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"action": "NONE", "texts": ["hi"]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            generic_guardrail.async_handler, "post", return_value=mock_response
+        ) as mock_post:
+            await generic_guardrail.apply_guardrail(
+                inputs={"texts": ["hi"], "tools": tools},
+                request_data={},
+                input_type="request",
+            )
+
+            forwarded_tools = mock_post.call_args.kwargs["json"]["tools"]
+
+        assert forwarded_tools == tools

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -1150,3 +1150,42 @@ class TestFailOnError:
                     request_data={},
                     input_type="request",
                 )
+
+    @pytest.mark.asyncio
+    async def test_response_path_continues_when_fail_on_error_false(
+        self, fail_open_guardrail
+    ):
+        """fail_on_error governs the response path identically to the request path."""
+        error = httpx.HTTPStatusError(
+            "bad request", request=MagicMock(), response=MagicMock(status_code=400)
+        )
+        with patch.object(
+            fail_open_guardrail.async_handler, "post", side_effect=error
+        ):
+            result = await fail_open_guardrail.apply_guardrail(
+                inputs={"texts": ["model output"]},
+                request_data={},
+                input_type="response",
+            )
+
+        assert result == {"texts": ["model output"]}
+
+    @pytest.mark.asyncio
+    async def test_response_path_valid_block_still_blocks(self, fail_open_guardrail):
+        """On the response path too, a valid BLOCKED decision raises despite fail_on_error=False."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "action": "BLOCKED",
+            "blocked_reason": "policy violation",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            fail_open_guardrail.async_handler, "post", return_value=mock_response
+        ):
+            with pytest.raises(GuardrailRaisedException):
+                await fail_open_guardrail.apply_guardrail(
+                    inputs={"texts": ["model output"]},
+                    request_data={},
+                    input_type="response",
+                )

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_generic_guardrail_api.py
@@ -1062,3 +1062,91 @@ class TestToolSupport:
             forwarded_tools = mock_post.call_args.kwargs["json"]["tools"]
 
         assert forwarded_tools == tools
+
+
+class TestFailOnError:
+    """Test fail_on_error: complete fail-open on any guardrail error"""
+
+    @pytest.fixture
+    def fail_open_guardrail(self):
+        return GenericGuardrailAPI(
+            api_base="https://api.test.guardrail.com",
+            guardrail_name="test-fail-open-guardrail",
+            event_hook="pre_call",
+            default_on=True,
+            fail_on_error=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_endpoint_error_continues_when_fail_on_error_false(
+        self, fail_open_guardrail
+    ):
+        """A non-unreachable endpoint error (HTTP 400) is swallowed and the request proceeds unchanged."""
+        error = httpx.HTTPStatusError(
+            "bad request", request=MagicMock(), response=MagicMock(status_code=400)
+        )
+        with patch.object(
+            fail_open_guardrail.async_handler, "post", side_effect=error
+        ):
+            result = await fail_open_guardrail.apply_guardrail(
+                inputs={"texts": ["hi"]},
+                request_data={},
+                input_type="request",
+            )
+
+        assert result == {"texts": ["hi"]}
+
+    @pytest.mark.asyncio
+    async def test_internal_error_continues_without_calling_endpoint(
+        self, fail_open_guardrail
+    ):
+        """An error while building the request (here: invalid input_type) fails open too.
+
+        Proves the request construction runs inside the protected block: the
+        endpoint is never called, yet the request still proceeds unchanged.
+        """
+        with patch.object(fail_open_guardrail.async_handler, "post") as mock_post:
+            result = await fail_open_guardrail.apply_guardrail(
+                inputs={"texts": ["hi"]},
+                request_data={},
+                input_type="bogus",  # type: ignore[arg-type]
+            )
+
+        mock_post.assert_not_called()
+        assert result == {"texts": ["hi"]}
+
+    @pytest.mark.asyncio
+    async def test_valid_block_still_blocks_when_fail_on_error_false(
+        self, fail_open_guardrail
+    ):
+        """Only a valid response acts: a BLOCKED decision still raises even with fail_on_error=False."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "action": "BLOCKED",
+            "blocked_reason": "policy violation",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            fail_open_guardrail.async_handler, "post", return_value=mock_response
+        ):
+            with pytest.raises(GuardrailRaisedException):
+                await fail_open_guardrail.apply_guardrail(
+                    inputs={"texts": ["hi"]},
+                    request_data={},
+                    input_type="request",
+                )
+
+    @pytest.mark.asyncio
+    async def test_endpoint_error_raises_by_default(self, generic_guardrail):
+        """Default fail_on_error=True keeps blocking on a non-unreachable endpoint error."""
+        error = httpx.HTTPStatusError(
+            "bad request", request=MagicMock(), response=MagicMock(status_code=400)
+        )
+        with patch.object(generic_guardrail.async_handler, "post", side_effect=error):
+            with pytest.raises(Exception, match="Generic Guardrail API failed"):
+                await generic_guardrail.apply_guardrail(
+                    inputs={"texts": ["hi"]},
+                    request_data={},
+                    input_type="request",
+                )


### PR DESCRIPTION
## Relevant issues

A user integrating a Generic Guardrail API hit a 500 on every request that carried a built-in tool (`code_interpreter`, `file_search`, ...). Digging into it surfaced a broader gap: when the guardrail itself errors for any reason, there was no way to keep serving traffic unless the error happened to be a network-unreachable one. This PR addresses both, because they are the same concern from two angles. The first removes a specific way the guardrail breaks a request; the second gives operators a general lever so that any guardrail failure can degrade gracefully instead of taking the request down with it

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix
🆕 New Feature

## Changes

The two changes are the same idea seen from two sides: the guardrail should not be the thing that breaks a request unexpectedly. The fix removes one concrete way that happened, and the fail-open mode is the general escape hatch for the rest

Built-in tools fix. Before forwarding a request to the guardrail, LiteLLM builds a `GenericGuardrailAPIRequest`. Its `tools` field validated each tool against `ChatCompletionToolParam`, whose base `TypedDict` marks `function` as required. Built-in tools such as `code_interpreter` and `file_search` carry only a `type` and no `function` block, so Pydantic raised a `ValidationError` that surfaced as a generic 500 before the request was ever sent. The schema was also internally inconsistent: the tool `type` was already `Union[Literal["function"], str]`, so it claimed to allow non-function tools while still mandating a function block. The field now uses a small `GuardrailToolParam` model that requires only `type` and sets `extra="allow"`, so built-in tools validate and their config is forwarded intact rather than stripped. This is contained to the guardrail request model and does not touch the shared `ChatCompletionToolParam`

Complete fail-open. Fixing the built-in tools crash removes one trigger, but a guardrail or its endpoint can fail in many other ways, and until now the only way to keep serving was `unreachable_fallback`, which fires solely on network-unreachable errors. This wires up the existing generic `fail_on_error` config (until now implemented only by Model Armor) for the Generic Guardrail. With `fail_on_error: false`, any guardrail error degrades to a critical-log warning and the request proceeds as if the guardrail were absent; only a valid guardrail response can act, so a parsed BLOCKED decision still raises while endpoint errors, malformed responses, and internal serialization or validation errors all fall through. To cover that last class the request construction now runs inside the protected block, which is why the very error category behind the original 500 is now also catchable here. It defaults to `true` (fail closed), so existing behavior is unchanged; turning it off is an explicit availability-over-security choice and is logged at critical level on every bypass. It composes with `unreachable_fallback` rather than replacing it

Tests. The tool change has a regression test that pushes a function tool, a `code_interpreter`, and a configured `file_search` through `apply_guardrail` and asserts the forwarded payload matches the input exactly. The fail-open change adds tests that a non-unreachable endpoint error and an internal construction error both proceed unchanged when `fail_on_error` is false (the latter also asserting the endpoint is never called, proving construction is inside the protected block), that a valid BLOCKED response still raises under fail-open, and that the default still blocks on error. The response path (`input_type="response"`) has its own tests for both the fail-open and the still-blocks cases, guarding against a regression that special-cases the hook in error handling. Each fails when its target behavior is mutated

## Credit

Adopted from #31286 by @itayov. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run. All commits preserve the original author metadata

## Linear ticket

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in fail_on_error=false weakens enforcement on guardrail outages/errors; default behavior is unchanged. Tool schema change is localized to the guardrail request path.
> 
> **Overview**
> Fixes **500s** when requests include built-in tools (`code_interpreter`, `file_search`, etc.) by replacing strict `ChatCompletionToolParam` validation with **`GuardrailToolParam`** (required `type`, `extra="allow"`) so full tool payloads reach the external guardrail unchanged.
> 
> Adds **`fail_on_error`** support for `generic_guardrail_api` (same knob as Model Armor): default **fail closed**; with `fail_on_error: false`, any guardrail failure (HTTP errors, serialization/validation, not only unreachable network) logs critically and **passthrough** proceeds—valid **BLOCKED** responses still raise. Request build + HTTP call now share one **try** block so pre-call validation errors are covered. Config/docs updated on shared `LitellmParams` and Generic Guardrail optional params; regression tests cover tools forwarding and fail-open paths on request/response.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653f0ab011ae3c05aec467b2e7cb4345f3338037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->