### PR TITLE
feat(router): use hashmap to store healthy deployments (N^2 -> N Optimisation)

### DIFF
--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -404,9 +404,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
         ### GET AVAILABLE DEPLOYMENTS ### filter out any deployments > tpm/rpm limits
 
         potential_deployments = []
-        deployment_map = {d["model_info"]["id"]: d for d in healthy_deployments}
+        healthy_deployment_map = {d["model_info"]["id"]: d for d in healthy_deployments}
         for item, item_map in all_deployments.items():
-            if (_deployment := deployment_map.get(item)) is None:
+            if (_deployment := healthy_deployment_map.get(item)) is None:
                 continue  # skip to next one
 
             _deployment_tpm = (

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -404,14 +404,9 @@ class LowestLatencyLoggingHandler(CustomLogger):
         ### GET AVAILABLE DEPLOYMENTS ### filter out any deployments > tpm/rpm limits
 
         potential_deployments = []
+        deployment_map = {d["model_info"]["id"]: d for d in healthy_deployments}
         for item, item_map in all_deployments.items():
-            ## get the item from model list
-            _deployment = None
-            for m in healthy_deployments:
-                if item == m["model_info"]["id"]:
-                    _deployment = m
-
-            if _deployment is None:
+            if (_deployment := deployment_map.get(item)) is None:
                 continue  # skip to next one
 
             _deployment_tpm = (


### PR DESCRIPTION
## Relevant issues

Follow up on https://github.com/BerriAI/litellm/issues/21270

## Summary

I'm not sure why the above ticket was closed but this is a real, observable performance bottleneck seen with sometimes less than 100 deployments.

Regarding scope of fix, I have left it to as small as possible for now, but happy to do the same with `usage-based-routing`, `least-busy` and  `cost-based-routing`


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [] I have added meaningful tests - performance optimistation, no unit testing
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Using just 100 deployments, here is the time taken to do 1000 calls to `_get_available_deployments` (simulated deployments)


### Old

<img width="842" height="104" alt="image" src="https://github.com/user-attachments/assets/8d6f1aba-2cd2-4b2a-95ef-4cb173c74390" />


### New

<img width="817" height="106" alt="image" src="https://github.com/user-attachments/assets/30ab71ae-4dd8-4d31-b548-fad8107bce4c" />


At 1,000 deployments, the performance gain is obvious:

### Old

<img width="794" height="100" alt="image" src="https://github.com/user-attachments/assets/6aea8749-9955-4630-927c-4a392aef84a7" />



### New

<img width="820" height="80" alt="image" src="https://github.com/user-attachments/assets/218ec072-5c5f-4340-abb1-978429e6bbeb" />



Testing script as follows:

```
import cProfile
import pstats
import random
from litellm.router_strategy.lowest_latency import LowestLatencyLoggingHandler
from litellm.caching.caching import DualCache

# ── tune these to match your real workload ──────────────────────────────────
N_DEPLOYMENTS = 1000  
N_ITERATIONS  = 1_000    # outer loop: how many routing decisions to profile
# ────────────────────────────────────────────────────────────────────────────

def run_benchmark():
    cache   = DualCache()
    handler = LowestLatencyLoggingHandler(router_cache=cache, routing_args={})

    healthy_deployments = [
        {
            "model_info": {"id": f"dep-{i}"},
            "tpm": 100_000,
            "rpm": 1_000,
            "litellm_params": {f"api_base": f"https://api.provider-{i}.com"},
        }
        for i in range(N_DEPLOYMENTS)
    ]

    model_group  = "gpt-4"
    latency_key  = f"{model_group}_map"
    precise_minute = "2026-06-28-10-00"   # static so it matches cache entries

    request_count_dict = {
        f"dep-{i}": {
            "latency":           [random.uniform(0.1, 0.5) for _ in range(10)],
            "time_to_first_token":[random.uniform(0.05, 0.2) for _ in range(10)],
            precise_minute:       {"tpm": 5_000, "rpm": 50},
        }
        for i in range(N_DEPLOYMENTS)
    }
    cache.set_cache(key=latency_key, value=request_count_dict)

    print(f"Running _get_available_deployments {N_ITERATIONS}x "
          f"with {N_DEPLOYMENTS} deployments...")

    for _ in range(N_ITERATIONS):
        handler._get_available_deployments(
            model_group=model_group,
            healthy_deployments=healthy_deployments,
            messages=[{"role": "user", "content": "hello"}],
            request_kwargs={"stream": True},
            request_count_dict=request_count_dict,
        )

if __name__ == "__main__":
    profiler = cProfile.Profile()
    profiler.enable()
    run_benchmark()
    profiler.disable()

    stats = pstats.Stats(profiler).sort_stats("tottime")
    stats.print_stats(20)

```


## Type

🧹 Refactoring

## Changes
