### PR TITLE
fix(bedrock/converse): drop toolSpec.strict for Opus 4.7/4.8 (#31582)

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5010,15 +5010,18 @@ def _bedrock_tools_pt(tools: List, model: Optional[str] = None) -> List[BedrockT
     ]
     """
     from litellm.llms.bedrock.common_utils import (
-        get_bedrock_base_model,
+        bedrock_converse_supports_strict_tools,
         normalize_json_schema_custom_types_to_object,
     )
     from litellm.litellm_core_utils.prompt_templates.common_utils import unpack_defs
 
     _valid_json_schema_root_types = frozenset(("array", "boolean", "integer", "null", "number", "object", "string"))
     # Only Claude on Bedrock honours strict tool schemas; other families
-    # (Nova, Llama, GPT-OSS) reject the strict field outright.
-    supports_strict_tools = bool(model and get_bedrock_base_model(model).startswith("anthropic"))
+    # (Nova, Llama, GPT-OSS) reject the strict field outright. Opus 4.7/4.8
+    # also reject `strict` on Bedrock Converse (see #31582) — their validator
+    # maps toolSpec to the native Anthropic tool shape, which has no strict
+    # field, even though Anthropic's native API accepts it as a top-level key.
+    supports_strict_tools = bool(model and bedrock_converse_supports_strict_tools(model))
     tool_block_list: List[BedrockToolBlock] = []
     for tool_idx, tool in enumerate(tools):
         # Check if tool is already a BedrockToolBlock (e.g., systemTool for Nova grounding)

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -718,6 +718,40 @@ def is_claude_4_5_on_bedrock(model: str) -> bool:
     return any(pattern in model_lower for pattern in claude_4_5_patterns)
 
 
+# Bedrock Converse routes Claude Opus 4.7/4.8 through an Anthropic-compatible
+# validator that maps toolSpec to the native tool shape and rejects the extra
+# ``strict`` key (``tools.N.custom.strict: Extra inputs are not permitted``).
+# Sonnet 4.5/4.6 and Opus ≤4.6 accept ``toolSpec.strict``. See #31582.
+_BEDROCK_CONVERSE_STRICT_REJECTED_OPUS_PATTERNS = (
+    "claude-opus-4-7",
+    "claude_opus_4_7",
+    "claude-opus-4.7",
+    "claude_opus_4.7",
+    "claude-opus-4-8",
+    "claude_opus_4_8",
+    "claude-opus-4.8",
+    "claude_opus_4.8",
+)
+
+
+def bedrock_converse_supports_strict_tools(model: str) -> bool:
+    """
+    Whether ``toolSpec.strict`` can be forwarded to Bedrock Converse for ``model``.
+
+    Returns ``True`` only for Anthropic models that are NOT in the
+    Opus 4.7/4.8 family — those route through a stricter validator on the
+    Bedrock side that rejects the ``strict`` key on ``toolSpec`` even though
+    Anthropic's native API accepts it as a top-level tool field.
+    """
+    base = get_bedrock_base_model(model)
+    if not base.startswith("anthropic"):
+        return False
+    base_lower = base.lower()
+    return not any(
+        p in base_lower for p in _BEDROCK_CONVERSE_STRICT_REJECTED_OPUS_PATTERNS
+    )
+
+
 def normalize_bedrock_opus_output_config_effort(model: str, output_config: Any) -> None:
     """
     Normalize Anthropic ``output_config.effort`` values for Bedrock Opus ids.

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -747,9 +747,7 @@ def bedrock_converse_supports_strict_tools(model: str) -> bool:
     if not base.startswith("anthropic"):
         return False
     base_lower = base.lower()
-    return not any(
-        p in base_lower for p in _BEDROCK_CONVERSE_STRICT_REJECTED_OPUS_PATTERNS
-    )
+    return not any(p in base_lower for p in _BEDROCK_CONVERSE_STRICT_REJECTED_OPUS_PATTERNS)
 
 
 def normalize_bedrock_opus_output_config_effort(model: str, output_config: Any) -> None:

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -1,0 +1,88 @@
+"""Regression tests for Bedrock Converse ``toolSpec.strict`` forwarding.
+
+Bedrock Converse routes Claude Opus 4.7/4.8 through an Anthropic-compatible
+validator that rejects ``toolSpec.strict`` even though Anthropic's native API
+accepts ``strict`` as a top-level tool field for the same models. See
+BerriAI/litellm#31582.
+"""
+
+import pytest
+
+from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+from litellm.llms.bedrock.common_utils import bedrock_converse_supports_strict_tools
+
+
+_STRICT_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "strict": True,
+            "description": "Get the weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string", "enum": ["celsius"]},
+                },
+                "required": ["city", "unit"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "bedrock/us.anthropic.claude-opus-4-7",
+        "bedrock/us.anthropic.claude-opus-4-8",
+        "anthropic.claude-opus-4-7-v1:0",
+        "anthropic.claude_opus_4_8-v1:0",
+        "bedrock/us.anthropic.claude-opus-4.7",
+        "bedrock/us.anthropic.claude_opus_4_8-v1:0",
+    ],
+)
+def test_bedrock_tools_pt_strict_dropped_for_opus_47_48(model_id: str) -> None:
+    """Opus 4.7/4.8 on Bedrock Converse reject toolSpec.strict — must be dropped."""
+    result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
+    assert "strict" not in result[0]["toolSpec"], f"strict leaked into toolSpec for {model_id}: {result[0]['toolSpec']}"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+        "bedrock/us.anthropic.claude-opus-4-6",
+        "bedrock/us.anthropic.claude-opus-4-5",
+    ],
+)
+def test_bedrock_tools_pt_strict_kept_for_other_anthropic(model_id: str) -> None:
+    """Sonnet 4.5/4.6 and Opus <=4.6 accept toolSpec.strict — keep forwarding it."""
+    result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
+    assert result[0]["toolSpec"]["strict"] is True, f"strict missing for {model_id}: {result[0]['toolSpec']}"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "us.amazon.nova-micro-v1:0",
+        "meta.llama3-2-11b-instruct-v1:0",
+    ],
+)
+def test_bedrock_tools_pt_strict_dropped_for_non_anthropic(model_id: str) -> None:
+    """Non-Anthropic Bedrock families reject toolSpec.strict — must be dropped."""
+    result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
+    assert "strict" not in result[0]["toolSpec"]
+
+
+def test_bedrock_converse_supports_strict_tools_helper() -> None:
+    """Direct check for the gate helper used by factory.py."""
+    assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-opus-4-7") is False
+    assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-opus-4-8") is False
+    assert bedrock_converse_supports_strict_tools("anthropic.claude-sonnet-4-5-20250929-v1:0") is True
+    assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-opus-4-6") is True
+    assert bedrock_converse_supports_strict_tools("us.amazon.nova-micro-v1:0") is False
+    assert bedrock_converse_supports_strict_tools("") is False

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -954,58 +954,6 @@ def test_bedrock_tools_pt_strict_parameter():
     assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
 
 
