### PR TITLE
fix(proxy): gate non-admin /key/generate budget_limits and permissions (VERIA-392)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -547,6 +547,63 @@ def _check_allowed_routes_caller_permission(
     )
 
 
+def _check_permissions_caller_permission(
+    permissions: Optional[dict],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """
+    Only proxy admins may set the `permissions` dict on a key.
+
+    The field grants ambient capabilities (e.g. `get_spend_routes` exposes
+    `/global/spend/*`), so it must follow the same admin gate as
+    `allowed_routes`. Without this gate a non-admin can self-grant capabilities
+    they do not hold, including read access to global spend.
+    """
+    if not permissions:
+        return
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={"error": "Only proxy admins can set `permissions` on a key."},
+    )
+
+
+def _check_budget_limits_delegation_ceiling(
+    budget_limits: Optional[List[BudgetLimitEntry]],
+    delegation_ceiling: Optional[float],
+    user_api_key_dict: UserAPIKeyAuth,
+    is_ui_session_team_key: bool,
+) -> None:
+    """
+    Enforce the delegation ceiling on every per-window budget entry.
+
+    The single-value `max_budget` check upstream guards the all-time budget;
+    `budget_limits` lets a key carry independent concurrent windows and was
+    bypassing the ceiling entirely, so a non-admin caller could mint a key
+    with a window budget far above their own authority.
+    """
+    if not budget_limits:
+        return
+    if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
+        return
+    if is_ui_session_team_key:
+        return
+    if delegation_ceiling is None:
+        return
+    over_ceiling = next((w for w in budget_limits if w.max_budget > delegation_ceiling), None)
+    if over_ceiling is not None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": (
+                    f"budget_limits entry max_budget ({over_ceiling.max_budget}) "
+                    f"cannot exceed the caller's own max_budget ({delegation_ceiling})."
+                )
+            },
+        )
+
+
 async def validate_team_id_used_in_service_account_request(
     team_id: Optional[str],
     prisma_client: Optional[PrismaClient],
@@ -743,6 +800,17 @@ async def _common_key_generation_helper(
                 )
             },
         )
+
+    _check_budget_limits_delegation_ceiling(
+        budget_limits=data.budget_limits,
+        delegation_ceiling=delegation_ceiling,
+        user_api_key_dict=user_api_key_dict,
+        is_ui_session_team_key=is_ui_session_team_key,
+    )
+    _check_permissions_caller_permission(
+        permissions=data.permissions,
+        user_api_key_dict=user_api_key_dict,
+    )
 
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -12761,3 +12761,177 @@ async def test_cli_session_token_personal_key_without_budget_allowed():
             team_table=None,  # no team in request = personal key, but no explicit budget
         )
     assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_window_cannot_exceed_caller_max_budget(monkeypatch):
