### PR TITLE
fix(ci): exclude deleted files from ruff format check

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git diff --name-only "$BASE_SHA"...HEAD -- 'litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
+          git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- 'litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
           if [ ! -s "$RUNNER_TEMP/ruff_format_files.txt" ]; then
             echo "No changed litellm Python files to check with ruff format."
             exit 0


### PR DESCRIPTION
## Relevant issues

The "Check ruff format" step in the LiteLLM Linting workflow fails with exit code 123 on any PR that deletes a `litellm/**/*.py` file. Surfaced on the promote-to-main PR #31384, which removes `litellm/ocr/rust_bridge.py`:

```
error: Failed to format litellm/ocr/rust_bridge.py: No such file or directory (os error 2)
301 files already formatted
```

## Type

🐛 Bug Fix

## Changes

The step builds its file list with `git diff --name-only`, which includes deleted paths. The deleted file is then piped to `ruff format --check`, which cannot format a file that no longer exists on disk and exits 123. Every other file is already correctly formatted; the failure is purely a workflow bug, not a real formatting issue.

The fix adds `--diff-filter=ACMR` so only added, copied, modified, and renamed files are checked, dropping deletions. This matches the pattern already used in `test-litellm-ui-build.yml`

## Screenshots / Proof of Fix

Local reproduction of the false positive and the fix, against the same base SHA CI used (`bd2a1653bd92aeef272b29feaa750706db094975`):

Before (current `main` behavior; lists the deleted file):

```
$ git diff --name-only "$BASE_SHA"...origin/litellm_internal_staging -- 'litellm/**/*.py' | grep -c '^litellm/ocr/rust_bridge.py$'
1
```

After (`--diff-filter=ACMR`; deleted file is gone):

```
$ git diff --name-only --diff-filter=ACMR "$BASE_SHA"...origin/litellm_internal_staging -- 'litellm/**/*.py' | grep -c '^litellm/ocr/rust_bridge.py$'
0
```

The CI run for this PR exercises the changed workflow directly, since `pull_request` runs the workflow from the merge commit
