### PR TITLE
fix(mcp): keep user token in tools preview for interactive OAuth servers

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    Literal,
     Optional,
     Set,
     Tuple,
@@ -991,12 +990,17 @@ if MCP_AVAILABLE:
         try:
             client_id, client_secret, scopes = _extract_credentials(request)
 
-            _oauth2_flow: Optional[
-                Literal["client_credentials", "authorization_code"]
-            ] = request.oauth2_flow or (
-                "client_credentials"
-                if client_id and client_secret and request.token_url
-                else None
+            # Match load-time flow resolution: only treat this as M2M when there
+            # is no authorization_url, so interactive/OBO OAuth servers keep the
+            # user's forwarded token instead of having it dropped for a
+            # client_credentials token fetch.
+            _oauth2_flow = global_mcp_server_manager._resolve_oauth2_flow(
+                auth_type=request.auth_type,
+                oauth2_flow=request.oauth2_flow,
+                token_url=request.token_url,
+                authorization_url=request.authorization_url,
+                client_id=client_id,
+                client_secret=client_secret,
             )
             # client_credentials requires token_url to fetch a token; without it the
             # incoming auth header would be dropped with nothing to replace it.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -271,6 +271,60 @@ class TestExecuteWithMcpClient:
         )
 
     @pytest.mark.asyncio
+    async def test_interactive_oauth_with_creds_keeps_user_token(self, monkeypatch):
+        """Regression: an interactive OAuth server that has client_id/secret/token_url
+        AND an authorization_url (e.g. the hosted Slack MCP) must NOT be mistaken
+        for M2M. The user's forwarded token must reach the MCP client, not be
+        dropped for a client_credentials fetch."""
+        captured: dict = {}
+
+        def fake_build_stdio_env(server, raw_headers):
+            return None
+
+        async def fake_create_client(*args, **kwargs):
+            captured["server"] = kwargs.get("server")
+            captured["extra_headers"] = kwargs.get("extra_headers")
+            return object()
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_build_stdio_env",
+            fake_build_stdio_env,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "_create_mcp_client",
+            fake_create_client,
+            raising=False,
+        )
+
+        async def ok_operation(client):
+            return {"status": "ok"}
+
+        payload = NewMCPServerRequest(
+            server_name="slack",
+            url="https://mcp.slack.com/mcp",
+            auth_type=MCPAuth.oauth2,
+            authorization_url="https://slack.com/oauth/v2_user/authorize",
+            token_url="https://slack.com/api/oauth.v2.user.access",
+            credentials={
+                "client_id": "123.456",
+                "client_secret": "my-secret",
+            },
+        )
+
+        result = await rest_endpoints._execute_with_mcp_client(
+            payload,
+            ok_operation,
+            oauth2_headers={"Authorization": "Bearer user-token"},
+        )
+
+        assert result["status"] == "ok"
+        assert captured["server"].has_client_credentials is False
+        assert captured["extra_headers"]["Authorization"] == "Bearer user-token"
+
+    @pytest.mark.asyncio
     async def test_catches_exception_group(self, monkeypatch):
         """MCP SDK's anyio TaskGroup raises BaseExceptionGroup which does not
         inherit from Exception.  The handler must catch it and return an error


### PR DESCRIPTION
## Relevant issues

The "Add MCP Server" create tab's Connection Status and Tool Configuration tabs failed to list tools for an interactive OAuth2 server (the hosted Slack MCP) right after "Authorize & Fetch", even though the same server listed tools fine once saved

## Linear ticket
Resolves LIT-4073

## Root cause

`/mcp-rest/test/tools/list` (the create-tab preview) resolved the OAuth2 flow with its own inline copy of the M2M detection: it treated a server as `client_credentials` (M2M) whenever `client_id`, `client_secret` and `token_url` were all present. Interactive / on-behalf-of OAuth servers legitimately have all three (the hosted Slack MCP, GitHub Enterprise, etc.), so they were mislabeled M2M. The preview then dropped the user's forwarded token and tried a `client_credentials` token fetch, which the interactive user flow does not support, so the upstream returned no `access_token` and the tabs showed "Failed to connect to MCP server". The saved server worked because its tool fetch uses the stored per-user token through a path that does not do this inference

This is the same regression the `has_client_credentials` property already guards against ("Auto-detecting M2M from field presence was a breaking regression"); the preview path had a leftover copy without the guard

## What changed

The preview now resolves the flow through the canonical `_resolve_oauth2_flow` used at load time. That helper only infers M2M when there is no `authorization_url`, so interactive/OBO servers keep the user's forwarded token instead of having it dropped. Genuine M2M servers (no `authorization_url`) are unchanged, and discovery/DCR OAuth servers that fill in neither `token_url` nor client credentials are unchanged

## Screenshots / Proof of Fix

UI repro on a live proxy at `http://localhost:4000/ui`

Before: MCP Servers -> Add New MCP Server -> Slack -> complete the OAuth (Authorize and Fetch) on the create tab; the Connection Status tab shows "Connection Failed" and Tool Configuration shows "Unable to load tools", while saving the server and opening the playground lists tools

After: the same create-tab Authorize and Fetch lists the tools in Connection Status and Tool Configuration before saving, matching the saved-server behavior

A regression test (`test_interactive_oauth_with_creds_keeps_user_token`) asserts that an interactive server with client_id/secret/token_url and an authorization_url keeps the forwarded user token (`has_client_credentials is False`, `Authorization` header preserved); it fails on the old code and passes on the fix

## Type

🐛 Bug Fix

## Changes

- Replace the inline M2M auto-detection in `_execute_with_mcp_client` with a call to `global_mcp_server_manager._resolve_oauth2_flow`, and drop the now-unused `Literal` import
- Add a regression test covering interactive OAuth servers that carry client credentials