+    """A non-admin caller may not set a `budget_limits` window above
+    their own `max_budget`."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=10.0,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[
+            {"budget_duration": "1d", "max_budget": 1_000_000.0},
+        ],
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "budget_limits" in str(exc_info.value.detail)
+    assert "1000000" in str(exc_info.value.detail).replace(",", "")
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_window_within_caller_max_budget_allowed(monkeypatch):
+    """Counterpart: a window within the caller's ceiling must still pass."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=100.0,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 25.0}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_admin_unrestricted(monkeypatch):
+    """Proxy admin can set any window budget regardless of their own max_budget."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+        max_budget=10.0,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "admin-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=admin,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_permissions_field_rejected_for_non_admin(monkeypatch):
+    """A non-admin caller may not set the `permissions` field on a key
+    they create."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=100.0,
+    )
+    request = GenerateKeyRequest(permissions={"get_spend_routes": True})
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_permissions_empty_default_allowed_for_non_admin(monkeypatch):
+    """
+    The empty `{}` default on GenerateKeyRequest.permissions must continue
+    to pass for non-admin callers; only a non-empty dict triggers the gate.
+    """
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=100.0,
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=GenerateKeyRequest(),
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_permissions_admin_can_set_any(monkeypatch):
+    """Proxy admin can still set `permissions` on a key."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+    )
+    request = GenerateKeyRequest(permissions={"get_spend_routes": True})
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "admin-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=admin,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert result is not None


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4072

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`/key/generate`, `/key/update`, and `/key/regenerate` shared the same two delegation gaps. The single-value `max_budget` was gated against the caller's ceiling, but the per-window entries in `budget_limits` and the `permissions` dict were ungated. A non-admin with `max_budget=10` could mint, update, or regenerate a key with a $1M daily window, or self-grant ambient capabilities like `get_spend_routes` and `enable_llm_guard_check`. A CLI session token bypassed the ceiling on the same path; a NaN window value bypassed both the gate and downstream enforcement

Setup: admin creates user `alice` with role `internal_user`, `max_budget=10`, models `["gpt-3.5-turbo"]`, and a personal key for her

### After (fixed code)

`/key/generate` budget_limits over-ceiling

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":1000000}]}'
```

```json
{"error":{"message":"{'error': \"budget_limits entry max_budget (1000000.0) cannot exceed the caller's own max_budget (10.0).\"}","code":"400"}}
```

`/key/generate` NaN window

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":NaN}]}'
```

```json
{"error":{"message":"{'error': 'budget_limits entry max_budget (nan) must be a finite number.'}","code":"400"}}
```

`/key/update` non-admin permissions on own key

```
curl -sS -X POST http://localhost:4000/key/update \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"key":"sk-alice","permissions":{"get_spend_routes":true}}'
```

```json
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

`/key/regenerate` non-admin budget_limits on own key

```
curl -sS -X POST http://localhost:4000/key/regenerate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"key":"sk-alice","budget_limits":[{"budget_duration":"1d","max_budget":1000000}]}'
```

```json
{"error":{"message":"{'error': \"budget_limits entry max_budget (1000000.0) cannot exceed the caller's own max_budget (10.0).\"}","code":"400"}}
```

`/key/regenerate` non-admin permissions on own key

```
curl -sS -X POST http://localhost:4000/key/regenerate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"key":"sk-alice","permissions":{"get_spend_routes":true}}'
```

```json
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

Controls

Admin can still set both fields, including over-ceiling

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"permissions":{"get_spend_routes":true},"budget_limits":[{"budget_duration":"1d","max_budget":1000000}]}'
```

```json
{"key":"sk-1T_510Ww7uo...","permissions":{"get_spend_routes":true},"budget_limits":[{"budget_duration":"1d","max_budget":1000000.0,"reset_at":"2026-06-28T00:00:00Z"}]}
```

Non-admin within her ceiling still mints

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":5}]}'
```

```json
{"key":"sk-401tRPzoNES...","budget_limits":[{"budget_duration":"1d","max_budget":5.0,"reset_at":"2026-06-28T00:00:00Z"}]}
```

## Type

🐛 Bug Fix

## Changes

Two helpers placed next to `_check_allowed_routes_caller_permission`

`_check_budget_limits_delegation_ceiling` walks every `BudgetLimitEntry` in `data.budget_limits`. It rejects non-finite values (NaN bypassed `>` because `NaN > x` is False, and the proxy never trips downstream because `spend > NaN` is always False), then refuses a CLI session token writing `budget_limits` to a personal key (the symmetric guard for the scalar `max_budget` already existed; `None` from a session token is zero delegation authority, not unlimited), then enforces the per-window ceiling. Carve-outs match the existing scalar check (proxy admin, UI-session team key, `delegation_ceiling is None` for regular non-admins whose admin granted them an unlimited budget)

`_check_permissions_caller_permission` requires `PROXY_ADMIN` for any non-empty `permissions` dict. The default `{}` still passes for non-admin callers

Three call sites:

- `_common_key_generation_helper` covers `/key/generate` and `/key/service-account/generate`
- `_validate_update_key_data` covers `/key/update` (`budget_limits` was already admin-only here via `_is_budget_change`, only `permissions` was open)
- `regenerate_key_fn` covers `/key/regenerate` (both fields were open; regenerate goes through `prepare_key_update_data` not `_validate_update_key_data`, so the gate lives at the handler)

`PermissionsDict` is a new TypedDict in `litellm/proxy/_types.py` next to where #31471 introduced `ObjectPermissionDict`. It names the keys the proxy actually reads off the dict (`get_spend_routes`, `enable_llm_guard_check`); `total=False` lets the dispatcher in `guardrail_helpers.py` accept arbitrary guardrail-name keys. Applied to `_check_permissions_caller_permission`, `generate_key_helper_fn`, and three `VerificationTokenRepository` builders. The wire-Pydantic field and the DB roundtrip stay as `Optional[dict]` per the precedent #31471 set for `ObjectPermissionBase`

Behavior change called out: docstrings on the four endpoints previously advertised `permissions={"pii": false}` and `permissions={"allow_pii_controls": true}` to non-admin callers. Disabling PII masking on your own key is exactly the control bypass this PR closes, so `permissions` is now admin-only. Docstring examples now use `{"get_spend_routes": true}`, a key the codebase actually honors. `allow_pii_controls` was removed; a grep of `litellm/` and `enterprise/` shows zero live readers (it appears only in docstrings and the `presidio.py:731` comment)

`ui/litellm-dashboard/src/lib/http/schema.d.ts` regenerated via `npm run gen:api` to keep the dashboard types in sync with the updated FastAPI docstrings

Regression tests in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`:

- `test_budget_limits_window_cannot_exceed_caller_max_budget` (non-admin, oversized window, 400)
- `test_budget_limits_window_within_caller_max_budget_allowed` (non-admin, in-ceiling, 200)
- `test_budget_limits_window_equal_to_ceiling_allowed` (boundary, pins `>` vs `>=`)
- `test_budget_limits_admin_unrestricted` (admin)
- `test_budget_limits_session_token_personal_key_blocked` (CLI session-token guard)
- `test_budget_limits_nan_window_rejected` (NaN finiteness guard)
- `test_permissions_field_rejected_for_non_admin` (generate, 403)
- `test_permissions_empty_default_allowed_for_non_admin` (default `{}` still passes)
- `test_permissions_admin_can_set_any` (admin)
- `test_update_key_non_admin_permissions_rejected` (/key/update)
- `test_regenerate_key_non_admin_permissions_rejected` (/key/regenerate)
- `test_regenerate_key_non_admin_budget_limits_rejected` (/key/regenerate)

Mutation check: each attack test fails on prior commits before each fix was applied; controls pass throughout. Full mapped test file is 314 tests, all green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix in proxy key delegation: closes privilege escalation via ungated `budget_limits` and `permissions` on key create paths.
> 
> **Overview**
> Closes delegation gaps on **`/key/generate`** (and shared **`_common_key_generation_helper`** path) where scalar **`max_budget`** was already capped but **`budget_limits`** windows and **`permissions`** were not.
> 
> Adds **`_check_budget_limits_delegation_ceiling`**, which rejects any per-window **`max_budget`** above the caller’s delegation ceiling for non-admins (with the same carve-outs as the existing scalar check: proxy admin, UI-session team keys, and **`delegation_ceiling is None`**). Adds **`_check_permissions_caller_permission`**, which returns **403** if a non-admin sets a non-empty **`permissions`** dict (empty **`{}`** still allowed).
> 
> Both checks run in **`_common_key_generation_helper`** immediately after the existing **`max_budget`** ceiling logic. Regression tests cover over-ceiling windows, in-ceiling success, admin bypass, non-admin **`permissions`**, and default empty permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f7688363de11c4f2a0a0d9406a689658bfcb84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->