### PR TITLE
fix: handle windows paths in compression keys

### DIFF
--- a/litellm/compression/message_stubbing.py
+++ b/litellm/compression/message_stubbing.py
@@ -34,7 +34,7 @@ def extract_key(message: dict, fallback_index: int, used_keys: Set[str]) -> str:
         if match:
             # Use just the filename, not full path
             path = match.group(1)
-            key = path.split("/")[-1]
+            key = re.split(r"[\\/]", path)[-1]
             break
 
     if key is None:

--- a/tests/test_litellm/test_compression.py
+++ b/tests/test_litellm/test_compression.py
@@ -98,6 +98,13 @@ def test_extract_key_with_filename():
     assert key == "auth.py"
 
 
+def test_extract_key_with_windows_file_path():
+    msg = {"role": "user", "content": r"File: C:\repo\auth.py"}
+    used: set = set()
+    key = extract_key(msg, fallback_index=0, used_keys=used)
+    assert key == "auth.py"
+
+
 def test_extract_key_fallback():
     msg = {"role": "user", "content": "Some random content without a filename"}
     used: set = set()


### PR DESCRIPTION
## Relevant issues

No linked issue

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## Screenshots / Proof of Fix

This is a pure compression key extraction bug, so the reproduction is the smallest direct call rather than a live provider request

Before this change, `extract_key({"content": r"File: C:\repo\auth.py"}, ...)` returned `C:\repo\auth.py`. After this change it returns `auth.py`, matching the existing POSIX path behavior

I ran `python -m pytest tests/test_litellm/test_compression.py::test_extract_key_with_windows_file_path -q`, `python -m pytest tests/test_litellm/test_compression.py -q`, and `python -m ruff check litellm/compression/message_stubbing.py tests/test_litellm/test_compression.py`

## Type

Bug Fix

## Changes

Compression message stubbing now treats both `/` and `\` as path separators when extracting a human-readable retrieval key from file path hints. This keeps `File: C:\repo\auth.py` aligned with `File: /repo/auth.py` and avoids exposing the whole Windows path as the compressed content key