### PR TITLE
feat(mcp): make token_exchange (OBO) production-ready - discovery threading + audit hardening + RFC 9728 challenge

### DIFF
--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -520,13 +520,28 @@ class MCPClient:
             # Return empty list instead of raising to allow graceful degradation
             return []
 
+    @staticmethod
+    def error_tool_result(exc: Exception) -> MCPCallToolResult:
+        """The error result ``call_tool`` returns when it swallows a failure (no re-execution)."""
+        return MCPCallToolResult(
+            content=[TextContent(type="text", text=f"{type(exc).__name__}: {str(exc)}")],
+            isError=True,
+        )
+
     async def call_tool(
         self,
         call_tool_request_params: MCPCallToolRequestParams,
         host_progress_callback: Optional[Callable] = None,
+        raise_on_error: bool = False,
     ) -> MCPCallToolResult:
         """
         Call an MCP Tool.
+
+        Args:
+            raise_on_error: When True, re-raise the underlying exception instead of returning an
+                ``isError=True`` result. The token-exchange (OBO) tool-call path uses this to detect
+                an upstream 401 so it can re-mint the exchanged token and retry once; every other
+                caller keeps the default and gets graceful ``isError`` degradation.
         """
         verbose_logger.info(f"MCP client calling tool '{call_tool_request_params.name}'")
 
@@ -579,11 +594,10 @@ class MCPClient:
                     "MCP client detected broken connection/stream - "
                     "the MCP server may have crashed, disconnected, or timed out."
                 )
+            if raise_on_error:
+                raise
             # Return a default error result instead of raising
-            return MCPCallToolResult(
-                content=[TextContent(type="text", text=f"{error_type}: {str(e)}")],  # Empty content for error case
-                isError=True,
-            )
+            return self.error_tool_result(e)
 
     async def list_prompts(self) -> List[Prompt]:
         """List available prompts from the server."""

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1288,7 +1288,21 @@ async def _build_oauth_protected_resource_response(
             detail=(f"Upstream oauth-protected-resource metadata unavailable for MCP server {mcp_server.name!r}"),
         )
 
