### PR TITLE
fix(cache): resolve semantic-cache embedding model via Router model-group lookup

### DIFF
--- a/litellm/caching/_embedding_router.py
+++ b/litellm/caching/_embedding_router.py
@@ -5,8 +5,8 @@ configured embedding model is a proxy Router deployment, embeddings must run
 through the Router so per-deployment auth (e.g. Bedrock aws_role_name) is
 applied. Otherwise fall back to a direct litellm embedding call.
 
-This module is dependency-injected: callers pass the proxy ``llm_router`` and
-``llm_model_list`` in, so the decision logic is unit-testable without importing
+This module is dependency-injected: callers pass the proxy ``llm_router`` in, so
+the decision logic is unit-testable without importing
 ``litellm.proxy.proxy_server``.
 """
 
@@ -21,15 +21,11 @@ if TYPE_CHECKING:
 def resolve_embedding_router(
     embedding_model: str,
     llm_router: Router | None,
-    llm_model_list: list[dict[str, Any]] | None,
 ) -> Router | None:
     """Return ``llm_router`` iff it serves ``embedding_model`` as a deployment."""
     if llm_router is None:
         return None
-    router_model_names: list[str] = (
-        [m["model_name"] for m in llm_model_list if "model_name" in m] if llm_model_list is not None else []
-    )
-    if embedding_model in router_model_names:
+    if llm_router.get_model_list(model_name=embedding_model):
         return llm_router
     return None
 

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -191,12 +191,11 @@ class QdrantSemanticCache(BaseCache):
     def _get_embedding(self, prompt: str, metadata: Dict[str, Any] | None = None) -> EmbeddingResponse:
         """Embed via the proxy Router when it serves the model, else direct."""
         try:
-            from litellm.proxy.proxy_server import llm_model_list, llm_router
+            from litellm.proxy.proxy_server import llm_router
         except ImportError:
-            llm_model_list = None
             llm_router = None
 
-        router = resolve_embedding_router(self.embedding_model, llm_router, llm_model_list)
+        router = resolve_embedding_router(self.embedding_model, llm_router)
         if router is not None:
             return router.embedding(
                 model=self.embedding_model,
@@ -212,12 +211,11 @@ class QdrantSemanticCache(BaseCache):
 
     async def _get_async_embedding(self, prompt: str, metadata: Dict[str, Any] | None = None) -> EmbeddingResponse:
         try:
-            from litellm.proxy.proxy_server import llm_model_list, llm_router
+            from litellm.proxy.proxy_server import llm_router
         except ImportError:
-            llm_model_list = None
             llm_router = None
 
-        router = resolve_embedding_router(self.embedding_model, llm_router, llm_model_list)
+        router = resolve_embedding_router(self.embedding_model, llm_router)
         if router is not None:
             return await router.aembedding(
                 model=self.embedding_model,

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -313,12 +313,11 @@ class RedisSemanticCache(BaseCache):
         mirroring ``_get_async_embedding``; otherwise embeds directly.
         """
         try:
-            from litellm.proxy.proxy_server import llm_model_list, llm_router
+            from litellm.proxy.proxy_server import llm_router
         except ImportError:
-            llm_model_list = None
             llm_router = None
 