-def test_bedrock_tools_pt_strict_dropped_for_opus_47_48():
-    """Regression for #31582.
-
-    Bedrock Converse routes Claude Opus 4.7/4.8 through an Anthropic-compatible
-    validator that rejects ``toolSpec.strict`` (``tools.N.custom.strict: Extra
-    inputs are not permitted``), even though Anthropic's native API accepts
-    ``strict`` as a top-level tool field for these models. Sonnet 4.5/4.6 and
-    Opus <=4.6 accept ``toolSpec.strict`` and keep the prior behavior.
-    """
-    tools_with_strict = [
-        {
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "strict": True,
-                "description": "Get the weather for a city",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "city": {"type": "string"},
-                        "unit": {"type": "string", "enum": ["celsius"]},
-                    },
-                    "required": ["city", "unit"],
-                    "additionalProperties": False,
-                },
-            },
-        }
-    ]
-
-    # Opus 4.7 / 4.8 on Bedrock Converse: strict must be dropped.
-    for model_id in (
-        "bedrock/us.anthropic.claude-opus-4-7",
-        "bedrock/us.anthropic.claude-opus-4-8",
-        "anthropic.claude-opus-4-7-v1:0",
-        "anthropic.claude_opus_4_8-v1:0",
-    ):
-        result = _bedrock_tools_pt(tools_with_strict, model=model_id)
-        assert "strict" not in result[0]["toolSpec"], (
-            f"strict leaked into toolSpec for {model_id}: {result[0]['toolSpec']}"
-        )
-
-    # Sonnet 4.5 / Opus 4.6 keep the existing behavior (strict forwarded).
-    for model_id in (
-        "anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "bedrock/us.anthropic.claude-opus-4-6",
-    ):
-        result = _bedrock_tools_pt(tools_with_strict, model=model_id)
-        assert result[0]["toolSpec"]["strict"] is True, (
-            f"strict missing for {model_id}: {result[0]['toolSpec']}"
-        )
-
-
 def test_bedrock_image_processor_content_type_fallback_url_extension():
     """
     Test that _post_call_image_processing falls back to URL extension

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -954,6 +954,58 @@ def test_bedrock_tools_pt_strict_parameter():
     assert "additionalProperties" not in result[0]["toolSpec"]["inputSchema"]["json"]
 
 
+def test_bedrock_tools_pt_strict_dropped_for_opus_47_48():
+    """Regression for #31582.
+
+    Bedrock Converse routes Claude Opus 4.7/4.8 through an Anthropic-compatible
+    validator that rejects ``toolSpec.strict`` (``tools.N.custom.strict: Extra
+    inputs are not permitted``), even though Anthropic's native API accepts
+    ``strict`` as a top-level tool field for these models. Sonnet 4.5/4.6 and
+    Opus <=4.6 accept ``toolSpec.strict`` and keep the prior behavior.
+    """
+    tools_with_strict = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "strict": True,
+                "description": "Get the weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string"},
+                        "unit": {"type": "string", "enum": ["celsius"]},
+                    },
+                    "required": ["city", "unit"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+    # Opus 4.7 / 4.8 on Bedrock Converse: strict must be dropped.
+    for model_id in (
+        "bedrock/us.anthropic.claude-opus-4-7",
+        "bedrock/us.anthropic.claude-opus-4-8",
+        "anthropic.claude-opus-4-7-v1:0",
+        "anthropic.claude_opus_4_8-v1:0",
+    ):
+        result = _bedrock_tools_pt(tools_with_strict, model=model_id)
+        assert "strict" not in result[0]["toolSpec"], (
+            f"strict leaked into toolSpec for {model_id}: {result[0]['toolSpec']}"
+        )
+
+    # Sonnet 4.5 / Opus 4.6 keep the existing behavior (strict forwarded).
+    for model_id in (
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/us.anthropic.claude-opus-4-6",
+    ):
+        result = _bedrock_tools_pt(tools_with_strict, model=model_id)
+        assert result[0]["toolSpec"]["strict"] is True, (
+            f"strict missing for {model_id}: {result[0]['toolSpec']}"
+        )
+
+
 def test_bedrock_image_processor_content_type_fallback_url_extension():
     """
     Test that _post_call_image_processing falls back to URL extension


