### PR TITLE
fix(pass_through): log pre-call guardrail blocks at WARNING, not ERROR with a traceback

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -36,6 +36,7 @@ import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
+from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
@@ -1423,11 +1424,17 @@ async def pass_through_request(
             cache_key=None,
             api_base=str(url._uri_reference) if url else None,
         )
-        verbose_proxy_logger.exception(
-            "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {}".format(
-                str(e)
+        if CustomGuardrail._is_guardrail_intervention(e):
+            verbose_proxy_logger.warning(
+                "pass_through_endpoint: request blocked by guardrail - %s",
+                str(e),
             )
-        )
+        else:
+            verbose_proxy_logger.exception(
+                "litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {}".format(
+                    str(e)
+                )
+            )
 
         #########################################################
         # Monitoring: Trigger post_call_failure_hook

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -3485,3 +3485,137 @@ class TestStaleRouteCleanupOnReload:
         assert InitPassThroughEndpointHelpers.is_registered_pass_through_route(
             "/live-passthrough/some/subpath"
         )
+
+
+# Regression (LIT-3538): a pre-call guardrail block on a passthrough endpoint
+# must be logged at WARNING without a traceback, not as an ERROR with a full
+# stack trace. The generic ``except Exception`` in ``pass_through_request`` used
+# to call ``verbose_proxy_logger.exception(...)`` for every exception, so an
+# intentional guardrail block (which the rest of the codebase already classifies
+# via ``CustomGuardrail._is_guardrail_intervention``) produced scary error noise
+# even though the client correctly receives the 4xx.
+from fastapi import HTTPException as _FastAPIHTTPException
+
+from litellm.exceptions import (
+    BlockedPiiEntityError,
+    GuardrailRaisedException,
+)
+
+_PT_MODULE = "litellm.proxy.pass_through_endpoints.pass_through_endpoints"
+
+
+def _lit3538_user_api_key_dict():
+    d = MagicMock()
+    d.api_key = "sk-test"
+    d.user_id = "user-1"
+    d.team_id = "team-1"
+    d.org_id = None
+    d.metadata = {}
+    d.team_metadata = {}
+    d.parent_otel_span = None
+    d.request_route = "/mock/echo"
+    return d
+
+
+def _lit3538_request():
+    r = MagicMock()
+    r.method = "POST"
+    r.query_params = {}
+    r.url = "http://testserver/mock/echo"
+    r.state = SimpleNamespace()
+    headers = MagicMock()
+    headers.copy.return_value = {}
+    r.headers = headers
+    return r
+
+
+async def _drive_pass_through_block(raised_exception):
+    """Drive the real ``pass_through_request`` so its pre_call_hook raises
+    ``raised_exception``, returning (status_code, logger_mock)."""
+    proxy_logging = MagicMock()
+    proxy_logging.pre_call_hook = AsyncMock(side_effect=raised_exception)
+    proxy_logging.post_call_failure_hook = AsyncMock()
+    proxy_logging.get_proxy_hook = MagicMock(return_value=None)
+
+    logger = MagicMock()
+
+    patches = [
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging),
+        patch(f"{_PT_MODULE}.verbose_proxy_logger", logger),
+        patch(
+            f"{_PT_MODULE}._read_request_body",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        patch(f"{_PT_MODULE}._safe_get_request_headers", return_value={}),
+        patch(
+            "litellm.proxy.pass_through_endpoints.passthrough_guardrails."
+            "PassthroughGuardrailHandler.collect_guardrails",
+            return_value=[],
+        ),
+    ]
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        status_code = None
+        try:
+            await pass_through_request(
+                request=_lit3538_request(),
+                target="https://upstream.example/echo",
+                custom_headers={"Content-Type": "application/json"},
+                user_api_key_dict=_lit3538_user_api_key_dict(),
+                stream=False,
+            )
+        except Exception as e:  # ProxyException carrying the original status
+            status_code = getattr(e, "code", None) or getattr(e, "status_code", None)
+    return status_code, logger
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "guardrail_exception, expected_code",
+    [
+        (
+            GuardrailRaisedException(guardrail_name="g", message="blocked"),
+            400,
+        ),
+        (
+            BlockedPiiEntityError(entity_type="EMAIL", guardrail_name="presidio"),
+            400,
+        ),
+        (
+            _FastAPIHTTPException(
+                status_code=400, detail={"error": "Violated moderation policy"}
+            ),
+            400,
+        ),
+    ],
+)
+async def test_pre_call_guardrail_block_logs_warning_not_exception(
+    guardrail_exception, expected_code
+):
+    status_code, logger = await _drive_pass_through_block(guardrail_exception)
+
+    assert int(status_code) == expected_code
+    assert (
+        logger.exception.call_count == 0
+    ), "guardrail block must not be logged as an ERROR with a traceback"
+    assert (
+        logger.warning.call_count == 1
+    ), "guardrail block must be logged once at WARNING"
+
+
+@pytest.mark.asyncio
+async def test_non_guardrail_exception_still_logs_with_traceback():
+    status_code, logger = await _drive_pass_through_block(
+        RuntimeError("upstream connection reset")
+    )
+
+    assert int(status_code) == 500
+    assert (
+        logger.exception.call_count == 1
+    ), "a genuine failure must still be logged via verbose_proxy_logger.exception"
+    assert (
+        logger.warning.call_count == 0
+    ), "a genuine failure must not be downgraded to WARNING"


