### PR TITLE
fix(completion): omit empty tools array on chat/completions path

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -4846,6 +4846,13 @@ def completion(  # type: ignore
     # validate messages
     messages = validate_and_fix_openai_messages(messages=messages)
     tools = validate_and_fix_openai_tools(tools=tools)
+    # An empty tools array is invalid per the OpenAI spec ("provide at least one
+    # tool or omit the field entirely") and strict OpenAI-compatible backends
+    # (e.g. vLLM) 422 on it. Normalize to no tools so the field (and the
+    # now-meaningless tool_choice) is omitted from the upstream request.
+    if tools is not None and len(tools) == 0:
+        tools = None
+        tool_choice = None
     # validate tool_choice
     tool_choice = validate_chat_completion_tool_choice(tool_choice=tool_choice)
     # validate optional params

--- a/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_empty_tools.py
+++ b/tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_empty_tools.py
@@ -1,0 +1,113 @@
+"""
+Test that an empty ``tools`` array is not forwarded to the upstream provider on
+the chat/completions path.
+
+An empty tools array is invalid per the OpenAI spec ("provide at least one tool
+or omit the field entirely") and strict OpenAI-compatible backends (e.g. vLLM)
+reject it with a 422. ``litellm.completion`` must normalize ``tools: []`` to no
+tools so neither ``tools`` nor the now-meaningless ``tool_choice`` is sent.
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+
+
+def _mock_chat_response() -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    payload = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": "test-model",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Test response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+    mock_response.json.return_value = payload
+    mock_response.text = json.dumps(payload)
+    return mock_response
+
+
+def _request_body_from_post(mock_post: MagicMock) -> dict:
+    mock_post.assert_called()
+    kwargs = mock_post.call_args.kwargs
+    raw = kwargs.get("data")
+    if raw is not None:
+        return json.loads(raw)
+    return kwargs.get("json", {})
+
+
+class TestHostedVLLMEmptyTools:
+    @patch("litellm.llms.custom_httpx.llm_http_handler._get_httpx_client")
+    def test_empty_tools_array_is_omitted(self, mock_get_httpx_client):
+        mock_client = MagicMock()
+        mock_client.post.return_value = _mock_chat_response()
+        mock_get_httpx_client.return_value = mock_client
+
+        litellm.completion(
+            model="hosted_vllm/test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            api_base="https://test-vllm.example.com/v1",
+            tools=[],
+            tool_choice="auto",
+        )
+
+        body = _request_body_from_post(mock_client.post)
+        assert "tools" not in body
+        # tool_choice is meaningless without tools and must not leak either.
+        assert "tool_choice" not in body
+
+    @patch("litellm.llms.custom_httpx.llm_http_handler._get_httpx_client")
+    def test_non_empty_tools_are_preserved(self, mock_get_httpx_client):
+        mock_client = MagicMock()
+        mock_client.post.return_value = _mock_chat_response()
+        mock_get_httpx_client.return_value = mock_client
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current temperature for a location.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"],
+                    },
+                },
+            }
+        ]
+
+        litellm.completion(
+            model="hosted_vllm/test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            api_base="https://test-vllm.example.com/v1",
+            tools=tools,
+        )
+
+        body = _request_body_from_post(mock_client.post)
+        assert "tools" in body
+        assert len(body["tools"]) == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Relevant issues

Follow-up to #30540 (which fixed the Responses → Chat Completions bridge). Addresses the direct `/v1/chat/completions` path reported by @sonoh5n in https://github.com/BerriAI/litellm/pull/30540#issuecomment-4779274792.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

A tool-less `/v1/chat/completions` request with `tools: []` is forwarded upstream unchanged, so strict OpenAI-compatible backends (e.g. **vLLM**) reject it with a 422:

```
`tools` must not be an empty array. Either provide at least one tool or omit the field entirely.
```

The only existing empty-tools normalization (`if tools is not None and len(tools) == 0: tools = None`) lives **inside the prompt-management hook block** in `acompletion` (added for #11404), so ordinary requests that don't trigger those hooks bypass it entirely.

**Fix:** normalize an empty `tools` array to no tools in `completion()`, right after `validate_and_fix_openai_tools`, and drop the now-meaningless `tool_choice` as well. This is the sync core that both `completion()` and `acompletion()` flow through. Semantics match what was requested:

```
tools: []      -> drop tools (and tool_choice) before forwarding
tools: [ ... ] -> preserve
tools absent   -> preserve
```

### Tests

`tests/test_litellm/llms/hosted_vllm/chat/test_hosted_vllm_empty_tools.py` — drives `litellm.completion` against a mocked httpx client and asserts the outgoing request body:
- `tools: []` → neither `tools` nor `tool_choice` is sent
- non-empty `tools` → preserved

Verified the test fails without the fix (the empty array reaches the request body) and passes with it.