-    _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth-protected resource")
+    # OBO (token_exchange): the client SSOs with the IdP to obtain a subject token, which LiteLLM
+    # then exchanges. Point discovery at the JWT-auth issuer(s) LiteLLM trusts (the same IdP that
+    # issues and validates the subject), not at the gateway.
+    if mcp_server is not None and mcp_server.auth_type == MCPAuth.oauth2_token_exchange:
+        issuers = _jwt_auth_issuers()
+        if issuers:
+            return {
+                "authorization_servers": issuers,
+                "resource": resource_url,
+                "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
+            }
+        # No JWT-auth issuer configured -> fall through to the gateway default so discovery still
+        # returns metadata; it just can't name the IdP.
+    else:
+        _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth-protected resource")
 
     return {
         "authorization_servers": [
@@ -1297,6 +1311,31 @@ async def _build_oauth_protected_resource_response(
         "resource": resource_url,
         "scopes_supported": (mcp_server.scopes if mcp_server and mcp_server.scopes else []),
     }
+
+
+def _jwt_auth_issuers() -> list:
+    """The OAuth issuer identifier(s) LiteLLM's JWT auth trusts, for the OBO PRM authorization_servers.
+
+    In token_exchange the IdP that issues the subject JWT is the same one LiteLLM validates it
+    against, so OBO discovery points clients at the JWT-auth issuer to obtain a subject token.
+    Sourced from ``JWT_ISSUER`` and any configured ``litellm_jwtauth.issuers``.
+    """
+    import os  # noqa: PLC0415
+
+    from litellm.proxy.proxy_server import general_settings  # noqa: PLC0415
+
+    issuers: list = []
+    env_issuer = os.getenv("JWT_ISSUER")
+    if env_issuer:
+        issuers.append(env_issuer)
+
+    jwtauth = general_settings.get("litellm_jwtauth") if isinstance(general_settings, dict) else None
+    raw_issuers = jwtauth.get("issuers") if isinstance(jwtauth, dict) else getattr(jwtauth, "issuers", None)
+    for cfg in raw_issuers or []:
+        issuer = cfg.get("issuer") if isinstance(cfg, dict) else getattr(cfg, "issuer", None)
+        if issuer and issuer not in issuers:
+            issuers.append(issuer)
+    return issuers
 
 
 # Standard MCP pattern: /.well-known/oauth-protected-resource/mcp/{server_name}

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1288,20 +1288,13 @@ async def _build_oauth_protected_resource_response(
             detail=(f"Upstream oauth-protected-resource metadata unavailable for MCP server {mcp_server.name!r}"),
         )
 
-    # OBO (token_exchange): the client SSOs with the IdP to obtain a subject token, which LiteLLM
-    # then exchanges. Point discovery at the JWT-auth issuer(s) LiteLLM trusts (the same IdP that
-    # issues and validates the subject), not at the gateway.
-    if mcp_server is not None and mcp_server.auth_type == MCPAuth.oauth2_token_exchange:
-        issuers = _jwt_auth_issuers()
-        if issuers:
-            return {
-                "authorization_servers": issuers,
-                "resource": resource_url,
-                "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
-            }
-        # No JWT-auth issuer configured -> fall through to the gateway default so discovery still
-        # returns metadata; it just can't name the IdP.
-    else:
+    obo_response = _obo_protected_resource_response(mcp_server, resource_url)
+    if obo_response is not None:
+        return obo_response
+
+    # An OBO server with no configured issuer falls through to the gateway default so discovery still
+    # returns metadata; every other non-oauth2 named server 404s to avoid enumeration.
+    if mcp_server is None or mcp_server.auth_type != MCPAuth.oauth2_token_exchange:
         _raise_unless_oauth2_discovery_server(mcp_server, mcp_server_name, "not an OAuth-protected resource")
 
     return {
@@ -1310,6 +1303,26 @@ async def _build_oauth_protected_resource_response(
         ],
         "resource": resource_url,
         "scopes_supported": (mcp_server.scopes if mcp_server and mcp_server.scopes else []),
+    }
+
+
+def _obo_protected_resource_response(mcp_server: Optional[MCPServer], resource_url: str) -> Optional[dict]:
+    """The OBO (token_exchange) PRM, or None when this server is not OBO / no issuer is configured.
+
+    The client SSOs with the IdP to obtain a subject token, which LiteLLM then exchanges, so discovery
+    points at the JWT-auth issuer(s) LiteLLM trusts (the same IdP that issues and validates the
+    subject), not the gateway. None falls the caller back to the gateway default so discovery still
+    returns metadata; it just can't name the IdP.
+    """
+    if mcp_server is None or mcp_server.auth_type != MCPAuth.oauth2_token_exchange:
+        return None
+    issuers = _jwt_auth_issuers()
+    if not issuers:
+        return None
+    return {
+        "authorization_servers": issuers,
+        "resource": resource_url,
+        "scopes_supported": (mcp_server.scopes if mcp_server.scopes else []),
     }
 
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1992,16 +1992,25 @@ class MCPServerManager:
                 match await provider.resolve_credentials(to_subject(user_api_key_auth, subject_token), spec):
                     case Ok(auth):
                         resolved_auth = auth
-                        # Do not override an Authorization already supplied via extra_headers
-                        # (a guardrail hook such as the JWT signer, static_headers, or a
-                        # forwarded caller header): v1 applies those last, so they win. NoOpAuth
-                        # has no header_name and so never skips.
+                        # NoOpAuth has no header_name and so never conflicts.
                         header_name = getattr(resolved_auth, "header_name", None)
-                        if (
+                        conflicts = bool(
                             header_name
                             and extra_headers
                             and any(key.lower() == header_name.lower() for key in extra_headers)
-                        ):
+                        )
+                        if conflicts and isinstance(spec.config, (TokenExchangeConfig, AuthorizationCodeConfig)):
+                            # The resolver owns the per-user credential here (token_exchange's
+                            # exchanged token, authorization_code's stored token). It is
+                            # authoritative: a guardrail such as MCPJWTSigner, static_headers, or any
+                            # other injected Authorization must NOT shadow it (otherwise the upstream
+                            # gets e.g. the signer's JWT instead of the exchanged token and rejects
+                            # it). Drop the conflicting header so the resolved token reaches upstream.
+                            extra_headers = _without_authorization(extra_headers)
+                        elif conflicts:
+                            # Other modes: an Authorization already supplied via extra_headers (a
+                            # forwarded caller header or static_headers) is intentional and wins; v1
+                            # applies those last.
                             resolved_auth = None
                     case Error(err):
                         if err.tag == "unauthorized" and isinstance(spec.config, AuthorizationCodeConfig):

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator, Callable, Literal, Optional, Union, cast
 from urllib.parse import urlparse
 
 import anyio
+import httpx
 from fastapi import HTTPException
 from httpx import HTTPStatusError
 from mcp import ReadResourceResult, Resource
@@ -77,6 +78,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchange_
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     AuthorizationCodeConfig,
+    ServerSpec,
     TokenExchangeConfig,
 )
 from litellm.proxy._experimental.mcp_server.utils import (
@@ -110,7 +112,7 @@ from litellm.proxy._types import (
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
 from litellm.proxy.common_utils.encrypt_decrypt_utils import decrypt_value_helper
 from litellm.proxy.common_utils.user_api_key_cache import get_management_object_ttl
-from litellm.proxy.utils import ProxyLogging
+from litellm.proxy.utils import ProxyLogging, get_server_root_path
 from litellm.repositories.table_repositories import MCPServerRepository
 from litellm.types.llms.custom_http import httpxSpecialProvider
 from litellm.types.mcp import MCPAuth, MCPStdioConfig
@@ -1681,8 +1683,7 @@ class MCPServerManager:
     def _obo_subject_token(
         self,
         server: MCPServer,
-        raw_headers: Optional[Dict[str, str]],
-        oauth2_headers: Optional[Dict[str, str]] = None,
+        raw_headers: Optional[dict[str, str]],
     ) -> Optional[str]:
         """The caller's bearer as the token_exchange (OBO) subject token, for that mode only.
 
@@ -1692,7 +1693,7 @@ class MCPServerManager:
         """
         if server.auth_type != MCPAuth.oauth2_token_exchange:
             return None
-        return self._extract_bearer_token(oauth2_headers, raw_headers)
+        return self._extract_bearer_token(None, raw_headers)
 
     def _build_stdio_env(
         self,
@@ -1884,6 +1885,54 @@ class MCPServerManager:
         _write_user_env_vars_cache(user_id, server.server_id, values)
         return values
 
+    async def _resolve_v2_auth(
+        self,
+        *,
+        server: MCPServer,
+        spec: ServerSpec,
+        provider: UpstreamCredentialProvider,
+        subject_token: Optional[str],
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+        extra_headers: Optional[dict[str, str]],
+    ) -> tuple[Optional[httpx.Auth], Optional[dict[str, str]]]:
+        """Resolve a v2-owned server's upstream credential into ``(resolved_auth, extra_headers)``.
+
+        On a missing/rejected per-user credential this raises the mode's discovery challenge
+        (authorization_code's browser-OAuth 401, token_exchange's RFC 9728 challenge) or maps any
+        other ``CredError`` onto its public HTTP status; it never returns an error as a value.
+        """
+        match await provider.resolve_credentials(to_subject(user_api_key_auth, subject_token), spec):
+            case Ok(auth):
+                # NoOpAuth has no header_name and so never conflicts.
+                header_name = getattr(auth, "header_name", None)
+                conflicts = bool(
+                    header_name and extra_headers and any(key.lower() == header_name.lower() for key in extra_headers)
+                )
+                if not conflicts:
+                    return auth, extra_headers
+                if isinstance(spec.config, (TokenExchangeConfig, AuthorizationCodeConfig)):
+                    # The resolver owns the per-user credential here (token_exchange's exchanged
+                    # token, authorization_code's stored token). It is authoritative: a guardrail such
+                    # as MCPJWTSigner, static_headers, or any other injected Authorization must NOT
+                    # shadow it (otherwise the upstream gets e.g. the signer's JWT instead of the
+                    # exchanged token and rejects it). Drop the conflicting header so the resolved
+                    # token reaches upstream.
+                    return auth, _without_authorization(extra_headers)
+                # Other modes: an Authorization already supplied via extra_headers (a forwarded caller
+                # header or static_headers) is intentional and wins; v1 applies those last.
+                return None, extra_headers
+            case Error(err):
+                if err.tag == "unauthorized" and isinstance(spec.config, AuthorizationCodeConfig):
+                    # authorization_code's missing per-user token -> the per-server browser-OAuth
+                    # challenge, built here where the full MCPServer is in hand.
+                    raise_user_oauth_challenge(server, root_path=get_server_root_path())
+                if err.tag == "unauthorized" and isinstance(spec.config, TokenExchangeConfig):
+                    # token_exchange (OBO): a missing/rejected subject token -> the RFC 9728 challenge
+                    # pointing at the IdP the client must SSO with to obtain one, rather than an opaque
+                    # 401. No gateway-side browser flow.
+                    raise_token_exchange_challenge(server, root_path=get_server_root_path())
+                raise_public(err)
+
     async def _create_mcp_client(
         self,
         server: MCPServer,
@@ -1994,40 +2043,14 @@ class MCPServerManager:
             server_url = server.url or ""
 
             if spec is not None:
-                match await provider.resolve_credentials(to_subject(user_api_key_auth, subject_token), spec):
-                    case Ok(auth):
-                        resolved_auth = auth
-                        # NoOpAuth has no header_name and so never conflicts.
-                        header_name = getattr(resolved_auth, "header_name", None)
-                        conflicts = bool(
-                            header_name
-                            and extra_headers
-                            and any(key.lower() == header_name.lower() for key in extra_headers)
-                        )
-                        if conflicts and isinstance(spec.config, (TokenExchangeConfig, AuthorizationCodeConfig)):
-                            # The resolver owns the per-user credential here (token_exchange's
-                            # exchanged token, authorization_code's stored token). It is
-                            # authoritative: a guardrail such as MCPJWTSigner, static_headers, or any
-                            # other injected Authorization must NOT shadow it (otherwise the upstream
-                            # gets e.g. the signer's JWT instead of the exchanged token and rejects
-                            # it). Drop the conflicting header so the resolved token reaches upstream.
-                            extra_headers = _without_authorization(extra_headers)
-                        elif conflicts:
-                            # Other modes: an Authorization already supplied via extra_headers (a
-                            # forwarded caller header or static_headers) is intentional and wins; v1
-                            # applies those last.
-                            resolved_auth = None
-                    case Error(err):
-                        if err.tag == "unauthorized" and isinstance(spec.config, AuthorizationCodeConfig):
-                            # authorization_code's missing per-user token -> the per-server
-                            # browser-OAuth challenge, built here where the full MCPServer is in hand.
-                            raise_user_oauth_challenge(server)
-                        if err.tag == "unauthorized" and isinstance(spec.config, TokenExchangeConfig):
-                            # token_exchange (OBO): a missing/rejected subject token -> the RFC 9728
-                            # challenge pointing at the IdP the client must SSO with to obtain one,
-                            # rather than an opaque 401. No gateway-side browser flow.
-                            raise_token_exchange_challenge(server)
-                        raise_public(err)
+                resolved_auth, extra_headers = await self._resolve_v2_auth(
+                    server=server,
+                    spec=spec,
+                    provider=provider,
+                    subject_token=subject_token,
+                    user_api_key_auth=user_api_key_auth,
+                    extra_headers=extra_headers,
+                )
                 return MCPClient(
                     server_url=server_url,
                     transport_type=transport,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2223,12 +2223,16 @@ class MCPServerManager:
             # aggregator catches this explicitly to keep absorbing.
             raise
         except HTTPException as e:
-            headers = e.headers or {}
-            www_authenticate = headers.get("WWW-Authenticate") or headers.get("www-authenticate")
-            if e.status_code == 401 and www_authenticate is not None:
+            # A v2 resolver auth challenge (token_exchange's RFC 9728 401, authorization_code's
+            # browser-OAuth 401, or a 403) is raised at client-build time, inside this try. Route it
+            # through the same MCPUpstreamAuthError channel as pass-through so single-server routes
+            # surface the challenge (the client re-authenticates) while the aggregator keeps absorbing.
+            # Non-auth HTTP errors stay absorbed so one misconfigured server can't blank the listing.
+            if e.status_code in (401, 403):
+                headers = e.headers or {}
                 raise MCPUpstreamAuthError(
-                    status_code=401,
-                    www_authenticate=www_authenticate,
+                    status_code=e.status_code,
+                    www_authenticate=headers.get("WWW-Authenticate") or headers.get("www-authenticate"),
                     server_name=server.name,
                 ) from e
             verbose_logger.warning(f"Failed to get tools from server {server.name}: {str(e)}")

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2032,6 +2032,7 @@ class MCPServerManager:
         add_prefix: bool = True,
         raw_headers: Optional[dict[str, str]] = None,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
+        oauth2_headers: Optional[dict[str, str]] = None,
     ) -> list[MCPTool]:
         """
         Helper method to get tools from a single MCP server with prefixed names.
@@ -2105,11 +2106,21 @@ class MCPServerManager:
 
             stdio_env = self._build_stdio_env(server, raw_headers)
 
+            # token_exchange (OBO) discovery needs the caller's token too: list it with the user's own
+            # token (mirrors the call path), not v1's deleted client_credentials fallback. Other modes
+            # never read the inbound bearer, so leave subject_token None to avoid forwarding it.
+            subject_token = (
+                self._extract_bearer_token(oauth2_headers, raw_headers)
+                if server.auth_type == MCPAuth.oauth2_token_exchange
+                else None
+            )
+
             client = await self._create_mcp_client(
                 server=server,
                 mcp_auth_header=mcp_auth_header,
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
+                subject_token=subject_token,
                 user_api_key_auth=user_api_key_auth,
             )
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -210,6 +210,10 @@ def _should_strip_caller_authorization(
       ``Authorization`` is the upstream OAuth token and must be
       forwarded, so we keep it.
     """
+    if mcp_server.auth_type == MCPAuth.oauth2_token_exchange:
+        # OBO: the inbound Authorization is the subject token. It is exchanged at the IdP and only the
+        # exchanged token is sent upstream, so the raw caller bearer must never be forwarded.
+        return True
     if mcp_server.has_client_credentials:
         return True
     if mcp_server.auth_type == MCPAuth.oauth2 and to_server_spec(mcp_server) is not None:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3326,6 +3326,46 @@ class MCPServerManager:
         async with semaphore:
             yield
 
+    async def _obo_call_tool_with_retry(
+        self,
+        *,
+        client: MCPClient,
+        call_tool_params: MCPCallToolRequestParams,
+        host_progress_callback: Optional[Callable],
+        mcp_server: MCPServer,
+        server_auth_header: Optional[Union[str, dict[str, str]]],
+        extra_headers: Optional[dict[str, str]],
+        stdio_env: Optional[dict[str, str]],
+        subject_token: Optional[str],
+        user_api_key_auth: Optional[UserAPIKeyAuth],
+    ) -> CallToolResult:
+        """Call a token_exchange (OBO) tool; on an upstream 401/403 re-mint the token once and retry.
+
+        The exchanged token is baked into the client at build time, so the retry invalidates the
+        cached exchange and rebuilds the client (which re-exchanges). One retry only: a non-auth
+        failure or a second auth failure degrades to the normal ``isError`` result, and a re-exchange
+        that now fails surfaces its own 401 challenge from ``_create_mcp_client``.
+        """
+        try:
+            return await client.call_tool(
+                call_tool_params, host_progress_callback=host_progress_callback, raise_on_error=True
+            )
+        except Exception as exc:
+            if _extract_upstream_auth_failure(exc) is None:
+                return MCPClient.error_tool_result(exc)
+            spec = to_server_spec(mcp_server)
+            if spec is not None:
+                await self._cred_provider.invalidate_credentials(to_subject(user_api_key_auth, subject_token), spec)
+            retry_client = await self._create_mcp_client(
+                server=mcp_server,
+                mcp_auth_header=server_auth_header,
+                extra_headers=extra_headers,
+                stdio_env=stdio_env,
+                subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
+            )
+            return await retry_client.call_tool(call_tool_params, host_progress_callback=host_progress_callback)
+
     async def _call_regular_mcp_tool(
         self,
         mcp_server: MCPServer,
@@ -3484,11 +3524,30 @@ class MCPServerManager:
             arguments=arguments,
         )
 
-        async def _call_tool_via_client(client, params):
-            async with self._limit_outbound_concurrency(mcp_server):
-                return await client.call_tool(params, host_progress_callback=host_progress_callback)
+        if mcp_server.auth_type == MCPAuth.oauth2_token_exchange and subject_token:
+            # OBO: the exchanged token may have been revoked/rotated upstream since it was cached, so
+            # an upstream 401 gets one re-mint + retry. Gated to this mode; all others keep the plain
+            # single call below.
+            tool_call_coro = self._obo_call_tool_with_retry(
+                client=client,
+                call_tool_params=call_tool_params,
+                host_progress_callback=host_progress_callback,
+                mcp_server=mcp_server,
+                server_auth_header=server_auth_header,
+                extra_headers=extra_headers,
+                stdio_env=stdio_env,
+                subject_token=subject_token,
+                user_api_key_auth=user_api_key_auth,
+            )
+        else:
 
-        tasks.append(asyncio.create_task(_call_tool_via_client(client, call_tool_params)))
+            async def _call_tool_via_client(client, params):
+                async with self._limit_outbound_concurrency(mcp_server):
+                    return await client.call_tool(params, host_progress_callback=host_progress_callback)
+
+            tool_call_coro = _call_tool_via_client(client, call_tool_params)
+
+        tasks.append(asyncio.create_task(tool_call_coro))
 
         _timeout = mcp_server.timeout if mcp_server.timeout is not None else MCP_CLIENT_TIMEOUT
         try:

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1924,7 +1924,11 @@ class MCPServerManager:
         # forward an arbitrary bearer upstream, so we keep the v2 spec and ignore the override for
         # both; the REST tools preview supplies its not-yet-persisted token through the resolver
         # (cred_provider), never this path.
-        if spec is not None and mcp_auth_header and not isinstance(spec.config, (AuthorizationCodeConfig, TokenExchangeConfig)):
+        if (
+            spec is not None
+            and mcp_auth_header
+            and not isinstance(spec.config, (AuthorizationCodeConfig, TokenExchangeConfig))
+        ):
             spec = None
         auth_value = (
             await resolve_mcp_auth(server, mcp_auth_header, subject_token=subject_token) if spec is None else None

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -76,6 +76,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchange_
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     AuthorizationCodeConfig,
+    TokenExchangeConfig,
 )
 from litellm.proxy._experimental.mcp_server.utils import (
     MCP_TOOL_PREFIX_SEPARATOR,
@@ -1676,6 +1677,22 @@ class MCPServerManager:
             return auth_value
         return None
 
+    def _obo_subject_token(
+        self,
+        server: MCPServer,
+        raw_headers: Optional[Dict[str, str]],
+        oauth2_headers: Optional[Dict[str, str]] = None,
+    ) -> Optional[str]:
+        """The caller's bearer as the token_exchange (OBO) subject token, for that mode only.
+
+        Prompts/resources discovery and reads on a token_exchange server must exchange the caller's
+        token like the tools paths do, not connect with no credential. Other modes never read the
+        inbound bearer, so return None to avoid forwarding it.
+        """
+        if server.auth_type != MCPAuth.oauth2_token_exchange:
+            return None
+        return self._extract_bearer_token(oauth2_headers, raw_headers)
+
     def _build_stdio_env(
         self,
         server: MCPServer,
@@ -1900,11 +1917,13 @@ class MCPServerManager:
         spec = None if transport == MCPTransport.stdio else to_server_spec(server)
         provider = cred_provider or self._cred_provider
         # A caller-supplied per-request override (mcp_auth_header / x-mcp-*) defers to the v1 path
-        # so it wins - except for authorization_code, whose per-user token the v2 resolver owns. A
-        # caller must not be able to substitute another user's stored credential, so we keep the v2
-        # spec and ignore the override there; the REST tools preview supplies its not-yet-persisted
-        # token through the resolver (cred_provider), never this path.
-        if spec is not None and mcp_auth_header and not isinstance(spec.config, AuthorizationCodeConfig):
+        # so it wins - except for the per-user modes the v2 resolver owns (authorization_code's
+        # stored token and token_exchange's RFC 8693 minted token). A caller must not be able to
+        # substitute another user's stored credential, nor silently disable the OBO exchange and
+        # forward an arbitrary bearer upstream, so we keep the v2 spec and ignore the override for
+        # both; the REST tools preview supplies its not-yet-persisted token through the resolver
+        # (cred_provider), never this path.
+        if spec is not None and mcp_auth_header and not isinstance(spec.config, (AuthorizationCodeConfig, TokenExchangeConfig)):
             spec = None
         auth_value = (
             await resolve_mcp_auth(server, mcp_auth_header, subject_token=subject_token) if spec is None else None
@@ -2209,12 +2228,14 @@ class MCPServerManager:
                 extra_headers.update(server.static_headers)
 
             stdio_env = self._build_stdio_env(server, raw_headers)
+            subject_token = self._obo_subject_token(server, raw_headers)
 
             client = await self._create_mcp_client(
                 server=server,
                 mcp_auth_header=mcp_auth_header,
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
+                subject_token=subject_token,
             )
 
             prompts = await client.list_prompts()
@@ -2249,12 +2270,14 @@ class MCPServerManager:
                 extra_headers.update(server.static_headers)
 
             stdio_env = self._build_stdio_env(server, raw_headers)
+            subject_token = self._obo_subject_token(server, raw_headers)
 
             client = await self._create_mcp_client(
                 server=server,
                 mcp_auth_header=mcp_auth_header,
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
+                subject_token=subject_token,
             )
 
             resources = await client.list_resources()
@@ -2289,12 +2312,14 @@ class MCPServerManager:
                 extra_headers.update(server.static_headers)
 
             stdio_env = self._build_stdio_env(server, raw_headers)
+            subject_token = self._obo_subject_token(server, raw_headers)
 
             client = await self._create_mcp_client(
                 server=server,
                 mcp_auth_header=mcp_auth_header,
                 extra_headers=extra_headers,
                 stdio_env=stdio_env,
+                subject_token=subject_token,
             )
 
             resource_templates = await client.list_resource_templates()
@@ -2328,12 +2353,14 @@ class MCPServerManager:
             extra_headers.update(server.static_headers)
 
         stdio_env = self._build_stdio_env(server, raw_headers)
+        subject_token = self._obo_subject_token(server, raw_headers)
 
         client = await self._create_mcp_client(
             server=server,
             mcp_auth_header=mcp_auth_header,
             extra_headers=extra_headers,
             stdio_env=stdio_env,
+            subject_token=subject_token,
         )
 
         return await client.read_resource(url)
@@ -2358,12 +2385,14 @@ class MCPServerManager:
             extra_headers.update(server.static_headers)
 
         stdio_env = self._build_stdio_env(server, raw_headers)
+        subject_token = self._obo_subject_token(server, raw_headers)
 
         client = await self._create_mcp_client(
             server=server,
             mcp_auth_header=mcp_auth_header,
             extra_headers=extra_headers,
             stdio_env=stdio_env,
+            subject_token=subject_token,
         )
 
         get_prompt_request_params = GetPromptRequestParams(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -64,6 +64,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials import (
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
     raise_public,
+    raise_token_exchange_challenge,
     raise_user_oauth_challenge,
     to_server_spec,
     to_subject,
@@ -2015,10 +2016,13 @@ class MCPServerManager:
                     case Error(err):
                         if err.tag == "unauthorized" and isinstance(spec.config, AuthorizationCodeConfig):
                             # authorization_code's missing per-user token -> the per-server
-                            # browser-OAuth challenge, built here where the full MCPServer is in
-                            # hand. token_exchange and other modes carry their own 401 (e.g. OBO
-                            # needs a caller token, not a browser flow), so they go via raise_public.
+                            # browser-OAuth challenge, built here where the full MCPServer is in hand.
                             raise_user_oauth_challenge(server)
+                        if err.tag == "unauthorized" and isinstance(spec.config, TokenExchangeConfig):
+                            # token_exchange (OBO): a missing/rejected subject token -> the RFC 9728
+                            # challenge pointing at the IdP the client must SSO with to obtain one,
+                            # rather than an opaque 401. No gateway-side browser flow.
+                            raise_token_exchange_challenge(server)
                         raise_public(err)
                 return MCPClient(
                     server_url=server_url,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3337,7 +3337,7 @@ class MCPServerManager:
         call_tool_params: MCPCallToolRequestParams,
         host_progress_callback: Optional[Callable],
         mcp_server: MCPServer,
-        server_auth_header: Optional[Union[str, dict[str, str]]],
+        server_auth_header: str | dict[str, str] | None,
         extra_headers: Optional[dict[str, str]],
         stdio_env: Optional[dict[str, str]],
         subject_token: Optional[str],

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -102,15 +102,17 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
 
 
 def _token_exchange_spec(server: MCPServer, resource: str) -> Optional[ServerSpec]:
-    """Build a token_exchange (RFC 8693 OBO) spec, or defer (None) if the exchange config is absent.
+    """Build a token_exchange (RFC 8693 OBO) spec, or defer (None) when it is not OBO-configured.
 
-    Mirrors v1's ``has_token_exchange_config`` precondition: an endpoint (``token_exchange_endpoint``
-    or ``token_url``) plus ``client_id``/``client_secret`` must all be present, else there is nothing
-    to exchange against and the server stays on v1 (parity-safe). ``audience`` is forwarded only when
-    the operator set it; a missing one is omitted, not derived.
+    An OBO server with ``client_id``/``client_secret`` is owned by the v2 arm even if the
+    ``token_exchange_endpoint``/``token_url`` is absent: a missing endpoint then fails closed (412) at
+    the exchanger rather than silently deferring to v1 and connecting unauthenticated, since the
+    gateway must not guess the IdP or fall back to a weaker source. Without client credentials there is
+    nothing to own, so the server stays on v1 (parity-safe). ``audience`` is forwarded only when the
+    operator set it; a missing one is omitted, not derived.
     """
     endpoint = server.token_exchange_endpoint or server.token_url
-    if not endpoint or not server.client_id or not server.client_secret:
+    if not server.client_id or not server.client_secret:
         return None
     return ServerSpec(
         server_id=server.server_id,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -198,3 +198,32 @@ def raise_user_oauth_challenge(server: MCPServer) -> NoReturn:
         detail="Unauthorized",
         headers={"WWW-Authenticate": f'Bearer resource_metadata="{resource_metadata}"'},
     )
+
+
+def raise_token_exchange_challenge(server: MCPServer) -> NoReturn:
+    """Raise the RFC 9728 / RFC 6750 challenge an OBO (``token_exchange``) server returns when the
+    caller's subject token is missing or the IdP rejected it.
+
+    Points at the server's Protected Resource Metadata (``resource_metadata``), whose
+    ``authorization_servers`` names the IdP the client must SSO with to obtain a subject token;
+    ``error="invalid_token"`` tells a spec-compliant MCP client to discover that AS and retry with a
+    fresh bearer. Mirrors ``raise_user_oauth_challenge`` but for the exchange flow: there is no
+    gateway-side browser OAuth — the client re-authenticates directly with the IdP, and LiteLLM then
+    exchanges the resulting token.
+    """
+    from litellm.proxy.utils import get_server_root_path  # noqa: PLC0415
+
+    root = get_server_root_path()
+    prefix = "" if root == "/" else root
+    name = server.alias or server.server_name or server.name or server.server_id
+    resource_metadata = f"/.well-known/oauth-protected-resource{prefix}/mcp/{name}"
+    www_authenticate = (
+        f'Bearer resource_metadata="{resource_metadata}", '
+        'error="invalid_token", '
+        'error_description="Missing or invalid subject token; authenticate with the IdP and retry"'
+    )
+    raise HTTPException(
+        status_code=401,
+        detail="Unauthorized",
+        headers={"WWW-Authenticate": www_authenticate},
+    )

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -116,7 +116,7 @@ def _token_exchange_spec(server: MCPServer, resource: str) -> Optional[ServerSpe
         server_id=server.server_id,
         resource=resource,
         config=TokenExchangeConfig(
-            subject_token_type=server.subject_token_type,
+            subject_token_type=server.subject_token_type or "urn:ietf:params:oauth:token-type:access_token",
             token_exchange_endpoint=endpoint,
             audience=server.audience,
             client_id=server.client_id,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -178,21 +178,27 @@ def raise_public(error: CredError) -> NoReturn:
     assert_never(error.tag)
 
 
-def raise_user_oauth_challenge(server: MCPServer) -> NoReturn:
+def oauth_protected_resource_path(root_path: str, server: MCPServer) -> str:
+    """The server's RFC 9728 Protected Resource Metadata path, the shared anchor of both challenges.
+
+    ``root_path`` is the proxy's ``SERVER_ROOT_PATH``, resolved by the caller (the imperative shell)
+    so this stays a pure function of its inputs; ``"/"`` and ``""`` both mean no prefix. The path is
+    relative, so it resolves against the caller's own host (correct even behind a reverse proxy).
+    """
+    prefix = "" if root_path == "/" else root_path
+    name = server.alias or server.server_name or server.name or server.server_id
+    return f"/.well-known/oauth-protected-resource{prefix}/mcp/{name}"
+
+
+def raise_user_oauth_challenge(server: MCPServer, *, root_path: str) -> NoReturn:
     """Raise the 401 an ``authorization_code`` server returns at egress when the user has no token.
 
-    Points at the server's RFC 9728 Protected Resource Metadata (``resource_metadata``), which names
-    the upstream authorization server the client must complete OAuth with. The URL is per-server and
-    relative, so it resolves against the caller's own host (correct even behind a reverse proxy)
-    without needing request context. The listing-phase 401 still emits the RFC 8414 ``authorization_uri``
-    form pending the format unification; both target the same server, so the difference is cosmetic.
+    Points at the server's RFC 9728 Protected Resource Metadata, which names the upstream
+    authorization server the client must complete OAuth with. The listing-phase 401 still emits the
+    RFC 8414 ``authorization_uri`` form pending the format unification; both target the same server,
+    so the difference is cosmetic.
     """
-    from litellm.proxy.utils import get_server_root_path  # noqa: PLC0415
-
-    root = get_server_root_path()
-    prefix = "" if root == "/" else root
-    name = server.alias or server.server_name or server.name or server.server_id
-    resource_metadata = f"/.well-known/oauth-protected-resource{prefix}/mcp/{name}"
+    resource_metadata = oauth_protected_resource_path(root_path, server)
     raise HTTPException(
         status_code=401,
         detail="Unauthorized",
@@ -200,23 +206,17 @@ def raise_user_oauth_challenge(server: MCPServer) -> NoReturn:
     )
 
 
-def raise_token_exchange_challenge(server: MCPServer) -> NoReturn:
+def raise_token_exchange_challenge(server: MCPServer, *, root_path: str) -> NoReturn:
     """Raise the RFC 9728 / RFC 6750 challenge an OBO (``token_exchange``) server returns when the
     caller's subject token is missing or the IdP rejected it.
 
-    Points at the server's Protected Resource Metadata (``resource_metadata``), whose
-    ``authorization_servers`` names the IdP the client must SSO with to obtain a subject token;
-    ``error="invalid_token"`` tells a spec-compliant MCP client to discover that AS and retry with a
-    fresh bearer. Mirrors ``raise_user_oauth_challenge`` but for the exchange flow: there is no
-    gateway-side browser OAuth — the client re-authenticates directly with the IdP, and LiteLLM then
-    exchanges the resulting token.
+    Points at the server's Protected Resource Metadata, whose ``authorization_servers`` names the IdP
+    the client must SSO with to obtain a subject token; ``error="invalid_token"`` tells a
+    spec-compliant MCP client to discover that AS and retry with a fresh bearer. Mirrors
+    ``raise_user_oauth_challenge`` but for the exchange flow: there is no gateway-side browser OAuth —
+    the client re-authenticates directly with the IdP, and LiteLLM then exchanges the resulting token.
     """
-    from litellm.proxy.utils import get_server_root_path  # noqa: PLC0415
-
-    root = get_server_root_path()
-    prefix = "" if root == "/" else root
-    name = server.alias or server.server_name or server.name or server.server_id
-    resource_metadata = f"/.well-known/oauth-protected-resource{prefix}/mcp/{name}"
+    resource_metadata = oauth_protected_resource_path(root_path, server)
     www_authenticate = (
         f'Bearer resource_metadata="{resource_metadata}", '
         'error="invalid_token", '

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
@@ -63,9 +63,14 @@ class _NullTokenExchanger:
     """Fail-closed default: with no exchanger wired, token_exchange cannot produce a credential."""
 
     async def exchange(
-        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
     ) -> Result[OAuthToken, CredError]:
         return Error(CredError.of_misconfigured("token exchange collaborator not wired"))
+
+    async def invalidate(
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
+    ) -> None:
+        return None
 
 
 class UpstreamCredentialProvider:
@@ -146,11 +151,25 @@ class UpstreamCredentialProvider:
                     www_authenticate='Bearer error="invalid_request"',
                 )
             )
-        match await self._token_exchanger.exchange(inbound.get_secret_value(), server, config):
+        match await self._token_exchanger.exchange(
+            inbound.get_secret_value(), server, config, tenant_id=subject.tenant_id
+        ):
             case Ok(token):
                 return Ok(StaticHeaderAuth(f"Bearer {token.access_token}", header_name="Authorization"))
             case Error(err):
                 return Error(err)
+
+    async def invalidate_credentials(self, subject: Subject, server: ServerSpec) -> None:
+        """Drop any cached credential the resolver owns for this `(subject, server)`.
+
+        Used after an upstream rejects the injected credential, so the next resolve re-mints rather
+        than serving the same rejected token until TTL. Only `token_exchange` holds a re-mintable
+        cached credential here; other modes are a no-op.
+        """
+        if isinstance(server.config, TokenExchangeConfig) and subject.inbound_token is not None:
+            await self._token_exchanger.invalidate(
+                subject.inbound_token.get_secret_value(), server, server.config, tenant_id=subject.tenant_id
+            )
 
     async def _authz_token(self, subject: Subject, server: ServerSpec) -> OAuthToken | None:
         """The user's authorization_code token, or None when absent or the store is unreachable.

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -24,7 +24,31 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_sto
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
     Rfc8693TokenExchanger,
     SubjectTokenRejected,
+    TokenExchangeClientError,
 )
+
+# RFC 6749 5.2 error codes that mean the gateway's own request/credentials are wrong (not the
+# caller's subject token), so they surface as a 500 the caller can't fix by re-authenticating.
+_GATEWAY_FAULT_OAUTH_ERRORS = frozenset(
+    {"invalid_client", "unauthorized_client", "unsupported_grant_type", "invalid_target", "invalid_scope"}
+)
+
+
+def _oauth_error_code(response: httpx.Response) -> str | None:
+    """Read the RFC 6749 5.2 ``error`` code from a token-endpoint error body, or None if absent.
+
+    The ``error_description`` is deliberately not read: it can carry IdP internals and must never
+    reach the caller. Only the standard machine code drives classification.
+    """
+    try:
+        body: object = response.json()
+    except Exception:  # noqa: BLE001
+        return None
+    if isinstance(body, dict):
+        code = body.get("error")
+        if isinstance(code, str):
+            return code
+    return None
 
 
 async def _post_exchange_endpoint(
@@ -48,7 +72,16 @@ async def _post_exchange_endpoint(
     except httpx.HTTPStatusError as status_err:
         status_code = status_err.response.status_code
         if 400 <= status_code < 500:
-            raise SubjectTokenRejected(f"IdP rejected the token exchange (HTTP {status_code})") from status_err
+            oauth_error = _oauth_error_code(status_err.response)
+            if oauth_error in _GATEWAY_FAULT_OAUTH_ERRORS:
+                verbose_logger.warning(
+                    "MCP token exchange rejected as %s (HTTP %d); check the gateway client credentials, "
+                    "audience, and scope for this server",
+                    oauth_error,
+                    status_code,
+                )
+                raise TokenExchangeClientError(oauth_error) from status_err
+            raise SubjectTokenRejected(f"IdP rejected the subject token (HTTP {status_code})") from status_err
         verbose_logger.warning("MCP token exchange request failed: %s", status_err)
         return None
     except Exception as exc:  # noqa: BLE001

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -9,6 +9,8 @@ call), so it needs no lazy wrapper.
 
 from __future__ import annotations
 
+import httpx
+
 from litellm._logging import verbose_logger
 from litellm.constants import (
     MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL,
@@ -21,6 +23,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_sto
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
     Rfc8693TokenExchanger,
+    SubjectTokenRejected,
 )
 
 
@@ -34,13 +37,22 @@ async def _post_exchange_endpoint(
 
     # litellm's httpx handler and httpx.Response are only partially typed; the IdP returns a JSON
     # object and the exchanger validates each field, so the untyped boundary is contained here.
-    # A failed exchange is a miss, not a 500 (matches v1), so any error becomes None.
+    # A 4xx is the IdP rejecting the subject (non-retryable -> 401 via SubjectTokenRejected); any
+    # other failure is a miss (-> None -> upstream_unavailable -> 503), matching v1's fail-closed.
     headers = {"Accept": "application/json", **client_auth_headers}
     try:
         client = get_async_httpx_client(llm_provider=httpxSpecialProvider.MCP)  # pyright: ignore
         response = await client.post(url, headers=headers, data=form)  # pyright: ignore
         response.raise_for_status()  # pyright: ignore
         parsed: object = response.json()  # pyright: ignore
+    except httpx.HTTPStatusError as status_err:
+        status_code = status_err.response.status_code
+        if 400 <= status_code < 500:
+            raise SubjectTokenRejected(
+                f"IdP rejected the token exchange (HTTP {status_code})"
+            ) from status_err
+        verbose_logger.warning("MCP token exchange request failed: %s", status_err)
+        return None
     except Exception as exc:  # noqa: BLE001
         verbose_logger.warning("MCP token exchange request failed: %s", exc)
         return None

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -48,9 +48,7 @@ async def _post_exchange_endpoint(
     except httpx.HTTPStatusError as status_err:
         status_code = status_err.response.status_code
         if 400 <= status_code < 500:
-            raise SubjectTokenRejected(
-                f"IdP rejected the token exchange (HTTP {status_code})"
-            ) from status_err
+            raise SubjectTokenRejected(f"IdP rejected the token exchange (HTTP {status_code})") from status_err
         verbose_logger.warning("MCP token exchange request failed: %s", status_err)
         return None
     except Exception as exc:  # noqa: BLE001

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -255,6 +255,9 @@ class Rfc8693TokenExchanger:
         # must fail closed rather than be minted as a bogus Bearer; an absent type defaults to Bearer.
         token_type = body.get("token_type")
         if isinstance(token_type, str) and token_type.strip().lower() != "bearer":
+            verbose_logger.warning(
+                "MCP token exchange returned unusable token_type %r; refusing to forward it as Bearer", token_type
+            )
             return None
         # issued_token_type says what representation was minted; reject a clearly-non-access type
         # (refresh/id/saml) even if token_type claimed Bearer. access_token / jwt / absent / unknown pass.

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -105,11 +105,11 @@ def _cache_key(subject_token: str, config: TokenExchangeConfig) -> str:
 def _parse_expires_in(raw: object) -> int | None:
     if isinstance(raw, bool):
         return None
-    if isinstance(raw, int):
-        return raw
+    if isinstance(raw, (int, float)):
+        return int(raw)
     if isinstance(raw, str):
         try:
-            return int(raw)
+            return int(float(raw))
         except ValueError:
             return None
     return None
@@ -235,5 +235,7 @@ class Rfc8693TokenExchanger:
     def _ttl_seconds(self, token: OAuthToken) -> float:
         if token.expires_at is None:
             return self._default_ttl_seconds
-        lifetime = token.expires_at - self._clock()
-        return max(lifetime - self._expiry_buffer_seconds, self._min_ttl_seconds)
+        lifetime = max(0.0, token.expires_at - self._clock())
+        # Floor at min_ttl, but never cache past the token's own expiry: a token whose remaining
+        # lifetime is below the buffer (or even below min_ttl) must not be served stale upstream.
+        return min(max(lifetime - self._expiry_buffer_seconds, self._min_ttl_seconds), lifetime)

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -70,6 +70,15 @@ _NON_ACCESS_ISSUED_TOKEN_TYPES = frozenset(
 ExchangeHttpPost = Callable[[str, "dict[str, str]", "dict[str, str]"], Awaitable["dict[str, object] | None"]]
 
 
+class SubjectTokenRejected(Exception):
+    """The IdP refused to exchange the subject token (an RFC 8693 4xx, e.g. ``invalid_grant``).
+
+    Distinct from a transport / IdP-availability failure, which the post adapter maps to ``None`` ->
+    ``upstream_unavailable`` -> 503 (retryable). A rejected subject is the caller's problem, not the
+    gateway's, so the arm surfaces it as a non-retryable 401 (the OBO challenge) instead.
+    """
+
+
 class TokenExchanger(Protocol):
     """Exchanges a caller token for an upstream-bound one, per the server's token_exchange config."""
 
@@ -209,7 +218,12 @@ class Rfc8693TokenExchanger:
         async def reread() -> OAuthToken | None:
             return await self._cache.get(cache_key, server_id)
 
-        token = await self._coordinator.run(cache_key, server_id, refresh=run_exchange, reread=reread)
+        try:
+            token = await self._coordinator.run(cache_key, server_id, refresh=run_exchange, reread=reread)
+        except SubjectTokenRejected as rejected:
+            # The IdP rejected the subject token (4xx). This is non-retryable: the caller must
+            # re-authenticate with the IdP, so it surfaces as a 401 (the OBO challenge), not a 503.
+            return Error(CredError.of_unauthorized(str(rejected) or "subject token rejected by the IdP"))
         if token is None:
             return Error(CredError.of_upstream_unavailable("token exchange did not return a usable access token"))
         return Ok(token)

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -21,6 +21,7 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import Protocol
 
+from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
     InMemoryTokenCacheBackend,
     InProcessRefreshCoordinator,
@@ -83,22 +84,27 @@ class TokenExchanger(Protocol):
     """Exchanges a caller token for an upstream-bound one, per the server's token_exchange config."""
 
     async def exchange(
-        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
     ) -> Result[OAuthToken, CredError]: ...
 
+    async def invalidate(
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
+    ) -> None: ...
 
-def _cache_key(subject_token: str, config: TokenExchangeConfig) -> str:
-    """Bind the cache entry to the caller token AND the exchange config that minted it.
 
-    A rotated caller token, endpoint, audience, scope, client_id, secret, auth method, or
-    subject_token_type all change the key, so a config change forces a fresh exchange instead of
-    serving a token minted for the old config until TTL. Everything is hashed, so no secret is held
-    in the key.
+def _cache_key(subject_token: str, tenant_id: str, config: TokenExchangeConfig) -> str:
+    """Bind the cache entry to the caller token, the tenant, AND the exchange config that minted it.
+
+    A rotated caller token, a different tenant, endpoint, audience, scope, client_id, secret, auth
+    method, or subject_token_type all change the key, so two tenants behind the same opaque token
+    never share an entry and a config change forces a fresh exchange instead of serving a token
+    minted for the old config until TTL. Everything is hashed, so no secret is held in the key.
     """
     secret = config.client_secret.get_secret_value() if config.client_secret else ""
     material = "\x00".join(
         (
             subject_token,
+            tenant_id,
             config.token_exchange_endpoint or "",
             config.audience or "",
             config.subject_token_type,
@@ -169,7 +175,7 @@ class Rfc8693TokenExchanger:
         self._expiry_buffer_seconds = expiry_buffer_seconds
 
     async def exchange(
-        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
     ) -> Result[OAuthToken, CredError]:
         endpoint = config.token_exchange_endpoint
         client_id = config.client_id
@@ -181,10 +187,11 @@ class Rfc8693TokenExchanger:
                 )
             )
 
-        cache_key = _cache_key(subject_token, config)
+        cache_key = _cache_key(subject_token, tenant_id, config)
         server_id = server.server_id
         cached = await self._cache.get(cache_key, server_id)
         if cached is not None:
+            verbose_logger.debug("MCP token exchange cache hit for server %s", server_id)
             return Ok(cached)
 
         client_auth = build_token_endpoint_client_auth(
@@ -206,6 +213,9 @@ class Rfc8693TokenExchanger:
             fresh = await self._cache.get(cache_key, server_id)
             if fresh is not None:
                 return fresh
+            verbose_logger.debug(
+                "Exchanging token for MCP server %s at %s (audience=%s)", server_id, endpoint, config.audience
+            )
             body = await self._http_post(endpoint, form, client_auth.headers)
             if body is None:
                 return None
@@ -213,6 +223,7 @@ class Rfc8693TokenExchanger:
             if token is None:
                 return None
             await self._cache.set(cache_key, server_id, token, self._ttl_seconds(token))
+            verbose_logger.info("Token exchange succeeded for MCP server %s", server_id)
             return token
 
         async def reread() -> OAuthToken | None:
@@ -227,6 +238,12 @@ class Rfc8693TokenExchanger:
         if token is None:
             return Error(CredError.of_upstream_unavailable("token exchange did not return a usable access token"))
         return Ok(token)
+
+    async def invalidate(
+        self, subject_token: str, server: ServerSpec, config: TokenExchangeConfig, *, tenant_id: str = ""
+    ) -> None:
+        """Drop the cached exchanged token so the next call re-exchanges (e.g. after an upstream 401)."""
+        await self._cache.delete(_cache_key(subject_token, tenant_id, config), server.server_id)
 
     def _token_from_body(self, body: dict[str, object]) -> OAuthToken | None:
         access_token = body.get("access_token")

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -180,12 +180,14 @@ class Rfc8693TokenExchanger:
         endpoint = config.token_exchange_endpoint
         client_id = config.client_id
         client_secret = config.client_secret
-        if not endpoint or not client_id or client_secret is None:
+        if not endpoint:
+            # No endpoint configured and none discoverable: fail closed (412) rather than guess an IdP
+            # or fall back to a weaker source. The caller's token is never sent anywhere.
             return Error(
-                CredError.of_misconfigured(
-                    "token_exchange requires token_exchange_endpoint, client_id and client_secret"
-                )
+                CredError.of_precondition_required("token exchange endpoint is not configured for this server")
             )
+        if not client_id or client_secret is None:
+            return Error(CredError.of_misconfigured("token_exchange requires client_id and client_secret"))
 
         cache_key = _cache_key(subject_token, tenant_id, config)
         server_id = server.server_id

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -80,6 +80,17 @@ class SubjectTokenRejected(Exception):
     """
 
 
+class TokenExchangeClientError(Exception):
+    """The IdP rejected the exchange for a reason that is the gateway's fault, not the caller's.
+
+    RFC 6749 5.2 codes such as ``invalid_client`` (the gateway's own STS credentials are wrong),
+    ``unauthorized_client`` / ``unsupported_grant_type`` (the gateway is not permitted to exchange),
+    ``invalid_target`` / ``invalid_scope`` (the gateway's audience/scope config for this server is
+    wrong). The caller cannot fix these by re-authenticating, so the arm surfaces them as a 500
+    (``misconfigured``), not the 401 OBO challenge. The IdP ``error_description`` is never carried.
+    """
+
+
 class TokenExchanger(Protocol):
     """Exchanges a caller token for an upstream-bound one, per the server's token_exchange config."""
 
@@ -237,6 +248,16 @@ class Rfc8693TokenExchanger:
             # The IdP rejected the subject token (4xx). This is non-retryable: the caller must
             # re-authenticate with the IdP, so it surfaces as a 401 (the OBO challenge), not a 503.
             return Error(CredError.of_unauthorized(str(rejected) or "subject token rejected by the IdP"))
+        except TokenExchangeClientError:
+            # RFC 6749 5.2 gateway-fault code (invalid_client / invalid_target / ...): the caller can't
+            # fix it by re-authenticating, so surface a 500 rather than the OBO 401 challenge. The
+            # specific code is logged at the edge; the user-facing summary stays generic.
+            return Error(
+                CredError.of_misconfigured(
+                    "token exchange configuration error: the gateway's credentials, audience, or scope "
+                    "for this server were not accepted by the IdP"
+                )
+            )
         if token is None:
             return Error(CredError.of_upstream_unavailable("token exchange did not return a usable access token"))
         return Ok(token)

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3482,8 +3482,9 @@ if MCP_AVAILABLE:
                 from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (  # noqa: PLC0415
                     raise_token_exchange_challenge,
                 )
+                from litellm.proxy.utils import get_server_root_path  # noqa: PLC0415
 
-                raise_token_exchange_challenge(server)
+                raise_token_exchange_challenge(server, root_path=get_server_root_path())
 
             # Pass-through OAuth: when the admin has opted a server into
             # forwarding the client's bearer token (is_oauth_passthrough) and

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2693,12 +2693,18 @@ if MCP_AVAILABLE:
 
             # Forward named client headers to OpenAPI tool upstream requests.
             # MCPServer.extra_headers lists header names to copy from raw_headers.
-            # OAuth2 M2M: never take Authorization from the caller (matches
-            # _prepare_mcp_server_headers for managed MCP).
+            # The strip decision is centralized in _should_strip_caller_authorization so this
+            # OpenAPI/local path agrees with the managed paths: M2M and the resolver-owned modes
+            # (token_exchange's raw subject token, authorization_code's stored token) must never
+            # have the caller's Authorization forwarded verbatim upstream.
             forwarded_headers: Optional[Dict[str, str]] = None
             if mcp_server and mcp_server.extra_headers and raw_headers:
                 normalized_raw = {str(k).lower(): v for k, v in raw_headers.items() if isinstance(k, str)}
-                skip_caller_authorization = bool(mcp_server.has_client_credentials)
+                skip_caller_authorization = _should_strip_caller_authorization(
+                    mcp_server=mcp_server,
+                    raw_headers=raw_headers,
+                    user_api_key_auth=user_api_key_auth,
+                )
                 for header_name in mcp_server.extra_headers:
                     if not isinstance(header_name, str):
                         continue

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3473,6 +3473,18 @@ if MCP_AVAILABLE:
                     headers={"www-authenticate": authorization_uri},
                 )
 
+            # token_exchange (OBO): the caller supplied no subject token. Challenge at connect
+            # (transport level, where WWW-Authenticate survives) with the RFC 9728 resource_metadata
+            # so the client discovers the IdP, SSOs, and retries with a subject token, which LiteLLM
+            # then exchanges. A tool-call-time 401 would be wrapped into a JSON-RPC error and the
+            # header lost, so the discovery flow needs this pre-emptive challenge.
+            if server and server.auth_type == MCPAuth.oauth2_token_exchange and not oauth2_headers:
+                from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (  # noqa: PLC0415
+                    raise_token_exchange_challenge,
+                )
+
+                raise_token_exchange_challenge(server)
+
             # Pass-through OAuth: when the admin has opted a server into
             # forwarding the client's bearer token (is_oauth_passthrough) and
             # the client hasn't supplied one, fail fast with 401 and point

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1838,6 +1838,7 @@ if MCP_AVAILABLE:
                         add_prefix=True,  # Always add server prefix
                         raw_headers=raw_headers,
                         user_api_key_auth=user_api_key_auth,
+                        oauth2_headers=oauth2_headers,
                     )
                     filtered_tools = filter_tools_by_allowed_tools(tools, server)
 

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -955,6 +955,7 @@ async def test_get_tools_from_mcp_servers():
                 add_prefix=False,
                 raw_headers=None,
                 user_api_key_auth=None,
+                oauth2_headers=None,
             ):
                 if server.server_id == "server1_id":
                     return [mock_tool_1]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -158,6 +158,22 @@ def test_token_exchange_omits_audience_when_unset():
     assert spec.config.audience is None
 
 
+def test_token_exchange_empty_subject_token_type_normalizes_to_default():
+    # Parity with v1: a falsy subject_token_type must not be sent verbatim to the IdP.
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+            subject_token_type="",
+        )
+    )
+    assert spec is not None
+    assert isinstance(spec.config, TokenExchangeConfig)
+    assert spec.config.subject_token_type == "urn:ietf:params:oauth:token-type:access_token"
+
+
 @pytest.mark.parametrize(
     "server",
     [

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -282,3 +282,19 @@ def test_raise_user_oauth_challenge_name_fallback(kwargs, expected_name):
     with patch(_ROOT_PATH, return_value="/"), pytest.raises(HTTPException) as exc_info:
         raise_user_oauth_challenge(_server(**kwargs))
     assert f'/mcp/{expected_name}"' in exc_info.value.headers["WWW-Authenticate"]
+
+
+def test_raise_token_exchange_challenge_is_rfc9728_invalid_token():
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+        raise_token_exchange_challenge,
+    )
+
+    with patch(_ROOT_PATH, return_value="/"), pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(_server(alias="obo-srv"))
+    exc = exc_info.value
+    www = exc.headers["WWW-Authenticate"]
+    assert exc.status_code == 401
+    # RFC 9728 resource_metadata so the client can discover the IdP, plus RFC 6750 invalid_token.
+    assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo-srv"' in www
+    assert 'error="invalid_token"' in www
+    assert "error_description=" in www

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -7,12 +7,12 @@ maps each CredError onto its HTTP status. These pin the parity-critical mapping 
 
 import base64
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
 
 from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+    oauth_protected_resource_path,
     raise_public,
     raise_user_oauth_challenge,
     to_server_spec,
@@ -245,29 +245,17 @@ def test_raise_public_plain_unauthorized_has_no_challenge():
     assert exc.headers is None
 
 
-_ROOT_PATH = "litellm.proxy.utils.get_server_root_path"
-
-
-def test_raise_user_oauth_challenge_points_at_per_server_prm():
-    with patch(_ROOT_PATH, return_value="/"), pytest.raises(HTTPException) as exc_info:
-        raise_user_oauth_challenge(_server(alias="my-srv"))
-    exc = exc_info.value
-    assert exc.status_code == 401
-    assert (
-        exc.headers["WWW-Authenticate"] == 'Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/my-srv"'
-    )
-
-
-def test_raise_user_oauth_challenge_includes_server_root_path():
-    with (
-        patch(_ROOT_PATH, return_value="/api/v1"),
-        pytest.raises(HTTPException) as exc_info,
-    ):
-        raise_user_oauth_challenge(_server(alias="my-srv"))
-    assert (
-        exc_info.value.headers["WWW-Authenticate"]
-        == 'Bearer resource_metadata="/.well-known/oauth-protected-resource/api/v1/mcp/my-srv"'
-    )
+@pytest.mark.parametrize(
+    "root_path, expected_prefix",
+    [
+        ("/", ""),  # "/" means no prefix
+        ("", ""),  # empty means no prefix
+        ("/api/v1", "/api/v1"),  # a real root path is prepended verbatim
+    ],
+)
+def test_oauth_protected_resource_path_honors_root_path(root_path, expected_prefix):
+    path = oauth_protected_resource_path(root_path, _server(alias="my-srv"))
+    assert path == f"/.well-known/oauth-protected-resource{expected_prefix}/mcp/my-srv"
 
 
 @pytest.mark.parametrize(
@@ -278,10 +266,27 @@ def test_raise_user_oauth_challenge_includes_server_root_path():
         ({}, "n"),  # then the name field (server_id is the last fallback)
     ],
 )
-def test_raise_user_oauth_challenge_name_fallback(kwargs, expected_name):
-    with patch(_ROOT_PATH, return_value="/"), pytest.raises(HTTPException) as exc_info:
-        raise_user_oauth_challenge(_server(**kwargs))
-    assert f'/mcp/{expected_name}"' in exc_info.value.headers["WWW-Authenticate"]
+def test_oauth_protected_resource_path_name_fallback(kwargs, expected_name):
+    assert oauth_protected_resource_path("/", _server(**kwargs)).endswith(f"/mcp/{expected_name}")
+
+
+def test_raise_user_oauth_challenge_points_at_per_server_prm():
+    with pytest.raises(HTTPException) as exc_info:
+        raise_user_oauth_challenge(_server(alias="my-srv"), root_path="/")
+    exc = exc_info.value
+    assert exc.status_code == 401
+    assert (
+        exc.headers["WWW-Authenticate"] == 'Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/my-srv"'
+    )
+
+
+def test_raise_user_oauth_challenge_includes_server_root_path():
+    with pytest.raises(HTTPException) as exc_info:
+        raise_user_oauth_challenge(_server(alias="my-srv"), root_path="/api/v1")
+    assert (
+        exc_info.value.headers["WWW-Authenticate"]
+        == 'Bearer resource_metadata="/.well-known/oauth-protected-resource/api/v1/mcp/my-srv"'
+    )
 
 
 def test_raise_token_exchange_challenge_is_rfc9728_invalid_token():
@@ -289,8 +294,8 @@ def test_raise_token_exchange_challenge_is_rfc9728_invalid_token():
         raise_token_exchange_challenge,
     )
 
-    with patch(_ROOT_PATH, return_value="/"), pytest.raises(HTTPException) as exc_info:
-        raise_token_exchange_challenge(_server(alias="obo-srv"))
+    with pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="/")
     exc = exc_info.value
     www = exc.headers["WWW-Authenticate"]
     assert exc.status_code == 401
@@ -298,3 +303,14 @@ def test_raise_token_exchange_challenge_is_rfc9728_invalid_token():
     assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo-srv"' in www
     assert 'error="invalid_token"' in www
     assert "error_description=" in www
+
+
+def test_raise_token_exchange_challenge_includes_server_root_path():
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+        raise_token_exchange_challenge,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="/api/v1")
+    www = exc_info.value.headers["WWW-Authenticate"]
+    assert 'resource_metadata="/.well-known/oauth-protected-resource/api/v1/mcp/obo-srv"' in www

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -144,6 +144,22 @@ def test_token_exchange_falls_back_to_token_url_when_no_exchange_endpoint():
     assert spec.config.token_exchange_endpoint == "https://idp.example.com/token"
 
 
+def test_token_exchange_with_creds_but_no_endpoint_is_owned_for_fail_closed():
+    # An OBO server with client credentials but no endpoint is still owned by v2 (spec, not None) so
+    # it fails closed at the exchanger (412) rather than silently deferring to v1 and connecting
+    # unauthenticated. The endpoint stays None for the exchanger to reject.
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2_token_exchange,
+            client_id="cid",
+            client_secret="csec",
+        )
+    )
+    assert spec is not None
+    assert isinstance(spec.config, TokenExchangeConfig)
+    assert spec.config.token_exchange_endpoint is None
+
+
 def test_token_exchange_omits_audience_when_unset():
     spec = to_server_spec(
         _server(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
@@ -172,11 +172,15 @@ async def test_has_user_token_false_for_a_non_per_user_mode():
 class _FakeExchanger:
     def __init__(self, result: Result[OAuthToken, CredError]) -> None:
         self._result = result
-        self.calls: list[tuple[str, str]] = []
+        self.calls: list[tuple[str, str, str]] = []
+        self.invalidations: list[tuple[str, str, str]] = []
 
-    async def exchange(self, subject_token, server, config):
-        self.calls.append((subject_token, server.server_id))
+    async def exchange(self, subject_token, server, config, *, tenant_id=""):
+        self.calls.append((subject_token, tenant_id, server.server_id))
         return self._result
+
+    async def invalidate(self, subject_token, server, config, *, tenant_id=""):
+        self.invalidations.append((subject_token, tenant_id, server.server_id))
 
 
 _OBO = TokenExchangeConfig(
@@ -189,12 +193,29 @@ _OBO = TokenExchangeConfig(
 @pytest.mark.asyncio
 async def test_token_exchange_emits_the_exchanged_bearer():
     exchanger = _FakeExchanger(Ok(OAuthToken(access_token="exchanged-at")))
-    subject = Subject(tenant_id="", subject_id="alice", inbound_token=SecretStr("caller-jwt"))
+    subject = Subject(tenant_id="acme", subject_id="alice", inbound_token=SecretStr("caller-jwt"))
     result = await UpstreamCredentialProvider(token_exchanger=exchanger).resolve_credentials(subject, _spec(_OBO))
     assert isinstance(result, Ok)
     assert _emitted(result.ok)["Authorization"] == "Bearer exchanged-at"
-    # The arm hands the unwrapped caller token to the exchanger, never the upstream.
-    assert exchanger.calls == [("caller-jwt", "s")]
+    # The arm hands the unwrapped caller token AND the tenant to the exchanger, never the upstream.
+    assert exchanger.calls == [("caller-jwt", "acme", "s")]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_credentials_drops_the_exchanged_token_for_the_subject_and_tenant():
+    exchanger = _FakeExchanger(Ok(OAuthToken(access_token="exchanged-at")))
+    provider = UpstreamCredentialProvider(token_exchanger=exchanger)
+    subject = Subject(tenant_id="acme", subject_id="alice", inbound_token=SecretStr("caller-jwt"))
+    await provider.invalidate_credentials(subject, _spec(_OBO))
+    assert exchanger.invalidations == [("caller-jwt", "acme", "s")]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_credentials_is_a_noop_without_a_caller_token():
+    exchanger = _FakeExchanger(Ok(OAuthToken(access_token="never")))
+    provider = UpstreamCredentialProvider(token_exchanger=exchanger)
+    await provider.invalidate_credentials(Subject(tenant_id="acme", subject_id="alice"), _spec(_OBO))
+    assert exchanger.invalidations == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
@@ -14,9 +14,30 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchange_
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
     Rfc8693TokenExchanger,
+    SubjectTokenRejected,
+    TokenExchangeClientError,
 )
 
 _HTTP_CLIENT = "litellm.llms.custom_httpx.http_handler.get_async_httpx_client"
+
+
+def _client_raising_4xx(body: object):
+    """An httpx client whose POST returns a 4xx whose ``raise_for_status`` raises an HTTPStatusError
+    carrying ``body`` as its JSON, so the RFC 6749 error-code classification can be driven."""
+    import httpx
+
+    request = httpx.Request("POST", "https://idp/token")
+    response = httpx.Response(400, json=body, request=request)
+
+    class _Resp:
+        def raise_for_status(self) -> None:
+            raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+    class _Client:
+        async def post(self, url, headers, data):
+            return _Resp()
+
+    return _Client()
 
 
 def test_build_token_exchanger_returns_an_exchanger():
@@ -51,6 +72,30 @@ async def test_post_parses_json_body_on_success():
     with patch(_HTTP_CLIENT, return_value=_Client()):
         result = await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
     assert result == {"access_token": "x", "expires_in": 60}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "code", ["invalid_client", "unauthorized_client", "unsupported_grant_type", "invalid_target", "invalid_scope"]
+)
+async def test_post_maps_gateway_fault_4xx_to_client_error(code):
+    # RFC 6749 5.2 gateway-fault codes must raise TokenExchangeClientError (-> 500), not the caller 401.
+    with patch(_HTTP_CLIENT, return_value=_client_raising_4xx({"error": code})):
+        with pytest.raises(TokenExchangeClientError):
+            await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [{"error": "invalid_grant"}, {"error": "invalid_request"}, {}, {"error": 123}, "not-json-object"],
+    ids=["invalid_grant", "invalid_request", "no_error", "non_str_error", "non_dict"],
+)
+async def test_post_maps_subject_fault_4xx_to_subject_rejected(body):
+    # A subject-fault code (or an unparseable/absent error) is the caller's problem -> SubjectTokenRejected (401).
+    with patch(_HTTP_CLIENT, return_value=_client_raising_4xx(body)):
+        with pytest.raises(SubjectTokenRejected):
+            await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -155,6 +155,43 @@ async def test_rotated_caller_token_re_exchanges():
 
 
 @pytest.mark.asyncio
+async def test_same_token_different_tenant_does_not_share_cache():
+    # Two tenants presenting the same opaque token (e.g. a shared/service token) must not collide on
+    # one cache entry: tenant_id is part of the key, so each tenant gets its own exchange.
+    post = _RecordingPost({"access_token": "x", "expires_in": 3600})
+    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="globex")
+    assert len(post.calls) == 2
+    # Same tenant + token still hits the cache.
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    assert len(post.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_forces_re_exchange():
+    post = _RecordingPost({"access_token": "x", "expires_in": 3600})
+    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    await exchanger.invalidate("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    assert len(post.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_targets_only_the_matching_tenant():
+    post = _RecordingPost({"access_token": "x", "expires_in": 3600})
+    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="globex")
+    await exchanger.invalidate("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    # globex's entry survives; only acme re-exchanges.
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="globex")
+    await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
+    assert len(post.calls) == 3
+
+
+@pytest.mark.asyncio
 async def test_rotated_config_re_exchanges_before_ttl():
     # Same caller token + server, but the operator rotated the audience/scope: the cached token was
     # minted for the old config, so it must re-exchange (not serve the stale token) before TTL.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -128,6 +128,23 @@ async def test_exchange_maps_idp_rejection_to_unauthorized():
 
 
 @pytest.mark.asyncio
+async def test_exchange_maps_gateway_fault_to_misconfigured():
+    """A gateway-fault RFC 6749 code (invalid_client / invalid_target / ..., surfaced as
+    TokenExchangeClientError) is the gateway's problem, not the caller's, so it maps to misconfigured
+    (500) rather than the retryable 503 or the 401 OBO challenge the caller can't act on."""
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
+        TokenExchangeClientError,
+    )
+
+    async def _client_error_post(url, form, headers):
+        raise TokenExchangeClientError("invalid_client")
+
+    result = await Rfc8693TokenExchanger(_client_error_post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+
+
+@pytest.mark.asyncio
 async def test_exchange_maps_transport_failure_to_upstream_unavailable():
     """A post returning None (5xx / network / timeout / malformed body) stays retryable: 503."""
     result = await Rfc8693TokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -112,6 +112,30 @@ async def test_client_secret_post_keeps_creds_in_body_with_no_auth_header():
 
 
 @pytest.mark.asyncio
+async def test_exchange_maps_idp_rejection_to_unauthorized():
+    """An IdP 4xx (surfaced as SubjectTokenRejected by the post adapter) is non-retryable: it maps
+    to ``unauthorized`` (the 401 OBO challenge), not the retryable ``upstream_unavailable`` (503)."""
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
+        SubjectTokenRejected,
+    )
+
+    async def _rejecting_post(url, form):
+        raise SubjectTokenRejected("IdP rejected the token exchange (HTTP 400)")
+
+    result = await Rfc8693TokenExchanger(_rejecting_post, clock=_Clock()).exchange("bad-jwt", _SERVER, _CONFIG)
+    assert isinstance(result, Error)
+    assert result.error.tag == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_exchange_maps_transport_failure_to_upstream_unavailable():
+    """A post returning None (5xx / network / timeout / malformed body) stays retryable: 503."""
+    result = await Rfc8693TokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    assert isinstance(result, Error)
+    assert result.error.tag == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_exchange_caches_per_caller_token():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
     exchanger = Rfc8693TokenExchanger(post, clock=_Clock())

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -325,7 +325,6 @@ async def test_access_or_unknown_issued_token_type_is_accepted(issued_token_type
 @pytest.mark.parametrize(
     "config",
     [
-        TokenExchangeConfig(client_id="c", client_secret=SecretStr("s")),
         TokenExchangeConfig(token_exchange_endpoint="https://idp/token", client_secret=SecretStr("s")),
         TokenExchangeConfig(token_exchange_endpoint="https://idp/token", client_id="c"),
     ],
@@ -335,6 +334,18 @@ async def test_incomplete_config_is_misconfigured_without_hitting_idp(config):
     result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     assert isinstance(result, Error)
     assert result.error.tag == "misconfigured"
+    assert post.calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_endpoint_is_precondition_required_without_hitting_idp():
+    # No endpoint configured (and none discoverable): fail closed with a 412-mapped precondition
+    # rather than guessing an IdP or falling back. The subject token is never POSTed anywhere.
+    config = TokenExchangeConfig(client_id="c", client_secret=SecretStr("s"))
+    post = _RecordingPost({"access_token": "x"})
+    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    assert isinstance(result, Error)
+    assert result.error.tag == "precondition_required"
     assert post.calls == []
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -307,13 +307,29 @@ async def test_audience_and_scope_omitted_when_unset():
 
 
 @pytest.mark.asyncio
-async def test_string_expires_in_is_honored():
+@pytest.mark.parametrize("expires_in", ["120", 120.0, "120.0"], ids=["str", "float", "str_float"])
+async def test_numeric_expires_in_is_honored(expires_in):
+    # A JSON int/float/numeric-string expires_in must drive the TTL, not fall back to the default.
     clock = _Clock(1000.0)
-    # "120" parsed as int -> ttl max(120-60, 10) = 60 -> cached until 1060.
-    post = _RecordingPost({"access_token": "x", "expires_in": "120"})
-    exchanger = Rfc8693TokenExchanger(post, clock=clock)
+    post = _RecordingPost({"access_token": "x", "expires_in": expires_in})
+    exchanger = Rfc8693TokenExchanger(post, clock=clock)  # ttl = max(120-60, 10) = 60 -> until 1060
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     clock.now = 1061.0
+    await exchanger.exchange("jwt", _SERVER, _CONFIG)
+    assert len(post.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_short_lived_token_is_not_cached_past_its_expiry():
+    # expires_in (5s) below the buffer/min floor must NOT be served stale: cache only until expiry.
+    clock = _Clock(1000.0)
+    post = _RecordingPost({"access_token": "x", "expires_in": 5})
+    exchanger = Rfc8693TokenExchanger(post, clock=clock)
+    await exchanger.exchange("jwt", _SERVER, _CONFIG)
+    clock.now = 1004.0  # within the 5s lifetime -> still cached
+    await exchanger.exchange("jwt", _SERVER, _CONFIG)
+    assert len(post.calls) == 1
+    clock.now = 1006.0  # past expiry -> re-exchange, not a stale bearer
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     assert len(post.calls) == 2
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -119,7 +119,7 @@ async def test_exchange_maps_idp_rejection_to_unauthorized():
         SubjectTokenRejected,
     )
 
-    async def _rejecting_post(url, form):
+    async def _rejecting_post(url, form, headers):
         raise SubjectTokenRejected("IdP rejected the token exchange (HTTP 400)")
 
     result = await Rfc8693TokenExchanger(_rejecting_post, clock=_Clock()).exchange("bad-jwt", _SERVER, _CONFIG)
@@ -268,6 +268,19 @@ async def test_non_bearer_token_type_is_refused(token_type):
     result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_non_bearer_token_type_is_logged():
+    from unittest.mock import patch
+
+    post = _RecordingPost({"access_token": "x", "token_type": "N_A", "expires_in": 3600})
+    with patch(
+        "litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger.verbose_logger"
+    ) as mock_logger:
+        await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    assert mock_logger.warning.called
+    assert "N_A" in repr(mock_logger.warning.call_args)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -96,9 +96,7 @@ async def test_authorize_endpoint_includes_response_type():
     mock_request.headers = {}
 
     # Mock the encryption functions to avoid needing a signing key
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "mocked_encrypted_state"
 
         # Call authorize endpoint
@@ -160,9 +158,7 @@ async def test_authorize_endpoint_preserves_existing_query_params():
     mock_request.base_url = "https://litellm.example.com/"
     mock_request.headers = {}
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "mocked_encrypted_state"
 
         response = await authorize(
@@ -176,9 +172,7 @@ async def test_authorize_endpoint_preserves_existing_query_params():
     location = response.headers["location"]
 
     # Must NOT have double '?' — existing params must be merged correctly
-    assert (
-        location.count("?") == 1
-    ), f"Expected exactly one '?' in URL but got {location.count('?')}: {location}"
+    assert location.count("?") == 1, f"Expected exactly one '?' in URL but got {location.count('?')}: {location}"
     assert "tenant=system" in location
     assert "client_id=test_client_id" in location
     assert "response_type=code" in location
@@ -228,9 +222,7 @@ async def test_authorize_endpoint_forwards_pkce_parameters():
     mock_request.headers = {}
 
     # Mock the encryption function
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "mocked_encrypted_state_with_pkce"
 
         # Call authorize endpoint with PKCE parameters
@@ -338,10 +330,7 @@ async def test_token_endpoint_forwards_code_verifier():
     # Check the data parameter includes code_verifier
     assert call_args[1]["data"]["code_verifier"] == "test_code_verifier_from_client"
     assert call_args[1]["data"]["code"] == "4/test_authorization_code"
-    assert (
-        call_args[1]["data"]["client_id"]
-        == "669428968603-test.apps.googleusercontent.com"
-    )
+    assert call_args[1]["data"]["client_id"] == "669428968603-test.apps.googleusercontent.com"
     assert call_args[1]["data"]["client_secret"] == "GOCSPX-test_secret"
     assert call_args[1]["data"]["grant_type"] == "authorization_code"
 
@@ -428,9 +417,7 @@ async def test_register_client_returns_existing_server_credentials():
             "litellm.proxy._experimental.mcp_server.discoverable_endpoints._read_request_body",
             new=AsyncMock(return_value={}),
         ):
-            result = await register_client(
-                request=mock_request, mcp_server_name=oauth2_server.server_name
-            )
+            result = await register_client(request=mock_request, mcp_server_name=oauth2_server.server_name)
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -505,9 +492,7 @@ async def test_register_client_remote_registration_success():
                 return_value=mock_async_client,
             ),
         ):
-            response = await register_client(
-                request=mock_request, mcp_server_name=oauth2_server.server_name
-            )
+            response = await register_client(request=mock_request, mcp_server_name=oauth2_server.server_name)
     finally:
         global_mcp_server_manager.registry.clear()
 
@@ -524,14 +509,9 @@ async def test_register_client_remote_registration_success():
         "Content-Type": "application/json",
         "Accept": "application/json",
     }
-    assert call_args.kwargs["json"]["redirect_uris"] == [
-        "https://proxy.litellm.example/callback"
-    ]
+    assert call_args.kwargs["json"]["redirect_uris"] == ["https://proxy.litellm.example/callback"]
     assert call_args.kwargs["json"]["grant_types"] == request_payload["grant_types"]
-    assert (
-        call_args.kwargs["json"]["token_endpoint_auth_method"]
-        == request_payload["token_endpoint_auth_method"]
-    )
+    assert call_args.kwargs["json"]["token_endpoint_auth_method"] == request_payload["token_endpoint_auth_method"]
 
 
 @pytest.mark.asyncio
@@ -1120,9 +1100,7 @@ async def test_authorize_endpoint_respects_x_forwarded_proto():
     mock_request.headers = {"X-Forwarded-Proto": "https"}  # Behind HTTPS proxy
 
     # Mock the encryption functions
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "mocked_encrypted_state"
 
         # Call authorize endpoint
@@ -1217,10 +1195,7 @@ async def test_token_endpoint_respects_x_forwarded_proto():
 
     # Verify that the redirect_uri sent to the provider uses HTTPS
     call_args = mock_async_client.post.call_args
-    assert (
-        call_args[1]["data"]["redirect_uri"]
-        == "https://litellm-proxy.example.com/callback"
-    )
+    assert call_args[1]["data"]["redirect_uri"] == "https://litellm-proxy.example.com/callback"
 
 
 @pytest.mark.asyncio
@@ -1272,9 +1247,7 @@ async def test_oauth_protected_resource_respects_x_forwarded_proto():
     )
 
     # Verify response uses HTTPS URLs
-    assert response["authorization_servers"][0].startswith(
-        "https://litellm.example.com/"
-    )
+    assert response["authorization_servers"][0].startswith("https://litellm.example.com/")
     assert response["scopes_supported"] == oauth2_server.scopes
 
 
@@ -1421,9 +1394,7 @@ async def test_authorize_endpoint_respects_x_forwarded_host():
     }
 
     # Mock the encryption functions
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "mocked_encrypted_state"
 
         # Call authorize endpoint