### PR DESCRIPTION
## Relevant issues

Resolves LIT-3538

## Linear ticket

LIT-3538

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run a proxy on a pass-through endpoint with a pre-call guardrail that blocks on a trigger word (a ~15-line `CustomGuardrail` whose `async_pre_call_hook` raises a plain `fastapi.HTTPException(400)`, exactly like `_check_moderation_result` in `openai/moderations.py`)

```yaml
guardrails:
  - guardrail_name: "block-demo"
    litellm_params:
      guardrail: block_guardrail.BlockSelfHarmGuardrail
      mode: "pre_call"

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  pass_through_endpoints:
    - path: "/openai-pt/chat/completions"
      target: "https://api.openai.com/v1/chat/completions"
      guardrails: ["block-demo"]
      headers:
        Authorization: "Bearer os.environ/OPENAI_API_KEY"
```

Blocked request (trigger word present), both before and after the fix, returns the same correct 400 to the client

```
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4538/openai-pt/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"BLOCKME I want to hurt myself"}]}'
{"error":{"message":"{'error': 'Violated moderation policy', 'moderation_result': {'violated_categories': ['self-harm']}, 'guardrail_name': 'block-demo', 'guardrail_mode': 'pre_call'}","type":"None","param":"None","code":"400"}}
HTTP 400
```

Before the fix, the proxy log shows an ERROR with a full traceback for what is the guardrail working as designed

```
11:03:42 - LiteLLM Proxy:ERROR: pass_through_endpoints.py:1426 - litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - 400: {'error': 'Violated moderation policy', ...}
Traceback (most recent call last):
  File ".../pass_through_endpoints.py", line 901, in pass_through_request
    _parsed_body = await proxy_logging_obj.pre_call_hook(
  ...
  File ".../block_guardrail.py", line 24, in async_pre_call_hook
    raise HTTPException(
fastapi.exceptions.HTTPException: 400: {'error': 'Violated moderation policy', ...}
```

After the fix, the same block logs once at WARNING with no traceback, and the client still receives the identical 400

```
11:09:28 - LiteLLM Proxy:WARNING: pass_through_endpoints.py:1428 - pass_through_endpoint: request blocked by guardrail - 400: {'error': 'Violated moderation policy', 'moderation_result': {'violated_categories': ['self-harm']}, 'guardrail_name': 'block-demo', 'guardrail_mode': 'pre_call'}
```

A normal request (no trigger word) still passes through to the real provider and returns 200

```
$ curl -s -X POST http://127.0.0.1:4538/openai-pt/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Reply with exactly the word: pong"}],"max_tokens":5}'
# -> assistant content: "pong"  (HTTP 200)
```

## Type

🐛 Bug Fix

## Changes

A pre-call guardrail block on a pass-through endpoint was logged at ERROR level with a full stack trace, even though the guardrail is working as designed and the client correctly receives the 4xx. The generic `except Exception` in `pass_through_request` logged every exception via `verbose_proxy_logger.exception(...)`, so an intentional block produced misleading traceback noise for an operator tailing logs

This branches on the existing `CustomGuardrail._is_guardrail_intervention` classifier, the same predicate `pipeline_executor` already uses to separate intentional blocks from genuine errors. Guardrail interventions now log once at WARNING without a traceback while real failures keep their ERROR and traceback. Because the classifier already recognizes the shared typed guardrail exceptions (`GuardrailRaisedException`, `BlockedPiiEntityError`, `SensitiveDataRouteException`, `ModifyResponseException`) and an `HTTPException` with status 400, this covers every guardrail that signals a block, not just OpenAI moderation, without string-matching the exception detail

The client-facing response is unchanged; only the log level and the absence of a traceback differ. Tests drive the real `pass_through_request` and assert that a guardrail block logs at WARNING and not via `exception()`, that a genuine non-guardrail error still logs via `exception()` with its traceback, and the block still re-raises as the correct status
