### PR TITLE
fix: read adaptive_router cost from model_info when not in litellm_params

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7685,8 +7685,12 @@ class Router:
 
             # `input_cost_per_token` is a LiteLLM_Params field per types/router.py.
             lp = d.get("litellm_params") if isinstance(d, dict) else d.litellm_params
-            lp_dict: Dict[str, Any] = lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
+            lp_dict: Dict[str, Any] = (
+                lp if isinstance(lp, dict) else (lp.model_dump() if lp else {})
+            )
             cost = lp_dict.get("input_cost_per_token")
+            if cost is None:
+                cost = mi_dict.get("input_cost_per_token")
             if cost is not None:
                 model_to_cost[name] = float(cost)
 

--- a/tests/test_litellm/router_strategy/adaptive_router/test_config.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_config.py
@@ -53,3 +53,18 @@ def test_config_accepts_all_six_request_types_in_strengths():
         ],
     )
     assert len(prefs.strengths) == 6
+
+
+def test_adaptive_router_cost_reads_model_info():
+    """GH#31481: cost should fall back to model_info when not set
+    in litellm_params."""
+    lp_dict = {}  # no cost in litellm_params
+    mi_dict = {"input_cost_per_token": 0.0001}
+    cost = lp_dict.get("input_cost_per_token")
+    if cost is None:
+        cost = mi_dict.get("input_cost_per_token")
+    assert cost == 0.0001
+
+    # Explicit zero in litellm_params should be preserved (not fallback)
+    cost = {"input_cost_per_token": 0}.get("input_cost_per_token")
+    assert cost == 0


### PR DESCRIPTION
Fixes #31481

`init_adaptive_router_deployment` only read `input_cost_per_token`
from `litellm_params`, ignoring `model_info` (the documented location
for cost tracking). Adds a fallback to `model_info` when the value is
not set in `litellm_params`.