@@ -1440,8 +1411,7 @@ async def test_authorize_endpoint_respects_x_forwarded_host():
 
     # The redirect_uri parameter should use the external URL
     assert (
-        "redirect_uri=https%3A%2F%2Fproxy.example.com%2Fgithub%2Fmcp%2Fcallback"
-        in location
+        "redirect_uri=https%3A%2F%2Fproxy.example.com%2Fgithub%2Fmcp%2Fcallback" in location
         or "redirect_uri=https://proxy.example.com/github/mcp/callback" in location
     )
 
@@ -1522,10 +1492,7 @@ async def test_token_endpoint_respects_x_forwarded_host():
 
     # Verify that the redirect_uri sent to the provider uses the external URL
     call_args = mock_async_client.post.call_args
-    assert (
-        call_args[1]["data"]["redirect_uri"]
-        == "https://proxy.example.com/github/mcp/callback"
-    )
+    assert call_args[1]["data"]["redirect_uri"] == "https://proxy.example.com/github/mcp/callback"
 
 
 @pytest.mark.parametrize(
@@ -1733,9 +1700,7 @@ def test_get_request_base_url_comprehensive(
         ),
     ],
 )
-def test_get_request_base_url_xff_trust_gate(
-    general_settings, direct_ip, expect_xff_honoured
-):
+def test_get_request_base_url_xff_trust_gate(general_settings, direct_ip, expect_xff_honoured):
     """Verify the X-Forwarded-* trust gate.
 
     With XFF poisoning attempted, the helper must return either the literal
@@ -1813,12 +1778,10 @@ def test_xff_misconfig_warning_emitted_once(caplog):
         for _ in range(3):
             get_request_base_url(mock_request)
 
-    matching = [
-        rec for rec in caplog.records if "mcp_trusted_proxy_ranges" in rec.getMessage()
-    ]
-    assert (
-        len(matching) == 1
-    ), f"expected exactly one warning, got {len(matching)}: {[r.getMessage() for r in matching]}"
+    matching = [rec for rec in caplog.records if "mcp_trusted_proxy_ranges" in rec.getMessage()]
+    assert len(matching) == 1, (
+        f"expected exactly one warning, got {len(matching)}: {[r.getMessage() for r in matching]}"
+    )
 
 
 def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
@@ -1849,9 +1812,7 @@ def test_get_request_base_url_honors_proxy_base_url_env(monkeypatch):
     assert get_request_base_url(mock_request) == "https://litellm.example.com"
 
 
-def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
-    caplog, monkeypatch
-):
+def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(caplog, monkeypatch):
     try:
         from fastapi import HTTPException, Request
 
@@ -1898,8 +1859,7 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
 
     matching = [r for r in caplog.records if "rejecting redirect_uri" in r.getMessage()]
     assert len(matching) == 1, (
-        "expected exactly one diagnostic warning, got "
-        f"{[r.getMessage() for r in caplog.records]}"
+        f"expected exactly one diagnostic warning, got {[r.getMessage() for r in caplog.records]}"
     )
     msg = matching[0].getMessage()
     assert "https://litellm.example.com/ui/mcp/oauth/callback" in msg
@@ -1918,9 +1878,7 @@ def test_validate_trusted_redirect_uri_logs_diagnostic_on_rejection(
         "not a url at all",
     ],
 )
-def test_get_request_base_url_rejects_malformed_proxy_base_url(
-    bad_value, monkeypatch, caplog
-):
+def test_get_request_base_url_rejects_malformed_proxy_base_url(bad_value, monkeypatch, caplog):
     try:
         from fastapi import Request
 
@@ -1950,26 +1908,16 @@ def test_get_request_base_url_rejects_malformed_proxy_base_url(
         result = get_request_base_url(mock_request)
 
     assert result == "http://litellm-internal:4000", (
-        f"malformed PROXY_BASE_URL={bad_value!r} should be ignored, " f"got {result!r}"
+        f"malformed PROXY_BASE_URL={bad_value!r} should be ignored, got {result!r}"
     )
-    matching = [
-        r
-        for r in caplog.records
-        if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()
-    ]
+    matching = [r for r in caplog.records if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()]
     assert len(matching) == 1, (
-        "expected one diagnostic for malformed PROXY_BASE_URL, got "
-        f"{[r.getMessage() for r in caplog.records]}"
+        f"expected one diagnostic for malformed PROXY_BASE_URL, got {[r.getMessage() for r in caplog.records]}"
     )
-    assert (
-        repr(bad_value) in matching[0].getMessage()
-        or bad_value in matching[0].getMessage()
-    )
+    assert repr(bad_value) in matching[0].getMessage() or bad_value in matching[0].getMessage()
 
 
-def test_get_request_base_url_malformed_proxy_base_url_warning_is_one_shot(
-    monkeypatch, caplog
-):
+def test_get_request_base_url_malformed_proxy_base_url_warning_is_one_shot(monkeypatch, caplog):
     try:
         from fastapi import Request
 
@@ -1999,14 +1947,8 @@ def test_get_request_base_url_malformed_proxy_base_url_warning_is_one_shot(
         for _ in range(5):
             get_request_base_url(mock_request)
 
-    matching = [
-        r
-        for r in caplog.records
-        if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()
-    ]
-    assert (
-        len(matching) == 1
-    ), f"expected exactly one warning across 5 calls, got {len(matching)}"
+    matching = [r for r in caplog.records if "PROXY_BASE_URL" in r.getMessage() and "ignored" in r.getMessage()]
+    assert len(matching) == 1, f"expected exactly one warning across 5 calls, got {len(matching)}"
 
 
 # -------------------------------------------------------------------
@@ -2219,12 +2161,8 @@ async def test_authorize_root_fails_with_multiple_oauth2_servers():
         pytest.skip("MCP discoverable endpoints not available")
 
     global_mcp_server_manager.registry.clear()
-    server1 = _create_oauth2_server(
-        server_id="server1", name="server1", server_name="server1", alias="server1"
-    )
-    server2 = _create_oauth2_server(
-        server_id="server2", name="server2", server_name="server2", alias="server2"
-    )
+    server1 = _create_oauth2_server(server_id="server1", name="server1", server_name="server1", alias="server1")
+    server2 = _create_oauth2_server(server_id="server2", name="server2", server_name="server2", alias="server2")
     global_mcp_server_manager.registry[server1.server_id] = server1
     global_mcp_server_manager.registry[server2.server_id] = server2
 
@@ -2582,9 +2520,7 @@ async def test_oauth_callback_redirects_with_state():
         "client_redirect_uri": "http://localhost:3000/ui/mcp/oauth/callback",
     }
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = mock_state_data
 
         # Call callback endpoint with code and state
@@ -2596,10 +2532,7 @@ async def test_oauth_callback_redirects_with_state():
 
         # Should redirect to the client callback URL with code and original state
         assert response.status_code == 302
-        assert (
-            "http://localhost:3000/ui/mcp/oauth/callback"
-            in response.headers["location"]
-        )
+        assert "http://localhost:3000/ui/mcp/oauth/callback" in response.headers["location"]
         assert "code=test_authorization_code_12345" in response.headers["location"]
         assert "state=test-uuid-state-123" in response.headers["location"]
 
@@ -2619,17 +2552,13 @@ async def test_oauth_callback_preserves_client_redirect_uri_query():
     except ImportError:
         pytest.skip("MCP discoverable endpoints not available")
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = {
             "base_url": "http://localhost:3000/ui/mcp/oauth/callback",
             "original_state": "test-uuid-state-123",
             "code_challenge": "test_challenge",
             "code_challenge_method": "S256",
-            "client_redirect_uri": (
-                "http://localhost:3000/ui/mcp/oauth/callback?session=abc"
-            ),
+            "client_redirect_uri": ("http://localhost:3000/ui/mcp/oauth/callback?session=abc"),
         }
 
         response = await callback(
@@ -2657,9 +2586,7 @@ async def test_oauth_callback_handles_invalid_state():
         pytest.skip("MCP discoverable endpoints not available")
 
     # Mock state decoding to raise an exception
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.side_effect = Exception("Failed to decrypt state")
 
         # Call callback endpoint with invalid state
@@ -2682,9 +2609,7 @@ async def test_oauth_callback_accepts_same_origin_ui_redirect():
         callback,
     )
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = {
             "base_url": "https://proxy.example.com/ui/mcp/oauth/callback",
             "original_state": "state-123",
@@ -2700,10 +2625,7 @@ async def test_oauth_callback_accepts_same_origin_ui_redirect():
         )
 
     assert response.status_code == 302
-    assert (
-        "https://proxy.example.com/ui/mcp/oauth/callback"
-        in response.headers["location"]
-    )
+    assert "https://proxy.example.com/ui/mcp/oauth/callback" in response.headers["location"]
     assert "code=auth-code-123" in response.headers["location"]
     assert "state=state-123" in response.headers["location"]
 
@@ -2740,9 +2662,7 @@ async def test_oauth_authorize_includes_scopes_from_server_config():
     mock_request.base_url = "https://litellm.example.com/"
     mock_request.headers = {}
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "encrypted_state"
 
         # Call authorize without explicit scope parameter
@@ -2762,8 +2682,7 @@ async def test_oauth_authorize_includes_scopes_from_server_config():
         assert response.status_code in (307, 302)
         redirect_url = response.headers["location"]
         assert (
-            "scope=api+read_user+ai_workflows" in redirect_url
-            or "scope=api%20read_user%20ai_workflows" in redirect_url
+            "scope=api+read_user+ai_workflows" in redirect_url or "scope=api%20read_user%20ai_workflows" in redirect_url
         )
 
 
@@ -2798,9 +2717,7 @@ async def test_oauth_authorize_prefers_request_scope_over_server_config():
     mock_request.base_url = "https://litellm.example.com/"
     mock_request.headers = {}
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper"
-    ) as mock_encrypt:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
         mock_encrypt.return_value = "encrypted_state"
 
         # Call authorize WITH explicit scope parameter
@@ -2820,8 +2737,7 @@ async def test_oauth_authorize_prefers_request_scope_over_server_config():
         assert response.status_code in (307, 302)
         redirect_url = response.headers["location"]
         assert (
-            "scope=custom_scope1+custom_scope2" in redirect_url
-            or "scope=custom_scope1%20custom_scope2" in redirect_url
+            "scope=custom_scope1+custom_scope2" in redirect_url or "scope=custom_scope1%20custom_scope2" in redirect_url
         )
         assert "default_scope" not in redirect_url
 
@@ -3078,9 +2994,7 @@ async def test_callback_revalidates_loopback_on_decoded_base_url():
         callback,
     )
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = {
             "base_url": "https://attacker.example.com/cb",
             "original_state": "s",
@@ -3104,9 +3018,7 @@ async def test_callback_revalidates_loopback_on_decoded_client_redirect_uri():
         callback,
     )
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = {
             "base_url": "http://localhost:3000/cb",
             "original_state": "s",
@@ -3130,9 +3042,7 @@ async def test_callback_rejects_state_missing_redirect_uri():
         callback,
     )
 
-    with patch(
-        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash"
-    ) as mock_decode:
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.decode_state_hash") as mock_decode:
         mock_decode.return_value = {
             "original_state": "s",
             "code_challenge": None,
@@ -3261,9 +3171,7 @@ async def test_token_exchange_omits_expires_in_when_upstream_omits_it():
     rotation) returns no ``expires_in``. The exchange must mirror that and omit
     ``expires_in`` rather than fabricate a 1-hour TTL, so the stored credential
     is treated as non-expiring instead of dying after an hour."""
