### PR TITLE
feat(deepseek): support disabled thinking mode

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -647,9 +647,7 @@ def _get_openai_compatible_provider_info(
         ) = litellm.LMStudioChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "deepseek":
         # deepseek is openai compatible, we just need to set this to custom_openai
-        api_base = (
-            api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
-        )  # type: ignore
+        api_base = api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com"  # type: ignore
 
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
     elif custom_llm_provider == "fireworks_ai":

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -646,8 +646,10 @@ def _get_openai_compatible_provider_info(
             dynamic_api_key,
         ) = litellm.LMStudioChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "deepseek":
-        # deepseek is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.deepseek.com/v1
-        api_base = api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"  # type: ignore
+        # deepseek is openai compatible, we just need to set this to custom_openai
+        api_base = (
+            api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com"
+        )  # type: ignore
 
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
     elif custom_llm_provider == "fireworks_ai":

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -264,7 +264,11 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
-        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"  # type: ignore
+        api_base = (
+            api_base
+            or get_secret_str("DEEPSEEK_API_BASE")
+            or "https://api.deepseek.com"
+        )  # type: ignore
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
         return api_base, dynamic_api_key
 
@@ -281,7 +285,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         If api_base is not provided, use the default DeepSeek /chat/completions endpoint.
         """
         if not api_base:
-            api_base = "https://api.deepseek.com/beta"
+            api_base = "https://api.deepseek.com"
 
         if not api_base.endswith("/chat/completions"):
             api_base = f"{api_base}/chat/completions"

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -43,9 +43,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
 
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
-        thinking_type = (
-            thinking_value.get("type") if isinstance(thinking_value, dict) else None
-        )
+        thinking_type = thinking_value.get("type") if isinstance(thinking_value, dict) else None
 
         if thinking_type == "disabled":
             optional_params["thinking"] = {"type": "disabled"}
@@ -264,11 +262,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: Optional[str], api_key: Optional[str]
     ) -> Tuple[Optional[str], Optional[str]]:
-        api_base = (
-            api_base
-            or get_secret_str("DEEPSEEK_API_BASE")
-            or "https://api.deepseek.com"
-        )  # type: ignore
+        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com"  # type: ignore
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -35,27 +35,33 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         Map OpenAI params to DeepSeek params.
 
         Handles `thinking` and `reasoning_effort` parameters for DeepSeek reasoner models.
-        DeepSeek only supports `{"type": "enabled"}` - no budget_tokens like Anthropic.
+        DeepSeek only supports the `type` field on thinking params.
 
         Reference: https://api-docs.deepseek.com/guides/thinking_mode
         """
-        # Let parent handle standard params first
         optional_params = super().map_openai_params(non_default_params, optional_params, model, drop_params)
 
-        # Pop thinking/reasoning_effort from optional_params first (parent may have added them)
-        # Then re-add only if valid for DeepSeek
         thinking_value = optional_params.pop("thinking", None)
         reasoning_effort = optional_params.pop("reasoning_effort", None)
+        thinking_type = (
+            thinking_value.get("type") if isinstance(thinking_value, dict) else None
+        )
 
-        # Handle thinking parameter - only accept {"type": "enabled"}
-        if thinking_value is not None:
-            if isinstance(thinking_value, dict) and thinking_value.get("type") == "enabled":
-                # DeepSeek only accepts {"type": "enabled"}, ignore budget_tokens
-                optional_params["thinking"] = {"type": "enabled"}
+        if thinking_type == "disabled":
+            optional_params["thinking"] = {"type": "disabled"}
+            return optional_params
 
-        # Handle reasoning_effort - map to thinking enabled
-        elif reasoning_effort is not None and reasoning_effort != "none":
+        if thinking_type == "enabled":
             optional_params["thinking"] = {"type": "enabled"}
+            if reasoning_effort is not None and reasoning_effort != "none":
+                optional_params["reasoning_effort"] = reasoning_effort
+            return optional_params
+
+        if reasoning_effort == "none":
+            optional_params["thinking"] = {"type": "disabled"}
+        elif reasoning_effort is not None:
+            optional_params["thinking"] = {"type": "enabled"}
+            optional_params["reasoning_effort"] = reasoning_effort
 
         return optional_params
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -265,6 +265,7 @@ from .llms.vllm.completion import handler as vllm_handler
 from .llms.watsonx.chat.handler import WatsonXChatHandler
 from .llms.watsonx.common_utils import IBMWatsonXMixin
 from .types.llms.anthropic import AnthropicThinkingParam
