### PR TITLE
fix(cost): compute timing metrics before response_cost for input_cost_per_second pricing

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
+++ b/litellm/litellm_core_utils/llm_response_utils/response_metadata.py
@@ -182,6 +182,11 @@ def update_response_metadata(
         return
 
     metadata = ResponseMetadata(result)
-    metadata.set_hidden_params(logging_obj, model, kwargs)
+    # set_timing_metrics must run first: it assigns result._response_ms, which
+    # set_hidden_params reads (via _response_cost_calculator) to compute
+    # input_cost_per_second / output_cost_per_second pricing. Reversing this
+    # order makes per-second cost calculation read a missing/stale _response_ms
+    # and permanently cache a response_cost of 0.0 (see litellm issue #20228).
     metadata.set_timing_metrics(start_time, end_time, logging_obj)
+    metadata.set_hidden_params(logging_obj, model, kwargs)
     metadata.apply()

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -265,6 +265,11 @@ class TestPerSecondCostUsesActualDuration:
             model=model,
             optional_params={},
             litellm_params={},
+            # Bypass the explicit per-provider branches in cost_per_token (e.g.
+            # the OpenAI one, which unprefixed model names resolve to by
+            # default) so the lookup reaches the generic input_cost_per_second
+            # fallback this test is exercising.
+            custom_llm_provider="custom",
         )
         return logging_obj
 

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_response_metadata.py
@@ -6,8 +6,12 @@ through _hidden_params to the x-litellm-callback-duration-ms response header.
 """
 
 import datetime
+import uuid
 from unittest.mock import MagicMock
 
+import pytest
+
+import litellm
 import litellm.litellm_core_utils.llm_response_utils.response_metadata as response_metadata_mod
 import litellm.proxy.common_request_processing as common_request_processing_mod
 from litellm.litellm_core_utils.litellm_logging import Logging
@@ -17,7 +21,7 @@ from litellm.litellm_core_utils.llm_response_utils.response_metadata import (
 )
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import ModelResponse, Usage
 
 
 class TestCallbackDurationMs:
@@ -232,6 +236,67 @@ class TestDetailedTiming:
 
         assert "x-litellm-timing-llm-api-ms" not in headers
         assert "x-litellm-timing-pre-processing-ms" not in headers
+
+
+class TestPerSecondCostUsesActualDuration:
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/20228 as it
+    affects standard chat completions priced with input_cost_per_second.
+
+    set_hidden_params triggers the real cost calculator, which for
+    input_cost_per_second models multiplies the rate by
+    completion_response._response_ms. That attribute is only assigned inside
+    set_timing_metrics, so calling set_hidden_params first makes the cost
+    calculator read a duration of 0 and the proxy permanently caches a
+    response_cost of 0.0 for that response.
+    """
+
+    def _make_logging_obj(self, model: str) -> Logging:
+        logging_obj = Logging(
+            model=model,
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            call_type="completion",
+            start_time=datetime.datetime.now(),
+            litellm_call_id=str(uuid.uuid4()),
+            function_id="1",
+        )
+        logging_obj.update_environment_variables(
+            model=model,
+            optional_params={},
+            litellm_params={},
+        )
+        return logging_obj
+
+    def test_update_response_metadata_charges_for_actual_duration(self):
+        model = f"per-second-test-model-{uuid.uuid4()}"
+        litellm.model_cost[model] = {
+            "input_cost_per_second": 0.01,
+            "output_cost_per_token": 0,
+            "input_cost_per_token": 0,
+            "litellm_provider": "custom",
+            "mode": "chat",
+        }
+        try:
+            logging_obj = self._make_logging_obj(model)
+            result = ModelResponse(usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15))
+
+            start = datetime.datetime(2025, 1, 1, 0, 0, 0)
+            end = datetime.datetime(2025, 1, 1, 0, 0, 2)  # 2 second call
+
+            update_response_metadata(
+                result=result,
+                logging_obj=logging_obj,
+                model=model,
+                kwargs={},
+                start_time=start,
+                end_time=end,
+            )
+
+            response_cost = result._hidden_params.get("response_cost")
+            assert response_cost == pytest.approx(0.02), f"expected 0.01/sec * 2 sec = 0.02, got {response_cost}"
+        finally:
+            litellm.model_cost.pop(model, None)
 
 
 class TestLoggingInitCallbackDuration:


### PR DESCRIPTION
## Relevant issues

Fixes the chat completion case described in #20228 and in the linked comment on #11975. `input_cost_per_second` configured on a model also produces $0 spend for plain text chat completions, not only for audio transcription.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I don't have a runnable litellm dev environment on this machine (Python 3.9 only, litellm requires >=3.10), so I could not curl a live proxy against a real provider for proof of fix. The added unit test exercises the real `Logging._response_cost_calculator` path end to end and fails against the current code (it asserts a response_cost of 0.01/sec * 2 sec = 0.02; today it gets 0.0). Happy to post a live proxy run if a maintainer points me to a Python 3.10+ box, or a maintainer can confirm against their own dev proxy.

## Type

🐛 Bug Fix
✅ Test

## Changes

`update_response_metadata()` in `litellm/litellm_core_utils/llm_response_utils/response_metadata.py` calls `ResponseMetadata.set_hidden_params()` before `ResponseMetadata.set_timing_metrics()`. `set_hidden_params()` is what computes and caches `response_cost` (via `Logging._response_cost_calculator`), and for models priced with `input_cost_per_second` / `output_cost_per_second`, that calculation multiplies the rate by `completion_response._response_ms`. That attribute is only assigned inside `set_timing_metrics()`, which runs second, so the very first cost calculation always sees a missing duration and returns 0.0.

That 0.0 then gets permanently stuck. The cache check in `_response_cost_calculator` is `"response_cost" in hidden_params and hidden_params["response_cost"] is not None`, so a cached `0.0` reads as "already calculated" and is never recomputed. Proxy spend tracking and per-user/team budget enforcement read this same cached field (`hidden_params["response_cost"]` -> `model_call_details["response_cost"]` -> `standard_logging_object["response_cost"]`), so every chat completion against a per-second-priced model gets logged with $0 spend for the life of the response object.

The fix swaps the order: timing metrics are set first, so `_response_ms` exists by the time the cost calculator runs.

This is a different bug from the transcription-specific one tracked across #16076 (merged then reverted same day via #16402, no public explanation given), #22498 (closed unmerged, fixed a missing `router_model_id` fallback and a missing entry in `SPECIAL_MODEL_INFO_PARAMS` for router-based transcription deployments), and #23842 (merged then reverted via #24297 for breaking `test_whisper_azure`/`test_whisper_openai`, after introducing a real fix for an unguarded `elif` in the OpenAI-specific `cost_per_second()`). Those three all touch `litellm/llms/openai/cost_calculation.py`, which `cost_router()` only routes to for `CallTypes.transcription`/`atranscription`. The bug here is in the generic `ResponseMetadata` path that every call type goes through, including plain chat completions, which is why `dotmobo`'s comment on #20228 ("even with text model, the input_cost_per_second feature is broken") and the original report on #11975 don't fit any of those three fixes.

Two adjacent issues found while researching this are still open and worth separate PRs: `SPECIAL_MODEL_INFO_PARAMS` in `litellm/types/router.py` still doesn't include `input_cost_per_second`/`output_cost_per_second`, so router/`model_list`-configured deployments don't get per-second pricing copied into `model_info` (the other half of what #22498 fixed). And the revert in #24297 restored the `elif` in `cost_per_second()`, which still silently returns $0 cost today for any model with `output_cost_per_second: 0.0` alongside a non-zero `input_cost_per_second` (currently true for `deepgram/whisper` and `groq/whisper-large-v3` and several siblings in `model_prices_and_context_window.json`).


