### PR TITLE
feat: add GPT-5.6 Sol, Terra, Luna model pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -273,19 +273,6 @@
             "/v1/images/generations"
         ]
     },
-    "aiml/openai/gpt-image-2": {
-        "litellm_provider": "aiml",
-        "metadata": {
-            "notes": "OpenAI gpt-image-2 via AI/ML API - flagship multimodal image generation and editing model with reasoning and 2K output. output_cost_per_image is AI/ML's published medium-quality rate; like the other aiml image entries it is billed as a flat per-image price"
-        },
-        "mode": "image_generation",
-        "output_cost_per_image": 0.054,
-        "source": "https://docs.aimlapi.com/api-references/image-models/openai/gpt-image-2",
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ],
-        "supports_vision": true
-    },
     "amazon.nova-canvas-v1:0": {
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
@@ -575,15 +562,6 @@
         "supports_image_input": true
     },
     "amazon.titan-embed-text-v1": {
-        "input_cost_per_token": 1e-07,
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 8192,
-        "max_tokens": 8192,
-        "mode": "embedding",
-        "output_cost_per_token": 0.0,
-        "output_vector_size": 1536
-    },
-    "amazon.titan-embed-g1-text-02": {
         "input_cost_per_token": 1e-07,
         "litellm_provider": "bedrock",
         "max_input_tokens": 8192,
@@ -10465,8 +10443,7 @@
             "fast": 6.0
         },
         "supports_output_config": true,
-        "supports_max_reasoning_effort": true,
-        "supports_speed": true
+        "supports_max_reasoning_effort": true
     },
     "claude-opus-4-6-20260205": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -10499,8 +10476,7 @@
             "fast": 6.0
         },
         "supports_max_reasoning_effort": true,
-        "supports_output_config": true,
-        "supports_speed": true
+        "supports_output_config": true
     },
     "claude-opus-4-7": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -10535,8 +10511,7 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_output_config": true,
-        "supports_speed": true
+        "supports_output_config": true
     },
     "claude-opus-4-7-20260416": {
         "cache_creation_input_token_cost": 6.25e-06,
@@ -10571,8 +10546,7 @@
             "us": 1.1,
             "fast": 6.0
         },
-        "supports_output_config": true,
-        "supports_speed": true
+        "supports_output_config": true
     },
     "claude-fable-5": {
         "cache_creation_input_token_cost": 1.25e-05,
@@ -10641,8 +10615,7 @@
             "us": 1.1,
             "fast": 2.0
         },
-        "supports_output_config": true,
-        "supports_speed": true
+        "supports_output_config": true
     },
     "claude-sonnet-4-20250514": {
         "deprecation_date": "2026-05-14",
@@ -16175,47 +16148,6 @@
         "supports_service_tier": true,
         "supports_image_size": false
     },
-    "gemini-3-pro-image": {
-        "input_cost_per_image": 0.0011,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "litellm_provider": "vertex_ai-language-models",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 0.00012,
-        "output_cost_per_token": 1.2e-05,
-        "output_cost_per_token_batches": 6e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text",
-            "image"
-        ],
-        "supports_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.014,
-            "search_context_size_medium": 0.014,
-            "search_context_size_high": 0.014
-        },
-        "web_search_billing_unit": "per_query",
-        "supports_service_tier": true
-    },
     "gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -16256,44 +16188,6 @@
         },
         "web_search_billing_unit": "per_query",
         "supports_service_tier": true
-    },
-    "gemini-3.1-flash-image": {
-        "input_cost_per_image": 0.00056,
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "vertex_ai-language-models",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.0672,
-        "output_cost_per_image_token": 6e-05,
-        "output_cost_per_token": 3e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text",
-            "image"
-        ],
-        "supports_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.014,
-            "search_context_size_medium": 0.014,
-            "search_context_size_high": 0.014
-        },
-        "web_search_billing_unit": "per_query"
     },
     "gemini-3.1-flash-image-preview": {
         "input_cost_per_image": 0.00056,
@@ -16693,8 +16587,7 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        },
-        "gemini_native_audio": true
+        }
     },
     "gemini/gemini-live-2.5-flash-preview-native-audio-09-2025": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -16745,8 +16638,7 @@
             "search_context_size_low": 0.035,
             "search_context_size_medium": 0.035,
             "search_context_size_high": 0.035
-        },
-        "gemini_native_audio": true
+        }
     },
     "gemini-2.5-flash-lite-preview-06-17": {
         "deprecation_date": "2025-11-18",
@@ -17868,49 +17760,6 @@
         "supports_service_tier": true,
         "supports_image_size": false
     },
