### PR TITLE
feat(prometheus): add litellm_overhead_with_guardrails_latency_metric

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -49,12 +49,16 @@ from litellm.proxy._types import (
 from litellm.repositories.organization_repository import OrganizationRepository
 from litellm.repositories.team_repository import TeamRepository
 from litellm.repositories.user_repository import UserRepository
+from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.integrations.prometheus import *
 from litellm.types.integrations.prometheus import (
     _sanitize_prometheus_label_name,
     _sanitize_prometheus_label_value,
 )
-from litellm.types.utils import StandardLoggingPayload
+from litellm.types.utils import (
+    StandardLoggingGuardrailInformation,
+    StandardLoggingPayload,
+)
 
 if TYPE_CHECKING:
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -64,6 +68,8 @@ else:
 
 class PrometheusLogger(CustomLogger):
     # Class variables or attributes
+
+    _ADDITIVE_GUARDRAIL_MODES = frozenset((GuardrailEventHooks.pre_call.value, GuardrailEventHooks.post_call.value))
 
     @staticmethod
     def get_instance() -> Optional["PrometheusLogger"]:
@@ -340,6 +346,14 @@ class PrometheusLogger(CustomLogger):
                 "litellm_overhead_latency_metric",
                 "Latency overhead (milliseconds) added by LiteLLM processing",
                 labelnames=self.get_labels_for_metric("litellm_overhead_latency_metric"),
+                buckets=self.latency_buckets,
+            )
+
+            self.litellm_overhead_with_guardrails_latency_metric = self._histogram_factory(
+                "litellm_overhead_with_guardrails_latency_metric",
+                "Total internal latency (seconds) added by LiteLLM, including "
+                "pre/post-call guardrails (excludes the LLM API call)",
+                labelnames=self.get_labels_for_metric("litellm_overhead_with_guardrails_latency_metric"),
                 buckets=self.latency_buckets,
             )
 
@@ -1000,6 +1014,67 @@ class PrometheusLogger(CustomLogger):
 
         self._cached_metric_labels[metric_name] = filtered_labels
         return filtered_labels
