### PR TITLE
feat(proxy): add disable_health_check_logs to silence health-check access logs

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -429,3 +429,46 @@ def _is_debugging_on() -> bool:
     Returns True if debugging is on
     """
     return verbose_logger.isEnabledFor(logging.DEBUG) or set_verbose is True
+
+
+_HEALTH_CHECK_PROBE_PATHS = frozenset(
+    {
+        "/health/liveliness",
+        "/health/liveness",
+        "/health/readiness",
+    }
+)
+
+
+class HealthCheckAccessLogFilter(logging.Filter):
+    """Drop uvicorn access-log records for health-check probe endpoints.
+
+    Liveness/readiness probes are polled constantly by orchestrators (k8s, load
+    balancers), drowning out real access logs. uvicorn emits each access record
+    with args ``(client_addr, method, full_path, http_version, status_code)``,
+    so the request path is matched to decide what to silence.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if not isinstance(args, tuple) or len(args) < 3:
+            return True
+        path = args[2]
+        if not isinstance(path, str):
+            return True
+        normalized = path.split("?", 1)[0].rstrip("/")
+        return normalized not in _HEALTH_CHECK_PROBE_PATHS
+
+
+def disable_health_check_access_logs() -> None:
+    """Silence uvicorn access logs for health-check probe endpoints.
+
+    Idempotent so repeated startup hooks (workers, reloads) don't stack filters.
+    """
+    access_logger = logging.getLogger("uvicorn.access")
+    if any(
+        isinstance(existing, HealthCheckAccessLogFilter)
+        for existing in access_logger.filters
+    ):
+        return
+    access_logger.addFilter(HealthCheckAccessLogFilter())

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -919,6 +919,11 @@ async def proxy_startup_event(app: FastAPI):
             )
         )
 
+    if general_settings.get("disable_health_check_logs") is True:
+        from litellm._logging import disable_health_check_access_logs
+
+        disable_health_check_access_logs()
+
     ProxyStartupEvent._initialize_startup_logging(
         llm_router=llm_router,
         proxy_logging_obj=proxy_logging_obj,

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -328,3 +328,84 @@ async def test_cache_hit_includes_custom_llm_provider():
         # Clean up
         litellm.callbacks = original_callbacks
         litellm.cache = None
+
+
+def _uvicorn_access_record(path: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=("127.0.0.1:1234", "GET", path, "1.1", 200),
+        exc_info=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/health/liveliness",
+        "/health/liveness",
+        "/health/readiness",
+        "/health/readiness/",
+        "/health/readiness?foo=bar",
+    ],
+)
+def test_health_check_filter_drops_probe_paths(path):
+    from litellm._logging import HealthCheckAccessLogFilter
+
+    assert HealthCheckAccessLogFilter().filter(_uvicorn_access_record(path)) is False
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/chat/completions",
+        "/health",
+        "/health/readiness/details",
+        "/v1/models",
+    ],
+)
+def test_health_check_filter_keeps_other_paths(path):
+    from litellm._logging import HealthCheckAccessLogFilter
+
+    assert HealthCheckAccessLogFilter().filter(_uvicorn_access_record(path)) is True
+
+
+def test_health_check_filter_ignores_non_access_records():
+    from litellm._logging import HealthCheckAccessLogFilter
+
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="server started",
+        args=None,
+        exc_info=None,
+    )
+    assert HealthCheckAccessLogFilter().filter(record) is True
+
+
+def test_disable_health_check_access_logs_is_idempotent_and_active():
+    from litellm._logging import (
+        HealthCheckAccessLogFilter,
+        disable_health_check_access_logs,
+    )
+
+    access_logger = logging.getLogger("uvicorn.access")
+    original_filters = list(access_logger.filters)
+    try:
+        disable_health_check_access_logs()
+        disable_health_check_access_logs()
+        installed = [
+            f
+            for f in access_logger.filters
+            if isinstance(f, HealthCheckAccessLogFilter)
+        ]
+        assert len(installed) == 1
+        assert access_logger.filter(_uvicorn_access_record("/health/liveliness")) is False
+        assert access_logger.filter(_uvicorn_access_record("/chat/completions")) is True
+    finally:
+        access_logger.filters = original_filters


### PR DESCRIPTION
## Relevant issues

Closes #17235

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint, format, and the affected unit tests locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Liveness and readiness probes are polled constantly by orchestrators (k8s, load balancers), so their uvicorn access logs bury real traffic. There was no way to silence just those lines short of raising the whole log level and losing everything

This adds `general_settings.disable_health_check_logs`. When set to true, proxy startup installs a filter on the `uvicorn.access` logger that drops records for the probe paths (`/health/liveliness`, `/health/liveness`, `/health/readiness`) while leaving every other request logged, including `/health` and `/health/readiness/details`

```yaml
general_settings:
  disable_health_check_logs: true
```

Behavior of the filter, which is what the access logger applies to each record:

```
>>> import logging
>>> from litellm._logging import HealthCheckAccessLogFilter
>>> f = HealthCheckAccessLogFilter()
>>> def rec(path):
...     return logging.LogRecord("uvicorn.access", logging.INFO, __file__, 1,
...         '%s - "%s %s HTTP/%s" %d', ("127.0.0.1:0", "GET", path, "1.1", 200), None)
>>> f.filter(rec("/health/liveliness"))
False
>>> f.filter(rec("/health/readiness?foo=bar"))
False
>>> f.filter(rec("/chat/completions"))
True
>>> f.filter(rec("/health/readiness/details"))
True
```

The filter sits on the `uvicorn.access` logger, so it works in both default and JSON logging modes, and installation is idempotent across workers and reloads

## Type

🆕 New Feature

## Changes

`litellm/_logging.py` gains `HealthCheckAccessLogFilter` and `disable_health_check_access_logs()`. The filter inspects the uvicorn access record args `(client_addr, method, full_path, http_version, status_code)`, normalizes the path (strips query string and trailing slash), and drops it only when it is one of the probe paths. Malformed or non-access records pass through untouched

`litellm/proxy/proxy_server.py` calls `disable_health_check_access_logs()` during `proxy_startup_event` when `general_settings.disable_health_check_logs` is true, right before startup logging is initialized

Tests in the mapped `tests/test_litellm/test_logging.py` cover the probe paths being dropped, normal and detail paths being kept, malformed records passing through, and the installer being idempotent and active

Defaults are unchanged: without the flag, all access logs behave exactly as before