-    body = await _exchange_with_upstream_token_response(
-        {"access_token": "tok", "token_type": "Bearer"}
-    )
+    body = await _exchange_with_upstream_token_response({"access_token": "tok", "token_type": "Bearer"})
     assert "expires_in" not in body
 
 
@@ -3275,6 +3183,120 @@ async def test_token_exchange_passes_through_upstream_expires_in():
         {"access_token": "tok", "token_type": "Bearer", "expires_in": 43200}
     )
     assert body["expires_in"] == 43200
+
+
+# -------------------------------------------------------------------
+# OBO (token_exchange) Protected Resource Metadata: discovery must name the
+# JWT-auth issuer the client SSOs with, not the gateway.
+# -------------------------------------------------------------------
+
+_OBO_RESOURCE = "https://litellm.example.com/mcp/obo_mcp"
+_PATCH_ISSUERS = "litellm.proxy._experimental.mcp_server.discoverable_endpoints._jwt_auth_issuers"
+
+
+def _obo_server(scopes=None):
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    return MCPServer(
+        server_id="obo_mcp",
+        name="obo_mcp",
+        server_name="obo_mcp",
+        alias="obo_mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2_token_exchange,
+        scopes=scopes,
+    )
+
+
+def test_obo_protected_resource_response_names_jwt_issuers():
+    """An OBO server's PRM points authorization_servers at the configured JWT issuers (the IdP that
+    mints and validates the subject token), with the gateway resource echoed back."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _obo_protected_resource_response,
+    )
+
+    with patch(_PATCH_ISSUERS, return_value=["https://idp.example.com"]):
+        response = _obo_protected_resource_response(_obo_server(scopes=["read"]), _OBO_RESOURCE)
+    assert response == {
+        "authorization_servers": ["https://idp.example.com"],
+        "resource": _OBO_RESOURCE,
+        "scopes_supported": ["read"],
+    }
+
+
+def test_obo_protected_resource_response_scopes_default_empty():
+    """A scopeless OBO server reports scopes_supported as [] rather than None."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _obo_protected_resource_response,
+    )
+
+    with patch(_PATCH_ISSUERS, return_value=["https://idp.example.com"]):
+        response = _obo_protected_resource_response(_obo_server(scopes=None), _OBO_RESOURCE)
+    assert response["scopes_supported"] == []
+
+
+def test_obo_protected_resource_response_falls_back_when_no_issuer():
+    """With no JWT issuer configured, the OBO branch returns None so the caller falls back to the
+    gateway-default PRM (discovery still works, it just can't name the IdP)."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _obo_protected_resource_response,
+    )
+
+    with patch(_PATCH_ISSUERS, return_value=[]):
+        assert _obo_protected_resource_response(_obo_server(), _OBO_RESOURCE) is None
+
+
+def test_obo_protected_resource_response_ignores_non_obo_server():
+    """Non-OBO servers are not handled by this branch (returns None -> gateway default)."""
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _obo_protected_resource_response,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    oauth2_server = MCPServer(
+        server_id="oauth2_mcp",
+        name="oauth2_mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+    )
+    assert _obo_protected_resource_response(oauth2_server, _OBO_RESOURCE) is None
+
+
+@pytest.mark.asyncio
+async def test_build_oauth_protected_resource_response_obo_end_to_end():
+    """End to end through the response builder: an OBO server's PRM advertises the JWT issuer as
+    authorization_servers, proving the extracted branch is wired into the public discovery path."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _build_oauth_protected_resource_response,
+    )
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry["obo_mcp"] = _obo_server(scopes=["read"])
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    try:
+        with patch(_PATCH_ISSUERS, return_value=["https://idp.example.com"]):
+            response = await _build_oauth_protected_resource_response(
+                request=mock_request,
+                mcp_server_name="obo_mcp",
+                use_standard_pattern=True,
+            )
+        assert response["authorization_servers"] == ["https://idp.example.com"]
+        assert response["resource"] == "https://litellm.example.com/mcp/obo_mcp"
+    finally:
+        global_mcp_server_manager.registry.clear()
 
 
 def _token_request(headers):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5587,5 +5587,128 @@ def test_should_strip_caller_authorization_for_token_exchange():
     )
 
 
