### PR TITLE
fix: strip codex metadata for copilot responses

### DIFF
--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -251,6 +251,22 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
                 message=str(e),
             )
 
+    def _validate_input_param(
+        self, input: Union[str, ResponseInputParam]
+    ) -> Union[str, ResponseInputParam]:
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            filter_value_from_dict,
+        )
+
+        validated_input = super()._validate_input_param(input)
+        if isinstance(validated_input, list):
+            for item in validated_input:
+                if isinstance(item, dict):
+                    filter_value_from_dict(
+                        item, "internal_chat_message_metadata_passthrough"
+                    )
+        return validated_input
+
     def get_complete_url(
         self,
         api_base: Optional[str],

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -320,6 +320,31 @@ class TestGithubCopilotResponsesAPITransformation:
         for param in expected_params:
             assert param in supported, f"{param} should be in supported params"
 
+    def test_transform_request_strips_codex_internal_metadata(self):
+        config = GithubCopilotResponsesAPIConfig()
+        transformed = config.transform_responses_api_request(
+            model="gpt-5.3-codex",
+            input=[
+                {
+                    "role": "user",
+                    "content": "hello",
+                    "internal_chat_message_metadata_passthrough": {"local": True},
+                    "nested": {
+                        "internal_chat_message_metadata_passthrough": "remove-me",
+                        "keep": "value",
+                    },
+                }
+            ],
+            response_api_optional_request_params={"max_output_tokens": 16},
+            litellm_params={},
+            headers={},
+        )
+
+        input_item = transformed["input"][0]
+        assert "internal_chat_message_metadata_passthrough" not in input_item
+        assert "internal_chat_message_metadata_passthrough" not in input_item["nested"]
+        assert input_item["nested"]["keep"] == "value"
+
     def test_handle_reasoning_item_preserves_encrypted_content(self):
         """Test that _handle_reasoning_item preserves encrypted_content for GitHub Copilot.
 


### PR DESCRIPTION
## Relevant issues

Fixes GitHub Copilot Responses requests that include Codex's local `internal_chat_message_metadata_passthrough` field

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the targeted checks listed below
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before this change, a Codex CLI request proxied through LiteLLM to GitHub Copilot Responses could fail because the request body kept a Codex-local field under `input[0].internal_chat_message_metadata_passthrough`. GitHub Copilot rejects that nested field as an unknown parameter

I verified the same request shape against a local LiteLLM proxy on port 4000 with the fix applied:

```text
POST http://127.0.0.1:4000/v1/responses
model: gpt-5.5
input[0].internal_chat_message_metadata_passthrough: {"local":"codex"}

STATUS 200
MODEL gpt-5.5
OUTPUT_TEXT PR-CODEX-METADATA-FIX-OK
```

Targeted local checks:

```text
python -m py_compile litellm/llms/github_copilot/responses/transformation.py tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
python -m pytest tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py -q
37 passed, 2 warnings in 1.49s

uvx --from ruff==0.15.3 ruff check litellm/llms/github_copilot/responses/transformation.py tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
All checks passed!

git diff --check
passed
```

I intentionally did not commit `ruff format` output because it reformats unrelated pre-existing lines in this provider test file and would make this small bug fix harder to review

## Type

Bug Fix
Test

## Changes

This overrides GitHub Copilot's Responses input validation to call the OpenAI base validation, then recursively removes `internal_chat_message_metadata_passthrough` from input message dictionaries before the upstream request is built. The change is limited to the GitHub Copilot Responses provider, so other Responses providers keep their existing behavior

A focused regression test covers the final transformed request body and verifies that the internal field is removed at both the top level and in nested dictionaries while preserving unrelated fields