+from .types.llms.deepseek import DeepSeekThinkingParam
 from .types.llms.openai import (
     ChatCompletionAssistantMessage,
     ChatCompletionAudioParam,
@@ -334,6 +335,7 @@ ovhcloud_transformation = OVHCloudChatConfig()
 lemonade_transformation = LemonadeChatConfig()
 
 MOCK_RESPONSE_TYPE = Union[str, Exception, dict, ModelResponse, ModelResponseStream]
+ThinkingParam = Union[AnthropicThinkingParam, DeepSeekThinkingParam]
 ####### COMPLETION ENDPOINTS ################
 
 
@@ -440,7 +442,7 @@ async def acompletion(
     model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     extra_headers: Optional[dict] = None,
     # Optional liteLLM function params
-    thinking: Optional[AnthropicThinkingParam] = None,
+    thinking: Optional[ThinkingParam] = None,
     web_search_options: Optional[OpenAIWebSearchOptions] = None,
     include_server_side_tool_invocations: Optional[bool] = None,
     # Session management
@@ -4747,7 +4749,7 @@ def completion(  # type: ignore
     api_key: Optional[str] = None,
     model_list: Optional[list] = None,  # pass in a list of api_base,keys, etc.
     # Optional liteLLM function params
-    thinking: Optional[AnthropicThinkingParam] = None,
+    thinking: Optional[ThinkingParam] = None,
     # Session management
     shared_session: Optional["ClientSession"] = None,
     # Per-request JSON schema validation (overrides litellm.enable_json_schema_validation)

--- a/litellm/types/llms/deepseek.py
+++ b/litellm/types/llms/deepseek.py
@@ -1,0 +1,5 @@
+from typing_extensions import Literal, TypedDict
+
+
+class DeepSeekThinkingParam(TypedDict, total=False):
+    type: Literal["enabled", "disabled"]

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -69,9 +69,7 @@ class TestDeepSeekThinkingParams:
         "reasoning_effort",
         ["minimal", "low", "medium", "high", "xhigh", "default"],
     )
-    def test_map_reasoning_effort_enables_thinking_and_passes_through(
-        self, reasoning_effort
-    ):
+    def test_map_reasoning_effort_enables_thinking_and_passes_through(self, reasoning_effort):
         """Test that reasoning_effort maps to thinking enabled and is passed through."""
         non_default_params = {"reasoning_effort": reasoning_effort}
         optional_params = {}
@@ -213,8 +211,6 @@ class TestDeepSeekThinkingParams:
 
         result = self.config._drop_unsupported_tools(optional_params)
 
-        assert result["tools"] == [
-            {"type": "function", "function": {"name": "get_weather"}}
-        ]
+        assert result["tools"] == [{"type": "function", "function": {"name": "get_weather"}}]
         assert "tool_choice" not in result
         assert result["parallel_tool_calls"] is True

--- a/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -35,6 +35,21 @@ class TestDeepSeekThinkingParams:
 
         assert result["thinking"] == {"type": "enabled"}
 
+    def test_map_thinking_disabled(self):
+        """Test that thinking={"type": "disabled"} is passed through correctly."""
+        non_default_params = {"thinking": {"type": "disabled"}}
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in result
+
     def test_map_thinking_with_budget_tokens_strips_budget(self):
         """Test that budget_tokens is stripped from thinking param (DeepSeek doesn't support it)."""
         non_default_params = {"thinking": {"type": "enabled", "budget_tokens": 2048}}
@@ -47,13 +62,18 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
-        # Should strip budget_tokens, only pass type
         assert result["thinking"] == {"type": "enabled"}
         assert "budget_tokens" not in result.get("thinking", {})
 
-    def test_map_reasoning_effort_medium(self):
-        """Test that reasoning_effort='medium' maps to thinking enabled."""
-        non_default_params = {"reasoning_effort": "medium"}
+    @pytest.mark.parametrize(
+        "reasoning_effort",
+        ["minimal", "low", "medium", "high", "xhigh", "default"],
+    )
+    def test_map_reasoning_effort_enables_thinking_and_passes_through(
+        self, reasoning_effort
+    ):
+        """Test that reasoning_effort maps to thinking enabled and is passed through."""
+        non_default_params = {"reasoning_effort": reasoning_effort}
         optional_params = {}
 
         result = self.config.map_openai_params(
@@ -64,37 +84,10 @@ class TestDeepSeekThinkingParams:
         )
 
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == reasoning_effort
 
-    def test_map_reasoning_effort_low(self):
-        """Test that reasoning_effort='low' maps to thinking enabled."""
-        non_default_params = {"reasoning_effort": "low"}
-        optional_params = {}
-
-        result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
-            model=self.model,
-            drop_params=False,
-        )
-
-        assert result["thinking"] == {"type": "enabled"}
-
-    def test_map_reasoning_effort_high(self):
-        """Test that reasoning_effort='high' maps to thinking enabled."""
-        non_default_params = {"reasoning_effort": "high"}
-        optional_params = {}
-
-        result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
-            model=self.model,
-            drop_params=False,
-        )
-
-        assert result["thinking"] == {"type": "enabled"}
-
-    def test_map_reasoning_effort_none_does_not_enable_thinking(self):
-        """Test that reasoning_effort='none' does not enable thinking."""
+    def test_map_reasoning_effort_none_disables_thinking(self):
+        """Test that reasoning_effort='none' maps to thinking disabled."""
         non_default_params = {"reasoning_effort": "none"}
         optional_params = {}
 
