### PR TITLE
refactor(bedrock): serve the whole Mantle endpoint through the bedrock_mantle provider

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -644,12 +644,17 @@ def _get_openai_compatible_provider_info(
             api_base, api_key
         )
     elif custom_llm_provider == "bedrock_mantle":
-        (
-            api_base,
-            dynamic_api_key,
-        ) = litellm.BedrockMantleChatConfig()._get_openai_compatible_provider_info(
-            api_base, api_key, litellm_params=litellm_params, model=model
+        from litellm.llms.bedrock_mantle.common_utils import (
+            mantle_uses_anthropic_messages,
         )
+
+        if not mantle_uses_anthropic_messages(model):
+            (
+                api_base,
+                dynamic_api_key,
+            ) = litellm.BedrockMantleChatConfig()._get_openai_compatible_provider_info(
+                api_base, api_key, litellm_params=litellm_params, model=model
+            )
     elif custom_llm_provider == "nvidia_nim":
         # nvidia_nim is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
         api_base = (

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -107,9 +107,11 @@ def get_supported_openai_params(
     elif custom_llm_provider == "groq":
         return litellm.GroqChatConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "bedrock_mantle":
-        return litellm.BedrockMantleChatConfig().get_supported_openai_params(
-            model=model
-        )
+        from litellm.utils import ProviderConfigManager
+
+        return ProviderConfigManager._get_bedrock_mantle_config(
+            model
+        ).get_supported_openai_params(model=model)
     elif custom_llm_provider == "hosted_vllm":
         return litellm.HostedVLLMChatConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "vllm":

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -145,3 +145,20 @@ def mantle_base_segment(model: str | None, model_cost: dict) -> str:
     """
     entry = model_cost.get(f"bedrock_mantle/{model}", {})
     return "openai/v1" if entry.get("use_openai_responses_path") is True else "v1"
+
+
+def mantle_uses_anthropic_messages(model: str | None) -> bool:
+    """Whether a Bedrock Mantle model is served over the Anthropic Messages wire
+    format (.../anthropic/v1/messages) rather than the OpenAI-compatible surface.
+
+    Mantle exposes Anthropic models (the anthropic.* vendor namespace, e.g.
+    anthropic.claude-mythos-preview) through the Anthropic Messages API, and every
+    other vendor (openai.*, google.*) through the OpenAI-compatible surface. The
+    vendor namespace is the routing signal because it is the literal identifier AWS
+    uses to decide which sub-API a model lives behind, so unlike a family substring
+    it cannot drift from the model. The provider prefix is stripped first so both
+    "bedrock_mantle/anthropic.x" and a bare "anthropic.x" resolve the same way.
+    """
+    if not model:
+        return False
+    return model.split("/")[-1].startswith("anthropic.")

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1944,13 +1944,19 @@ def _complete_bedrock_mantle(
     stream = ctx.stream
     timeout = ctx.timeout
 
-    api_base = api_base or litellm.api_base or get_secret("BEDROCK_MANTLE_API_BASE")
+    from litellm.llms.bedrock_mantle.common_utils import (
+        mantle_uses_anthropic_messages,
+    )
+
+    api_base = api_base or litellm.api_base
     api_key = api_key or litellm.api_key or get_secret("BEDROCK_MANTLE_API_KEY")
     headers = headers or litellm.headers
-    config = litellm.BedrockMantleChatConfig.get_config()
-    for k, v in config.items():
-        if k not in optional_params:
-            optional_params[k] = v
+    if not mantle_uses_anthropic_messages(model):
+        api_base = api_base or get_secret("BEDROCK_MANTLE_API_BASE")
+        config = litellm.BedrockMantleChatConfig.get_config()
+        for k, v in config.items():
+            if k not in optional_params:
+                optional_params[k] = v
     return base_llm_http_handler.completion(
         model=model,
         stream=stream,

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4784,7 +4784,9 @@ def get_optional_params(
             ),
         )
     elif custom_llm_provider == "bedrock_mantle":
-        optional_params = litellm.BedrockMantleChatConfig().map_openai_params(
+        optional_params = ProviderConfigManager._get_bedrock_mantle_config(
+            model
+        ).map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
             model=model,
@@ -8474,8 +8476,8 @@ class ProviderConfigManager:
             LlmProviders.DEEPSEEK: (lambda: litellm.DeepSeekChatConfig(), False),
             LlmProviders.GROQ: (lambda: litellm.GroqChatConfig(), False),
             LlmProviders.BEDROCK_MANTLE: (
-                lambda: litellm.BedrockMantleChatConfig(),
-                False,
+                lambda model: ProviderConfigManager._get_bedrock_mantle_config(model),
+                True,
             ),
             LlmProviders.A2A: (lambda: litellm.A2AConfig(), False),
             LlmProviders.BYTEZ: (lambda: litellm.BytezChatConfig(), False),
@@ -8650,6 +8652,27 @@ class ProviderConfigManager:
         from litellm.llms.bedrock.common_utils import get_bedrock_chat_config
 
         return get_bedrock_chat_config(model=model)
+
+    @staticmethod
+    def _get_bedrock_mantle_config(model: str) -> BaseConfig:
+        """Get the Bedrock Mantle config for a model's wire format.
+
+        The Mantle endpoint hosts both an OpenAI-compatible surface and the
+        Anthropic Messages surface; the vendor namespace decides which, so the
+        bedrock_mantle provider owns the whole endpoint and the format is an
+        internal routing detail rather than a separate provider.
+        """
+        from litellm.llms.bedrock_mantle.common_utils import (
+            mantle_uses_anthropic_messages,
+        )
+
+        if mantle_uses_anthropic_messages(model):
+            from litellm.llms.bedrock.chat.mantle.transformation import (
+                AmazonMantleConfig,
+            )
+
+            return AmazonMantleConfig()
+        return litellm.BedrockMantleChatConfig()
 
     @staticmethod
     def _get_cohere_config(model: str) -> BaseConfig:

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -685,3 +685,81 @@ def test_gemma_4_models_register_under_bedrock_mantle(local_cost_map, model_id):
     resolved_model, provider, _, _ = litellm.get_llm_provider(full_model_name)
     assert provider == "bedrock_mantle"
     assert resolved_model == model_id
+
+
+class TestBedrockMantleWireFormatDispatch:
+    """The bedrock_mantle provider owns the whole Mantle endpoint; the AWS vendor
+    namespace selects the wire format. Anthropic models (anthropic.*) are served
+    over the Anthropic Messages surface, every other vendor over the
+    OpenAI-compatible surface, so the format is an internal routing detail rather
+    than a separate provider."""
+
+    def test_helper_routes_only_anthropic_namespace_to_messages(self):
+        from litellm.llms.bedrock_mantle.common_utils import (
+            mantle_uses_anthropic_messages,
+        )
+
+        assert mantle_uses_anthropic_messages("anthropic.claude-mythos-preview") is True
+        assert (
+            mantle_uses_anthropic_messages(
+                "bedrock_mantle/anthropic.claude-mythos-preview"
+            )
+            is True
+        )
+        assert mantle_uses_anthropic_messages("openai.gpt-5.5") is False
+        assert mantle_uses_anthropic_messages("google.gemma-4-31b") is False
+        assert mantle_uses_anthropic_messages(None) is False
+
+    def test_config_resolver_dispatches_on_namespace(self):
+        from litellm.llms.bedrock.chat.mantle.transformation import AmazonMantleConfig
+        from litellm.utils import ProviderConfigManager
+
+        anthropic_cfg = ProviderConfigManager._get_bedrock_mantle_config(
+            "anthropic.claude-mythos-preview"
+        )
+        openai_cfg = ProviderConfigManager._get_bedrock_mantle_config("openai.gpt-5.5")
+
+        assert isinstance(anthropic_cfg, AmazonMantleConfig)
+        assert isinstance(openai_cfg, BedrockMantleChatConfig)
+
+    def test_provider_chat_config_resolves_anthropic_via_bedrock_mantle(self):
+        from litellm.llms.bedrock.chat.mantle.transformation import AmazonMantleConfig
+        from litellm.utils import ProviderConfigManager
+
+        cfg = ProviderConfigManager.get_provider_chat_config(
+            model="anthropic.claude-mythos-preview",
+            provider=LlmProviders.BEDROCK_MANTLE,
+        )
+
+        assert isinstance(cfg, AmazonMantleConfig)
+
+    def test_anthropic_mantle_model_targets_messages_endpoint(self):
+        from litellm.utils import ProviderConfigManager
+
+        cfg = ProviderConfigManager._get_bedrock_mantle_config(
+            "anthropic.claude-mythos-preview"
+        )
+
+        url = cfg.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="anthropic.claude-mythos-preview",
+            optional_params={"aws_region_name": "us-east-1"},
+            litellm_params={},
+        )
+
+        assert url == "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
+
+    def test_get_llm_provider_leaves_anthropic_mantle_api_base_for_sigv4(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
+
+        resolved_model, provider, dynamic_api_key, api_base = litellm.get_llm_provider(
+            model="bedrock_mantle/anthropic.claude-mythos-preview"
+        )
+
+        assert provider == "bedrock_mantle"
+        assert resolved_model == "anthropic.claude-mythos-preview"
+        assert api_base is None
+        assert dynamic_api_key is None

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -50,14 +50,8 @@ class TestBedrockMantleProviderRegistration:
         assert len(litellm.bedrock_mantle_models) > 0
         assert "bedrock_mantle/openai.gpt-oss-120b" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-oss-20b" in litellm.bedrock_mantle_models
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-            in litellm.bedrock_mantle_models
-        )
-        assert (
-            "bedrock_mantle/openai.gpt-oss-safeguard-20b"
-            in litellm.bedrock_mantle_models
-        )
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-120b" in litellm.bedrock_mantle_models
+        assert "bedrock_mantle/openai.gpt-oss-safeguard-20b" in litellm.bedrock_mantle_models
 
 
 class TestBedrockMantleConfig:
@@ -111,9 +105,7 @@ class TestBedrockMantleConfig:
             cfg._get_openai_compatible_provider_info(
                 None,
                 None,
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
     def test_get_llm_provider_rejects_malicious_aws_region_name(self, monkeypatch):
@@ -126,14 +118,10 @@ class TestBedrockMantleConfig:
             litellm.get_llm_provider(
                 model="openai.gpt-5.5",
                 custom_llm_provider="bedrock_mantle",
-                litellm_params=GenericLiteLLMParams(
-                    aws_region_name="us-east-1.api.aws.attacker.example/"
-                ),
+                litellm_params=GenericLiteLLMParams(aws_region_name="us-east-1.api.aws.attacker.example/"),
             )
 
-    def test_get_llm_provider_uses_aws_region_name_for_responses(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_get_llm_provider_uses_aws_region_name_for_responses(self, monkeypatch, local_cost_map):
         from litellm.types.router import GenericLiteLLMParams
 
         monkeypatch.delenv("BEDROCK_MANTLE_REGION", raising=False)
@@ -170,18 +158,14 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model="openai.gpt-oss-120b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model="openai.gpt-oss-120b")
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/v1"
 
     @pytest.mark.parametrize(
         "model_id",
         ["google.gemma-4-31b", "google.gemma-4-26b-a4b", "google.gemma-4-e2b"],
     )
-    def test_chat_base_for_gemma_4_uses_openai_v1(
-        self, monkeypatch, local_cost_map, model_id
-    ):
+    def test_chat_base_for_gemma_4_uses_openai_v1(self, monkeypatch, local_cost_map, model_id):
         # The chat-config bug the Gemma 4 cards exposed: gemma-4-* is served on the
         # /openai/v1 base, not the hardcoded /v1. Driven by the price-map
         # use_openai_responses_path flag (loaded by local_cost_map). Fails before
@@ -189,22 +173,16 @@ class TestBedrockMantleConfig:
         monkeypatch.setenv("BEDROCK_MANTLE_REGION", "us-east-2")
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            None, None, model=model_id
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(None, None, model=model_id)
         assert api_base == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
 
-    def test_chat_base_explicit_api_base_wins_over_derived(
-        self, monkeypatch, local_cost_map
-    ):
+    def test_chat_base_explicit_api_base_wins_over_derived(self, monkeypatch, local_cost_map):
         # An explicit api_base must not be overridden by the data-driven default,
         # even for a model whose default differs (gemma-4 -> openai/v1).
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
         custom_base = "https://bedrock-mantle.us-west-2.api.aws/v1"
         cfg = BedrockMantleChatConfig()
-        api_base, _ = cfg._get_openai_compatible_provider_info(
-            custom_base, None, model="google.gemma-4-31b"
-        )
+        api_base, _ = cfg._get_openai_compatible_provider_info(custom_base, None, model="google.gemma-4-31b")
         assert api_base == custom_base
 
     def test_api_key_from_env(self, monkeypatch):
@@ -247,9 +225,7 @@ class TestBedrockMantleChatAuth:
         from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
         signer = BaseAWSLLM()
-        signer.get_credentials = MagicMock(
-            side_effect=AssertionError("SigV4 must not run when a Bearer token exists")
-        )
+        signer.get_credentials = MagicMock(side_effect=AssertionError("SigV4 must not run when a Bearer token exists"))
         return signer
 
     def test_bearer_token_skips_sigv4(self, monkeypatch):
@@ -366,9 +342,7 @@ class TestBedrockMantleChatAuth:
 
         assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
 
-    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
-        self, monkeypatch
-    ):
+    def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(self, monkeypatch):
         # If a caller (e.g. proxy) passes a stale api_base in one region and an
         # aws_region_name in a different region, the SigV4 credential scope must
         # match the URL host or Bedrock rejects the request with 401. Without the
@@ -442,9 +416,7 @@ class TestBedrockMantleChatAuth:
         ):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
-        monkeypatch.setenv(
-            "AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0"
-        )
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
         monkeypatch.setenv("AWS_REGION", "us-east-2")
 
         requests = []
@@ -474,9 +446,7 @@ class TestBedrockMantleChatAuth:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -521,9 +491,7 @@ class TestBedrockMantleProjectHeader:
 
         def mock_post(self, url, data=None, headers=None, **kwargs):
             raw_body = data.decode("utf-8") if isinstance(data, bytes) else data
-            requests.append(
-                {"headers": headers or {}, "body": json.loads(raw_body or "{}")}
-            )
+            requests.append({"headers": headers or {}, "body": json.loads(raw_body or "{}")})
             return httpx.Response(
                 status_code=200,
                 json={
@@ -547,9 +515,7 @@ class TestBedrockMantleProjectHeader:
                 request=httpx.Request("POST", url),
             )
 
-        with patch(
-            "litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post
-        ):
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
             response = litellm.completion(
                 model="bedrock_mantle/openai.gpt-oss-120b",
                 messages=[{"role": "user", "content": "hello"}],
@@ -565,16 +531,12 @@ class TestBedrockMantleProjectHeader:
 
 class TestBedrockMantleProviderResolution:
     def test_get_llm_provider_resolves_correctly(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-120b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-120b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-120b"
 
     def test_get_llm_provider_20b(self):
-        model, provider, _, _ = litellm.get_llm_provider(
-            "bedrock_mantle/openai.gpt-oss-20b"
-        )
+        model, provider, _, _ = litellm.get_llm_provider("bedrock_mantle/openai.gpt-oss-20b")
         assert provider == "bedrock_mantle"
         assert model == "openai.gpt-oss-20b"
 
@@ -620,9 +582,7 @@ class TestBedrockMantlePricing:
         monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "true")
         litellm.add_known_models()
         info_120b = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-120b")
-        info_safeguard = litellm.get_model_info(
-            "bedrock_mantle/openai.gpt-oss-safeguard-120b"
-        )
+        info_safeguard = litellm.get_model_info("bedrock_mantle/openai.gpt-oss-safeguard-120b")
         assert info_safeguard["max_output_tokens"] > info_120b["max_output_tokens"]
 
     def test_reasoning_support(self, monkeypatch):
@@ -646,9 +606,7 @@ class TestBedrockMantlePricing:
         ("google.gemma-4-e2b", 4e-08, 8e-08, 128000),
     ],
 )
-def test_gemma_4_bedrock_mantle_model_metadata(
-    local_cost_map, model_id, input_cost, output_cost, max_tokens
-):
+def test_gemma_4_bedrock_mantle_model_metadata(local_cost_map, model_id, input_cost, output_cost, max_tokens):
     full_model_name = f"bedrock_mantle/{model_id}"
     info = litellm.get_model_info(full_model_name)
 
@@ -662,10 +620,7 @@ def test_gemma_4_bedrock_mantle_model_metadata(
     assert info["supports_tool_choice"] is True
     assert info["supports_vision"] is True
     assert (
-        litellm.supports_parallel_function_calling(
-            model=full_model_name, custom_llm_provider="bedrock_mantle"
-        )
-        is False
+        litellm.supports_parallel_function_calling(model=full_model_name, custom_llm_provider="bedrock_mantle") is False
     )
 
 
@@ -700,12 +655,7 @@ class TestBedrockMantleWireFormatDispatch:
         )
 
         assert mantle_uses_anthropic_messages("anthropic.claude-mythos-preview") is True
-        assert (
-            mantle_uses_anthropic_messages(
-                "bedrock_mantle/anthropic.claude-mythos-preview"
-            )
-            is True
-        )
+        assert mantle_uses_anthropic_messages("bedrock_mantle/anthropic.claude-mythos-preview") is True
         assert mantle_uses_anthropic_messages("openai.gpt-5.5") is False
         assert mantle_uses_anthropic_messages("google.gemma-4-31b") is False
         assert mantle_uses_anthropic_messages(None) is False
@@ -714,9 +664,7 @@ class TestBedrockMantleWireFormatDispatch:
         from litellm.llms.bedrock.chat.mantle.transformation import AmazonMantleConfig
         from litellm.utils import ProviderConfigManager
 
-        anthropic_cfg = ProviderConfigManager._get_bedrock_mantle_config(
-            "anthropic.claude-mythos-preview"
-        )
+        anthropic_cfg = ProviderConfigManager._get_bedrock_mantle_config("anthropic.claude-mythos-preview")
         openai_cfg = ProviderConfigManager._get_bedrock_mantle_config("openai.gpt-5.5")
 
         assert isinstance(anthropic_cfg, AmazonMantleConfig)
@@ -736,9 +684,7 @@ class TestBedrockMantleWireFormatDispatch:
     def test_anthropic_mantle_model_targets_messages_endpoint(self):
         from litellm.utils import ProviderConfigManager
 
-        cfg = ProviderConfigManager._get_bedrock_mantle_config(
-            "anthropic.claude-mythos-preview"
-        )
+        cfg = ProviderConfigManager._get_bedrock_mantle_config("anthropic.claude-mythos-preview")
 
         url = cfg.get_complete_url(
             api_base=None,
@@ -750,9 +696,7 @@ class TestBedrockMantleWireFormatDispatch:
 
         assert url == "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
 
-    def test_get_llm_provider_leaves_anthropic_mantle_api_base_for_sigv4(
-        self, monkeypatch
-    ):
+    def test_get_llm_provider_leaves_anthropic_mantle_api_base_for_sigv4(self, monkeypatch):
         monkeypatch.delenv("BEDROCK_MANTLE_API_BASE", raising=False)
 
         resolved_model, provider, dynamic_api_key, api_base = litellm.get_llm_provider(
@@ -763,3 +707,52 @@ class TestBedrockMantleWireFormatDispatch:
         assert resolved_model == "anthropic.claude-mythos-preview"
         assert api_base is None
         assert dynamic_api_key is None
+
+    def test_anthropic_mantle_ignores_openai_base_env_end_to_end(self, monkeypatch):
+        """Regression: a single BEDROCK_MANTLE_API_BASE pointing at the
+        OpenAI-compatible surface must not leak onto the Anthropic path. The
+        unified completion dispatch used to apply that env to every model, so an
+        Anthropic Mantle call appended the messages path to the OpenAI base and
+        signed https://.../openai/v1/anthropic/v1/messages. The Anthropic surface
+        must instead derive its own regional messages endpoint."""
+        monkeypatch.setenv(
+            "BEDROCK_MANTLE_API_BASE",
+            "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
+        )
+
+        requests = []
+
+        def mock_post(self, url, data=None, headers=None, **kwargs):
+            requests.append(str(url))
+            return httpx.Response(
+                status_code=200,
+                json={
+                    "id": "msg_test",
+                    "type": "message",
+                    "role": "assistant",
+                    "model": "anthropic.claude-mythos-preview",
+                    "content": [{"type": "text", "text": "ok"}],
+                    "stop_reason": "end_turn",
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 1, "output_tokens": 1},
+                },
+                request=httpx.Request("POST", url),
+            )
+
+        with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+            response = litellm.completion(
+                model="bedrock_mantle/anthropic.claude-mythos-preview",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=10,
+                aws_access_key_id="fake-key",
+                aws_secret_access_key="fake-secret",
+                aws_region_name="us-east-1",
+            )
+
+        assert response.choices[0].message.content == "ok"
+        assert len(requests) == 1
+        signed_url = httpx.URL(requests[0])
+        assert signed_url.path == "/anthropic/v1/messages"
+        assert "/openai/v1" not in requests[0]
+        assert signed_url.host.startswith("bedrock-mantle.")
+        assert signed_url.host.endswith(".api.aws")

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -715,6 +715,9 @@ class TestBedrockMantleWireFormatDispatch:
         Anthropic Mantle call appended the messages path to the OpenAI base and
         signed https://.../openai/v1/anthropic/v1/messages. The Anthropic surface
         must instead derive its own regional messages endpoint."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "c2VjcmV0LXRlc3Qtc2VjcmV0LXRlc3Qtc2VjcmV0")
+        monkeypatch.setenv("AWS_REGION", "us-east-2")
         monkeypatch.setenv(
             "BEDROCK_MANTLE_API_BASE",
             "https://bedrock-mantle.us-east-2.api.aws/openai/v1",
@@ -744,9 +747,6 @@ class TestBedrockMantleWireFormatDispatch:
                 model="bedrock_mantle/anthropic.claude-mythos-preview",
                 messages=[{"role": "user", "content": "hello"}],
                 max_tokens=10,
-                aws_access_key_id="fake-key",
-                aws_secret_access_key="fake-secret",
-                aws_region_name="us-east-1",
             )
 
         assert response.choices[0].message.content == "ok"


### PR DESCRIPTION
## Relevant issues

Follow-up to #31478 (the UI-only fix that stops listing `bedrock_mantle/*` under the plain Bedrock provider). This PR addresses the underlying architecture so the split makes sense end to end.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Why this is a draft

The Anthropic-format Mantle surface only hosts `anthropic.claude-mythos-preview`, a gated research-preview model whose access AWS revoked on 2026-06-12 for export-control compliance, so I cannot produce the usual live-proxy curl proof against a real Anthropic Mantle call. The change is therefore covered by unit tests that pin the routing and endpoint selection, and I am opening it as a draft for design review before it goes further. The OpenAI-compatible Mantle path (the live one) is exercised end to end and unchanged.

## Screenshots / Proof of Fix

Routing is verified by unit tests (no live Mythos access; see above). The dispatch resolves as expected for both wire formats:

```
ProviderConfigManager._get_bedrock_mantle_config("anthropic.claude-mythos-preview") -> AmazonMantleConfig
ProviderConfigManager._get_bedrock_mantle_config("openai.gpt-5.5")                  -> BedrockMantleChatConfig

get_complete_url(anthropic.claude-mythos-preview) -> https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages
get_llm_provider("bedrock_mantle/openai.gpt-5.5") api_base -> https://bedrock-mantle.us-east-1.api.aws/openai/v1
```

## Type

🧹 Refactoring

## Changes

The Mantle endpoint (`bedrock-mantle.{region}.api.aws`) hosts two wire formats: an OpenAI-compatible surface (`openai.*`, `google.*`) and the Anthropic Messages surface (`anthropic.*`, e.g. `anthropic.claude-mythos-preview`). Before this PR those were split across two providers, so the OpenAI-compatible models lived under `bedrock_mantle` while the Anthropic ones were only reachable via the `bedrock/mantle/` route. That is what put "mantle" under two different providers in the first place.

This makes `bedrock_mantle` own the whole endpoint and treats the wire format as an internal routing detail keyed off the AWS vendor namespace. `mantle_uses_anthropic_messages` resolves the format from the `anthropic.*` prefix (the literal identifier AWS uses to decide which sub-API a model lives behind, so unlike a family substring it cannot drift from the model), and `ProviderConfigManager._get_bedrock_mantle_config` dispatches to `AmazonMantleConfig` for Anthropic models and `BedrockMantleChatConfig` otherwise. The same dispatch is threaded through `map_openai_params`, `get_supported_openai_params`, and the `get_llm_provider` api_base derivation, so an Anthropic Mantle model is signed for SigV4 and sent to `/anthropic/v1/messages` rather than the OpenAI-compatible base.

The existing `bedrock/mantle/...` route is left intact for backward compatibility.

Tests live in `tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py` and assert the namespace helper, the config dispatch, the resolved Anthropic Messages endpoint, and that `get_llm_provider` leaves the api_base unset for the SigV4 Anthropic path. They fail on the pre-refactor behavior (which always resolved `BedrockMantleChatConfig` and the OpenAI-compatible base) and pass after it.

One thing worth a reviewer's eye: `_complete_bedrock_mantle` merges `BedrockMantleChatConfig.get_config()` class defaults into `optional_params` regardless of model. It is empty in practice today, but if Anthropic-specific defaults are ever added there they would leak onto the OpenAI path or vice versa, so the per-model config is the better long-term home for those.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core completion routing and AWS SigV4 URL selection for `bedrock_mantle`; OpenAI-compatible Mantle behavior is intended to stay the same, but Anthropic-namespace routing is new and was previously easy to misconfigure via shared env defaults.
> 
> **Overview**
> **Unifies Bedrock Mantle under `bedrock_mantle`** by routing on the AWS vendor namespace instead of splitting Anthropic models behind a separate provider path.
> 
> Adds **`mantle_uses_anthropic_messages`** (`anthropic.*` → Anthropic Messages API) and **`ProviderConfigManager._get_bedrock_mantle_config`**, which picks **`AmazonMantleConfig`** vs **`BedrockMantleChatConfig`**. That dispatch is wired through param mapping, supported OpenAI params, provider chat config, and **`get_llm_provider`** (OpenAI-compatible **`api_base`** is only derived for non-Anthropic models).
> 
> **`_complete_bedrock_mantle`** no longer always applies **`BEDROCK_MANTLE_API_BASE`** and OpenAI chat defaults for every model, fixing a regression where Anthropic Mantle calls could hit malformed URLs like `.../openai/v1/anthropic/v1/messages` when the OpenAI base env was set.
> 
> New tests cover namespace routing, config selection, the **`/anthropic/v1/messages`** endpoint, and the end-to-end env regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f7ff66845d4607c0038b5553fcdc32d01e85ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->