### PR TITLE
fix(anthropic): clamp max_output_tokens to Responses API minimum (>=16) on /v1/messages (#31451)

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -31,6 +31,11 @@ from litellm.types.llms.anthropic_messages.anthropic_response import (
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 
+# OpenAI's Responses API rejects ``max_output_tokens`` below 16. Anthropic clients
+# (e.g. Claude Code's small warm-up request) may send a smaller ``max_tokens``, so the
+# adapter clamps up to this minimum to avoid an OpenAI 400. See issue #31451.
+RESPONSES_API_MIN_MAX_OUTPUT_TOKENS = 16
+
 
 class LiteLLMAnthropicToResponsesAPIAdapter:
     """
@@ -308,10 +313,13 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
                 text_parts = [b.get("text", "") for b in system if isinstance(b, dict) and b.get("type") == "text"]
                 responses_kwargs["instructions"] = "\n".join(filter(None, text_parts))
 
-        # max_tokens -> max_output_tokens
+        # max_tokens -> max_output_tokens. The Responses API requires
+        # max_output_tokens >= RESPONSES_API_MIN_MAX_OUTPUT_TOKENS, but Anthropic
+        # clients (e.g. Claude Code's warm-up request) may send a smaller value,
+        # so clamp up to the minimum instead of forwarding a value OpenAI rejects.
         max_tokens = anthropic_request.get("max_tokens")
         if max_tokens:
-            responses_kwargs["max_output_tokens"] = max_tokens
+            responses_kwargs["max_output_tokens"] = max(max_tokens, RESPONSES_API_MIN_MAX_OUTPUT_TOKENS)
 
         # temperature / top_p passed through
         if "temperature" in anthropic_request:

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -1071,3 +1071,21 @@ class TestTranslateResponse:
         assert "text" in types
         assert "tool_use" in types
         assert result["stop_reason"] == "tool_use"
+
+
+class TestMaxOutputTokensMinimum:
+    """max_tokens -> max_output_tokens must respect the Responses API minimum (>= 16).
+
+    Anthropic clients (e.g. Claude Code's warm-up request) may send a tiny
+    max_tokens; forwarding it verbatim makes OpenAI's Responses API 400 with
+    "'max_output_tokens': integer below minimum value (Expected a value >= 16)".
+    Regression test for issue #31451.
+    """
+
+    def test_small_max_tokens_is_clamped_to_minimum(self):
+        kwargs = _ADAPTER.translate_request(_make_request(max_tokens=1))
+        assert kwargs["max_output_tokens"] >= 16
+
+    def test_normal_max_tokens_is_preserved(self):
+        kwargs = _ADAPTER.translate_request(_make_request(max_tokens=1024))
+        assert kwargs["max_output_tokens"] == 1024


### PR DESCRIPTION
## Relevant issues

Fixes #31451

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Proof of Fix

**Root cause.** When an Anthropic `/v1/messages` request targets a GPT-5.x model, LiteLLM routes it through the Anthropic → OpenAI Responses adapter (`LiteLLMAnthropicToResponsesAPIAdapter.translate_request`). That adapter mapped Anthropic `max_tokens` directly to `max_output_tokens` with no lower bound. Claude Code issues small warm-up requests with `max_tokens: 1`, and OpenAI's Responses API requires `max_output_tokens >= 16`, so the request 400s:

```
Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 1 instead.
```

The fix clamps `max_output_tokens` up to the minimum (16) — the same minimum the health-check path (`litellm_core_utils/health_check_helpers.py`) already enforces for GPT-5 models.

**End-to-end verification — real OpenAI Responses API call, no mocks** (`gpt-5-nano`, an Anthropic `/v1/messages` request with `max_tokens=1`):

_Before this fix:_
```
❌ REJECTED by OpenAI:
{
  "error": {
    "message": "Invalid 'max_output_tokens': integer below minimum value. Expected a value >= 16, but got 1 instead.",
    "type": "invalid_request_error",
    "param": "max_output_tokens",
    "code": "integer_below_min_value"
  }
}
```

_After this fix:_
```
✅ HTTP 200 — OpenAI ACCEPTED the request. max_output_tokens was clamped to the minimum.
stop_reason: max_tokens
```

Unit coverage: `tests/.../responses_adapters/test_responses_adapters_transformation.py::TestMaxOutputTokensMinimum` — a `max_tokens=1` request is clamped to `>= 16` (fails before the change, passes after), and a normal `max_tokens=1024` is preserved.

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py`: add `RESPONSES_API_MIN_MAX_OUTPUT_TOKENS = 16` and clamp `max_output_tokens` to it when mapping Anthropic `max_tokens` in `translate_request`.
- `tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py`: regression tests for the clamp and the preserve-normal-value case.
