### PR TITLE
fix(base_model_iterator): exact-match [DONE] termination check to pre…fix(base_model_iterator): exact-match [DONE] to prevent false stream termination

### DIFF
--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -111,7 +111,8 @@ class BaseModelResponseIterator:
     def _handle_string_chunk(self, str_line: str) -> Union[GenericStreamingChunk, ModelResponseStream]:
         # chunk is a str at this point
         stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(str_line=str_line)
-        if str_line.strip() in ("data: [DONE]", "[DONE]", "data:  [DONE]"):
+        stripped_sse_chunk = litellm.CustomStreamWrapper._strip_sse_data_from_chunk(str_line)
+        if stripped_sse_chunk is not None and stripped_sse_chunk.strip() == "[DONE]":
             return GenericStreamingChunk(
                 text="",
                 is_finished=True,

--- a/litellm/llms/base_llm/base_model_iterator.py
+++ b/litellm/llms/base_llm/base_model_iterator.py
@@ -111,7 +111,7 @@ class BaseModelResponseIterator:
     def _handle_string_chunk(self, str_line: str) -> Union[GenericStreamingChunk, ModelResponseStream]:
         # chunk is a str at this point
         stripped_json_chunk = BaseModelResponseIterator._string_to_dict_parser(str_line=str_line)
-        if "[DONE]" in str_line:
+        if str_line.strip() in ("data: [DONE]", "[DONE]", "data:  [DONE]"):
             return GenericStreamingChunk(
                 text="",
                 is_finished=True,


### PR DESCRIPTION
Fixes #31562

## Problem
`_handle_string_chunk` used a substring check (`if "[DONE]" in str_line`) 
to detect SSE stream termination. This caused false termination when a 
valid JSON chunk contained `[DONE]` as a substring in its content (e.g. 
tool-call arguments like `{"status": "[DONE]"}`).

## Fix
Changed to an exact match check after stripping whitespace:
```python
if str_line.strip() in ("data: [DONE]", "[DONE]", "data:  [DONE]"):
```
Valid JSON can never equal the bare string `[DONE]`, so this eliminates 
false positives while preserving all legitimate termination signals.

## Tests
All three regression tests from the issue pass:
- JSON chunk containing `[DONE]` substring → `is_finished=False` 
- Exact `data: [DONE]` signal → `is_finished=True` 
- `data:  [DONE]` with extra whitespace → `is_finished=True` 