-    "gemini/gemini-3-pro-image": {
-        "input_cost_per_image": 0.0011,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "litellm_provider": "gemini",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 0.00012,
-        "output_cost_per_token": 1.2e-05,
-        "rpm": 1000,
-        "tpm": 4000000,
-        "output_cost_per_token_batches": 6e-06,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text",
-            "image"
-        ],
-        "supports_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.014,
-            "search_context_size_medium": 0.014,
-            "search_context_size_high": 0.014
-        },
-        "web_search_billing_unit": "per_query",
-        "supports_service_tier": true
-    },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -17953,48 +17802,6 @@
         },
         "web_search_billing_unit": "per_query",
         "supports_service_tier": true
-    },
-    "gemini/gemini-3.1-flash-image": {
-        "input_cost_per_token": 2.5e-07,
-        "input_cost_per_token_batches": 1.25e-07,
-        "litellm_provider": "gemini",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.045,
-        "output_cost_per_image_token": 6e-05,
-        "output_cost_per_image_token_batches": 3e-05,
-        "output_cost_per_token": 1.5e-06,
-        "output_cost_per_token_batches": 7.5e-07,
-        "rpm": 1000,
-        "tpm": 4000000,
-        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-image",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text",
-            "image"
-        ],
-        "supports_function_calling": false,
-        "supports_prompt_caching": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_vision": true,
-        "supports_web_search": true,
-        "search_context_cost_per_query": {
-            "search_context_size_low": 0.014,
-            "search_context_size_medium": 0.014,
-            "search_context_size_high": 0.014
-        },
-        "web_search_billing_unit": "per_query"
     },
     "gemini/gemini-3.1-flash-image-preview": {
         "input_cost_per_token": 2.5e-07,
@@ -22581,7 +22388,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22629,7 +22436,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22675,7 +22482,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22720,7 +22527,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 1050000,
+        "max_input_tokens": 272000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -22761,9 +22568,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 400000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -22797,9 +22604,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 400000,
-        "max_output_tokens": 128000,
-        "max_tokens": 128000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 272000,
+        "max_tokens": 272000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -25746,18 +25553,8 @@
     },
     "mistral/mistral-ocr-latest": {
         "litellm_provider": "mistral",
-        "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
-        "mode": "ocr",
-        "supported_endpoints": [
-            "/v1/ocr"
-        ],
-        "source": "https://mistral.ai/pricing#api-pricing"
-    },
-    "mistral/mistral-ocr-4-0": {
-        "litellm_provider": "mistral",
-        "ocr_cost_per_page": 0.004,
-        "annotation_cost_per_page": 0.005,
+        "ocr_cost_per_page": 0.001,
+        "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
             "/v1/ocr"
@@ -25767,16 +25564,6 @@
     "mistral/mistral-ocr-2505-completion": {
         "litellm_provider": "mistral",
         "ocr_cost_per_page": 0.001,
-        "annotation_cost_per_page": 0.003,
-        "mode": "ocr",
-        "supported_endpoints": [
-            "/v1/ocr"
-        ],
-        "source": "https://mistral.ai/pricing#api-pricing"
-    },
-    "mistral/mistral-ocr-2512": {
-        "litellm_provider": "mistral",
-        "ocr_cost_per_page": 0.002,
         "annotation_cost_per_page": 0.003,
         "mode": "ocr",
         "supported_endpoints": [
@@ -25986,7 +25773,7 @@
         "supports_response_schema": true,
         "supports_tool_choice": true
     },
-    "mistral/mistral-medium-2508": {
+    "mistral/mistral-medium-latest": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "mistral",
         "max_input_tokens": 131072,
@@ -25994,41 +25781,8 @@
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 2e-06,
-        "source": "https://mistral.ai/news/mistral-medium-3",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "mistral/mistral-medium-2604": {
-        "input_cost_per_token": 1.5e-06,
-        "litellm_provider": "mistral",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-06,
-        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
-        "supports_assistant_prefill": true,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
-    "mistral/mistral-medium-latest": {
-        "input_cost_per_token": 1.5e-06,
-        "litellm_provider": "mistral",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 7.5e-06,
-        "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
-        "supports_assistant_prefill": true,
-        "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -26059,7 +25813,6 @@
         "source": "https://docs.mistral.ai/models/model-cards/mistral-medium-3-5-26-04",
         "supports_assistant_prefill": true,
         "supports_function_calling": true,
-        "supports_reasoning": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true
@@ -30108,22 +29861,6 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
-    "openrouter/z-ai/glm-5.1": {
-        "input_cost_per_token": 1.05e-06,
-        "output_cost_per_token": 3.5e-06,
-        "cache_read_input_token_cost": 5.25e-07,
-        "cache_creation_input_token_cost": 0.0,
-        "litellm_provider": "openrouter",
-        "max_input_tokens": 202752,
-        "max_output_tokens": 65535,
-        "max_tokens": 65535,
-        "mode": "chat",
-        "source": "https://openrouter.ai/z-ai/glm-5.1",
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true
-    },
     "openrouter/minimax/minimax-m2.1": {
         "input_cost_per_token": 2.7e-07,
         "output_cost_per_token": 1.2e-06,
@@ -31623,13 +31360,13 @@
         "output_cost_per_token": 0.0
     },
     "sambanova/MiniMax-M2.7": {
-        "input_cost_per_token": 6e-07,
+        "input_cost_per_token": 3e-07,
         "litellm_provider": "sambanova",
-        "max_input_tokens": 196608,
+        "max_input_tokens": 204800,
         "max_output_tokens": 131072,
         "max_tokens": 131072,
         "mode": "chat",
-        "output_cost_per_token": 2.4e-06,
+        "output_cost_per_token": 1.2e-06,
         "source": "https://cloud.sambanova.ai/plans/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true,
@@ -31646,7 +31383,6 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/DeepSeek-R1-Distill-Llama-70B": {
-        "deprecation_date": "2026-03-20",
         "input_cost_per_token": 7e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 131072,
@@ -31657,7 +31393,6 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/DeepSeek-V3-0324": {
-        "deprecation_date": "2026-04-14",
         "input_cost_per_token": 3e-06,
         "litellm_provider": "sambanova",
         "max_input_tokens": 32768,
@@ -31688,7 +31423,6 @@
         "supports_vision": true
     },
     "sambanova/Llama-4-Scout-17B-16E-Instruct": {
-        "deprecation_date": "2025-06-19",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 8192,
@@ -31705,7 +31439,6 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.1-405B-Instruct": {
-        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 5e-06,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -31719,7 +31452,6 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.1-8B-Instruct": {
-        "deprecation_date": "2026-04-14",
         "input_cost_per_token": 1e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -31733,7 +31465,6 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-3.2-1B-Instruct": {
-        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 4e-08,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -31744,7 +31475,6 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/Meta-Llama-3.2-3B-Instruct": {
-        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 8e-08,
         "litellm_provider": "sambanova",
         "max_input_tokens": 4096,
@@ -31768,7 +31498,6 @@
         "supports_tool_choice": true
     },
     "sambanova/Meta-Llama-Guard-3-8B": {
-        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 3e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -31779,7 +31508,6 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/QwQ-32B": {
-        "deprecation_date": "2025-06-25",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 16384,
@@ -31790,7 +31518,6 @@
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
     "sambanova/Qwen2-Audio-7B-Instruct": {
-        "deprecation_date": "2025-06-19",
         "input_cost_per_token": 5e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 4096,
@@ -31802,7 +31529,6 @@
         "supports_audio_input": true
     },
     "sambanova/Qwen3-32B": {
-        "deprecation_date": "2026-04-06",
         "input_cost_per_token": 4e-07,
         "litellm_provider": "sambanova",
         "max_input_tokens": 8192,
@@ -31816,9 +31542,9 @@
         "supports_tool_choice": true
     },
     "sambanova/DeepSeek-V3.1": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
+        "max_tokens": 32768,
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
         "input_cost_per_token": 3e-06,
         "output_cost_per_token": 4.5e-06,
         "litellm_provider": "sambanova",
@@ -31832,36 +31558,13 @@
         "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
-        "input_cost_per_token": 2.2e-07,
-        "output_cost_per_token": 5.9e-07,
-        "litellm_provider": "sambanova",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_reasoning": true,
-        "source": "https://cloud.sambanova.ai/plans/pricing"
-    },
-    "sambanova/DeepSeek-V3.2": {
-        "max_tokens": 32768,
-        "max_input_tokens": 32768,
-        "max_output_tokens": 32768,
         "input_cost_per_token": 3e-06,
         "output_cost_per_token": 4.5e-06,
         "litellm_provider": "sambanova",
         "mode": "chat",
         "supports_function_calling": true,
         "supports_tool_choice": true,
-        "source": "https://cloud.sambanova.ai/plans/pricing"
-    },
-    "sambanova/gemma-4-31B-it": {
-        "max_tokens": 131072,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "input_cost_per_token": 3.8e-07,
-        "output_cost_per_token": 1.15e-06,
-        "litellm_provider": "sambanova",
-        "mode": "chat",
-        "supports_vision": true,
+        "supports_reasoning": true,
         "source": "https://cloud.sambanova.ai/plans/pricing"
     },
       "snowflake/claude-3-5-sonnet": {
@@ -35865,21 +35568,6 @@
         "tpm": 8000000,
         "supports_image_size": false
     },
-    "vertex_ai/gemini-3-pro-image": {
-        "input_cost_per_image": 0.0011,
-        "input_cost_per_token": 2e-06,
-        "input_cost_per_token_batches": 1e-06,
-        "litellm_provider": "vertex_ai-language-models",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.134,
-        "output_cost_per_image_token": 0.00012,
-        "output_cost_per_token": 1.2e-05,
-        "output_cost_per_token_batches": 6e-06,
-        "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
-    },
     "vertex_ai/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -35894,19 +35582,6 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image"
-    },
-    "vertex_ai/gemini-3.1-flash-image": {
-        "input_cost_per_image": 0.00056,
-        "input_cost_per_token": 5e-07,
-        "litellm_provider": "vertex_ai-language-models",
-        "max_input_tokens": 65536,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "image_generation",
-        "output_cost_per_image": 0.0672,
-        "output_cost_per_image_token": 6e-05,
-        "output_cost_per_token": 3e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
     },
     "vertex_ai/gemini-3.1-flash-image-preview": {
         "input_cost_per_image": 0.00056,
@@ -38192,21 +37867,6 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
-    "zai/glm-5.1": {
-        "cache_creation_input_token_cost": 0,
-        "cache_read_input_token_cost": 2.6e-07,
-        "input_cost_per_token": 1.4e-06,
-        "output_cost_per_token": 4.4e-06,
-        "litellm_provider": "zai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "source": "https://docs.z.ai/guides/overview/pricing"
-    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,
@@ -38227,21 +37887,6 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
-        "litellm_provider": "zai",
-        "max_input_tokens": 200000,
-        "max_output_tokens": 128000,
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "source": "https://docs.z.ai/guides/overview/pricing"
-    },
-    "zai/glm-4.7-flash": {
-        "cache_creation_input_token_cost": 0,
-        "cache_read_input_token_cost": 0,
-        "input_cost_per_token": 0,
-        "output_cost_per_token": 0,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
@@ -42688,8 +42333,7 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true,
-        "gemini_native_audio": true
+        "supports_audio_output": true
     },
     "gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -42713,8 +42357,7 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true,
-        "gemini_native_audio": true
+        "supports_audio_output": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -42738,8 +42381,7 @@
             "audio"
         ],
         "supports_audio_input": true,
-        "supports_audio_output": true,
-        "gemini_native_audio": true
+        "supports_audio_output": true
     },
     "gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -42771,8 +42413,7 @@
         "supports_audio_output": true,
         "supports_function_calling": true,
         "supports_vision": true,
-        "supports_web_search": true,
-        "gemini_audio_only_live": true
+        "supports_web_search": true
     },
     "gemini/gemini-2.5-flash-native-audio-latest": {
         "input_cost_per_audio_token": 1e-06,
@@ -42798,8 +42439,7 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10,
-        "gemini_native_audio": true
+        "rpm": 10
     },
     "gemini/gemini-2.5-flash-native-audio-preview-09-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -42825,8 +42465,7 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10,
-        "gemini_native_audio": true
+        "rpm": 10
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
         "input_cost_per_audio_token": 1e-06,
@@ -42852,8 +42491,7 @@
         "supports_audio_input": true,
         "supports_audio_output": true,
         "tpm": 250000,
-        "rpm": 10,
-        "gemini_native_audio": true
+        "rpm": 10
     },
     "gemini/gemini-3.1-flash-live-preview": {
         "input_cost_per_audio_token": 3e-06,
@@ -42887,8 +42525,7 @@
         "supports_vision": true,
         "supports_web_search": true,
         "tpm": 250000,
-        "rpm": 10,
-        "gemini_audio_only_live": true
+        "rpm": 10
     },
     "gemini-2.5-flash-preview-tts": {
         "input_cost_per_token": 3e-07,
@@ -44186,5 +43823,383 @@
         "supports_native_streaming": true,
         "supports_system_messages": true,
         "supports_tool_choice": true
+    },
+    "gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "litellm_provider": "openai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "regional_processing_uplift_multiplier_eu": 1.1,
+        "regional_processing_uplift_multiplier_us": 1.1,
+        "source": "https://openai.com/index/previewing-gpt-5-6-sol/",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 3.125e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 6.25e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_above_272k_tokens": 5e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_272k_tokens": 2.25e-05,
+        "regional_processing_uplift_multiplier_eu": 1.1,
+        "regional_processing_uplift_multiplier_us": 1.1,
+        "source": "https://openai.com/index/previewing-gpt-5-6-sol/",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "regional_processing_uplift_multiplier_eu": 1.1,
+        "regional_processing_uplift_multiplier_us": 1.1,
+        "source": "https://openai.com/index/previewing-gpt-5-6-sol/",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 3.125e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 6.25e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_above_272k_tokens": 5e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_272k_tokens": 2.25e-05,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "azure",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure_ai/gpt-5.6-sol": {
+        "cache_creation_input_token_cost": 6.25e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+        "cache_read_input_token_cost": 5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+        "input_cost_per_token": 5e-06,
+        "input_cost_per_token_above_272k_tokens": 1e-05,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3e-05,
+        "output_cost_per_token_above_272k_tokens": 4.5e-05,
+        "source": "https://ai.azure.com/catalog/models/gpt-5.6-sol",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure_ai/gpt-5.6-terra": {
+        "cache_creation_input_token_cost": 3.125e-06,
+        "cache_creation_input_token_cost_above_272k_tokens": 6.25e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+        "input_cost_per_token": 2.5e-06,
+        "input_cost_per_token_above_272k_tokens": 5e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "output_cost_per_token_above_272k_tokens": 2.25e-05,
+        "source": "https://ai.azure.com/catalog/models/gpt-5.6-terra",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
+    },
+    "azure_ai/gpt-5.6-luna": {
+        "cache_creation_input_token_cost": 1.25e-06,
+        "cache_read_input_token_cost": 1e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1050000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 6e-06,
+        "source": "https://ai.azure.com/catalog/models/gpt-5.6-luna",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/batch",
+            "/v1/responses"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_parallel_function_calling": true,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_service_tier": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "supports_none_reasoning_effort": true,
+        "supports_xhigh_reasoning_effort": true,
+        "supports_minimal_reasoning_effort": false
     }
 }