### PR DESCRIPTION
## What Problem This Solves

Closes #31582.

Sending a tool with `strict: true` to Claude Opus 4.7 or Opus 4.8 on Bedrock Converse fails with a 400:

```
litellm.BadRequestError: BedrockException - {"message":"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted"}
```

The same request works on direct Anthropic and on Bedrock Sonnet 4.5/4.6 and Opus 4.5/4.6, so this is specific to Opus 4.7/4.8 on Bedrock Converse. It is a regression: working on 1.85.1, broken on 1.90.0/1.90.0-rc.1.

## Why This Change Was Made

PR #29814 ("feat(bedrock): forward strict and additionalProperties to Converse toolSpec") started forwarding `strict` into the Bedrock Converse `toolSpec`, gated on `get_bedrock_base_model(model).startswith("anthropic")`. That gate is too broad: Bedrock Converse routes Opus 4.7/4.8 through an Anthropic-compatible validator that maps `toolSpec` to the native tool shape (the `custom` variant) and rejects the extra `strict` key, even though Anthropic's native API accepts `strict` as a top-level tool field for these models. Sonnet 4.5/4.6 and Opus ≤4.6 accept `toolSpec.strict` and keep the existing behavior.

The fix is a focused exclusion: replace the broad `startswith("anthropic")` gate in `litellm_core_utils/prompt_templates/factory.py` with a small helper `bedrock_converse_supports_strict_tools` in `litellm/llms/bedrock/common_utils.py` that:

- returns `False` for non-Anthropic Bedrock models (preserves the existing "drop strict for Nova/Llama/GPT-OSS" behavior from #29814),
- returns `False` for the Opus 4.7/4.8 family,
- returns `True` for every other Anthropic model on Bedrock (Sonnet 4.5/4.6, Opus ≤4.6, Haiku, etc.).

The alternative — always drop `strict` on Bedrock and re-add it elsewhere — would undo the user-visible enum-constraint fix from #29814 for Sonnet/Opus ≤4.6 callers. The targeted exclusion preserves the #29814 fix where it works and removes it only where Bedrock rejects the field.

## User Impact

- Callers sending `strict: true` tools to `bedrock/...claude-opus-4-7` or `bedrock/...claude-opus-4-8` stop getting `400 BadRequestError: tools.N.custom.strict: Extra inputs are not permitted`. The tool call succeeds (with `strict` dropped on the Bedrock hop, matching pre-1.86 behavior).
- Callers using Sonnet 4.5/4.6, Opus ≤4.6, or any other Anthropic model on Bedrock see no change — `strict` is still forwarded to `toolSpec` as before.
- Non-Anthropic Bedrock families (Nova, Llama, GPT-OSS) see no change.

## Evidence

- New regression test `test_bedrock_tools_pt_strict_dropped_for_opus_47_48` covers: Opus 4.7 (3 id spellings — `bedrock/us.anthropic.claude-opus-4-7`, `anthropic.claude-opus-4-7-v1:0`, mixed dash/underscore) and Opus 4.8 (same spellings) all drop `strict`; Sonnet 4.5 and Opus 4.6 still forward `strict`.
- Existing `test_bedrock_tools_pt_strict_parameter` (the #29814 regression test) still passes — confirms the Sonnet/Nova behavior is unchanged.
- Reproducer from the issue (`bedrock/us.anthropic.claude-opus-4-7` with `strict: true`) is the case the new test locks in.
- Local run: `python3 -m pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py -k strict` → 2 passed.
- One unrelated test (`test_bedrock_converse_messages_pt_document_various_formats`) fails in this file both with and without my changes (verified via `git stash`) — it's a pre-existing MIME-type environment issue, not caused by this PR.
