### PR TITLE
fix(proxy): return text/plain for audio transcriptions when response_…

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9643,6 +9643,10 @@ async def embeddings(
             version=version,
         )
 
+        if data.get("response_format") in ("text", "srt", "vtt"):
+            from fastapi.responses import Response as FastAPIResponse
+            return FastAPIResponse(content=response.text, media_type="text/plain")
+
         return response
     except Exception as e:
         # Use unified error handler

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9643,10 +9643,6 @@ async def embeddings(
             version=version,
         )
 
-        if data.get("response_format") in ("text", "srt", "vtt"):
-            from fastapi.responses import Response as FastAPIResponse
-            return FastAPIResponse(content=response.text, media_type="text/plain")
-
         return response
     except Exception as e:
         # Use unified error handler
@@ -10054,6 +10050,10 @@ async def audio_transcriptions(
         )
         if callback_headers:
             fastapi_response.headers.update(callback_headers)
+
+        if data.get("response_format") in ("text", "srt", "vtt"):
+            from fastapi.responses import Response as FastAPIResponse
+            return FastAPIResponse(content=response.text, media_type="text/plain")
 
         return response
     except Exception as e:


### PR DESCRIPTION
Fixes #31457

## Problem
When `response_format=text` is passed to `/v1/audio/transcriptions`, 
the proxy returns `application/json` instead of `text/plain`, 
breaking OpenAI API compatibility.

## Fix
Added a check before returning the response. If `response_format` 
is `text`, `srt`, or `vtt`, we now return a plain `FastAPIResponse` 
with `media_type="text/plain"` instead of serializing the Pydantic 
object as JSON.

## Type
- Bug Fix