### PR TITLE
feat(mistral): add mistral/mistral-ocr-2512 (OCR 3) to cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25610,6 +25610,16 @@
         ],
         "source": "https://mistral.ai/pricing#api-pricing"
     },
+    "mistral/mistral-ocr-2512": {
+        "litellm_provider": "mistral",
+        "ocr_cost_per_page": 0.002,
+        "annotation_cost_per_page": 0.003,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://mistral.ai/pricing#api-pricing"
+    },
     "mistral/magistral-medium-latest": {
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25774,6 +25774,16 @@
         ],
         "source": "https://mistral.ai/pricing#api-pricing"
     },
+    "mistral/mistral-ocr-2512": {
+        "litellm_provider": "mistral",
+        "ocr_cost_per_page": 0.002,
+        "annotation_cost_per_page": 0.003,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://mistral.ai/pricing#api-pricing"
+    },
     "mistral/magistral-medium-latest": {
         "input_cost_per_token": 2e-06,
         "litellm_provider": "mistral",

--- a/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
+++ b/tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py
@@ -5,6 +5,9 @@ for mistral-ocr-4-0 and mistral-ocr-latest, which now both resolve to
 OCR 4 at $4 / 1000 pages.
 """
 
+import json
+from pathlib import Path
+
 import pytest
 
 import litellm
@@ -12,6 +15,14 @@ from litellm.cost_calculator import completion_cost
 from litellm.llms.base_llm.ocr.transformation import OCRPage, OCRResponse, OCRUsageInfo
 
 OCR4_COST_PER_PAGE = 0.004
+
+REPO_ROOT = Path(__file__).parents[5]
+MAIN_COST_MAP = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_COST_MAP = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+OCR3_MODEL = "mistral/mistral-ocr-2512"
+OCR3_COST_PER_PAGE = 0.002
+OCR3_ANNOTATION_COST_PER_PAGE = 0.003
 
 
 def _ocr_response(model: str, pages_processed: int) -> OCRResponse:
@@ -38,3 +49,43 @@ def test_ocr4_cost_scales_with_pages(model: str, pages_processed: int) -> None:
         call_type="ocr",
     )
     assert cost == pytest.approx(OCR4_COST_PER_PAGE * pages_processed)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    """Force get_model_info to resolve against the in-repo cost map instead of the
+    remote one fetched at import time, which does not yet carry OCR 3 pricing."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+    litellm.get_model_info.cache_clear()
+    yield
+    litellm.get_model_info.cache_clear()
+
+
+@pytest.mark.parametrize("cost_map_path", [MAIN_COST_MAP, BACKUP_COST_MAP])
+def test_ocr3_pricing_entry(cost_map_path: Path) -> None:
+    with open(cost_map_path) as f:
+        info = json.load(f).get(OCR3_MODEL)
+
+    assert info is not None, f"{OCR3_MODEL} missing from {cost_map_path.name}"
+    assert info["litellm_provider"] == "mistral"
+    assert info["mode"] == "ocr"
+    assert info["supported_endpoints"] == ["/v1/ocr"]
+    assert info["ocr_cost_per_page"] == OCR3_COST_PER_PAGE
+    assert info["annotation_cost_per_page"] == OCR3_ANNOTATION_COST_PER_PAGE
+
+
+def test_ocr3_model_info_price(local_model_cost_map) -> None:
+    info = litellm.get_model_info(model=OCR3_MODEL, custom_llm_provider="mistral")
+    assert info["ocr_cost_per_page"] == OCR3_COST_PER_PAGE
+
+
+@pytest.mark.parametrize("pages_processed", [1, 3, 10])
+def test_ocr3_cost_scales_with_pages(local_model_cost_map, pages_processed: int) -> None:
+    cost = completion_cost(
+        completion_response=_ocr_response("mistral-ocr-2512", pages_processed),
+        model=OCR3_MODEL,
+        custom_llm_provider="mistral",
+        call_type="ocr",
+    )
+    assert cost == pytest.approx(OCR3_COST_PER_PAGE * pages_processed)


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3882

## Linear ticket

LIT-3882

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Ran a live proxy with the new entry (registering `mistral/mistral-ocr-2512` and forcing the in-repo cost map so the brand-new price resolves before it lands on main) and sent a real OCR request to the Mistral API.

```bash
export LITELLM_LOCAL_MODEL_COST_MAP=True
python litellm/proxy/proxy_cli.py --config ocr_2512_proof_config.yaml --port 4000
```

config:

```yaml
model_list:
  - model_name: mistral-ocr-2512
    litellm_params:
      model: mistral/mistral-ocr-2512
      api_key: os.environ/MISTRAL_API_KEY
```

5-page OCR call, checking the cost header (5 pages x $0.002/page = $0.01):

```bash
curl -s -D - http://localhost:4000/v1/ocr \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "mistral-ocr-2512",
    "document": {"type": "document_url", "document_url": "https://arxiv.org/pdf/2201.04234"},
    "pages": [0, 1, 2, 3, 4]
  }' -o /dev/null
```

```
x-litellm-model-id: adb9957c3bd90d1c88196506af492c7fde40c2ddf35e04b0309d85eb7d657826
x-litellm-response-cost: 0.01
x-litellm-response-cost-original: 0.01
```

The response came back from the real API with `model: mistral-ocr-2512` and `usage_info.pages_processed: 2` on a 2-page call, and the 5-page call above billed exactly $0.01

## Type

🆕 New Feature

## Changes

`mistral/mistral-ocr-2512` (Mistral OCR 3, Premier v25.12, released 2025-12-18) was missing from LiteLLM. This adds it to both `model_prices_and_context_window.json` and the bundled `litellm/model_prices_and_context_window_backup.json` at $2 / 1000 pages (`ocr_cost_per_page: 0.002`) and $3 / 1000 annotated pages (`annotation_cost_per_page: 0.003`), per the [OCR 3 model card](https://docs.mistral.ai/models/model-cards/ocr-3-25-12), mirroring the shape of the existing Mistral OCR entries. The Mistral OCR transformation is model-agnostic and passes the model name straight through, so no code changes were needed beyond the cost map.

Regression tests in `tests/test_litellm/llms/mistral/ocr/test_mistral_ocr_cost.py` assert the entry exists with the correct pricing in both cost maps and that `completion_cost` scales at $0.002/page. Mutating either pricing value fails the new tests.
