### PR TITLE
refactor(bedrock-mantle): align SigV4 signing service name with canonical "bedrock-mantle"

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -66,13 +66,9 @@ class AwsAuthError(Exception):
     def __init__(self, status_code, message):
         self.status_code = status_code
         self.message = message
-        self.request = httpx.Request(
-            method="POST", url="https://us-west-2.console.aws.amazon.com/bedrock"
-        )
+        self.request = httpx.Request(method="POST", url="https://us-west-2.console.aws.amazon.com/bedrock")
         self.response = httpx.Response(status_code=status_code, request=self.request)
-        super().__init__(
-            self.message
-        )  # Call the base class constructor with the parameters it needs
+        super().__init__(self.message)  # Call the base class constructor with the parameters it needs
 
 
 class BaseAWSLLM:
@@ -159,11 +155,7 @@ class BaseAWSLLM:
         aws_role_name: Optional[str],
         aws_session_name: Optional[str],
     ) -> bool:
-        return (
-            aws_web_identity_token is not None
-            and aws_role_name is not None
-            and aws_session_name is not None
-        )
+        return aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None
 
     @staticmethod
     def _is_auth_with_aws_role(aws_role_name: Optional[str]) -> bool:
@@ -179,11 +171,7 @@ class BaseAWSLLM:
         aws_secret_access_key: Optional[str],
         aws_session_token: Optional[str],
     ) -> bool:
-        return (
-            aws_access_key_id is not None
-            and aws_secret_access_key is not None
-            and aws_session_token is not None
-        )
+        return aws_access_key_id is not None and aws_secret_access_key is not None and aws_session_token is not None
 
     @staticmethod
     def _is_auth_with_access_key_and_secret_key(
@@ -191,11 +179,7 @@ class BaseAWSLLM:
         aws_secret_access_key: Optional[str],
         aws_region_name: Optional[str],
     ) -> bool:
-        return (
-            aws_access_key_id is not None
-            and aws_secret_access_key is not None
-            and aws_region_name is not None
-        )
+        return aws_access_key_id is not None and aws_secret_access_key is not None and aws_region_name is not None
 
     @tracer.wrap()
     def get_credentials(
@@ -271,11 +255,7 @@ class BaseAWSLLM:
             aws_external_id,
         )
 
-        args = {
-            k: v
-            for k, v in locals().items()
-            if k.startswith("aws_") or k == "ssl_verify"
-        }
+        args = {k: v for k, v in locals().items() if k.startswith("aws_") or k == "ssl_verify"}
 
         #########################################################
         # Handle diff boto3 auth flows
@@ -304,16 +284,12 @@ class BaseAWSLLM:
         elif self._is_auth_with_aws_role(aws_role_name):
             # Same role (IRSA/ECS/EC2): ambient creds via _get_or_set_cached_credentials like the
             # default env branch; never pre-read cache (must run _is_already_running_as_role first).
-            if self._is_already_running_as_role(
-                cast(str, aws_role_name), ssl_verify=ssl_verify
-            ):
+            if self._is_already_running_as_role(cast(str, aws_role_name), ssl_verify=ssl_verify):
                 verbose_logger.debug(
                     "Already running as target role %s, using ambient credentials",
                     aws_role_name,
                 )
-                return self._get_or_set_cached_credentials(
-                    args, self._auth_with_env_vars
-                )
+                return self._get_or_set_cached_credentials(args, self._auth_with_env_vars)
             verbose_logger.debug("Using role assumption: calling _auth_with_aws_role")
             # If aws_session_name is not provided, generate a default one
             if aws_session_name is None:
@@ -332,9 +308,7 @@ class BaseAWSLLM:
             return credentials
 
         elif self._is_auth_with_aws_profile(aws_profile_name):
