### PR TITLE
fix(vertex_ai): append rawPredict suffix for custom api_base on /v1/m…

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/experimental_pass_through/transformation.py
@@ -49,17 +49,15 @@ class VertexAIPartnerModelsAnthropicMessagesConfig(AnthropicMessagesConfig, Vert
         )
         headers["Authorization"] = f"Bearer {access_token}"
 
-        # Calculate api_base if not provided
-        if api_base is None:
-            api_base = self.get_complete_vertex_url(
-                custom_api_base=api_base,
-                vertex_location=vertex_ai_location,
-                vertex_project=vertex_ai_project,
-                project_id=project_id or "",
-                partner=VertexPartnerProvider.claude,
-                stream=optional_params.get("stream", False),
-                model=model,
-            )
+        api_base = self.get_complete_vertex_url(
+            custom_api_base=api_base,
+            vertex_location=vertex_ai_location,
+            vertex_project=vertex_ai_project,
+            project_id=project_id or "",
+            partner=VertexPartnerProvider.claude,
+            stream=optional_params.get("stream", False),
+            model=model,
+        )
 
         headers["content-type"] = "application/json"
 

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
@@ -266,6 +266,73 @@ def test_validate_environment_always_refreshes_token_ignoring_stale_bearer():
         assert api_base == "https://mock-vertex-url"
 
 
+def test_validate_environment_appends_stream_raw_predict_with_custom_api_base():
+    """Regression: a custom api_base on /v1/messages must still get the endpoint
+    suffix appended. The old `if api_base is None` guard skipped
+    get_complete_vertex_url entirely, leaving the api_base without
+    `:streamRawPredict`."""
+    config = VertexAIPartnerModelsAnthropicMessagesConfig()
+    litellm_params = {
+        "vertex_ai_project": "test-project",
+        "vertex_ai_location": "us-central1",
+    }
+
+    with (
+        patch.object(
+            config,
+            "get_complete_vertex_url",
+            wraps=config.get_complete_vertex_url,
+        ) as spy_get_url,
+        patch.object(
+            config, "_ensure_access_token", return_value=("token", "test-project")
+        ),
+    ):
+        _, api_base = config.validate_anthropic_messages_environment(
+            headers={},
+            model="claude-sonnet-4",
+            messages=[],
+            optional_params={"stream": True},
+            litellm_params=litellm_params,
+            api_base="https://my-proxy.example.com",
+        )
+
+    spy_get_url.assert_called_once()
+    assert api_base is not None
+    assert ":streamRawPredict" in api_base
+
+
+def test_validate_environment_appends_raw_predict_with_custom_api_base():
+    """Regression: non-streaming custom api_base must end with `:rawPredict`."""
+    config = VertexAIPartnerModelsAnthropicMessagesConfig()
+    litellm_params = {
+        "vertex_ai_project": "test-project",
+        "vertex_ai_location": "us-central1",
+    }
+
+    with (
+        patch.object(
+            config,
+            "get_complete_vertex_url",
+            wraps=config.get_complete_vertex_url,
+        ) as spy_get_url,
+        patch.object(
+            config, "_ensure_access_token", return_value=("token", "test-project")
+        ),
+    ):
+        _, api_base = config.validate_anthropic_messages_environment(
+            headers={},
+            model="claude-sonnet-4",
+            messages=[],
+            optional_params={},
+            litellm_params=litellm_params,
+            api_base="https://my-proxy.example.com",
+        )
+
+    spy_get_url.assert_called_once()
+    assert api_base is not None
+    assert api_base.endswith(":rawPredict")
+
+
 def test_transform_anthropic_messages_request_removes_scope_from_cache_control():
     """Ensure scope field is removed from cache_control for Vertex AI (not supported)."""
     config = VertexAIPartnerModelsAnthropicMessagesConfig()


### PR DESCRIPTION
Relevant issues
Fixes custom api_base handling on the Vertex AI Anthropic /v1/messages pass-through path

Issue
When a deployment sets a custom api_base for Vertex Claude and routes through LiteLLM's /v1/messages pass-through, requests fail because the URL never gets the Vertex partner-model endpoint suffix (:rawPredict for non-streaming, :streamRawPredict for streaming). The proxy forwards to the bare proxy URL instead of {api_base}:{endpoint}

The chat/completions path in litellm/llms/vertex_ai/vertex_ai_partner_models/main.py is unaffected; it always calls get_complete_vertex_url(). This bug is specific to validate_anthropic_messages_environment() in the messages pass-through config

Cause
PR #21658 (cdb4917185) added a guard so get_complete_vertex_url() only ran when api_base is None:

if api_base is None:
    api_base = self.get_complete_vertex_url(...)
When a user supplied a custom api_base, that block was skipped entirely, so no suffix was appended. That was a regression from the intended behavior: get_complete_vertex_url() already handles custom bases via _check_custom_proxy() in vertex_llm_base.py, which builds {api_base}:{endpoint} (and adds ?alt=sse for streaming)

Fix
Remove the if api_base is None: guard and always call get_complete_vertex_url() in validate_anthropic_messages_environment(), matching the chat/completions path

This does not regress the stale-token fix from PR #31276 (062d8ceeed): _ensure_access_token() still runs on every request, and headers is still copied locally before mutation

Before: 404
<img width="731" height="402" alt="Screenshot 2026-06-27 at 2 43 08 PM" src="https://github.com/user-attachments/assets/56f8d0e4-ac00-43aa-b134-768a6bd0bcb8" />

After: Request reaches the provider
<img width="678" height="380" alt="Screenshot 2026-06-27 at 2 42 11 PM" src="https://github.com/user-attachments/assets/f60e2c1d-43b0-4d44-921f-f33745193d71" />
