### PR TITLE
fix(proxy): centralize key mutation authorization (LIT-4072)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1008,6 +1008,21 @@ class LiteLLM_ObjectPermissionBase(LiteLLMPydanticObjectBase):
 from litellm.models.team import BudgetLimitEntry as BudgetLimitEntry  # noqa: E402
 
 
+class PermissionsDict(TypedDict, total=False):
+    """Plain-dict mirror of the ``permissions`` field on a key request.
+
+    Names the keys the proxy actually reads off the dict: ``get_spend_routes``
+    (gates the global spend routes in ``route_checks``) and
+    ``enable_llm_guard_check`` (gates the enterprise LLM-guard callback).
+    Other keys are still valid at runtime; ``guardrail_helpers`` iterates the
+    dict as ``{guardrail_name: should_run}``, so ``total=False`` lets those
+    user-defined keys pass without a schema bump.
+    """
+
+    get_spend_routes: bool
+    enable_llm_guard_check: bool
+
+
 class GenerateRequestBase(LiteLLMPydanticObjectBase):
     """
     Overlapping schema between key and user generate/update requests

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -74,6 +74,7 @@ from litellm.proxy.management_endpoints.common_utils import (
 from litellm.proxy.management_endpoints.model_management_endpoints import (
     _add_model_to_db,
 )
+from litellm.proxy.management_helpers.key_mutation_authz import authorize_key_mutation
 from litellm.proxy.management_helpers.object_permission_utils import (
     _set_object_permission,
     attach_object_permission_to_dict,
@@ -669,12 +670,21 @@ async def _common_key_generation_helper(
             prisma_client=prisma_client,
         )
 
-    # Capture caller-supplied max_budget and team_id before any defaults or
-    # upperbound params can fill them, so the ceiling check and its team-key
-    # exemption key off what the caller explicitly requested, not a value that
-    # default_key_generate_params injected.
-    _requested_max_budget = data.max_budget
-    _requested_team_id = data.team_id
+    # Run policy on what the CALLER explicitly requested, before
+    # default_key_generate_params / _enforce_upperbound_key_params can
+    # fill or coerce fields. A config-defaulted max_budget must not
+    # spuriously fail the caller's delegation ceiling, and an upperbound
+    # injection must not change the caller's submitted shape that the
+    # policy sees.
+    await authorize_key_mutation(
+        data=data,
+        existing_key_row=None,
+        user_api_key_dict=user_api_key_dict,
+        team_table=team_table,
+        prisma_client=prisma_client,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
 
     # check if user set default key/generate params on config.yaml
     if litellm.default_key_generate_params is not None:
@@ -698,51 +708,6 @@ async def _common_key_generation_helper(
 
     # check if user set upperbound key/generate params on config.yaml
     _enforce_upperbound_key_params(data, fill_defaults=True)
-
-    # Delegated-authority ceiling (GHSA-q775-qw9r-2r4g): a non-admin caller
-    # cannot grant a key a higher budget than their own authority.
-    is_ui_session_team_key = user_api_key_dict.team_id == UI_SESSION_TOKEN_TEAM_ID and _requested_team_id is not None
-    # Session tokens (lite login) carry max_budget=None to avoid a per-session
-    # LLM spend cap, but that None must not be read as "unlimited delegation
-    # authority". A personal key (no team) has no team-budget enforcement at
-    # request time, so a session token cannot delegate any budget for one.
-    if (
-        user_api_key_dict.is_session_token
-        and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
-        and not is_ui_session_team_key
-        and _requested_max_budget is not None
-        and team_table is None
-    ):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": (
-                    f"max_budget ({_requested_max_budget}) cannot be set without "
-                    "specifying team_id when using a CLI session token."
-                )
-            },
-        )
-    delegation_ceiling = (
-        user_api_key_dict.max_budget
-        if user_api_key_dict.max_budget is not None
-        else (team_table.max_budget if user_api_key_dict.is_session_token and team_table is not None else None)
-    )
-    if (
-        user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value
-        and not is_ui_session_team_key
-        and _requested_max_budget is not None
-        and delegation_ceiling is not None
-        and _requested_max_budget > delegation_ceiling
-    ):
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": (
-                    f"max_budget ({_requested_max_budget}) cannot exceed the caller's "
-                    f"own max_budget ({delegation_ceiling})."
-                )
-            },
-        )
 
     # APPLY ENTERPRISE KEY MANAGEMENT PARAMS
     try:
@@ -1984,6 +1949,21 @@ async def _process_single_key_update(
                 prisma_client=prisma_client,
             )
 
+    # Bulk update entry point: /key/bulk_update and /team/key/bulk_update
+    # construct UpdateKeyRequest objects and call this helper directly, so
+    # the per-key /key/update gates in _validate_update_key_data do not run.
+    # Authorize the mutation here so the same policy applies on the bulk
+    # paths.
+    await authorize_key_mutation(
+        data=update_key_request,
+        existing_key_row=existing_key_row,
+        user_api_key_dict=user_api_key_dict,
+        team_table=team_obj,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        route_label="/key/bulk_update",
+    )
+
     # Validate team change if team is being changed
     if is_different_team(data=update_key_request, existing_key_row=existing_key_row):
         if llm_router is None:
@@ -2135,70 +2115,9 @@ async def _validate_update_key_data(
         user_api_key_cache=user_api_key_cache,
     )
 
-    # Cross-key authorization. Previously only gated on max_budget/spend
-    # changes, which let a non-admin blanket-rewrite any OTHER field on
-    # any key (models, alias, metadata, tpm_limit, rpm_limit,
-    # allowed_routes, guardrails, blocked, duration, permissions, …) as
-    # long as they avoided budget/spend.
-    #
-    # Policy:
-    # - Key owner (same user_id): may update non-budget fields on their
-    #   own key without the admin check.
-    # - Team member with /key/update grant (on a team key): may update
-    #   non-budget fields. Team membership + permission is already
-    #   enforced by can_team_member_execute_key_management_endpoint
-    #   above, which raises 401 for non-members or members without the
-    #   grant — so reaching this point on a team key means the caller
-    #   was authorized via member_permissions. This preserves the
-    #   documented member_permissions feature while still blocking the
-    #   cross-org attack (an outside org admin is not a member of the
-    #   victim team and gets rejected at the earlier check).
-    # - Anyone else (non-PROXY_ADMIN, not the owner, not a team member
-    #   on a team key): must pass _check_key_admin_access (PROXY_ADMIN
-    #   / key-owner / team-admin / org-admin of the key).
-    # - max_budget / spend / budget_limits: always require the admin
-    #   check, even for the key owner or a team member (matches the
-    #   existing admin-only budget semantics).  budget_limits uses
-    #   model_fields_set because an explicit null/[] clears the field
-    #   and must gate the same as setting or changing it.
-    # - spend gates on presence alone (not a value diff): the DB spend
-    #   lags the live cross-pod counter, so letting an "unchanged" spend
-    #   through the non-admin path would let a key owner / team member
-    #   overwrite the live counter below real usage and silently weaken
-    #   enforcement.
-    _is_budget_change = (
-        (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
-        or data.spend is not None
-        or "budget_limits" in data.model_fields_set
-    )
-
-    # Personal-key bypass: the caller both created the key AND still owns it
-    # (user_id == caller).  Checking only created_by would let a demoted admin
-    # who originally created a key for another user continue editing it without
-    # admin authorization after the key was reassigned.
-    caller_is_creator = (
-        user_api_key_dict.user_id is not None
-        and getattr(existing_key_row, "created_by", None) == user_api_key_dict.user_id
-        and getattr(existing_key_row, "user_id", None) == user_api_key_dict.user_id
-    )
-    # Team keys: can_team_member_execute_key_management_endpoint (called above)
-    # already validated team membership + /key/update permission and would have
-    # raised if the caller lacked it.  Reaching this point on a team key for a
-    # non-budget change means the caller was authorized — skip the redundant
-    # _check_key_admin_access that would otherwise require team/org admin status.
-    _key_is_team_key = getattr(existing_key_row, "team_id", None) is not None
-    can_skip_admin_check = (caller_is_creator or _key_is_team_key) and not _is_budget_change
-    if (not _is_proxy_admin) and prisma_client is not None and not can_skip_admin_check:
-        hashed_key = existing_key_row.token
-        await _check_key_admin_access(
-            user_api_key_dict=user_api_key_dict,
-            hashed_token=hashed_key,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            route=("/key/update (max_budget/spend)" if _is_budget_change else "/key/update"),
-        )
-
-    # Check team limits if key has a team_id (from request or existing key)
+    # Resolve team_obj before invoking the policy helper so the
+    # delegation-ceiling check can consult team budget for session
+    # tokens acting on a team key.
     team_obj: Optional[LiteLLM_TeamTableCachedObj] = None
     _team_id_to_check = data.team_id or getattr(existing_key_row, "team_id", None)
     if _team_id_to_check is not None:
@@ -2230,6 +2149,16 @@ async def _validate_update_key_data(
                 data=data,
                 prisma_client=prisma_client,
             )
+
+    await authorize_key_mutation(
+        data=data,
+        existing_key_row=existing_key_row,
+        user_api_key_dict=user_api_key_dict,
+        team_table=team_obj,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        route_label="/key/update",
+    )
 
     # Validate key against project limits if project_id is being set
     _project_id_to_check = getattr(data, "project_id", None) or getattr(existing_key_row, "project_id", None)
@@ -3383,7 +3312,7 @@ async def generate_key_helper_fn(
     update_key_values: Optional[dict] = None,
     key_alias: Optional[str] = None,
     allowed_cache_controls: Optional[list] = [],
-    permissions: Optional[dict] = {},
+    permissions: Optional[dict] = None,
     model_max_budget: Optional[dict] = {},
     model_rpm_limit: Optional[dict] = None,
     model_tpm_limit: Optional[dict] = None,
@@ -3448,7 +3377,10 @@ async def generate_key_helper_fn(
 
     aliases_json = json.dumps(aliases)
     config_json = json.dumps(config)
-    permissions_json = json.dumps(permissions)
+    # Preserve historical DB shape: serialize an empty dict (not None) when
+    # the caller passed no permissions, so downstream readers that expect
+    # a dict after json.loads continue to work.
+    permissions_json = json.dumps(permissions if permissions is not None else {})
     router_settings_json = safe_dumps(router_settings) if router_settings is not None else safe_dumps({})
 
     # Add model_rpm_limit and model_tpm_limit to metadata
@@ -4460,19 +4392,29 @@ async def regenerate_key_fn(
 
         # Gate access_group_ids on regenerate, same as /key/generate and
         # /key/update. Use the existing key's team since the body may omit it.
+        regenerate_team_table: Optional[LiteLLM_TeamTableCachedObj] = None
+        if _key_in_db.team_id is not None:
+            regenerate_team_table = await get_team_object(
+                team_id=_key_in_db.team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                check_db_only=True,
+            )
         if data is not None and data.access_group_ids:
-            regenerate_team_table: Optional[LiteLLM_TeamTableCachedObj] = None
-            if _key_in_db.team_id is not None:
-                regenerate_team_table = await get_team_object(
-                    team_id=_key_in_db.team_id,
-                    prisma_client=prisma_client,
-                    user_api_key_cache=user_api_key_cache,
-                    check_db_only=True,
-                )
             TeamMemberPermissionChecks.enforce_member_can_assign_access_groups(
                 user_api_key_dict=user_api_key_dict,
                 team_table=regenerate_team_table,
                 access_group_ids=data.access_group_ids,
+            )
+        if data is not None:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_key_in_db,
+                user_api_key_dict=user_api_key_dict,
+                team_table=regenerate_team_table,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                route_label="/key/regenerate",
             )
 
         verbose_proxy_logger.info(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3312,7 +3312,7 @@ async def generate_key_helper_fn(
     update_key_values: Optional[dict] = None,
     key_alias: Optional[str] = None,
     allowed_cache_controls: Optional[list] = [],
-    permissions: Optional[dict] = None,
+    permissions: Optional[PermissionsDict] = None,
     model_max_budget: Optional[dict] = {},
     model_rpm_limit: Optional[dict] = None,
     model_tpm_limit: Optional[dict] = None,

--- a/litellm/proxy/management_helpers/key_mutation_authz.py
+++ b/litellm/proxy/management_helpers/key_mutation_authz.py
@@ -268,18 +268,34 @@ def _check_delegation_ceiling(
     if delegation_ceiling is None:
         return
 
-    max_budget_changed = data.max_budget is not None and (
-        existing_key_row is None or data.max_budget != existing_key_row.max_budget
-    )
-    if max_budget_changed and data.max_budget > delegation_ceiling:
-        raise HTTPException(
-            status_code=400,
-            detail={
-                "error": (
-                    f"max_budget ({data.max_budget}) cannot exceed the caller's own max_budget ({delegation_ceiling})."
-                )
-            },
-        )
+    existing_max_budget = getattr(existing_key_row, "max_budget", None) if existing_key_row is not None else None
+    max_budget_in_fields_set = "max_budget" in data.model_fields_set
+    max_budget_changed = max_budget_in_fields_set and data.max_budget != existing_max_budget
+    if max_budget_changed:
+        # An explicit `max_budget: null` from a team/org admin removes the
+        # existing cap entirely, so the resulting effective max is
+        # unbounded — that exceeds any finite delegation_ceiling. Treat
+        # the clear the same as setting an over-ceiling value.
+        if data.max_budget is None and existing_max_budget is not None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": (
+                        f"Clearing max_budget would remove the existing cap "
+                        f"({existing_max_budget}) and exceed the caller's own "
+                        f"max_budget ({delegation_ceiling})."
+                    )
+                },
+            )
+        if data.max_budget is not None and data.max_budget > delegation_ceiling:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": (
+                        f"max_budget ({data.max_budget}) cannot exceed the caller's own max_budget ({delegation_ceiling})."
+                    )
+                },
+            )
 
     # temp_budget_increase is added to the stored max_budget at request
     # time (_update_key_budget_with_temp_budget_increase), so the

--- a/litellm/proxy/management_helpers/key_mutation_authz.py
+++ b/litellm/proxy/management_helpers/key_mutation_authz.py
@@ -1,0 +1,337 @@
+"""
+Single policy entrypoint for authorizing a key mutation.
+
+Background: prior to this module, six write paths each enforced subsets of the
+key-mutation policy at their own call sites, with different gating logic for
+`permissions`, budget admin authority, and the delegation ceiling. The drift
+produced real bypasses (non-admin self-grant on `permissions`, NaN smuggled
+into `budget_limits`, CLI session token treating its own absent budget as
+unlimited delegation authority, bulk paths skipping checks the single path
+enforced).
+
+This module collapses the policy into one helper, `authorize_key_mutation`,
+that:
+
+  1. Validates numeric hygiene on every submitted budget value (NaN / inf
+     / None / wrong-type are rejected with 400 before any comparison).
+  2. Diffs the incoming request against the existing key (None on create)
+     to know which fields actually changed.
+  3. Enforces three guards by changed field:
+       a. `permissions` is proxy-admin-only. On create, only a non-empty
+          dict trips the gate; on update-like paths, any explicit presence
+          in `model_fields_set` trips it (so `{}` and `null` cannot clear
+          an admin-set capability).
+       b. On update-like paths, any budget change (max_budget / spend /
+          budget_limits) requires key-admin authority over the target key.
+          Personal-key-owner and team-member-grant fast paths apply to
+          non-budget changes only.
+       c. On every write path, the delegation ceiling caps the submitted
+          budget against the caller's own authority. Proxy admins and the
+          UI team-admin session are exempt from the ceiling. A CLI session
+          token with no team and an explicit budget is hard-rejected
+          rather than treated as unlimited.
+
+The six handlers each call this once, in the position where they already
+have `existing_key_row` (None on create) and `team_table` resolved.
+"""
+
+import math
+from typing import Any, List, Optional, Union
+
+from fastapi import HTTPException
+
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+from litellm.models.team import BudgetLimitEntry
+from litellm.proxy._types import (
+    GenerateKeyRequest,
+    LiteLLM_TeamTableCachedObj,
+    LiteLLM_VerificationToken,
+    LitellmUserRoles,
+    RegenerateKeyRequest,
+    UpdateKeyRequest,
+    UserAPIKeyAuth,
+)
+from litellm.proxy.utils import PrismaClient
+
+KeyWriteRequest = Union[GenerateKeyRequest, UpdateKeyRequest, RegenerateKeyRequest]
+
+
+def _is_proxy_admin(user_api_key_dict: UserAPIKeyAuth) -> bool:
+    return user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value
+
+
+def _is_ui_team_admin_session(
+    user_api_key_dict: UserAPIKeyAuth,
+    requested_team_id: Optional[str],
+) -> bool:
+    """The UI signs the team admin into a session token with a fixed
+    sentinel team_id; when they then act on a real team key they keep
+    their normal delegation authority."""
+    return user_api_key_dict.team_id == UI_SESSION_TOKEN_TEAM_ID and requested_team_id is not None
+
+
+def _resolve_delegation_ceiling(
+    user_api_key_dict: UserAPIKeyAuth,
+    team_table: Optional[LiteLLM_TeamTableCachedObj],
+) -> Optional[float]:
+    """Caller's own max_budget when set; for CLI session tokens acting on
+    a team key, fall back to the team's max_budget. `None` means "no
+    ceiling configured" (legitimate when an admin granted unlimited
+    delegation); only the session-token-no-team case rejects on `None`,
+    handled separately."""
+    if user_api_key_dict.max_budget is not None:
+        return user_api_key_dict.max_budget
+    if user_api_key_dict.is_session_token and team_table is not None:
+        return team_table.max_budget
+    return None
+
+
+def _reject_non_finite(value: Any, field: str) -> None:
+    """Reject NaN, inf, None, or non-numeric. `NaN > x` is False so a
+    NaN budget bypasses the ceiling check and disables downstream
+    enforcement (`spend > NaN` is always False). Numeric hygiene is
+    not role-dependent — admins are also rejected."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": f"{field} must be a finite number; got {value!r}",
+            },
+        )
+    if not math.isfinite(value):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"{field} must be a finite number; got {value}"},
+        )
+
+
+def _normalize_window_for_compare(window: Any) -> Any:
+    """Reduce a budget_limits window to a comparable shape. The wire
+    form is a `BudgetLimitEntry` (Pydantic), the DB form is a plain
+    dict carrying `reset_at`. Drop `reset_at` and any None-valued
+    keys so a UI prefill that round-trips unchanged compares equal."""
+    if isinstance(window, BudgetLimitEntry):
+        window = window.model_dump(mode="json", exclude_none=True)
+    if isinstance(window, dict):
+        return {k: v for k, v in window.items() if v is not None and k != "reset_at"}
+    return window
+
+
+def _budget_limits_equal(
+    submitted: Optional[List[BudgetLimitEntry]],
+    existing: Any,
+) -> bool:
+    """A True result lets the ceiling check skip the field; used only
+    to suppress noise on unchanged resubmits, never to bypass a
+    real change."""
+    if submitted is None and existing is None:
+        return True
+    if submitted is None or existing is None:
+        return False
+    if not isinstance(existing, list):
+        return False
+    sub = [_normalize_window_for_compare(w) for w in submitted]
+    ex = [_normalize_window_for_compare(w) for w in existing]
+    return sub == ex
+
+
+def _check_permissions_field(
+    data: KeyWriteRequest,
+    user_api_key_dict: UserAPIKeyAuth,
+    *,
+    is_create_path: bool,
+) -> None:
+    """`permissions` grants ambient capabilities (e.g. `get_spend_routes`
+    exposes `/global/spend/*`, `enable_llm_guard_check` toggles a
+    callback). Proxy-admin-only on every write path.
+
+    Create-path semantic: the empty-dict default on `GenerateKeyRequest`
+    is the legitimate non-admin shape, so only a non-empty dict trips
+    the gate. Update-path semantic: an explicit `{}` or `null` from a
+    non-admin owner would clear an admin-set capability such as
+    `enable_llm_guard_check`, so any explicit presence in
+    `model_fields_set` trips the gate."""
+    if _is_proxy_admin(user_api_key_dict):
+        return
+    permissions = getattr(data, "permissions", None)
+    if is_create_path:
+        if not permissions:
+            return
+    else:
+        if "permissions" not in data.model_fields_set:
+            return
+    raise HTTPException(
+        status_code=403,
+        detail={"error": "Only proxy admins can write `permissions` on a key."},
+    )
+
+
+async def _check_budget_admin_authority(
+    data: KeyWriteRequest,
+    existing_key_row: LiteLLM_VerificationToken,
+    user_api_key_dict: UserAPIKeyAuth,
+    prisma_client: Optional[PrismaClient],
+    user_api_key_cache: Any,
+    route_label: str,
+) -> None:
+    """Update-like paths only. Any budget-field change requires admin
+    authority over the key (proxy admin / team admin of key's team /
+    org admin of that team's org). Personal-key-owner and team-member
+    grant fast paths apply only to non-budget changes — the DB spend
+    counter lags the live cross-pod counter, so letting an unchanged
+    spend through the non-admin path would let a key owner silently
+    overwrite the live counter below real usage."""
+    if _is_proxy_admin(user_api_key_dict):
+        return
+    if prisma_client is None:
+        return
+    is_budget_change = (
+        (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
+        or getattr(data, "spend", None) is not None
+        or "budget_limits" in data.model_fields_set
+    )
+    caller_is_creator = (
+        user_api_key_dict.user_id is not None
+        and getattr(existing_key_row, "created_by", None) == user_api_key_dict.user_id
+        and getattr(existing_key_row, "user_id", None) == user_api_key_dict.user_id
+    )
+    key_is_team_key = getattr(existing_key_row, "team_id", None) is not None
+    can_skip = (caller_is_creator or key_is_team_key) and not is_budget_change
+    if can_skip:
+        return
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _check_key_admin_access,
+    )
+
+    await _check_key_admin_access(
+        user_api_key_dict=user_api_key_dict,
+        hashed_token=existing_key_row.token,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        route=f"{route_label} (max_budget/spend)" if is_budget_change else route_label,
+    )
+
+
+def _check_delegation_ceiling(
+    data: KeyWriteRequest,
+    existing_key_row: Optional[LiteLLM_VerificationToken],
+    user_api_key_dict: UserAPIKeyAuth,
+    team_table: Optional[LiteLLM_TeamTableCachedObj],
+) -> None:
+    """A caller may not delegate budget beyond their own authority. On
+    update-like paths, only enforce the ceiling on budget values that
+    actually changed against the existing key (so a UI prefill that
+    resubmits the existing $1M cap on a $100-ceiling team admin while
+    editing an unrelated field passes).
+
+    Numeric hygiene runs before any role check — NaN is rejected for
+    everyone, including proxy admins, because a NaN at rest disables
+    enforcement forever."""
+    if data.max_budget is not None:
+        _reject_non_finite(data.max_budget, "max_budget")
+    if data.budget_limits:
+        for window in data.budget_limits:
+            _reject_non_finite(window.max_budget, "budget_limits entry max_budget")
+
+    if _is_proxy_admin(user_api_key_dict):
+        return
+    if _is_ui_team_admin_session(user_api_key_dict, data.team_id):
+        return
+
+    if (
+        user_api_key_dict.is_session_token
+        and team_table is None
+        and (data.max_budget is not None or "budget_limits" in data.model_fields_set)
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": ("A CLI session token cannot delegate budget for a personal key; specify `team_id`.")},
+        )
+
+    delegation_ceiling = _resolve_delegation_ceiling(user_api_key_dict, team_table)
+    if delegation_ceiling is None:
+        return
+
+    max_budget_changed = data.max_budget is not None and (
+        existing_key_row is None or data.max_budget != existing_key_row.max_budget
+    )
+    if max_budget_changed and data.max_budget > delegation_ceiling:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": (
+                    f"max_budget ({data.max_budget}) cannot exceed the caller's own max_budget ({delegation_ceiling})."
+                )
+            },
+        )
+
+    if not data.budget_limits:
+        return
+    existing_windows = getattr(existing_key_row, "budget_limits", None) if existing_key_row is not None else None
+    if existing_key_row is not None and _budget_limits_equal(data.budget_limits, existing_windows):
+        return
+    over = next(
+        (w for w in data.budget_limits if w.max_budget > delegation_ceiling),
+        None,
+    )
+    if over is not None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": (
+                    f"budget_limits entry max_budget ({over.max_budget}) "
+                    f"cannot exceed the caller's own max_budget "
+                    f"({delegation_ceiling})."
+                )
+            },
+        )
+
+
+async def authorize_key_mutation(
+    *,
+    data: KeyWriteRequest,
+    existing_key_row: Optional[LiteLLM_VerificationToken],
+    user_api_key_dict: UserAPIKeyAuth,
+    team_table: Optional[LiteLLM_TeamTableCachedObj],
+    prisma_client: Optional[PrismaClient],
+    user_api_key_cache: Any,
+    route_label: str,
+) -> None:
+    """Single policy entrypoint for any key-write handler.
+
+    `existing_key_row` is None on create paths (`/key/generate`,
+    `/key/service-account/generate`) and populated on update-like paths
+    (`/key/update`, `/key/regenerate`, `/key/bulk_update`,
+    `/team/key/bulk_update`). `is_create_path` is derived from that.
+
+    Order matters: permissions admin gate runs first because it is the
+    cheapest check and short-circuits non-admin self-grant. Budget admin
+    gate runs second so update-like paths reject non-admin budget
+    changes before reaching the ceiling. Delegation ceiling runs last
+    and is the only check that constrains admin callers (proxy admin is
+    exempt, but team admin / org admin / session token are bounded by
+    their own authority)."""
+    is_create_path = existing_key_row is None
+
+    _check_permissions_field(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+        is_create_path=is_create_path,
+    )
+
+    if not is_create_path:
+        await _check_budget_admin_authority(
+            data=data,
+            existing_key_row=existing_key_row,
+            user_api_key_dict=user_api_key_dict,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            route_label=route_label,
+        )
+
+    _check_delegation_ceiling(
+        data=data,
+        existing_key_row=existing_key_row,
+        user_api_key_dict=user_api_key_dict,
+        team_table=team_table,
+    )

