### PR TITLE
fix(responses): drop empty assistant message from responses input conversion

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -462,8 +462,57 @@ class LiteLLMCompletionResponsesConfig:
                     messages.extend(deduped_in_place)
                     continue
 
-                messages.extend(chat_completion_messages)
+                messages.extend(
+                    message
+                    for message in chat_completion_messages
+                    if not LiteLLMCompletionResponsesConfig._is_blank_assistant_message(message)
+                )
         return messages
+
+    @staticmethod
+    def _is_blank_assistant_message(
+        message: Union[
+            AllMessageValues,
+            GenericChatCompletionMessage,
+            ChatCompletionMessageToolCall,
+            ChatCompletionResponseMessage,
+        ],
+    ) -> bool:
+        """
+        Whether an assistant message has no tool calls and no non-empty content.
+
+        Codex-style Responses input includes an assistant message item whose text
+        is empty when that turn only produced a tool call. Converting it yields a
+        content-less assistant message that strict OpenAI-compatible providers
+        (e.g. DeepSeek) reject when it trails an assistant tool_calls message,
+        since a tool_calls message must be followed by tool results.
+        """
+        get = LiteLLMCompletionResponsesConfig._get_mapping_or_attr_value
+        role = cast(object, get(message, "role"))
+        if role != "assistant":
+            return False
+        tool_calls = cast(object, get(message, "tool_calls"))
+        if tool_calls:
+            return False
+        content = cast(object, get(message, "content"))
+        if content is None or content == "":
+            return True
+        if isinstance(content, str):
+            return content.strip() == ""
+        if isinstance(content, list):
+            parts = cast(List[object], content)
+            return all(LiteLLMCompletionResponsesConfig._is_empty_text_part(part) for part in parts)
+        return False
+
+    @staticmethod
+    def _is_empty_text_part(part: object) -> bool:
+        if not isinstance(part, dict):
+            return False
+        typed_part = cast(Dict[str, object], part)
+        if typed_part.get("type") not in (None, "text"):
+            return False
+        text = typed_part.get("text")
+        return not (isinstance(text, str) and bool(text.strip()))
 
     @staticmethod
     def _deduplicate_tool_call_output_messages(

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -800,6 +800,44 @@ class TestFunctionCallTransformation:
         assert [m.get("role") for m in messages] == ["user", "assistant"]
         assert "hello there" in str(messages[1].get("content"))
 
+    def test_is_blank_assistant_message_detection(self):
+        """Cover the blank-detection branches across content shapes."""
+        is_blank = LiteLLMCompletionResponsesConfig._is_blank_assistant_message
+
+        assert is_blank({"role": "assistant", "content": None})
+        assert is_blank({"role": "assistant", "content": ""})
+        assert is_blank({"role": "assistant", "content": "   "})
+        assert is_blank({"role": "assistant", "content": []})
+        assert is_blank(
+            {"role": "assistant", "content": [{"type": "text", "text": "  "}]}
+        )
+
+        assert not is_blank({"role": "user", "content": ""})
+        assert not is_blank(
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "c"}]}
+        )
+        assert not is_blank({"role": "assistant", "content": "hello"})
+        assert not is_blank({"role": "assistant", "content": 123})
+        assert not is_blank(
+            {"role": "assistant", "content": [{"type": "text", "text": "hi"}]}
+        )
+        assert not is_blank(
+            {
+                "role": "assistant",
+                "content": [{"type": "image_url", "image_url": {"url": "u"}}],
+            }
+        )
+
+    def test_is_empty_text_part_detection(self):
+        """Cover the empty-text-part branches including non-dict and non-text parts."""
+        is_empty = LiteLLMCompletionResponsesConfig._is_empty_text_part
+
+        assert is_empty({"type": "text", "text": ""})
+        assert is_empty({"type": None, "text": "   "})
+        assert not is_empty("not a dict")
+        assert not is_empty({"type": "text", "text": "x"})
+        assert not is_empty({"type": "image_url", "image_url": {"url": "u"}})
+
     def test_complete_request_transformation_with_function_calls(self):
         """Test the complete request transformation that would be used by the responses API"""
         test_input = [

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -735,6 +735,71 @@ class TestFunctionCallTransformation:
             tool_msg.get("tool_call_id") == "call_1fe70e2a-a596-45ef-b72c-9b8567c460e5"
         )
 
+    def test_empty_assistant_message_after_tool_call_is_dropped(self):
+        """Regression: an empty assistant message trailing an assistant tool_calls message must be dropped.
+
+        Codex replays the prior turn as a function_call followed by an assistant
+        message with empty output_text. The empty assistant message must not survive,
+        otherwise strict OpenAI-compatible providers (e.g. DeepSeek) reject the request
+        with "assistant message with tool_calls must be followed by tool messages".
+        """
+        test_input = [
+            {
+                "type": "function_call",
+                "arguments": '{"command": "ls"}',
+                "call_id": "call_00_abc",
+                "name": "shell_command",
+                "id": "call_00_abc",
+                "status": "completed",
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": ""}],
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_00_abc",
+                "output": "file1\nfile2",
+            },
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=test_input
+        )
+
+        assert [m.get("role") for m in messages] == ["assistant", "tool"]
+        assert len(messages[0].get("tool_calls", [])) == 1
+
+        blank_assistant_messages = [
+            message
+            for message in messages
+            if message.get("role") == "assistant" and not message.get("tool_calls")
+        ]
+        assert blank_assistant_messages == []
+
+    def test_assistant_message_with_text_is_preserved(self):
+        """A non-empty assistant message must not be dropped by the blank-message filter."""
+        test_input = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hi"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hello there"}],
+            },
+        ]
+
+        messages = LiteLLMCompletionResponsesConfig._transform_response_input_param_to_chat_completion_message(
+            input=test_input
+        )
+
+        assert [m.get("role") for m in messages] == ["user", "assistant"]
+        assert "hello there" in str(messages[1].get("content"))
+
     def test_complete_request_transformation_with_function_calls(self):
         """Test the complete request transformation that would be used by the responses API"""
         test_input = [


### PR DESCRIPTION
## Relevant issues

Fixes #31553

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I reproduced this at the Responses input conversion layer, which is where the bad message is produced, so it does not need a provider key to trigger. Codex replays a tool-only turn as a `function_call` item followed by an assistant `message` item whose `output_text` is empty.

Before this change, converting that input produced two assistant messages back to back:

```
[{"role": "assistant", "tool_calls": [{"id": "call_00_abc", ...}], "content": null},
 {"role": "assistant", "content": [{"type": "text", "text": ""}]}]
```

That trailing blank assistant message is what DeepSeek rejects with `An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.

After the change the empty assistant message is dropped, so the tool result follows the tool_calls message as the provider expects:

```
[{"role": "assistant", "tool_calls": [{"id": "call_00_abc", ...}], "content": null},
 {"role": "tool", "tool_call_id": "call_00_abc", "content": "file1\nfile2"}]
```

A non-empty assistant message is left untouched, so normal assistant turns are preserved

## Type

🐛 Bug Fix

## Changes

`_transform_response_input_param_to_chat_completion_message` now skips assistant messages that carry no tool calls and no non-empty content when extending the converted message list. A small `_is_blank_assistant_message` helper (plus `_is_empty_text_part`) decides this, treating `None`, empty string, and a content list whose only text parts are empty as blank. The regression test lives in `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py` and fails on `main` (the blank assistant message survives) and passes with the fix
