### PR TITLE
fix(auth): team.model_aliases must not bypass key.models allowlist

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2896,11 +2896,6 @@ def _can_object_call_model(
         _model = llm_router._get_model_from_alias(model)
         if _model:
             potential_models.append(_model)
-    # Expand the team-alias TARGET so it is checked against the caller's
-    # allowlist (key.models / team.models / org.models). The legacy
-    # `_model_in_team_aliases` short-circuit treated any alias source as
-    # authorized regardless of target — that let a key bypass its own
-    # `models` allowlist whenever the team had a matching alias.
     if team_model_aliases and isinstance(model, str) and model in team_model_aliases:
         potential_models.append(team_model_aliases[model])
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -2833,9 +2833,6 @@ def _check_model_access_helper(
     # Filter out models that are access_groups
     filtered_models = [m for m in models if m not in access_groups]
 
-    if _model_in_team_aliases(model=model, team_model_aliases=team_model_aliases):
-        return True
-
     if _model_matches_any_wildcard_pattern_in_list(model=model, allowed_model_list=filtered_models):
         return True
 
@@ -2899,6 +2896,13 @@ def _can_object_call_model(
         _model = llm_router._get_model_from_alias(model)
         if _model:
             potential_models.append(_model)
+    # Expand the team-alias TARGET so it is checked against the caller's
+    # allowlist (key.models / team.models / org.models). The legacy
+    # `_model_in_team_aliases` short-circuit treated any alias source as
+    # authorized regardless of target — that let a key bypass its own
+    # `models` allowlist whenever the team had a matching alias.
+    if team_model_aliases and isinstance(model, str) and model in team_model_aliases:
+        potential_models.append(team_model_aliases[model])
 
     ## check model access for alias + underlying model - allow if either is in allowed models
     for m in potential_models:
@@ -2917,24 +2921,6 @@ def _can_object_call_model(
         param="model",
         code=status.HTTP_403_FORBIDDEN,
     )
-
-
-def _model_in_team_aliases(model: str, team_model_aliases: Optional[Dict[str, str]] = None) -> bool:
-    """
-    Returns True if `model` being accessed is an alias of a team model
-
-    - `model=gpt-4o`
-    - `team_model_aliases={"gpt-4o": "gpt-4o-team-1"}`
-        - returns True
-
-    - `model=gp-4o`
-    - `team_model_aliases={"o-3": "o3-preview"}`
-        - returns False
-    """
-    if team_model_aliases:
-        if model in team_model_aliases:
-            return True
-    return False
 
 
 def _resolve_key_models_for_auth_check(valid_token: UserAPIKeyAuth) -> List[str]:

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -408,6 +408,139 @@ async def test_can_key_call_resolved_model_teamless_all_team_models_denied():
 
 
 @pytest.mark.asyncio
+async def test_team_model_aliases_cannot_bypass_key_models():
+    """team_model_aliases must not let a key reach models outside its own allowlist.
+
+    Regression guard: when `_check_model_access_helper` short-circuited on any
+    model name present as a key in `team_model_aliases` (regardless of target),
+    a key restricted to one prefixed model could call sibling models simply
+    because the team had a short-name alias for them.
+    """
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        api_key="sk-key",
+        team_id="team-1",
+        models=["main-g/claude-opus-4-7"],
+        team_models=[
+            "main-g/claude-opus-4-7",
+            "main-g/claude-opus-4-8",
+            "main-d/gpt-5.5",
+        ],
+        team_model_aliases={
+            "claude-opus-4-7": "main-g/claude-opus-4-7",
+            "claude-opus-4-8": "main-g/claude-opus-4-8",
+            "gpt-5.5": "main-d/gpt-5.5",
+        },
+    )
+
+    for short in ("claude-opus-4-8", "gpt-5.5"):
+        with pytest.raises(ProxyException) as exc_info:
+            await can_key_call_model(
+                model=short,
+                llm_model_list=None,
+                valid_token=valid_token,
+                llm_router=None,
+            )
+        assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_team_model_aliases_resolves_short_to_in_key_target():
+    """Short name whose alias target IS in key.models is allowed (legitimate path)."""
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        api_key="sk-key",
+        team_id="team-1",
+        models=["main-g/claude-opus-4-7"],
+        team_models=["main-g/claude-opus-4-7", "main-g/claude-opus-4-8"],
+        team_model_aliases={
+            "claude-opus-4-7": "main-g/claude-opus-4-7",
+            "claude-opus-4-8": "main-g/claude-opus-4-8",
+        },
+    )
+
+    assert (
+        await can_key_call_model(
+            model="claude-opus-4-7",
+            llm_model_list=None,
+            valid_token=valid_token,
+            llm_router=None,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_team_model_aliases_with_all_team_models_sentinel():
+    """all-team-models sentinel expands to team_models; alias target must still be in team_models."""
+    from litellm.proxy._types import SpecialModelNames
+    from litellm.proxy.auth.auth_checks import can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        api_key="sk-key",
+        team_id="team-1",
+        models=[SpecialModelNames.all_team_models.value],
+        team_models=["main-g/claude-opus-4-7", "main-g/claude-opus-4-8"],
+        team_model_aliases={
+            "claude-opus-4-7": "main-g/claude-opus-4-7",
+            "claude-opus-4-8": "main-g/claude-opus-4-8",
+            "gpt-5.5": "main-d/gpt-5.5",
+        },
+    )
+
+    assert (
+        await can_key_call_model(
+            model="claude-opus-4-8",
+            llm_model_list=None,
+            valid_token=valid_token,
+            llm_router=None,
+        )
+        is True
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_key_call_model(
+            model="gpt-5.5",
+            llm_model_list=None,
+            valid_token=valid_token,
+            llm_router=None,
+        )
+    assert exc_info.value.type == ProxyErrorTypes.key_model_access_denied
+
+
+@pytest.mark.asyncio
+async def test_can_team_access_model_with_team_owned_aliases():
+    """can_team_access_model: alias target in team.models is allowed; outside team.models is denied."""
+    from litellm.proxy.auth.auth_checks import can_team_access_model
+
+    team_object = LiteLLM_TeamTable(
+        team_id="team-1",
+        models=["main-g/claude-opus-4-7"],
+    )
+
+    assert (
+        await can_team_access_model(
+            model="claude-opus-4-7",
+            team_object=team_object,
+            llm_router=None,
+            team_model_aliases={"claude-opus-4-7": "main-g/claude-opus-4-7"},
+        )
+        is True
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await can_team_access_model(
+            model="claude-opus-4-8",
+            team_object=team_object,
+            llm_router=None,
+            team_model_aliases={"claude-opus-4-8": "main-g/claude-opus-4-8"},
+        )
+    assert exc_info.value.type == ProxyErrorTypes.team_model_access_denied
+
+
+@pytest.mark.asyncio
 async def test_can_team_access_model_all_team_models_expands_router_models():
     from litellm import Router
     from litellm.proxy._types import SpecialModelNames

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -409,13 +409,7 @@ async def test_can_key_call_resolved_model_teamless_all_team_models_denied():
 
 @pytest.mark.asyncio
 async def test_team_model_aliases_cannot_bypass_key_models():
-    """team_model_aliases must not let a key reach models outside its own allowlist.
-
-    Regression guard: when `_check_model_access_helper` short-circuited on any
-    model name present as a key in `team_model_aliases` (regardless of target),
-    a key restricted to one prefixed model could call sibling models simply
-    because the team had a short-name alias for them.
-    """
+    """A team alias whose target is not in `key.models` must be denied."""
     from litellm.proxy.auth.auth_checks import can_key_call_model
 
     valid_token = UserAPIKeyAuth(


### PR DESCRIPTION
## Relevant issues

No existing issue. This PR fixes a privilege-escalation bug where `team.model_aliases` lets a virtual key reach models outside its own `models` allowlist — discovered today during an internal audit.

## Type

🐛 Bug Fix

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Description

`_check_model_access_helper` in `litellm/proxy/auth/auth_checks.py` short-circuited to `return True` whenever the requested model was a key in `team_model_aliases`, **without verifying the resolved alias target was in the caller's `models` allowlist**. A virtual key restricted to a single prefixed model could call sibling models simply because the team had a short-name alias for them — even though the prefixed form itself was correctly denied.

**Operator impact:** team-level `model_aliases` becomes a privilege-escalation primitive. Any time a team is configured with a `short → prefixed` alias map (common pattern for letting clients call `claude-opus-4-8` instead of `main-g/claude-opus-4-8`), key-level `models` restrictions are silently broken for every aliased name.

**Bug origin:** introduced in `5cd20d2abc` ("allow adding model aliases for teams", 2025-02-11) — that commit added `_model_in_team_aliases` and the unconditional `return True` short-circuit. The intent was to let team-aliased short names resolve; the implementation forgot to validate the target.

## Fix

Three coordinated edits in `litellm/proxy/auth/auth_checks.py`:

1. **Add team-alias target expansion to `_can_object_call_model`** — same `potential_models` mechanism already used for `litellm.model_alias_map` and `llm_router.model_group_alias`:
   ```python
   if team_model_aliases and isinstance(model, str) and model in team_model_aliases:
       potential_models.append(team_model_aliases[model])
   ```
   The alias target now flows through the normal `_check_model_access_helper` allowlist check, the same as every other alias source.

2. **Remove the unconditional `_model_in_team_aliases` short-circuit** from `_check_model_access_helper`. There is no longer a per-alias bypass — every potential model is checked uniformly.

3. **Delete the now-orphaned `_model_in_team_aliases` function**. Grep shows no other callers across `litellm/` or `tests/`. Keeping it would leave a footgun for future contributors.

## Semantics preserved (regression matrix)

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| key.models=[A], team_aliases={short: A}, request `short` | 200 | **200** (alias resolves to allowed target) |
| key.models=[A], team_aliases={short: B}, request `short` | 200 (BUG) | **403** (alias target not in allowlist) |
| key.models=[A], team_aliases={}, request `A` | 200 | 200 |
| key.models=[A], request `B` (no aliases) | 403 | 403 |
| key.models=[all-team-models], team_models=[A,B], team_aliases={short: A}, request `short` | 200 | 200 |
| can_team_access_model: team.models=[A], team_aliases={short: A}, request `short` | 200 | 200 |
| can_team_access_model: team.models=[A], team_aliases={short: B}, request `short` | 200 (BUG) | **403** |

The pre-existing parametrized test `test_can_key_call_model_with_aliases` in `tests/proxy_unit_tests/test_auth_checks.py` (added in `5cd20d2abc`) passes unchanged under the new logic — both its cases still validate correctly.

## Test plan

4 new unit tests in `tests/test_litellm/proxy/auth/test_auth_checks.py`:

- `test_team_model_aliases_cannot_bypass_key_models` — primary bug repro: alias target outside `key.models` must raise `key_model_access_denied`.
- `test_team_model_aliases_resolves_short_to_in_key_target` — legitimate alias path still allowed.
- `test_team_model_aliases_with_all_team_models_sentinel` — sentinel + alias interaction is correct.
- `test_can_team_access_model_with_team_owned_aliases` — team-side check with aliases (target in `team.models` allowed, outside denied).

All 8 tests pass (4 new + 3 existing `all_team_models` sentinel tests + 1 `team_owned_aliases`). The full `tests/test_litellm/proxy/auth/test_auth_checks.py` file (159 tests) passes. The parametrized `test_can_key_call_model_with_aliases` (2 cases) in `tests/proxy_unit_tests/test_auth_checks.py` continues to pass.

```
$ uv run pytest tests/test_litellm/proxy/auth/test_auth_checks.py -v -k "team_model_alias or team_owned_aliases or all_team_models"
================ 8 passed, 151 deselected, 1 warning in 10.01s =================

$ uv run pytest tests/test_litellm/proxy/auth/test_auth_checks.py -q
=========================== 159 passed in 14.73s ===============================

$ uv run pytest tests/proxy_unit_tests/test_auth_checks.py::test_can_key_call_model_with_aliases -v
============================== 2 passed in 0.14s ===============================
```

## Proof of fix (end-to-end repro against a real proxy)

Reproduced both the bug and the fix on a live LiteLLM proxy (Postgres + Redis + real key/team workflow) — not just unit tests.

**Setup**:
```
team.models        = [claude-sonnet-cache, claude-haiku-cache, gpt-4o-mini-cache]
team.model_aliases = {sonnet: claude-sonnet-cache,
                      haiku:  claude-haiku-cache,
                      mini:   gpt-4o-mini-cache}
key.models         = [claude-sonnet-cache]    # narrowly scoped
```

**Pre-fix behavior** (model name → HTTP status):

| Request | Status |
|---|---|
| `model=claude-sonnet-cache` (in key) | 200 ✅ |
| `model=sonnet` (alias → in-key target) | 200 ✅ |
| `model=claude-haiku-cache` (in team, NOT in key) | 403 ✅ |
| `model=haiku` (alias → in-team, NOT-in-key target) | **200 ❌ BUG** |
| `model=mini` (alias → in-team, NOT-in-key target) | **200 ❌ BUG** |

**Post-fix behavior** (same proxy, fix applied, container rebuilt):

| Request | Status |
|---|---|
| `model=claude-sonnet-cache` | 200 ✅ |
| `model=sonnet` | 200 ✅ |
| `model=claude-haiku-cache` | 403 ✅ |
| `model=haiku` | **403 ✅ fixed** |
| `model=mini` | **403 ✅ fixed** |

The body of a `403` post-fix:
```
key not allowed to access model. This key can only access models=['claude-sonnet-cache']. Tried to access haiku
```

Same regression guard also verified for:
- **Fallback smuggling**: `{model: in-key, fallbacks: [alias→not-in-key]}` returns 403 (covers `_enforce_key_and_fallback_model_access` which runs `can_key_call_model` on every fallback list entry).
- **`all-team-models` + alias bypass**: a key with `models=[all-team-models]` and a team alias whose target is NOT in `team.models` returns 403 (covers `_resolve_all_team_model_sentinel_for_auth_check` interaction with the new alias expansion).

## Risk

Low. The change only **tightens** access: it denies short-name requests that were wrongly allowed before, and never widens what was already allowed. A team owner can recover the prior (insecure) behavior either by adding the target to the relevant `models` allowlist or by removing the alias. No client-side observable behavior changes for legitimate setups where alias targets were already in the allowlist.

Co-authored-by: songkuan-zheng <252822057+songkuan-zheng@users.noreply.github.com>
Co-authored-by: songkuan-zheng <songkuan-zheng@users.noreply.github.com>