@@ -105,7 +98,8 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
-        assert "thinking" not in result
+        assert result["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in result
 
     def test_map_reasoning_effort_null_does_not_enable_thinking(self):
         """Test that reasoning_effort=None does not enable thinking."""
@@ -121,8 +115,8 @@ class TestDeepSeekThinkingParams:
 
         assert "thinking" not in result
 
-    def test_thinking_takes_precedence_over_reasoning_effort(self):
-        """Test that thinking param takes precedence when both are provided."""
+    def test_thinking_enabled_keeps_reasoning_effort(self):
+        """Test that thinking enabled keeps non-none reasoning_effort."""
         non_default_params = {
             "thinking": {"type": "enabled"},
             "reasoning_effort": "high",
@@ -136,8 +130,45 @@ class TestDeepSeekThinkingParams:
             drop_params=False,
         )
 
-        # thinking should be set, reasoning_effort should not override
         assert result["thinking"] == {"type": "enabled"}
+        assert result["reasoning_effort"] == "high"
+
+    def test_thinking_enabled_drops_reasoning_effort_none(self):
+        """Test that thinking enabled drops reasoning_effort='none'."""
+        non_default_params = {
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "none",
+        }
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "enabled"}
+        assert "reasoning_effort" not in result
+
+    @pytest.mark.parametrize("reasoning_effort", ["none", "high"])
+    def test_thinking_disabled_drops_reasoning_effort(self, reasoning_effort):
+        """Test that thinking disabled never sends reasoning_effort."""
+        non_default_params = {
+            "thinking": {"type": "disabled"},
+            "reasoning_effort": reasoning_effort,
+        }
+        optional_params = {}
+
+        result = self.config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=self.model,
+            drop_params=False,
+        )
+
+        assert result["thinking"] == {"type": "disabled"}
+        assert "reasoning_effort" not in result
 
     def test_invalid_thinking_type_ignored(self):
         """Test that invalid thinking type values are ignored."""

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -99,7 +99,7 @@ async def test_deepseek_provider_async_completion(stream):
 
     # Check request body
     request_body = json.loads(call_args.kwargs["data"])
-    assert call_args.kwargs["url"] == "https://api.deepseek.com/beta/chat/completions"
+    assert call_args.kwargs["url"] == "https://api.deepseek.com/chat/completions"
     assert (
         request_body["model"] == "deepseek-reasoner"
     )  # Model name should be stripped of provider prefix
@@ -191,7 +191,11 @@ def test_deepseek_fill_reasoning_content_multiturn():
     # Case 1: assistant message already has reasoning_content — should be left as-is
     messages_with_rc = [
         {"role": "user", "content": "Hello"},
-        {"role": "assistant", "content": "Hi", "reasoning_content": "I thought about it"},
+        {
+            "role": "assistant",
+            "content": "Hi",
+            "reasoning_content": "I thought about it",
+        },
         {"role": "user", "content": "Follow up"},
     ]
     result = config._fill_reasoning_content(messages_with_rc)

