### PR TITLE
fix(passthrough): schedule spend logging via durable logging worker

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -37,6 +37,7 @@ from litellm._uuid import uuid
 from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.base_llm.managed_resources.utils import (
     resolve_passthrough_managed_id_provider,
@@ -1310,8 +1311,8 @@ async def pass_through_request(
         ## LOG SUCCESS
         passthrough_logging_payload["response_body"] = response_body
         end_time = datetime.now()
-        asyncio.create_task(
-            pass_through_endpoint_logging.pass_through_async_success_handler(
+        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+            async_coroutine=pass_through_endpoint_logging.pass_through_async_success_handler(
                 httpx_response=response,
                 response_body=response_body,
                 url_route=str(url),
@@ -2153,8 +2154,8 @@ async def websocket_passthrough_request(
             mock_response = MockWebSocketResponse(target)
 
             # Use the same success handler as HTTP passthrough endpoints
-            asyncio.create_task(
-                pass_through_endpoint_logging.pass_through_async_success_handler(
+            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+                async_coroutine=pass_through_endpoint_logging.pass_through_async_success_handler(
                     httpx_response=mock_response,  # type: ignore
                     response_body=websocket_messages,  # type: ignore
                     url_route=endpoint or "",

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime
 from typing import List, Optional, Tuple
 
@@ -7,6 +6,7 @@ import httpx
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy._types import PassThroughEndpointLoggingResultValues
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
 from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointType
@@ -92,8 +92,8 @@ class PassThroughStreamingHandler:
             if not logging_scheduled and raw_bytes:
                 logging_scheduled = True
                 try:
-                    asyncio.create_task(
-                        PassThroughStreamingHandler._route_streaming_logging_to_handler(
+                    GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+                        async_coroutine=PassThroughStreamingHandler._route_streaming_logging_to_handler(
                             litellm_logging_obj=litellm_logging_obj,
                             passthrough_success_handler_obj=passthrough_success_handler_obj,
                             url_route=url_route,

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.proxy.pass_through_endpoints.streaming_handler import (
     PassThroughStreamingHandler,
 )
@@ -118,6 +119,91 @@ async def test_chunk_processor_does_not_schedule_logging_when_no_chunks():
 
     assert received == []
     mock_route.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_routes_logging_through_logging_worker():
+    """The spend-log coroutine must be handed to the durable logging worker, which
+    keeps a strong reference and drains on shutdown, instead of a bare
+    asyncio.create_task that the event loop only weak-references and can drop
+    under GC/load, silently losing the SpendLogs row for a successful call."""
+    chunks = [b"chunk-1", b"chunk-2"]
+    response = _make_streaming_response(chunks)
+
+    enqueued = []
+
+    def _capture(async_coroutine):
+        enqueued.append(async_coroutine)
+        async_coroutine.close()
+
+    with (
+        patch.object(
+            PassThroughStreamingHandler,
+            "_route_streaming_logging_to_handler",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            GLOBAL_LOGGING_WORKER,
+            "ensure_initialized_and_enqueue",
+            side_effect=_capture,
+        ) as mock_enqueue,
+    ):
+        received = []
+        async for chunk in PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "claude-3-haiku"},
+            litellm_logging_obj=MagicMock(),
+            endpoint_type=EndpointType.GENERIC,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/bedrock/model/claude/invoke-with-response-stream",
+        ):
+            received.append(chunk)
+
+    assert received == chunks
+    mock_enqueue.assert_called_once()
+    assert asyncio.iscoroutine(enqueued[0])
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_routes_logging_through_logging_worker_on_disconnect():
+    """Even when the client disconnects mid-stream, the partial-usage log must go
+    through the durable logging worker rather than a droppable bare task."""
+    chunks = [b"event-1", b"event-2", b"event-3"]
+    response = _make_streaming_response(chunks)
+
+    enqueued = []
+
+    def _capture(async_coroutine):
+        enqueued.append(async_coroutine)
+        async_coroutine.close()
+
+    with (
+        patch.object(
+            PassThroughStreamingHandler,
+            "_route_streaming_logging_to_handler",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            GLOBAL_LOGGING_WORKER,
+            "ensure_initialized_and_enqueue",
+            side_effect=_capture,
+        ) as mock_enqueue,
+    ):
+        gen = PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "claude-3-haiku"},
+            litellm_logging_obj=MagicMock(),
+            endpoint_type=EndpointType.GENERIC,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=MagicMock(),
+            url_route="/bedrock/model/claude/invoke-with-response-stream",
+        )
+        await gen.__anext__()
+        await gen.aclose()
+
+    mock_enqueue.assert_called_once()
+    assert asyncio.iscoroutine(enqueued[0])
 
 
 def test_convert_raw_bytes_survives_truncated_multibyte_sequence():


### PR DESCRIPTION
## Relevant issues

Investigation of a flaky vertex pass-through e2e test (the one that polls `/spend/logs?request_id=<x-litellm-call-id>` for a costed row and often times out at 240s even though the write should take seconds)

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

This is a logging-durability fix; the cleanest live proof is to drive a real pass-through call through a proxy on localhost:4000 and confirm the SpendLogs row lands, hitting a real provider so it costs real money. With a Gemini key configured for the `/gemini` pass-through route:

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Send a native Gemini pass-through call and capture the call id

```
CALL_ID=$(curl -sS -D /dev/stderr -o /tmp/resp.json \
  -X POST "http://localhost:4000/gemini/v1beta/models/gemini-2.5-flash:generateContent" \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"parts":[{"text":"Say hello in one word"}]}]}' \
  2>&1 1>/dev/null | tr -d '\r' | awk -F': ' 'tolower($1)=="x-litellm-call-id"{print $2}')
echo "call_id=$CALL_ID"
```

3. A couple seconds later, confirm a costed row exists for that call id

```
curl -sS "http://localhost:4000/spend/logs?request_id=$CALL_ID" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[0] | {request_id, call_type, model, spend, status}'
```

Expect `call_type: "pass_through_endpoint"`, the gemini model, `spend > 0`, and `status: "success"`. Repeat the loop a few dozen times in a `for` loop to confirm the row shows up every time rather than intermittently going missing.

## Type

🐛 Bug Fix

## Changes

Pass-through success logging was scheduled with a bare `asyncio.create_task(...)` whose return value is discarded, in three places: the non-streaming HTTP path (`pass_through_endpoints.py`), the streaming finally-block (`streaming_handler.py`), and the vertex live websocket path. The asyncio event loop keeps only a weak reference to such tasks, so under GC or load pressure the task can be collected before it finishes writing the SpendLogs row. The request then returns 2xx to the caller while its spend log silently never gets written. This is the most likely cause of the flaky vertex pass-through e2e test, and a rare but real source of unbilled pass-through spend in prod.

Worth being precise about the blast radius: for pass-through, the budget/cost increment rides in the same dispatched success-logging callback as the SpendLogs row (it dispatches to `_PROXY_track_cost_callback` -> `db_spend_update_writer.update_database`, which both writes the row and bumps key/team/user spend). So a dropped task loses both the audit row and the aggregate spend; the cost never even reaches the durable spend queue. Normal (non-pass-through) completions are unaffected because their callback is awaited inline and reliably enters that durable queue; pass-through is exactly the path that lacked that guarantee.

The fix routes those coroutines through `GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(...)`, the same async logging worker the SDK completion path already uses (`litellm/utils.py`, `caching_handler.py`). The worker keeps a strong reference to each in-flight task in its `_running_tasks` set and drains on shutdown via `flush`/`stop`/`clear_queue` plus an `atexit` handler, so the spend write can no longer be dropped mid-flight.

### Tradeoffs

This deliberately reuses the existing best-effort worker rather than building a new durable-delivery path, so the pros and cons are worth being explicit about.

Pros. It fixes the GC-drop without changing the non-blocking behavior pass-through wants, since the caller's response is still returned before logging runs. It inherits real shutdown draining instead of losing in-flight tasks on process exit. It bounds concurrency and applies a per-coroutine timeout, so a stuck log can't pile up unbounded. And it follows an established in-repo pattern (the same `_running_tasks` + `add_done_callback(discard)` shape used by `LoggingWorker` and the akto guardrail) rather than hand-rolling another bespoke task set that would need its own shutdown drain to be correct.

Cons. The logging worker is explicitly best-effort with a bounded queue, so under sustained overload it aggressively clears and can still drop logs; this turns a guaranteed-drop-under-GC into a much-less-likely drop-under-overload, but it is not at-least-once delivery. It also swallows per-task exceptions internally, so this does not fix the separate issue where a failing cost-calc / payload-build in the pass-through handlers logs-and-returns and the row never gets queued; that silent-swallow path is worth a follow-up. And pass-through spend logging now shares the process-global worker's queue and concurrency budget with all other async callback logging, so their backpressure is coupled.

Truly durable at-least-once spend logging (persist-before-return outbox + reconciler keyed on `request_id`) would be a larger, separate change; this PR is the minimal fix for the actual flake and the GC-drop behind it.

### Tests

Added two regression tests to `test_streaming_handler_interrupt.py` asserting that `chunk_processor` hands its logging coroutine to `GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue` (rather than a bare task), on both normal completion and client-disconnect. Both fail against the pre-fix `asyncio.create_task` code (`ensure_initialized_and_enqueue` called 0 times) and pass after the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing/audit paths for pass-through only; behavior stays async and non-blocking but now shares the global worker’s bounded queue and overload behavior with other logging.
> 
> **Overview**
> Pass-through **success/spend logging** no longer uses discarded `asyncio.create_task` calls. Those coroutines are enqueued on **`GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue`**, matching the SDK completion path so in-flight log tasks keep strong references and can drain on shutdown.
> 
> **Scope:** non-streaming HTTP success logging, streaming `chunk_processor` finally-block (including client disconnect), and Vertex live **WebSocket** success logging.
> 
> **Tests:** two regressions assert streaming logging is enqueued on the worker for normal completion and mid-stream disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d702ce69a62fc7030488c751190333bb313ca0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->