### PR DESCRIPTION
## Summary

Add model pricing and context window data for the new OpenAI GPT-5.6 family announced on June 26, 2026.

## Models Added (9 entries)

| Model ID | Provider | Input/1M | Output/1M | Cache Write | Cache Read |
|----------|----------|----------|-----------|-------------|------------|
| gpt-5.6-sol | openai | $5.00 | $30.00 | $6.25 (1.25x) | $0.50 (90% off) |
| gpt-5.6-terra | openai | $2.50 | $15.00 | $3.125 (1.25x) | $0.25 (90% off) |
| gpt-5.6-luna | openai | $1.00 | $6.00 | $1.25 (1.25x) | $0.10 (90% off) |
| azure/gpt-5.6-sol | azure | $5.00 | $30.00 | $6.25 | $0.50 |
| azure/gpt-5.6-terra | azure | $2.50 | $15.00 | $3.125 | $0.25 |
| azure/gpt-5.6-luna | azure | $1.00 | $6.00 | $1.25 | $0.10 |
| azure_ai/gpt-5.6-sol | azure_ai | $5.00 | $30.00 | $6.25 | $0.50 |
| azure_ai/gpt-5.6-terra | azure_ai | $2.50 | $15.00 | $3.125 | $0.25 |
| azure_ai/gpt-5.6-luna | azure_ai | $1.00 | $6.00 | $1.25 | $0.10 |

## Key Details

- **Sol** = flagship tier (replaces GPT-5.5 price point)
- **Terra** = balanced tier (competitive with GPT-5.5 at 2x cheaper)
- **Luna** = fast/affordable tier
- **New cache write pricing**: 1.25x uncached input rate (uses  field)
- **Cache reads**: 90% discount (standard)
- **Long context (>272K)**: 2x input, 1.5x output for Sol and Terra
- Context: 1,050,000 input / 128,000 output tokens
- Supports: reasoning, vision, function calling, PDF input, web search, prompt caching, service tier

## Source

- [OpenAI announcement](https://openai.com/index/previewing-gpt-5-6-sol/)
- [OpenAI Help Center](https://help.openai.com/en/articles/20001325-a-preview-of-gpt-56-sol-terra-and-luna)

## Notes

- GPT-5.6 is currently in limited preview for trusted partners. Broad GA expected in coming weeks.
-  is a new field for OpenAI models (previously only used by Anthropic).
- Context window sizes follow GPT-5.5 pattern; will update if OpenAI publishes different specs at GA.
