### PR TITLE
fix(ui): prevent usage indicator from covering sidebar items

### DIFF
--- a/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
@@ -40,6 +40,14 @@ describe("UsageIndicator", () => {
     expect(screen.getByText("Usage")).toBeInTheDocument();
   });
 
+  it("should not use fixed positioning that can cover sidebar items", async () => {
+    render(<UsageIndicator accessToken="token" width={220} />);
+
+    const usageLabel = await screen.findByText("Usage");
+
+    expect(usageLabel.closest(".fixed")).toBeNull();
+  });
+
   it("should not show Near limit when users usage is below 80% (1/100 -> 1%)", async () => {
     render(<UsageIndicator accessToken="token" width={220} />);
 

--- a/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.test.tsx
@@ -41,11 +41,12 @@ describe("UsageIndicator", () => {
   });
 
   it("should not use fixed positioning that can cover sidebar items", async () => {
-    render(<UsageIndicator accessToken="token" width={220} />);
+    const { container } = render(<UsageIndicator accessToken="token" width={220} />);
 
-    const usageLabel = await screen.findByText("Usage");
+    await screen.findByText("Usage");
 
-    expect(usageLabel.closest(".fixed")).toBeNull();
+    expect(container.firstElementChild).not.toHaveClass("fixed");
+    expect(container.firstElementChild).not.toHaveStyle({ position: "fixed" });
   });
 
   it("should not show Near limit when users usage is below 80% (1/100 -> 1%)", async () => {

--- a/ui/litellm-dashboard/src/components/UsageIndicator.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.tsx
@@ -688,7 +688,10 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
   }
 
   return (
-    <div className="sticky bottom-0 left-0 bg-white border-t border-gray-200 z-10 px-4 py-2" style={{ width: `${Math.min(width, 220)}px` }}>
+    <div
+      className="sticky bottom-0 left-0 bg-white border-t border-gray-200 z-10 px-4 py-2"
+      style={{ width: `${Math.min(width, 220)}px` }}
+    >
       <CardStyleView />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/UsageIndicator.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.tsx
@@ -687,9 +687,8 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
     return null;
   }
 
-  // Fixed positioning with proper spacing from edges
   return (
-    <div className="fixed bottom-4 left-4 z-50" style={{ width: `${Math.min(width, 220)}px` }}>
+    <div className="px-4 py-2" style={{ boxSizing: "border-box", width: `${Math.min(width, 220)}px` }}>
       <CardStyleView />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/UsageIndicator.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.tsx
@@ -688,7 +688,7 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
   }
 
   return (
-    <div className="px-4 py-2" style={{ width: `${Math.min(width, 220)}px` }}>
+    <div className="sticky bottom-0 left-0 bg-white border-t border-gray-200 z-10 px-4 py-2" style={{ width: `${Math.min(width, 220)}px` }}>
       <CardStyleView />
     </div>
   );

--- a/ui/litellm-dashboard/src/components/UsageIndicator.tsx
+++ b/ui/litellm-dashboard/src/components/UsageIndicator.tsx
@@ -688,7 +688,7 @@ export default function UsageIndicator({ accessToken, width = 220 }: UsageIndica
   }
 
   return (
-    <div className="px-4 py-2" style={{ boxSizing: "border-box", width: `${Math.min(width, 220)}px` }}>
+    <div className="px-4 py-2" style={{ width: `${Math.min(width, 220)}px` }}>
       <CardStyleView />
     </div>
   );


### PR DESCRIPTION
## Relevant issues

Fixes #28679

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I reproduced the overlap in the local dashboard at a 453 x 820 viewport with the usage count set to 2/5

Before this change, minimizing the card left it fixed to the bottom-left of the viewport, where it covered the lower Access Control navigation rows

After this change, the minimized card stays in the sidebar's normal document flow below Settings. A browser geometry check found no overlap with any of the 22 rendered menu items

Before/after screenshots will be attached to this draft

## Type

🐛 Bug Fix

## Changes

The usage indicator used `position: fixed`, so its compact state was detached from the sidebar layout and could cover navigation items as the menu grew

This keeps the indicator in normal document flow after the menu while preserving its existing width and spacing. It also adds a regression test that prevents fixed positioning from being reintroduced

Local verification:

- `npm run test -- src/components/UsageIndicator.test.tsx src/components/leftnav.test.tsx --run` (21 passed)
- `npm run test -- --run` (3,968 passed)
- `npm run format:check`
- `npm run lint` (0 errors, existing warnings only)
- `npm run build`