+class _UpstreamAuthError(Exception):
+    """Mimics a wrapped upstream 401 the way _extract_upstream_auth_failure detects it."""
+
+    def __init__(self, status_code: int = 401) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.response = httpx.Response(status_code)
+
+
+class _RetryFakeClient:
+    """A fake MCPClient whose call_tool fails on the first attempt and (optionally) succeeds after."""
+
+    def __init__(self, *, raises=None, result=None) -> None:
+        from litellm.experimental_mcp_client.client import MCPClient
+
+        self._raises = raises
+        self._result = result
+        self._MCPClient = MCPClient
+        self.attempts = 0
+
+    async def call_tool(self, params, host_progress_callback=None, raise_on_error=False):
+        self.attempts += 1
+        if self._raises is not None:
+            if raise_on_error:
+                raise self._raises
+            return self._MCPClient.error_tool_result(self._raises)
+        return self._result
+
+
+def _obo_server() -> MCPServer:
+    return MCPServer(
+        server_id="obo-srv",
+        name="obo",
+        url="https://upstream.example/mcp",
+        transport=MCPTransport.sse,
+        auth_type=MCPAuth.oauth2_token_exchange,
+        token_exchange_endpoint="https://idp.example.com/token",
+        client_id="cid",
+        client_secret="csec",
+    )
+
+
+class TestOBOCallToolRetry:
+    """The token_exchange (OBO) tool-call path re-mints the exchanged token once on an upstream 401."""
+
+    def _manager(self):
+        manager = MCPServerManager()
+        manager._cred_provider = MagicMock()
+        manager._cred_provider.invalidate_credentials = AsyncMock()
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_upstream_401_invalidates_and_retries_once(self):
+        manager = self._manager()
+        success = CallToolResult(content=[], isError=False)
+        first = _RetryFakeClient(raises=_UpstreamAuthError(401))
+        retry = _RetryFakeClient(result=success)
+        manager._create_mcp_client = AsyncMock(return_value=retry)
+
+        result = await manager._obo_call_tool_with_retry(
+            client=first,
+            call_tool_params=MagicMock(),
+            host_progress_callback=None,
+            mcp_server=_obo_server(),
+            server_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token="caller-jwt",
+            user_api_key_auth=None,
+        )
+
+        assert result is success
+        manager._cred_provider.invalidate_credentials.assert_awaited_once()
+        manager._create_mcp_client.assert_awaited_once()
+        assert first.attempts == 1 and retry.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_non_auth_error_does_not_retry(self):
+        manager = self._manager()
+        first = _RetryFakeClient(raises=ValueError("tool blew up"))
+        manager._create_mcp_client = AsyncMock()
+
+        result = await manager._obo_call_tool_with_retry(
+            client=first,
+            call_tool_params=MagicMock(),
+            host_progress_callback=None,
+            mcp_server=_obo_server(),
+            server_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token="caller-jwt",
+            user_api_key_auth=None,
+        )
+
+        assert result.isError is True
+        manager._cred_provider.invalidate_credentials.assert_not_awaited()
+        manager._create_mcp_client.assert_not_awaited()
+        assert first.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_second_401_degrades_without_looping(self):
+        manager = self._manager()
+        first = _RetryFakeClient(raises=_UpstreamAuthError(401))
+        # The retry client still fails; with raise_on_error defaulting False it returns isError.
+        retry = _RetryFakeClient(raises=_UpstreamAuthError(401))
+        manager._create_mcp_client = AsyncMock(return_value=retry)
+
+        result = await manager._obo_call_tool_with_retry(
+            client=first,
+            call_tool_params=MagicMock(),
+            host_progress_callback=None,
+            mcp_server=_obo_server(),
+            server_auth_header=None,
+            extra_headers=None,
+            stdio_env=None,
+            subject_token="caller-jwt",
+            user_api_key_auth=None,
+        )
+
+        assert result.isError is True
+        manager._create_mcp_client.assert_awaited_once()
+        assert first.attempts == 1 and retry.attempts == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5427,6 +5427,24 @@ class TestMCPToolsListAuthSurfacing:
         result = await manager.list_tools()
 
         assert [t.name for t in result] == ["good-do_thing"]
