### PR TITLE
fix(ui): make auto router Test Connection work instead of crashing

### DIFF
--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -5,7 +5,13 @@ import { Text, TextInput } from "@tremor/react";
 import { modelAvailableCall } from "../networking";
 import ConnectionErrorDisplay from "./model_connection_test";
 import { all_admin_roles } from "@/utils/roles";
-import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
+import {
+  handleAddAutoRouterSubmit,
+  prepareAutoRouterTestDeployment,
+  resolveAutoRouterDefaultModel,
+  type AutoRouterType,
+  type ComplexityTiers,
+} from "./handle_add_auto_router_submit";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import RouterConfigBuilder from "./RouterConfigBuilder";
 import ComplexityRouterConfig from "./ComplexityRouterConfig";
@@ -19,14 +25,7 @@ interface AddAutoRouterTabProps {
   userRole: string;
 }
 
-type RouterType = "complexity" | "semantic";
-
-interface ComplexityTiers {
-  SIMPLE: string;
-  MEDIUM: string;
-  COMPLEX: string;
-  REASONING: string;
-}
+type RouterType = AutoRouterType;
 
 const { Title, Link } = Typography;
 
@@ -109,8 +108,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
       }
 
       // For complexity router, use the first non-empty tier as default
-      const defaultModel =
-        complexityTiers.MEDIUM || complexityTiers.SIMPLE || complexityTiers.COMPLEX || complexityTiers.REASONING;
+      const defaultModel = resolveAutoRouterDefaultModel("complexity", complexityTiers);
 
       // Set form values for complexity router
       form.setFieldsValue({
@@ -437,20 +435,38 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
         width={700}
       >
         {/* Only render the ConnectionErrorDisplay when modal is visible and we have a test ID */}
-        {isResultModalVisible && (
-          <ConnectionErrorDisplay
-            key={connectionTestId}
-            formValues={form.getFieldsValue()}
-            accessToken={accessToken}
-            testMode="chat"
-            modelName={form.getFieldValue("auto_router_name")}
-            onClose={() => {
-              setIsResultModalVisible(false);
-              setIsTestingConnection(false);
-            }}
-            onTestComplete={() => setIsTestingConnection(false)}
-          />
-        )}
+        {isResultModalVisible &&
+          (() => {
+            const defaultModel = resolveAutoRouterDefaultModel(
+              routerType,
+              complexityTiers,
+              form.getFieldValue("auto_router_default_model"),
+            );
+            return (
+              <ConnectionErrorDisplay
+                key={connectionTestId}
+                formValues={form.getFieldsValue()}
+                accessToken={accessToken}
+                testMode="chat"
+                modelName={defaultModel || form.getFieldValue("auto_router_name")}
+                prepareDeployments={async () => {
+                  if (!defaultModel) {
+                    throw new Error(
+                      routerType === "complexity"
+                        ? "Select at least one complexity tier model before testing the connection."
+                        : "Select a default model before testing the connection.",
+                    );
+                  }
+                  return prepareAutoRouterTestDeployment(defaultModel);
+                }}
+                onClose={() => {
+                  setIsResultModalVisible(false);
+                  setIsTestingConnection(false);
+                }}
+                onTestComplete={() => setIsTestingConnection(false)}
+              />
+            );
+          })()}
       </Modal>
     </>
   );

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { prepareAutoRouterTestDeployment, resolveAutoRouterDefaultModel } from "./handle_add_auto_router_submit";
+
+const tiers = (overrides: Partial<Record<"SIMPLE" | "MEDIUM" | "COMPLEX" | "REASONING", string>> = {}) => ({
+  SIMPLE: "",
+  MEDIUM: "",
+  COMPLEX: "",
+  REASONING: "",
+  ...overrides,
+});
+
+describe("resolveAutoRouterDefaultModel", () => {
+  it("prefers the MEDIUM tier for a complexity router", () => {
+    expect(resolveAutoRouterDefaultModel("complexity", tiers({ SIMPLE: "small", MEDIUM: "mid", COMPLEX: "big" }))).toBe(
+      "mid",
+    );
+  });
+
+  it("falls back through the tiers when MEDIUM is empty", () => {
+    expect(resolveAutoRouterDefaultModel("complexity", tiers({ COMPLEX: "big", REASONING: "reason" }))).toBe("big");
+  });
+
+  it("returns an empty string when no complexity tier is set", () => {
+    expect(resolveAutoRouterDefaultModel("complexity", tiers())).toBe("");
+  });
+
+  it("uses the explicit default model for a semantic router", () => {
+    expect(resolveAutoRouterDefaultModel("semantic", tiers({ MEDIUM: "ignored" }), "gpt-4o")).toBe("gpt-4o");
+  });
+});
+
+describe("prepareAutoRouterTestDeployment", () => {
+  it("builds a single deployment that targets the default model", () => {
+    expect(prepareAutoRouterTestDeployment("gpt-4o-mini")).toEqual([
+      { litellmParamsObj: { model: "gpt-4o-mini" }, modelInfoObj: {}, modelName: "gpt-4o-mini" },
+    ]);
+  });
+
+  it("returns no deployments when there is no default model", () => {
+    expect(prepareAutoRouterTestDeployment("")).toEqual([]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/handle_add_auto_router_submit.tsx
@@ -1,6 +1,33 @@
 import { modelCreateCall, Model } from "../networking";
 import NotificationManager from "../molecules/notifications_manager";
 
+export type AutoRouterType = "complexity" | "semantic";
+
+export interface ComplexityTiers {
+  SIMPLE: string;
+  MEDIUM: string;
+  COMPLEX: string;
+  REASONING: string;
+}
+
+export interface ModelTestDeployment {
+  litellmParamsObj: Record<string, unknown>;
+  modelInfoObj: Record<string, unknown>;
+  modelName: string;
+}
+
+export const resolveAutoRouterDefaultModel = (
+  routerType: AutoRouterType,
+  complexityTiers: ComplexityTiers,
+  semanticDefaultModel?: string,
+): string =>
+  routerType === "complexity"
+    ? complexityTiers.MEDIUM || complexityTiers.SIMPLE || complexityTiers.COMPLEX || complexityTiers.REASONING || ""
+    : semanticDefaultModel || "";
+
+export const prepareAutoRouterTestDeployment = (defaultModel: string): ModelTestDeployment[] =>
+  defaultModel ? [{ litellmParamsObj: { model: defaultModel }, modelInfoObj: {}, modelName: defaultModel }] : [];
+
 export const handleAddAutoRouterSubmit = async (values: any, accessToken: string, form: any, callback?: () => void) => {
   try {
     console.log("=== AUTO ROUTER SUBMIT HANDLER CALLED ===");

--- a/ui/litellm-dashboard/src/components/add_model/model_connection_test.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/model_connection_test.test.tsx
@@ -1,0 +1,64 @@
+import { screen, waitFor, renderWithProviders } from "../../../tests/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ModelConnectionTest from "./model_connection_test";
+
+const prepareModelAddRequest = vi.fn();
+const testConnectionRequest = vi.fn();
+
+vi.mock("./handle_add_model_submit", () => ({
+  prepareModelAddRequest: (...args: unknown[]) => prepareModelAddRequest(...args),
+}));
+
+vi.mock("../networking", () => ({
+  testConnectionRequest: (...args: unknown[]) => testConnectionRequest(...args),
+}));
+
+vi.mock("../molecules/notifications_manager", () => ({
+  default: { success: vi.fn(), fromBackend: vi.fn() },
+}));
+
+describe("ModelConnectionTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a friendly error instead of crashing when no deployments are prepared", async () => {
+    // Auto Router forms have no model_mappings, so prepareModelAddRequest resolves to []
+    prepareModelAddRequest.mockResolvedValue([]);
+
+    renderWithProviders(
+      <ModelConnectionTest formValues={{ auto_router_name: "smart_router" }} accessToken="token" testMode="chat" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connection-failure-msg")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Failed to prepare model data. Please check your form inputs.")).toBeInTheDocument();
+    expect(screen.queryByText(/Cannot destructure/i)).not.toBeInTheDocument();
+    expect(testConnectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("tests the injected deployment instead of the default add-model path", async () => {
+    testConnectionRequest.mockResolvedValue({ status: "success" });
+    const prepareDeployments = vi
+      .fn()
+      .mockResolvedValue([{ litellmParamsObj: { model: "gpt-4o-mini" }, modelInfoObj: {}, modelName: "gpt-4o-mini" }]);
+
+    renderWithProviders(
+      <ModelConnectionTest
+        formValues={{ auto_router_name: "smart_router" }}
+        accessToken="token"
+        testMode="chat"
+        prepareDeployments={prepareDeployments}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("connection-success-msg")).toBeInTheDocument();
+    });
+
+    expect(prepareModelAddRequest).not.toHaveBeenCalled();
+    expect(testConnectionRequest).toHaveBeenCalledWith("token", { model: "gpt-4o-mini" }, {}, "chat");
+  });
+});

--- a/ui/litellm-dashboard/src/components/add_model/model_connection_test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/model_connection_test.tsx
@@ -3,8 +3,14 @@ import { Typography, Button, Divider } from "antd";
 import { WarningOutlined, InfoCircleOutlined, CopyOutlined } from "@ant-design/icons";
 import { testConnectionRequest } from "../networking";
 import { prepareModelAddRequest } from "./handle_add_model_submit";
+import type { ModelTestDeployment } from "./handle_add_auto_router_submit";
 import NotificationsManager from "../molecules/notifications_manager";
 const { Text } = Typography;
+
+type PrepareDeployments = (
+  formValues: Record<string, unknown>,
+  accessToken: string,
+) => Promise<ModelTestDeployment[] | undefined>;
 
 interface ModelConnectionTestProps {
   formValues: Record<string, any>;
@@ -13,6 +19,7 @@ interface ModelConnectionTestProps {
   modelName?: string;
   onClose?: () => void;
   onTestComplete?: () => void;
+  prepareDeployments?: PrepareDeployments;
 }
 
 const ModelConnectionTest: React.FC<ModelConnectionTestProps> = ({
@@ -22,6 +29,7 @@ const ModelConnectionTest: React.FC<ModelConnectionTestProps> = ({
   modelName = "this model",
   onClose,
   onTestComplete,
+  prepareDeployments = (formValues, accessToken) => prepareModelAddRequest(formValues, accessToken, null),
 }) => {
   const [error, setError] = React.useState<Error | string | null>(null);
   const [rawRequest, setRawRequest] = React.useState<any>(null);
@@ -43,9 +51,9 @@ const ModelConnectionTest: React.FC<ModelConnectionTestProps> = ({
 
     try {
       console.log("Testing connection with form values:", formValues);
-      const result = await prepareModelAddRequest(formValues, accessToken, null);
+      const result = await prepareDeployments(formValues, accessToken);
 
-      if (!result) {
+      if (!result || result.length === 0) {
         console.log("No result from prepareModelAddRequest");
         setError("Failed to prepare model data. Please check your form inputs.");
         setIsSuccess(false);
@@ -57,7 +65,9 @@ const ModelConnectionTest: React.FC<ModelConnectionTestProps> = ({
 
       const { litellmParamsObj, modelInfoObj, modelName: returnedModelName } = result[0];
 
-      const response = await testConnectionRequest(accessToken, litellmParamsObj, modelInfoObj, modelInfoObj?.mode);
+      const rawMode = modelInfoObj?.mode;
+      const resolvedMode = typeof rawMode === "string" ? rawMode : testMode;
+      const response = await testConnectionRequest(accessToken, litellmParamsObj, modelInfoObj, resolvedMode);
       if (response.status === "success") {
         NotificationsManager.success("Connection test successful!");
         setError(null);


### PR DESCRIPTION
## Relevant issues

Fixes #31590

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is client-side dashboard logic with no LLM call on the path, so the authoritative proof is the dashboard test suite, run red-then-green

Before the fix, the regression test reproduces the exact runtime error from the issue:

​```
$ cd ui/litellm-dashboard
$ git stash push src/components/add_model/model_connection_test.tsx
$ npm run test -- run src/components/add_model/model_connection_test.test.tsx
Test connection error: TypeError: Cannot destructure property 'litellmParamsObj' of 'result[0]' as it is undefined.
1 failed
$ git stash pop
​```

After the fix, the new and existing tests pass with no regressions across the Add Model area:

​```
$ npm run test -- run src/components/add_model
Test Files  11 passed (11)
      Tests  57 passed (57)
​```

To see it live: open http://localhost:4000/ui/, go to Models -> Add Auto Router, enter a name, pick a model for at least one complexity tier (or a default model for a semantic router), then click Test Connection. Before this change the modal showed "Cannot destructure property 'litellmParamsObj' of 'l[0]'"; now it runs a real health check against the router's default model and reports success or a clear failure

## Type

🐛 Bug Fix

## Changes

Clicking Test Connection on the Add Auto Router tab threw "Cannot destructure property 'litellmParamsObj' of 'l[0]'" and blocked the user. `ModelConnectionTest` prepares deployments via `prepareModelAddRequest`, which derives them from `model_mappings`. Auto routers never set `model_mappings`, so it returned an empty array, and the guard only checked for a falsy result; the empty array passed through and `result[0]` was destructured on `undefined`

The guard now treats an empty result the same as a missing one. Beyond stopping the crash, `ModelConnectionTest` accepts an injected `prepareDeployments` function (defaulting to the existing add-model path, so the normal Add Model flow is unchanged), and the auto router tab injects a preparer that targets the router's resolved default model. That turns Test Connection into a genuine health check against the model the router falls back to, since the router itself cannot be probed before it exists. When no default model is selected yet, the user gets a clear message instead of a vague failure. `resolveAutoRouterDefaultModel` is extracted so the submit and test paths share one source of truth rather than duplicating the tier-fallback logic

Tests cover the two pure helpers (default-model resolution across complexity tiers and the semantic default, plus the test-deployment shape) and the component behavior (the empty-result regression that reproduces the issue, and that an injected deployment is what actually gets tested)