### PR TITLE
fix: log spamming for custom sagemaker [DONE] chunk in streams

### DIFF
--- a/litellm/llms/sagemaker/common_utils.py
+++ b/litellm/llms/sagemaker/common_utils.py
@@ -173,7 +173,11 @@ class AWSEventStreamDecoder:
                 except Exception as e:
                     verbose_logger.error(f"Error parsing message: {e}. Attempting to combine with next event.")
                     continue
-
+        
+        # remove custom sagemaker [DONE] message in stream
+        if accumulated_json.endswith("[DONE]"):
+            accumulated_json = accumulated_json[:-6].strip()
+        
         # Handle any remaining data after the iterator is exhausted
         if accumulated_json:
             try:


### PR DESCRIPTION
## Relevant issues

* Sagemaker endpoints with vllm container appends a custom `[Done]` message to every stream leading to log spamming and sometimes last data chunks getting lost when combined with the `[Done]` message:

```
11:02:31 - LiteLLM:ERROR: common_utils.py:211 - Warning: Unparseable JSON data remained: [DONE]
11:02:31 - LiteLLM:ERROR: common_utils.py:211 - Warning: Unparseable JSON data remained: [DONE]
11:02:31 - LiteLLM:ERROR: common_utils.py:211 - Warning: Unparseable JSON data remained: [DONE]
11:02:31 - LiteLLM:ERROR: common_utils.py:211 - Warning: Unparseable JSON data remained: [DONE]
11:02:31 - LiteLLM:ERROR: common_utils.py:211 - Warning: Unparseable JSON data remained: data: {"id":"chatcmpl-9004af2d48821c07","object":"chat.completion.chunk","created":1782723751,"model":"google/gemma-4-26B-A4B-it","choices":[],"usage":{"prompt_tokens":7213,"total_tokens":7229,"completion_tokens":16},"system_fingerprint":"vllm-0.22.1-97af4d8e"}[DONE]
```


## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before the fix:
<img width="2539" height="921" alt="Screenshot 2026-06-29 at 12 16 24" src="https://github.com/user-attachments/assets/24d50d22-2215-47b1-bf77-e06ad4b2d248" />

After the fix
<img width="2555" height="277" alt="Screenshot 2026-06-29 at 12 17 01" src="https://github.com/user-attachments/assets/3a4e27f8-312a-4648-9c8a-fad1fd54e3f1" />


<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->


🐛 Bug Fix

## Changes

* scan the last chunk for the custom `[DONE]` message, remove it, and only then parse json if anything is left after removal.