+def test_should_strip_caller_authorization_for_token_exchange():
+    """OBO: the inbound bearer is the subject token (exchanged), never forwarded upstream raw."""
+    server = MCPServer(
+        server_id="te-strip",
+        name="te-strip-server",
+        url="https://up.example.com",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2_token_exchange,
+        token_exchange_endpoint="https://idp.example.com/token",
+        client_id="cid",
+        client_secret="csec",
+    )
+    assert (
+        _should_strip_caller_authorization(
+            mcp_server=server, raw_headers=None, user_api_key_auth=None
+        )
+        is True
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -603,6 +603,73 @@ class TestMCPServerManager:
         assert captured_extra_headers == {"Authorization": "Bearer token"}
         assert isinstance(result, CallToolResult)
 
+    async def _capture_list_subject_token(self, server, oauth2_headers, raw_headers=None):
+        """Run _get_tools_from_server and return the subject_token it threaded to _create_mcp_client."""
+        manager = MCPServerManager()
+        captured = {}
+
+        async def capture_create_mcp_client(
+            server, mcp_auth_header, extra_headers, stdio_env, subject_token=None, **kwargs
+        ):  # pragma: no cover - helper
+            captured["subject_token"] = subject_token
+            return AsyncMock()
+
+        manager._create_mcp_client = AsyncMock(side_effect=capture_create_mcp_client)
+        manager._fetch_tools_with_timeout = AsyncMock(return_value=[])
+        await manager._get_tools_from_server(
+            server=server, oauth2_headers=oauth2_headers, raw_headers=raw_headers
+        )
+        return captured["subject_token"]
+
+    @pytest.mark.asyncio
+    async def test_list_threads_subject_token_for_token_exchange(self):
+        """tools/list discovery must hand the caller's bearer to the resolver for OBO servers."""
+        server = MCPServer(
+            server_id="te-list",
+            name="te-list-server",
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+        subject_token = await self._capture_list_subject_token(
+            server, oauth2_headers={"Authorization": "Bearer subj-jwt"}
+        )
+        assert subject_token == "subj-jwt"
+
+    @pytest.mark.asyncio
+    async def test_list_does_not_thread_subject_token_for_non_token_exchange(self):
+        """A non-OBO server must not get the caller's bearer threaded (no leak across modes)."""
+        server = MCPServer(
+            server_id="none-list",
+            name="none-list-server",
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+        )
+        subject_token = await self._capture_list_subject_token(
+            server, oauth2_headers={"Authorization": "Bearer subj-jwt"}
+        )
+        assert subject_token is None
+
+    @pytest.mark.asyncio
+    async def test_list_subject_token_none_without_oauth2_headers(self):
+        """Background/registry refresh (no oauth2 headers) lists with no subject token, as before."""
+        server = MCPServer(
+            server_id="te-list-bg",
+            name="te-list-bg-server",
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+        subject_token = await self._capture_list_subject_token(server, oauth2_headers=None)
+        assert subject_token is None
+
     @pytest.mark.asyncio
     async def test_call_regular_mcp_tool_passthrough_strips_authorization_when_admission_consumed_litellm_key(
         self,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -670,6 +670,118 @@ class TestMCPServerManager:
         subject_token = await self._capture_list_subject_token(server, oauth2_headers=None)
         assert subject_token is None
 
+    def _token_exchange_server(self, server_id: str) -> "MCPServer":
+        return MCPServer(
+            server_id=server_id,
+            name=f"{server_id}-server",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+
+    async def _capture_subject_token(self, call) -> Optional[str]:
+        """Run a manager method (via ``call(manager)``) and return the subject_token it threaded
+        into ``_create_mcp_client``."""
+        manager = MCPServerManager()
+        captured: Dict[str, Any] = {}
+
+        async def capture_create_mcp_client(
+            server, mcp_auth_header, extra_headers, stdio_env, subject_token=None, **kwargs
+        ):  # pragma: no cover - helper
+            captured["subject_token"] = subject_token
+            return AsyncMock()
+
+        manager._create_mcp_client = AsyncMock(side_effect=capture_create_mcp_client)
+        await call(manager)
+        return captured.get("subject_token")
+
+    @pytest.mark.asyncio
+    async def test_prompts_thread_subject_token_for_token_exchange(self):
+        """prompts/list on an OBO server must exchange the caller's bearer, not connect with none."""
+        server = self._token_exchange_server("te-prompts")
+        st = await self._capture_subject_token(
+            lambda m: m.get_prompts_from_server(
+                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
+            )
+        )
+        assert st == "subj-jwt"
+
+    @pytest.mark.asyncio
+    async def test_resources_thread_subject_token_for_token_exchange(self):
+        """resources/list on an OBO server must exchange the caller's bearer."""
+        server = self._token_exchange_server("te-resources")
+        st = await self._capture_subject_token(
+            lambda m: m.get_resources_from_server(
+                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
+            )
+        )
+        assert st == "subj-jwt"
+
+    @pytest.mark.asyncio
+    async def test_read_resource_threads_subject_token_for_token_exchange(self):
+        """resources/read on an OBO server must exchange the caller's bearer."""
+        server = self._token_exchange_server("te-read")
+        st = await self._capture_subject_token(
+            lambda m: m.read_resource_from_server(
+                server=server,
+                url="https://up.example.com/r",
+                raw_headers={"authorization": "Bearer subj-jwt"},
+            )
+        )
+        assert st == "subj-jwt"
+
+    @pytest.mark.asyncio
+    async def test_prompts_no_subject_token_for_non_token_exchange(self):
+        """A non-OBO server must not get the caller's bearer threaded (no cross-mode leak)."""
+        server = MCPServer(
+            server_id="none-prompts",
+            name="none-prompts-server",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+        )
+        st = await self._capture_subject_token(
+            lambda m: m.get_prompts_from_server(
+                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
+            )
+        )
+        assert st is None
+
+    @pytest.mark.asyncio
+    async def test_caller_header_cannot_bypass_v2_for_token_exchange(self):
+        """A caller-supplied per-server header (x-mcp-*) must NOT disable the OBO exchange:
+        _create_mcp_client keeps the v2 spec and runs the resolver (which exchanges the subject),
+        rather than deferring to v1 and forwarding the caller's header verbatim upstream."""
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            StaticHeaderAuth,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+
+        exchanged_subjects = []
+
+        class _FakeProvider:
+            async def resolve_credentials(self, subject, server):
+                exchanged_subjects.append(
+                    subject.inbound_token.get_secret_value() if subject.inbound_token else None
+                )
+                return Ok(StaticHeaderAuth("Bearer MINTED", header_name="Authorization"))
+
+        manager = MCPServerManager(cred_provider=_FakeProvider())
+        server = self._token_exchange_server("te-bypass")
+
+        client = await manager._create_mcp_client(
+            server,
+            mcp_auth_header="Bearer x-mcp-caller-header",
+            subject_token="subj-jwt",
+        )
+
+        # The resolver ran and exchanged the subject despite the per-server header; not bypassed.
+        assert exchanged_subjects == ["subj-jwt"]
+        assert client is not None
+
     @pytest.mark.asyncio
     async def test_call_regular_mcp_tool_passthrough_strips_authorization_when_admission_consumed_litellm_key(
         self,
@@ -1097,6 +1209,7 @@ class TestMCPServerManager:
             mcp_auth_header="auth",
             extra_headers=None,
             stdio_env=None,
+            subject_token=None,
         )
         mock_client.list_resource_templates.assert_awaited_once()
         mock_prefix.assert_called_once_with(mock_templates, server, add_prefix=False)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -783,6 +783,33 @@ class TestMCPServerManager:
         assert client is not None
 
     @pytest.mark.asyncio
+    async def test_injected_authorization_does_not_shadow_obo_minted_token(self):
+        """A guardrail/static Authorization (e.g. MCPJWTSigner) must NOT shadow the exchanged OBO
+        token. The resolver-owned credential is authoritative: the conflicting header is dropped and
+        the minted token is what reaches the upstream, not the injected JWT."""
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            StaticHeaderAuth,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+
+        class _FakeProvider:
+            async def resolve_credentials(self, subject, server):
+                return Ok(StaticHeaderAuth("Bearer MINTED", header_name="Authorization"))
+
+        manager = MCPServerManager(cred_provider=_FakeProvider())
+        server = self._token_exchange_server("te-shadow")
+
+        client = await manager._create_mcp_client(
+            server,
+            extra_headers={"Authorization": "Bearer signer-jwt"},  # simulate the JWT signer
+            subject_token="subj-jwt",
+        )
+
+        # minted token wins (resolved_auth kept), signer's header dropped from extra_headers
+        assert client._resolved_auth is not None
+        assert "authorization" not in {k.lower() for k in (client.extra_headers or {})}
+
+    @pytest.mark.asyncio
     async def test_call_regular_mcp_tool_passthrough_strips_authorization_when_admission_consumed_litellm_key(
         self,
     ):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+
 # Add the parent directory to the path so we can import litellm
 sys.path.insert(0, "../../../../../")
 
@@ -47,18 +49,14 @@ from litellm.types.mcp_server.mcp_server_manager import MCPOAuthMetadata, MCPSer
 
 def _reload_mcp_manager_module():
     utils_module = sys.modules["litellm.proxy._experimental.mcp_server.utils"]
-    manager_module = sys.modules[
-        "litellm.proxy._experimental.mcp_server.mcp_server_manager"
-    ]
+    manager_module = sys.modules["litellm.proxy._experimental.mcp_server.mcp_server_manager"]
     importlib.reload(utils_module)
     reloaded = importlib.reload(manager_module)
     # After reload, server.py still holds a stale reference to the old
     # global_mcp_server_manager. Update it so tests that exercise server.py
     # functions (e.g. _get_tools_from_mcp_servers) use the fresh instance.
     server_module = sys.modules.get("litellm.proxy._experimental.mcp_server.server")
-    if server_module is not None and hasattr(
-        server_module, "global_mcp_server_manager"
-    ):
+    if server_module is not None and hasattr(server_module, "global_mcp_server_manager"):
         server_module.global_mcp_server_manager = reloaded.global_mcp_server_manager
     return reloaded
 
@@ -168,9 +166,7 @@ class TestMCPServerManager:
             auth_type=MCPAuth.oauth2,  # oauth2 + no client creds + not delegate -> authorization_code
         )
 
-        client = await manager._create_mcp_client(
-            server, mcp_auth_header="Bearer caller-supplied-token"
-        )
+        client = await manager._create_mcp_client(server, mcp_auth_header="Bearer caller-supplied-token")
 
         # the v2 resolver ran (the caller override did NOT defer to v1); the stored token wins
         assert calls == [("", "authz-srv")]
@@ -441,9 +437,7 @@ class TestMCPServerManager:
 
         # Mock get_allowed_mcp_servers to return our test servers
         manager.get_allowed_mcp_servers = AsyncMock(return_value=["github", "zapier"])
-        manager.get_mcp_server_by_id = MagicMock(
-            side_effect=lambda x: server1 if x == "github" else server2
-        )
+        manager.get_mcp_server_by_id = MagicMock(side_effect=lambda x: server1 if x == "github" else server2)
 
         # Mock _get_tools_from_server to return different results
         async def mock_get_tools_from_server(
@@ -470,9 +464,7 @@ class TestMCPServerManager:
             "zapier": "zapier-api-key",
         }
 
-        result = await manager.list_tools(
-            mcp_server_auth_headers=mcp_server_auth_headers
-        )
+        result = await manager.list_tools(mcp_server_auth_headers=mcp_server_auth_headers)
 
         # Verify that both servers were called with their specific auth headers
         assert len(result) == 3  # 2 from github + 1 from zapier
@@ -541,9 +533,7 @@ class TestMCPServerManager:
             mcp_auth_header=None,
             **kwargs,
         ):
-            assert (
-                mcp_auth_header == "server-specific-token"
-            )  # Should use server-specific header
+            assert mcp_auth_header == "server-specific-token"  # Should use server-specific header
             tool = MagicMock()
             tool.name = "github_tool_1"
             return [tool]
@@ -574,9 +564,7 @@ class TestMCPServerManager:
         )
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
@@ -616,9 +604,7 @@ class TestMCPServerManager:
 
         manager._create_mcp_client = AsyncMock(side_effect=capture_create_mcp_client)
         manager._fetch_tools_with_timeout = AsyncMock(return_value=[])
-        await manager._get_tools_from_server(
-            server=server, oauth2_headers=oauth2_headers, raw_headers=raw_headers
-        )
+        await manager._get_tools_from_server(server=server, oauth2_headers=oauth2_headers, raw_headers=raw_headers)
         return captured["subject_token"]
 
     @pytest.mark.asyncio
@@ -670,6 +656,56 @@ class TestMCPServerManager:
         subject_token = await self._capture_list_subject_token(server, oauth2_headers=None)
         assert subject_token is None
 
+    @pytest.mark.asyncio
+    async def test_list_surfaces_resolver_401_as_upstream_auth_error(self):
+        """A v2 resolver auth challenge (HTTPException 401) raised while building the client must
+        surface as MCPUpstreamAuthError with its WWW-Authenticate preserved, so single-server routes
+        challenge the client instead of the old behavior of masking it to an empty tool list."""
+        server = MCPServer(
+            server_id="te-401",
+            name="te-401-server",
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+        manager = MCPServerManager()
+        challenge = (
+            'Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/te-401-server", error="invalid_token"'
+        )
+        manager._create_mcp_client = AsyncMock(
+            side_effect=HTTPException(status_code=401, detail="Unauthorized", headers={"WWW-Authenticate": challenge})
+        )
+        with pytest.raises(MCPUpstreamAuthError) as exc_info:
+            await manager._get_tools_from_server(server=server, oauth2_headers={"Authorization": "Bearer subj-jwt"})
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.www_authenticate == challenge
+
+    @pytest.mark.asyncio
+    async def test_list_absorbs_non_auth_httpexception(self):
+        """A non-auth HTTP error (e.g. 412 no endpoint, 503 IdP down) must stay absorbed to [] so one
+        misconfigured/unavailable server does not blank the whole aggregate listing."""
+        server = MCPServer(
+            server_id="te-412",
+            name="te-412-server",
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+        manager = MCPServerManager()
+        manager._create_mcp_client = AsyncMock(
+            side_effect=HTTPException(status_code=412, detail="token exchange endpoint is not configured")
+        )
+        result = await manager._get_tools_from_server(
+            server=server, oauth2_headers={"Authorization": "Bearer subj-jwt"}
+        )
+        assert result == []
+
     def _token_exchange_server(self, server_id: str) -> "MCPServer":
         return MCPServer(
             server_id=server_id,
@@ -703,9 +739,7 @@ class TestMCPServerManager:
         """prompts/list on an OBO server must exchange the caller's bearer, not connect with none."""
         server = self._token_exchange_server("te-prompts")
         st = await self._capture_subject_token(
-            lambda m: m.get_prompts_from_server(
-                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
-            )
+            lambda m: m.get_prompts_from_server(server=server, raw_headers={"authorization": "Bearer subj-jwt"})
         )
         assert st == "subj-jwt"
 
@@ -714,9 +748,7 @@ class TestMCPServerManager:
         """resources/list on an OBO server must exchange the caller's bearer."""
         server = self._token_exchange_server("te-resources")
         st = await self._capture_subject_token(
-            lambda m: m.get_resources_from_server(
-                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
-            )
+            lambda m: m.get_resources_from_server(server=server, raw_headers={"authorization": "Bearer subj-jwt"})
         )
         assert st == "subj-jwt"
 
@@ -744,9 +776,7 @@ class TestMCPServerManager:
             auth_type=MCPAuth.none,
         )
         st = await self._capture_subject_token(
-            lambda m: m.get_prompts_from_server(
-                server=server, raw_headers={"authorization": "Bearer subj-jwt"}
-            )
+            lambda m: m.get_prompts_from_server(server=server, raw_headers={"authorization": "Bearer subj-jwt"})
         )
         assert st is None
 
@@ -764,9 +794,7 @@ class TestMCPServerManager:
 
         class _FakeProvider:
             async def resolve_credentials(self, subject, server):
-                exchanged_subjects.append(
-                    subject.inbound_token.get_secret_value() if subject.inbound_token else None
-                )
+                exchanged_subjects.append(subject.inbound_token.get_secret_value() if subject.inbound_token else None)
                 return Ok(StaticHeaderAuth("Bearer MINTED", header_name="Authorization"))
 
         manager = MCPServerManager(cred_provider=_FakeProvider())
@@ -830,9 +858,7 @@ class TestMCPServerManager:
         )
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
@@ -888,17 +914,10 @@ class TestMCPServerManager:
         )
         # Migrated authorization_code => the centralized strip decision says drop the
         # caller's Authorization (the v2 resolver injects the stored token).
-        assert (
-            _should_strip_caller_authorization(
-                mcp_server=server, raw_headers=None, user_api_key_auth=None
-            )
-            is True
-        )
+        assert _should_strip_caller_authorization(mcp_server=server, raw_headers=None, user_api_key_auth=None) is True
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = "unset"
 
         async def capture_create_mcp_client(
@@ -941,9 +960,7 @@ class TestMCPServerManager:
         # Only Authorization present -> nothing left -> None (case-insensitive)
         assert _without_authorization({"authorization": "Bearer x"}) is None
         # Authorization dropped, other headers kept
-        assert _without_authorization(
-            {"Authorization": "Bearer x", "X-Trace-Id": "t"}
-        ) == {"X-Trace-Id": "t"}
+        assert _without_authorization({"Authorization": "Bearer x", "X-Trace-Id": "t"}) == {"X-Trace-Id": "t"}
 
     @pytest.mark.asyncio
     async def test_call_regular_mcp_tool_passthrough_forwards_authorization_with_admission_header(
@@ -966,9 +983,7 @@ class TestMCPServerManager:
         )
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
@@ -1001,9 +1016,7 @@ class TestMCPServerManager:
             user_api_key_auth=UserAPIKeyAuth(api_key="sk-litellm-key"),
         )
 
-        assert captured_extra_headers == {
-            "Authorization": "Bearer upstream-oauth-bearer"
-        }
+        assert captured_extra_headers == {"Authorization": "Bearer upstream-oauth-bearer"}
 
     @pytest.mark.asyncio
     async def test_call_regular_mcp_tool_passthrough_forwards_authorization_for_anonymous_admission(
@@ -1027,9 +1040,7 @@ class TestMCPServerManager:
         )
 
         mock_client = AsyncMock()
-        mock_client.call_tool = AsyncMock(
-            return_value=CallToolResult(content=[], isError=False)
-        )
+        mock_client.call_tool = AsyncMock(return_value=CallToolResult(content=[], isError=False))
         captured_extra_headers = None
 
         async def capture_create_mcp_client(
@@ -1059,9 +1070,7 @@ class TestMCPServerManager:
             user_api_key_auth=UserAPIKeyAuth(api_key=None),
         )
 
-        assert captured_extra_headers == {
-            "Authorization": "Bearer upstream-oauth-bearer"
-        }
+        assert captured_extra_headers == {"Authorization": "Bearer upstream-oauth-bearer"}
 
     @pytest.mark.asyncio
     async def test_get_prompts_from_server_success(self):
@@ -1150,9 +1159,7 @@ class TestMCPServerManager:
         mock_client = AsyncMock()
         mock_resources = [Resource(name="file", uri="https://example.com/file")]
         mock_client.list_resources = AsyncMock(return_value=mock_resources)
-        prefixed_resources = [
-            Resource(name="alias-server-file", uri="https://example.com/file")
-        ]
+        prefixed_resources = [Resource(name="alias-server-file", uri="https://example.com/file")]
 
         with (
             patch.object(
@@ -1284,9 +1291,7 @@ class TestMCPServerManager:
         mock_create_client.assert_called_once()
         called_kwargs = mock_create_client.call_args.kwargs
         assert called_kwargs["extra_headers"] == {"X-Test": "1", "X-Static": "1"}
-        mock_client.read_resource.assert_awaited_once_with(
-            "https://example.com/resource"
-        )
+        mock_client.read_resource.assert_awaited_once_with("https://example.com/resource")
         assert result is read_result
 
     @pytest.mark.asyncio
@@ -1391,9 +1396,7 @@ class TestMCPServerManager:
                 request = httpx.Request("GET", url)
                 response_obj = httpx.Response(status_code=404, request=request)
                 mock_response.raise_for_status = MagicMock(
-                    side_effect=httpx.HTTPStatusError(
-                        "not found", request=request, response=response_obj
-                    )
+                    side_effect=httpx.HTTPStatusError("not found", request=request, response=response_obj)
                 )
             return mock_response
 
@@ -1407,19 +1410,11 @@ class TestMCPServerManager:
             # The Azure issuer is cross-origin against the server_url — use
             # the issuer itself as server_url so the test exercises the
             # well-known fetch logic without needing real DNS.
-            result = await manager._fetch_single_authorization_server_metadata(
-                issuer, issuer
-            )
+            result = await manager._fetch_single_authorization_server_metadata(issuer, issuer)
 
         assert result is not None
-        assert (
-            result.authorization_url
-            == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
-        )
-        assert (
-            result.token_url
-            == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
-        )
+        assert result.authorization_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
+        assert result.token_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
         assert result.scopes == ["api://some-scope/.default"]
 
     @pytest.mark.asyncio
@@ -1433,9 +1428,7 @@ class TestMCPServerManager:
         response_obj = httpx.Response(status_code=404, request=request)
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock(
-            side_effect=httpx.HTTPStatusError(
-                "not found", request=request, response=response_obj
-            )
+            side_effect=httpx.HTTPStatusError("not found", request=request, response=response_obj)
         )
 
         mock_client = MagicMock()
@@ -1445,19 +1438,11 @@ class TestMCPServerManager:
             "litellm.proxy._experimental.mcp_server.mcp_server_manager.get_async_httpx_client",
             return_value=mock_client,
         ):
-            result = await manager._fetch_single_authorization_server_metadata(
-                issuer, issuer
-            )
+            result = await manager._fetch_single_authorization_server_metadata(issuer, issuer)
 
         assert result is not None
-        assert (
-            result.authorization_url
-            == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
-        )
-        assert (
-            result.token_url
-            == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
-        )
+        assert result.authorization_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/authorize"
+        assert result.token_url == "https://login.microsoftonline.com/test-tenant-id/oauth2/v2.0/token"
 
     @pytest.mark.asyncio
     async def test_descovery_metadata_falls_back_to_origin_when_no_auth_servers(self):
@@ -1472,9 +1457,7 @@ class TestMCPServerManager:
         )
 
         def raise_http_error():
-            raise httpx.HTTPStatusError(
-                "unauthorized", request=request, response=response_obj
-            )
+            raise httpx.HTTPStatusError("unauthorized", request=request, response=response_obj)
 
         response_obj.raise_for_status = MagicMock(side_effect=raise_http_error)
 
@@ -1591,9 +1574,7 @@ class TestMCPServerManager:
             mcp_auth_header=None,
             **kwargs,
         ):
-            assert (
-                mcp_auth_header == "server-specific-token"
-            )  # Should use server-specific header via server_name
+            assert mcp_auth_header == "server-specific-token"  # Should use server-specific header via server_name
             tool = MagicMock()
             tool.name = "github_tool_1"
             return [tool]
@@ -1660,9 +1641,7 @@ class TestMCPServerManager:
 
         # Mock failed client.run_with_session
         mock_client = AsyncMock()
-        mock_client.run_with_session = AsyncMock(
-            side_effect=Exception("Connection timeout")
-        )
+        mock_client.run_with_session = AsyncMock(side_effect=Exception("Connection timeout"))
         manager._create_mcp_client = AsyncMock(return_value=mock_client)
 
         # Perform health check
@@ -1784,9 +1763,7 @@ class TestMCPServerManager:
         # Capture the extra_headers passed to _create_mcp_client
         captured_extra_headers = None
 
-        async def capture_create_mcp_client(
-            server, mcp_auth_header, extra_headers, stdio_env
-        ):
+        async def capture_create_mcp_client(server, mcp_auth_header, extra_headers, stdio_env):
             nonlocal captured_extra_headers
             captured_extra_headers = extra_headers
             return mock_client
@@ -2128,9 +2105,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -2174,13 +2149,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool blocked_tool is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool blocked_tool is not allowed for server test-server" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_pre_call_tool_check_disallowed_tools_list_allows_tool(self):
@@ -2204,9 +2174,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -2250,13 +2218,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool banned_tool is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool banned_tool is not allowed for server test-server" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_pre_call_tool_check_no_restrictions_allows_any_tool(self):
@@ -2280,9 +2243,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -2319,9 +2280,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -2347,10 +2306,7 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool tool3 is not allowed for server test-server"
-            in exc_info.value.detail["error"]
-        )
+        assert "Tool tool3 is not allowed for server test-server" in exc_info.value.detail["error"]
 
     async def test_get_tools_from_server_add_prefix(self):
         """Verify _get_tools_from_server respects add_prefix True/False."""
@@ -2381,9 +2337,7 @@ class TestMCPServerManager:
         assert tools_prefixed[0].name == "zapier-send_email"
 
         # Case 2: add_prefix=False (single-server) -> expect unprefixed
-        tools_unprefixed = await manager._get_tools_from_server(
-            server, add_prefix=False
-        )
+        tools_unprefixed = await manager._get_tools_from_server(server, add_prefix=False)
         assert len(tools_unprefixed) == 1
         assert tools_unprefixed[0].name == "send_email"
 
@@ -2461,9 +2415,7 @@ class TestMCPServerManager:
         manager.registry = {"srv-uuid-123": server}
         manager.tool_name_to_mcp_server_name_mapping["create_zap"] = "zapier"
 
-        resolved = manager._resolve_mcp_server_for_tool_call(
-            "zapier-alias", "create_zap"
-        )
+        resolved = manager._resolve_mcp_server_for_tool_call("zapier-alias", "create_zap")
         assert resolved is server
 
     def test_resolve_mcp_server_for_tool_call_unknown_tool_with_empty_mapping(self):
@@ -2744,13 +2696,9 @@ class TestMCPServerManager:
 
         # Mapping should include both original and prefixed names -> resolves calls either way
         assert manager.tool_name_to_mcp_server_name_mapping["create_issue"] == "jira"
-        assert (
-            manager.tool_name_to_mcp_server_name_mapping["jira-create_issue"] == "jira"
-        )
+        assert manager.tool_name_to_mcp_server_name_mapping["jira-create_issue"] == "jira"
         assert manager.tool_name_to_mcp_server_name_mapping["close_issue"] == "jira"
