### PR TITLE
fix(websearch): wrap agentic loop response in fake stream for streaming requests

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5507,12 +5507,20 @@ class BaseLLMHTTPHandler:
     def _maybe_wrap_in_fake_stream(
         self,
         response: Any,
-        logging_obj: "LiteLLMLoggingObj",
+        logging_obj: Optional["LiteLLMLoggingObj"],
+        api_surface: str,
     ) -> Any:
         """
         If the original request was streaming but converted to non-streaming for
         WebSearch interception, wrap the dict response in a FakeAnthropicMessagesStreamIterator.
+
+        The converted-stream flag is only ever set by anthropic-messages websearch
+        interception, and the wrapper rebuilds an Anthropic SSE stream, so wrapping
+        is gated on ``api_surface == "anthropic_messages"`` to leave other surfaces
+        (e.g. the responses API) untouched.
         """
+        if api_surface != "anthropic_messages":
+            return response
         websearch_converted_stream = (
             logging_obj.model_call_details.get(
                 "websearch_interception_converted_stream", False
@@ -5633,7 +5641,9 @@ class BaseLLMHTTPHandler:
                         stream=stream,
                         kwargs=kwargs_with_provider,
                     )
-                    return self._maybe_wrap_in_fake_stream(agentic_result, logging_obj)
+                    return self._maybe_wrap_in_fake_stream(
+                        agentic_result, logging_obj, api_surface
+                    )
 
                 plan = await callback.async_build_agentic_loop_plan(
                     tools=tool_calls,
@@ -5649,7 +5659,7 @@ class BaseLLMHTTPHandler:
 
                 if plan.response_override is not None:
                     return self._maybe_wrap_in_fake_stream(
-                        plan.response_override, logging_obj
+                        plan.response_override, logging_obj, api_surface
                     )
                 if plan.terminate:
                     verbose_logger.debug(
@@ -5657,7 +5667,9 @@ class BaseLLMHTTPHandler:
                         callback.__class__.__name__,
                         plan.stop_reason,
                     )
-                    return self._maybe_wrap_in_fake_stream(response, logging_obj)
+                    return self._maybe_wrap_in_fake_stream(
+                        response, logging_obj, api_surface
+                    )
                 if not plan.run_agentic_loop:
                     continue
 
@@ -5691,6 +5703,7 @@ class BaseLLMHTTPHandler:
                         callback=callback,
                     ),
                     logging_obj,
+                    api_surface,
                 )
             except Exception as e:
                 _call_id = getattr(logging_obj, "litellm_call_id", "unknown")
@@ -5707,7 +5720,7 @@ class BaseLLMHTTPHandler:
         # 1. Stream was originally True but converted to False for WebSearch interception
         # 2. No agentic loop ran (LLM didn't use the tool)
         # 3. We have a non-streaming response that needs to be converted to streaming
-        result = self._maybe_wrap_in_fake_stream(response, logging_obj)
+        result = self._maybe_wrap_in_fake_stream(response, logging_obj, api_surface)
         if result is not response:
             return result
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5504,6 +5504,42 @@ class BaseLLMHTTPHandler:
             **kwargs_for_followup,
         )
 
+    def _maybe_wrap_in_fake_stream(
+        self,
+        response: Any,
+        logging_obj: "LiteLLMLoggingObj",
+    ) -> Any:
+        """
+        If the original request was streaming but converted to non-streaming for
+        WebSearch interception, wrap the dict response in a FakeAnthropicMessagesStreamIterator.
+        """
+        websearch_converted_stream = (
+            logging_obj.model_call_details.get(
+                "websearch_interception_converted_stream", False
+            )
+            if logging_obj is not None
+            else False
+        )
+        if websearch_converted_stream and isinstance(response, dict):
+            from typing import cast
+
+            from litellm._logging import verbose_logger
+            from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+                FakeAnthropicMessagesStreamIterator,
+            )
+            from litellm.types.llms.anthropic_messages.anthropic_response import (
+                AnthropicMessagesResponse,
+            )
+
+            verbose_logger.debug(
+                "WebSearchInterception: Agentic loop completed, "
+                "converting non-streaming response to fake stream"
+            )
+            return FakeAnthropicMessagesStreamIterator(
+                response=cast(AnthropicMessagesResponse, response)
+            )
+        return response
+
     async def _call_agentic_completion_hooks(
         self,
         response: Any,
@@ -5586,7 +5622,7 @@ class BaseLLMHTTPHandler:
                     is not CustomLogger.async_build_agentic_loop_plan
                 )
                 if not build_plan_overridden:
-                    return await callback.async_run_agentic_loop(
+                    agentic_result = await callback.async_run_agentic_loop(
                         tools=tool_calls,
                         model=model,
                         messages=messages,
@@ -5597,6 +5633,7 @@ class BaseLLMHTTPHandler:
                         stream=stream,
                         kwargs=kwargs_with_provider,
                     )
+                    return self._maybe_wrap_in_fake_stream(agentic_result, logging_obj)
 
                 plan = await callback.async_build_agentic_loop_plan(
                     tools=tool_calls,
@@ -5611,14 +5648,16 @@ class BaseLLMHTTPHandler:
                 )
 
                 if plan.response_override is not None:
-                    return plan.response_override
+                    return self._maybe_wrap_in_fake_stream(
+                        plan.response_override, logging_obj
+                    )
                 if plan.terminate:
                     verbose_logger.debug(
                         "Agentic loop terminated by callback=%s reason=%s",
                         callback.__class__.__name__,
                         plan.stop_reason,
                     )
-                    return response
+                    return self._maybe_wrap_in_fake_stream(response, logging_obj)
                 if not plan.run_agentic_loop:
                     continue
 
@@ -5636,19 +5675,22 @@ class BaseLLMHTTPHandler:
                         callback=callback,
                     )
 
-                return await self._execute_anthropic_agentic_plan(
-                    plan=plan,
-                    model=model,
-                    messages=messages,
-                    anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
-                    logging_obj=logging_obj,
-                    kwargs=kwargs_with_provider,
-                    depth=depth,
-                    max_loops=max_loops,
-                    fingerprints=fingerprints,
-                    fingerprint=fingerprint,
-                    stream=stream,
-                    callback=callback,
+                return self._maybe_wrap_in_fake_stream(
+                    await self._execute_anthropic_agentic_plan(
+                        plan=plan,
+                        model=model,
+                        messages=messages,
+                        anthropic_messages_optional_request_params=anthropic_messages_optional_request_params,
+                        logging_obj=logging_obj,
+                        kwargs=kwargs_with_provider,
+                        depth=depth,
+                        max_loops=max_loops,
+                        fingerprints=fingerprints,
+                        fingerprint=fingerprint,
+                        stream=stream,
+                        callback=callback,
+                    ),
+                    logging_obj,
                 )
             except Exception as e:
                 _call_id = getattr(logging_obj, "litellm_call_id", "unknown")
@@ -5665,37 +5707,9 @@ class BaseLLMHTTPHandler:
         # 1. Stream was originally True but converted to False for WebSearch interception
         # 2. No agentic loop ran (LLM didn't use the tool)
         # 3. We have a non-streaming response that needs to be converted to streaming
-        websearch_converted_stream = (
-            logging_obj.model_call_details.get(
-                "websearch_interception_converted_stream", False
-            )
-            if logging_obj is not None
-            else False
-        )
-
-        if api_surface == "anthropic_messages" and websearch_converted_stream:
-            from typing import cast
-
-            from litellm._logging import verbose_logger
-            from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
-                FakeAnthropicMessagesStreamIterator,
-            )
-            from litellm.types.llms.anthropic_messages.anthropic_response import (
-                AnthropicMessagesResponse,
-            )
-
-            verbose_logger.debug(
-                "WebSearchInterception: No tool call made, converting non-streaming response to fake stream"
-            )
-
-            # Convert the non-streaming response to a fake stream
-            # The response should be an AnthropicMessagesResponse (dict)
-            if isinstance(response, dict):
-                # Create a fake streaming iterator
-                fake_stream = FakeAnthropicMessagesStreamIterator(
-                    response=cast(AnthropicMessagesResponse, response)
-                )
-                return fake_stream
+        result = self._maybe_wrap_in_fake_stream(response, logging_obj)
+        if result is not response:
+            return result
 
         return None
 

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for _maybe_wrap_in_fake_stream in BaseLLMHTTPHandler.
+
+Tests that agentic loop responses are correctly wrapped in
+FakeAnthropicMessagesStreamIterator when the original request was streaming.
+"""
+
+from unittest.mock import MagicMock
+
+
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+    FakeAnthropicMessagesStreamIterator,
+)
+
+
+class TestMaybeWrapInFakeStream:
+    def setup_method(self):
+        self.handler = BaseLLMHTTPHandler()
+
+    def test_wraps_dict_when_converted_stream_flag_is_true(self):
+        """When websearch_interception_converted_stream is True and response is dict, wrap it."""
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "websearch_interception_converted_stream": True
+        }
+        response = {
+            "id": "msg_123",
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    def test_returns_response_unchanged_when_flag_is_false(self):
+        """When flag is False, return response as-is."""
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "websearch_interception_converted_stream": False
+        }
+        response = {"id": "msg_123", "content": []}
+
+        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+
+        assert result is response
+
+    def test_returns_response_unchanged_when_not_dict(self):
+        """When response is not a dict (e.g., already a stream), return as-is."""
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "websearch_interception_converted_stream": True
+        }
+        response = MagicMock()  # Not a dict
+
+        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+
+        assert result is response
+
+    def test_returns_response_when_logging_obj_is_none(self):
+        """When logging_obj is None, return response as-is."""
+        response = {"id": "msg_123", "content": []}
+
+        result = self.handler._maybe_wrap_in_fake_stream(response, None)
+
+        assert result is response

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
@@ -1,17 +1,54 @@
 """
