### PR TITLE
fix(exceptions): stop leaking stack traces / internal file paths in API error responses (#30948)

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -207,6 +207,15 @@ redact_user_api_key_info: Optional[bool] = False
 # major release; opt in early with `litellm.expose_router_debug_in_errors
 # = False`.
 expose_router_debug_in_errors: bool = True
+# When True, unmapped / connection errors append the captured Python
+# traceback (absolute file paths, line numbers, internal call stack) onto
+# the exception message that is surfaced to API clients via
+# ProxyException.message. This is an information-disclosure leak (CWE-209) -
+# see https://github.com/BerriAI/litellm/issues/30948. Defaults to False so
+# the traceback stays in the server-side logs only. Set to True to restore
+# the legacy behavior of returning the traceback in the error response
+# (https://github.com/BerriAI/litellm/issues/4201).
+expose_traceback_in_errors: bool = False
 filter_invalid_headers: Optional[bool] = False
 add_user_information_to_llm_headers: Optional[bool] = (
     None  # adds user_id, team_id, token hash (params from StandardLoggingMetadata) to request headers

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -28,6 +28,36 @@ from ..exceptions import (
 )
 
 
+def _build_client_error_message(base_message: str) -> str:
+    """
+    Build the client-facing message for an unmapped / connection error.
+
+    Python tracebacks include absolute file paths, line numbers, and the
+    proxy's internal call stack. Returning them in the API error response
+    (surfaced to clients via ProxyException.message) is an
+    information-disclosure leak (CWE-209) -
+    see https://github.com/BerriAI/litellm/issues/30948.
+
+    By default the (secret-redacted) traceback is written to the server-side
+    logs only and kept out of the response, while the human-useful error
+    message is preserved for the client. Set
+    ``litellm.expose_traceback_in_errors = True`` to restore the legacy
+    behavior of appending the traceback to the message
+    (https://github.com/BerriAI/litellm/issues/4201).
+    """
+    redacted_traceback = _redact_string(traceback.format_exc())
+    if litellm.expose_traceback_in_errors:
+        return "{}\n{}".format(base_message, redacted_traceback)
+
+    # Keep full debugging detail server-side without leaking it to the client.
+    # Surfaces in logs when `litellm._turn_on_debug()` is enabled.
+    verbose_logger.debug(
+        "litellm.exception_type: suppressed traceback in client response:\n%s",
+        redacted_traceback,
+    )
+    return base_message
+
+
 class ExceptionCheckers:
     """
     Helper class for checking various error conditions in exception strings.
@@ -2045,7 +2075,7 @@ def _map_azure_exception(
     else:
         # if no status code then it is an APIConnectionError: https://github.com/openai/openai-python#handling-errors
         raise APIConnectionError(
-            message=f"{exception_provider} APIConnectionError - {message}\n{_redact_string(traceback.format_exc())}",
+            message=_build_client_error_message(f"{exception_provider} APIConnectionError - {message}"),
             llm_provider="azure",
             model=model,
             litellm_debug_info=extra_information,
@@ -2469,10 +2499,7 @@ def exception_type(  # type: ignore
                 )
             else:
                 raise APIConnectionError(
-                    message="{}\n{}".format(
-                        str(original_exception),
-                        _redact_string(traceback.format_exc()),
-                    ),
+                    message=_build_client_error_message(str(original_exception)),
                     llm_provider=custom_llm_provider,
                     model=model,
                     request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),  # stub the request
@@ -2498,10 +2525,7 @@ def exception_type(  # type: ignore
                     setattr(e, "litellm_response_headers", litellm_response_headers)
                     raise e  # it's already mapped
             raised_exc = APIConnectionError(
-                message="{}\n{}".format(
-                    original_exception,
-                    _redact_string(traceback.format_exc()),
-                ),
+                message=_build_client_error_message(str(original_exception)),
                 llm_provider="",
                 model="",
             )

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -626,3 +626,70 @@ def test_replicate_422_maps_to_unprocessable_entity():
         )
 
     assert excinfo.value.llm_provider == "replicate"
+
+
+class TestTracebackNotLeakedToClient:
+    """
+    Regression tests for https://github.com/BerriAI/litellm/issues/30948
+
+    An unmapped provider exception (e.g. the Vertex/Gemini "Invalid Message
+    passed in" error triggered by a bad ``role``) was surfaced to API
+    clients with the full Python traceback - absolute file paths, line
+    numbers, and the proxy's internal call stack - embedded in the error
+    message. That is a CWE-209 information-disclosure leak.
+
+    By default the traceback must stay out of the client-facing message
+    (it is logged server-side instead) while the useful error text is
+    preserved. ``litellm.expose_traceback_in_errors = True`` restores the
+    legacy behavior (https://github.com/BerriAI/litellm/issues/4201).
+    """
+
+    _BAD_ROLE_ERROR = (
+        "Invalid Message passed in - {'role': 'admin', 'content': 'test'}. "
+        "File an issue https://github.com/BerriAI/litellm/issues"
+    )
+
+    def _map_unmapped_exception(self):
+        """Reproduce the real flow: raise, catch, and map from inside the
+        ``except`` block so traceback.format_exc() captures a real
+        traceback with file paths (as it would in production)."""
+        try:
+            raise Exception(self._BAD_ROLE_ERROR)
+        except Exception as e:  # noqa: BLE001
+            exception_type(
+                model="gemini/gemini-2.5-flash",
+                original_exception=e,
+                custom_llm_provider="vertex_ai",
+            )
+
+    def test_traceback_not_leaked_to_client_by_default(self):
+        prev = litellm.expose_traceback_in_errors
+        litellm.expose_traceback_in_errors = False
+        try:
+            with pytest.raises(litellm.APIConnectionError) as excinfo:
+                self._map_unmapped_exception()
+        finally:
+            litellm.expose_traceback_in_errors = prev
+
+        message = excinfo.value.message
+        # Useful, non-sensitive detail is preserved for the client.
+        assert "Invalid Message passed in" in message
+        # No stack trace / internal file paths leak to the client.
+        assert "Traceback (most recent call last)" not in message
+        assert "exception_mapping_utils.py" not in message
+        assert "site-packages" not in message
+        assert '.py", line' not in message
+
+    def test_traceback_exposed_when_explicitly_opted_in(self):
+        prev = litellm.expose_traceback_in_errors
+        litellm.expose_traceback_in_errors = True
+        try:
+            with pytest.raises(litellm.APIConnectionError) as excinfo:
+                self._map_unmapped_exception()
+        finally:
+            litellm.expose_traceback_in_errors = prev
+
+        message = excinfo.value.message
+        assert "Invalid Message passed in" in message
+        # Legacy opt-in behavior (#4201) is still available for debugging.
+        assert "Traceback (most recent call last)" in message


### PR DESCRIPTION
## What
Closes #30948. Chat-completion error responses no longer leak Python stack traces or internal filesystem paths to API callers.

## Root cause
For *unmapped* provider exceptions (e.g. Vertex/Gemini's "Invalid Message passed in" raised by an unexpected message `role`), `exception_type()` and `_map_azure_exception()` appended `traceback.format_exc()` to the `APIConnectionError` **message**. That message is returned to clients via `ProxyException.message`, so a `POST /v1/chat/completions` caller received the full traceback including `/usr/lib/.../site-packages/litellm/...` paths — a CWE-209 information-disclosure leak. `_redact_string` only scrubs secrets, not file paths, so the paths leaked through.

## Fix
- New helper `_build_client_error_message()` keeps the human-useful error text in the response and writes the (secret-redacted) traceback to server-side logs only (`verbose_logger.debug`, surfaced via `litellm._turn_on_debug()`).
- Applied at all three traceback-in-message fallback sites (`_map_azure_exception` no-status fallback; the generic unmapped-exception fallback; the mapping-failure handler).
- The legacy #4201 behavior (traceback in the message, handy for SDK debugging) is preserved behind a new opt-in flag `litellm.expose_traceback_in_errors` (default `False`), mirroring the existing `litellm.expose_router_debug_in_errors` pattern.

## Tests
Adds `TestTracebackNotLeakedToClient` — asserts a triggering error no longer returns a traceback / file path to the client by default, and that the opt-in flag restores it. Target file: 59 passed; adjacent leak/redaction suites: 84 passed.

## Notes
- Targets `litellm_oss_staging` per the external-contribution policy.
- Default-safe choice: unlike `expose_router_debug_in_errors` (default `True`), this flag defaults to `False` because a full stack trace + absolute paths is a clear-cut disclosure with no client value. Happy to flip the default if maintainers prefer strict parity with the router flag.
