### PR TITLE
fix(bedrock): drop schema bounds from tools

### DIFF
--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -168,10 +168,12 @@ def remove_custom_field_from_tools(request_body: dict) -> None:
 
 def normalize_json_schema_custom_types_to_object(schema: dict) -> None:
     """
-    In-place: replace JSON Schema ``type: \"custom\"`` with ``\"object\"`` (iterative walk).
+    In-place: normalize JSON Schema fields unsupported by Bedrock (iterative walk).
 
     Anthropic / Claude Code use ``custom`` for tool schemas; Bedrock Invoke and
     Bedrock Converse only accept standard JSON Schema type strings.
+    Bedrock Invoke also rejects ``minimum`` and ``maximum`` on number schemas,
+    even though other providers accept those JSON Schema validation keywords.
 
     Uses an explicit stack (not recursion) to satisfy recursive-function guards in CI.
     """
@@ -187,6 +189,8 @@ def normalize_json_schema_custom_types_to_object(schema: dict) -> None:
         seen.add(node_id)
         if node.get("type") == "custom":
             node["type"] = "object"
+        node.pop("minimum", None)
+        node.pop("maximum", None)
         items = node.get("items")
         if isinstance(items, dict):
             stack.append(items)
@@ -211,8 +215,9 @@ def normalize_tool_input_schema_types_for_bedrock_invoke(request_body: dict) -> 
     Bedrock Invoke (Anthropic Messages) validates ``input_schema`` as JSON Schema.
     Anthropic's API allows ``type: \"custom\"`` for Claude Code custom tools; Bedrock
     rejects it with: ``tools.0.custom.input_schema.type: Input should be 'object'``.
+    Bedrock also rejects ``minimum`` and ``maximum`` constraints on number schemas.
 
-    Normalizes ``type: \"custom\"`` to ``\"object\"`` throughout each tool's
+    Normalizes provider-unsupported schema fields throughout each tool's
     ``input_schema`` (recursive for nested properties, items, combinators).
 
     Args:

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 import json
 import os
@@ -327,6 +326,7 @@ def test_normalize_tool_input_schema_types_for_bedrock_invoke():
     """
     Claude Code sends ``input_schema.type: \"custom\"`` for custom tools.
     Bedrock Invoke rejects this; it requires JSON Schema ``type: \"object\"``.
+    Bedrock also rejects ``minimum`` and ``maximum`` numeric bounds.
     """
 
     request = {
@@ -341,7 +341,31 @@ def test_normalize_tool_input_schema_types_for_bedrock_invoke():
                     "properties": {
                         "nested": {
                             "type": "custom",
-                            "properties": {"x": {"type": "string"}},
+                            "properties": {
+                                "x": {"type": "string"},
+                                "score": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1,
+                                },
+                                "values": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "number",
+                                        "minimum": -1,
+                                        "maximum": 1,
+                                    },
+                                },
+                                "choice": {
+                                    "oneOf": [
+                                        {
+                                            "type": "number",
+                                            "minimum": 0,
+                                            "maximum": 10,
+                                        }
+                                    ]
+                                },
+                            },
                         }
                     },
                     "required": ["nested"],
@@ -359,7 +383,14 @@ def test_normalize_tool_input_schema_types_for_bedrock_invoke():
     agent_tool = request["tools"][0]
     assert agent_tool["type"] == "custom"
     assert agent_tool["input_schema"]["type"] == "object"
-    assert agent_tool["input_schema"]["properties"]["nested"]["type"] == "object"
+    nested_schema = agent_tool["input_schema"]["properties"]["nested"]
+    assert nested_schema["type"] == "object"
+    assert "minimum" not in nested_schema["properties"]["score"]
+    assert "maximum" not in nested_schema["properties"]["score"]
+    assert "minimum" not in nested_schema["properties"]["values"]["items"]
+    assert "maximum" not in nested_schema["properties"]["values"]["items"]
+    assert "minimum" not in nested_schema["properties"]["choice"]["oneOf"][0]
+    assert "maximum" not in nested_schema["properties"]["choice"]["oneOf"][0]
     assert request["tools"][1]["input_schema"]["type"] == "object"
 
     request2 = {"messages": []}


### PR DESCRIPTION
## Relevant issues

Fixes #29168

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a Bedrock request-transformation fix. The previous transform dropped `default` and `format` schema fields but still left JSON schema numeric bounds (`minimum` / `maximum`) in nested tool schemas. This PR extends the same schema normalization path to remove those bounds recursively, including nested object properties, array items, and `oneOf` entries.

Local validation:

```text
uv run pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py -q
84 passed

uv run ruff check litellm/llms/bedrock/common_utils.py tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
All checks passed
```

I also reproduced the request transform locally and confirmed the Bedrock tool schema no longer contains `minimum` or `maximum` after normalization.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Drop `minimum` and `maximum` from Bedrock tool input schemas during recursive schema normalization.
- Preserve existing behavior for dropping unsupported `default` and `format` fields.
- Add regression coverage for nested object properties, array items, and `oneOf` schema branches.
