### PR TITLE
feat(model_prices): add dashscope deepseek-v4-pro and deepseek-v4-flash

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11300,6 +11300,34 @@
         "supports_system_messages": true,
         "supports_tool_choice": false
     },
+    "dashscope/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.38e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 1.38e-07,
+        "input_cost_per_token": 1.65e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 3.301e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "dashscope/qwen-coder": {
         "input_cost_per_token": 3e-07,
         "litellm_provider": "dashscope",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11300,6 +11300,34 @@
         "supports_system_messages": true,
         "supports_tool_choice": false
     },
+    "dashscope/deepseek-v4-flash": {
+        "cache_read_input_token_cost": 2.8e-08,
+        "input_cost_per_token": 1.38e-07,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 2.75e-07,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "dashscope/deepseek-v4-pro": {
+        "cache_read_input_token_cost": 1.38e-07,
+        "input_cost_per_token": 1.65e-06,
+        "litellm_provider": "dashscope",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 393216,
+        "max_tokens": 393216,
+        "mode": "chat",
+        "output_cost_per_token": 3.301e-06,
+        "source": "https://www.alibabacloud.com/help/en/model-studio/models",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "dashscope/qwen-coder": {
         "input_cost_per_token": 3e-07,
         "litellm_provider": "dashscope",


### PR DESCRIPTION
Addresses part of #31408

## Linear ticket

None (first-time external contributor)

## Pre-Submission checklist

- [x] I have added meaningful tests

  No new tests added. This PR only adds two model entries to a data file (`model_prices_and_context_window.json` plus its backup copy). The entries follow the exact schema of neighboring `dashscope/*` entries, and the existing cost calculation tests pass without modification. Adding a Python test that asserts the file contains these two keys would not be a meaningful regression test; it would only re-test the JSON file content. The litellm cost calculator itself is unchanged and exercises every entry at runtime when callers use these models.

  Note that the issue also asks for `dashscope/deepseek-v3.2`, which I have intentionally left out of this PR. That model is scheduled for deprecation on 2026-07-09 (per the [Alibaba Cloud Model Studio docs](https://www.alibabacloud.com/help/en/model-studio/deepseek-api)), so an entry added now would be stale in ~2 weeks. Happy to send a follow-up PR for it if a maintainer wants it included before deprecation.

- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)

  `make lint` is fully green on my end. All six sub-checks pass: format-check, lint-ruff, lint-basedpyright, check-circular-imports, check-import-safety, lint-ruff-budget. Cost-related unit tests pass (21/21). The full `make test-unit` has a pre-existing collection error in this repo where two files share the basename `test_models.py` (`tests/test_litellm/models/test_models.py` and `tests/test_litellm/proxy/client/test_models.py`); this exists on `origin/litellm_internal_staging` HEAD and is unrelated to this PR.

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of 5/5** before requesting a maintainer review

  Greptile issued two reviews: an initial 4/5 with a P1 inline comment, then a revised 5/5 explicitly stating "No specific files require follow-up attention." The P1 was retracted on re-review. For the record, the authoritative source is the Alibaba Cloud Model Studio model table at https://www.alibabacloud.com/help/en/model-studio/text-generation-model (the "Recommended" section), which lists for `deepseek-v4-pro` and `deepseek-v4-flash`: Function Calling = Supported, Thinking mode = Supported, Built-in tools = Supported, Structured output = Unsupported, Batch calling = Unsupported. This matches our entry flags: `supports_function_calling: true`, `supports_tool_choice: true`, `supports_reasoning: true`. `supports_structured_output` and `supports_web_search` are intentionally omitted because 0 of the 36 existing `dashscope/*` entries in this file set either flag, and adding them would break the established dashscope pattern.

## Screenshots / Proof of Fix

This is a data-only change, so no e2e curl/proxy proof is applicable. Validation I ran locally:

```
$ uv run python -c "import json; d = json.load(open('model_prices_and_context_window.json')); print(d['dashscope/deepseek-v4-pro'])"
{'cache_read_input_token_cost': 1.38e-07,
 'input_cost_per_token': 1.65e-06,
 'litellm_provider': 'dashscope',
 'max_input_tokens': 1048576,
 'max_output_tokens': 393216,
 'max_tokens': 393216,
 'mode': 'chat',
 'output_cost_per_token': 3.301e-06,
 'source': 'https://www.alibabacloud.com/help/en/model-studio/models',
 'supports_function_calling': True,
 'supports_reasoning': True,
 'supports_tool_choice': True}

$ uv run pytest tests/test_litellm/test_cost_calculation_log_level.py -v
============================== 2 passed in 0.66s ==============================
```

Both files (`model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`) are updated identically, satisfying `ci_cd/check_files_match.py`. Alphabetical ordering of the `dashscope/` block is preserved.

## Type

Data update (not in the template's type list; closest fit is none of the listed options since this is neither a feature, bug fix, refactor, doc, infra, nor test)

## Changes

Adds two entries to the model registry:

- `dashscope/deepseek-v4-pro` at $1.65 / M input, $3.301 / M output, with cache reads at $0.138 / M
- `dashscope/deepseek-v4-flash` at $0.138 / M input, $0.275 / M output, with cache reads at $0.028 / M

Both models support 1M context, 384K max output, function calling, tool choice, and reasoning. The cache-hit pricing field (`cache_read_input_token_cost`) is already used by ~650 other entries in the file and is wired up in `litellm/types/utils.py`, so no schema change was needed.

USD pricing comes from the Alibaba Cloud Model Studio console for the US (Virginia) region, read directly from the live model detail page. The context window, max output, RPM, and TPM values come from the same console page. Capability flags come from the [public deepseek-api docs page](https://www.alibabacloud.com/help/en/model-studio/deepseek-api).

I excluded `cache_creation_input_cost_per_token` (the write side of context caching) because Alibaba's console exposes the cache-read price but not a separate cache-write price for these two models. If a maintainer knows the cache-write rate from another source, I can add it in a follow-up.