### PR TITLE
fix(dashboard): guard gen:api against unsupported Python and prefer a venv

### DIFF
--- a/ui/litellm-dashboard/scripts/gen-api-types.mjs
+++ b/ui/litellm-dashboard/scripts/gen-api-types.mjs
@@ -7,46 +7,96 @@
  * the spec is read straight off the app object, so this runs in CI without a
  * database or proxy boot.
  *
- * The Python interpreter must have litellm installed. Override which one via
- * LITELLM_PYTHON (CI passes "uv run --no-sync python"); defaults to python3.
+ * The Python interpreter must have litellm installed and be at least the
+ * version litellm requires. Override which one via LITELLM_PYTHON (CI passes
+ * "uv run --no-sync python"); otherwise the repo's .venv is preferred, falling
+ * back to python3.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const dashboardDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const repoRoot = resolve(dashboardDir, "..", "..");
-const outPath = join(dashboardDir, "src", "lib", "http", "schema.d.ts");
-const specDir = mkdtempSync(join(tmpdir(), "litellm-openapi-"));
-const specPath = join(specDir, "openapi.json");
+const MIN_PYTHON = { major: 3, minor: 10 };
 
-const python = (process.env.LITELLM_PYTHON ?? "python3").split(" ");
-// The dashboard calls internal UI routes that the public /openapi.json hides via
-// include_in_schema=False. Force them in so they get typed here; this mutates a
-// throwaway interpreter, so the spec the proxy actually serves is unchanged.
-const dumpSpec = [
-  "import json, sys",
-  "from litellm.proxy.proxy_server import app",
-  "from fastapi.routing import APIRoute",
-  "for route in app.routes:",
-  "    if isinstance(route, APIRoute):",
-  "        route.include_in_schema = True",
-  "app.openapi_schema = None",
-  "with open(sys.argv[1], 'w') as f: json.dump(app.openapi(), f, sort_keys=True)",
-].join("\n");
-
-try {
-  execFileSync(python[0], [...python.slice(1), "-c", dumpSpec, specPath], {
-    cwd: repoRoot,
-    stdio: "inherit",
-  });
-
-  execFileSync(join(dashboardDir, "node_modules", ".bin", "openapi-typescript"), [specPath, "-o", outPath], {
-    cwd: dashboardDir,
-    stdio: "inherit",
-  });
-} finally {
-  rmSync(specDir, { recursive: true, force: true });
+export function resolvePythonCommand(env, repoRoot, exists = existsSync) {
+  if (env.LITELLM_PYTHON) return env.LITELLM_PYTHON.split(" ").filter(Boolean);
+  const venvCandidates = [join(repoRoot, ".venv", "bin", "python"), join(repoRoot, ".venv", "Scripts", "python.exe")];
+  const venvPython = venvCandidates.find((candidate) => exists(candidate));
+  return venvPython ? [venvPython] : ["python3"];
 }
+
+export function parsePythonVersion(stdout) {
+  const match = stdout.match(/(\d+)\.(\d+)/);
+  return match ? { major: Number(match[1]), minor: Number(match[2]) } : null;
+}
+
+export function isSupportedPython(version) {
+  if (!version) return false;
+  return version.major > MIN_PYTHON.major || (version.major === MIN_PYTHON.major && version.minor >= MIN_PYTHON.minor);
+}
+
+export function unsupportedPythonMessage(pythonCommand, version) {
+  const interpreter = pythonCommand.join(" ");
+  const detected = version ? `${version.major}.${version.minor}` : "unknown";
+  return (
+    `litellm requires Python >=${MIN_PYTHON.major}.${MIN_PYTHON.minor}, ` +
+    `but \`${interpreter}\` reports ${detected}. ` +
+    "Point gen:api at a supported interpreter (e.g. `uv venv && uv sync`, or set " +
+    "LITELLM_PYTHON to one with litellm installed), then re-run `npm run gen:api`."
+  );
+}
+
+function assertSupportedPython(pythonCommand) {
+  const probe = "import sys; print('.'.join(map(str, sys.version_info[:2])))";
+  const stdout = execFileSync(pythonCommand[0], [...pythonCommand.slice(1), "-c", probe], {
+    encoding: "utf8",
+  });
+  const version = parsePythonVersion(stdout);
+  if (!isSupportedPython(version)) {
+    throw new Error(unsupportedPythonMessage(pythonCommand, version));
+  }
+}
+
+function main() {
+  const dashboardDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const repoRoot = resolve(dashboardDir, "..", "..");
+  const outPath = join(dashboardDir, "src", "lib", "http", "schema.d.ts");
+  const specDir = mkdtempSync(join(tmpdir(), "litellm-openapi-"));
+  const specPath = join(specDir, "openapi.json");
+
+  const python = resolvePythonCommand(process.env, repoRoot);
+  // The dashboard calls internal UI routes that the public /openapi.json hides via
+  // include_in_schema=False. Force them in so they get typed here; this mutates a
+  // throwaway interpreter, so the spec the proxy actually serves is unchanged.
+  const dumpSpec = [
+    "import json, sys",
+    "from litellm.proxy.proxy_server import app",
+    "from fastapi.routing import APIRoute",
+    "for route in app.routes:",
+    "    if isinstance(route, APIRoute):",
+    "        route.include_in_schema = True",
+    "app.openapi_schema = None",
+    "with open(sys.argv[1], 'w') as f: json.dump(app.openapi(), f, sort_keys=True)",
+  ].join("\n");
+
+  try {
+    assertSupportedPython(python);
+
+    execFileSync(python[0], [...python.slice(1), "-c", dumpSpec, specPath], {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+
+    execFileSync(join(dashboardDir, "node_modules", ".bin", "openapi-typescript"), [specPath, "-o", outPath], {
+      cwd: dashboardDir,
+      stdio: "inherit",
+    });
+  } finally {
+    rmSync(specDir, { recursive: true, force: true });
+  }
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) main();

--- a/ui/litellm-dashboard/scripts/gen-api-types.mjs
+++ b/ui/litellm-dashboard/scripts/gen-api-types.mjs
@@ -55,12 +55,17 @@ export function unsupportedPythonMessage(pythonCommand, version) {
   );
 }
 
-function assertSupportedPython(pythonCommand) {
+export function probePythonVersion(pythonCommand, cwd, exec = execFileSync) {
   const probe = "import sys; print('.'.join(map(str, sys.version_info[:2])))";
-  const stdout = execFileSync(pythonCommand[0], [...pythonCommand.slice(1), "-c", probe], {
+  const stdout = exec(pythonCommand[0], [...pythonCommand.slice(1), "-c", probe], {
+    cwd,
     encoding: "utf8",
   });
-  const version = parsePythonVersion(stdout);
+  return parsePythonVersion(stdout);
+}
+
+function assertSupportedPython(pythonCommand, cwd) {
+  const version = probePythonVersion(pythonCommand, cwd);
   if (!isSupportedPython(version)) {
     throw new Error(unsupportedPythonMessage(pythonCommand, version));
   }
@@ -89,7 +94,7 @@ function main() {
   ].join("\n");
 
   try {
-    assertSupportedPython(python);
+    assertSupportedPython(python, repoRoot);
 
     execFileSync(python[0], [...python.slice(1), "-c", dumpSpec, specPath], {
       cwd: repoRoot,

--- a/ui/litellm-dashboard/scripts/gen-api-types.mjs
+++ b/ui/litellm-dashboard/scripts/gen-api-types.mjs
@@ -20,11 +20,18 @@ import { fileURLToPath } from "node:url";
 
 const MIN_PYTHON = { major: 3, minor: 10 };
 
+function venvInterpreter(root) {
+  return [join(root, "bin", "python"), join(root, "Scripts", "python.exe")];
+}
+
 export function resolvePythonCommand(env, repoRoot, exists = existsSync) {
   if (env.LITELLM_PYTHON) return env.LITELLM_PYTHON.split(" ").filter(Boolean);
-  const venvCandidates = [join(repoRoot, ".venv", "bin", "python"), join(repoRoot, ".venv", "Scripts", "python.exe")];
-  const venvPython = venvCandidates.find((candidate) => exists(candidate));
-  return venvPython ? [venvPython] : ["python3"];
+  const candidates = [
+    ...(env.VIRTUAL_ENV ? venvInterpreter(env.VIRTUAL_ENV) : []),
+    ...venvInterpreter(join(repoRoot, ".venv")),
+  ];
+  const found = candidates.find((candidate) => exists(candidate));
+  return found ? [found] : ["python3"];
 }
 
 export function parsePythonVersion(stdout) {

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -43770,13 +43770,13 @@ export interface operations {
             /**
              * @description Unified rate-limit error.
              *
-             *     Every rate-limit condition surfaced by litellm — whether it originated from
-             *     an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
-             *     proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
-             *     max-iterations, etc.) — is raised as an instance of this class.
+             *         Every rate-limit condition surfaced by litellm — whether it originated from
+             *         an upstream LLM provider, a vendor batch endpoint, or one of litellm's own
+             *         proxy-side limiters (parallel-requests, dynamic-rate, batch-rate, budget,
+             *         max-iterations, etc.) — is raised as an instance of this class.
              *
-             *     The :attr:`category` attribute lets callers distinguish the source. See
-             *     :class:`RateLimitErrorCategory` for the available values.
+             *         The :attr:`category` attribute lets callers distinguish the source. See
+             *         :class:`RateLimitErrorCategory` for the available values.
              */
             429: {
                 headers: {

--- a/ui/litellm-dashboard/tests/gen-api-types.test.ts
+++ b/ui/litellm-dashboard/tests/gen-api-types.test.ts
@@ -14,6 +14,13 @@ describe("resolvePythonCommand", () => {
     expect(cmd).toEqual(["uv", "run", "--no-sync", "python"]);
   });
 
+  it("prefers an activated $VIRTUAL_ENV over the repo's .venv", () => {
+    const active = "/active/bin/python";
+    const repoVenv = `${repoRoot}/.venv/bin/python`;
+    const cmd = resolvePythonCommand({ VIRTUAL_ENV: "/active" }, repoRoot, (p) => p === active || p === repoVenv);
+    expect(cmd).toEqual([active]);
+  });
+
   it("prefers the repo's .venv interpreter over a bare python3", () => {
     const venv = `${repoRoot}/.venv/bin/python`;
     const cmd = resolvePythonCommand({}, repoRoot, (p) => p === venv);

--- a/ui/litellm-dashboard/tests/gen-api-types.test.ts
+++ b/ui/litellm-dashboard/tests/gen-api-types.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolvePythonCommand,
+  parsePythonVersion,
+  isSupportedPython,
+  unsupportedPythonMessage,
+} from "../scripts/gen-api-types.mjs";
+
+const repoRoot = "/repo";
+
+describe("resolvePythonCommand", () => {
+  it("honors LITELLM_PYTHON, splitting multi-word commands", () => {
+    const cmd = resolvePythonCommand({ LITELLM_PYTHON: "uv run --no-sync python" }, repoRoot, () => false);
+    expect(cmd).toEqual(["uv", "run", "--no-sync", "python"]);
+  });
+
+  it("prefers the repo's .venv interpreter over a bare python3", () => {
+    const venv = `${repoRoot}/.venv/bin/python`;
+    const cmd = resolvePythonCommand({}, repoRoot, (p) => p === venv);
+    expect(cmd).toEqual([venv]);
+  });
+
+  it("finds the Windows .venv interpreter", () => {
+    const venv = `${repoRoot}/.venv/Scripts/python.exe`;
+    const cmd = resolvePythonCommand({}, repoRoot, (p) => p === venv);
+    expect(cmd).toEqual([venv]);
+  });
+
+  it("falls back to python3 when no venv exists", () => {
+    expect(resolvePythonCommand({}, repoRoot, () => false)).toEqual(["python3"]);
+  });
+});
+
+describe("parsePythonVersion", () => {
+  it("parses major.minor from the probe output", () => {
+    expect(parsePythonVersion("3.9\n")).toEqual({ major: 3, minor: 9 });
+    expect(parsePythonVersion("3.13\n")).toEqual({ major: 3, minor: 13 });
+  });
+
+  it("returns null on unparseable output", () => {
+    expect(parsePythonVersion("not a version")).toBeNull();
+  });
+});
+
+describe("isSupportedPython", () => {
+  it("rejects the 3.9 interpreter that breaks on dataclass slots=True", () => {
+    expect(isSupportedPython({ major: 3, minor: 9 })).toBe(false);
+  });
+
+  it("accepts 3.10 and newer", () => {
+    expect(isSupportedPython({ major: 3, minor: 10 })).toBe(true);
+    expect(isSupportedPython({ major: 3, minor: 13 })).toBe(true);
+    expect(isSupportedPython({ major: 4, minor: 0 })).toBe(true);
+  });
+
+  it("rejects an unknown version", () => {
+    expect(isSupportedPython(null)).toBe(false);
+  });
+});
+
+describe("unsupportedPythonMessage", () => {
+  it("names the interpreter, the detected version, and how to fix it", () => {
+    const message = unsupportedPythonMessage(["python3"], { major: 3, minor: 9 });
+    expect(message).toContain("python3");
+    expect(message).toContain("3.9");
+    expect(message).toContain("LITELLM_PYTHON");
+    expect(message).toContain(">=3.10");
+  });
+});

--- a/ui/litellm-dashboard/tests/gen-api-types.test.ts
+++ b/ui/litellm-dashboard/tests/gen-api-types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   resolvePythonCommand,
   parsePythonVersion,
+  probePythonVersion,
   isSupportedPython,
   unsupportedPythonMessage,
 } from "../scripts/gen-api-types.mjs";
@@ -46,6 +47,32 @@ describe("parsePythonVersion", () => {
 
   it("returns null on unparseable output", () => {
     expect(parsePythonVersion("not a version")).toBeNull();
+  });
+});
+
+describe("probePythonVersion", () => {
+  it("probes the interpreter from the repo root, matching the spec-dump cwd", () => {
+    let seenCwd: string | undefined;
+    const exec = (_bin: string, _args: string[], opts: { cwd?: string }) => {
+      seenCwd = opts.cwd;
+      return "3.11\n";
+    };
+    const version = probePythonVersion(["python3"], repoRoot, exec);
+    expect(seenCwd).toBe(repoRoot);
+    expect(version).toEqual({ major: 3, minor: 11 });
+  });
+
+  it("resolves a repo-root-relative interpreter against the repo root, not the dashboard cwd", () => {
+    let seenBin: string | undefined;
+    let seenCwd: string | undefined;
+    const exec = (bin: string, _args: string[], opts: { cwd?: string }) => {
+      seenBin = bin;
+      seenCwd = opts.cwd;
+      return "3.12\n";
+    };
+    probePythonVersion([".venv/bin/python"], repoRoot, exec);
+    expect(seenBin).toBe(".venv/bin/python");
+    expect(seenCwd).toBe(repoRoot);
   });
 });
 


### PR DESCRIPTION
## Relevant issues

Running `npm run gen:api` in `ui/litellm-dashboard` fails with a confusing traceback that points at `litellm/types/completion.py`:

```
TypeError: dataclass() got an unexpected keyword argument 'slots'
```

## Linear ticket

## What this does

The real cause is not that file. `gen-api-types.mjs` defaulted to a bare `python3`, which on macOS is usually the system interpreter (3.9). The script runs that interpreter against the repo source tree, and on import litellm hits `@dataclass(frozen=True, slots=True)`; `slots=` only exists from Python 3.10 (which is what `pyproject.toml` already requires via `requires-python = ">=3.10"`). So the user ends up on an unsupported interpreter and gets a traceback that blames `completion.py` rather than their Python version.

This makes the script resolve a real interpreter before falling back to `python3`, with precedence `LITELLM_PYTHON`, then an activated `$VIRTUAL_ENV`, then the repo's `.venv`, so a stale repo `.venv` never shadows an environment the developer already activated. It also probes the chosen interpreter's version up front, so an unsupported Python fails with an actionable message that names the interpreter, its detected version, and how to fix it, instead of the cryptic slots traceback. `LITELLM_PYTHON` still takes precedence, so CI (which passes `uv run --no-sync python`) is unchanged.

The version probe runs from the repo root, the same working directory the later spec dump uses, so a repo-root-relative `LITELLM_PYTHON` (e.g. `.venv/bin/python`) resolves to the same interpreter in both the guard and the actual generation rather than being probed against the dashboard directory the npm script runs in.

The script's imperative body was wrapped in a `main()` guarded by an `import.meta`/`process.argv` check so the pure helpers (`resolvePythonCommand`, `parsePythonVersion`, `probePythonVersion`, `isSupportedPython`, `unsupportedPythonMessage`) can be unit tested without triggering a spec dump, following the existing `scripts/lint-budget-lib.mjs` pattern.

Because this PR touches `gen-api-types.mjs`, the Check UI API Types Sync job runs and regenerates `schema.d.ts`. The committed types had drifted from the spec: the shared `RateLimitError` 429 description now renders with deeper indentation, so one commit checks in the regenerated, unedited output to get that job green.

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

The unsupported-interpreter path, exercised against the resolver/guard helpers (3.9 is what breaks on `slots=`):

```
$ node -e "import('./scripts/gen-api-types.mjs').then(m => {
    const v = m.parsePythonVersion('3.9\n');
    console.log('supported:', m.isSupportedPython(v));
    console.log(m.unsupportedPythonMessage(['python3'], v));
  })"
supported: false
litellm requires Python >=3.10, but `python3` reports 3.9. Point gen:api at a supported interpreter (e.g. `uv venv && uv sync`, or set LITELLM_PYTHON to one with litellm installed), then re-run `npm run gen:api`.
```

A supported interpreter (3.11 here) still passes the guard, and interpreter resolution (`LITELLM_PYTHON`, `$VIRTUAL_ENV`, `.venv`) plus the repo-root-relative probe cwd are covered by the vitest suite:

```
$ npx vitest run tests/gen-api-types.test.ts
 ✓ tests/gen-api-types.test.ts (13 tests)
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Changes

`ui/litellm-dashboard/scripts/gen-api-types.mjs`: resolve the interpreter as `LITELLM_PYTHON` then `$VIRTUAL_ENV` then repo `.venv` then `python3`, validate it is >=3.10 before importing litellm, probe that interpreter from the repo root so a relative `LITELLM_PYTHON` matches the spec-dump cwd, and extract testable pure helpers behind a main guard

`ui/litellm-dashboard/tests/gen-api-types.test.ts`: unit tests for interpreter resolution, version parsing, the repo-root probe cwd, the >=3.10 gate, and the error message

`ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated to match the current proxy OpenAPI spec (RateLimitError 429 description indentation); generated output, not hand-edited

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the dashboard OpenAPI codegen script, its tests, and generated types—no runtime proxy or auth behavior.
> 
> **Overview**
> **`gen-api-types.mjs`** no longer defaults straight to `python3`. It picks an interpreter in order: `LITELLM_PYTHON`, active `$VIRTUAL_ENV`, repo `.venv` (Unix/Windows), then `python3`. Before importing litellm it probes that interpreter from the **repo root** (same cwd as the OpenAPI dump) and fails fast with a clear **>=3.10** message instead of a `dataclass(slots=True)` traceback on 3.9.
> 
> The script body moves behind a **`main()`** guard so resolver/version helpers are exported and unit-testable without running generation.
> 
> Adds **`tests/gen-api-types.test.ts`** (Vitest) for resolution, probing cwd, version gate, and error text. **`schema.d.ts`** is regenerated only for a minor **RateLimitError** 429 doc-comment indentation drift so API-types sync CI passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a16db0f53565f1a90f96f4d23bcc1c38c8def78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->