### PR TITLE
fix(deepseek): downgrade json_schema response_format to json_object

### DIFF
--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -172,17 +172,20 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             json_schema = nested_schema.get("schema")
         elif "response_schema" in response_format:
             json_schema = response_format["response_schema"]
-        if not json_schema:
-            return messages, optional_params
 
-        messages = messages + [
-            {
-                "role": "user",
-                "content": response_schema_prompt(
-                    model=model, response_schema=json_schema
-                ),
-            }
-        ]
+        # DeepSeek rejects the json_schema *type* itself, so the format must always be
+        # downgraded to json_object — even when the schema body is absent/empty, where
+        # there is simply nothing to inject. Only convey the schema (and satisfy the
+        # "json" keyword requirement) via the prompt when one is actually present.
+        if json_schema:
+            messages = messages + [
+                {
+                    "role": "user",
+                    "content": response_schema_prompt(
+                        model=model, response_schema=json_schema
+                    ),
+                }
+            ]
         optional_params = {
             **optional_params,
             "response_format": {"type": "json_object"},

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -160,10 +160,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         no DeepSeek model supports native json_schema.
         """
         response_format = optional_params.get("response_format")
-        if (
-            not isinstance(response_format, dict)
-            or response_format.get("type") != "json_schema"
-        ):
+        if not isinstance(response_format, dict) or response_format.get("type") != "json_schema":
             return messages, optional_params
 
         json_schema: Optional[dict] = None
@@ -181,9 +178,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             messages = messages + [
                 {
                     "role": "user",
-                    "content": response_schema_prompt(
-                        model=model, response_schema=json_schema
-                    ),
+                    "content": response_schema_prompt(model=model, response_schema=json_schema),
                 }
             ]
         optional_params = {

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -8,6 +8,7 @@ import litellm
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     handle_messages_with_content_list_to_str_conversion,
 )
+from litellm.litellm_core_utils.prompt_templates.factory import response_schema_prompt
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import AllMessageValues
 from litellm.utils import supports_reasoning
@@ -135,6 +136,59 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
             and (optional_params.get("thinking") or {}).get("type") == "enabled"
         )
 
+    def _downgrade_json_schema_to_json_object(
+        self,
+        model: str,
+        messages: List[AllMessageValues],
+        optional_params: dict,
+    ) -> Tuple[List[AllMessageValues], dict]:
+        """
+        DeepSeek's /chat/completions rejects `response_format={"type": "json_schema"}`
+        with "This response_format type is unavailable now" — no DeepSeek model
+        supports native Structured Outputs, only JSON mode (`{"type": "json_object"}`).
+        See recurring reports #7580 and #7646.
+
+        DeepSeek models are marked `supports_response_schema=True` in the model-cost
+        map (#20885) and downstream consumers filter their model lists on that flag, so
+        flipping it is not an option. Instead, honour the flag: downgrade json_schema to
+        json_object and move the schema into the prompt via `response_schema_prompt`
+        (the same helper the Gemini path uses when it can't enforce a schema natively).
+        The injected message also satisfies DeepSeek's requirement that the word "json"
+        appear in the input when json_object mode is used.
+
+        The downgrade is unconditional (not gated on `supports_response_schema`) because
+        no DeepSeek model supports native json_schema.
+        """
+        response_format = optional_params.get("response_format")
+        if (
+            not isinstance(response_format, dict)
+            or response_format.get("type") != "json_schema"
+        ):
+            return messages, optional_params
+
+        json_schema: Optional[dict] = None
+        nested_schema = response_format.get("json_schema")
+        if isinstance(nested_schema, dict):
+            json_schema = nested_schema.get("schema")
+        elif "response_schema" in response_format:
+            json_schema = response_format["response_schema"]
+        if not json_schema:
+            return messages, optional_params
+
+        messages = messages + [
+            {
+                "role": "user",
+                "content": response_schema_prompt(
+                    model=model, response_schema=json_schema
+                ),
+            }
+        ]
+        optional_params = {
+            **optional_params,
+            "response_format": {"type": "json_object"},
+        }
+        return messages, optional_params
+
     @staticmethod
     def _drop_unsupported_tools(optional_params: dict) -> dict:
         """
@@ -222,6 +276,9 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         like deepseek-v3.2 that support thinking as opt-in but not always-on.
         """
         optional_params = self._drop_unsupported_tools(optional_params)
+        messages, optional_params = self._downgrade_json_schema_to_json_object(
+            model=model, messages=messages, optional_params=optional_params
+        )
         if self._thinking_mode_active(model=model, optional_params=optional_params):
             messages = self._fill_reasoning_content(messages)
         return super().transform_request(
@@ -245,6 +302,9 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
         fix for multi-turn thinking-mode conversations.
         """
         optional_params = self._drop_unsupported_tools(optional_params)
+        messages, optional_params = self._downgrade_json_schema_to_json_object(
+            model=model, messages=messages, optional_params=optional_params
+        )
         if self._thinking_mode_active(model=model, optional_params=optional_params):
             messages = self._fill_reasoning_content(messages)
         return await super().async_transform_request(

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -139,9 +139,9 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
     def _downgrade_json_schema_to_json_object(
         self,
         model: str,
-        messages: List[AllMessageValues],
+        messages: list[AllMessageValues],
         optional_params: dict,
-    ) -> Tuple[List[AllMessageValues], dict]:
+    ) -> tuple[list[AllMessageValues], dict]:
         """
         DeepSeek's /chat/completions rejects `response_format={"type": "json_schema"}`
         with "This response_format type is unavailable now" — no DeepSeek model

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -153,6 +153,30 @@ def test_downgrade_json_schema_without_schema_body_still_downgrades():
         assert messages == original_messages
 
 
+def test_downgrade_reads_response_schema_key():
+    """Some callers pass the schema under a top-level `response_schema` key
+    (mirrors GroqChatConfig's extraction); it is downgraded and injected too."""
+    config = DeepSeekChatConfig()
+    messages, optional_params = config._downgrade_json_schema_to_json_object(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "Is the sky blue?"}],
+        optional_params={
+            "response_format": {
+                "type": "json_schema",
+                "response_schema": {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                    "additionalProperties": False,
+                },
+            }
+        },
+    )
+
+    assert optional_params["response_format"] == {"type": "json_object"}
+    assert "answer" in messages[-1]["content"]
+
+
 def test_downgrade_is_noop_for_json_object():
     config = DeepSeekChatConfig()
     original_messages = [{"role": "user", "content": "Is the sky blue?"}]

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -101,3 +101,75 @@ async def test_async_transform_request_strips_unsupported_tools_from_body():
 
     assert [tool["type"] for tool in body["tools"]] == ["function"]
     assert body["tools"][0]["function"]["name"] == "shell"
+
+
+_JSON_SCHEMA_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "answer",
+        "schema": {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+            "additionalProperties": False,
+        },
+        "strict": True,
+    },
+}
+
+
+def test_downgrade_json_schema_to_json_object():
+    config = DeepSeekChatConfig()
+    messages, optional_params = config._downgrade_json_schema_to_json_object(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "Is the sky blue?"}],
+        optional_params={"response_format": dict(_JSON_SCHEMA_RESPONSE_FORMAT)},
+    )
+
+    assert optional_params["response_format"] == {"type": "json_object"}
+    injected = messages[-1]
+    assert injected["role"] == "user"
+    # DeepSeek json_object mode requires the word "json" in the prompt
+    assert "json" in injected["content"].lower()
+    assert "answer" in injected["content"]
+
+
+def test_downgrade_is_noop_for_json_object():
+    config = DeepSeekChatConfig()
+    original_messages = [{"role": "user", "content": "Is the sky blue?"}]
+    messages, optional_params = config._downgrade_json_schema_to_json_object(
+        model="deepseek-chat",
+        messages=original_messages,
+        optional_params={"response_format": {"type": "json_object"}},
+    )
+
+    assert optional_params["response_format"] == {"type": "json_object"}
+    assert messages == original_messages
+
+
+def test_transform_request_downgrades_json_schema_response_format():
+    config = DeepSeekChatConfig()
+    body = config.transform_request(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "Is the sky blue?"}],
+        optional_params={"response_format": dict(_JSON_SCHEMA_RESPONSE_FORMAT)},
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["response_format"] == {"type": "json_object"}
+    assert any("answer" in m.get("content", "") for m in body["messages"])
+
+
+async def test_async_transform_request_downgrades_json_schema_response_format():
+    config = DeepSeekChatConfig()
+    body = await config.async_transform_request(
+        model="deepseek-chat",
+        messages=[{"role": "user", "content": "Is the sky blue?"}],
+        optional_params={"response_format": dict(_JSON_SCHEMA_RESPONSE_FORMAT)},
+        litellm_params={},
+        headers={},
+    )
+
+    assert body["response_format"] == {"type": "json_object"}
+    assert any("answer" in m.get("content", "") for m in body["messages"])

