### PR TITLE
feat(openai): fake stream when model_info marks supports_native_streaming false

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 import httpx
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.core_helpers import map_finish_reason
 from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
     _extract_reasoning_content,
@@ -56,7 +57,7 @@ from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
 )
-from litellm.utils import convert_to_model_response_object
+from litellm.utils import convert_to_model_response_object, get_model_info
 
 from ..common_utils import OpenAIError
 
@@ -188,6 +189,32 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 "user"
             )  # user is not a param supported by all openai-compatible endpoints - e.g. azure ai
         return base_params + model_specific_params
+
+    def should_fake_stream(
+        self,
+        model: Optional[str],
+        stream: Optional[bool],
+        custom_llm_provider: Optional[str] = None,
+    ) -> bool:
+        """
+        Fake stream when the model is explicitly marked as not supporting native
+        streaming via model_info (supports_native_streaming=False), e.g. an
+        OpenAI-compatible endpoint that cannot stream.
+        """
+        if stream is not True:
+            return False
+        if model is not None:
+            try:
+                model_info = get_model_info(
+                    model=model, custom_llm_provider=custom_llm_provider
+                )
+                if model_info.get("supports_native_streaming") is False:
+                    return True
+            except Exception as e:
+                verbose_logger.debug(
+                    f"Error getting model info in OpenAIGPTConfig.should_fake_stream: {e}"
+                )
+        return False
 
     def _map_openai_params(
         self,

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -4,6 +4,7 @@ Tests for OpenAI GPT transformation (litellm/llms/openai/chat/gpt_transformation
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -731,3 +732,58 @@ class TestCacheControlPreservationForCustomEndpoint:
             headers={},
         )
         assert all("cache_control" not in m for m in body["messages"])
+
+
+class TestOpenAIShouldFakeStream:
+    """should_fake_stream honors model_info['supports_native_streaming'].
+
+    Regression test for: https://github.com/BerriAI/litellm/issues/30208
+    OpenAI-compatible endpoints that cannot stream natively can be flagged with
+    model_info={"supports_native_streaming": False} to enable client-side fake
+    streaming instead of sending stream=True to an endpoint that rejects it.
+    """
+
+    GET_MODEL_INFO = "litellm.llms.openai.chat.gpt_transformation.get_model_info"
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    def test_fake_stream_when_native_streaming_unsupported(self):
+        with patch(
+            self.GET_MODEL_INFO, return_value={"supports_native_streaming": False}
+        ):
+            assert (
+                self.config.should_fake_stream(model="openai/no-stream", stream=True)
+                is True
+            )
+
+    def test_no_fake_stream_when_native_streaming_supported(self):
+        with patch(
+            self.GET_MODEL_INFO, return_value={"supports_native_streaming": True}
+        ):
+            assert (
+                self.config.should_fake_stream(model="openai/gpt-4o", stream=True)
+                is False
+            )
+
+    def test_no_fake_stream_when_field_absent(self):
+        with patch(self.GET_MODEL_INFO, return_value={}):
+            assert (
+                self.config.should_fake_stream(model="openai/gpt-4o", stream=True)
+                is False
+            )
+
+    def test_no_fake_stream_and_no_lookup_when_stream_not_requested(self):
+        with patch(self.GET_MODEL_INFO) as mock_get_model_info:
+            assert (
+                self.config.should_fake_stream(model="openai/no-stream", stream=False)
+                is False
+            )
+            mock_get_model_info.assert_not_called()
+
+    def test_no_fake_stream_when_model_info_lookup_fails(self):
+        with patch(self.GET_MODEL_INFO, side_effect=Exception("unknown model")):
+            assert (
+                self.config.should_fake_stream(model="openai/unknown", stream=True)
+                is False
+            )

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -16,7 +16,8 @@ from litellm.llms.openai.chat.gpt_transformation import (
     OpenAIChatCompletionStreamingHandler,
     OpenAIGPTConfig,
 )
-from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+from litellm.llms.openai.chat.o_series_transformation import OpenAIOSeriesConfig
+from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
 
 
 class TestOpenAIGPTConfig:
@@ -755,6 +756,29 @@ class TestOpenAIShouldFakeStream:
             assert (
                 self.config.should_fake_stream(model="openai/no-stream", stream=True)
                 is True
+            )
+
+    @pytest.mark.parametrize(
+        "config_class",
+        (OpenAIGPT5Config, OpenAIOSeriesConfig, OpenAILikeChatConfig),
+    )
+    def test_fake_stream_for_openai_config_variants(
+        self, config_class: type[OpenAIGPTConfig]
+    ) -> None:
+        with patch(
+            self.GET_MODEL_INFO, return_value={"supports_native_streaming": False}
+        ) as mock_get_model_info:
+            assert (
+                config_class().should_fake_stream(
+                    model="gateway-model",
+                    stream=True,
+                    custom_llm_provider="custom_openai",
+                )
+                is True
+            )
+            mock_get_model_info.assert_called_once_with(
+                model="gateway-model",
+                custom_llm_provider="custom_openai",
             )
 
     def test_no_fake_stream_when_native_streaming_supported(self):


### PR DESCRIPTION
## Relevant issues

Closes #30208

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🆕 New Feature

## Changes

`OpenAIGPTConfig.should_fake_stream` inherited the base default of `False`, so an OpenAI-compatible endpoint that cannot stream natively still received `stream=true` and errored, with no way to opt out. This overrides `should_fake_stream` on the OpenAI config to honor `model_info["supports_native_streaming"]`, the same field `AzureOpenAIO1Config` already reads. When a model is flagged with `supports_native_streaming: false` and a streaming request comes in, LiteLLM makes a non-streaming upstream call and emulates the stream client-side instead of forwarding `stream=true`

Because openai-compatible providers subclass `OpenAIGPTConfig`, they inherit the same opt-in. Default behavior is unchanged; no registry entry sets the field to `false`, so fake streaming only turns on when a user explicitly sets it

## Screenshots / Proof of Fix

Register a non-streaming OpenAI-compatible deployment with `supports_native_streaming: false`

```yaml
model_list:
  - model_name: no-stream-model
    litellm_params:
      model: openai/your-model
      api_base: http://your-openai-compatible-endpoint/v1
      api_key: os.environ/YOUR_KEY
    model_info:
      supports_native_streaming: false
```

```bash
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model": "no-stream-model", "messages": [{"role": "user", "content": "hi"}], "stream": true}'
```

Without the change the upstream call is made with `stream=true` and fails on an endpoint that cannot stream; with the change the request succeeds via client-side fake streaming

`tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py::TestOpenAIShouldFakeStream` locks the behavior: fake streaming turns on only when `supports_native_streaming` is explicitly `false` and `stream=True`, stays off by default (field absent or `true`), skips the model_info lookup entirely when streaming is not requested, and falls back to native streaming if the lookup raises