### PR TITLE
fix(cohere): normalize rerank v2 api base

### DIFF
--- a/litellm/llms/cohere/rerank_v2/transformation.py
+++ b/litellm/llms/cohere/rerank_v2/transformation.py
@@ -19,9 +19,10 @@ class CohereRerankV2Config(CohereRerankConfig):
         optional_params: Optional[dict] = None,
     ) -> str:
         if api_base:
-            # Remove trailing slashes and ensure clean base URL
             api_base = api_base.rstrip("/")
-            if not api_base.endswith("/v2/rerank"):
+            if api_base.endswith("/v2"):
+                api_base = f"{api_base}/rerank"
+            elif not api_base.endswith("/v2/rerank"):
                 api_base = f"{api_base}/v2/rerank"
             return api_base
         return "https://api.cohere.ai/v2/rerank"

--- a/tests/test_litellm/llms/cohere/rerank/test_rerank_v2_transformation.py
+++ b/tests/test_litellm/llms/cohere/rerank/test_rerank_v2_transformation.py
@@ -1,0 +1,20 @@
+import pytest
+
+from litellm.llms.cohere.rerank_v2.transformation import CohereRerankV2Config
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected_url"),
+    [
+        ("https://api.cohere.ai", "https://api.cohere.ai/v2/rerank"),
+        ("https://api.cohere.ai/v2", "https://api.cohere.ai/v2/rerank"),
+        ("https://api.cohere.ai/v2/rerank/", "https://api.cohere.ai/v2/rerank"),
+    ],
+)
+def test_get_complete_url_normalizes_cohere_rerank_v2_api_base(
+    api_base: str, expected_url: str
+) -> None:
+    assert (
+        CohereRerankV2Config().get_complete_url(api_base=api_base, model="rerank-v3.5")
+        == expected_url
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #31167

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [x] **Branch creation CI run**  
       Link: https://github.com/BerriAI/litellm/pull/31162/checks

- [x] **CI run for the last commit**  
       Link: https://github.com/BerriAI/litellm/pull/31162/checks?sha=bf5a8a324ae3b6ef87aa40fe63cc607743a079ea

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

### What Problem This Solves

When using Cohere rerank v2 with a custom `api_base` that already includes the version root, LiteLLM appends the full `/v2/rerank` endpoint again.

Before this change, a versioned base URL like:

```text
https://api.cohere.ai/v2
```

resolved to this duplicated endpoint path:

```text
https://api.cohere.ai/v2/v2/rerank
```

That path does not match Cohere's v2 rerank endpoint shape. Versioned API roots should resolve to:

```text
https://api.cohere.ai/v2/rerank
```

### Change

`CohereRerankV2Config.get_complete_url` now normalizes custom Cohere rerank v2 API bases before appending the rerank endpoint path.

The change keeps existing behavior for bare API roots and full endpoint URLs, while adding support for versioned API roots:

```text
https://api.cohere.ai -> https://api.cohere.ai/v2/rerank
https://api.cohere.ai/v2 -> https://api.cohere.ai/v2/rerank
https://api.cohere.ai/v2/rerank/ -> https://api.cohere.ai/v2/rerank
```

### Evidence

Focused validation run locally:

```text
uv run pytest tests/test_litellm/llms/cohere/rerank/test_rerank_v2_transformation.py -q
...                                                                      [100%]
3 passed in 0.80s
```

The regression test covers three URL forms: bare API root, versioned API root, and full endpoint URL with a trailing slash. The versioned API root case would have produced `/v2/v2/rerank` before this fix.

Formatting was applied to the changed files with:

```text
uv run black litellm/llms/cohere/rerank_v2/transformation.py tests/test_litellm/llms/cohere/rerank/test_rerank_v2_transformation.py
```

CI status as of this draft update: lint, code quality, provider transformation tests, proxy tests, UI build, security scans, and Codecov patch coverage are passing on the PR checks page. I did not run the full `make test-unit` command locally.

![](https://img.vectorpeak.cn/obsidian/2026/05-06/20260624134816160.png?imageSlim)

### Possible call chain / impact

The affected path is Cohere rerank v2 URL construction:

```text
litellm.rerank(..., custom_llm_provider="cohere", api_base="https://api.cohere.ai/v2")
-> rerank provider config selection
-> CohereRerankV2Config.get_complete_url(...)
-> HTTP request URL for Cohere rerank v2
```

Only custom Cohere rerank v2 base URL normalization is affected. Bare Cohere API roots and already-complete `/v2/rerank` endpoint URLs continue to resolve to the same final endpoint.

## Type

Bug Fix

Test

## Changes

Normalize custom Cohere rerank v2 API bases before appending the rerank endpoint path. A custom base that already ends at `/v2` now resolves to `/v2/rerank` instead of appending a second `/v2/rerank`.

This keeps the existing behavior for bare API roots and full rerank endpoint URLs, and adds focused regression coverage for the versioned API root case.