-        router = resolve_embedding_router(self.embedding_model, llm_router, llm_model_list)
+        router = resolve_embedding_router(self.embedding_model, llm_router)
         if router is not None:
             embedding_response = cast(
                 EmbeddingResponse,
@@ -483,12 +482,11 @@ class RedisSemanticCache(BaseCache):
             List[float]: The embedding vector
         """
         try:
-            from litellm.proxy.proxy_server import llm_model_list, llm_router
+            from litellm.proxy.proxy_server import llm_router
         except ImportError:
-            llm_model_list = None
             llm_router = None
 
-        router = resolve_embedding_router(self.embedding_model, llm_router, llm_model_list)
+        router = resolve_embedding_router(self.embedding_model, llm_router)
         try:
             if router is not None:
                 embedding_response = await router.aembedding(

--- a/tests/test_litellm/caching/test_embedding_router.py
+++ b/tests/test_litellm/caching/test_embedding_router.py
@@ -4,47 +4,76 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
+import litellm
+
 from litellm.caching._embedding_router import (
     build_router_embedding_metadata,
     resolve_embedding_router,
 )
 
 
-def test_resolve_returns_router_when_model_is_a_deployment():
-    router = MagicMock()
+def test_resolve_routes_exact_name_model_via_real_router():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "sem-embed",
+                "litellm_params": {"model": "text-embedding-3-small"},
+            }
+        ]
+    )
+    assert resolve_embedding_router("sem-embed", router) is router
+
+
+def test_resolve_routes_provider_prefixed_wildcard_via_real_router():
+    router = litellm.Router(
+        model_list=[
+            {"model_name": "bedrock/*", "litellm_params": {"model": "bedrock/*"}}
+        ]
+    )
+    # bedrock/amazon.titan-embed-text-v2:0 is NOT an exact model_name; only the
+    # bedrock/* pattern serves it. The old exact-name code returned None here.
     assert (
-        resolve_embedding_router("sem-embed", router, [{"model_name": "sem-embed"}])
+        resolve_embedding_router("bedrock/amazon.titan-embed-text-v2:0", router)
         is router
     )
 
 
-def test_resolve_returns_none_when_model_not_in_router():
-    router = MagicMock()
-    assert (
-        resolve_embedding_router("sem-embed", router, [{"model_name": "other"}]) is None
+def test_resolve_routes_visible_model_group_alias_via_real_router():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "real-embed",
+                "litellm_params": {"model": "text-embedding-3-small"},
+            }
+        ],
+        model_group_alias={"aliased-embed": "real-embed"},
     )
+    # aliased-embed is only reachable through model_group_alias.
+    assert resolve_embedding_router("aliased-embed", router) is router
+
+
+def test_resolve_returns_none_when_real_router_does_not_serve_model():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "other-embed",
+                "litellm_params": {"model": "text-embedding-3-small"},
+            }
+        ]
+    )
+    assert resolve_embedding_router("sem-embed", router) is None
 
 
 def test_resolve_returns_none_when_router_is_none():
-    assert (
-        resolve_embedding_router("sem-embed", None, [{"model_name": "sem-embed"}])
-        is None
-    )
+    assert resolve_embedding_router("sem-embed", None) is None
 
 
-def test_resolve_returns_none_when_model_list_is_none():
+def test_resolve_returns_none_when_get_model_list_returns_none():
+    # get_model_list is annotated Optional[List]; in practice it returns [],
+    # but pin the falsy-None path so the `if ...:` gate stays correct.
     router = MagicMock()
-    assert resolve_embedding_router("sem-embed", router, None) is None
-
-
-def test_resolve_skips_entries_missing_model_name():
-    router = MagicMock()
-    model_list = [
-        {"litellm_params": {"model": "bedrock/x"}},
-        {"model_name": "sem-embed"},
-    ]
-    assert resolve_embedding_router("sem-embed", router, model_list) is router
-    assert resolve_embedding_router("other", router, [{"litellm_params": {}}]) is None
+    router.get_model_list = MagicMock(return_value=None)
+    assert resolve_embedding_router("sem-embed", router) is None
 
 
 def test_build_metadata_preserves_request_fields_and_adds_flag():

--- a/tests/test_litellm/caching/test_qdrant_semantic_cache.py
+++ b/tests/test_litellm/caching/test_qdrant_semantic_cache.py
@@ -22,7 +22,6 @@ def test_qdrant_semantic_cache_initialization(monkeypatch):
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -82,7 +81,6 @@ def test_qdrant_semantic_cache_get_cache_hit():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -162,7 +160,6 @@ def test_qdrant_semantic_cache_rejects_unscoped_cache_hit():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"result": {"exists": True}}
@@ -323,7 +320,6 @@ def test_qdrant_semantic_cache_get_cache_miss():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -379,7 +375,6 @@ async def test_qdrant_semantic_cache_async_get_cache_hit():
             "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
         ) as mock_async_client,
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -470,7 +465,6 @@ async def test_qdrant_semantic_cache_async_get_cache_miss():
             "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
         ) as mock_async_client,
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -530,7 +524,6 @@ def test_qdrant_semantic_cache_set_cache():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -596,7 +589,6 @@ async def test_qdrant_semantic_cache_async_set_cache():
             "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
         ) as mock_async_client,
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -666,7 +658,6 @@ def test_qdrant_semantic_cache_custom_vector_size():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection does NOT exist (so it will be created)
         mock_exists_response = MagicMock()
         mock_exists_response.status_code = 200
@@ -727,7 +718,6 @@ def test_qdrant_semantic_cache_default_vector_size():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection exists check
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -763,7 +753,6 @@ def test_qdrant_semantic_cache_large_vector_size():
         ) as mock_sync_client,
         patch("litellm.llms.custom_httpx.http_handler.get_async_httpx_client"),
     ):
-
         # Mock the collection does NOT exist (so it will be created)
         mock_exists_response = MagicMock()
         mock_exists_response.status_code = 200
@@ -809,10 +798,10 @@ def test_qdrant_semantic_cache_large_vector_size():
         assert create_payload["vectors"]["size"] == 4096
 
 
-def _router_proxy_module(router, model_name):
+def _router_proxy_module(router):
     mod = types.ModuleType("litellm.proxy.proxy_server")
     mod.llm_router = router
-    mod.llm_model_list = [{"model_name": model_name}]
+    mod.llm_model_list = None
     return mod
 
 
@@ -832,13 +821,14 @@ def test_qdrant_sync_get_cache_routes_through_router(monkeypatch):
     cache.sync_client.post.return_value = search_response
 
     router = MagicMock()
+    router.get_model_list = MagicMock(return_value=[{"model_name": "sem-embed"}])
     router.embedding = MagicMock(
         return_value={"data": [{"embedding": [0.3, 0.3, 0.3]}]}
     )
     monkeypatch.setitem(
         sys.modules,
         "litellm.proxy.proxy_server",
-        _router_proxy_module(router, "sem-embed"),
+        _router_proxy_module(router),
     )
 
     with patch("litellm.embedding") as direct_embed:
@@ -892,11 +882,12 @@ async def test_qdrant_async_embedding_forwards_full_metadata(monkeypatch):
     cache.embedding_model = "sem-embed"
 
     router = MagicMock()
+    router.get_model_list = MagicMock(return_value=[{"model_name": "sem-embed"}])
     router.aembedding = AsyncMock(return_value={"data": [{"embedding": [0.1, 0.2]}]})
     monkeypatch.setitem(
         sys.modules,
         "litellm.proxy.proxy_server",
-        _router_proxy_module(router, "sem-embed"),
+        _router_proxy_module(router),
     )
 
     await cache._get_async_embedding(

--- a/tests/test_litellm/caching/test_redis_semantic_cache.py
+++ b/tests/test_litellm/caching/test_redis_semantic_cache.py
@@ -901,10 +901,11 @@ def test_redis_get_embedding_routes_through_router(monkeypatch):
     cache.embedding_model = "sem-embed"
 
     router = MagicMock()
+    router.get_model_list = MagicMock(return_value=[{"model_name": "sem-embed"}])
     router.embedding = MagicMock(return_value={"data": [{"embedding": [0.5, 0.6]}]})
     fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
     fake_proxy.llm_router = router
-    fake_proxy.llm_model_list = [{"model_name": "sem-embed"}]
+    fake_proxy.llm_model_list = None
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
 
     with patch("litellm.embedding") as direct_embed:
@@ -1145,10 +1146,10 @@ async def test_redis_async_embedding_forwards_full_metadata(monkeypatch):
     cache.embedding_model = "sem-embed"
 
     router = MagicMock()
+    router.get_model_list = MagicMock(return_value=[{"model_name": "sem-embed"}])
     router.aembedding = AsyncMock(return_value={"data": [{"embedding": [0.1, 0.2]}]})
     fake_proxy = types.ModuleType("litellm.proxy.proxy_server")
     fake_proxy.llm_router = router
-    fake_proxy.llm_model_list = [{"model_name": "sem-embed"}]
     monkeypatch.setitem(sys.modules, "litellm.proxy.proxy_server", fake_proxy)
 
     await cache._get_async_embedding(


### PR DESCRIPTION
## Relevant issues

Follow-up to #31198 (#28244). That PR routed the sync semantic-cache embedding path through the proxy Router and recorded a known limitation: the shared `resolve_embedding_router` helper gated on an exact model-name match, so wildcard/pattern and alias embedding models still fell back to a direct call. This PR closes that gap.

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## What this fixes

The semantic cache embeds the prompt to do similarity lookups. `resolve_embedding_router` (litellm/caching/_embedding_router.py) decides whether that embedding runs through the proxy Router (so the deployment's `litellm_params`, including Bedrock `aws_role_name` / `aws_region_name`, apply) or falls back to a direct `litellm.embedding()` call.

The old gate was an exact-name membership check, `embedding_model in [m["model_name"] for m in llm_model_list]`. For a wildcard route like `bedrock/*`, `llm_model_list` holds only the literal `"bedrock/*"`, so a concrete embedding model name never matched. The cache then fell back to a direct embedding call that carried none of the deployment config, so it either failed outright or dropped the deployment credentials, the same class of failure as #28244. When the embedding fails, nothing is stored and the semantic cache silently degrades to a permanent miss.

This switches the gate to `Router.get_model_list(model_name=...)`, which already unifies exact-name, visible `model_group_alias`, and provider-prefixed wildcard/pattern resolution, with no selection or cooldown cost and no team_id needed. The now-redundant `llm_model_list` argument is dropped from all four sync/async call sites in the Redis and Qdrant semantic caches; `ValkeySemanticCache` inherits the fix since it subclasses `RedisSemanticCache`.

`get_model_list` is a listing resolver, not a faithful "would the Router route this request" predicate, so a few niche configurations still resolve empty and keep falling back to the direct call (unchanged from prior behavior, not a regression): hidden `model_group_alias` entries, a bare unprefixed name matched only against a provider-prefixed wildcard, a deployment addressed by its raw `litellm_params.model` or `model_info.id`, and team-public names without a team_id. The faithful alternative, `_common_checks_available_deployment`, raises on no-match (against the don't-throw convention) and does extra selection work, so it was deliberately not used here.

## Changes

`resolve_embedding_router` now returns the router when `llm_router.get_model_list(model_name=embedding_model)` is non-empty, and its `llm_model_list` parameter is removed. The four executors in `redis_semantic_cache.py` and `qdrant_semantic_cache.py` stop importing and passing `llm_model_list`. Tests in `test_embedding_router.py` are rewritten to drive resolution against a real `litellm.Router` (not a mock), so the wildcard and alias cases fail on the old exact-name logic and pass on the new resolver; the Redis and Qdrant routing tests set an explicit `get_model_list` return so an always-route mutation cannot slip through.

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

Real proxy on localhost hitting real Bedrock (`amazon.titan-embed-text-v2:0` for embeddings, `claude-haiku-4-5` for the chat completion). The semantic cache embedding model is `sem-embed-titan`, served only by a `sem-embed-*` wildcard route, so the old exact-name check misses it.

Setup (not screenshotted): redis-stack-server on 6379 with a password, then the proxy started with `proxy_cli.py --config <semantic-cache config> --detailed_debug`. The same config is run twice: once on this branch (post-fix) and once on the base commit (pre-fix).

The headline before/after is the similarity pair: post-fix the second identical request is a cache hit (~1.0), pre-fix it never is (stays 0.0).

### Post-fix (this branch): semantic cache works

A1. Two identical chat completions. First is a miss and stores the embedding; second hits the semantic cache.
Expected: req1 `x-litellm-semantic-similarity: 0.0`, req2 `~0.9999998`

<img width="1246" height="438" alt="A2" src="https://github.com/user-attachments/assets/f353c52e-f75e-4bb0-b5e0-21508ec5965c" />

A2. Redis after the two requests: the entry and the index exist, so the embedding was computed and stored.
Expected: `DBSIZE` -> 1, `FT._LIST` -> `litellm_semantic_cache_index`

<img width="1246" height="261" alt="A3" src="https://github.com/user-attachments/assets/9b270e65-28c5-4a5f-9543-e24abc884445" />

A3. Proxy log: the wildcard `sem-embed-titan` resolved to the real Bedrock deployment and the embedding ran through the Router.
Expected: `litellm.aembedding(model=bedrock/amazon.titan-embed-text-v2:0) 200 OK`

<img width="1246" height="212" alt="A4" src="https://github.com/user-attachments/assets/e4c76b05-9436-4bce-aca4-161da13290b6" />

### Pre-fix (base commit `52e5b3ae98`): semantic cache never works

B1. Same two identical requests against the pre-fix proxy. Neither is a hit because the wildcard embedding model is not resolved.
Expected: both req1 and req2 `x-litellm-semantic-similarity: 0.0`

<img width="1246" height="446" alt="B2" src="https://github.com/user-attachments/assets/f5822585-7673-49a9-a286-fd7ba7088683" />

B2. Redis stayed empty, and the log shows why: the embedding fell back to a direct call that cannot resolve a provider for the wildcard name.
Expected: `DBSIZE` -> 0, log `BadRequestError: LLM Provider NOT provided ... model=sem-embed-titan`

<img width="1246" height="296" alt="B3" src="https://github.com/user-attachments/assets/d06f7738-ec62-4d31-b6e3-d170788e7e41" />

Note on scope: this proof exercises the wildcard-resolution path rather than a literal cross-account `aws_role_name` drop. The local AWS profile has a default region and valid credentials, so a fully-qualified `bedrock/...` model embeds fine on the direct path and would not discriminate pre vs post. The wildcard scenario hits the exact code change in this PR (`resolve_embedding_router` -> `get_model_list`) and is the headline case the fix addresses.