### PR TITLE
chore: ignore ruff-format reformat commits in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,3 +11,9 @@
 
 # style(ui): run prettier --write across the dashboard (#29622)
 7edf3a9cb55548b143df1692f4ed7c4681d7fcf7
+
+# style: reformat litellm/ with ruff format (#31317)
+430b5b8f1b12dc261a49fda99ac5d1b22381a428
+
+# style: unify ruff format width on 120 (#31518)
+3dfbeabe626d203ac9de86024519d9a96c484ce4


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

There are no tests because this only adds two commit hashes to `.git-blame-ignore-revs`; there is no runtime behavior to assert on

## Screenshots / Proof of Fix

This is a metadata-only change to `.git-blame-ignore-revs`, so there is no proxy behavior to curl. The effect is that `git blame` (and the GitHub Blame UI) skip the two mechanical reformat commits and point at the real authors of each line. Locally:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
git blame <file>   # lines no longer attributed to the reformat commits
```

## Type

🧹 Refactoring

🚄 Infrastructure

## Changes

Both #31317 (black to ruff format) and #31518 (unify ruff format width on 120) were pure mechanical reformats, each verified semantically inert by an AST-equivalence proof on its PR. Lines they touched currently show up under the reformat commit in `git blame`, which buries the real authorship. Adding the two reformat commit hashes to `.git-blame-ignore-revs` makes blame skip them, which is exactly what the existing entries in that file (the pydantic warning fix and the prettier dashboard run) already do

The hashes added are 430b5b8f1b12dc261a49fda99ac5d1b22381a428 for #31317 and 3dfbeabe626d203ac9de86024519d9a96c484ce4 for #31518

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw7SayUrnSTKZ3jQrP1BXZ)_