### PR TITLE
fix(spend): include whole-session aggregate in /spend/logs/session/ui

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3330,6 +3330,12 @@ async def ui_view_session_spend_logs(
             "page": int,
             "page_size": int,
             "total_pages": int,
+            "aggregate": {
+                "total_spend": float,
+                "first_start_time": str | None,
+                "last_end_time": str | None,
+                "call_type_counts": dict[str, int],
+            },
         }
     """
     from litellm.proxy.proxy_server import prisma_client
@@ -3341,16 +3347,11 @@ async def ui_view_session_spend_logs(
                 detail="Database not connected",
             )
 
-        # Build query conditions
         where_conditions = {"session_id": session_id}
-
-        # Calculate pagination offsets
         skip = (page - 1) * page_size
 
-        # Get total count for pagination metadata
         total_records = await SpendLogsRepository(prisma_client).table.count(where=where_conditions)
 
-        # Query with raw SQL to exclude heavy columns (messages, response, proxy_server_request)
         sql_query = """
             SELECT
                 request_id, call_type, api_key, spend, total_tokens,
@@ -3368,6 +3369,7 @@ async def ui_view_session_spend_logs(
         result = await prisma_client.db.query_raw(sql_query, session_id, page_size, skip)
 
         total_pages = (total_records + page_size - 1) // page_size
+        aggregate = await _session_aggregate(prisma_client, session_id)
 
         return {
             "data": result,
@@ -3375,6 +3377,7 @@ async def ui_view_session_spend_logs(
             "page": page,
             "page_size": page_size,
             "total_pages": total_pages,
+            "aggregate": aggregate,
         }
     except Exception as e:
         if isinstance(e, HTTPException):
@@ -3384,6 +3387,51 @@ async def ui_view_session_spend_logs(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail=str(e),
             )
+
+
+def _isoformat_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+async def _session_aggregate(prisma_client: "PrismaClient", session_id: str) -> dict[str, Any]:
+    group_response = await prisma_client.db.litellm_spendlogs.group_by(
+        by=["call_type"],
+        where={"session_id": session_id},
+        count={"_all": True},
+        sum={"spend": True},
+        min={"startTime": True},
+        max={"endTime": True},
+    )
+
+    call_type_counts: dict[str, int] = {}
+    total_spend = 0.0
+    first_start_time: datetime | None = None
+    last_end_time: datetime | None = None
+
+    for row in group_response or []:
+        call_type = row.get("call_type") or "unknown"
+        count_val = (row.get("_count") or {}).get("_all", 0) or 0
+        sum_spend = (row.get("_sum") or {}).get("spend") or 0
+        row_start = (row.get("_min") or {}).get("startTime")
+        row_end = (row.get("_max") or {}).get("endTime")
+
+        call_type_counts[call_type] = call_type_counts.get(call_type, 0) + count_val
+        total_spend += float(sum_spend)
+        if row_start is not None and (first_start_time is None or row_start < first_start_time):
+            first_start_time = row_start
+        if row_end is not None and (last_end_time is None or row_end > last_end_time):
+            last_end_time = row_end
+
+    return {
+        "total_spend": total_spend,
+        "first_start_time": _isoformat_or_none(first_start_time),
+        "last_end_time": _isoformat_or_none(last_end_time),
+        "call_type_counts": call_type_counts,
+    }
 
 
 async def _build_ui_spend_logs_response(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1414,6 +1414,19 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             assert 'ORDER BY "startTime" DESC' in sql_query
             return [mock_spend_logs[0]]
 
+        async def group_by(self, *args, **kwargs):
+            assert kwargs.get("by") == ["call_type"]
+            assert kwargs.get("where") == {"session_id": "session-123"}
+            return [
+                {
+                    "call_type": "completion",
+                    "_count": {"_all": 2},
+                    "_sum": {"spend": 0.30},
+                    "_min": {"startTime": "2024-01-01T00:00:00Z"},
+                    "_max": {"endTime": "2024-01-02T00:00:05Z"},
+                }
+            ]
+
     class MockPrismaClient:
         def __init__(self):
             self.db = MockDB()
@@ -1436,6 +1449,140 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
     assert data["total_pages"] == 2
     assert len(data["data"]) == 1
     assert data["data"][0]["request_id"] == "req1"
+
+    aggregate = data["aggregate"]
+    assert aggregate["total_spend"] == pytest.approx(0.30)
+    assert aggregate["first_start_time"] == "2024-01-01T00:00:00Z"
+    assert aggregate["last_end_time"] == "2024-01-02T00:00:05Z"
+    assert aggregate["call_type_counts"] == {"completion": 2}
+
+
+@pytest.mark.asyncio
+async def test_ui_view_session_spend_logs_aggregate_reflects_whole_session(client, monkeypatch):
+    """Aggregate spans the whole session even when the data page is empty or partial.
+
+    Regression guard for sessions larger than the UI page cap: the dashboard reads
+    `total_spend`, `first_start_time`, `last_end_time`, and `call_type_counts` from
+    `aggregate` so the trace header stays correct when only a slice of rows is fetched.
+    """
+
+    class MockDB:
+        async def count(self, *args, **kwargs):
+            return 10000
+
+        async def query_raw(self, sql_query, session_id, page_size, skip):
+            assert 'ORDER BY "startTime" DESC' in sql_query
+            return []
+
+        async def group_by(self, *args, **kwargs):
+            return [
+                {
+                    "call_type": "completion",
+                    "_count": {"_all": 9000},
+                    "_sum": {"spend": 12.5},
+                    "_min": {"startTime": "2024-01-01T00:00:00Z"},
+                    "_max": {"endTime": "2024-01-01T05:00:00Z"},
+                },
+                {
+                    "call_type": "call_mcp_tool",
+                    "_count": {"_all": 800},
+                    "_sum": {"spend": 0.0},
+                    "_min": {"startTime": "2024-01-01T00:30:00Z"},
+                    "_max": {"endTime": "2024-01-01T04:30:00Z"},
+                },
+                {
+                    "call_type": "asend_message",
+                    "_count": {"_all": 200},
+                    "_sum": {"spend": 1.25},
+                    "_min": {"startTime": "2024-01-01T00:10:00Z"},
+                    "_max": {"endTime": "2024-01-01T05:10:00Z"},
+                },
+            ]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MockDB()
+            self.db.litellm_spendlogs = self.db
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+
+    response = client.get(
+        "/spend/logs/session/ui",
+        params={"session_id": "huge", "page": 1, "page_size": 50},
+        headers={"Authorization": "Bearer sk-test"},
+    )
+
+    assert response.status_code == 200
+    aggregate = response.json()["aggregate"]
+    assert aggregate["total_spend"] == pytest.approx(12.5 + 0.0 + 1.25)
+    assert aggregate["first_start_time"] == "2024-01-01T00:00:00Z"
+    assert aggregate["last_end_time"] == "2024-01-01T05:10:00Z"
+    assert aggregate["call_type_counts"] == {
+        "completion": 9000,
+        "call_mcp_tool": 800,
+        "asend_message": 200,
+    }
+
+
+@pytest.mark.asyncio
+async def test_session_aggregate_helper_branches():
+    """Cover the empty group_by and datetime-typed startTime/endTime paths.
+
+    The endpoint-level tests pass ISO strings, which traverse `str(value)` in
+    `_isoformat_or_none`. Real Prisma returns `datetime` objects for `_min`/`_max`
+    timestamps; this test pins that path so the helper keeps returning ISO output
+    when Prisma's behavior shifts back to typed datetimes.
+    """
+    from datetime import datetime as _dt
+
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        _isoformat_or_none,
+        _session_aggregate,
+    )
+
+    assert _isoformat_or_none(None) is None
+    assert _isoformat_or_none(_dt(2024, 1, 2, 3, 4, 5)) == "2024-01-02T03:04:05"
+    assert _isoformat_or_none("2024-01-02T03:04:05Z") == "2024-01-02T03:04:05Z"
+
+    class _EmptyDB:
+        async def group_by(self, *args, **kwargs):
+            return []
+
+    class _EmptyPrisma:
+        def __init__(self):
+            self.db = _EmptyDB()
+            self.db.litellm_spendlogs = self.db
+
+    empty = await _session_aggregate(_EmptyPrisma(), "no-such-session")
+    assert empty == {
+        "total_spend": 0.0,
+        "first_start_time": None,
+        "last_end_time": None,
+        "call_type_counts": {},
+    }
+
+    class _DatetimeDB:
+        async def group_by(self, *args, **kwargs):
+            return [
+                {
+                    "call_type": "completion",
+                    "_count": {"_all": 3},
+                    "_sum": {"spend": 0.45},
+                    "_min": {"startTime": _dt(2024, 5, 1, 10, 0, 0)},
+                    "_max": {"endTime": _dt(2024, 5, 1, 10, 5, 0)},
+                }
+            ]
+
+    class _DatetimePrisma:
+        def __init__(self):
+            self.db = _DatetimeDB()
+            self.db.litellm_spendlogs = self.db
+
+    typed = await _session_aggregate(_DatetimePrisma(), "sid")
+    assert typed["first_start_time"] == "2024-05-01T10:00:00"
+    assert typed["last_end_time"] == "2024-05-01T10:05:00"
+    assert typed["call_type_counts"] == {"completion": 3}
+    assert typed["total_spend"] == pytest.approx(0.45)
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -123,7 +123,7 @@ export function LogDetailsDrawer({
   const { data: sessionData } = useQuery({
     queryKey: ["sessionLogs", sessionId],
     queryFn: async () => {
-      if (!sessionId || !accessToken) return { logs: [] as LogEntry[], total: 0 };
+      if (!sessionId || !accessToken) return { logs: [] as LogEntry[], total: 0, aggregate: undefined };
 
       // Fetch the first page, then page through the rest so sessions with more
       // than one page of logs are shown in full (capped for safety).
@@ -151,6 +151,7 @@ export function LogDetailsDrawer({
       // Fall back to the accumulated row count (not just the first page) when the
       // backend omits total, so the truncation note reflects what was fetched.
       const total: number = firstPage.total ?? rows.length;
+      const aggregate = firstPage.aggregate;
 
       const logs = rows
         .map((row) => ({
@@ -166,7 +167,7 @@ export function LogDetailsDrawer({
           return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
         });
 
-      return { logs, total };
+      return { logs, total, aggregate };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
@@ -176,6 +177,7 @@ export function LogDetailsDrawer({
   // exceeds sessionLogs.length, which drives the "showing most recent" note.
   const sessionTotalCount = sessionData?.total ?? sessionLogs.length;
   const sessionTruncated = sessionTotalCount > sessionLogs.length;
+  const sessionAggregate = sessionData?.aggregate;
 
   // Default selection for a freshly opened session: the most recent log (latest
   // startTime). The list is sorted newest-first, but MCP calls are grouped last,
@@ -266,18 +268,42 @@ export function LogDetailsDrawer({
   const statusColor = metadata.status === "failure" ? ("error" as const) : ("success" as const);
   const environment = metadata?.user_api_key_team_alias || "default";
 
-  const totalSessionCost = sessionLogs.reduce((sum, row) => sum + (row.spend || 0), 0);
-  const sessionStart =
-    sessionLogs.length > 0 ? new Date(Math.min(...sessionLogs.map((r) => new Date(r.startTime).getTime()))) : null;
-  const sessionEnd =
-    sessionLogs.length > 0 ? new Date(Math.max(...sessionLogs.map((r) => new Date(r.endTime).getTime()))) : null;
+  const totalSessionCost = sessionAggregate
+    ? Number(sessionAggregate.total_spend ?? 0)
+    : sessionLogs.reduce((sum, row) => sum + (row.spend || 0), 0);
+  const sessionStart = sessionAggregate?.first_start_time
+    ? new Date(sessionAggregate.first_start_time)
+    : sessionLogs.length > 0
+      ? new Date(Math.min(...sessionLogs.map((r) => new Date(r.startTime).getTime())))
+      : null;
+  const sessionEnd = sessionAggregate?.last_end_time
+    ? new Date(sessionAggregate.last_end_time)
+    : sessionLogs.length > 0
+      ? new Date(Math.max(...sessionLogs.map((r) => new Date(r.endTime).getTime())))
+      : null;
   const sessionDurationSeconds =
     sessionStart && sessionEnd ? ((sessionEnd.getTime() - sessionStart.getTime()) / 1000).toFixed(2) : "0.00";
-  const llmCount = sessionLogs.filter(
-    (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
-  ).length;
-  const agentCount = sessionLogs.filter((row) => AGENT_CALL_TYPES.includes(row.call_type)).length;
-  const mcpCount = sessionLogs.filter((row) => MCP_CALL_TYPES.includes(row.call_type)).length;
+
+  let llmCount: number;
+  let agentCount: number;
+  let mcpCount: number;
+  if (sessionAggregate?.call_type_counts) {
+    llmCount = 0;
+    agentCount = 0;
+    mcpCount = 0;
+    for (const [callType, count] of Object.entries(sessionAggregate.call_type_counts)) {
+      const n = Number(count) || 0;
+      if (MCP_CALL_TYPES.includes(callType)) mcpCount += n;
+      else if (AGENT_CALL_TYPES.includes(callType)) agentCount += n;
+      else llmCount += n;
+    }
+  } else {
+    llmCount = sessionLogs.filter(
+      (row) => !MCP_CALL_TYPES.includes(row.call_type) && !AGENT_CALL_TYPES.includes(row.call_type),
+    ).length;
+    agentCount = sessionLogs.filter((row) => AGENT_CALL_TYPES.includes(row.call_type)).length;
+    mcpCount = sessionLogs.filter((row) => MCP_CALL_TYPES.includes(row.call_type)).length;
+  }
   const logsForList = isSessionMode ? sessionLogs : currentLog ? [currentLog] : [];
   const leftPanelId = isSessionMode ? sessionId || "" : currentLog?.request_id || "";
   const leftPanelDisplayId = leftPanelId.length > 14 ? `${leftPanelId.slice(0, 11)}...` : leftPanelId;
@@ -356,7 +382,7 @@ export function LogDetailsDrawer({
                 </div>
               </div>
               <div className="mt-1 text-[11px] text-slate-500 font-mono">
-                {logsForList.length} req
+                {isSessionMode ? sessionTotalCount : logsForList.length} req
                 {[
                   isSessionMode
                     ? llmCount

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -12349,6 +12349,12 @@ export interface paths {
          *             "page": int,
          *             "page_size": int,
          *             "total_pages": int,
+         *             "aggregate": {
+         *                 "total_spend": float,
+         *                 "first_start_time": str | None,
+         *                 "last_end_time": str | None,
+         *                 "call_type_counts": dict[str, int],
+         *             },
          *         }
          */
         get: operations["ui_view_session_spend_logs_spend_logs_session_ui_get"];


### PR DESCRIPTION
The session drawer's per-session header (total spend, first/last timestamps, LLM/agent/MCP counts) was computed in the browser from the rows it managed to fetch. The dashboard caps the fetch at 5000 rows (50 pages of 100); for sessions larger than that, the truncation note fires but the header still showed undercounts because the math ran on the visible slice. The backend already returns total separately, so the truncation banner was honest while the spend and time-range figures silently understated the session.

The endpoint now returns an `aggregate` block alongside the page, with `total_spend`, `first_start_time`, `last_end_time`, and `call_type_counts` covering the whole session. The aggregate is a single `group_by` over `LiteLLM_SpendLogs` keyed by `call_type`, so it stays cheap on the indexed `session_id` column and returns the per-bucket counts the dashboard needs without a second round-trip. The drawer reads `aggregate` when present and falls back to the in-memory reduction when an older proxy serves a session response without it.

Backend test coverage extends the existing pagination test with the new aggregate fields, then adds a regression that drives the endpoint with a 10000-row session and an empty data page; the test fails if the aggregate is computed from the page slice instead of the full session, which is the exact bug this commit closes.

Tier: C

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
