### PR TITLE
fix(proxy): return text/plain for audio transcription response_format=text

### DIFF
--- a/litellm/proxy/common_utils/openai_endpoint_utils.py
+++ b/litellm/proxy/common_utils/openai_endpoint_utils.py
@@ -2,12 +2,14 @@
 Contains utils used by OpenAI compatible endpoints
 """
 
-from typing import Optional, Set
+from typing import Optional, Set, Union
 
 from fastapi import Request
+from fastapi.responses import PlainTextResponse
 
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
+from litellm.types.utils import TranscriptionResponse
 
 SENSITIVE_DATA_MASKER = SensitiveDataMasker()
 
@@ -79,3 +81,22 @@ def get_custom_llm_provider_from_request_headers(request: Request) -> Optional[s
     if "custom-llm-provider" in request.headers:
         return request.headers["custom-llm-provider"]
     return None
+
+
+def get_transcription_proxy_response(
+    response: TranscriptionResponse,
+    response_format: Optional[str],
+    headers: Optional[dict] = None,
+) -> Union[TranscriptionResponse, PlainTextResponse]:
+    """
+    Preserve OpenAI-compatible HTTP envelopes for transcription response formats.
+
+    LiteLLM normalizes upstream transcription bodies into TranscriptionResponse
+    objects, but callers requesting response_format=text expect a text/plain body.
+    """
+    if response_format == "text":
+        return PlainTextResponse(
+            content=response.text or "",
+            headers=headers or {},
+        )
+    return response

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -310,6 +310,7 @@ from litellm.proxy.common_utils.load_config_utils import (
 )
 from litellm.proxy.common_utils.model_listing_utils import TeamModelNameTranslator
 from litellm.proxy.common_utils.openai_endpoint_utils import (
+    get_transcription_proxy_response,
     remove_sensitive_info_from_deployment,
 )
 from litellm.proxy.common_utils.proxy_state import ProxyState
@@ -10051,7 +10052,11 @@ async def audio_transcriptions(
         if callback_headers:
             fastapi_response.headers.update(callback_headers)
 
-        return response
+        return get_transcription_proxy_response(
+            response=response,
+            response_format=data.get("response_format"),
+            headers=dict(fastapi_response.headers),
+        )
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data

--- a/tests/test_litellm/llms/openai/transcriptions/test_transcription_proxy_response.py
+++ b/tests/test_litellm/llms/openai/transcriptions/test_transcription_proxy_response.py
@@ -1,0 +1,36 @@
+from litellm.proxy.common_utils.openai_endpoint_utils import (
+    get_transcription_proxy_response,
+)
+from litellm.types.utils import TranscriptionResponse
+
+
+def test_get_transcription_proxy_response_text_format_returns_plain_text():
+    response = TranscriptionResponse(text="Hello world.")
+
+    result = get_transcription_proxy_response(
+        response,
+        "text",
+        headers={"x-litellm-call-id": "test-call-id"},
+    )
+
+    assert result.media_type.startswith("text/plain")
+    assert result.body == b"Hello world."
+    assert result.headers["x-litellm-call-id"] == "test-call-id"
+
+
+def test_get_transcription_proxy_response_json_format_returns_model():
+    response = TranscriptionResponse(text="Hello world.")
+
+    result = get_transcription_proxy_response(response, "json")
+
+    assert isinstance(result, TranscriptionResponse)
+    assert result.text == "Hello world."
+
+
+def test_get_transcription_proxy_response_default_format_returns_model():
+    response = TranscriptionResponse(text="Hello world.")
+
+    result = get_transcription_proxy_response(response, None)
+
+    assert isinstance(result, TranscriptionResponse)
+    assert result.text == "Hello world."


### PR DESCRIPTION
## Relevant issues

Fixes #31457

## Summary

When callers request `response_format=text` on `/v1/audio/transcriptions`, the LiteLLM proxy now returns a `text/plain` body with the transcript instead of serializing the normalized `TranscriptionResponse` object as JSON.

## Motivation

After #30599, LiteLLM correctly forwards `response_format=text` to upstream transcription backends and parses plain-text responses internally. However, the proxy endpoint still returned `application/json`, which breaks OpenAI-compatible clients expecting a raw transcript body.

## Changes

- Add `get_transcription_proxy_response()` in `litellm/proxy/common_utils/openai_endpoint_utils.py`
- Use the helper from `audio_transcriptions` in `proxy_server.py`
- Forward existing LiteLLM response headers into the plain-text response
- Add unit tests for `text`, `json`, and default response paths

## Tests

```bash
python3 -m pytest tests/test_litellm/llms/openai/transcriptions/test_transcription_proxy_response.py -v
```

Result: **3 passed**

## Notes

- Scope is intentionally limited to `response_format=text`; `srt`/`vtt` may need the same treatment in a follow-up.
- Full proxy e2e with a live transcription backend was not run in this session.

## Type

🐛 Bug Fix
