### PR TITLE
fix: handle missing httpx_response in Google GenAI logging handler

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3247,10 +3247,17 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         import httpx
 
+        if isinstance(result, ModelResponse):
+            return result
+
         httpx_response = self.model_call_details.get("httpx_response", None)
-        if httpx_response is None:
+        if httpx_response is not None:
+            dict_result = httpx_response.json()
+        elif isinstance(result, dict):
+            dict_result = result
+        else:
             raise ValueError("Google GenAI Generate Content: httpx_response is None")
-        dict_result = httpx_response.json()
+
         result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3536,10 +3536,16 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         import httpx
 
+        if isinstance(result, ModelResponse):
+            return result
+
         httpx_response: Final = self.model_call_details.get("httpx_response", None)
-        if httpx_response is None:
+        if httpx_response is not None:
+            dict_result: Final = httpx_response.json()
+        elif isinstance(result, dict):
+            dict_result = result
+        else:
             raise ValueError("Google GenAI Generate Content: httpx_response is None")
-        dict_result: Final = httpx_response.json()
         result = litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
             completion_response=dict_result,
             model_response=litellm.ModelResponse(),

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4539,3 +4539,117 @@ async def test_restore_correlation_context_works_across_asyncio_task_boundary():
     finally:
         trace_id_var.set("")
         session_id_var.set("")
+
+
+def test_handle_non_streaming_google_genai_returns_modelresponse_unchanged():
+    """When result is already a ModelResponse, the handler must return it
+    verbatim. This avoids an unnecessary (and potentially expensive)
+    transform pass on responses that have already been converted upstream."""
+    from litellm.types.utils import ModelResponse
+
+    logging_obj = LitellmLogging(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="genai-mr-early-return",
+        function_id="genai-mr-early-return",
+    )
+    logging_obj.optional_params = {}
+
+    mr = ModelResponse(model="gemini-2.5-flash", usage=None)
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(result=mr)
+    assert result is mr
+
+
+def test_handle_non_streaming_google_genai_falls_back_to_dict_when_no_httpx_response():
+    """When ``httpx_response`` is missing, the handler must fall back to the
+    dict ``result`` instead of raising. This covers cases where the SDK
+    returns a pre-parsed payload (e.g., some Vertex AI paths) rather than an
+    httpx.Response."""
+    from litellm.types.utils import ModelResponse
+
+    logging_obj = LitellmLogging(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="genai-dict-fallback",
+        function_id="genai-dict-fallback",
+    )
+    logging_obj.optional_params = {}
+
+    native_body = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "hi"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+        },
+    }
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result=native_body
+    )
+    assert isinstance(result, ModelResponse)
+    assert result.usage is not None
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 5
+
+
+def test_handle_non_streaming_google_genai_raises_on_none_without_httpx_response():
+    """When both ``httpx_response`` and ``result`` are unavailable, the
+    handler should still raise — the old behaviour for truly missing data."""
+    logging_obj = LitellmLogging(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="genai-none-missing",
+        function_id="genai-none-missing",
+    )
+    logging_obj.optional_params = {}
+
+    with pytest.raises(ValueError, match="Google GenAI Generate Content: httpx_response is None"):
+        logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(result=None)
+
+
+def test_handle_non_streaming_google_genai_prefers_httpx_response_over_dict():
+    """When ``httpx_response`` is present the handler must use it, ignoring
+    any dict ``result`` passed in. This preserves the original path while
+    ensuring the new fallback doesn't short-circuit an existing response."""
+    logging_obj = LitellmLogging(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="generate_content",
+        start_time=time.time(),
+        litellm_call_id="genai-httpx-wins",
+        function_id="genai-httpx-wins",
+    )
+    logging_obj.optional_params = {}
+
+    httpx_resp = MagicMock(spec=httpx.Response)
+    httpx_resp.json.return_value = {
+        "candidates": [
+            {"content": {"parts": [{"text": "from-httpx"}], "role": "model"}, "finishReason": "STOP"}
+        ],
+        "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2},
+    }
+    logging_obj.model_call_details["httpx_response"] = httpx_resp
+
+    result = logging_obj._handle_non_streaming_google_genai_generate_content_response_logging(
+        result={"candidates": [{"content": {"parts": [{"text": "ignored"}], "role": "model"}}]}
+    )
+    assert isinstance(result, ModelResponse)
+    httpx_resp.json.assert_called_once()
+    assert result.usage is not None
+    assert result.usage.total_tokens == 2


### PR DESCRIPTION
## TLDR

Problem this solves:

- Google GenAI generateContent logging crashes with ValueError when the adapter path builds a ModelResponse without populating httpx_response
- The handler unconditionally read model_call_details["httpx_response"] and raised before doing any useful work

How it solves it:

- Early-return when result is already a ModelResponse, skipping the transform pass entirely
- Fall back to the dict result when httpx_response is absent, mirroring the Anthropic handler pattern
- Raise only when neither source is available, preserving the old behaviour for truly missing data

## User Flow

Before: a developer calling the Google GenAI generateContent endpoint through the adapter path gets a 500 because the logging worker throws

1. They send POST http://localhost:4000/v1beta/models/gemini-2.5-flash:generateContent with a contents body
2. The call completes against the provider, but the response never comes back; the logs show ValueError: Google GenAI Generate Content: httpx_response is None
3. http://localhost:4000/ui/?page=logs shows no spend row for that request because logging aborted before writing it

After: the same request returns the provider response and the spend row is written

1. They send the same POST http://localhost:4000/v1beta/models/gemini-2.5-flash:generateContent
2. The handler sees the already-built ModelResponse, returns it verbatim, and logging continues
3. http://localhost:4000/ui/?page=logs shows the request with non-zero spend

## Relevant issues

Fixes the ValueError: Google GenAI Generate Content: httpx_response is None error in logging.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment @greptileai to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review): https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA

## Screenshots / Proof of Fix

Rebased onto litellm_internal_staging at commit b571d2eead plus regression tests at f64489a2aa.

Before fix, the logging worker crashes with:

ValueError: Google GenAI Generate Content: httpx_response is None

After fix, the Google GenAI endpoint returns proper responses with no logging errors.

Regression tests cover all four code paths (commit f64489a2aa):

- test_handle_non_streaming_google_genai_returns_modelresponse_unchanged asserts a ModelResponse input is returned verbatim, no transform pass
- test_handle_non_streaming_google_genai_falls_back_to_dict_when_no_httpx_response asserts a native dict body is transformed into a ModelResponse with correct usage tokens when httpx_response is absent
- test_handle_non_streaming_google_genai_raises_on_none_without_httpx_response asserts the ValueError is still raised when neither source exists
- test_handle_non_streaming_google_genai_prefers_httpx_response_over_dict asserts the handler uses httpx_response when present, ignoring a stale dict result

## Type

Bug Fix

## Changes

When generate_content_provider_config is None (adapter path), two nested @client decorators create separate LiteLLMLoggingObj instances. The outer one (with call_type="generate_content") never gets httpx_response set, but the logging handler unconditionally read from it and raised ValueError.

The fix adds:
1. Early return if result is already a ModelResponse
2. Fallback to using result as a dict when httpx_response is None (matching the Anthropic handler pattern)
3. Raise only when both are missing

## Caveats (if any)

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
