### PR TITLE
fix(ui): stop listing bedrock_mantle models under the Bedrock provider

### DIFF
--- a/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.test.tsx
@@ -308,17 +308,17 @@ describe("provider_info_helpers", () => {
       expect(result).not.toContain("anthropic-native");
     });
 
-    it("should include bedrock variants (converse, mantle) when called with 'Bedrock' provider key", () => {
+    it("should include bedrock converse but exclude standalone bedrock_mantle when called with 'Bedrock' provider key", () => {
       const modelMap = {
         "bedrock-base": { litellm_provider: "bedrock" },
         "bedrock-converse-model": { litellm_provider: "bedrock_converse" },
-        "bedrock-mantle-model": { litellm_provider: "bedrock_mantle" },
+        "bedrock_mantle/openai.gpt-5.4": { litellm_provider: "bedrock_mantle" },
         "openai-model": { litellm_provider: "openai" },
       };
       const result = getProviderModels("Bedrock" as Providers, modelMap);
       expect(result).toContain("bedrock-base");
       expect(result).toContain("bedrock-converse-model");
-      expect(result).toContain("bedrock-mantle-model");
+      expect(result).not.toContain("bedrock_mantle/openai.gpt-5.4");
       expect(result).not.toContain("openai-model");
     });
 

--- a/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
+++ b/ui/litellm-dashboard/src/components/provider_info_helpers.tsx
@@ -218,6 +218,8 @@ export const provider_map: Record<string, string> = {
   ZAI: "zai",
 };
 
+const standaloneSubproviderSlugs = new Set<string>(["bedrock_mantle"]);
+
 const asset_logos_folder = "/ui/assets/logos/";
 
 export const providerLogoMap: Record<string, string> = {
@@ -394,11 +396,13 @@ export const getProviderModels = (provider: Providers, modelMap: any): Array<str
     Object.entries(modelMap).forEach(([key, value]) => {
       if (value !== null && typeof value === "object" && "litellm_provider" in (value as object)) {
         const litellmProvider = (value as any)["litellm_provider"];
+        const isPrefixVariant =
+          typeof litellmProvider === "string" &&
+          (litellmProvider.startsWith(`${custom_llm_provider}_`) ||
+            litellmProvider.startsWith(`${custom_llm_provider}-`));
         if (
           litellmProvider === custom_llm_provider ||
-          (typeof litellmProvider === "string" &&
-            (litellmProvider.startsWith(`${custom_llm_provider}_`) ||
-              litellmProvider.startsWith(`${custom_llm_provider}-`)))
+          (isPrefixVariant && !standaloneSubproviderSlugs.has(litellmProvider))
         ) {
           providerModels.push(key);
         }


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3992

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a dropdown-filtering fix in the Add Model form, so the proof is what you see in the UI. To reproduce on a local proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload`):

1. Go to http://localhost:4000/ui/?page=models-and-endpoints and open the Add Model tab
2. Select Provider "Amazon Bedrock". Before this change the LiteLLM Model Name(s) suggestions include `bedrock_mantle/...` entries; after this change they no longer appear (you still see `bedrock`/`bedrock_converse` models)
3. Select Provider "Amazon Bedrock Mantle". The `bedrock_mantle/...` models still appear there

I will attach before/after screenshots of both provider selections

## Type

🐛 Bug Fix

## Changes

`getProviderModels` in `provider_info_helpers.tsx` built each provider's model list by rolling in every `litellm_provider` that starts with the selected provider's slug. Because `"bedrock_mantle".startsWith("bedrock_")` is true, the OpenAI-compatible `bedrock_mantle/*` models (served at `bedrock-mantle.{region}.api.aws`) were offered under plain Amazon Bedrock. That combination is dead on arrival: a `bedrock_mantle/openai....` model string under the bedrock provider does not match the `mantle/` route, so it falls through to `bedrock-runtime` and the request fails.

The prefix rollup is still the right behavior for genuine sub-variants like `bedrock_converse`, which are not separately selectable providers. The fix introduces a small `standaloneSubproviderSlugs` set and excludes those slugs from the prefix rollup, so `bedrock_mantle/*` only shows under the Amazon Bedrock Mantle provider while everything else is unchanged.

I considered a general rule that excludes any registered sub-provider from prefix matching, but `vertex_ai_beta` is structurally identical to `bedrock_mantle` (both are registered `${parent}_suffix` providers) and the existing tests require it to keep rolling up under Vertex. There is no structural signal separating the two, so the exception lives in one explicit, named place.

Updated `provider_info_helpers.test.tsx`: the test that previously asserted `bedrock_mantle` shows under Bedrock now asserts it is excluded (while `bedrock` and `bedrock_converse` remain). It fails on the old code and passes on the new code. Full suite: 59/59.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted UI filtering change with unit test coverage; no auth, routing, or backend behavior changes.
> 
> **Overview**
> Fixes **Add Model** suggestions so `bedrock_mantle/*` models no longer appear when **Amazon Bedrock** is selected, while **Amazon Bedrock Mantle** still lists only Mantle models.
> 
> `getProviderModels` still rolls in prefix-matched `litellm_provider` variants (e.g. `bedrock_converse`), but **`bedrock_mantle` is excluded** via a new `standaloneSubproviderSlugs` set because it is a separately selectable provider whose slug falsely matched the `bedrock_` prefix.
> 
> Tests now assert Mantle models are **not** included under the `Bedrock` key and still appear under `BedrockMantle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 875b12401793ebf9e7591181dc4e0740c4267592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->