### PR TITLE
fix(build): restore pure-Python uv_build backend to unblock PyPI publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,24 +234,8 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["maturin==1.9.4"]
-build-backend = "maturin"
-
-[tool.maturin]
-manifest-path = "litellm-rust/crates/python-bridge/Cargo.toml"
-module-name = "litellm.rust_bridge._native"
-python-source = "."
-bindings = "pyo3"
-exclude = [
-    "litellm/proxy/enterprise",
-    "litellm/proxy/enterprise/**",
-    "**/__pycache__",
-    "**/__pycache__/**",
-    "**/.pytest_cache",
-    "**/.pytest_cache/**",
-    "**/.ruff_cache",
-    "**/.ruff_cache/**",
-]
+requires = ["uv_build==0.11.8"]
+build-backend = "uv_build"
 
 [tool.uv]
 constraint-dependencies = [
@@ -268,6 +252,18 @@ litellm-enterprise = { workspace = true }
 
 [tool.uv.workspace]
 members = ["enterprise", "litellm-proxy-extras"]
+
+[tool.uv.build-backend]
+module-root = ""
+source-exclude = [
+    "litellm/proxy/enterprise",
+    "**/__pycache__",
+    "**/__pycache__/**",
+    "**/.pytest_cache",
+    "**/.pytest_cache/**",
+    "**/.ruff_cache",
+    "**/.ruff_cache/**",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Relevant issues

PyPI publish failure on the `1.91.0.dev2` release: the litellm wheel was rejected by PyPI with `400 Bad Request - Binary wheel 'litellm-1.91.0.dev2-cp312-cp312-linux_x86_64.whl' has an unsupported platform tag 'linux_x86_64'`.

## Linear ticket

<!-- internal: add "Resolves LIT-XXXX" if there is a ticket -->

## Pre-Submission checklist

- [ ] I have added meaningful tests — N/A, this is a build-system revert; verified by building the wheel (see Proof of Fix).
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

**Problem.** #31267 switched the build backend from `uv_build` to `maturin` to bundle the Rust OCR bridge into the litellm wheel, making litellm a compiled package. When the release builds with `python -m build` on a stock runner (no manylinux container), maturin defaults to `--compatibility off` and emits a `cp312-cp312-linux_x86_64` wheel. PyPI only accepts `manylinux*` Linux wheels, so the upload fails and the publish is blocked.

**Fix.** Revert `[build-system]` to the pure-Python `uv_build` backend and restore `[tool.uv.build-backend]`. The release again produces a universal `litellm-<ver>-py3-none-any.whl` that installs on every OS / arch / Python version.

The Rust bridge remains **optional** — `litellm/rust_bridge/loader.py` already degrades gracefully when the native module is missing (`try/except ImportError`), so runtime behavior is unchanged; the compiled `_native` module is simply not bundled in the wheel. Bundling Rust into the published wheel requires a full multi-platform wheel matrix (manylinux + macOS + Windows × x86_64 + aarch64 × supported Pythons) in the release pipeline, which can be pursued separately if/when we want the native path shipped on PyPI.

## Proof of Fix

Built locally with `uv build --wheel`:

- **Before** (maturin): `litellm-1.91.0.dev2-cp312-cp312-linux_x86_64.whl` → rejected by PyPI (`unsupported platform tag`)
- **After** (this PR): `litellm-1.91.0-py3-none-any.whl` → `Root-Is-Purelib: true`, `Tag: py3-none-any`

The pure-Python `litellm/rust_bridge/` package (`__init__.py`, `loader.py`) is still included in the wheel; no `.so` / `_native` extension is present, confirming the graceful pure-Python path.

## Out of scope (follow-ups)

- The maturin-specific CI hardening from #31348 is now unused for the wheel build and can be removed separately.
- `litellm-rust/` source is still included in the sdist (harmless); can be excluded later if desired.