--- a/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
+++ b/tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py
@@ -134,6 +134,25 @@ def test_downgrade_json_schema_to_json_object():
     assert "answer" in injected["content"]
 
 
+def test_downgrade_json_schema_without_schema_body_still_downgrades():
+    """DeepSeek rejects the json_schema type itself, so a json_schema response_format
+    with no nested schema must still be downgraded to json_object (nothing to inject,
+    but the format must not reach the API unchanged and 400)."""
+    config = DeepSeekChatConfig()
+    original_messages = [{"role": "user", "content": "Reply in json."}]
+    for response_format in (
+        {"type": "json_schema"},
+        {"type": "json_schema", "json_schema": {}},
+    ):
+        messages, optional_params = config._downgrade_json_schema_to_json_object(
+            model="deepseek-chat",
+            messages=list(original_messages),
+            optional_params={"response_format": response_format},
+        )
+        assert optional_params["response_format"] == {"type": "json_object"}
+        assert messages == original_messages
+
+
 def test_downgrade_is_noop_for_json_object():
     config = DeepSeekChatConfig()
     original_messages = [{"role": "user", "content": "Is the sky blue?"}]


### PR DESCRIPTION
## Relevant issues

Fixes #7580
Fixes #7646

Both report this exact error and were closed stale without a fix; it still reproduces on `main`.