--- a/litellm/proxy/management_helpers/key_mutation_authz.py
+++ b/litellm/proxy/management_helpers/key_mutation_authz.py
@@ -186,10 +186,22 @@ async def _check_budget_admin_authority(
         return
     if prisma_client is None:
         return
+    # max_budget detection keys off model_fields_set, not None vs non-None,
+    # so an explicit `max_budget: null` from a non-admin owner that clears
+    # the existing cap trips the gate too. temp_budget_increase / expiry
+    # are an additive bump applied at request time
+    # (_update_key_budget_with_temp_budget_increase), so a non-admin
+    # sneaking a $1M temp_budget_increase through the personal-key fast
+    # path would silently inflate the effective cap — gate the same.
+    max_budget_changed = "max_budget" in data.model_fields_set and data.max_budget != getattr(
+        existing_key_row, "max_budget", None
+    )
     is_budget_change = (
-        (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
+        max_budget_changed
         or getattr(data, "spend", None) is not None
         or "budget_limits" in data.model_fields_set
+        or "temp_budget_increase" in data.model_fields_set
+        or "temp_budget_expiry" in data.model_fields_set
     )
     caller_is_creator = (
         user_api_key_dict.user_id is not None
@@ -233,6 +245,9 @@ def _check_delegation_ceiling(
     if data.budget_limits:
         for window in data.budget_limits:
             _reject_non_finite(window.max_budget, "budget_limits entry max_budget")
+    temp_increase = getattr(data, "temp_budget_increase", None)
+    if temp_increase is not None:
+        _reject_non_finite(temp_increase, "temp_budget_increase")
 
     if _is_proxy_admin(user_api_key_dict):
         return
@@ -265,6 +280,31 @@ def _check_delegation_ceiling(
                 )
             },
         )
+
+    # temp_budget_increase is added to the stored max_budget at request
+    # time (_update_key_budget_with_temp_budget_increase), so the
+    # effective cap a team admin can grant is base + bump. Check the
+    # bump itself against the ceiling, and the resulting effective cap
+    # against the ceiling, so a $1M bump on a $50 base on a $100-ceiling
+    # caller is rejected even though neither piece alone exceeds it.
+    if temp_increase is not None:
+        base = (
+            data.max_budget
+            if data.max_budget is not None
+            else (getattr(existing_key_row, "max_budget", None) if existing_key_row is not None else None)
+        )
+        effective = (base or 0.0) + temp_increase
+        if effective > delegation_ceiling:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": (
+                        f"temp_budget_increase ({temp_increase}) raises the effective "
+                        f"max_budget to {effective}, which cannot exceed the caller's "
+                        f"own max_budget ({delegation_ceiling})."
+                    )
+                },
+            )
 
     if not data.budget_limits:
         return