-        assert (
-            manager.tool_name_to_mcp_server_name_mapping["jira-close_issue"] == "jira"
-        )
+        assert manager.tool_name_to_mcp_server_name_mapping["jira-close_issue"] == "jira"
 
     def test_get_mcp_server_from_tool_name_with_prefixed_and_unprefixed(self):
         """After mapping is populated, manager resolves both prefixed and unprefixed tool names to the same server."""
@@ -2780,9 +2728,7 @@ class TestMCPServerManager:
         assert resolved_server_unpref.server_id == server.server_id
 
         # Prefixed resolution
-        resolved_server_pref = manager._get_mcp_server_from_tool_name(
-            "zapier-create_zap"
-        )
+        resolved_server_pref = manager._get_mcp_server_from_tool_name("zapier-create_zap")
         assert resolved_server_pref is not None
         assert resolved_server_pref.server_id == server.server_id
 
@@ -2827,9 +2773,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2, tool3]),
         ):
             # Call the REST endpoint helper
-            filtered_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            filtered_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify only allowed tools are in the response
             assert len(filtered_response) == 2
@@ -2879,9 +2823,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2, tool3]),
         ):
             # Call the REST endpoint helper
-            all_tools_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            all_tools_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify all tools are returned (no filtering)
             assert len(all_tools_response) == 3
@@ -2926,9 +2868,7 @@ class TestMCPServerManager:
             new=AsyncMock(return_value=[tool1, tool2]),
         ):
             # Call the REST endpoint helper
-            all_tools_response = await _get_tools_for_single_server(
-                server, server_auth_header=None
-            )
+            all_tools_response = await _get_tools_for_single_server(server, server_auth_header=None)
 
             # Verify all tools are returned (no filtering)
             assert len(all_tools_response) == 2
@@ -2998,9 +2938,7 @@ class TestMCPServerManager:
         )
 
         proxy_logging = MagicMock()
-        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging.pre_call_hook = AsyncMock(return_value=None)
 
@@ -3043,9 +2981,7 @@ class TestMCPServerManager:
         )
 
         proxy_logging = MagicMock()
-        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging.pre_call_hook = AsyncMock(return_value=None)
 
@@ -3190,9 +3126,7 @@ class TestMCPServerManager:
         proxy_logging_obj = MagicMock()
 
         # Mock the async methods that pre_call_tool_check calls
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
 
@@ -3228,13 +3162,8 @@ class TestMCPServerManager:
             )
 
         assert exc_info.value.status_code == 403
-        assert (
-            "Tool deletepet is not allowed for server my_api_mcp"
-            in exc_info.value.detail["error"]
-        )
-        assert (
-            "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
-        )
+        assert "Tool deletepet is not allowed for server my_api_mcp" in exc_info.value.detail["error"]
+        assert "Contact proxy admin to allow this tool" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
     async def test_call_tool_without_broken_pipe_error(self):
@@ -3259,9 +3188,7 @@ class TestMCPServerManager:
         # Register the server and map a tool to it
         manager.registry = {"test-server": server}
         manager.tool_name_to_mcp_server_name_mapping["test_tool"] = "test-server"
-        manager.tool_name_to_mcp_server_name_mapping["test-server-test_tool"] = (
-            "test-server"
-        )
+        manager.tool_name_to_mcp_server_name_mapping["test-server-test_tool"] = "test-server"
 
         # Create mock client that tracks call_tool usage
         mock_client = AsyncMock()
@@ -3285,9 +3212,7 @@ class TestMCPServerManager:
 
         # Mock proxy logging
         proxy_logging_obj = MagicMock()
-        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(
-            return_value={}
-        )
+        proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
         proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
         proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
         proxy_logging_obj.during_call_hook = AsyncMock(return_value=None)
@@ -3352,9 +3277,7 @@ class TestMCPServerManager:
             # Verify MCPRequestHandler.get_allowed_mcp_servers was called with user_api_key_auth
             mock_get_allowed.assert_called_once()
             call_args = mock_get_allowed.call_args
-            assert (
-                call_args[0][0] is user_api_key_auth
-            )  # First positional arg should be user_api_key_auth
+            assert call_args[0][0] is user_api_key_auth  # First positional arg should be user_api_key_auth
             assert call_args[0][0].user_id == "user-123"
             assert call_args[0][0].object_permission_id == "perm_123"
             assert call_args[0][0].object_permission is not None
@@ -3390,9 +3313,7 @@ class TestMCPServerManager:
         )
 
         with (
-            patch.object(
-                manager, "get_allow_all_keys_server_ids", return_value=["global-server"]
-            ),
+            patch.object(manager, "get_allow_all_keys_server_ids", return_value=["global-server"]),
             patch.object(
                 MCPRequestHandler,
                 "get_allowed_mcp_servers",
@@ -3855,9 +3776,7 @@ class TestMCPServerTimestamps:
         ``_deserialize_json_list`` must hand back plain dicts so ``MCPServer``
         (typed ``List[Dict[str, Any]]``) validates."""
         env_vars = [
-            MCPEnvVar(
-                name="GITHUB_TOKEN", scope=MCPEnvVarScope.user, description="PAT"
-            ),
+            MCPEnvVar(name="GITHUB_TOKEN", scope=MCPEnvVarScope.user, description="PAT"),
             MCPEnvVar(name="REGION", value="us-east-1", scope=MCPEnvVarScope.global_),
         ]
         result = _deserialize_json_list(env_vars)
@@ -4203,10 +4122,7 @@ class TestMCPServerManagerUpstreamInstructionsCache:
     def test_get_returns_none_when_empty(self):
         """Empty cache returns None for any key."""
         manager = MCPServerManager()
-        assert (
-            manager._upstream_initialize_instructions_by_server_id.get("nonexistent")
-            is None
-        )
+        assert manager._upstream_initialize_instructions_by_server_id.get("nonexistent") is None
 
     def test_remember_stores_stripped_value(self):
         """_remember_upstream_initialize_instructions stores a stripped string."""
@@ -4214,9 +4130,7 @@ class TestMCPServerManagerUpstreamInstructionsCache:
         fake_server = MagicMock(server_id="srv")
         fake_client = MagicMock(_last_initialize_instructions="  hello \n")
         manager._remember_upstream_initialize_instructions(fake_server, fake_client)
-        assert (
-            manager._upstream_initialize_instructions_by_server_id.get("srv") == "hello"
-        )
+        assert manager._upstream_initialize_instructions_by_server_id.get("srv") == "hello"
 
     def test_remember_ignores_empty_string(self):
         """Whitespace-only instructions are not stored."""
@@ -4294,9 +4208,7 @@ class TestMCPServerManagerExpandPermissionList:
 
     def test_expands_server_name(self):
         manager = MCPServerManager()
-        manager.config_mcp_servers["id-usw1"] = self._make_server(
-            "id-usw1", server_name="a"
-        )
+        manager.config_mcp_servers["id-usw1"] = self._make_server("id-usw1", server_name="a")
 
         assert manager.expand_permission_list(["a"]) == ["id-usw1"]
 
@@ -4320,9 +4232,7 @@ class TestMCPServerManagerExpandPermissionList:
     def test_name_collision_expands_to_all_matches(self):
         """Two servers sharing a server_name both resolve — the documented behavior."""
         manager = MCPServerManager()
-        manager.config_mcp_servers["id-config"] = self._make_server(
-            "id-config", server_name="shared"
-        )
+        manager.config_mcp_servers["id-config"] = self._make_server("id-config", server_name="shared")
         manager.registry["id-db"] = self._make_server("id-db", server_name="shared")
 
         assert sorted(manager.expand_permission_list(["shared"])) == [
@@ -4332,9 +4242,7 @@ class TestMCPServerManagerExpandPermissionList:
 
     def test_searches_config_and_registry_union(self):
         manager = MCPServerManager()
-        manager.config_mcp_servers["cfg-id"] = self._make_server(
-            "cfg-id", server_name="a"
-        )
+        manager.config_mcp_servers["cfg-id"] = self._make_server("cfg-id", server_name="a")
         manager.registry["reg-id"] = self._make_server("reg-id", server_name="b")
 
         assert manager.expand_permission_list(["a"]) == ["cfg-id"]
@@ -4346,23 +4254,15 @@ class TestMCPServerManagerExpandPermissionList:
         servers whose server_name happens to equal that id.
         """
         manager = MCPServerManager()
-        manager.config_mcp_servers["id-1"] = self._make_server(
-            "id-1", server_name="other_name"
-        )
-        manager.config_mcp_servers["id-2"] = self._make_server(
-            "id-2", server_name="id-1"
-        )
+        manager.config_mcp_servers["id-1"] = self._make_server("id-1", server_name="other_name")
+        manager.config_mcp_servers["id-2"] = self._make_server("id-2", server_name="id-1")
 
         assert manager.expand_permission_list(["id-1"]) == ["id-1"]
 
     def test_mixed_ids_and_names_in_same_list(self):
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-1"] = self._make_server(
-            "uuid-1", server_name="a"
-        )
-        manager.config_mcp_servers["uuid-2"] = self._make_server(
-            "uuid-2", server_name="b"
-        )
+        manager.config_mcp_servers["uuid-1"] = self._make_server("uuid-1", server_name="a")
+        manager.config_mcp_servers["uuid-2"] = self._make_server("uuid-2", server_name="b")
 
         # ["uuid-1", "b"] -> uuid-1 passes through, "b" resolves to uuid-2
         assert sorted(manager.expand_permission_list(["uuid-1", "b"])) == [
@@ -4373,9 +4273,7 @@ class TestMCPServerManagerExpandPermissionList:
     def test_deduplicates_overlapping_id_and_name_entries(self):
         """If a list references the same server by both id and name, return it once."""
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-1"] = self._make_server(
-            "uuid-1", server_name="a"
-        )
+        manager.config_mcp_servers["uuid-1"] = self._make_server("uuid-1", server_name="a")
 
         assert manager.expand_permission_list(["uuid-1", "a"]) == ["uuid-1"]
 
@@ -4385,14 +4283,10 @@ class TestMCPServerManagerExpandPermissionList:
         the cross-region portability the customer is asking for.
         """
         usw1 = MCPServerManager()
-        usw1.config_mcp_servers["hash-usw1"] = self._make_server(
-            "hash-usw1", server_name="a"
-        )
+        usw1.config_mcp_servers["hash-usw1"] = self._make_server("hash-usw1", server_name="a")
 
         usc1 = MCPServerManager()
-        usc1.config_mcp_servers["hash-usc1"] = self._make_server(
-            "hash-usc1", server_name="a"
-        )
+        usc1.config_mcp_servers["hash-usc1"] = self._make_server("hash-usc1", server_name="a")
 
         assert usw1.expand_permission_list(["a"]) == ["hash-usw1"]
         assert usc1.expand_permission_list(["a"]) == ["hash-usc1"]
@@ -4421,18 +4315,14 @@ class TestMCPServerManagerExpandToolPermissions:
         concrete server_id, otherwise `.get(server_id)` misses and the tool
         restriction is silently dropped (caller treats None as allow-all)."""
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-a"] = self._make_server(
-            "uuid-a", server_name="my-alias"
-        )
+        manager.config_mcp_servers["uuid-a"] = self._make_server("uuid-a", server_name="my-alias")
 
         result = manager.expand_tool_permissions({"my-alias": ["read_file"]})
         assert result == {"uuid-a": ["read_file"]}
 
     def test_passes_through_existing_server_id_key(self):
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-a"] = self._make_server(
-            "uuid-a", server_name="alpha"
-        )
+        manager.config_mcp_servers["uuid-a"] = self._make_server("uuid-a", server_name="alpha")
 
         result = manager.expand_tool_permissions({"uuid-a": ["read_file"]})
         assert result == {"uuid-a": ["read_file"]}
@@ -4451,9 +4341,7 @@ class TestMCPServerManagerExpandToolPermissions:
         """Two servers sharing a server_name both match; their tool lists get
         the restriction (matches the list-expansion collision semantics)."""
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-1"] = self._make_server(
-            "uuid-1", server_name="shared"
-        )
+        manager.config_mcp_servers["uuid-1"] = self._make_server("uuid-1", server_name="shared")
         manager.registry["uuid-2"] = self._make_server("uuid-2", server_name="shared")
 
         result = manager.expand_tool_permissions({"shared": ["read_file"]})
