### PR TITLE
fix(cost): surface cache_read_cost in breakdown for OpenAI-compatible cache hits

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -1631,14 +1631,27 @@ def completion_cost(
                     _cache_read_cost: Optional[float] = None
                     _cache_creation_cost: Optional[float] = None
                     if cost_per_token_usage_object is not None:
+                        _ptd = getattr(cost_per_token_usage_object, "prompt_tokens_details", None)
                         _cr = getattr(cost_per_token_usage_object, "cache_read_input_tokens", None) or (
                             cost_per_token_usage_object.model_extra or {}
                         ).get("cache_read_input_tokens")
+                        # OpenAI-compatible providers (deepseek, etc.) report cache reads under
+                        # prompt_tokens_details.cached_tokens instead of the Anthropic-style
+                        # top-level field. Mirror db_spend_update_writer._extract_cache_read_tokens
+                        # so the breakdown surfaces cache_read_cost for them too. (#31594)
+                        if not _cr and _ptd is not None:
+                            _cr = getattr(_ptd, "cached_tokens", None)
                         _cc = getattr(
                             cost_per_token_usage_object,
                             "cache_creation_input_tokens",
                             None,
                         ) or (cost_per_token_usage_object.model_extra or {}).get("cache_creation_input_tokens")
+                        # OpenAI-compatible cache-write aliases (kimi-k2 etc.), mirroring
+                        # db_spend_update_writer._extract_cache_creation_tokens.
+                        if not _cc and _ptd is not None:
+                            _cc = getattr(_ptd, "cache_write_tokens", None) or getattr(
+                                _ptd, "cache_creation_tokens", None
+                            )
                         if (_cr or _cc) and model:
                             try:
                                 _mi = litellm.get_model_info(model=model, custom_llm_provider=custom_llm_provider)

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3115,3 +3115,64 @@ def test_openrouter_gemini_3_1_flash_lite_stable_pricing():
     assert model_info["cache_read_input_token_cost"] == 2.5e-08
     assert model_info["max_input_tokens"] == 1048576
     assert model_info["max_output_tokens"] == 65536
+
+
+def test_cost_breakdown_surfaces_cache_read_cost_for_openai_compatible():
+    """
+    Regression for #31594: OpenAI-compatible providers (DeepSeek, etc.) report cache
+    hits under ``usage.prompt_tokens_details.cached_tokens`` rather than the Anthropic-style
+    top-level ``usage.cache_read_input_tokens``.
+
+    completion_cost() already folds the cache discount into the total correctly (via
+    generic_cost_per_token), but the cost_breakdown stored on the logging object omitted
+    ``cache_read_cost`` because that block only read the Anthropic field. The breakdown
+    must surface ``cache_read_cost`` from the prompt_tokens_details fallback too, mirroring
+    db_spend_update_writer._extract_cache_read_tokens.
+    """
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    model = "deepseek/deepseek-chat"
+    cache_read_rate = litellm.get_model_info(model)["cache_read_input_token_cost"]
+    assert cache_read_rate, "test precondition: deepseek model must define cache_read_input_token_cost"
+
+    cached_tokens = 135936
+    usage = Usage(
+        prompt_tokens=136153,
+        completion_tokens=418,
+        total_tokens=136571,
+        # DeepSeek-style: cache hits only in prompt_tokens_details, no top-level
+        # cache_read_input_tokens (Anthropic convention).
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cached_tokens),
+    )
+    response = ModelResponse(
+        id="test-id",
+        created=1234567890,
+        model=model,
+        object="chat.completion",
+        choices=[],
+        usage=usage,
+    )
+
+    logging_obj = Logging(
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-31594",
+        function_id="test-function",
+    )
+
+    litellm.completion_cost(
+        completion_response=response,
+        model=model,
+        custom_llm_provider="deepseek",
+        litellm_logging_obj=logging_obj,
+    )
+
+    assert logging_obj.cost_breakdown is not None
+    assert logging_obj.cost_breakdown.get("cache_read_cost") == pytest.approx(
+        cached_tokens * cache_read_rate
+    )


### PR DESCRIPTION
## Summary

Fixes #31594.

OpenAI-compatible providers (DeepSeek, etc.) report cache hits under
`usage.prompt_tokens_details.cached_tokens` rather than the Anthropic-style
top-level `usage.cache_read_input_tokens`. `completion_cost()` already folds the
cache discount into the **total** correctly (via `generic_cost_per_token`), so
spend is billed right — but the `cost_breakdown` stored on the logging object
omitted `cache_read_cost`, because that block only inspected the Anthropic field.
Result: spend logs show the correct total but no `cache_read_cost`/`cache_creation_cost`
line, making cache savings invisible.

## Root cause

In `litellm/cost_calculator.py` (`completion_cost`), the breakdown block derived
the cache token counts only from `cache_read_input_tokens` / `cache_creation_input_tokens`
(top-level or `model_extra`). For OpenAI-compatible usage these are absent, so
`cache_read_cost` stayed `None`.

The repo already handles this asymmetry for DB spend tracking via
`db_spend_update_writer._extract_cache_read_tokens` / `_extract_cache_creation_tokens`,
which fall back to `prompt_tokens_details`. The breakdown path simply wasn't mirroring it.

## Fix

When the Anthropic-style field is absent, fall back to
`prompt_tokens_details.cached_tokens` (cache read) and
`prompt_tokens_details.cache_write_tokens` / `cache_creation_tokens` (cache write),
mirroring the existing extraction helpers. Purely additive: the total is unchanged,
Anthropic behavior is untouched (top-level field still wins, no double counting),
and only the breakdown gains the previously-missing line.

## Test

Added `test_cost_breakdown_surfaces_cache_read_cost_for_openai_compatible`, which
drives `completion_cost()` with a DeepSeek-style `Usage`
(`prompt_tokens_details.cached_tokens` set, no top-level `cache_read_input_tokens`)
and asserts the stored `cost_breakdown["cache_read_cost"]` equals
`cached_tokens * cache_read_input_token_cost`.

Before/after (RED->GREEN), fix stashed vs applied:
- **without the fix:** fails - `cost_breakdown["cache_read_cost"]` is `None`.
- **with the fix:** passes.

`tests/test_litellm/test_cost_calculator.py` passes in full (72 passed); `ruff check`
is clean on `litellm/cost_calculator.py`.
