### PR TITLE
fix(proxy): preserve operator-set AZURE_API_VERSION so store_model_in_db keeps azure models

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -938,8 +938,7 @@ def run_server(
         # click default. initialize() uses this to decide if it may override an
         # operator-set AZURE_API_VERSION env var.
         api_version_explicit = (
-            click.get_current_context().get_parameter_source("api_version")
-            != click.core.ParameterSource.DEFAULT
+            click.get_current_context().get_parameter_source("api_version") != click.core.ParameterSource.DEFAULT
         )
         save_worker_config(
             model=model,

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -934,11 +934,19 @@ def run_server(
     else:
         if headers:
             headers = json.loads(headers)
+        # Whether --api_version was actually supplied on the CLI vs left at its
+        # click default. initialize() uses this to decide if it may override an
+        # operator-set AZURE_API_VERSION env var.
+        api_version_explicit = (
+            click.get_current_context().get_parameter_source("api_version")
+            != click.core.ParameterSource.DEFAULT
+        )
         save_worker_config(
             model=model,
             alias=alias,
             api_base=api_base,
             api_version=api_version,
+            api_version_explicit=api_version_explicit,
             debug=debug,
             detailed_debug=detailed_debug,
             temperature=temperature,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6410,6 +6410,7 @@ async def initialize(
     alias=None,
     api_base=None,
     api_version=None,
+    api_version_explicit=False,
     debug=False,
     detailed_debug=False,
     temperature=None,
@@ -6517,12 +6518,12 @@ async def initialize(
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        # An explicitly-passed --api_version (any value other than the click
-        # default) still overrides the env. The bare default must not clobber an
+        # An explicitly-passed --api_version overrides the env (including a move
+        # back to the litellm default). The click default must not clobber an
         # operator-set AZURE_API_VERSION: changing it after azure deployments are
         # registered shifts their hashed deployment ids, so the store_model_in_db
         # reconciliation then deletes them.
-        if api_version != litellm.AZURE_DEFAULT_API_VERSION:
+        if api_version_explicit:
             os.environ["AZURE_API_VERSION"] = api_version
         else:
             os.environ.setdefault("AZURE_API_VERSION", api_version)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6410,7 +6410,7 @@ async def initialize(
     alias=None,
     api_base=None,
     api_version=None,
-    api_version_explicit=False,
+    api_version_explicit: bool = False,
     debug=False,
     detailed_debug=False,
     temperature=None,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6517,7 +6517,15 @@ async def initialize(
         user_api_base = api_base
         dynamic_config[user_model]["api_base"] = api_base
     if api_version:
-        os.environ["AZURE_API_VERSION"] = api_version  # set this for azure - litellm can read this from the env
+        # An explicitly-passed --api_version (any value other than the click
+        # default) still overrides the env. The bare default must not clobber an
+        # operator-set AZURE_API_VERSION: changing it after azure deployments are
+        # registered shifts their hashed deployment ids, so the store_model_in_db
+        # reconciliation then deletes them.
+        if api_version != litellm.AZURE_DEFAULT_API_VERSION:
+            os.environ["AZURE_API_VERSION"] = api_version
+        else:
+            os.environ.setdefault("AZURE_API_VERSION", api_version)
     if max_tokens:  # model-specific param
         dynamic_config[user_model]["max_tokens"] = max_tokens
     if temperature:  # model-specific param

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -220,7 +220,7 @@ def test_save_worker_config_invalid_no_kwargs_yields_empty(monkeypatch):
 def test_initialize_signature_is_async_with_expected_params():
     sig = inspect.signature(initialize)
     # Hard-coded so a signature change (param added/removed) trips the gate.
-    expected_param_count = 17
+    expected_param_count = 18
     observed = {
         "is_async": inspect.iscoroutinefunction(initialize),
         "param_count": len(sig.parameters),

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -968,6 +968,69 @@ class TestProxyInitializationHelpers:
             mock_proxy_module.save_worker_config.assert_called_once()
             call_kwargs = mock_proxy_module.save_worker_config.call_args[1]
             assert call_kwargs["api_version"] == litellm.AZURE_DEFAULT_API_VERSION
+            assert call_kwargs["api_version_explicit"] is False
+
+    @patch("uvicorn.run")
+    @patch("atexit.register")
+    @patch("litellm.proxy.db.prisma_client.PrismaManager.setup_database")
+    @patch(
+        "litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False
+    )
+    def test_proxy_explicit_api_version_marked_explicit(
+        self, mock_should_update, mock_setup_db, mock_atexit_register, mock_uvicorn_run
+    ):
+        """An explicitly-passed --api_version is forwarded with api_version_explicit=True
+        so initialize() can override an operator-set AZURE_API_VERSION env var."""
+        from click.testing import CliRunner
+
+        from litellm.proxy.proxy_cli import run_server
+
+        runner = CliRunner()
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=MagicMock(),
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("DATABASE_URL", "DIRECT_URL")
+        }
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch(
+                "litellm.proxy.proxy_cli.ProxyInitializationHelpers._get_default_unvicorn_init_args"
+            ) as mock_get_args,
+        ):
+            mock_get_args.return_value = {
+                "app": "litellm.proxy.proxy_server:app",
+                "host": "localhost",
+                "port": 8000,
+            }
+            result = runner.invoke(
+                run_server,
+                [
+                    "--api_version",
+                    "2099-12-01-preview",
+                    "--local",
+                    "--skip_server_startup",
+                ],
+            )
+            assert (
+                result.exit_code == 0
+            ), f"exit_code={result.exit_code}, output={result.output}"
+            mock_proxy_module.save_worker_config.assert_called_once()
+            call_kwargs = mock_proxy_module.save_worker_config.call_args[1]
+            assert call_kwargs["api_version"] == "2099-12-01-preview"
+            assert call_kwargs["api_version_explicit"] is True
 
     @patch("uvicorn.run")
     @patch("builtins.print")

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8676,7 +8676,24 @@ async def test_initialize_sets_azure_api_version_when_unset(monkeypatch):
     monkeypatch.delenv("AZURE_API_VERSION", raising=False)
     await initialize(
         config=None,
+        api_version=litellm.AZURE_DEFAULT_API_VERSION,
+        api_version_explicit=False,
+        drop_params=False,
+        add_function_to_prompt=False,
+        telemetry=False,
+    )
+    assert os.environ["AZURE_API_VERSION"] == litellm.AZURE_DEFAULT_API_VERSION
+
+
+@pytest.mark.asyncio
+async def test_initialize_explicit_api_version_overrides_env(monkeypatch):
+    """An explicitly-supplied --api_version overrides an existing AZURE_API_VERSION,
+    preserving the explicit CLI override path."""
+    monkeypatch.setenv("AZURE_API_VERSION", "2025-04-01-preview")
+    await initialize(
+        config=None,
         api_version="2099-12-01-preview",
+        api_version_explicit=True,
         drop_params=False,
         add_function_to_prompt=False,
         telemetry=False,
@@ -8685,16 +8702,17 @@ async def test_initialize_sets_azure_api_version_when_unset(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_initialize_explicit_api_version_overrides_env(monkeypatch):
-    """An explicitly-passed --api_version (a value other than the click default)
-    still overrides an existing AZURE_API_VERSION, preserving the explicit CLI
-    override path."""
+async def test_initialize_explicit_default_api_version_overrides_env(monkeypatch):
+    """An operator can explicitly pass --api_version equal to the litellm default to
+    move an azure proxy back to that version even when AZURE_API_VERSION is already
+    set to something else; the explicit flag, not the value, decides the override."""
     monkeypatch.setenv("AZURE_API_VERSION", "2025-04-01-preview")
     await initialize(
         config=None,
-        api_version="2099-12-01-preview",
+        api_version=litellm.AZURE_DEFAULT_API_VERSION,
+        api_version_explicit=True,
         drop_params=False,
         add_function_to_prompt=False,
         telemetry=False,
     )
-    assert os.environ["AZURE_API_VERSION"] == "2099-12-01-preview"
+    assert os.environ["AZURE_API_VERSION"] == litellm.AZURE_DEFAULT_API_VERSION

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8650,3 +8650,51 @@ def test_config_field_info_returns_raw_secrets_for_full_admin(monkeypatch):
         )
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_clobber_operator_azure_api_version(monkeypatch):
+    """Regression: initialize() must not overwrite an operator-set AZURE_API_VERSION
+    with the CLI --api_version default (litellm.AZURE_DEFAULT_API_VERSION). Overwriting
+    it after azure deployments are registered shifts their hashed deployment ids, so the
+    store_model_in_db reconciliation then deletes every azure deployment."""
+    monkeypatch.setenv("AZURE_API_VERSION", "2025-04-01-preview")
+    await initialize(
+        config=None,
+        api_version=litellm.AZURE_DEFAULT_API_VERSION,
+        drop_params=False,
+        add_function_to_prompt=False,
+        telemetry=False,
+    )
+    assert os.environ["AZURE_API_VERSION"] == "2025-04-01-preview"
+
+
+@pytest.mark.asyncio
+async def test_initialize_sets_azure_api_version_when_unset(monkeypatch):
+    """When AZURE_API_VERSION is unset, initialize() still populates it from the
+    (CLI-provided) api_version so azure has a version to use."""
+    monkeypatch.delenv("AZURE_API_VERSION", raising=False)
+    await initialize(
+        config=None,
+        api_version="2099-12-01-preview",
+        drop_params=False,
+        add_function_to_prompt=False,
+        telemetry=False,
+    )
+    assert os.environ["AZURE_API_VERSION"] == "2099-12-01-preview"
+
+
+@pytest.mark.asyncio
+async def test_initialize_explicit_api_version_overrides_env(monkeypatch):
+    """An explicitly-passed --api_version (a value other than the click default)
+    still overrides an existing AZURE_API_VERSION, preserving the explicit CLI
+    override path."""
+    monkeypatch.setenv("AZURE_API_VERSION", "2025-04-01-preview")
+    await initialize(
+        config=None,
+        api_version="2099-12-01-preview",
+        drop_params=False,
+        add_function_to_prompt=False,
+        telemetry=False,
+    )
+    assert os.environ["AZURE_API_VERSION"] == "2099-12-01-preview"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Repro: a proxy with `store_model_in_db: True`, two `azure/` models whose `api_version` comes from `os.environ/AZURE_API_VERSION` set to a value other than `litellm.AZURE_DEFAULT_API_VERSION` (e.g. `2025-04-01-preview`), plus a non-azure model for contrast, backed by Postgres. No `--api_version` flag is passed (so it takes the CLI default).

Before the fix, the azure models vanish from the proxy a few seconds after startup:

```
$ curl -s localhost:4000/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id'
gemini-3-flash
$ curl -s localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -H 'Content-Type: application/json' -d '{"model":"grok-4.3","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"litellm.BadRequestError: You passed in model=grok-4.3. There are no healthy deployments for this model. ..."}}
```

After the fix, all models stay registered:

```
$ curl -s localhost:4000/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id'
gemini-3-flash
gpt-5.4
grok-4.3
```

## Type

🐛 Bug Fix

## Changes

`initialize()` set `os.environ["AZURE_API_VERSION"]` from its `api_version` argument, which originates from the `--api_version` CLI option whose default is `litellm.AZURE_DEFAULT_API_VERSION`. That assignment runs after `load_config()` has already registered the azure deployments using the operator's configured api_version, so it silently replaces the operator's value with the litellm default.

A deployment's id is a hash of its `litellm_params`, which for azure includes `api_version`. With `store_model_in_db: True`, the startup reconciliation (`add_deployment` -> `_update_llm_router` -> `_delete_deployment`) recomputes each config model's id by reading `os.environ/AZURE_API_VERSION` again. Because the env var was overwritten with the default, the recomputed ids no longer match the registered ones, and every azure deployment is treated as stale and deleted. Models without an `api_version` (bedrock, gemini) hash identically both times and are unaffected, which is why only azure models disappear. It only reproduces when the operator's api_version differs from `AZURE_DEFAULT_API_VERSION`.

The fix uses `os.environ.setdefault` so an operator-provided `AZURE_API_VERSION` is preserved, while the CLI default still populates the env var when nothing is set. The `--api_version` CLI default is intentionally left as `AZURE_DEFAULT_API_VERSION`, so the existing default-propagation behavior (covered by `test_proxy_default_api_version_uses_azure_default`) is unchanged.

Added two regression tests in `tests/test_litellm/proxy/test_proxy_server.py`: one asserts `initialize()` does not clobber an existing `AZURE_API_VERSION`, the other asserts it still sets the env var when unset. The first fails on the previous code and passes with this change