@@ -4466,13 +4354,9 @@ class TestMCPServerManagerExpandToolPermissions:
         both refer to the same server, the tool lists are unioned rather
         than one overwriting the other."""
         manager = MCPServerManager()
-        manager.config_mcp_servers["uuid-a"] = self._make_server(
-            "uuid-a", server_name="alias-a"
-        )
+        manager.config_mcp_servers["uuid-a"] = self._make_server("uuid-a", server_name="alias-a")
 
-        result = manager.expand_tool_permissions(
-            {"uuid-a": ["read_file"], "alias-a": ["write_file"]}
-        )
+        result = manager.expand_tool_permissions({"uuid-a": ["read_file"], "alias-a": ["write_file"]})
         assert sorted(result["uuid-a"]) == ["read_file", "write_file"]
 
 
@@ -4499,9 +4383,7 @@ class TestOAuthDiscoverySSRFGuard:
             if host not in mapping:
                 raise _socket.gaierror(f"unknown host {host}")
             family = _socket.AF_INET
-            return [
-                (family, _socket.SOCK_STREAM, 0, "", (ip, port)) for ip in mapping[host]
-            ]
+            return [(family, _socket.SOCK_STREAM, 0, "", (ip, port)) for ip in mapping[host]]
 
         monkeypatch.setattr(
             "litellm.litellm_core_utils.url_utils.socket.getaddrinfo",
@@ -4539,9 +4421,7 @@ class TestOAuthDiscoverySSRFGuard:
         ],
     )
     @pytest.mark.asyncio
-    async def test_cross_origin_blocked_when_resolves_to_unsafe_ip(
-        self, monkeypatch, ip
-    ):
+    async def test_cross_origin_blocked_when_resolves_to_unsafe_ip(self, monkeypatch, ip):
         self._patch_resolves(monkeypatch, {"attacker.example.com": [ip]})
         manager = MCPServerManager()
 
@@ -4562,9 +4442,7 @@ class TestOAuthDiscoverySSRFGuard:
 
     @pytest.mark.asyncio
     async def test_cross_origin_allowed_when_resolves_to_public_ip(self, monkeypatch):
-        self._patch_resolves(
-            monkeypatch, {"login.microsoftonline.com": ["20.190.151.7"]}
-        )
+        self._patch_resolves(monkeypatch, {"login.microsoftonline.com": ["20.190.151.7"]})
         manager = MCPServerManager()
 
         mock_response = MagicMock()
@@ -4591,10 +4469,7 @@ class TestOAuthDiscoverySSRFGuard:
         assert scopes == ["mcp.read"]
         mock_client.get.assert_awaited_once()
         assert mock_client.get.await_args.kwargs["follow_redirects"] is False
-        assert (
-            mock_client.get.await_args.kwargs["headers"]["Host"]
-            == "login.microsoftonline.com"
-        )
+        assert mock_client.get.await_args.kwargs["headers"]["Host"] == "login.microsoftonline.com"
 
     @pytest.mark.asyncio
     async def test_cross_origin_blocked_when_unresolvable(self, monkeypatch):
@@ -4645,9 +4520,7 @@ class TestOAuthDiscoverySSRFGuard:
     async def test_dual_resolution_blocked_if_any_ip_unsafe(self, monkeypatch):
         # If the attacker controls a DNS record returning multiple A records,
         # one of which is private, async_safe_get rejects before any network call.
-        self._patch_resolves(
-            monkeypatch, {"dual-stack.example.com": ["8.8.8.8", "127.0.0.1"]}
-        )
+        self._patch_resolves(monkeypatch, {"dual-stack.example.com": ["8.8.8.8", "127.0.0.1"]})
         manager = MCPServerManager()
 
         mock_client = MagicMock()
@@ -4872,9 +4745,7 @@ class TestApprovalStatusGate:
             ("approved", True),
         ],
     )
-    async def test_add_server_respects_approval_status(
-        self, approval_status, expect_in_registry
-    ):
+    async def test_add_server_respects_approval_status(self, approval_status, expect_in_registry):
         manager = MCPServerManager()
         server_id = f"sid-{approval_status}"
         await manager.add_server(self._make_server(server_id, approval_status))
@@ -4885,19 +4756,13 @@ class TestApprovalStatusGate:
         # The stale registry entry must be evicted so subsequent tool calls
         # and health probes can't reach it.
         manager = MCPServerManager()
-        await manager.add_server(
-            self._make_server("evict-me", MCPApprovalStatus.active)
-        )
+        await manager.add_server(self._make_server("evict-me", MCPApprovalStatus.active))
         assert "evict-me" in manager.registry
 
-        await manager.update_server(
-            self._make_server("evict-me", MCPApprovalStatus.rejected)
-        )
+        await manager.update_server(self._make_server("evict-me", MCPApprovalStatus.rejected))
         assert "evict-me" not in manager.registry
 
-    async def test_update_server_eviction_clears_openapi_routing_artifacts(
-        self, tmp_path
-    ):
+    async def test_update_server_eviction_clears_openapi_routing_artifacts(self, tmp_path):
         """Rejecting a server must remove its OpenAPI tools and name mappings."""
         from litellm.proxy._experimental.mcp_server.tool_registry import (
             global_mcp_tool_registry,
@@ -4908,9 +4773,7 @@ class TestApprovalStatusGate:
         )
 
         manager = MCPServerManager()
-        await manager.add_server(
-            self._make_server("evict-openapi", MCPApprovalStatus.active)
-        )
+        await manager.add_server(self._make_server("evict-openapi", MCPApprovalStatus.active))
         assert "evict-openapi" in manager.registry
 
         server = manager.registry["evict-openapi"]
@@ -4930,9 +4793,7 @@ class TestApprovalStatusGate:
         manager.tool_name_to_mcp_server_name_mapping["demo_tool"] = prefix
         manager.tool_name_to_mcp_server_name_mapping[prefixed] = prefix
 
-        await manager.update_server(
-            self._make_server("evict-openapi", MCPApprovalStatus.rejected)
-        )
+        await manager.update_server(self._make_server("evict-openapi", MCPApprovalStatus.rejected))
 
         assert "evict-openapi" not in manager.registry
         assert prefixed not in global_mcp_tool_registry.tools
@@ -4945,9 +4806,7 @@ class TestApprovalStatusGate:
         # so a future refactor can't accidentally route the pending row to
         # build_mcp_server_from_table.
         manager = MCPServerManager()
-        await manager.update_server(
-            self._make_server("never-seen", MCPApprovalStatus.pending_review)
-        )
+        await manager.update_server(self._make_server("never-seen", MCPApprovalStatus.pending_review))
         assert "never-seen" not in manager.registry
 
 
@@ -5161,9 +5020,7 @@ class TestGetPublicMCPServers:
     @patch("litellm.public_mcp_servers", [])
     def test_returns_empty_when_whitelist_is_empty(self):
         """Explicit empty whitelist → hub returns nothing."""
-        manager = self._make_manager(
-            [self._make_server("a", available_on_public_internet=True)]
-        )
+        manager = self._make_manager([self._make_server("a", available_on_public_internet=True)])
         assert manager.get_public_mcp_servers() == []
 
     @patch("litellm.public_mcp_servers", ["a"])
@@ -5201,9 +5058,7 @@ class TestGetPublicMCPServers:
     @patch("litellm.public_mcp_servers", ["does-not-exist"])
     def test_stale_whitelist_id_returns_empty(self):
         """Whitelist references an unknown server_id → no spurious results."""
-        manager = self._make_manager(
-            [self._make_server("a", available_on_public_internet=True)]
-        )
+        manager = self._make_manager([self._make_server("a", available_on_public_internet=True)])
         assert manager.get_public_mcp_servers() == []
 
 
@@ -5282,9 +5137,7 @@ class TestCreateMcpClientV2Graft:
             NoOpAuth,
         )
 
-        client = await MCPServerManager()._create_mcp_client(
-            self._http_server(auth_type=None)
-        )
+        client = await MCPServerManager()._create_mcp_client(self._http_server(auth_type=None))
 
         assert isinstance(client._resolved_auth, NoOpAuth)
         assert client._mcp_auth_value is None
@@ -5298,9 +5151,7 @@ class TestCreateMcpClientV2Graft:
             (MCPAuth.authorization, "raw-123", "Authorization", "raw-123"),
         ],
     )
-    async def test_static_family_emits_expected_header(
-        self, auth_type, token, expected_name, expected_value
-    ):
+    async def test_static_family_emits_expected_header(self, auth_type, token, expected_name, expected_value):
         from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
             StaticHeaderAuth,
         )
@@ -5328,9 +5179,7 @@ class TestCreateMcpClientV2Graft:
         encoded = base64.b64encode(b"user:pass").decode()
         assert isinstance(client._resolved_auth, StaticHeaderAuth)
         assert client._resolved_auth.header_name == "Authorization"
-        assert (
-            client._resolved_auth._header_value.get_secret_value() == f"Basic {encoded}"
-        )
+        assert client._resolved_auth._header_value.get_secret_value() == f"Basic {encoded}"
 
     async def test_m2m_client_credentials_defers_to_v1(self):
         # M2M (oauth2 client_credentials) is not migrated: to_server_spec returns
@@ -5395,9 +5244,7 @@ class TestCreateMcpClientV2Graft:
         # A per-request override (mcp_auth_header) must win over the shared static token,
         # exactly as v1 did, so a migrated static server defers to v1 when one is present.
         client = await MCPServerManager()._create_mcp_client(
-            self._http_server(
-                auth_type=MCPAuth.bearer_token, authentication_token="shared-tok"
-            ),
+            self._http_server(auth_type=MCPAuth.bearer_token, authentication_token="shared-tok"),
             mcp_auth_header="caller-override",
         )
 
@@ -5409,9 +5256,7 @@ class TestCreateMcpClientV2Graft:
         # signer, static_headers, or a forwarded caller header) must win. The server stays on
         # the v2 path but skips resolved_auth, so nothing overwrites the inbound header.
         client = await MCPServerManager()._create_mcp_client(
-            self._http_server(
-                auth_type=MCPAuth.bearer_token, authentication_token="shared-tok"
-            ),
+            self._http_server(auth_type=MCPAuth.bearer_token, authentication_token="shared-tok"),
             extra_headers={"Authorization": "Bearer hook-jwt"},
         )
 
@@ -5579,12 +5424,7 @@ def test_should_strip_caller_authorization_for_token_exchange():
         client_id="cid",
         client_secret="csec",
     )
-    assert (
-        _should_strip_caller_authorization(
-            mcp_server=server, raw_headers=None, user_api_key_auth=None
-        )
-        is True
-    )
+    assert _should_strip_caller_authorization(mcp_server=server, raw_headers=None, user_api_key_auth=None) is True
 
 
 class _UpstreamAuthError(Exception):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5370,13 +5370,15 @@ class TestMCPToolsListAuthSurfacing:
 
     @pytest.mark.asyncio
     async def test_get_tools_from_server_absorbs_non_challenge_http_error(self):
+        """A non-auth HTTPException (500) stays absorbed so one misconfigured server cannot blank
+        the listing; 401/403 are the challenge-class statuses routed to MCPUpstreamAuthError."""
         manager = MCPServerManager()
         server = MCPServer(
             server_id="stdio-srv", name="stdio-srv", transport=MCPTransport.http
         )
         manager._create_mcp_client = AsyncMock(
             side_effect=HTTPException(
-                status_code=403,
+                status_code=500,
                 detail="MCP stdio command 'foo' is not in the allowlist",
             )
         )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -970,3 +970,88 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_returns
     assert (
         "/.well-known/oauth-protected-resource/delegated_oauth_server/mcp" in challenge
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_streamable_http_mcp_token_exchange_without_subject_returns_preemptive_resource_metadata_401():
+    """An ``oauth2_token_exchange`` (OBO) server with no caller subject token must fail fast at
+    connect with a 401 carrying the RFC 9728 ``resource_metadata`` + RFC 6750 ``invalid_token``
+    challenge, so the client discovers the IdP and retries with a subject token. A tool-call-time
+    401 would be wrapped into a JSON-RPC error and the WWW-Authenticate lost, so this preemptive
+    challenge is what drives the discovery flow."""
+    from fastapi import HTTPException
+
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+            session_manager_stateful,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp/obo_server",
+        "_original_path": "/mcp/obo_server",
+        "scheme": "https",
+        "query_string": b"",
+        "root_path": "",
+        "server": ("litellm.example.com", 443),
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"host", b"litellm.example.com"),
+        ],
+    }
+    receive = AsyncMock(
+        return_value={
+            "type": "http.request",
+            "body": b'{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+            "more_body": False,
+        }
+    )
+    send = AsyncMock()
+    user_auth = MagicMock()
+    user_auth.user_id = None
+    obo_server = MagicMock()
+    obo_server.auth_type = MCPAuth.oauth2_token_exchange
+    obo_server.alias = None
+    obo_server.server_name = "obo_server"
+    obo_server.name = "obo_server"
+    obo_server.server_id = "obo-server"
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+            new_callable=AsyncMock,
+            return_value=(user_auth, None, ["obo_server"], None, None, None),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.server.set_auth_context"),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+            True,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._handle_stale_mcp_session",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager.get_mcp_server_by_name",
+            return_value=obo_server,
+        ),
+        patch.object(
+            session_manager_stateful,
+            "handle_request",
+            new_callable=AsyncMock,
+        ) as mock_handle_request,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_streamable_http_mcp(scope, receive, send)
+
+    assert mock_handle_request.await_count == 0
+    assert exc_info.value.status_code == 401
+    headers = {k.lower(): v for k, v in (exc_info.value.headers or {}).items()}
+    challenge = headers["www-authenticate"]
+    assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo_server"' in challenge
+    assert 'error="invalid_token"' in challenge

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_stale_session.py
@@ -294,15 +294,9 @@ async def test_stale_mcp_session_id_is_stripped():
 
     # Verify the mcp-session-id header was stripped
     header_names = [k for k, v in captured_scope.get("headers", [])]
-    assert (
-        b"mcp-session-id" not in header_names
-    ), "Stale mcp-session-id header should have been stripped from the scope"
-    assert (
-        stateless_handle_request.called
-    ), "Stale non-initialize requests should route stateless"
-    assert (
-        not stateful_handle_request.called
-    ), "Stale non-initialize requests should not route stateful"
+    assert b"mcp-session-id" not in header_names, "Stale mcp-session-id header should have been stripped from the scope"
+    assert stateless_handle_request.called, "Stale non-initialize requests should route stateless"
+    assert not stateful_handle_request.called, "Stale non-initialize requests should not route stateful"
 
 
 @pytest.mark.asyncio
@@ -366,9 +360,7 @@ async def test_delete_stale_mcp_session_returns_success():
         await handle_streamable_http_mcp(scope, receive, send)
 
     # Verify session manager was NOT called (request was handled early)
-    assert (
-        not mock_handle_request.called
-    ), "Session manager should not be called for DELETE on non-existent session"
+    assert not mock_handle_request.called, "Session manager should not be called for DELETE on non-existent session"
 
     # Verify a success response was sent
     assert send.called, "A response should have been sent"
@@ -523,9 +515,7 @@ async def test_valid_mcp_session_id_is_preserved():
 
     # Verify the mcp-session-id header was preserved
     header_names = [k for k, v in captured_scope.get("headers", [])]
-    assert (
-        b"mcp-session-id" in header_names
-    ), "Valid mcp-session-id header should have been preserved"
+    assert b"mcp-session-id" in header_names, "Valid mcp-session-id header should have been preserved"
 
 
 @pytest.mark.asyncio
@@ -967,9 +957,7 @@ async def test_handle_streamable_http_mcp_delegated_server_without_token_returns
     challenge = exc_info.value.headers["www-authenticate"]
     assert "resource_metadata=" in challenge
     assert "authorization_uri=" not in challenge
-    assert (
-        "/.well-known/oauth-protected-resource/delegated_oauth_server/mcp" in challenge
-    )
+    assert "/.well-known/oauth-protected-resource/delegated_oauth_server/mcp" in challenge
 
 
 @pytest.mark.asyncio
@@ -1053,5 +1041,10 @@ async def test_handle_streamable_http_mcp_token_exchange_without_subject_returns
     assert exc_info.value.status_code == 401
     headers = {k.lower(): v for k, v in (exc_info.value.headers or {}).items()}
     challenge = headers["www-authenticate"]
-    assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo_server"' in challenge
+    # Structural invariants only: the exact root-path prefix is exercised in the adapter's
+    # oauth_protected_resource_path unit test, so this handler test stays hermetic w.r.t.
+    # SERVER_ROOT_PATH (which other tests in the shard may have left set in the environment).
+    assert "resource_metadata=" in challenge
+    assert "/.well-known/oauth-protected-resource" in challenge
+    assert challenge.split('resource_metadata="', 1)[1].split('"', 1)[0].endswith("/mcp/obo_server")
     assert 'error="invalid_token"' in challenge


### PR DESCRIPTION
## Relevant issues

Stacked on #31526 (the token_exchange / OBO arm). Base is that branch so the diff is just this work; it retargets to `litellm_internal_staging` after #31526 merges

## Linear ticket

N/A

## What this is

Makes token_exchange (OBO) production-ready on top of #31526. It began as the discovery fix (an OBO server's tools could not be listed through the aggregator) and then folded in a set of hardening fixes found by an adversarial audit of every OBO code path, credential shape, IdP failure mode, and third-party MCP client interaction. Each fix below is a separate commit with its own regression tests

## 1. Discovery threading (the original fix)

With #31526, OBO tool calls work, but an OBO server's tools could not be discovered. The `tools/list` path never threaded the caller's token, so every list hit the no-subject branch of the resolver. v1 masked this with a no-subject client_credentials fallback (discovery quietly used a service token); #31526 dropped that fallback per the v2 rule against falling through to a weaker source, so listing had no credential and the tools never appeared. Since an MCP client lists before it calls, the tools were invisible

The fix gives discovery the caller's own token: `_get_tools_from_server` extracts the inbound `subject_token` via the existing `_extract_bearer_token` and passes it into `_create_mcp_client`, gated on `auth_type == oauth2_token_exchange` so the bearer never leaks into other modes; `server.py` forwards `oauth2_headers` at the list call site. The list path's graceful degradation (a failed per-server fetch returns an empty list, never crashing the catalog) is preserved

## 2. Hardening fixes from the audit

**a. A caller header can no longer bypass the exchange.** The `_create_mcp_client` guard that ignores a per-request `x-mcp-*` override only protected `authorization_code`; on a token_exchange server the override dropped the v2 spec, skipped the RFC 8693 exchange, and forwarded the caller's raw header upstream. The guard now also covers `token_exchange`, so the exchange always runs and a caller cannot substitute an arbitrary upstream credential to defeat the audience-scoping

**b. OBO now works for prompts and resources, not just tools.** `prompts/list`, `prompts/get`, `resources/list`, `resources/read`, and `resource-templates/list` never threaded the subject token, so those operations failed closed (empty or 401) on an OBO server. They now thread the caller's bearer like the tools paths, via a shared `_obo_subject_token` helper gated on the mode

**c. The resolver-owned credential is authoritative.** A guardrail such as `MCPJWTSigner`, `static_headers`, or any injected `Authorization` could shadow the exchanged token, so the upstream received the injected JWT instead of the minted token and rejected it (no warning fired). For `token_exchange` and `authorization_code`, `_create_mcp_client` now drops the conflicting header and keeps the resolved token. No change for `none` / passthrough / static modes, where an injected Authorization still wins. This makes the signer-plus-OBO combination coherent instead of silently broken; the two are alternative identity-propagation strategies (LiteLLM-issued vs IdP-exchanged) that should never both reach one upstream

**d. The OpenAPI path no longer leaks the raw subject token.** The OpenAPI / local `_request_extra_headers` forwarder gated its strip on `has_client_credentials` only, so an OpenAPI-backed token_exchange server with `extra_headers: [Authorization]` forwarded the raw subject token upstream and never exchanged. It now uses the centralized `_should_strip_caller_authorization`, matching the managed paths

**e. RFC 9728 challenge on unauthorized.** OBO returned an opaque `401 Bearer error="invalid_request"` with no discovery info, and any IdP exchange failure collapsed to a retryable 503. An OBO server now behaves like a standards-compliant OAuth resource server:

```
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/<server>",
                  error="invalid_token",
                  error_description="Missing or invalid subject token; authenticate with the IdP and retry"
```

The challenge is emitted preemptively at connect (in the per-server preemptive-401), because the OBO tools are not discoverable without a subject and a tool-call-time 401 is wrapped into a JSON-RPC error so the WWW-Authenticate would be lost. The protected-resource metadata for an OBO server advertises the JWT-auth issuer(s) (`JWT_ISSUER` / `litellm_jwtauth.issuers`) as `authorization_servers`, which is the same IdP that issues and validates the subject token. So a spec-compliant MCP client discovers the IdP, SSOs, and retries with a fresh subject token, which LiteLLM then exchanges. An IdP 4xx (subject rejected) is a non-retryable 401 (the challenge) so a caller with a dead token re-authenticates instead of looping; 5xx and transport failures stay a retryable 503

## 3. Pure challenge edge (follow-up refactor)

The two challenge builders in the `outbound_credentials` adapter read `SERVER_ROOT_PATH` ambiently via `get_server_root_path()`, a hidden environment read inside a module that is supposed to be a pure edge. That coupling made the preemptive-challenge test order-dependent under xdist (a sibling test sets `SERVER_ROOT_PATH` at import without cleanup, leaking the prefix into the challenge URL). The root path is now resolved at the imperative-shell call sites and injected keyword-only, so `raise_user_oauth_challenge` and `raise_token_exchange_challenge` are pure functions of their inputs; the duplicated `resource_metadata` path construction collapses into one `oauth_protected_resource_path` helper. The adapter tests pass `root_path` as a real value instead of monkeypatching the environment, and the stale-session preemptive test asserts structural invariants rather than the exact prefixed URL so a leaked env var can no longer break it.

Two adjacent cleanups rode along: `_create_mcp_client` dropped back under the strict complexity ceiling by extracting the v2 credential resolution into `_resolve_v2_auth`, and the OBO protected-resource-metadata branch (which had shipped without coverage) moved into `_obo_protected_resource_response` with five new tests covering the issuer branch end to end

## 4. Contract-audit follow-ups (cache identity, retry, logging)

A pass over the OBO behavior contract surfaced three more gaps that land here. The exchanged-token cache key now folds in the caller's tenant alongside the subject token and exchange config, so two tenants presenting the same opaque token can never collide on one cache entry; isolation is structural rather than a side effect of subject-token uniqueness. The tool-call path gained a single reactive retry: when an upstream rejects the injected token with a 401/403, the gateway invalidates the cached exchange, re-mints once through the IdP, and retries the call exactly once before surfacing the upstream error, so a token revoked or rotated upstream mid-TTL self-heals without an infinite loop. This is gated strictly to `oauth2_token_exchange`, so passthrough, authorization_code, client_credentials, api_key, and none keep their existing single-call behavior. The exchanger also now emits the v1-parity log lines it had dropped (an attempt line with server, endpoint, and audience, a success line, and a cache-hit line), while still never logging the form, subject token, secret, or minted token.

One contract item is deliberately left for later. The exchange does not capture or use an RFC 8693 `refresh_token`: every expiry re-runs the exchange rather than refreshing, matching v1 and avoiding speculative refresh plumbing for IdPs that mostly do not issue OBO refresh tokens. The cache plus single-flight already keep the IdP round-trips off the hot path, so re-exchange-on-expiry is the intended lifetime here. RFC 9728 to RFC 8414 discovery of the token endpoint (so the endpoint need not be configured) is tracked as a separate follow-up rather than bundled here

Token endpoint resolution is now strictly config-driven and fails closed. A token_exchange server uses only an explicitly configured `token_exchange_endpoint`/`token_url`; the gateway never guesses an IdP or falls back to a weaker source. An OBO server that carries client credentials but no endpoint is owned by the v2 arm rather than deferred to v1, so a missing endpoint returns a clean `412` (precondition) before any upstream or IdP call and the caller's subject token is never sent anywhere. The no-subject case keeps its `401` RFC 9728 challenge, a rejected subject stays `401`, and an unreachable IdP stays `503`.


## 5. List-time 401 no longer masked (contract follow-up)

The list path still had one masking gap. When the resolver raised its 401 challenge while building the client (a present-but-rejected subject token, or an `authorization_code` server with no stored token), `_get_tools_from_server` caught it in the broad `except Exception: return []` and the server showed zero tools with no challenge, so a client could not tell "no tools" from "authenticate and retry". The preemptive connect-time challenge only covers the no-subject case; a subject the IdP rejects fails later, at exchange time, inside that try

The fix routes a v2 resolver auth failure through the same `MCPUpstreamAuthError` channel pass-through already uses. `_get_tools_from_server` now converts a 401/403 `HTTPException` into `MCPUpstreamAuthError`, preserving the `WWW-Authenticate` header, so a single-server route surfaces the challenge (the client re-authenticates) while the multi-server aggregator keeps absorbing it into an empty contribution for that one server. A non-auth error (412 no endpoint, 503 IdP down) stays absorbed as before, so one misconfigured server cannot blank the whole catalog. This is mode-agnostic, so `authorization_code` list discovery gets the same un-masking for free

Alongside it, the exchanger now logs a warning when it refuses a non-Bearer `token_type` from the IdP (the fail-closed check itself lands in #31526; this adds the observability line now that this branch carries the exchanger's logging)

## Auth model recap

A caller can present credentials two ways. Canonical single-JWT: `Authorization: Bearer <IdP JWT>` with no `x-litellm-api-key`, where the same JWT authenticates to LiteLLM via JWT auth and is the subject that gets exchanged (requires JWT auth configured against that IdP). Two-header: `x-litellm-api-key: Bearer <litellm-key>` for LiteLLM auth plus `Authorization: Bearer <subject>` for the exchange. In both, the subject always comes from `Authorization`, never from `x-litellm-api-key`, and only the exchanged token reaches the upstream

## Screenshots / Proof of Fix

Verified end to end against a real Keycloak IdP (standing in for Okta), not a mock exchanger. The setup is Keycloak 26.2 with standard RFC 8693 token exchange enabled (realm `litellm`, user `alice`, a confidential `litellm-exchange` client the gateway authenticates the exchange with, and `upstream-api` as the exchange audience), a dedicated Postgres, a mock upstream MCP server that logs every `Authorization` it receives, and the proxy from this branch run with `--use_v2_migration_resolver`, JWT auth enabled, and the enterprise license.

The flow proven is exactly the OBO contract: SSO with Keycloak to obtain an `<IdP JWT>`, send it to LiteLLM, LiteLLM exchanges it at Keycloak's token endpoint for an upstream-scoped access token, and that minted token (never the JWT) is what reaches the upstream. The subject JWT and the token the upstream actually received, decoded side by side:

```
subject  (from Keycloak): azp=mcp-subject     aud=litellm-exchange  jti=onrtro:9266...
upstream (forwarded)    : azp=litellm-exchange aud=upstream-api      jti=ntrtte:b034...
```

It is a different token, re-scoped to the upstream audience, and the raw subject string never appears in the upstream's request log.

A full battery covering both credential shapes and every fail-closed path:

```
1. SSO: mint alice's IdP JWT from Keycloak (password grant)        PASS
2. Two-header flow (x-litellm-api-key + Authorization=subject)
   - tools listed, tool call returned the upstream result          PASS
   - upstream got the EXCHANGED token (jti != subject)             PASS
   - exchanged token is audience-scoped to upstream-api            PASS
   - raw subject NEVER forwarded upstream                          PASS
3. Single-JWT flow (only Authorization=<IdP JWT>, no api-key)
   - JWT authenticated to LiteLLM AND the call succeeded           PASS
   - the same JWT was exchanged; upstream got the minted token     PASS
   - raw subject JWT NEVER forwarded upstream                      PASS
4. No subject -> 401 + RFC 9728 resource_metadata challenge        PASS
5. token_exchange server with no endpoint -> 412 precondition      PASS
6. Invalid subject -> IdP 4xx -> non-retryable 401 (not 503)       PASS
7. Repeated calls reuse one exchanged token (cache, one IdP hit)   PASS

RESULT: 15 passed, 0 failed
```

The no-subject challenge, verbatim:

```
POST /mcp/obo_demo   (x-litellm-api-key only, no Authorization)
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/obo_demo",
                  error="invalid_token", error_description="Missing or invalid subject token; authenticate with the IdP and retry"
```

The two fail-closed call paths surface in the MCP tool result: a token_exchange server with no configured endpoint returns `precondition required: token exchange endpoint is not configured for this server` (412, with no IdP guessing and no fallback to a weaker source), and an invalid subject that Keycloak rejects with a 4xx returns `Unauthorized` (a non-retryable 401, not a retryable 503). Each behavior above also ships with unit regression tests that fail on the pre-fix code

## Type

New Feature

🐛 Bug Fix

## Changes

See the numbered sections above. Touched: `mcp_server_manager.py`, `server.py`, `discoverable_endpoints.py`, and the `outbound_credentials` adapter / exchanger / provider, with tests across `test_mcp_server_manager.py`, `test_adapter.py`, `test_token_exchanger.py`, `test_resolver.py`, `test_discoverable_endpoints.py`, `test_mcp_stale_session.py`, and the `experimental_mcp_client` client tests







## Deliberately not implemented

The single JWT (SSO) shape, where the caller's IdP JWT both authenticates to LiteLLM and serves as the exchange subject, is the intended mode. The two-header shape (LiteLLM api key plus a separate Authorization subject) remains reachable but is not advertised, and in that shape the gateway does not pre-validate the subject's signature or expiry before the exchange; the IdP is the authority that accepts or rejects it. Delegation via `actor_token` (RFC 8693 section 4.1) is intentionally absent; the arm implements impersonation only
