### PR TITLE
fix(triton): forward sampling params to /generate instead of dropping them

### DIFF
--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -55,7 +55,14 @@ class TritonConfig(BaseConfig):
         return {"Content-Type": "application/json"}
 
     def get_supported_openai_params(self, model: str) -> List:
-        return ["max_tokens", "max_completion_tokens"]
+        return [
+            "max_tokens",
+            "max_completion_tokens",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+        ]
 
     def map_openai_params(
         self,
@@ -66,6 +73,18 @@ class TritonConfig(BaseConfig):
     ) -> Dict:
         for param, value in non_default_params.items():
             if param == "max_tokens" or param == "max_completion_tokens":
+                # Triton's /generate and /infer endpoints expect `max_tokens`,
+                # so normalize `max_completion_tokens` to it instead of
+                # forwarding an unrecognized key.
+                optional_params["max_tokens"] = value
+            elif param in (
+                "temperature",
+                "top_p",
+                "frequency_penalty",
+                "presence_penalty",
+            ):
+                # These sampling params share the same name across the Triton
+                # TensorRT-LLM and vLLM backends, so forward them as-is.
                 optional_params[param] = value
         return optional_params
 

--- a/tests/test_litellm/llms/triton/test_triton_transformation.py
+++ b/tests/test_litellm/llms/triton/test_triton_transformation.py
@@ -1,0 +1,171 @@
+"""
+Unit tests for Triton request transformation.
+
+Covers the parameter handling for the Triton `/generate` endpoint:
+- Standard sampling params (temperature, top_p, presence_penalty,
+  frequency_penalty) are forwarded instead of being dropped / rejected.
+- `max_completion_tokens` is normalized to Triton's `max_tokens`.
+- Provider-specific passthrough params (e.g. `chat_template_kwargs`, `top_k`)
+  still reach the request body.
+
+Related issue: https://github.com/BerriAI/litellm/issues/31092
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import litellm
+from litellm.llms.triton.completion.transformation import (
+    TritonConfig,
+    TritonGenerateConfig,
+)
+from litellm.utils import get_optional_params
+
+
+def test_get_supported_openai_params_includes_sampling_params():
+    """Triton should advertise support for the common sampling params."""
+    supported = TritonConfig().get_supported_openai_params(model="any-triton-model")
+    for param in [
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "frequency_penalty",
+        "presence_penalty",
+    ]:
+        assert param in supported
+
+
+def test_map_openai_params_forwards_sampling_params():
+    """Sampling params should be mapped 1:1 into optional_params."""
+    non_default_params = {
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "presence_penalty": 1.5,
+        "frequency_penalty": 0.5,
+    }
+    optional_params = TritonConfig().map_openai_params(
+        non_default_params=non_default_params,
+        optional_params={},
+        model="any-triton-model",
+        drop_params=False,
+    )
+    assert optional_params == non_default_params
+
+
+def test_map_openai_params_normalizes_max_completion_tokens():
+    """`max_completion_tokens` should be normalized to Triton's `max_tokens`."""
+    optional_params = TritonConfig().map_openai_params(
+        non_default_params={"max_completion_tokens": 42},
+        optional_params={},
+        model="any-triton-model",
+        drop_params=False,
+    )
+    assert optional_params == {"max_tokens": 42}
+
+
+def test_get_optional_params_does_not_drop_sampling_params():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/31092
+
+    Standard sampling params used to raise `UnsupportedParamsError` (or be
+    silently dropped with `drop_params=True`) because Triton only advertised
+    `max_tokens`. They should now flow through to optional_params.
+    """
+    optional_params = get_optional_params(
+        model="any-triton-model",
+        custom_llm_provider="triton",
+        max_tokens=100,
+        temperature=0.7,
+        top_p=0.8,
+        presence_penalty=1.5,
+        frequency_penalty=0.5,
+    )
+    assert optional_params["temperature"] == 0.7
+    assert optional_params["top_p"] == 0.8
+    assert optional_params["presence_penalty"] == 1.5
+    assert optional_params["frequency_penalty"] == 0.5
+    assert optional_params["max_tokens"] == 100
+
+
+def test_generate_transform_request_includes_sampling_params():
+    """The `/generate` request body should carry the sampling params."""
+    optional_params = {
+        "max_tokens": 100,
+        "temperature": 0.7,
+        "top_p": 0.8,
+        "presence_penalty": 1.5,
+        "frequency_penalty": 0.5,
+    }
+    body = TritonGenerateConfig().transform_request(
+        model="any-triton-model",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={"api_base": "http://localhost:8000/generate"},
+        headers={},
+    )
+    parameters = body["parameters"]
+    assert parameters["max_tokens"] == 100
+    assert parameters["temperature"] == 0.7
+    assert parameters["top_p"] == 0.8
+    assert parameters["presence_penalty"] == 1.5
+    assert parameters["frequency_penalty"] == 0.5
+
+
+def test_generate_transform_request_forwards_chat_template_kwargs():
+    """
+    Provider-specific passthrough params (e.g. `chat_template_kwargs` to control
+    `enable_thinking`, or `top_k`) must reach the Triton request body so the
+    backend can act on them. See issue #31092.
+    """
+    optional_params = {
+        "max_tokens": 100,
+        "top_k": 20,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    body = TritonGenerateConfig().transform_request(
+        model="any-triton-model",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={"api_base": "http://localhost:8000/generate"},
+        headers={},
+    )
+    parameters = body["parameters"]
+    assert parameters["top_k"] == 20
+    assert parameters["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_completion_triton_generate_forwards_sampling_params_end_to_end():
+    """
+    End-to-end check (mocked HTTP): sampling params provided to
+    `litellm.completion` reach the Triton `/generate` request body.
+    """
+    mock_response = MagicMock()
+    mock_response.json = lambda: {"text_output": "hello"}
+    mock_response.status_code = 200
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.HTTPHandler.post",
+        return_value=mock_response,
+    ) as mock_post:
+        litellm.completion(
+            model="triton/llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "who are u?"}],
+            max_tokens=10,
+            temperature=0.3,
+            top_p=0.9,
+            presence_penalty=0.5,
+            frequency_penalty=0.2,
+            api_base="http://localhost:8000/generate",
+        )
+
+        mock_post.assert_called_once()
+        request_data = json.loads(mock_post.call_args.kwargs["data"])
+        parameters = request_data["parameters"]
+        assert parameters["max_tokens"] == 10
+        assert parameters["temperature"] == 0.3
+        assert parameters["top_p"] == 0.9
+        assert parameters["presence_penalty"] == 0.5
+        assert parameters["frequency_penalty"] == 0.2


### PR DESCRIPTION
## Relevant issues

Related to #31092

## Type

🐛 Bug Fix

## Changes

`TritonConfig.get_supported_openai_params()` only advertised `max_tokens` / `max_completion_tokens`. As a result, standard sampling parameters were never forwarded to Triton's `/generate` endpoint:

- With `drop_params=True`, params like `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty` were **silently dropped**.
- Without it, the same request raised `UnsupportedParamsError`.

This happened even though Triton's TensorRT-LLM and vLLM `/generate` backends accept these params **under the same names**.

This PR:

1. Adds `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty` to the supported params and forwards them as-is (1:1 names, identical across the TensorRT-LLM and vLLM backends).
2. Normalizes `max_completion_tokens` to Triton's `max_tokens` instead of forwarding an unrecognized key.

### Note on #31092 (`chat_template_kwargs`)

While investigating #31092, I verified that provider-specific passthrough params such as `chat_template_kwargs` (e.g. `{"enable_thinking": false}`) and `top_k` **already reach** the Triton request body today — they flow through the non-OpenAI passthrough path into `parameters`. The actual gap surfaced by that report was the sampling params above. This PR keeps `chat_template_kwargs`/`top_k` passthrough working and adds regression tests to lock it in. Whether the backend acts on `chat_template_kwargs` depends on the Triton deployment.

## Testing

Added mocked unit tests in `tests/test_litellm/llms/triton/test_triton_transformation.py` (7 tests):

- `get_supported_openai_params` advertises the sampling params.
- `map_openai_params` forwards them 1:1 and normalizes `max_completion_tokens` → `max_tokens`.
- `get_optional_params` no longer drops/rejects them (regression for #31092).
- The `/generate` transform body carries the sampling params.
- The `/generate` transform body still forwards `chat_template_kwargs` and `top_k`.
- End-to-end (mocked HTTP) `litellm.completion` call reaches `/generate` with the sampling params.

```bash
$ pytest tests/test_litellm/llms/triton/test_triton_transformation.py -v
7 passed
```

- [x] I have Added testing in the `tests/test_litellm` directory
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible
