### PR TITLE
fix(utils): merge user extra_body with provider-set extra_body for non-openai-compatible providers

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5021,7 +5021,17 @@ def add_provider_specific_params_to_optional_params(
                     k=k, additional_drop_params=additional_drop_params
                 ):
                     continue
-                optional_params[k] = passed_params[k]
+                if (
+                    k == "extra_body"
+                    and isinstance(passed_params[k], dict)
+                    and isinstance(optional_params.get("extra_body"), dict)
+                ):
+                    optional_params["extra_body"] = {
+                        **optional_params["extra_body"],
+                        **passed_params[k],
+                    }
+                else:
+                    optional_params[k] = passed_params[k]
     return optional_params
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4560,3 +4560,26 @@ def test_aws_bedrock_project_id_excluded_from_bedrock_optional_params():
     assert "aws_bedrock_project_id" not in result
     assert result["aws_region_name"] == "us-east-1"
 
+
+def test_get_optional_params_merges_user_extra_body_for_non_openai_compatible_provider():
+    """A provider-set extra_body must survive when the user also passes extra_body.
+
+    mistral is not openai-compatible, so user-supplied extra_body is applied via
+    the non-openai-compatible branch of get_optional_params. That branch
+    overwrote the extra_body the provider had already populated (mistral maps
+    seed to extra_body["random_seed"]), silently dropping the seed whenever a
+    user also passed their own extra_body. The branch now merges, matching the
+    openai-compatible branch above it."""
+    from litellm.utils import get_optional_params
+
+    result = get_optional_params(
+        model="mistral-large-latest",
+        custom_llm_provider="mistral",
+        seed=42,
+        extra_body={"custom_field": "keep_me"},
+    )
+
+    extra_body = result.get("extra_body") or {}
+    assert extra_body.get("random_seed") == 42
+    assert extra_body.get("custom_field") == "keep_me"
+


### PR DESCRIPTION
## Relevant issues

None; found while reading `litellm/llms/mistral/chat/transformation.py` and tracing how its `extra_body` survives `get_optional_params`

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint, format, and the affected unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

`get_optional_params` has two branches for attaching the caller's `extra_body`. The openai-compatible branch merges the caller's `extra_body` into whatever a provider config already populated, but the non-openai-compatible branch overwrote it. So any provider that maps a parameter into `extra_body` lost that value whenever the caller also passed their own `extra_body`

mistral is the concrete case: it maps `seed` to `extra_body["random_seed"]`, and mistral is not openai-compatible. Passing both `seed` and `extra_body` silently dropped the seed, which quietly breaks reproducibility

Before, on `litellm_internal_staging`:

```
>>> import litellm
>>> litellm.get_optional_params(model="mistral-large-latest", custom_llm_provider="mistral", seed=42).get("extra_body")
{'random_seed': 42}
>>> litellm.get_optional_params(model="mistral-large-latest", custom_llm_provider="mistral", seed=42, extra_body={"custom_field": "x"}).get("extra_body")
{'custom_field': 'x'}
```

The second call should carry both; `random_seed` is gone

After:

```
>>> litellm.get_optional_params(model="mistral-large-latest", custom_llm_provider="mistral", seed=42, extra_body={"custom_field": "x"}).get("extra_body")
{'random_seed': 42, 'custom_field': 'x'}
```

seed alone and extra_body alone are unchanged

## Type

🐛 Bug Fix

## Changes

The non-openai-compatible branch of `get_optional_params` now merges a dict `extra_body` from the caller into the provider-populated `extra_body` rather than replacing it, mirroring the openai-compatible branch. Non-dict values and every other param keep their existing overwrite behavior

Added a regression test in the mapped `tests/test_litellm/test_utils.py` that calls `get_optional_params` for mistral with both `seed` and `extra_body` and asserts both keys survive. It fails on the previous overwrite and passes with the merge