+
+    @staticmethod
+    def _guardrail_is_additive(info: StandardLoggingGuardrailInformation) -> bool:
+        mode = info.get("guardrail_mode")
+        modes = mode if isinstance(mode, list) else [mode]
+        mode_values = frozenset(
+            m.value if isinstance(m, GuardrailEventHooks) else m for m in modes if isinstance(m, str)
+        )
+        return bool(mode_values) and mode_values <= PrometheusLogger._ADDITIVE_GUARDRAIL_MODES
+
+    @staticmethod
+    def _get_guardrail_overhead_seconds(
+        standard_logging_payload: StandardLoggingPayload,
+    ) -> float:
+        """Seconds of additive guardrail time (pre/post-call only) on the payload.
+
+        during_call guardrails run concurrently with the LLM call, so their
+        wall-clock overlaps the provider call and is not additive overhead;
+        logging_only and MCP modes never block the user-facing response. A
+        guardrail counts only when every mode it carries is pre/post-call, so a
+        mixed list such as ["pre_call", "during_call"] is excluded.
+
+        guardrail_information is typed as a list, but some guardrails assign a
+        single dict directly, so normalize that shape to a one-item list.
+        """
+        guardrail_information = standard_logging_payload.get("guardrail_information")
+        entries: list[StandardLoggingGuardrailInformation] = (
+            [cast("StandardLoggingGuardrailInformation", guardrail_information)]
+            if isinstance(guardrail_information, dict)
+            else guardrail_information or []
+        )
+        return sum(
+            (float(info.get("duration") or 0.0) for info in entries if PrometheusLogger._guardrail_is_additive(info)),
+            0.0,
+        )
+
+    def _set_overhead_with_guardrails_metric(
+        self,
+        standard_logging_payload: StandardLoggingPayload,
+        enum_values: UserAPIKeyLabelValues,
+        label_context: Optional[PrometheusLabelFactoryContext] = None,
+    ) -> None:
+        """Record litellm_overhead_with_guardrails_latency_metric (seconds): SDK overhead +
+        pre/post-call guardrail time. Recorded outside the SDK-overhead gate so
+        guardrail-only overhead is still captured when litellm_overhead_time_ms
+        is 0 or absent.
+        """
+        litellm_overhead_time_ms = standard_logging_payload["hidden_params"].get("litellm_overhead_time_ms")
+        guardrail_overhead_seconds = self._get_guardrail_overhead_seconds(standard_logging_payload)
+        if litellm_overhead_time_ms is None and guardrail_overhead_seconds <= 0:
+            return
+        labels = prometheus_label_factory(
+            supported_enum_labels=self.get_labels_for_metric(
+                metric_name="litellm_overhead_with_guardrails_latency_metric"
+            ),
+            enum_values=enum_values,
+            label_context=label_context,
+        )
+        self.litellm_overhead_with_guardrails_latency_metric.labels(**labels).observe(
+            ((litellm_overhead_time_ms or 0.0) / 1000) + guardrail_overhead_seconds
+        )
 
     def _track_end_user_metric_series(
         self,
@@ -2345,6 +2420,12 @@ class PrometheusLogger(CustomLogger):
                 self.litellm_overhead_latency_metric.labels(**_labels).observe(
                     litellm_overhead_time_ms / 1000
                 )  # set as seconds
+
+            self._set_overhead_with_guardrails_metric(
+                standard_logging_payload=standard_logging_payload,
+                enum_values=enum_values,
+                label_context=label_context,
+            )
 
             if remaining_requests:
                 """

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -195,6 +195,7 @@ DEFINED_PROMETHEUS_METRICS = Literal[
     "litellm_llm_api_time_to_first_token_metric",
     "litellm_request_total_latency_metric",
     "litellm_overhead_latency_metric",
+    "litellm_overhead_with_guardrails_latency_metric",
     "litellm_remaining_requests_metric",
     "litellm_remaining_tokens_metric",
     "litellm_proxy_total_requests_metric",
@@ -370,6 +371,16 @@ class PrometheusMetricLabels:
     ]
 
     litellm_overhead_latency_metric = [
+        UserAPIKeyLabelNames.MODEL_GROUP.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.API_BASE.value,
+        UserAPIKeyLabelNames.v2_LITELLM_MODEL_NAME.value,
+        UserAPIKeyLabelNames.API_KEY_HASH.value,
+        UserAPIKeyLabelNames.API_KEY_ALIAS.value,
+        UserAPIKeyLabelNames.MODEL_ID.value,
+    ]
+
+    litellm_overhead_with_guardrails_latency_metric = [
         UserAPIKeyLabelNames.MODEL_GROUP.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.API_BASE.value,

--- a/tests/test_litellm/integrations/test_prometheus_overhead_with_guardrails.py
+++ b/tests/test_litellm/integrations/test_prometheus_overhead_with_guardrails.py
@@ -1,0 +1,238 @@
+"""
+Unit tests for litellm_overhead_with_guardrails_latency_metric.
+
+The metric reports total internal latency LiteLLM adds around the provider
+call = SDK overhead (litellm_overhead_time_ms) + pre/post-call guardrail
+durations. During-call (moderation) guardrails run concurrently with the LLM
+call and are excluded so they don't inflate the overhead.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.utils import StandardLoggingPayload
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    """Clean up prometheus registry before/after each test."""
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+    yield
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        REGISTRY.unregister(collector)
+
+
+def test_get_guardrail_overhead_seconds_sums_pre_post_excludes_during():
+    """Helper sums pre/post durations, excludes during_call, tolerates missing values."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.pre_call, "duration": 0.1},
+            {"guardrail_mode": GuardrailEventHooks.during_call, "duration": 0.5},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.25},
+            {"guardrail_mode": GuardrailEventHooks.post_call},  # no duration -> 0
+        ],
+    )
+    # 0.1 (pre) + 0.25 (post) = 0.35; during_call 0.5 excluded; missing duration -> 0
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.35) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_no_guardrails_is_zero():
+    """No guardrail_information at all -> 0.0."""
+    assert (
+        PrometheusLogger._get_guardrail_overhead_seconds(
+            StandardLoggingPayload(model="gpt-4o")
+        )
+        == 0.0
+    )
+
+
+def test_get_guardrail_overhead_seconds_accepts_plain_string_mode():
+    """guardrail_mode may arrive as a plain string after serialization."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": "pre_call", "duration": 0.2},
+            {"guardrail_mode": "during_call", "duration": 0.9},
+        ],
+    )
+    # only pre_call counts; during_call excluded
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.2) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_excludes_list_mode_with_during_call():
+    """A list-typed guardrail_mode containing during_call must be excluded.
+
+    guardrail_mode is typed Optional[Union[GuardrailEventHooks,
+    List[GuardrailEventHooks], GuardrailMode]]; a list mixing in during_call is
+    not additive (concurrent) overhead and must not be counted.
+    """
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {
+                "guardrail_mode": [
+                    GuardrailEventHooks.pre_call,
+                    GuardrailEventHooks.during_call,
+                ],
+                "duration": 0.3,
+            },
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # the list entry mixes in during_call -> excluded; only the post_call counts
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_counts_pure_pre_post_list_mode():
+    """A list-typed mode containing only additive (pre/post) phases is counted."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": [GuardrailEventHooks.pre_call], "duration": 0.1},
+            {"guardrail_mode": ["post_call"], "duration": 0.2},
+        ],
+    )
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.3) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_excludes_logging_only_and_mcp():
+    """logging_only and MCP-specific modes do not block the response -> excluded."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.logging_only, "duration": 0.4},
+            {"guardrail_mode": GuardrailEventHooks.pre_mcp_call, "duration": 0.3},
+            {"guardrail_mode": GuardrailEventHooks.during_mcp_call, "duration": 0.2},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # only the post_call guardrail is additive, user-visible overhead
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_ignores_dict_mode_without_error():
+    """guardrail_mode may be a GuardrailMode TypedDict (an unhashable dict at
+    runtime, from the enterprise Mode-hook path). It must not raise TypeError and
+    must not be counted (the phase can't be resolved to a blocking pre/post)."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            # GuardrailMode TypedDict -> plain dict at runtime
+            {"guardrail_mode": {"tags": {"default": ["pre_call"]}}, "duration": 0.3},
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.05},
+        ],
+    )
+    # dict-typed mode is ignored (no TypeError); only the post_call entry counts
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.05) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_ignores_dict_inside_list_mode():
+    """A list-typed mode containing a dict must not raise and the dict is ignored."""
+    payload = StandardLoggingPayload(
+        guardrail_information=[
+            {"guardrail_mode": [GuardrailEventHooks.pre_call, {"k": "v"}], "duration": 0.1},
+        ],
+    )
+    # the dict is ignored; remaining mode is pre_call -> counted
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.1) < 1e-6
+
+
+def test_get_guardrail_overhead_seconds_handles_single_dict_payload():
+    """guardrail_information may be a single dict (e.g. xecguard) rather than a
+    list. Iterating it would yield string keys and crash the success-metrics
+    block, so a lone dict must be evaluated as one entry, not raise."""
+    payload = StandardLoggingPayload(
+        guardrail_information={
+            "guardrail_mode": "logging_only",
+            "duration": 0.7,
+            "guardrail_name": "xecguard",
+        },
+    )
+    # the single dict is logging_only -> excluded, and must not raise
+    assert PrometheusLogger._get_guardrail_overhead_seconds(payload) == 0.0
+
+
+def test_get_guardrail_overhead_seconds_counts_single_pre_call_dict():
+    """A single pre/post-call dict (not wrapped in a list) is still counted."""
+    payload = StandardLoggingPayload(
+        guardrail_information={"guardrail_mode": "pre_call", "duration": 0.3},
+    )
+    assert abs(PrometheusLogger._get_guardrail_overhead_seconds(payload) - 0.3) < 1e-6
+
+
+def _patch_label_factory(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.integrations.prometheus.prometheus_label_factory",
+        lambda **kwargs: {},
+    )
+
+
+def test_overhead_with_guardrails_recorded_when_only_guardrails_no_sdk_overhead(monkeypatch):
+    """Guardrail-only overhead is recorded even when SDK overhead is absent."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_overhead_with_guardrails_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(
+        hidden_params={},  # no litellm_overhead_time_ms
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.post_call, "duration": 0.2}
+        ],
+    )
+    logger._set_overhead_with_guardrails_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    mock_metric.labels.return_value.observe.assert_called_once()
+    observed = mock_metric.labels.return_value.observe.call_args[0][0]
+    assert abs(observed - 0.2) < 1e-6
+
+
+def test_overhead_with_guardrails_recorded_when_sdk_overhead_is_zero(monkeypatch):
+    """SDK overhead of exactly 0 (walrus-falsy) must not suppress the metric."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_overhead_with_guardrails_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(
+        hidden_params={"litellm_overhead_time_ms": 0.0},
+        guardrail_information=[
+            {"guardrail_mode": GuardrailEventHooks.pre_call, "duration": 0.1}
+        ],
+    )
+    logger._set_overhead_with_guardrails_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    observed = mock_metric.labels.return_value.observe.call_args[0][0]
+    assert abs(observed - 0.1) < 1e-6
+
+
+def test_overhead_with_guardrails_skipped_when_no_overhead_and_no_guardrails(monkeypatch):
+    """Nothing to record -> the metric is not touched."""
+    _patch_label_factory(monkeypatch)
+    logger = PrometheusLogger()
+    mock_metric = MagicMock()
+    logger.litellm_overhead_with_guardrails_latency_metric = mock_metric
+
+    payload = StandardLoggingPayload(hidden_params={})
+    logger._set_overhead_with_guardrails_metric(
+        payload, enum_values=MagicMock(), label_context=MagicMock()
+    )
+
+    mock_metric.labels.assert_not_called()
+
+
+def test_overhead_with_guardrails_metric_is_registered():
+    """The overhead-with-guardrails histogram is defined and registered on logger init."""
+    logger = PrometheusLogger()
+    assert logger.litellm_overhead_with_guardrails_latency_metric is not None
+
+    registered = [
+        name
+        for name in REGISTRY._names_to_collectors
+        if name.startswith("litellm_overhead_with_guardrails_latency_metric")
+    ]
+    assert registered, "litellm_overhead_with_guardrails_latency_metric not registered"


### PR DESCRIPTION
## Relevant issues

Supersedes #31454 (original work by @kunal2002); same feature, refactored to satisfy this repo's coding standards

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] My PR passes all unit tests on `make test-unit`
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Type

🆕 New Feature

## Changes

LiteLLM already exposes `litellm_overhead_latency_metric`, but it only measures the SDK wrapper window: it reads `litellm_overhead_time_ms = (end_time - start_time) - llm_api_duration`, and `end_time` is captured the instant the provider response returns into the wrapper (`litellm/utils.py`, right after `result = await original_function(...)`). Proxy guardrails run outside that window (pre-call before the wrapper starts, post-call after `end_time`, during-call concurrently with the LLM call), so no existing metric reflects guardrail latency as part of LiteLLM's overhead. There was no single number for "how much latency does LiteLLM itself add around the call, including guardrails"

This PR adds a new histogram, `litellm_overhead_with_guardrails_latency_metric`, recorded once per successful request alongside the existing overhead metric in `litellm/integrations/prometheus.py`:

```
litellm_overhead_with_guardrails_latency_metric
    = litellm_overhead_time_ms / 1000                 # existing SDK overhead
    + sum(pre_call + post_call guardrail durations)   # from StandardLoggingPayload.guardrail_information
```

The name spells out "with guardrails" so it reads distinctly from `litellm_overhead_latency_metric` rather than as a vague second overhead number; the only delta in the name is exactly the only delta in the math

A `_get_guardrail_overhead_seconds` helper sums the guardrail durations already recorded on the `StandardLoggingPayload`, counting only `pre_call` and `post_call` modes. `during_call` (moderation) runs concurrently with the LLM API call (`asyncio.gather`), so its wall-clock overlaps the provider call and is not additive overhead; `logging_only` and the MCP-specific modes never block the user-facing response. A guardrail with a mixed mode list such as `["pre_call", "during_call"]` is excluded, since it is not purely additive

The metric reuses the exact label set and latency buckets of `litellm_overhead_latency_metric`, and is registered in `litellm/types/integrations/prometheus.py` (`DEFINED_PROMETHEUS_METRICS` and `PrometheusMetricLabels`) so the label machinery and metric-name validation accept it. It is recorded outside the SDK-overhead gate used by the existing metric, so guardrail-only overhead is still captured when `litellm_overhead_time_ms` is `0` or absent. No existing metric's value or math is changed

`guardrail_information` is typed as a list, but a few guardrails (for example `xecguard`) assign a single dict directly to `standard_logging_object["guardrail_information"]`. Iterating that dict yields its string keys, so `_guardrail_is_additive` would receive a `str` and `info.get(...)` would raise `AttributeError`, aborting the whole success-metrics block for that request. `_get_guardrail_overhead_seconds` now normalizes a lone dict to a one-item list before summing, so a single pre/post dict is counted and a single logging_only dict (xecguard's case) is excluded without crashing

Because it is a histogram (same buckets as the other latency metrics), p95/p99 are available server side and aggregate correctly across replicas:

```promql
histogram_quantile(0.95, sum(rate(litellm_overhead_with_guardrails_latency_metric_bucket[5m])) by (le))
```

### What changed relative to #31454

The feature and its math are identical; this branch refactors the new code to match the repo's standards. The duration accounting was rewritten functionally (a `sum()` over a generator plus a `_guardrail_is_additive` predicate building a `frozenset`, with the pre/post allowlist hoisted to a class constant) instead of seeding and mutating an accumulator and a `set`. Two `Any` leaks were removed: mode values are resolved with a typed `m.value if isinstance(m, GuardrailEventHooks) else m` rather than `getattr(m, "value", m)`, and `litellm_overhead_time_ms` is read via the typed required `hidden_params` key so it stays `Optional[float]`. The verbose inline comments and docstrings were trimmed to a single line stating the business rationale (why during-call/logging-only/MCP are excluded)

The metric was originally named `litellm_total_overhead_latency_metric`; it was renamed to `litellm_overhead_with_guardrails_latency_metric` so that sitting next to `litellm_overhead_latency_metric` it reads as a clearly different number rather than as a second, vaguely-named overhead metric

## Tests

`tests/test_litellm/integrations/test_prometheus_overhead_with_guardrails.py` (14 tests): the helper sums pre and post and excludes `during_call`; tolerates plain-string `guardrail_mode`, list modes (pure pre/post counted, any mix with during-call excluded), `logging_only`/MCP modes, dict-typed `GuardrailMode` (no `TypeError`), and missing durations; returns `0.0` with no guardrails; records guardrail-only overhead when SDK overhead is `0` or absent; skips when there is nothing to record; and the histogram registers in the Prometheus registry. Two cover the single-dict `guardrail_information` shape: a lone `logging_only` dict (xecguard's payload) is excluded without raising, and a lone `pre_call` dict is still counted. The existing `test_prometheus_metric_name_consistency.py` and `test_prometheus_missing_metrics.py` suites (which enumerate every defined metric) pass with the new metric, confirming no name or label collision

A mutation check confirms the tests are meaningful: adding `during_call` to the additive-mode allowlist fails three of the helper tests, and reverting the dict normalization makes both single-dict tests fail with the exact `AttributeError: 'str' object has no attribute 'get'`

## Screenshots / Proof of Fix

Live proxy on `localhost:4093` with prometheus enabled and two real OpenAI moderation guardrails, one in `pre_call` mode (additive) and one in `during_call` mode (concurrent, must be excluded). A small success callback prints the guardrail durations and SDK overhead recorded on the `StandardLoggingPayload`, so the metric arithmetic can be checked against the live `/metrics` scrape

litellm_settings and guardrails from the config:

```yaml
litellm_settings:
  callbacks: ["prometheus", "proof_logger.proof_handler"]
guardrails:
  - guardrail_name: "moderation-pre"
    litellm_params: {guardrail: openai_moderation, mode: "pre_call", api_key: os.environ/OPENAI_API_KEY, default_on: true}
  - guardrail_name: "moderation-during"
    litellm_params: {guardrail: openai_moderation, mode: "during_call", api_key: os.environ/OPENAI_API_KEY, default_on: true}
```

One real chat completion (which also fires both moderation calls against OpenAI):

```bash
curl -s http://localhost:4093/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"reply with the single word ok"}]}'
# {"choices":[{"message":{"content":"Ok."}}], ...}
```

The success callback shows what was recorded on the payload (durations in seconds):

```
PROOF_GUARDRAILS [('moderation-pre', 'pre_call', 1.449396), ('moderation-during', 'during_call', 1.174044)]
PROOF_OVERHEAD_MS 16.051
```

So the expected total overhead is `0.016051 (SDK) + 1.449396 (pre_call) = 1.465447`, and the `during_call` 1.174044s must be excluded (if it were wrongly added the total would be 2.639491)

```bash
curl -s http://localhost:4093/metrics/ -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  | grep -E 'litellm_(overhead_latency_metric|overhead_with_guardrails_latency_metric)_(sum|count)'
```

```
litellm_overhead_latency_metric_count                  1.0
litellm_overhead_latency_metric_sum                    0.016051
litellm_overhead_with_guardrails_latency_metric_count  1.0
litellm_overhead_with_guardrails_latency_metric_sum    1.465447
```

`litellm_overhead_with_guardrails_latency_metric_sum` is exactly SDK overhead plus the `pre_call` guardrail, and the concurrent `during_call` guardrail is excluded, matching the design