-Unit tests for _maybe_wrap_in_fake_stream in BaseLLMHTTPHandler.
+Unit tests for fake-stream wrapping of agentic loop responses in
+BaseLLMHTTPHandler.
 
 Tests that agentic loop responses are correctly wrapped in
-FakeAnthropicMessagesStreamIterator when the original request was streaming.
+FakeAnthropicMessagesStreamIterator when the original request was streaming
+but converted to non-streaming for WebSearch interception.
 """
 
 from unittest.mock import MagicMock
 
+import pytest
 
+from litellm.integrations.custom_logger import CustomLogger
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
     FakeAnthropicMessagesStreamIterator,
 )
+from litellm.types.integrations.custom_logger import AgenticLoopPlan
+
+
+def _anthropic_response() -> dict:
+    return {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "hello"}],
+        "stop_reason": "end_turn",
+        "usage": {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+def _converted_stream_logging_obj(callback: CustomLogger) -> MagicMock:
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {"websearch_interception_converted_stream": True}
+    logging_obj.dynamic_success_callbacks = [callback]
+    return logging_obj
+
+
+async def _run_hooks(handler: BaseLLMHTTPHandler, logging_obj: MagicMock):
+    return await handler._call_agentic_completion_hooks(
+        response=_anthropic_response(),
+        model="claude-3-5-sonnet",
+        messages=[{"role": "user", "content": "search the web"}],
+        anthropic_messages_provider_config=MagicMock(),
+        anthropic_messages_optional_request_params={},
+        logging_obj=logging_obj,
+        stream=True,
+        custom_llm_provider="anthropic",
+        kwargs={},
+    )
 
 
 class TestMaybeWrapInFakeStream:
@@ -24,16 +61,10 @@ class TestMaybeWrapInFakeStream:
         logging_obj.model_call_details = {
             "websearch_interception_converted_stream": True
         }
-        response = {
-            "id": "msg_123",
-            "type": "message",
-            "role": "assistant",
-            "content": [{"type": "text", "text": "hello"}],
-            "stop_reason": "end_turn",
-            "usage": {"input_tokens": 10, "output_tokens": 5},
-        }
 
-        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+        result = self.handler._maybe_wrap_in_fake_stream(
+            _anthropic_response(), logging_obj, "anthropic_messages"
+        )
 
         assert isinstance(result, FakeAnthropicMessagesStreamIterator)
 
@@ -45,7 +76,9 @@ class TestMaybeWrapInFakeStream:
         }
         response = {"id": "msg_123", "content": []}
 
-        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+        result = self.handler._maybe_wrap_in_fake_stream(
+            response, logging_obj, "anthropic_messages"
+        )
 
         assert result is response
 
@@ -57,7 +90,9 @@ class TestMaybeWrapInFakeStream:
         }
         response = MagicMock()  # Not a dict
 
-        result = self.handler._maybe_wrap_in_fake_stream(response, logging_obj)
+        result = self.handler._maybe_wrap_in_fake_stream(
+            response, logging_obj, "anthropic_messages"
+        )
 
         assert result is response
 
@@ -65,6 +100,113 @@ class TestMaybeWrapInFakeStream:
         """When logging_obj is None, return response as-is."""
         response = {"id": "msg_123", "content": []}
 
-        result = self.handler._maybe_wrap_in_fake_stream(response, None)
+        result = self.handler._maybe_wrap_in_fake_stream(
+            response, None, "anthropic_messages"
+        )
 
         assert result is response
+
+    def test_does_not_wrap_for_non_anthropic_surface(self):
+        """Even with the flag set and a dict response, leave non-anthropic surfaces untouched."""
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "websearch_interception_converted_stream": True
+        }
+
+        result = self.handler._maybe_wrap_in_fake_stream(
+            _anthropic_response(), logging_obj, "responses"
+        )
+
+        assert isinstance(result, dict)
+
+
+class _LegacyAgenticCallback(CustomLogger):
+    """Triggers the agentic loop via the legacy async_run_agentic_loop path."""
+
+    async def async_should_run_agentic_loop(
+        self, response, model, messages, tools, stream, custom_llm_provider, kwargs
+    ):
+        return True, {"tool_calls": [{"name": "web_search"}]}
+
+    async def async_run_agentic_loop(
+        self,
+        tools,
+        model,
+        messages,
+        response,
+        anthropic_messages_provider_config,
+        anthropic_messages_optional_request_params,
+        logging_obj,
+        stream,
+        kwargs,
+    ):
+        return _anthropic_response()
+
+
+class _PlanAgenticCallback(CustomLogger):
+    """Drives the plan-based paths by returning a caller-supplied plan."""
+
+    def __init__(self, plan: AgenticLoopPlan):
+        self._plan = plan
+
+    async def async_should_run_agentic_loop(
+        self, response, model, messages, tools, stream, custom_llm_provider, kwargs
+    ):
+        return True, {"tool_calls": [{"name": "web_search"}]}
+
+    async def async_build_agentic_loop_plan(
+        self,
+        tools,
+        model,
+        messages,
+        response,
+        anthropic_messages_provider_config,
+        anthropic_messages_optional_request_params,
+        logging_obj,
+        stream,
+        kwargs,
+    ):
+        return self._plan
+
+
+class TestCallAgenticCompletionHooksWrapping:
+    """Regression tests: every agentic-loop return path must wrap the dict
+    response in a fake stream when the request was a converted stream."""
+
+    def setup_method(self):
+        self.handler = BaseLLMHTTPHandler()
+
+    @pytest.mark.asyncio
+    async def test_legacy_run_agentic_loop_path_wraps(self):
+        logging_obj = _converted_stream_logging_obj(_LegacyAgenticCallback())
+
+        result = await _run_hooks(self.handler, logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    @pytest.mark.asyncio
+    async def test_response_override_path_wraps(self):
+        plan = AgenticLoopPlan(response_override=_anthropic_response())
+        logging_obj = _converted_stream_logging_obj(_PlanAgenticCallback(plan))
+
+        result = await _run_hooks(self.handler, logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    @pytest.mark.asyncio
+    async def test_terminate_path_wraps(self):
+        plan = AgenticLoopPlan(terminate=True, stop_reason="done")
+        logging_obj = _converted_stream_logging_obj(_PlanAgenticCallback(plan))
+
+        result = await _run_hooks(self.handler, logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    @pytest.mark.asyncio
+    async def test_legacy_path_not_wrapped_without_flag(self):
+        logging_obj = _converted_stream_logging_obj(_LegacyAgenticCallback())
+        logging_obj.model_call_details = {}
+
+        result = await _run_hooks(self.handler, logging_obj)
+
+        assert isinstance(result, dict)

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py
@@ -169,6 +169,14 @@ class _PlanAgenticCallback(CustomLogger):
         return self._plan
 
 
+class _StubExecuteHandler(BaseLLMHTTPHandler):
+    """Handler whose agentic-plan execution is stubbed to a dict so the
+    _execute_anthropic_agentic_plan return path can be exercised in isolation."""
+
+    async def _execute_anthropic_agentic_plan(self, **kwargs):
+        return _anthropic_response()
+
+
 class TestCallAgenticCompletionHooksWrapping:
     """Regression tests: every agentic-loop return path must wrap the dict
     response in a fake stream when the request was a converted stream."""
@@ -196,6 +204,24 @@ class TestCallAgenticCompletionHooksWrapping:
     @pytest.mark.asyncio
     async def test_terminate_path_wraps(self):
         plan = AgenticLoopPlan(terminate=True, stop_reason="done")
+        logging_obj = _converted_stream_logging_obj(_PlanAgenticCallback(plan))
+
+        result = await _run_hooks(self.handler, logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    @pytest.mark.asyncio
+    async def test_anthropic_plan_execution_path_wraps(self):
+        plan = AgenticLoopPlan(run_agentic_loop=True)
+        logging_obj = _converted_stream_logging_obj(_PlanAgenticCallback(plan))
+
+        result = await _run_hooks(_StubExecuteHandler(), logging_obj)
+
+        assert isinstance(result, FakeAnthropicMessagesStreamIterator)
+
+    @pytest.mark.asyncio
+    async def test_tail_path_wraps_when_no_loop_runs(self):
+        plan = AgenticLoopPlan(run_agentic_loop=False)
         logging_obj = _converted_stream_logging_obj(_PlanAgenticCallback(plan))
 
         result = await _run_hooks(self.handler, logging_obj)


### PR DESCRIPTION
## Relevant issues

Copy of #27449 by @vokako, re-targeted onto an internal branch so it can run through CircleCI. Original authorship is preserved on the commit

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Fully end to end against a live proxy with real web search, no mocks. A proxy runs `websearch_interception` on the `anthropic` provider wired to a real Tavily `search_tools` backend, then a streaming `/v1/messages` request whose prompt forces the model to call `web_search`, so the agentic loop runs a real search and synthesizes a grounded answer. The only thing that changes between before and after is how that final answer is framed back to the client: one JSON body, or an SSE stream

Setup is identical for before and after (any configured `search_provider` works; Tavily shown here):

```bash
cat > config.yaml <<'YAML'
model_list:
  - model_name: anthropic-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

search_tools:
  - search_tool_name: tavily-search
    litellm_params:
      search_provider: tavily
      api_key: os.environ/TAVILY_API_KEY

general_settings:
  master_key: sk-1234

litellm_settings:
  callbacks: ["websearch_interception"]
  websearch_interception_params:
    enabled_providers: ["anthropic"]
    search_tool_name: tavily-search
YAML

litellm --config config.yaml --port 4000
```

Reproduction request (streaming, native `web_search` tool, prompt forces a tool call so the agentic loop runs):

```bash
curl -sS -N -D /tmp/headers.txt -o /tmp/body.txt \
  -X POST http://localhost:4000/v1/messages \
  -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{
        "model": "anthropic-haiku-4-5",
        "max_tokens": 1024,
        "stream": true,
        "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 3}],
        "messages": [{"role": "user", "content": "Use the web_search tool to find who won the 2022 FIFA World Cup, then tell me. You must call web_search."}]
      }'

grep -i '^content-type' /tmp/headers.txt
grep -cE '^(event|data):' /tmp/body.txt   # how many SSE lines came back
```

### Before (on `litellm_internal_staging`, without this PR)

The real Tavily search runs and the model answers (note the live `web_search_result` citations), but the whole thing comes back as a single JSON body with `content-type: application/json`, so an SSE client reads zero events

```text
$ grep -i '^content-type' /tmp/headers.txt
content-type: application/json

$ grep -cE '^(event|data):' /tmp/body.txt
0

$ cat /tmp/body.txt
{"model":"anthropic-haiku-4-5","id":"msg_01Nx...","type":"message","role":"assistant",
 "content":[{"type":"web_search_tool_result","tool_use_id":"toolu_01AL...","content":[
     {"type":"web_search_result","url":"https://en.wikipedia.org/wiki/2022_FIFA_World_Cup","title":"2022 FIFA World Cup - Wikipedia"},
     {"type":"web_search_result","url":"https://www.fifa.com/en/tournaments/mens/worldcup/qatar2022","title":"..."}]},
   {"type":"text","text":"... Argentina won the 2022 FIFA World Cup ..."}],
 "stop_reason":"end_turn","usage":{"input_tokens":3170,"output_tokens":119}}
```

### After (with this PR)

Same request, same real search, but the response is re-wrapped as an Anthropic SSE stream with `content-type: text/event-stream` and the grounded answer streams as `text_delta` events

```text
$ grep -i '^content-type' /tmp/headers.txt
content-type: text/event-stream; charset=utf-8

$ grep -cE '^(event|data):' /tmp/body.txt
14

$ cat /tmp/body.txt
event: message_start
data: {"type": "message_start", "message": {"id": "msg_01Cx...", "role": "assistant", "model": "claude-haiku-4-5", "usage": {"input_tokens": 3170, "output_tokens": 0}}}

event: content_block_start
data: {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}}

event: content_block_delta
data: {"type": "content_block_delta", "index": 1, "delta": {"type": "text_delta", "text": "**Argentina** won the 2022 FIFA World Cup! They defeated France in the final on December 18, 2022, in Qatar ... 4-2 on penalty kicks ... Lionel Messi's first World Cup championship."}}

event: content_block_stop
data: {"type": "content_block_stop", "index": 1}

event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence": null}}

event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 3170, "output_tokens": 118}}
```

## Type

🐛 Bug Fix

## Changes

When `websearch_interception` is enabled and a client sends a streaming request via `/v1/messages`, the handler converts `stream=True` to `stream=False` internally to execute the search. After the agentic loop completes, the non-streaming dict response was returned directly to the client expecting SSE events, resulting in empty streams

In `_call_agentic_completion_hooks()`, the `FakeAnthropicMessagesStreamIterator` wrapping previously only ran when no agentic loop executed. When the agentic loop did run, the return paths returned the dict directly without wrapping

This adds a `_maybe_wrap_in_fake_stream()` helper that checks the `websearch_interception_converted_stream` flag and wraps dict responses in `FakeAnthropicMessagesStreamIterator`, applied to all return paths in `_call_agentic_completion_hooks` (`async_run_agentic_loop`, `_execute_anthropic_agentic_plan`, `plan.response_override`, and `plan.terminate`)

The helper is gated on `api_surface == "anthropic_messages"`; the converted-stream flag is only ever set by anthropic-messages websearch interception and the wrapper rebuilds an Anthropic SSE stream, so other surfaces (e.g. the responses API) are left untouched on every return path. `logging_obj` is typed `Optional` to match the `None` call sites

This copy resolves merge conflicts against `litellm_internal_staging`; the base had since added a `responses` API-surface path, which is kept intact while the anthropic_messages path gets the fake-stream wrapping

Tests drive the helper across all branches and additionally exercise the legacy, `response_override`, and `terminate` return paths of `_call_agentic_completion_hooks` end to end, asserting the dict response is wrapped only when the converted-stream flag is set on the anthropic_messages surface

Files touched: `litellm/llms/custom_httpx/llm_http_handler.py` and `tests/test_litellm/integrations/websearch_interception/test_websearch_streaming_wrap.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agentic completion hook return behavior for Anthropic messages and websearch interception; scope is narrow (gated flag + surface) but affects streaming contract for clients using that path.
> 
> **Overview**
> Fixes **empty SSE streams** when websearch interception runs an agentic loop on `/v1/messages` requests that were originally `stream=True` but forced to non-streaming internally.
> 
> Introduces **`_maybe_wrap_in_fake_stream()`** on `BaseLLMHTTPHandler`, which reads `websearch_interception_converted_stream` on the logging object and, for **`api_surface == "anthropic_messages"`** dict responses, returns a **`FakeAnthropicMessagesStreamIterator`** instead of the raw message dict.
> 
> That helper is now applied on **every exit path** from **`_call_agentic_completion_hooks`** (legacy `async_run_agentic_loop`, plan `response_override`, `terminate`, `_execute_anthropic_agentic_plan`, and the no-loop tail), replacing logic that only wrapped when no agentic loop ran. Non-anthropic surfaces (e.g. responses API) are unchanged.
> 
> Adds **`test_websearch_streaming_wrap.py`** covering the helper branches and hook return paths with and without the converted-stream flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec6c87eeebc29329b624b2a15de8c748762b7cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