--- a/tests/llm_translation/test_deepseek_completion.py
+++ b/tests/llm_translation/test_deepseek_completion.py
@@ -60,9 +60,7 @@ async def test_deepseek_provider_async_completion(stream):
     messages = [{"role": "user", "content": "Hello, world!"}]
 
     # Mock AsyncHTTPHandler.post method for async test
-    with patch(
-        "litellm.llms.custom_httpx.llm_http_handler.AsyncHTTPHandler.post"
-    ) as mock_post:
+    with patch("litellm.llms.custom_httpx.llm_http_handler.AsyncHTTPHandler.post") as mock_post:
         mock_response_data = litellm.ModelResponse(
             choices=[
                 litellm.Choices(
@@ -100,9 +98,7 @@ async def test_deepseek_provider_async_completion(stream):
     # Check request body
     request_body = json.loads(call_args.kwargs["data"])
     assert call_args.kwargs["url"] == "https://api.deepseek.com/chat/completions"
-    assert (
-        request_body["model"] == "deepseek-reasoner"
-    )  # Model name should be stripped of provider prefix
+    assert request_body["model"] == "deepseek-reasoner"  # Model name should be stripped of provider prefix
     assert request_body["messages"] == messages
     assert request_body["stream"] == stream
 
@@ -165,13 +161,9 @@ def test_completion_cost_deepseek():
         assert response_2.usage.prompt_cache_miss_tokens is not None
         assert (
             response_2.usage.prompt_tokens
-            == response_2.usage.prompt_cache_miss_tokens
-            + response_2.usage.prompt_cache_hit_tokens
+            == response_2.usage.prompt_cache_miss_tokens + response_2.usage.prompt_cache_hit_tokens
         )
-        assert (
-            response_2.usage._cache_read_input_tokens
-            == response_2.usage.prompt_cache_hit_tokens
-        )
+        assert response_2.usage._cache_read_input_tokens == response_2.usage.prompt_cache_hit_tokens
     except litellm.APIError as e:
         pass
     except Exception as e:


### PR DESCRIPTION
## Relevant issues

  N/A

  ## Linear ticket

  N/A

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have added meaningful tests
  - [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
  - [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
  - [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before
  requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

  ## Screenshots / Proof of Fix

  Tested with real DeepSeek API calls using `deepseek/deepseek-v4-flash`

  Verified `thinking={"type": "enabled"}` with multiple `reasoning_effort` combinations. All requests succeeded and returned reasoning output as expected

  Verified `thinking={"type": "disabled"}`. The request succeeded and disabled reasoning output as expected

  Example request shape:

  ```python
  litellm.completion(
      model="deepseek/deepseek-v4-flash",
      api_key="<redacted>",
      messages=[
          {"role": "system", "content": "..."},
          {"role": "user", "content": "..."},
      ],
      thinking={"type": "disabled"},
      reasoning_effort="none",
  )
  ```

  Local checks run:

  make format

  .venv/bin/pytest tests/litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py -q
  .venv/bin/pytest tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py -q
  .venv/bin/pytest tests/llm_translation/test_deepseek_completion.py::test_deepseek_provider_async_completion -q

  Additional lint checks run:

  ```shell
  make check-circular-imports
  make check-import-safety
  make lint-ruff-budget
  ```

  Notes:

  make test-unit was attempted, but pytest stopped during collection due to an existing import mismatch between tests/test_litellm/models/ test_models.py and tests/test_litellm/proxy/client/test_models.py. Targeted DeepSeek tests passed

  ## Type

  🆕 New Feature
  🐛 Bug Fix
  ✅ Test

  ## Changes

  Adds a DeepSeek-specific thinking type that supports {"type": "disabled"} and updates the completion entrypoint typing to accept it

  Updates the DeepSeek chat adapter so thinking={"type": "enabled"} and thinking={"type": "disabled"} are forwarded using DeepSeek’s supported shape. reasoning_effort="none" maps to disabled thinking when no explicit thinking switch is provided. Other OpenAI reasoning effort values are passed through unchanged

  Updates the default DeepSeek chat API base from https://api.deepseek.com/beta to https://api.deepseek.com

  Adds regression coverage for disabled thinking, reasoning_effort="none", explicit thinking precedence, and OpenAI reasoning effort passthrough