## What this fixes

DeepSeek's `/chat/completions` rejects `response_format={"type": "json_schema"}` with:

```
DeepseekException - response_format.type `json_schema` is unavailable now
```

No DeepSeek model supports native Structured Outputs — only JSON mode (`{"type": "json_object"}`). Because the model-cost map marks DeepSeek `supports_response_schema=True` (#20885), callers pass a json_schema response_format and the request 400s. Unlike Gemini, `DeepSeekChatConfig` had no provider-side downgrade.

This PR makes `DeepSeekChatConfig` downgrade `json_schema` → `json_object` and move the schema into the prompt via `response_schema_prompt` — **the same mechanism the Gemini path already uses** when it can't enforce a schema natively (`vertex_ai/gemini/transformation.py`). The injected message also satisfies DeepSeek's requirement that the word "json" appear in the input for json_object mode.

### Why not the Groq-style tool-calling workaround?

`GroqChatConfig` handles json-schema-incapable models by converting the schema into a forced `tool_choice` function call. That does **not** work for DeepSeek: the v4 reasoning models (`deepseek-v4-flash`, `deepseek-v4-pro`) reject a forced/required `tool_choice` with `"Thinking mode does not support this tool_choice"`. `json_object` + `response_schema_prompt` (the Gemini approach) works across **all** DeepSeek models, including the thinking ones.

### Why unconditional (not gated on `supports_response_schema`)?

No DeepSeek model supports native json_schema, and the flag is intentionally `True` (#20885) — downstream consumers filter their model lists on it — so the metadata is left unchanged and the downgrade always applies when a json_schema response_format is sent.

## Screenshots / Proof of Fix

Real `litellm.acompletion` calls against `api.deepseek.com` (no mocks).

Reproduction:
```python
import asyncio, litellm

schema = {"type": "object",
          "properties": {"answer": {"type": "string"}, "confidence": {"type": "number"}},
          "required": ["answer", "confidence"], "additionalProperties": False}

asyncio.run(litellm.acompletion(
    model="deepseek/deepseek-chat",
    messages=[{"role": "user", "content": "Is the sky blue? answer + confidence 0-1."}],
    response_format={"type": "json_schema",
                     "json_schema": {"name": "r", "strict": True, "schema": schema}},
))
```

**Before (main):**
```
litellm.BadRequestError: DeepseekException - "This response_format type is unavailable now"
```

**After (this PR)** — same call, verified on every served model:
```
deepseek/deepseek-v4-flash -> {"answer": "yes", "confidence": 0.95}
deepseek/deepseek-v4-pro   -> {"answer": "yes", "confidence": 1.0}
deepseek/deepseek-chat     -> {"answer": "Yes", "confidence": 1.0}
```

(The API currently serves only `deepseek-v4-pro` / `deepseek-v4-flash`; `chat`/`reasoner`/`coder` route to v4. All reject `json_schema`, all work after this change.)

## Pre-Submission checklist

- [x] I have added meaningful tests (`tests/test_litellm/llms/deepseek/chat/test_deepseek_chat_transformation.py`)
- [x] My PR passes lint/format (ruff check + black) and unit tests; the #20885 metadata regression suite stays green (metadata untouched)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

🐛 Bug Fix
