### PR TITLE
fix(redis): re-establish async cluster connections after a node restart

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -23,7 +23,11 @@ from litellm._redis_credential_provider import (
     GCPIAMCredentialProvider,
     _generate_gcp_iam_access_token,
 )
-from litellm.constants import REDIS_CONNECTION_POOL_TIMEOUT, REDIS_SOCKET_TIMEOUT
+from litellm.constants import (
+    REDIS_CLUSTER_HEALTH_CHECK_INTERVAL,
+    REDIS_CONNECTION_POOL_TIMEOUT,
+    REDIS_SOCKET_TIMEOUT,
+)
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 
 from ._logging import verbose_logger
@@ -102,6 +106,8 @@ def _get_redis_cluster_kwargs(client=None):
         "max_connections",
         "socket_timeout",
         "socket_connect_timeout",
+        "health_check_interval",
+        "socket_keepalive",
     }
 
     return available_args
@@ -578,6 +584,13 @@ def get_redis_async_client(
         for item in redis_kwargs["startup_nodes"]:
             new_startup_nodes.append(ClusterNode(**item))
         cluster_kwargs.pop("startup_nodes", None)
+
+        # Default to a periodic health check + TCP keepalive so a connection silently dropped
+        # by a cluster restart (e.g. ElastiCache Serverless maintenance) is revalidated and
+        # reconnected before reuse instead of stalling in re-initialization; an explicit value
+        # from config still wins.
+        cluster_kwargs.setdefault("health_check_interval", REDIS_CLUSTER_HEALTH_CHECK_INTERVAL)
+        cluster_kwargs.setdefault("socket_keepalive", True)
 
         # Create async RedisCluster with IAM token as password if available
         cluster_client = async_redis.RedisCluster(

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -332,6 +332,10 @@ REDIS_CONNECTION_POOL_TIMEOUT = int(os.getenv("REDIS_CONNECTION_POOL_TIMEOUT", 5
 REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD = int(os.getenv("REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5))
 REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT = int(os.getenv("REDIS_CIRCUIT_BREAKER_RECOVERY_TIMEOUT", 60))
 REDIS_CIRCUIT_BREAKER_ENABLED = os.getenv("REDIS_CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"
+# Seconds of idle before a Redis cluster connection is validated with a PING and
+# reconnected if dead, so a connection silently dropped by a cluster restart
+# (e.g. ElastiCache Serverless maintenance) is not reused while broken
+REDIS_CLUSTER_HEALTH_CHECK_INTERVAL = 25
 # Default Redis major version to assume when version cannot be determined
 # Using 7 as it's the modern version that supports LPOP with count parameter
 DEFAULT_REDIS_MAJOR_VERSION = int(os.getenv("DEFAULT_REDIS_MAJOR_VERSION", 7))

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -12,6 +12,7 @@ from litellm._redis import (
     get_redis_connection_pool,
     get_redis_url_from_environment,
 )
+from litellm.constants import REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
 from litellm._redis_credential_provider import (
     GCPIAMCredentialProvider,
     _token_cache,
@@ -169,6 +170,46 @@ def test_socket_timeouts_in_cluster_kwargs():
     kwargs = _get_redis_cluster_kwargs()
     assert "socket_timeout" in kwargs
     assert "socket_connect_timeout" in kwargs
+
+
+def test_reconnect_kwargs_in_cluster_kwargs():
+    """Health check and keepalive must survive the cluster kwarg allow-list so
+    operators can tune Redis cluster reconnection behavior via config."""
+    kwargs = _get_redis_cluster_kwargs()
+    assert "health_check_interval" in kwargs
+    assert "socket_keepalive" in kwargs
+
+
+@patch("litellm._redis.async_redis.RedisCluster")
+def test_async_cluster_sets_reconnect_defaults(mock_cluster_cls):
+    """
+    The async RedisCluster client must be built with a periodic health check and
+    TCP keepalive so a connection silently dropped by a cluster restart (e.g.
+    ElastiCache Serverless maintenance) is revalidated and reconnected before
+    reuse instead of stalling in re-initialization. Regression for LIT-4083.
+    """
+    get_redis_async_client(startup_nodes=[{"host": "cluster-node", "port": 6379}])
+
+    mock_cluster_cls.assert_called_once()
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["health_check_interval"] == REDIS_CLUSTER_HEALTH_CHECK_INTERVAL
+    assert call_kwargs["health_check_interval"] > 0
+    assert call_kwargs["socket_keepalive"] is True
+
+
+@patch("litellm._redis.async_redis.RedisCluster")
+def test_async_cluster_reconnect_defaults_are_overridable(mock_cluster_cls):
+    """An explicit health_check_interval / socket_keepalive from config must win
+    over the built-in reconnect defaults."""
+    get_redis_async_client(
+        startup_nodes=[{"host": "cluster-node", "port": 6379}],
+        health_check_interval=7,
+        socket_keepalive=False,
+    )
+
+    call_kwargs = mock_cluster_cls.call_args[1]
+    assert call_kwargs["health_check_interval"] == 7
+    assert call_kwargs["socket_keepalive"] is False
 
 
 def test_get_redis_async_client_with_connection_pool():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4083

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

### Root cause

When `cache_params.redis_startup_nodes` is set, litellm builds a redis-py async `RedisCluster` in `get_redis_async_client`. That client was constructed with no health check (`health_check_interval=0`, disabled) and no TCP keepalive (`socket_keepalive=False`). The async cluster client is created once and reused for the life of the process (cached in `in_memory_llm_clients_cache` / `RedisClusterCache.redis_async_redis_cluster_client`), so when a cluster restarts (the customer hit periodic ElastiCache Serverless maintenance restarts) the dropped connection sits in the pool and gets reused while dead. The first command after the restart stalls in `RedisCluster.initialize()`, and the spend-counter path runs that command under the LoggingWorker's `asyncio.wait_for`, so the stall is cancelled and surfaces exactly as reported

```
redis/asyncio/cluster.py execute_command -> await self.initialize()
redis/asyncio/cluster.py initialize -> async with self._lock
asyncio.exceptions.CancelledError
-> TimeoutError  (logging_worker.py _process_log_task)
```

### The change

Build the async cluster client with a 25s `health_check_interval` and `socket_keepalive=True`, and let an explicit value from config still win. A non-zero `health_check_interval` is redis-py's documented mechanism for exactly this: before reusing an idle connection it sends a `PING`, and a dead connection is re-established before the real command runs

### Proof 1 - the constructed client now carries the resilience config (real litellm client, against a real cluster)

Same `get_redis_async_client(startup_nodes=...)` the proxy uses, before and after the change

```
# base (litellm_internal_staging)
CONSTRUCTED health_check_interval=0  socket_keepalive=False

# this PR
CONSTRUCTED health_check_interval=25 socket_keepalive=True
```

### Proof 2 - a non-zero health_check_interval actually re-validates an idle connection

Driving the real redis-py async cluster against a live single-node cluster, resetting the server command stats, idling past the interval, then issuing one `GET`, and counting health-check `PING`s the server saw

```
interval=0  (base default) , idle 35s -> server saw 0 health-check PINGs   (dead conn would be reused)
interval=1                 , idle 6s  -> server saw 1 health-check PING
interval=25 (this PR)      , idle 30s -> server saw 1 health-check PING     (idle conn validated + reconnected)
```

### Proof 3 - live proxy end to end on the failing path

Proxy launched with the cluster cache pointed at a live redis cluster, real Anthropic calls

```yaml
litellm_settings:
  cache: true
  cache_params:
    type: redis
    redis_startup_nodes:
      - host: "127.0.0.1"
        port: 6883
    ttl: 600
```

```bash
# the cluster cache client pings + sets against the cluster
curl -s :4483/cache/ping -H "Authorization: Bearer $KEY"
{"status":"healthy","cache_type":"redis","ping_response":true,"set_cache_response":"success",
 "health_check_cache_params":{"redis_kwargs":{"startup_nodes":[{"host":"127.0.0.1","port":6883}],...},"redis_version":"7.4.9"}}

# two identical chat completions: the 2nd is served from the cluster cache
REQUEST 1 (cold):  content="redis cluster reconnect ok"  id=chatcmpl-3f366c60-...  latency 1.21s
REQUEST 2 (warm):  content="redis cluster reconnect ok"  id=chatcmpl-3f366c60-...  latency 0.029s
```

Same response id on the second call with a 40x latency drop confirms the async cluster cache get/set path (the path in the stack trace) works end to end with the resilient client, and the proxy log shows no `CancelledError` / redis exceptions

A laptop cannot reproduce the precise ElastiCache restart-window stall (a local `docker restart` closes connections gracefully, so redis-py recovers immediately regardless), but the fix activates redis-py's documented idle-connection health check plus keepalive, which is the mechanism that detects and re-establishes a connection silently dropped by a restart

## Type

🐛 Bug Fix

## Changes

`get_redis_async_client` now builds the async `RedisCluster` with reconnection-resilient defaults (`health_check_interval=25`, `socket_keepalive=True`) via a small `_async_cluster_reconnect_kwargs` helper, and `health_check_interval` / `socket_keepalive` are added to the cluster kwarg allow-list so they can be tuned or disabled per config. New regression tests in `tests/test_litellm/test_redis.py` assert the resilient defaults are applied and that an explicit config value overrides them
