### PR TITLE
fix(otel): point AgentOps OTLP exporter at otlp.agentops.ai

### DIFF
--- a/litellm/integrations/otel/presets/agentops.py
+++ b/litellm/integrations/otel/presets/agentops.py
@@ -23,7 +23,7 @@ from litellm.integrations.otel.model.config import (
 )
 from litellm.integrations.otel.plumbing.providers import register_exporter_factory
 
-_AGENTOPS_ENDPOINT = "https://otlp.agentops.cloud/v1/traces"
+_AGENTOPS_ENDPOINT = "https://otlp.agentops.ai/v1/traces"
 _AGENTOPS_AUTH_ENDPOINT = "https://api.agentops.ai/v3/auth/token"
 _AGENTOPS_EXPORTER_KIND = "agentops"
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_presets.py
@@ -151,3 +151,12 @@ def test_fetch_jwt_uses_owned_client_not_shared_pool(monkeypatch):
     result = _fetch_agentops_jwt("api-key")
     assert result == {"token": "jwt-123"}
     assert closed["n"] == 1  # the owned client was closed
+
+
+def test_agentops_endpoint_points_at_live_host():
+    # Regression: the OTLP endpoint must be the resolvable AgentOps host. The
+    # deprecated otlp.agentops.cloud domain no longer resolves (NXDOMAIN), so
+    # spans silently failed to export with a NameResolutionError. Pin the host
+    # so a typo or stale domain can never ship again.
+    assert _AGENTOPS_ENDPOINT == "https://otlp.agentops.ai/v1/traces"
+    assert "agentops.cloud" not in _AGENTOPS_ENDPOINT


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The AgentOps OTLP preset pointed at `https://otlp.agentops.cloud/v1/traces`, which no longer resolves, so spans were dropped before leaving the process

Before, the deprecated domain fails to resolve:

```
$ nslookup otlp.agentops.cloud
** server can't find otlp.agentops.cloud: SERVFAIL
```

and the exporter aborts:

```
urllib3.exceptions.NameResolutionError: HTTPSConnection(host='otlp.agentops.cloud', port=443): Failed to resolve 'otlp.agentops.cloud'
  File ".../litellm/integrations/otel/presets/agentops.py", line 120, in export
requests.exceptions.ConnectionError: ... Max retries exceeded with url: /v1/traces
```

After, the live host is reachable:

```
$ curl -s -o /dev/null -w '%{http_code}\n' https://otlp.agentops.ai/v1/traces
401
```

End to end with the fix: a litellm proxy with `LITELLM_OTEL_V2=true` and `callbacks: ["agentops"]`, hitting a real Anthropic model, exported the full request trace (server span, auth, postgres lookups, guardrail, the LLM call, and the spend write) to AgentOps. The span landed with `service_name=agentops` and a real `ProjectId` in the AgentOps waterfall view; before the fix nothing arrived

## Type

🐛 Bug Fix

## Changes

`_AGENTOPS_ENDPOINT` now points at `https://otlp.agentops.ai/v1/traces` instead of the unresolvable `otlp.agentops.cloud`. The auth host (`api.agentops.ai`) was already correct and is unchanged. Added a regression test pinning the constant to the live host so a stale domain can never ship again
