### PR TITLE
fix(vertex_ai): keep context-1m beta out of the Vertex anthropic-beta header

### DIFF
--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/transformation.py
@@ -12,6 +12,10 @@ from litellm.types.utils import ModelResponse
 from ....anthropic.chat.transformation import AnthropicConfig
 from .output_params_utils import sanitize_vertex_anthropic_output_params
 
+# Betas that Vertex's rawPredict rejects (400) when sent in the anthropic-beta HTTP
+# header; they are only accepted in the anthropic_beta request body (e.g. context-1m).
+VERTEX_BODY_ONLY_ANTHROPIC_BETAS = frozenset({"context-1m-2025-08-07"})
+
 
 class VertexAIError(Exception):
     def __init__(self, status_code, message):
@@ -137,7 +141,9 @@ class VertexAIAnthropicConfig(AnthropicConfig):
 
         if beta_set:
             data["anthropic_beta"] = list(beta_set)
-            headers["anthropic-beta"] = ",".join(beta_set)
+            header_betas = beta_set - VERTEX_BODY_ONLY_ANTHROPIC_BETAS
+            if header_betas:
+                headers["anthropic-beta"] = ",".join(header_betas)
 
         return data
 

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_transformation.py
@@ -463,6 +463,62 @@ def test_vertex_ai_anthropic_no_extra_headers_unchanged():
     assert "anthropic-beta" not in headers
 
 
+def test_vertex_ai_anthropic_context_1m_beta_in_body_not_header():
+    """context-1m-2025-08-07 must go in the anthropic_beta body field only.
+
+    Vertex's rawPredict 400s ("Unexpected value(s) ... for the anthropic-beta header")
+    when this beta is sent in the HTTP header, so it must not be forwarded there.
+    """
+    config = VertexAIAnthropicConfig()
+
+    headers = {}
+    optional_params = {
+        "max_tokens": 100,
+        "is_vertex_request": True,
+        "extra_headers": {"anthropic-beta": "context-1m-2025-08-07"},
+    }
+
+    result = config.transform_request(
+        model="claude-sonnet-4-5@20250929",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers=headers,
+    )
+
+    assert "context-1m-2025-08-07" in result["anthropic_beta"]
+    assert "anthropic-beta" not in headers
+
+
+def test_vertex_ai_anthropic_context_1m_excluded_from_header_but_others_kept():
+    """When context-1m is combined with a header-compatible beta, only context-1m is
+    stripped from the HTTP header; both still travel in the body."""
+    config = VertexAIAnthropicConfig()
+
+    headers = {}
+    optional_params = {
+        "max_tokens": 100,
+        "is_vertex_request": True,
+        "extra_headers": {
+            "anthropic-beta": "context-1m-2025-08-07,interleaved-thinking-2025-05-14",
+        },
+    }
+
+    result = config.transform_request(
+        model="claude-sonnet-4-5@20250929",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers=headers,
+    )
+
+    assert "context-1m-2025-08-07" in result["anthropic_beta"]
+    assert "interleaved-thinking-2025-05-14" in result["anthropic_beta"]
+
+    assert "interleaved-thinking-2025-05-14" in headers["anthropic-beta"]
+    assert "context-1m-2025-08-07" not in headers["anthropic-beta"]
+
+
 def test_vertex_ai_partner_models_anthropic_remove_prompt_caching_scope_beta_header():
     """
     Test that remove_unsupported_beta correctly filters out prompt-caching-scope-2026-01-05


### PR DESCRIPTION
## Relevant issues

On Vertex AI, enabling Claude's 1M context window via `anthropic-beta: context-1m-2025-08-07` fails with a 400. Vertex's `rawPredict` validates the `anthropic-beta` HTTP header against an allowed set and rejects this value:

```
{"type":"error","error":{"type":"invalid_request_error",
 "message":"Unexpected value(s) `context-1m-2025-08-07` for the `anthropic-beta` header. Please consult our documentation at docs.anthropic.com or try again without the header."}}
```

Anthropic betas on Vertex are read from the `anthropic_beta` field in the request body (the same place `anthropic_version` lives), so this beta must travel in the body only. The header forwarding was introduced in #22321, which is correct for betas Vertex wants in the header (tool-search, context_management) but breaks 1M context. It also takes down any fallback that lands on a Vertex Claude deployment while the client is pinned to a `[1m]` model variant.

## Linear ticket

n/a

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Reproduction against a Vertex Claude deployment (any `vertex_ai/claude-*` model group), before the fix:

```bash
# WITH the 1M beta header -> HTTP 400, Vertex rejects the header value
curl -sS https://<your-proxy>/v1/messages \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -H "anthropic-beta: context-1m-2025-08-07" \
  -d '{"model":"vertex_ai/claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
# -> 400 "Unexpected value(s) `context-1m-2025-08-07` for the `anthropic-beta` header"

# WITHOUT the header -> HTTP 200 (control)
curl -sS https://<your-proxy>/v1/messages \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"vertex_ai/claude-sonnet-4-5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
# -> 200
```

After the fix, `context-1m-2025-08-07` is sent in the `anthropic_beta` body field (where Vertex reads it) and omitted from the `anthropic-beta` header, so the request no longer 400s. The two added regression tests assert exactly this body/header split and fail on the current code.

## Type

🐛 Bug Fix

## Changes

`VertexAIAnthropicConfig.transform_request` previously forwarded every beta into both the request body and the `anthropic-beta` HTTP header. This introduces `VERTEX_BODY_ONLY_ANTHROPIC_BETAS` (currently `context-1m-2025-08-07`); those betas still go into the `anthropic_beta` body field but are excluded from the header. Betas that Vertex expects in the header (tool-search, context_management, interleaved-thinking) are unaffected.

Tests in `test_vertex_ai_partner_models_anthropic_transformation.py`:
- `test_vertex_ai_anthropic_context_1m_beta_in_body_not_header`
- `test_vertex_ai_anthropic_context_1m_excluded_from_header_but_others_kept`