### PR TITLE
fix(files): raise resumable upload chunk size to cut GCS round-trips

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -3508,8 +3508,10 @@ class BaseLLMHTTPHandler:
             litellm_params=litellm_params,
         )
 
-    # 8 MiB; a 256 KiB multiple, which GCS requires for every non-final chunk.
-    _RESUMABLE_CHUNK_SIZE = 8 * 1024 * 1024
+    # 32 MiB (a 256 KiB multiple, which GCS requires for every non-final chunk).
+    # Larger chunks mean fewer sequential round-trips on a multi-GB upload, which
+    # is what pushes total upload time past client/LB timeouts.
+    _RESUMABLE_CHUNK_SIZE = 32 * 1024 * 1024
 
     @staticmethod
     def _iter_resumable_chunks(byte_iter: Iterator[bytes], chunk_size: int) -> Iterator[bytes]:

--- a/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
+++ b/tests/test_litellm/llms/vertex_ai/files/test_vertex_ai_files_streaming.py
@@ -17,6 +17,7 @@ replaced by a list-based pipeline:
      cursor).
 """
 
+import asyncio
 import gc
 import io
 import json
@@ -572,6 +573,12 @@ class TestResumableChunking:
     def test_default_chunk_size_is_256kib_multiple(self):
         assert BaseLLMHTTPHandler._RESUMABLE_CHUNK_SIZE % (256 * 1024) == 0
 
+    def test_default_chunk_size_limits_round_trips(self):
+        # At 8 MiB a 2 GB upload was ~256 strictly-sequential PUTs, whose total
+        # round-trip time trips client/LB timeouts (the 499). Keep chunks large
+        # so big uploads make far fewer round-trips.
+        assert BaseLLMHTTPHandler._RESUMABLE_CHUNK_SIZE >= 32 * 1024 * 1024
+
     def test_content_range_intermediate_uses_star_total(self):
         assert (
             BaseLLMHTTPHandler._resumable_content_range(0, 4096, is_final=False)
@@ -694,3 +701,46 @@ class TestResumableUploadProtocol:
         raw = _make_openai_jsonl_bytes(80)
         with pytest.raises(Exception):
             await self._run(raw, chunk_size=4096, final_status=403)
+
+
+@pytest.mark.asyncio
+class TestResumableUploadDoesNotBlockEventLoop:
+    """Generating each chunk runs the synchronous JSONL read + provider
+    transform. If that runs inline on the event loop, a multi-GB upload starves
+    every other coroutine on the worker, which is what makes the proxy drop
+    connections (the 499). The pull must be offloaded to a thread."""
+
+    async def test_chunk_generation_does_not_starve_the_loop(self):
+        class _BlockingStream(BaseFileUploadStream):
+            def iter_bytes(self):
+                for _ in range(3):
+                    time.sleep(0.1)  # stand-in for the per-chunk transform cost
+                    yield b"x" * 256
+
+        config = {"body_stream": _BlockingStream(), "chunk_size": 256}
+        session_url = "https://storage.googleapis.com/upload/sess?upload_id=SID"
+        mock, _state = _gcs_resumable_mock(session_url)
+
+        ticks = 0
+
+        async def _ticker():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        ticker = asyncio.create_task(_ticker())
+        try:
+            await BaseLLMHTTPHandler()._aresumable_chunked_upload(
+                client=_async_handler_with(mock),
+                initiate_url="https://storage.googleapis.com/upload?uploadType=resumable",
+                base_headers={"Authorization": "Bearer x"},
+                config=config,
+                timeout=None,
+            )
+        finally:
+            ticker.cancel()
+
+        # ~0.3s of blocking generation. Run inline the 10ms ticker is starved
+        # (at most ~1 tick); offloaded it keeps advancing throughout.
+        assert ticks >= 5


### PR DESCRIPTION
## Relevant issues

Large vertex/Gemini batch file uploads through `/v1/files` return 499s (client closed connection) on multi-GB inputs.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Real-provider proof is pending; the Vertex project available for local verification has billing disabled, so the live `/v1/files` -> GCS path returns a 403 before the upload streams. The change is covered by a mutation-verified regression test (a deliberately blocking chunk generator must not starve a concurrent coroutine; it fails on a synchronous pull and passes with the offload) and a guard on the chunk-size floor. Once a Vertex project with active billing is available, the proof is a `curl` of a multi-GB batch upload against a live proxy showing the request completing well inside the client timeout.

## Type

🐛 Bug Fix

## Changes

The resumable upload to GCS was using an 8 MiB chunk size, so a 2 GB batch input made roughly 256 strictly-sequential PUTs whose combined round-trip time overran client and load-balancer timeouts and surfaced as a 499. This raises the chunk size to 32 MiB (still a 256 KiB multiple, which GCS requires for non-final chunks), cutting that to about 64 round-trips. Peak memory stays bounded at one chunk, and the request stays synchronous so the returned file object is real and `POST /v1/batches` keeps working immediately.

The companion event-loop offload (pulling each chunk via `asyncio.to_thread` so the per-chunk transform does not block the worker) already landed separately; this adds a mutation-verified regression test that guards it.