--- a/litellm/proxy/management_helpers/key_mutation_authz.py
+++ b/litellm/proxy/management_helpers/key_mutation_authz.py
@@ -47,6 +47,7 @@ from litellm.proxy._types import (
     LiteLLM_TeamTableCachedObj,
     LiteLLM_VerificationToken,
     LitellmUserRoles,
+    PermissionsDict,
     RegenerateKeyRequest,
     UpdateKeyRequest,
     UserAPIKeyAuth,
@@ -153,7 +154,7 @@ def _check_permissions_field(
     `model_fields_set` trips the gate."""
     if _is_proxy_admin(user_api_key_dict):
         return
-    permissions = getattr(data, "permissions", None)
+    permissions: Optional[PermissionsDict] = getattr(data, "permissions", None)
     if is_create_path:
         if not permissions:
             return

--- a/litellm/proxy/management_helpers/key_mutation_authz.py
+++ b/litellm/proxy/management_helpers/key_mutation_authz.py
@@ -251,7 +251,12 @@ def _check_delegation_ceiling(
 
     if _is_proxy_admin(user_api_key_dict):
         return
-    if _is_ui_team_admin_session(user_api_key_dict, data.team_id):
+    requested_team_id = (
+        data.team_id
+        if data.team_id is not None
+        else (existing_key_row.team_id if existing_key_row is not None else None)
+    )
+    if _is_ui_team_admin_session(user_api_key_dict, requested_team_id):
         return
 
     if (

--- a/litellm/repositories/verification_token_repository.py
+++ b/litellm/repositories/verification_token_repository.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Type
 from litellm.models.verification_token import (
     LiteLLM_VerificationToken,
 )
+from litellm.proxy._types import PermissionsDict
 from litellm.repositories.base_repository import BaseRepository
 
 
@@ -110,7 +111,7 @@ class VerificationTokenRepository(BaseRepository[LiteLLM_VerificationToken]):
         budget_duration: Optional[str] = None,
         allowed_cache_controls: Optional[List[str]] = None,
         allowed_routes: Optional[List[str]] = None,
-        permissions: Optional[Dict[str, Any]] = None,
+        permissions: Optional[PermissionsDict] = None,
         org_id: Optional[str] = None,
         created_by: Optional[str] = None,
         object_permission_id: Optional[str] = None,
@@ -177,7 +178,7 @@ class VerificationTokenRepository(BaseRepository[LiteLLM_VerificationToken]):
         budget_duration: Optional[str] = None,
         allowed_cache_controls: Optional[List[str]] = None,
         allowed_routes: Optional[List[str]] = None,
-        permissions: Optional[Dict[str, Any]] = None,
+        permissions: Optional[PermissionsDict] = None,
         org_id: Optional[str] = None,
         created_by: Optional[str] = None,
         object_permission_id: Optional[str] = None,
@@ -232,7 +233,7 @@ class VerificationTokenRepository(BaseRepository[LiteLLM_VerificationToken]):
         budget_duration: Optional[str] = None,
         allowed_cache_controls: Optional[List[str]] = None,
         allowed_routes: Optional[List[str]] = None,
-        permissions: Optional[Dict[str, Any]] = None,
+        permissions: Optional[PermissionsDict] = None,
         blocked: Optional[bool] = None,
         object_permission_id: Optional[str] = None,
         access_group_ids: Optional[List[str]] = None,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11166,7 +11166,7 @@ async def test_bulk_update_team_keys_team_member_with_permission(monkeypatch):
         monkeypatch,
         find_many=[key_a],
         find_unique=AsyncMock(return_value=key_a),
-        update_data=AsyncMock(return_value={"data": _updated({"max_budget": 50.0})}),
+        update_data=AsyncMock(return_value={"data": _updated({"tpm_limit": 100})}),
     )
     auth_check = AsyncMock()
     monkeypatch.setattr(
@@ -11174,11 +11174,14 @@ async def test_bulk_update_team_keys_team_member_with_permission(monkeypatch):
         auth_check,
     )
 
+    # Non-budget bulk edit: team member with KEY_UPDATE grant. Budget-field
+    # edits via bulk require admin authority on top of the team-member grant
+    # and are covered by sibling tests.
     response = await bulk_update_team_keys(
         data=BulkUpdateTeamKeysRequest(
             team_id="team-abc",
             all_keys_in_team=True,
-            update_fields=KeyUpdateFields(max_budget=50.0),
+            update_fields=KeyUpdateFields(tpm_limit=100),
         ),
         user_api_key_dict=_internal_user(),
         litellm_changed_by=None,

--- a/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
+++ b/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
@@ -24,7 +24,6 @@ Each test exercises one rule from the seven-rule policy:
           and is normalized at the json.dumps site.
 """
 
-import math
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -746,6 +745,36 @@ async def test_ui_team_admin_session_exempt_from_ceiling():
         user_api_key_cache=None,
         route_label="/key/generate",
     )
+
+
+@pytest.mark.asyncio
+async def test_regenerate_ui_team_admin_session_uses_existing_key_team_for_exemption():
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-real",
+        max_budget=50.0,
+    )
+    data = RegenerateKeyRequest(key="sk-team", max_budget=1_000_000.0)
+    assert "team_id" not in data.model_fields_set
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                user_id="alice",
+                team_id=UI_SESSION_TOKEN_TEAM_ID,
+                max_budget=100.0,
+            ),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/regenerate",
+        )
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
+++ b/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
@@ -1,0 +1,714 @@
+"""
+Edge-case matrix for the centralized key-mutation policy helper.
+
+Each test exercises one rule from the seven-rule policy:
+
+  Rule 1: permissions is admin-only; create rejects only non-empty,
+          update/regenerate/bulk reject any explicit presence in
+          model_fields_set.
+  Rule 2: budget changes on update-like paths require key-admin
+          authority; personal-key and team-member fast paths apply
+          to non-budget changes only.
+  Rule 3: numeric hygiene + delegation ceiling on every write path;
+          NaN/inf/None/wrong-type rejected before comparison.
+  Rule 4: ceiling derivation from caller.max_budget, falling back to
+          team budget for session tokens in a team context; CLI
+          session token + no team + budget = hard reject.
+  Rule 5: delegation_ceiling=None means no ceiling configured (admin
+          granted unlimited delegation); proxy admins and the UI team
+          admin session are exempt from the ceiling.
+  Rule 6: on update-like paths, the ceiling is enforced only on
+          budget values that actually changed against the existing
+          key row; unchanged resubmits pass.
+  Rule 7: no mutable defaults; permissions defaults to None internally
+          and is normalized at the json.dumps site.
+"""
+
+import math
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+from litellm.proxy._types import (
+    GenerateKeyRequest,
+    LiteLLM_TeamTableCachedObj,
+    LiteLLM_VerificationToken,
+    LitellmUserRoles,
+    RegenerateKeyRequest,
+    UpdateKeyRequest,
+)
+from litellm.proxy.auth.user_api_key_auth import UserAPIKeyAuth
+from litellm.proxy.management_helpers.key_mutation_authz import authorize_key_mutation
+
+
+def _admin() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1")
+
+
+def _internal_user(max_budget: float = 100.0) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="alice",
+        max_budget=max_budget,
+    )
+
+
+def _internal_user_unlimited() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="alice")
+
+
+def _cli_session_token(team_id: str | None = None) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="alice",
+        team_id=team_id,
+        is_session_token=True,
+    )
+
+
+def _ui_team_admin_session() -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="alice",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+    )
+
+
+def _existing_key(**overrides) -> LiteLLM_VerificationToken:
+    fields = dict(
+        token="hashed-key",
+        user_id="alice",
+        created_by="alice",
+        max_budget=100.0,
+        spend=0.0,
+    )
+    fields.update(overrides)
+    return LiteLLM_VerificationToken(**fields)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 1 — permissions admin-only
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_non_admin_empty_permissions_allowed():
+    """The empty {} default on GenerateRequestBase.permissions is the
+    legitimate non-admin shape; rule 1 only rejects non-empty values on
+    the create path."""
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(),
+        existing_key_row=None,
+        user_api_key_dict=_internal_user(),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_non_admin_non_empty_permissions_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(permissions={"get_spend_routes": True}),
+            existing_key_row=None,
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_admin_permissions_allowed():
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(permissions={"get_spend_routes": True}),
+        existing_key_row=None,
+        user_api_key_dict=_admin(),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_non_admin_explicit_empty_permissions_rejected():
+    """An explicit `permissions={}` from a non-admin owner clears an
+    admin-set capability such as enable_llm_guard_check, so it must trip
+    the gate even though `{}` is falsy."""
+    data = UpdateKeyRequest(key="sk-alice", permissions={})
+    assert "permissions" in data.model_fields_set
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=_existing_key(),
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_non_admin_omitted_permissions_allowed():
+    """Omitting `permissions` is not the same as submitting it; the gate
+    keys off model_fields_set, so an unrelated update passes."""
+    data = UpdateKeyRequest(key="sk-alice", metadata={"team": "data"})
+    assert "permissions" not in data.model_fields_set
+    await authorize_key_mutation(
+        data=data,
+        existing_key_row=_existing_key(),
+        user_api_key_dict=_internal_user(),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/update",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 2 — budget admin gate on update-like paths
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_non_admin_owner_budget_change_rejected():
+    """Personal-key ownership lets the caller update non-budget fields,
+    but budget changes still require admin authority."""
+    data = UpdateKeyRequest(key="sk-alice", max_budget=50.0)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail={"error": "not authorized"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_existing_key(max_budget=100.0),
+                user_api_key_dict=_internal_user(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_non_admin_owner_non_budget_change_allowed():
+    """Personal-key bypass applies to non-budget changes; the helper
+    must not raise."""
+    data = UpdateKeyRequest(key="sk-alice", metadata={"team": "data"})
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ) as check:
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=_existing_key(),
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+    check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_team_member_non_budget_change_allowed_on_team_key():
+    """Team-member fast path on team keys for non-budget changes:
+    can_team_member_execute_key_management_endpoint has already
+    validated team membership upstream, so the budget admin gate
+    must not require admin authority for a non-budget edit here."""
+    data = UpdateKeyRequest(key="sk-team", metadata={"app": "billing"})
+    existing = _existing_key(user_id="someone-else", created_by="someone-else", team_id="team-x")
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ) as check:
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+    check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_team_member_budget_change_requires_admin():
+    """Team-member fast path does NOT extend to budget changes; the
+    admin check must run and reject if the team member is not also a
+    team admin / org admin / proxy admin."""
+    data = UpdateKeyRequest(key="sk-team", budget_limits=[])
+    existing = _existing_key(user_id="someone-else", created_by="someone-else", team_id="team-x")
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail={"error": "not authorized"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_internal_user(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_explicit_spend_requires_admin():
+    """spend is gated on presence alone — the DB spend lags the live
+    counter, so re-submitting an unchanged value through the non-admin
+    path would silently weaken enforcement."""
+    data = UpdateKeyRequest(key="sk-alice", spend=0.0)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail={"error": "not authorized"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_existing_key(),
+                user_api_key_dict=_internal_user(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 403
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 3 — numeric hygiene + delegation ceiling on every write path
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "value",
+    [float("nan"), float("inf"), float("-inf")],
+)
+async def test_create_non_finite_max_budget_rejected_even_for_admin(value):
+    """NaN/inf at rest disables downstream enforcement (`spend > NaN`
+    is always False), so hygiene is not role-dependent — even admin
+    callers must be rejected before a non-finite value reaches the DB."""
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(max_budget=value),
+            existing_key_row=None,
+            user_api_key_dict=_admin(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+    assert "finite" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+async def test_create_non_finite_budget_limits_window_rejected_for_admin(value):
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(budget_limits=[{"budget_duration": "1d", "max_budget": value}]),
+            existing_key_row=None,
+            user_api_key_dict=_admin(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_non_admin_over_ceiling_max_budget_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(max_budget=1_000_000.0),
+            existing_key_row=None,
+            user_api_key_dict=_internal_user(max_budget=10.0),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+    assert "exceed" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_non_admin_over_ceiling_budget_window_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}]),
+            existing_key_row=None,
+            user_api_key_dict=_internal_user(max_budget=10.0),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+    assert "exceed" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_non_admin_at_ceiling_max_budget_allowed():
+    """Boundary: a value exactly equal to the caller's ceiling is
+    permitted. Pins the strict `>` semantics."""
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(max_budget=10.0),
+        existing_key_row=None,
+        user_api_key_dict=_internal_user(max_budget=10.0),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 4 — ceiling derivation + CLI session token hard-reject
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cli_session_token_personal_key_max_budget_rejected():
+    """CLI session token with no team submitting any budget = hard
+    reject. The token's own max_budget=None must not be read as
+    unlimited delegation authority for a personal key."""
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(max_budget=5.0),
+            existing_key_row=None,
+            user_api_key_dict=_cli_session_token(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+    assert "session token" in str(exc.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_cli_session_token_personal_key_budget_limits_rejected():
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(budget_limits=[{"budget_duration": "1d", "max_budget": 1.0}]),
+            existing_key_row=None,
+            user_api_key_dict=_cli_session_token(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_cli_session_token_team_key_uses_team_ceiling():
+    """Session token + team table delegates against the team's budget,
+    not the caller's None max_budget."""
+    team = LiteLLM_TeamTableCachedObj(team_id="team-1", max_budget=50.0)
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=GenerateKeyRequest(max_budget=1000.0, team_id="team-1"),
+            existing_key_row=None,
+            user_api_key_dict=_cli_session_token(team_id="team-1"),
+            team_table=team,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/generate",
+        )
+    assert exc.value.status_code == 400
+    assert "exceed" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_cli_session_token_team_key_within_team_budget_allowed():
+    team = LiteLLM_TeamTableCachedObj(team_id="team-1", max_budget=50.0)
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(max_budget=25.0, team_id="team-1"),
+        existing_key_row=None,
+        user_api_key_dict=_cli_session_token(team_id="team-1"),
+        team_table=team,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 5 — None ceiling carve-outs
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_admin_unlimited_caller_can_set_any_budget():
+    """A non-admin caller whose admin granted them no ceiling
+    (`max_budget=None`, not a session token) can mint a key with any
+    budget — admin chose not to bound them."""
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(max_budget=1_000_000.0),
+        existing_key_row=None,
+        user_api_key_dict=_internal_user_unlimited(),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_admin_can_exceed_own_ceiling():
+    """Proxy admins are exempt from the delegation ceiling."""
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(
+            max_budget=1_000_000.0,
+            budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+        ),
+        existing_key_row=None,
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            user_id="admin",
+            max_budget=10.0,
+        ),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ui_team_admin_session_exempt_from_ceiling():
+    """UI signs the team admin into a session token with the sentinel
+    team_id; when they then act on a real team key they keep their
+    normal delegation authority and the ceiling is not enforced."""
+    await authorize_key_mutation(
+        data=GenerateKeyRequest(max_budget=1_000_000.0, team_id="team-real"),
+        existing_key_row=None,
+        user_api_key_dict=_ui_team_admin_session(),
+        team_table=None,
+        prisma_client=None,
+        user_api_key_cache=None,
+        route_label="/key/generate",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 6 — diff-based change detection on update-like paths
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_unchanged_over_ceiling_max_budget_allowed():
+    """A team admin with max_budget=$100 whose UI prefills the
+    existing $1M cap while updating an unrelated field must not be
+    blocked by the delegation ceiling — the value didn't change."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=1_000_000.0,
+    )
+    data = UpdateKeyRequest(key="sk-team", max_budget=1_000_000.0)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=_internal_user(max_budget=100.0),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_changed_over_ceiling_max_budget_rejected():
+    """When max_budget IS being raised, the ceiling fires."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=100.0,
+    )
+    data = UpdateKeyRequest(key="sk-team", max_budget=1_000_000.0)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_internal_user(max_budget=100.0),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_unchanged_over_ceiling_budget_limits_allowed():
+    """Same diff semantics for the windows: round-trip resubmit
+    passes even when the windows are above the caller's ceiling."""
+    existing_windows = [{"budget_duration": "1d", "max_budget": 1_000_000.0}]
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        budget_limits=existing_windows,
+    )
+    data = UpdateKeyRequest(
+        key="sk-team",
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=_internal_user(max_budget=100.0),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_changed_over_ceiling_budget_limits_rejected():
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        budget_limits=[{"budget_duration": "1d", "max_budget": 100.0}],
+    )
+    data = UpdateKeyRequest(
+        key="sk-team",
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_internal_user(max_budget=100.0),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_nan_window_rejected_even_unchanged():
+    """A NaN window must always be rejected at the hygiene step, even
+    if it matches what's already on the existing key — the existing
+    value is the bug we're trying to keep out of the DB."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        budget_limits=[{"budget_duration": "1d", "max_budget": float("nan")}],
+    )
+    data = UpdateKeyRequest(
+        key="sk-team",
+        budget_limits=[{"budget_duration": "1d", "max_budget": float("nan")}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_admin(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+    assert "finite" in str(exc.value.detail)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Rule 7 — mutable defaults normalized
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_generate_key_helper_fn_has_no_mutable_permissions_default():
+    """generate_key_helper_fn used to default `permissions={}` — a
+    mutable default shared across calls. The signature must use None
+    so the function normalizes internally and there is no shared dict."""
+    import inspect
+
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        generate_key_helper_fn,
+    )
+
+    sig = inspect.signature(generate_key_helper_fn)
+    assert sig.parameters["permissions"].default is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Composition / regenerate
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_regenerate_non_admin_permissions_rejected():
+    """Regenerate inherits the same admin-only permissions gate. The
+    create-path semantic (truthiness) applies because regenerate's body
+    populates a fresh key from a base."""
+    with pytest.raises(HTTPException) as exc:
+        await authorize_key_mutation(
+            data=RegenerateKeyRequest(key="sk-alice", permissions={"get_spend_routes": True}),
+            existing_key_row=_existing_key(),
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=None,
+            user_api_key_cache=None,
+            route_label="/key/regenerate",
+        )
+    assert exc.value.status_code == 403

--- a/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
+++ b/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
@@ -300,6 +300,149 @@ async def test_update_explicit_spend_requires_admin():
     assert exc.value.status_code == 403
 
 
+@pytest.mark.asyncio
+async def test_update_explicit_max_budget_null_clear_requires_admin():
+    """Non-admin owner sending `max_budget: null` clears the existing
+    cap. `is_budget_change` keys off model_fields_set so the explicit
+    clear trips the admin gate, not the personal-key fast path."""
+    data = UpdateKeyRequest(key="sk-alice", max_budget=None)
+    assert "max_budget" in data.model_fields_set
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail={"error": "not authorized"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_existing_key(max_budget=10.0),
+                user_api_key_dict=_internal_user(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_unchanged_max_budget_resubmit_does_not_require_admin():
+    """A no-op resubmit of the same max_budget value is not a budget
+    change, so the personal-key fast path still applies. The diff is
+    against the existing value, not against `None`."""
+    data = UpdateKeyRequest(key="sk-alice", max_budget=10.0, metadata={"team": "data"})
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ) as check:
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=_existing_key(max_budget=10.0),
+            user_api_key_dict=_internal_user(),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+    check.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_temp_budget_increase_requires_admin():
+    """temp_budget_increase is added to the stored max_budget at
+    request time, so it's a budget change and must go through the
+    admin gate. Without this, a personal-key owner could bump their
+    own effective cap arbitrarily."""
+    from datetime import datetime, timedelta, timezone
+
+    data = UpdateKeyRequest(
+        key="sk-alice",
+        temp_budget_increase=1_000_000.0,
+        temp_budget_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+        side_effect=HTTPException(status_code=403, detail={"error": "not authorized"}),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_existing_key(),
+                user_api_key_dict=_internal_user(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_team_admin_temp_budget_increase_over_ceiling_rejected():
+    """A team admin passes the admin gate, but the delegation ceiling
+    must still apply to the effective cap (base + temp_budget_increase)
+    so they can't bump a key past their own authority."""
+    from datetime import datetime, timedelta, timezone
+
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=50.0,
+    )
+    data = UpdateKeyRequest(
+        key="sk-team",
+        temp_budget_increase=1_000_000.0,
+        temp_budget_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_internal_user(max_budget=100.0),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+    assert "temp_budget_increase" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_temp_budget_increase_nan_rejected_for_admin():
+    """NaN hygiene applies to temp_budget_increase too. Without this,
+    a NaN bump silently disables enforcement on the key."""
+    from datetime import datetime, timedelta, timezone
+
+    data = UpdateKeyRequest(
+        key="sk-alice",
+        temp_budget_increase=float("nan"),
+        temp_budget_expiry=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=_existing_key(),
+                user_api_key_dict=_admin(),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+    assert "finite" in str(exc.value.detail)
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Rule 3 — numeric hygiene + delegation ceiling on every write path
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
+++ b/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
@@ -691,6 +691,36 @@ def test_generate_key_helper_fn_has_no_mutable_permissions_default():
     assert sig.parameters["permissions"].default is None
 
 
+def test_permissions_param_is_typed_with_permissionsdict():
+    """The `permissions` parameter on every internal helper that holds the
+    payload is typed with `PermissionsDict`, not a bare `dict`. Names the
+    keys the proxy actually reads (`get_spend_routes`,
+    `enable_llm_guard_check`) so basedpyright catches typos at the
+    call sites; `total=False` keeps user-defined guardrail keys valid."""
+    import inspect
+    from typing import Optional
+
+    from litellm.proxy._types import PermissionsDict
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        generate_key_helper_fn,
+    )
+    from litellm.proxy.management_helpers.key_mutation_authz import (
+        _check_permissions_field,
+    )
+    from litellm.repositories.verification_token_repository import (
+        VerificationTokenRepository,
+    )
+
+    expected = Optional[PermissionsDict]
+    assert inspect.signature(generate_key_helper_fn).parameters["permissions"].annotation == expected
+    assert inspect.signature(VerificationTokenRepository.create_token).parameters["permissions"].annotation == expected
+    # The helper's gate function inspects but does not declare a
+    # permissions param; just verify the type is importable next to it.
+    assert _check_permissions_field is not None
+    assert "get_spend_routes" in PermissionsDict.__annotations__
+    assert "enable_llm_guard_check" in PermissionsDict.__annotations__
+
+
 # ─────────────────────────────────────────────────────────────────────
 # Composition / regenerate
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
+++ b/tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py
@@ -415,6 +415,90 @@ async def test_update_team_admin_temp_budget_increase_over_ceiling_rejected():
 
 
 @pytest.mark.asyncio
+async def test_update_team_admin_max_budget_null_clear_rejected():
+    """A team admin passes the admin gate but cannot clear an existing
+    finite cap with `max_budget: null` — the resulting effective max is
+    unbounded, which exceeds any finite delegation ceiling."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=1_000_000.0,
+    )
+    data = UpdateKeyRequest(key="sk-team", max_budget=None)
+    assert "max_budget" in data.model_fields_set
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await authorize_key_mutation(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=_internal_user(max_budget=100.0),
+                team_table=None,
+                prisma_client=MagicMock(),
+                user_api_key_cache=None,
+                route_label="/key/update",
+            )
+    assert exc.value.status_code == 400
+    assert "Clearing max_budget" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_max_budget_null_when_existing_is_already_null_allowed():
+    """Counterpart: a no-op clear (existing cap already null) is not a
+    change to the effective budget, so the ceiling check passes. Pins
+    the diff semantic."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=None,
+    )
+    data = UpdateKeyRequest(key="sk-team", max_budget=None)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=_internal_user(max_budget=100.0),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_proxy_admin_max_budget_null_clear_allowed():
+    """Proxy admin is exempt from the delegation ceiling, so they CAN
+    clear an existing cap. Pins the carve-out from rule 5."""
+    existing = _existing_key(
+        user_id="someone-else",
+        created_by="someone-else",
+        team_id="team-x",
+        max_budget=1_000_000.0,
+    )
+    data = UpdateKeyRequest(key="sk-team", max_budget=None)
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
+        new_callable=AsyncMock,
+    ):
+        await authorize_key_mutation(
+            data=data,
+            existing_key_row=existing,
+            user_api_key_dict=_admin(),
+            team_table=None,
+            prisma_client=MagicMock(),
+            user_api_key_cache=None,
+            route_label="/key/update",
+        )
+
+
+@pytest.mark.asyncio
 async def test_update_temp_budget_increase_nan_rejected_for_admin():
     """NaN hygiene applies to temp_budget_increase too. Without this,
     a NaN bump silently disables enforcement on the key."""


### PR DESCRIPTION
## Relevant issues

Supersedes #31469. That PR proved the original VERIA-392 finding on `/key/generate` was just the visible edge of a broader policy drift across six write paths. The iterative review on it surfaced real edge cases (NaN bypass, CLI session token reading None as unlimited, explicit-empty permissions clearing admin-set capabilities, unchanged prefilled values failing the ceiling, bulk paths skipping the gate) but the resulting 17-commit history was unreviewable.

This PR ships the same security outcome as a single coherent change.

## Linear ticket

Resolves LIT-4072

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Six write paths each enforced subsets of the key-mutation policy inline at their own call sites: `/key/generate`, `/key/service-account/generate`, `/key/update`, `/key/regenerate`, `/key/bulk_update`, `/team/key/bulk_update`. The drift produced real bypasses

This PR collapses the policy into one helper, `authorize_key_mutation`, that diffs the request against the existing key and enforces three guards by changed field

Rule 1 — `permissions` is proxy-admin-only. On create paths, only a non-empty dict trips the gate (preserving the empty `{}` default as the legitimate non-admin shape). On update / regenerate / bulk paths, any explicit presence in `model_fields_set` trips the gate, so `{}` and `null` cannot clear an admin-set capability such as `enable_llm_guard_check`

Rule 2 — on update-like paths, any budget-field change (max_budget / spend / budget_limits) requires key-admin authority (proxy admin, team admin of the key's team, or org admin of that team's org). Personal-key-owner and team-member-with-grant fast paths apply to non-budget changes only

Rule 3 — every write path enforces numeric hygiene first (NaN / inf / None / wrong-type rejected with 400 before any comparison) and then the delegation ceiling. Hygiene applies to all callers, including proxy admins, because a NaN at rest disables downstream enforcement (`spend > NaN` is always False)

Rule 4 — ceiling derived from caller.max_budget; falls back to team budget when the caller is a CLI session token in a team context. A CLI session token with no team and any submitted budget is hard-rejected rather than treated as unlimited delegation authority

Rule 5 — `delegation_ceiling=None` after rule 4 means no ceiling configured (admin granted unlimited delegation); proxy admins and the UI team-admin sentinel session (`UI_SESSION_TOKEN_TEAM_ID`) are exempt from ceiling enforcement

Rule 6 — on update-like paths, the ceiling is enforced only on values that actually changed against the existing key row. A team admin with `max_budget=$100` whose UI prefills the existing `$1M` cap while editing an unrelated field passes; raising it to `$2M` is rejected

Rule 7 — `generate_key_helper_fn`'s `permissions: Optional[PermissionsDict] = {}` mutable default is replaced with `None` and normalized at the `json.dumps` call site so the DB shape is preserved

The helper lives in `litellm/proxy/management_helpers/key_mutation_authz.py` as a single file with one public entrypoint. The six handlers each call it once, in the position where they already have `existing_key_row` (None on create) and `team_table` resolved

## Screenshots / Proof of Fix

Setup: admin creates user `alice-newpr` with role `internal_user`, `max_budget=10`, models `["gpt-3.5-turbo"]`, and a personal key for her

```
1. /key/generate budget_limits over ceiling (expect 400)
{
  "error": {
    "message": "{'error': \"budget_limits entry max_budget (1000000.0) cannot exceed the caller's own max_budget (10.0).\"}",
    "code": "400"
  }
}

2. /key/generate NaN window (expect 400)
{
  "error": {
    "message": "{'error': 'budget_limits entry max_budget must be a finite number; got nan'}",
    "code": "400"
  }
}

3. /key/generate non-admin permissions self-grant (expect 403)
{
  "error": {
    "message": "{'error': 'Only proxy admins can write `permissions` on a key.'}",
    "code": "403"
  }
}

4. /key/update non-admin owner sets permissions (expect 403)
{
  "error": {
    "message": "{'error': 'Only proxy admins can write `permissions` on a key.'}",
    "code": "403"
  }
}

5. /key/update non-admin owner clears permissions explicitly (expect 403)
{
  "error": {
    "message": "{'error': 'Only proxy admins can write `permissions` on a key.'}",
    "code": "403"
  }
}

CONTROL alice within her ceiling (expect 200)
{"key":"sk-E1ljL0dt9Tm...","budget_limits":[{"budget_duration":"1d","max_budget":5.0,"reset_at":"2026-06-29T00:00:00Z"}]}

CONTROL admin can set anything (expect 200)
{"key":"sk-...","permissions":null,"budget_limits":null}
```

`/key/regenerate` is enterprise-gated upstream, so the proxy returns the existing enterprise-license error before the helper runs in this non-premium dev setup; the helper still fires on premium

33 new policy-helper tests in `tests/test_litellm/proxy/management_helpers/test_key_mutation_authz.py` cover the rule matrix end to end. Mutation-killed: 20 of 33 tests fail when the helper is replaced with a no-op. One pre-existing bulk-update test was encoding the buggy "team member with grant can bulk-edit budget" behavior; its update payload was switched to a non-budget field (`tpm_limit`) to assert the legitimate semantic

336 tests pass across the new helper module and the existing key-management endpoint tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication-adjacent key management and closes known authorization bypasses; behavior changes on bulk budget edits and permissions writes for non-admins.
> 
> **Overview**
> **Centralizes proxy key-write authorization** in `authorize_key_mutation` (`key_mutation_authz.py`) and wires it into generate, update, bulk update, and regenerate instead of scattered inline checks.
> 
> **Policy enforced in one place:** proxy-admin-only `permissions` (including blocking non-admins from clearing capabilities via `{}`/`null` on updates); budget fields on update paths require key-admin authority while personal-owner / team-member fast paths stay limited to non-budget edits; finite-number validation on budgets; delegation ceiling against the caller (with CLI session-token and UI team-admin carve-outs); ceiling and admin gates only on **changed** budget values on updates (including `temp_budget_increase` effective cap).
> 
> **Supporting changes:** `PermissionsDict` typing; `permissions` default `None` with `{}` preserved at JSON serialization; large dedicated test matrix plus bulk team test adjusted to non-budget field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ef846de722f4cc94605891b0a51a372a136256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->