-            credentials, _cache_ttl = self._auth_with_aws_profile(
-                cast(str, aws_profile_name)
-            )
+            credentials, _cache_ttl = self._auth_with_aws_profile(cast(str, aws_profile_name))
             return credentials
         elif self._is_auth_with_aws_session_token_tuple(
             aws_access_key_id,
@@ -475,41 +449,23 @@ class BaseAWSLLM:
 
         model_id = model_id.replace("invoke/", "", 1)
         if provider == "llama" and "llama/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="llama"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="llama")
         elif provider == "deepseek_r1" and "deepseek_r1/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="deepseek_r1"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="deepseek_r1")
         elif provider == "openai" and "openai/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="openai"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="openai")
         elif provider == "qwen2" and "qwen2/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="qwen2"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="qwen2")
         elif provider == "qwen3" and "qwen3/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="qwen3"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="qwen3")
         elif provider == "stability" and "stability/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="stability"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="stability")
         elif provider == "moonshot" and "moonshot/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="moonshot"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="moonshot")
         elif "nova-2/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="nova-2"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="nova-2")
         elif "nova/" in model_id:
-            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(
-                model_id, spec="nova"
-            )
+            model_id = BaseAWSLLM._get_model_id_from_model_with_spec(model_id, spec="nova")
         return model_id
 
     @staticmethod
@@ -559,16 +515,12 @@ class BaseAWSLLM:
             parts = model.split(".")
             # Check if the second part (after potential region) is a known provider
             if len(parts) >= 2:
-                potential_provider = parts[
-                    1
-                ]  # e.g., "twelvelabs" from "us.twelvelabs.marengo-embed-2-7-v1:0"
+                potential_provider = parts[1]  # e.g., "twelvelabs" from "us.twelvelabs.marengo-embed-2-7-v1:0"
                 if potential_provider in get_args(BEDROCK_EMBEDDING_PROVIDERS_LITERAL):
                     return cast(BEDROCK_EMBEDDING_PROVIDERS_LITERAL, potential_provider)
 
             # Check if the first part is a known provider (standard format)
-            potential_provider = parts[
-                0
-            ]  # e.g., "cohere" from "cohere.embed-english-v3:0"
+            potential_provider = parts[0]  # e.g., "cohere" from "cohere.embed-english-v3:0"
             if potential_provider in get_args(BEDROCK_EMBEDDING_PROVIDERS_LITERAL):
                 return cast(BEDROCK_EMBEDDING_PROVIDERS_LITERAL, potential_provider)
 
@@ -647,9 +599,7 @@ class BaseAWSLLM:
         """
         if aws_region_name is None:
             return
-        if not isinstance(aws_region_name, str) or not _VALID_AWS_REGION_PATTERN.match(
-            aws_region_name
-        ):
+        if not isinstance(aws_region_name, str) or not _VALID_AWS_REGION_PATTERN.match(aws_region_name):
             raise ValueError(
                 f"Invalid AWS region format: {aws_region_name!r}. "
                 "Region names must contain only lowercase letters, digits, and hyphens."
@@ -705,15 +655,11 @@ class BaseAWSLLM:
             # check env #
             litellm_aws_region_name = get_secret("AWS_REGION_NAME", None)
 
-            if litellm_aws_region_name is not None and isinstance(
-                litellm_aws_region_name, str
-            ):
+            if litellm_aws_region_name is not None and isinstance(litellm_aws_region_name, str):
                 aws_region_name = litellm_aws_region_name
 
             standard_aws_region_name = get_secret("AWS_REGION", None)
-            if standard_aws_region_name is not None and isinstance(
-                standard_aws_region_name, str
-            ):
+            if standard_aws_region_name is not None and isinstance(standard_aws_region_name, str):
                 aws_region_name = standard_aws_region_name
 
             if aws_region_name is None:
@@ -796,9 +742,7 @@ class BaseAWSLLM:
             import boto3
 
             with tracer.trace("boto3.client(sts).get_caller_identity"):
-                sts_client = boto3.client(
-                    "sts", verify=self._get_ssl_verify(ssl_verify)
-                )
+                sts_client = boto3.client("sts", verify=self._get_ssl_verify(ssl_verify))
                 identity = sts_client.get_caller_identity()
                 caller_arn = identity.get("Arn", "")
 
@@ -817,9 +761,7 @@ class BaseAWSLLM:
                     return True
 
         except Exception as e:
-            verbose_logger.debug(
-                "Could not determine current role identity: %s", str(e)
-            )
+            verbose_logger.debug("Could not determine current role identity: %s", str(e))
 
         return False
 
@@ -867,10 +809,7 @@ class BaseAWSLLM:
         # references are expanded at load time, so such a reference reaching here is
         # caller-supplied input; reject it rather than expanding a process-environment
         # value for use as the token.
-        if (
-            aws_web_identity_token.startswith("os.environ/")
-            or aws_web_identity_token in os.environ
-        ):
+        if aws_web_identity_token.startswith("os.environ/") or aws_web_identity_token in os.environ:
             raise AwsAuthError(
                 message="Invalid web identity token reference.",
                 status_code=400,
@@ -951,15 +890,9 @@ class BaseAWSLLM:
             assume_role_params["ExternalId"] = aws_external_id
 
         try:
-            sts_response = sts_client.assume_role_with_web_identity(
-                **assume_role_params
-            )
+            sts_response = sts_client.assume_role_with_web_identity(**assume_role_params)
         except sts_client.exceptions.InvalidIdentityTokenException as e:
-            audience = (
-                self._unverified_web_identity_audience(oidc_token)
-                if isinstance(oidc_token, str)
-                else None
-            )
+            audience = self._unverified_web_identity_audience(oidc_token) if isinstance(oidc_token, str) else None
             detail = f" Token {audience}" if audience else ""
             raise AwsAuthError(
                 status_code=401,
@@ -1013,9 +946,7 @@ class BaseAWSLLM:
             sts_client = boto3.client("sts", **irsa_sts_kwargs)
 
         # Manually assume the IRSA role with the session name
-        verbose_logger.debug(
-            f"Manually assuming IRSA role {irsa_role_arn} with session {aws_session_name}"
-        )
+        verbose_logger.debug(f"Manually assuming IRSA role {irsa_role_arn} with session {aws_session_name}")
         irsa_response = sts_client.assume_role_with_web_identity(
             RoleArn=irsa_role_arn,
             RoleSessionName=aws_session_name,
@@ -1045,9 +976,7 @@ class BaseAWSLLM:
             verbose_logger.debug(f"Failed to get caller identity: {e}")
 
         # Now assume the target role
-        verbose_logger.debug(
-            f"Attempting to assume target role: {aws_role_name} with session: {aws_session_name}"
-        )
+        verbose_logger.debug(f"Attempting to assume target role: {aws_role_name} with session: {aws_session_name}")
         assume_role_params = {
             "RoleArn": aws_role_name,
             "RoleSessionName": aws_session_name,
@@ -1082,16 +1011,12 @@ class BaseAWSLLM:
         # Get current caller identity for debugging
         try:
             caller_identity = sts_client.get_caller_identity()
-            verbose_logger.debug(
-                f"Current IRSA identity: {caller_identity.get('Arn', 'unknown')}"
-            )
+            verbose_logger.debug(f"Current IRSA identity: {caller_identity.get('Arn', 'unknown')}")
         except Exception as e:
             verbose_logger.debug(f"Failed to get caller identity: {e}")
 
         # Assume the role
-        verbose_logger.debug(
-            f"Attempting to assume role: {aws_role_name} with session: {aws_session_name}"
-        )
+        verbose_logger.debug(f"Attempting to assume role: {aws_role_name} with session: {aws_session_name}")
         assume_role_params = {
             "RoleArn": aws_role_name,
             "RoleSessionName": aws_session_name,
@@ -1103,9 +1028,7 @@ class BaseAWSLLM:
 
         return sts_client.assume_role(**assume_role_params)
 
-    def _extract_credentials_and_ttl(
-        self, sts_response: dict
-    ) -> Tuple[Credentials, Optional[int]]:
+    def _extract_credentials_and_ttl(self, sts_response: dict) -> Tuple[Credentials, Optional[int]]:
         """Extract credentials and TTL from STS response."""
         from botocore.credentials import Credentials
 
@@ -1117,9 +1040,7 @@ class BaseAWSLLM:
         )
 
         expiration_time = sts_credentials["Expiration"]
-        ttl = int(
-            (expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds()
-        )
+        ttl = int((expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds())
 
         return credentials, ttl
 
@@ -1148,17 +1069,10 @@ class BaseAWSLLM:
 
         # If we have IRSA environment variables and no explicit credentials,
         # we need to use the web identity token flow
-        if (
-            web_identity_token_file
-            and irsa_role_arn
-            and aws_access_key_id is None
-            and aws_secret_access_key is None
-        ):
+        if web_identity_token_file and irsa_role_arn and aws_access_key_id is None and aws_secret_access_key is None:
             # For cross-account role assumption with specific session names,
             # we need to manually assume the IRSA role first with the correct session name
-            verbose_logger.debug(
-                f"IRSA detected: using web identity token from {web_identity_token_file}"
-            )
+            verbose_logger.debug(f"IRSA detected: using web identity token from {web_identity_token_file}")
 
             try:
                 # Check if we need to do cross-account role assumption
@@ -1185,9 +1099,7 @@ class BaseAWSLLM:
 
             except Exception as e:
                 verbose_logger.debug(f"Failed to assume role via IRSA: {e}")
-                if "AccessDenied" in str(
-                    e
-                ) and "is not authorized to perform: sts:AssumeRole" in str(e):
+                if "AccessDenied" in str(e) and "is not authorized to perform: sts:AssumeRole" in str(e):
                     # Provide a more helpful error message for trust policy issues
                     verbose_logger.error(
                         f"Access denied when trying to assume role {aws_role_name}. "
@@ -1235,9 +1147,7 @@ class BaseAWSLLM:
                 # partition, and role name).  This avoids silently using the
                 # wrong identity when there is a genuine trust-policy or
                 # permission misconfiguration.
-                if self._is_already_running_as_role(
-                    aws_role_name, ssl_verify=ssl_verify
-                ):
+                if self._is_already_running_as_role(aws_role_name, ssl_verify=ssl_verify):
                     verbose_logger.warning(
                         "AssumeRole failed for %s (%s). "
                         "Caller is already running as this role; "
@@ -1248,8 +1158,7 @@ class BaseAWSLLM:
                     return self._auth_with_env_vars()
                 # Genuine permission error — re-raise
                 verbose_logger.error(
-                    "AssumeRole AccessDenied for %s and caller is NOT "
-                    "the same role. Re-raising. Error: %s",
+                    "AssumeRole AccessDenied for %s and caller is NOT the same role. Re-raising. Error: %s",
                     aws_role_name,
                     error_str,
                 )
@@ -1270,9 +1179,7 @@ class BaseAWSLLM:
         return credentials, sts_ttl
 
     @tracer.wrap()
-    def _auth_with_aws_profile(
-        self, aws_profile_name: str
-    ) -> Tuple[Credentials, Optional[int]]:
+    def _auth_with_aws_profile(self, aws_profile_name: str) -> Tuple[Credentials, Optional[int]]:
         """
         Authenticate with AWS profile
         """
@@ -1360,13 +1267,9 @@ class BaseAWSLLM:
         env_aws_bedrock_runtime_endpoint = get_secret("AWS_BEDROCK_RUNTIME_ENDPOINT")
         if api_base is not None:
             endpoint_url = api_base
-        elif aws_bedrock_runtime_endpoint is not None and isinstance(
-            aws_bedrock_runtime_endpoint, str
-        ):
+        elif aws_bedrock_runtime_endpoint is not None and isinstance(aws_bedrock_runtime_endpoint, str):
             endpoint_url = aws_bedrock_runtime_endpoint
-        elif env_aws_bedrock_runtime_endpoint and isinstance(
-            env_aws_bedrock_runtime_endpoint, str
-        ):
+        elif env_aws_bedrock_runtime_endpoint and isinstance(env_aws_bedrock_runtime_endpoint, str):
             endpoint_url = env_aws_bedrock_runtime_endpoint
         else:
             endpoint_url = self._select_default_endpoint_url(
@@ -1375,13 +1278,9 @@ class BaseAWSLLM:
             )
 
         # Determine proxy_endpoint_url
-        if aws_bedrock_runtime_endpoint is not None and isinstance(
-            aws_bedrock_runtime_endpoint, str
-        ):
+        if aws_bedrock_runtime_endpoint is not None and isinstance(aws_bedrock_runtime_endpoint, str):
             proxy_endpoint_url = aws_bedrock_runtime_endpoint
-        elif env_aws_bedrock_runtime_endpoint and isinstance(
-            env_aws_bedrock_runtime_endpoint, str
-        ):
+        elif env_aws_bedrock_runtime_endpoint and isinstance(env_aws_bedrock_runtime_endpoint, str):
             proxy_endpoint_url = env_aws_bedrock_runtime_endpoint
         else:
             proxy_endpoint_url = endpoint_url
@@ -1477,21 +1376,15 @@ class BaseAWSLLM:
             try:
                 from botocore.awsrequest import AWSRequest
             except ImportError:
-                raise ImportError(
-                    "Missing boto3 to call bedrock. Run 'pip install boto3'."
-                )
+                raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
             headers["Authorization"] = f"Bearer {aws_bearer_token}"
-            request = AWSRequest(
-                method="POST", url=endpoint_url, data=data, headers=headers
-            )
+            request = AWSRequest(method="POST", url=endpoint_url, data=data, headers=headers)
         else:
             try:
                 from botocore.auth import SigV4Auth
                 from botocore.awsrequest import AWSRequest
             except ImportError:
-                raise ImportError(
-                    "Missing boto3 to call bedrock. Run 'pip install boto3'."
-                )
+                raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
 
             # Filter headers for AWS signature calculation
             # AWS SigV4 only includes specific headers in signature calculation
@@ -1541,11 +1434,7 @@ class BaseAWSLLM:
             if header_value is None:
                 continue
             header_lower = header_name.lower()
-            if (
-                header_lower in aws_headers
-                or header_lower.startswith("x-amz-")
-                or header_lower.startswith("x-amzn-")
-            ):
+            if header_lower in aws_headers or header_lower.startswith("x-amz-") or header_lower.startswith("x-amzn-"):
                 aws_signature_headers[header_name] = header_value
 
         return aws_signature_headers
@@ -1606,9 +1495,7 @@ class BaseAWSLLM:
         aws_web_identity_token = optional_params.get("aws_web_identity_token", None)
         aws_sts_endpoint = optional_params.get("aws_sts_endpoint", None)
         aws_external_id = optional_params.get("aws_external_id", None)
-        aws_region_name = self._get_aws_region_name(
-            optional_params=optional_params, model=model
-        )
+        aws_region_name = self._get_aws_region_name(optional_params=optional_params, model=model)
 
         credentials: Credentials = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
@@ -1643,9 +1530,7 @@ class BaseAWSLLM:
         for header_name, header_value in headers.items():
             if header_value is not None:
                 request_headers_dict[header_name] = header_value
-        if (
-            headers is not None and "Authorization" in headers
-        ):  # prevent sigv4 from overwriting the auth header
+        if headers is not None and "Authorization" in headers:  # prevent sigv4 from overwriting the auth header
             request_headers_dict["Authorization"] = headers["Authorization"]
 
         return request_headers_dict, request.body

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1554,6 +1554,7 @@ class BaseAWSLLM:
         self,
         service_name: Literal[
             "bedrock",
+            "bedrock-mantle",
             "sagemaker",
             "bedrock-agentcore",
             "s3vectors",
@@ -1572,7 +1573,7 @@ class BaseAWSLLM:
         Sign a request for Bedrock or Sagemaker
 
         Returns:
-            Tuple[dict, Optional[str]]: A tuple containing the headers and the json str body of the request
+            Tuple[dict, Optional[bytes]]: A tuple containing the headers and the json str body of the request
         """
         if api_key is not None:
             aws_bearer_token: Optional[str] = api_key

--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -68,9 +68,7 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
         region = self._get_aws_region_name(optional_params=optional_params, model=model)
         return build_mantle_messages_url(
             api_base=api_base,
-            aws_bedrock_runtime_endpoint=optional_params.get(
-                "aws_bedrock_runtime_endpoint"
-            ),
+            aws_bedrock_runtime_endpoint=optional_params.get("aws_bedrock_runtime_endpoint"),
             region=region,
         )
 

--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -33,6 +33,29 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
     Usage: model="bedrock/mantle/anthropic.claude-mythos-preview"
     """
 
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> tuple[dict, Optional[bytes]]:
+        return self._sign_request(
+            service_name="bedrock-mantle",
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            stream=stream,
+            fake_stream=fake_stream,
+        )
+
     def get_complete_url(
         self,
         api_base: Optional[str],

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -65,9 +65,7 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         region = self._get_aws_region_name(optional_params=optional_params, model=model)
         return build_mantle_messages_url(
             api_base=api_base,
-            aws_bedrock_runtime_endpoint=optional_params.get(
-                "aws_bedrock_runtime_endpoint"
-            ),
+            aws_bedrock_runtime_endpoint=optional_params.get("aws_bedrock_runtime_endpoint"),
             region=region,
         )
 

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -30,6 +30,29 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
     model ID in the request body (unlike Bedrock Invoke which puts it in the URL).
     """
 
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> tuple[dict, Optional[bytes]]:
+        return self._sign_request(
+            service_name="bedrock-mantle",
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            stream=stream,
+            fake_stream=fake_stream,
+        )
+
     def get_complete_url(
         self,
         api_base: Optional[str],

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -97,15 +97,11 @@ class BedrockMantleChatConfig(BedrockMantleAuthMixin, OpenAILikeChatConfig):
     def get_supported_openai_params(self, model: str) -> list:
         base_params = super().get_supported_openai_params(model)
         try:
-            if litellm.supports_reasoning(
-                model=model, custom_llm_provider=self.custom_llm_provider
-            ):
+            if litellm.supports_reasoning(model=model, custom_llm_provider=self.custom_llm_provider):
                 if "reasoning_effort" not in base_params:
                     base_params.append("reasoning_effort")
         except Exception as e:
-            verbose_logger.debug(
-                f"BedrockMantleChatConfig: error checking reasoning support: {e}"
-            )
+            verbose_logger.debug(f"BedrockMantleChatConfig: error checking reasoning support: {e}")
         return base_params
 
     def get_model_response_iterator(

--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -6,7 +6,7 @@ API docs: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.ht
 Base URL: https://bedrock-mantle.{region}.api.aws/v1
 Auth: Bearer token (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the
       standard AWS_BEARER_TOKEN_BEDROCK) when present; otherwise AWS SigV4
-      (service "bedrock") over the standard credential chain. See
+      (service "bedrock-mantle") over the standard credential chain. See
       BedrockMantleAuthMixin in common_utils.
 """
 

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -28,9 +28,7 @@ from litellm.secret_managers.main import get_secret_str
 BEDROCK_MANTLE_DEFAULT_REGION = "us-east-1"
 
 # Standard Mantle host: https://bedrock-mantle.<region>.api.aws (group 1 = region).
-MANTLE_HOST_RE = re.compile(
-    r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE
-)
+MANTLE_HOST_RE = re.compile(r"^https?://bedrock-mantle\.([^/.]+)\.api\.aws", re.IGNORECASE)
 
 
 class BedrockMantleAuthMixin:
@@ -38,11 +36,7 @@ class BedrockMantleAuthMixin:
 
     @staticmethod
     def _resolve_bearer_token(api_key: str | None) -> str | None:
-        return (
-            api_key
-            or get_secret_str("BEDROCK_MANTLE_API_KEY")
-            or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
-        )
+        return api_key or get_secret_str("BEDROCK_MANTLE_API_KEY") or get_secret_str("AWS_BEARER_TOKEN_BEDROCK")
 
     @staticmethod
     def _resolve_region(params: dict) -> str:

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -3,7 +3,7 @@
 Mantle authenticates with a Bearer token when one is available
 (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the standard
 AWS_BEARER_TOKEN_BEDROCK); otherwise it falls back to AWS SigV4 (service
-"bedrock") over the standard credential chain (IAM role / access key / profile /
+"bedrock-mantle") over the standard credential chain (IAM role / access key / profile /
 web identity). The Chat Completions and Responses backends share this behaviour
 through BedrockMantleAuthMixin so the two paths can never drift apart.
 
@@ -90,7 +90,7 @@ class BedrockMantleAuthMixin:
             headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
         try:
             return self._aws_signer._sign_request(
-                service_name="bedrock",
+                service_name="bedrock-mantle",
                 headers=headers,
                 optional_params=optional_params,
                 request_data=request_data,

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -40,9 +40,7 @@ _BASE_SUFFIXES_TO_STRIP = (
 )
 
 # Per Bedrock Mantle Responses API validation errors.
-_BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES = frozenset(
-    {"function", "mcp", "custom", "namespace", "tool_search"}
-)
+_BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES = frozenset({"function", "mcp", "custom", "namespace", "tool_search"})
 
 
 class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPIConfig):
@@ -65,11 +63,7 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
         litellm_params: dict,
     ) -> str:
         region = self._resolve_region({**litellm_params, "api_base": api_base})
-        base = (
-            api_base
-            or get_secret_str("BEDROCK_MANTLE_API_BASE")
-            or f"https://bedrock-mantle.{region}.api.aws"
-        )
+        base = api_base or get_secret_str("BEDROCK_MANTLE_API_BASE") or f"https://bedrock-mantle.{region}.api.aws"
         base = base.rstrip("/")
         for suffix in _BASE_SUFFIXES_TO_STRIP:
             if base.endswith(suffix):
@@ -83,9 +77,7 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
         path = "/openai/v1/responses" if self.use_openai_path else "/v1/responses"
         return f"{base}{path}"
 
-    def validate_environment(
-        self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]
-    ) -> dict:
+    def validate_environment(self, headers: dict, model: str, litellm_params: Optional[GenericLiteLLMParams]) -> dict:
         litellm_params = litellm_params or GenericLiteLLMParams()
         bearer = self._resolve_bearer_token(litellm_params.api_key)
         if bearer:
@@ -117,8 +109,7 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
 
         if dropped_types:
             verbose_logger.warning(
-                "Bedrock Mantle Responses API: dropping unsupported tool type(s) "
-                "%s (supported: %s).",
+                "Bedrock Mantle Responses API: dropping unsupported tool type(s) %s (supported: %s).",
                 sorted(set(dropped_types)),
                 sorted(_BEDROCK_MANTLE_SUPPORTED_RESPONSE_TOOL_TYPES),
             )

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -10,7 +10,7 @@ only the endpoint URL and authentication.
 
 Auth: Bearer token (BEDROCK_MANTLE_API_KEY or the standard
 AWS_BEARER_TOKEN_BEDROCK, or litellm_params.api_key) when present; otherwise
-AWS SigV4 (service name "bedrock") using the standard credential chain (IAM
+AWS SigV4 (service name "bedrock-mantle") using the standard credential chain (IAM
 role / access key / profile / web identity), signed via the shared
 BaseAWSLLM._sign_request after the request body is finalized.
 """

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -46,35 +46,18 @@ def _capture_request(url: str, headers: dict, data) -> dict:
 
 
 def test_get_bedrock_route_mantle():
-    assert (
-        BedrockModelInfo.get_bedrock_route("mantle/anthropic.claude-mythos-preview")
-        == "mantle"
-    )
+    assert BedrockModelInfo.get_bedrock_route("mantle/anthropic.claude-mythos-preview") == "mantle"
 
 
 def test_get_bedrock_route_mantle_does_not_match_other_routes():
-    assert (
-        BedrockModelInfo.get_bedrock_route("anthropic.claude-3-sonnet-20240229-v1:0")
-        != "mantle"
-    )
-    assert (
-        BedrockModelInfo.get_bedrock_route("converse/anthropic.claude-3-sonnet")
-        != "mantle"
-    )
+    assert BedrockModelInfo.get_bedrock_route("anthropic.claude-3-sonnet-20240229-v1:0") != "mantle"
+    assert BedrockModelInfo.get_bedrock_route("converse/anthropic.claude-3-sonnet") != "mantle"
 
 
 def test_explicit_mantle_route_flag():
-    assert (
-        BedrockModelInfo._explicit_mantle_route(
-            "mantle/anthropic.claude-mythos-preview"
-        )
-        is True
-    )
+    assert BedrockModelInfo._explicit_mantle_route("mantle/anthropic.claude-mythos-preview") is True
     assert BedrockModelInfo._explicit_mantle_route("anthropic.claude-3-sonnet") is False
-    assert (
-        BedrockModelInfo._explicit_mantle_route("converse/anthropic.claude-3-sonnet")
-        is False
-    )
+    assert BedrockModelInfo._explicit_mantle_route("converse/anthropic.claude-3-sonnet") is False
 
 
 def test_mantle_url_construction():
@@ -107,9 +90,7 @@ def test_get_bedrock_chat_config_returns_mantle_config():
 
 
 def test_get_bedrock_provider_config_for_messages_api_mantle():
-    config = BedrockModelInfo.get_bedrock_provider_config_for_messages_api(
-        "mantle/anthropic.claude-mythos-preview"
-    )
+    config = BedrockModelInfo.get_bedrock_provider_config_for_messages_api("mantle/anthropic.claude-mythos-preview")
     assert isinstance(config, AmazonMantleMessagesConfig)
 
 

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -347,3 +347,88 @@ async def test_mantle_anthropic_messages_routes_to_vpc_api_base():
     assert len(urls) == 1
     assert urls[0] == f"{_VPC_ENDPOINT}/anthropic/v1/messages"
     assert "api.aws" not in urls[0]
+
+
+def test_mantle_chat_config_signs_with_bedrock_mantle_service():
+    """The bedrock/mantle/ chat route must SigV4-sign with service 'bedrock-mantle'."""
+    config = AmazonMantleConfig()
+    signed_service = None
+
+    def capture_sign(self, *, service_name, **kwargs):
+        nonlocal signed_service
+        signed_service = service_name
+        return {"Authorization": "AWS4-HMAC-SHA256 ..."}, b"{}"
+
+    with patch(
+        "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM._sign_request",
+        capture_sign,
+    ):
+        config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "fake",
+                "aws_secret_access_key": "fake",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+    assert signed_service == "bedrock-mantle"
+
+
+def test_mantle_messages_config_signs_with_bedrock_mantle_service():
+    """The bedrock/mantle/ messages route must SigV4-sign with service 'bedrock-mantle'."""
+    config = AmazonMantleMessagesConfig()
+    signed_service = None
+
+    def capture_sign(self, *, service_name, **kwargs):
+        nonlocal signed_service
+        signed_service = service_name
+        return {"Authorization": "AWS4-HMAC-SHA256 ..."}, b"{}"
+
+    with patch(
+        "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM._sign_request",
+        capture_sign,
+    ):
+        config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "fake",
+                "aws_secret_access_key": "fake",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+    assert signed_service == "bedrock-mantle"
+
+
+def test_mantle_configs_sign_real_sigv4_scope_is_bedrock_mantle(monkeypatch):
+    """Both bedrock/mantle/ configs must produce a *real* SigV4 signature whose
+    credential scope names service 'bedrock-mantle' (not 'bedrock').
+
+    Unlike the two tests above this does NOT mock _sign_request: it drives the
+    real botocore SigV4Auth with fake static creds (offline, no network), so a
+    regression in the signed service name would change the credential scope and
+    fail here. Cred setup mirrors test_no_bearer_signs_with_sigv4 in
+    tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py.
+    """
+    # No Bearer token -> _sign_request must take the SigV4 path, not Bearer auth.
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+    for config in (AmazonMantleConfig(), AmazonMantleMessagesConfig()):
+        headers, _ = config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-1/bedrock-mantle/aws4_request" in headers["Authorization"]

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -923,7 +923,7 @@ class TestBedrockMantleResponsesSigV4:
         )
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "X-Amz-Date" in headers
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert signed_body == b'{"input": "hi"}'
@@ -962,7 +962,7 @@ class TestBedrockMantleResponsesSigV4:
         assert call["aws_role_name"] == "arn:aws:iam::000000000000:role/test-role"
         assert call["aws_session_name"] == "litellm-test"
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_signed_body_matches_final_data_after_normalize(self, monkeypatch):
         """Core regression: the signed bytes must equal the bytes actually sent.
@@ -1012,7 +1012,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base="https://bedrock-mantle.eu-west-1.api.aws/openai/v1/responses",
             api_key=None,
         )
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_url_region_and_sigv4_region_agree_from_litellm_params(self, monkeypatch):
         """Adversarial-review regression: a caller-supplied aws_region_name (no region
@@ -1046,7 +1046,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/ap-southeast-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/ap-southeast-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_injected_default_region_base_does_not_override_aws_region_name(
         self, monkeypatch
@@ -1084,7 +1084,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "us-east-1" not in headers["Authorization"]
 
     def test_custom_proxy_host_is_preserved(self, monkeypatch):

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -49,10 +49,7 @@ class TestBedrockMantleResponsesURL:
             api_base="https://bedrock-mantle.us-east-2.api.aws/v1/",
             litellm_params={},
         )
-        assert (
-            url_trailing
-            == "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
-        )
+        assert url_trailing == "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
 
     def test_url_does_not_double_openai_v1(self, monkeypatch):
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
@@ -112,9 +109,7 @@ class TestBedrockMantleResponsesURL:
         with pytest.raises(ValueError):
             cfg.get_complete_url(
                 api_base=None,
-                litellm_params={
-                    "aws_region_name": "us-east-1.api.aws.attacker.example/"
-                },
+                litellm_params={"aws_region_name": "us-east-1.api.aws.attacker.example/"},
             )
 
     def test_url_region_default_us_east_1(self, monkeypatch):
@@ -174,9 +169,7 @@ class TestBedrockMantleResponsesURL:
 
 
 class TestBedrockMantleGetLlmProviderRegion:
-    def test_get_llm_provider_uses_supplemental_litellm_params(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_supplemental_litellm_params(self, monkeypatch, local_cost_map):
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         monkeypatch.delenv("AWS_REGION", raising=False)
@@ -193,9 +186,7 @@ class TestBedrockMantleGetLlmProviderRegion:
         # the resolved chat base) is on the /openai/v1 base per the AWS card.
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
-    def test_get_llm_provider_uses_aws_region_from_litellm_params(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_aws_region_from_litellm_params(self, monkeypatch, local_cost_map):
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         monkeypatch.delenv("AWS_REGION", raising=False)
@@ -229,18 +220,14 @@ class TestBedrockMantleResponsesAuth:
         monkeypatch.setenv("BEDROCK_MANTLE_API_KEY", "env-key")
         monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
         cfg = BedrockMantleResponsesAPIConfig()
-        headers = cfg.validate_environment(
-            headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams()
-        )
+        headers = cfg.validate_environment(headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams())
         assert headers["Authorization"] == "Bearer env-key"
 
     def test_bedrock_bearer_token_fallback(self, monkeypatch):
         monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
         monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "bearer-key")
         cfg = BedrockMantleResponsesAPIConfig()
-        headers = cfg.validate_environment(
-            headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams()
-        )
+        headers = cfg.validate_environment(headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams())
         assert headers["Authorization"] == "Bearer bearer-key"
 
     def test_missing_bearer_does_not_raise_in_validate_environment(self, monkeypatch):
@@ -248,9 +235,7 @@ class TestBedrockMantleResponsesAuth:
         monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
         monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
         cfg = BedrockMantleResponsesAPIConfig()
-        headers = cfg.validate_environment(
-            headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams()
-        )
+        headers = cfg.validate_environment(headers={}, model="openai.gpt-5.5", litellm_params=GenericLiteLLMParams())
         assert "Authorization" not in headers
 
     def test_project_id_sets_openai_project_header(self):
@@ -258,9 +243,7 @@ class TestBedrockMantleResponsesAuth:
         headers = cfg.validate_environment(
             headers={},
             model="openai.gpt-5.5",
-            litellm_params=GenericLiteLLMParams(
-                api_key="fake-key", aws_bedrock_project_id="proj_abc123def456"
-            ),
+            litellm_params=GenericLiteLLMParams(api_key="fake-key", aws_bedrock_project_id="proj_abc123def456"),
         )
         assert headers["OpenAI-Project"] == "proj_abc123def456"
 
@@ -361,9 +344,7 @@ class TestBedrockMantleResponsesTools:
         from unittest.mock import patch
 
         cfg = BedrockMantleResponsesAPIConfig()
-        with patch(
-            "litellm.llms.bedrock_mantle.responses.transformation.verbose_logger.warning"
-        ) as mock_warning:
+        with patch("litellm.llms.bedrock_mantle.responses.transformation.verbose_logger.warning") as mock_warning:
             cfg.map_openai_params(
                 response_api_optional_params={"tools": [{"type": "web_search"}]},
                 model="openai.gpt-5.5",
@@ -468,9 +449,7 @@ class TestBedrockMantleResponsesRegistry:
         )
         assert cfg is None
 
-    def test_price_map_flag_routes_non_gpt_name_to_openai_path(
-        self, restore_model_cost
-    ):
+    def test_price_map_flag_routes_non_gpt_name_to_openai_path(self, restore_model_cost):
         # Data-driven onboarding: a frontier model whose name does NOT match the
         # openai.gpt- convention can still be routed to /openai/v1/responses by
         # declaring use_openai_responses_path in its price-map entry, with no code
@@ -496,18 +475,8 @@ class TestBedrockMantleResponsesRegistry:
     def test_gpt_5_5_price_map_declares_openai_responses_path(self, local_cost_map):
         # The gpt-5.x entries must carry the data-driven flag so frontier routing
         # does not rely on the name-string fallback alone.
-        assert (
-            litellm.model_cost["bedrock_mantle/openai.gpt-5.5"].get(
-                "use_openai_responses_path"
-            )
-            is True
-        )
-        assert (
-            litellm.model_cost["bedrock_mantle/openai.gpt-5.4"].get(
-                "use_openai_responses_path"
-            )
-            is True
-        )
+        assert litellm.model_cost["bedrock_mantle/openai.gpt-5.5"].get("use_openai_responses_path") is True
+        assert litellm.model_cost["bedrock_mantle/openai.gpt-5.4"].get("use_openai_responses_path") is True
 
     @pytest.mark.parametrize(
         "model",
@@ -542,9 +511,7 @@ class TestBedrockMantleResponsesRegistry:
         )
         assert cfg is None
 
-    def test_declared_responses_non_openai_routes_to_standard_path(
-        self, restore_model_cost
-    ):
+    def test_declared_responses_non_openai_routes_to_standard_path(self, restore_model_cost):
         # New feature: a non-OpenAI model declared mode=responses (e.g. via a
         # user's proxy model_info block) must route to the STANDARD /v1/responses
         # path, not the frontier /openai/v1/responses path. Fails before the
@@ -652,11 +619,7 @@ class TestMantleBaseSegment:
             ),
             (
                 "google.gemma-4-31b",
-                {
-                    "bedrock_mantle/google.gemma-4-31b": {
-                        "use_openai_responses_path": True
-                    }
-                },
+                {"bedrock_mantle/google.gemma-4-31b": {"use_openai_responses_path": True}},
                 "openai/v1",
             ),
             (
@@ -695,11 +658,7 @@ class TestMantleSupportsResponses:
             # chat-only supported_endpoints -> not supported (the discriminator)
             (
                 "openai.gpt-oss-safeguard-120b",
-                {
-                    "bedrock_mantle/openai.gpt-oss-safeguard-120b": {
-                        "supported_endpoints": ["/v1/chat/completions"]
-                    }
-                },
+                {"bedrock_mantle/openai.gpt-oss-safeguard-120b": {"supported_endpoints": ["/v1/chat/completions"]}},
                 False,
             ),
             # mode=responses (no supported_endpoints) -> supported
@@ -738,9 +697,7 @@ class TestBedrockMantlePerModelResponsesURL:
             model=model,
         )
         assert isinstance(cfg, BedrockMantleResponsesAPIConfig)
-        return cfg.get_complete_url(
-            api_base=None, litellm_params={"aws_region_name": region}
-        )
+        return cfg.get_complete_url(api_base=None, litellm_params={"aws_region_name": region})
 
     def test_gpt_oss_uses_standard_responses_path(self, local_cost_map):
         url = self._url_for("openai.gpt-oss-120b")
@@ -839,9 +796,7 @@ class TestBedrockMantleResponsesSigV4:
         monkeypatch.delenv("BEDROCK_MANTLE_API_KEY", raising=False)
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("get_credentials must not run for bearer auth")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("get_credentials must not run for bearer auth"))
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 
         headers, signed_body = cfg.sign_request(
@@ -863,9 +818,7 @@ class TestBedrockMantleResponsesSigV4:
         monkeypatch.setenv("BEDROCK_MANTLE_API_KEY", "env-bearer")
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("get_credentials must not run for bearer auth")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("get_credentials must not run for bearer auth"))
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 
         headers, _ = cfg.sign_request(
@@ -887,9 +840,7 @@ class TestBedrockMantleResponsesSigV4:
         monkeypatch.setenv("BEDROCK_MANTLE_API_KEY", "env-bearer")
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("get_credentials must not run for bearer auth")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("get_credentials must not run for bearer auth"))
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 
         headers, _ = cfg.sign_request(
@@ -1035,9 +986,7 @@ class TestBedrockMantleResponsesSigV4:
         }
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=BaseAWSLLM())
         url = cfg.get_complete_url(api_base=None, litellm_params=params)
-        assert (
-            url == "https://bedrock-mantle.ap-southeast-2.api.aws/openai/v1/responses"
-        )
+        assert url == "https://bedrock-mantle.ap-southeast-2.api.aws/openai/v1/responses"
 
         headers, _ = cfg.sign_request(
             headers={},
@@ -1048,9 +997,7 @@ class TestBedrockMantleResponsesSigV4:
         )
         assert "/ap-southeast-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
-    def test_injected_default_region_base_does_not_override_aws_region_name(
-        self, monkeypatch
-    ):
+    def test_injected_default_region_base_does_not_override_aws_region_name(self, monkeypatch):
         """2nd-round adversarial regression: responses/main.py auto-injects
         litellm_params.api_base = https://bedrock-mantle.<DEFAULT>.api.aws/v1 (default
         region, ignoring aws_region_name). The config must still pin BOTH the URL host
@@ -1191,9 +1138,7 @@ class TestBedrockMantleResponsesSigV4:
 
         signer = BaseAWSLLM()
         signer.get_credentials = MagicMock(
-            side_effect=ConnectTimeoutError(
-                endpoint_url="https://sts.us-east-2.amazonaws.com"
-            )
+            side_effect=ConnectTimeoutError(endpoint_url="https://sts.us-east-2.amazonaws.com")
         )
         cfg = BedrockMantleResponsesAPIConfig(aws_signer=signer)
 

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -329,7 +329,7 @@ class TestBedrockMantleChatAuth:
 
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert json.loads(signed_body) == {
             "model": "openai.gpt-oss-120b",
@@ -364,7 +364,7 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
         self, monkeypatch
@@ -399,8 +399,8 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
-        assert "/us-west-2/bedrock/aws4_request" not in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
+        assert "/us-west-2/bedrock-mantle/aws4_request" not in headers["Authorization"]
 
     def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
         from unittest.mock import MagicMock
@@ -486,7 +486,7 @@ class TestBedrockMantleChatAuth:
         assert len(requests) == 1
         authorization = requests[0]["headers"]["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in authorization
+        assert "/us-east-2/bedrock-mantle/aws4_request" in authorization
         assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
 
 

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -50,14 +50,8 @@ class TestBedrockMantleProviderRegistration:
         assert len(litellm.bedrock_mantle_models) > 0
         assert "bedrock_mantle/openai.gpt-oss-120b" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-oss-20b" in litellm.bedrock_mantle_models
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-            in litellm.bedrock_mantle_models
-        )
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-20b"
-            in litellm.bedrock_mantle_models
-        )
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-120b" in litellm.bedrock_mantle_models
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-20b" in litellm.bedrock_mantle_models
 
 
 class TestBedrockMantleConfig:
@@ -111,9 +105,7 @@ class TestBedrockMantleConfig:
             cfg._get_openai_compatible_provider_info(
                 None,
                 None,
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
     def test_get_llm_provider_rejects_malicious_aws_region_name(self, monkeypatch):
@@ -126,14 +118,10 @@ class TestBedrockMantleConfig:
             litellm.get_llm_provider(
                 model="openai.gpt-5.5",
                 custom_llm_provider="bedrock_mantle",
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
-    def test_get_llm_provider_uses_aws_region_name_for_responses(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_aws_region_name_for_responses(self, monkeypatch, local_cost_map):
         from litellm.types.router import GenericLiteLLMParams
 
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
@@ -170,18 +158,14 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model="openai.gpt-oss-120b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model="openai.gpt-oss-120b")
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/v1"
 
     @pytest.mark.parametrize(
         "model_id",
         ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
     )
-    def test_chat_base_for_gemma_4_uses_openai_v1(
-        self, monkeypatch, local_cost_map, model_id
-    ):
+    def test_chat_base_for_gemma_4_uses_openai_v1(self, monkeypatch, local_cost_map, model_id):
         # The chat-config bug the Gemma 4 cards exposed: gemma-4-* is served on the
         # /openai/v1 base, not the hardcoded /v1. Driven by the price-map
         # use_openai_responses_path flag (loaded by local_cost_map). Fails before
@@ -189,22 +173,16 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model=model_id
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model=model_id)
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
-    def test_chat_base_explicit_api_base_wins_over_derived(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_chat_base_explicit_api_base_wins_over_derived(self, monkeypatch, local_cost_map):
         # An explicit api_base must not be overridden by the data-driven default,
         # even for a model whose default differs (gemma-4 -> openai/v1).
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         custom_base = "https://bedrock-mantle.us-west-2.api.aws/v1"
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            custom_base, None, model="google.gemma-4-31b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(custom_base, None, model="google.gemma-4-31b")
         assert api_base == custom_base
 
     def test_api_key_from_env(self, monkeypatch):
@@ -247,9 +225,7 @@ class TestBedrockMantleChatAuth:
         from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("SigV4 must not run when a Bearer token exists")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("SigV4 must not run when a Bearer token exists"))
         return signer
 
     def test_bearer_token_skips_sigv4(self, monkeypatch):
@@ -366,9 +342,7 @@ class TestBedrockMantleChatAuth:
 
         assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
-    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
-        self, monkeypatch
-    ):
+    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(self, monkeypatch):
         # If a caller (e.g. proxy) passes a stale api_base in one region and an
         # aws_region_name in a different region, the SigV4 credential scope must
         # match the URL host or Bedrock rejects the request with 401. Without the
@@ -442,9 +416,7 @@ class TestBedrockMantleChatAuth:
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
-        monkeypatch.setenv(
-            "AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0"
-        )
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
         monkeypatch.setenv("AWS_REGION", "us-east-2")
 
         requests = []
@@ -474,9 +446,7 @@ class TestBedrockMantleChatAuth:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -521,9 +491,7 @@ class TestBedrockMantleProjectHeader:
 
         def mock_post(self, url, data=None, headers=None, **kwargs):
             raw_body = data.decode("utf-8") if isinstance(data, bytes) else data
-            requests.append(
-                {"headers": headers or {}, "body": json.loads(raw_body or "{}")}
-            )
+            requests.append({"headers": headers or {}, "body": json.loads(raw_body or "{}")})
             return httpx.Response(
                 status_code=200,
                 json={
@@ -547,9 +515,7 @@ class TestBedrockMantleProjectHeader:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -565,16 +531,12 @@ class TestBedrockMantleProjectHeader:
 
 class TestBedrockMantleProviderResolution:
     def test_get_llm_provider_resolves_correctly(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-120b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-120b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-120b"
 
     def test_get_llm_provider_20b(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-20b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-20b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-20b"
 
@@ -620,9 +582,7 @@ class TestBedrockMantlePricing:
         monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
         litellm.add_known_models()
         info_120b = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-120b")
-        info_safeguard = litellm.get_model_info(
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-        )
+        info_safeguard = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-safeguard-120b")
         assert info_safeguard["max_output_tokens"] > info_120b["max_output_tokens"]
 
     def test_reasoning_support(self, monkeypatch):
@@ -646,9 +606,7 @@ class TestBedrockMantlePricing:
         ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
     ],
 )
-def test_gemma_4_bedrock_mantle_model_metadata(
-    local_cost_map, model_id, input_cost, output_cost, max_tokens
-):
+def test_gemma_4_bedrock_mantle_model_metadata(local_cost_map, model_id, input_cost, output_cost, max_tokens):
     full_model_name = f"bedrock_mantle/{model_id}"
     info = litellm.get_model_info(full_model_name)
 
@@ -662,10 +620,7 @@ def test_gemma_4_bedrock_mantle_model_metadata(
     assert info["supports_tool_choice"] is True
     assert info["supports_vision"] is True
     assert (
-        litellm.supports_parallel_function_calling(
-            model=full_model_name, custom_llm_provider="bedrock_mantle"
-        )
-        is False
+        litellm.supports_parallel_function_calling(model=full_model_name, custom_llm_provider="bedrock_mantle") is False
     )
 
 


### PR DESCRIPTION
## Relevant issues

Related: #31475, #31113, #31196, #30714

## Type

Refactor / Naming Alignment

## Changes

The `bedrock-mantle` endpoint (`bedrock-mantle.{region}.api.aws`) declares `bedrock-mantle` as its canonical SigV4 signing service name. However, the endpoint's credential-scope authorizer also accepts `bedrock` (the legacy name used by `bedrock-runtime`), so the previous signing was **not broken** -- both return HTTP 200 for real inference. This is a naming alignment, not a bug fix.

This PR aligns all Bedrock Mantle signing paths with the canonical service name `"bedrock-mantle"` to match the service's own IAM namespace and the naming convention used by the AWS-managed `AmazonBedrockMantle*Access` policies.

### Evidence: this is cosmetic, not a fix

Tested with a role scoped to **only** `AmazonBedrockMantleInferenceAccess` (`bedrock-mantle:*` actions) -- the narrowest possible permission set:

```
POST https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions
  (role: only bedrock-mantle:* via AmazonBedrockMantleInferenceAccess)

  service="bedrock-mantle"  ->  HTTP 200  (real completion)
  service="bedrock"         ->  HTTP 200  (real completion)
  service="mantle"          ->  HTTP 401  "Credential should be scoped to correct service: 'bedrock-mantle'."
```

Both `bedrock` and `bedrock-mantle` authenticate successfully, even with restricted IAM. The endpoint rejects only genuinely unrecognized names like `mantle`. The credential-scope service name affects signature verification routing, not IAM action authorization.

<details>
<summary>Why align anyway?</summary>

- `bedrock-mantle` is the canonical name declared by the endpoint itself (the 401 message names it)
- It matches the IAM action namespace (`bedrock-mantle:*`) and ARN namespace (`arn:aws:bedrock-mantle:*`)
- It follows the pattern of `bedrock-agentcore` (owns its IAM namespace, signs as itself)
- Forward-correctness: if AWS ever tightens the authorizer to reject `bedrock`, this code is already correct
</details>

### Code changes

1. `litellm/llms/bedrock/base_aws_llm.py` -- add `"bedrock-mantle"` to the `Literal` on `_sign_request` (and correct the docstring return type to `Optional[bytes]`).
2. `litellm/llms/bedrock/chat/mantle/transformation.py` -- `AmazonMantleConfig.sign_request` override signing with `bedrock-mantle` (the `bedrock/mantle/` chat route).
3. `litellm/llms/bedrock/messages/mantle_transformation.py` -- `AmazonMantleMessagesConfig.sign_request` override signing with `bedrock-mantle` (the `bedrock/mantle/` messages route).
4. `litellm/llms/bedrock_mantle/common_utils.py` -- `BedrockMantleAuthMixin.sign_request` signs with `bedrock-mantle` (the standalone `bedrock_mantle/` provider, shared by chat + responses).
5. Docstrings in the `bedrock_mantle/` module updated to say `bedrock-mantle`.
6. Tests: all SigV4 credential-scope assertions updated from `/bedrock/aws4_request` to `/bedrock-mantle/aws4_request`; added unit tests asserting the signing service, plus a **real-signature** test asserting the actual credential scope for both `bedrock/mantle/` configs.

<details>
<summary>Full diff</summary>

```diff
diff --git a/litellm/llms/bedrock/base_aws_llm.py b/litellm/llms/bedrock/base_aws_llm.py
index b71f37023e..27a43f76aa 100644
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -1554,6 +1554,7 @@ class BaseAWSLLM:
         self,
         service_name: Literal[
             "bedrock",
+            "bedrock-mantle",
             "sagemaker",
             "bedrock-agentcore",
             "s3vectors",
@@ -1572,7 +1573,7 @@ class BaseAWSLLM:
         Sign a request for Bedrock or Sagemaker
 
         Returns:
-            Tuple[dict, Optional[str]]: A tuple containing the headers and the json str body of the request
+            Tuple[dict, Optional[bytes]]: A tuple containing the headers and the json str body of the request
         """
         if api_key is not None:
             aws_bearer_token: Optional[str] = api_key
diff --git a/litellm/llms/bedrock/chat/mantle/transformation.py b/litellm/llms/bedrock/chat/mantle/transformation.py
index 93306025b0..eb3612b009 100644
--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -33,6 +33,29 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
     Usage: model="bedrock/mantle/anthropic.claude-mythos-preview"
     """
 
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> tuple[dict, Optional[bytes]]:
+        return self._sign_request(
+            service_name="bedrock-mantle",
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            stream=stream,
+            fake_stream=fake_stream,
+        )
+
     def get_complete_url(
         self,
         api_base: Optional[str],
diff --git a/litellm/llms/bedrock/messages/mantle_transformation.py b/litellm/llms/bedrock/messages/mantle_transformation.py
index 94e7f90b71..5758359ead 100644
--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -30,6 +30,29 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
     model ID in the request body (unlike Bedrock Invoke which puts it in the URL).
     """
 
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> tuple[dict, Optional[bytes]]:
+        return self._sign_request(
+            service_name="bedrock-mantle",
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            stream=stream,
+            fake_stream=fake_stream,
+        )
+
     def get_complete_url(
         self,
         api_base: Optional[str],
diff --git a/litellm/llms/bedrock_mantle/chat/transformation.py b/litellm/llms/bedrock_mantle/chat/transformation.py
index f688cea10f..d7e3b9e2a7 100644
--- a/litellm/llms/bedrock_mantle/chat/transformation.py
+++ b/litellm/llms/bedrock_mantle/chat/transformation.py
@@ -6,7 +6,7 @@ API docs: https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.ht
 Base URL: https://bedrock-mantle.{region}.api.aws/v1
 Auth: Bearer token (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the
       standard AWS_BEARER_TOKEN_BEDROCK) when present; otherwise AWS SigV4
-      (service "bedrock") over the standard credential chain. See
+      (service "bedrock-mantle") over the standard credential chain. See
       BedrockMantleAuthMixin in common_utils.
 """
 
diff --git a/litellm/llms/bedrock_mantle/common_utils.py b/litellm/llms/bedrock_mantle/common_utils.py
index d517ab940c..cda409a20d 100644
--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -3,7 +3,7 @@
 Mantle authenticates with a Bearer token when one is available
 (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the standard
 AWS_BEARER_TOKEN_BEDROCK); otherwise it falls back to AWS SigV4 (service
-"bedrock") over the standard credential chain (IAM role / access key / profile /
+"bedrock-mantle") over the standard credential chain (IAM role / access key / profile /
 web identity). The Chat Completions and Responses backends share this behaviour
 through BedrockMantleAuthMixin so the two paths can never drift apart.
 
@@ -90,7 +90,7 @@ class BedrockMantleAuthMixin:
             headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
         try:
             return self._aws_signer._sign_request(
-                service_name="bedrock",
+                service_name="bedrock-mantle",
                 headers=headers,
                 optional_params=optional_params,
                 request_data=request_data,
diff --git a/litellm/llms/bedrock_mantle/responses/transformation.py b/litellm/llms/bedrock_mantle/responses/transformation.py
index 2e30f85fd0..72a99ba5e7 100644
--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -10,7 +10,7 @@ only the endpoint URL and authentication.
 
 Auth: Bearer token (BEDROCK_MANTLE_API_KEY or the standard
 AWS_BEARER_TOKEN_BEDROCK, or litellm_params.api_key) when present; otherwise
-AWS SigV4 (service name "bedrock") using the standard credential chain (IAM
+AWS SigV4 (service name "bedrock-mantle") using the standard credential chain (IAM
 role / access key / profile / web identity), signed via the shared
 BaseAWSLLM._sign_request after the request body is finalized.
 """
diff --git a/tests/test_litellm/llms/bedrock/test_mantle.py b/tests/test_litellm/llms/bedrock/test_mantle.py
index f7f8f582ab..aa1b30c172 100644
--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -347,3 +347,88 @@ async def test_mantle_anthropic_messages_routes_to_vpc_api_base():
     assert len(urls) == 1
     assert urls[0] == f"{_VPC_ENDPOINT}/anthropic/v1/messages"
     assert "api.aws" not in urls[0]
+
+
+def test_mantle_chat_config_signs_with_bedrock_mantle_service():
+    """The bedrock/mantle/ chat route must SigV4-sign with service 'bedrock-mantle'."""
+    config = AmazonMantleConfig()
+    signed_service = None
+
+    def capture_sign(self, *, service_name, **kwargs):
+        nonlocal signed_service
+        signed_service = service_name
+        return {"Authorization": "AWS4-HMAC-SHA256 ..."}, b"{}"
+
+    with patch(
+        "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM._sign_request",
+        capture_sign,
+    ):
+        config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "fake",
+                "aws_secret_access_key": "fake",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+    assert signed_service == "bedrock-mantle"
+
+
+def test_mantle_messages_config_signs_with_bedrock_mantle_service():
+    """The bedrock/mantle/ messages route must SigV4-sign with service 'bedrock-mantle'."""
+    config = AmazonMantleMessagesConfig()
+    signed_service = None
+
+    def capture_sign(self, *, service_name, **kwargs):
+        nonlocal signed_service
+        signed_service = service_name
+        return {"Authorization": "AWS4-HMAC-SHA256 ..."}, b"{}"
+
+    with patch(
+        "litellm.llms.bedrock.base_aws_llm.BaseAWSLLM._sign_request",
+        capture_sign,
+    ):
+        config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "fake",
+                "aws_secret_access_key": "fake",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+    assert signed_service == "bedrock-mantle"
+
+
+def test_mantle_configs_sign_real_sigv4_scope_is_bedrock_mantle(monkeypatch):
+    """Both bedrock/mantle/ configs must produce a *real* SigV4 signature whose
+    credential scope names service 'bedrock-mantle' (not 'bedrock').
+
+    Unlike the two tests above this does NOT mock _sign_request: it drives the
+    real botocore SigV4Auth with fake static creds (offline, no network), so a
+    regression in the signed service name would change the credential scope and
+    fail here. Cred setup mirrors test_no_bearer_signs_with_sigv4 in
+    tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py.
+    """
+    # No Bearer token -> _sign_request must take the SigV4 path, not Bearer auth.
+    monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+
+    for config in (AmazonMantleConfig(), AmazonMantleMessagesConfig()):
+        headers, _ = config.sign_request(
+            headers={"Content-Type": "application/json"},
+            optional_params={
+                "aws_access_key_id": "AKIAEXAMPLE",
+                "aws_secret_access_key": "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0",
+                "aws_region_name": "us-east-1",
+            },
+            request_data={"model": "anthropic.claude-opus-4-8", "messages": []},
+            api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
+        )
+
+        assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+        assert "/us-east-1/bedrock-mantle/aws4_request" in headers["Authorization"]
diff --git a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
index 94efc7c51e..c99ba034b1 100644
--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -923,7 +923,7 @@ class TestBedrockMantleResponsesSigV4:
         )
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "X-Amz-Date" in headers
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert signed_body == b'{"input": "hi"}'
@@ -962,7 +962,7 @@ class TestBedrockMantleResponsesSigV4:
         assert call["aws_role_name"] == "arn:aws:iam::000000000000:role/test-role"
         assert call["aws_session_name"] == "litellm-test"
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_signed_body_matches_final_data_after_normalize(self, monkeypatch):
         """Core regression: the signed bytes must equal the bytes actually sent.
@@ -1012,7 +1012,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base="https://bedrock-mantle.eu-west-1.api.aws/openai/v1/responses",
             api_key=None,
         )
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_url_region_and_sigv4_region_agree_from_litellm_params(self, monkeypatch):
         """Adversarial-review regression: a caller-supplied aws_region_name (no region
@@ -1046,7 +1046,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/ap-southeast-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/ap-southeast-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_injected_default_region_base_does_not_override_aws_region_name(
         self, monkeypatch
@@ -1084,7 +1084,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "us-east-1" not in headers["Authorization"]
 
     def test_custom_proxy_host_is_preserved(self, monkeypatch):
diff --git a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
index 275fb460b9..dd39089f2f 100644
--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -329,7 +329,7 @@ class TestBedrockMantleChatAuth:
 
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert json.loads(signed_body) == {
             "model": "openai.gpt-oss-120b",
@@ -364,7 +364,7 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
         self, monkeypatch
@@ -399,8 +399,8 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
-        assert "/us-west-2/bedrock/aws4_request" not in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
+        assert "/us-west-2/bedrock-mantle/aws4_request" not in headers["Authorization"]
 
     def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
         from unittest.mock import MagicMock
@@ -486,7 +486,7 @@ class TestBedrockMantleChatAuth:
         assert len(requests) == 1
         authorization = requests[0]["headers"]["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in authorization
+        assert "/us-east-2/bedrock-mantle/aws4_request" in authorization
         assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
 
 
```
</details>

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests (157 mantle tests pass; ruff strict gate passes)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

All bedrock-mantle unit tests pass and the ruff strict gate is green:

```
tests/test_litellm/llms/bedrock/test_mantle.py ......................... 24
tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py 47
tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py 86
157 passed

scripts/ruff_strict_gate.py -> OK: every strict rule is within its codebase ceiling
```
