### PR TITLE
fix(azure): stop duplicating logprobs params for gpt-5.2 and gpt-5.4

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -84,8 +84,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         ) and not self.is_model_gpt_5_2_model(model):
             params = [p for p in params if p not in ["logprobs", "top_logprobs"]]
         elif self.is_model_gpt_5_2_model(model):
-            azure_supported_params = ["logprobs", "top_logprobs"]
-            params.extend(azure_supported_params)
+            params.extend(p for p in ("logprobs", "top_logprobs") if p not in params)
 
         return params
 

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -299,3 +299,21 @@ def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
     supported_params = config.get_supported_openai_params(model="gpt-5.1")
     assert "logprobs" not in supported_params
     assert "top_logprobs" not in supported_params
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5.2", "azure/gpt-5.2", "gpt5_series/gpt-5.2", "azure/gpt-5.4"],
+)
+def test_azure_gpt5_2_logprobs_not_duplicated(
+    config: AzureOpenAIGPT5Config, model: str
+):
+    """Regression: gpt-5.2/5.4 must list logprobs and top_logprobs exactly once.
+
+    These models support reasoning_effort="none", so the base config already
+    includes the logprobs params; the Azure override must not append a second
+    copy.
+    """
+    supported_params = config.get_supported_openai_params(model=model)
+    assert supported_params.count("logprobs") == 1
+    assert supported_params.count("top_logprobs") == 1


### PR DESCRIPTION
## Relevant issues

None; found while reading `litellm/llms/azure/chat/gpt_5_transformation.py`

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint, format, and the affected unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

`AzureOpenAIGPT5Config.get_supported_openai_params` listed `logprobs` and `top_logprobs` twice for gpt-5.2 and gpt-5.4. The base OpenAI gpt-5 config already includes those two params for any model that supports `reasoning_effort="none"` (which gpt-5.2/5.4 do), and the Azure override then appended them again with no guard, unlike the `tool_choice` append right above it that does guard

Before (on this branch's parent commit):

```
>>> from litellm.llms.azure.chat.gpt_5_transformation import AzureOpenAIGPT5Config
>>> cfg = AzureOpenAIGPT5Config()
>>> p = cfg.get_supported_openai_params(model="azure/gpt-5.2")
>>> p.count("logprobs"), p.count("top_logprobs")
(2, 2)
>>> q = cfg.get_supported_openai_params(model="azure/gpt-5.4")
>>> q.count("logprobs"), q.count("top_logprobs")
(2, 2)
```

After:

```
>>> p = cfg.get_supported_openai_params(model="azure/gpt-5.2")
>>> p.count("logprobs"), p.count("top_logprobs")
(1, 1)
>>> "logprobs" in p, "top_logprobs" in p
(True, True)
```

Membership is preserved (gpt-5.2/5.4 still advertise logprobs support), and gpt-5/gpt-5.1 are unaffected (they still exclude logprobs, since Azure has not verified support there)

## Type

🐛 Bug Fix

## Changes

In `get_supported_openai_params`, the gpt-5.2/5.4 branch now appends `logprobs` and `top_logprobs` only when they are not already present, mirroring the `tool_choice` guard a few lines above. This keeps the deduplication correct whether or not the base config already added them, so it still covers a hypothetical 5.2-family model where the base omitted them

Added a parametrized regression test in the mapped test file covering `gpt-5.2`, `azure/gpt-5.2`, `gpt5_series/gpt-5.2`, and `azure/gpt-5.4`; it asserts each param appears exactly once and fails on the previous unconditional `extend`
