### PR TITLE
fix(s3-vectors): use selected embedding model during ingest

### DIFF
--- a/litellm/rag/ingestion/s3_vectors_ingestion.py
+++ b/litellm/rag/ingestion/s3_vectors_ingestion.py
@@ -67,6 +67,9 @@ class S3VectorsRAGIngestion(BaseRAGIngestion, BaseAWSLLM):
 
         # Extract config
         self.vector_bucket_name = self.vector_store_config["vector_bucket_name"]
+        embedding_model = self.vector_store_config.get("embedding_model")
+        if not self.embedding_config and embedding_model:
+            self.embedding_config = {"model": embedding_model}
         self.index_name = self.vector_store_config.get("index_name")
         self.distance_metric = self.vector_store_config.get("distance_metric", S3_VECTORS_DEFAULT_DISTANCE_METRIC)
         self.non_filterable_metadata_keys = self.vector_store_config.get(

--- a/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
+++ b/tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.rag.ingestion.s3_vectors_ingestion import S3VectorsRAGIngestion
+
+
+def _s3_vectors_ingest_options(**overrides):
+    vector_store = {
+        "custom_llm_provider": "s3_vectors",
+        "vector_bucket_name": "test-vector-bucket",
+        "aws_region_name": "us-east-1",
+    }
+    vector_store.update(overrides.pop("vector_store", {}))
+    return {
+        "vector_store": vector_store,
+        **overrides,
+    }
+
+
+@pytest.mark.asyncio
+async def test_s3_vectors_ingestion_uses_vector_store_embedding_model():
+    ingestion = S3VectorsRAGIngestion(
+        ingest_options=_s3_vectors_ingest_options(
+            vector_store={"embedding_model": "text-embedding-3-large"}
+        )
+    )
+
+    with patch(
+        "litellm.rag.ingestion.s3_vectors_ingestion.litellm.aembedding",
+        new_callable=AsyncMock,
+    ) as mock_aembedding:
+        mock_aembedding.return_value = SimpleNamespace(
+            data=[{"embedding": [0.1, 0.2, 0.3]}]
+        )
+
+        embeddings = await ingestion.embed(["hello"])
+
+        mock_aembedding.assert_awaited_once_with(
+            model="text-embedding-3-large", input=["hello"]
+        )
+        assert embeddings == [[0.1, 0.2, 0.3]]
+
+        # Scope the next assertion to dimension auto-detection. It must call
+        # aembedding with the selected model instead of returning the default
+        # S3 vector dimension without probing the embedding model.
+        mock_aembedding.reset_mock()
+        mock_aembedding.return_value = SimpleNamespace(
+            data=[{"embedding": [0.1, 0.2, 0.3]}]
+        )
+
+        dimension = await ingestion._get_dimension_from_embedding_request()
+
+    mock_aembedding.assert_awaited_once_with(
+        model="text-embedding-3-large", input=["test"]
+    )
+    assert dimension == 3
+
+
+def test_s3_vectors_ingestion_prefers_top_level_embedding_config():
+    ingestion = S3VectorsRAGIngestion(
+        ingest_options=_s3_vectors_ingest_options(
+            embedding={"model": "text-embedding-3-small"},
+            vector_store={"embedding_model": "text-embedding-3-large"},
+        )
+    )
+
+    assert ingestion.embedding_config == {"model": "text-embedding-3-small"}


### PR DESCRIPTION
## Relevant issues

Fixes #28905
Replaces closed PR #28920, which could not be reopened because the prior fork/head branch no longer existed.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated RAG/S3 vectors change: `uv run --extra proxy pytest tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py -q` (2 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, the dashboard S3 vector-store create flow could send the selected model as `ingest_options.vector_store.embedding_model`, but `S3VectorsRAGIngestion` only read `ingest_options.embedding`. Ingest therefore fell back to `text-embedding-3-small` while the saved vector-store config used the selected model for search.

After this change, S3 vectors ingestion uses `vector_store.embedding_model` when top-level `ingest_options.embedding` is absent. If callers provide top-level embedding config, it still takes precedence. Dimension auto-detection also uses the selected embedding model instead of returning the default dimension without probing.

Reviewer-note coverage from #28920 is preserved: the regression test resets the `litellm.aembedding` mock before calling `_get_dimension_from_embedding_request()`, then asserts the auto-detect request is made with `model="text-embedding-3-large"` and `input=["test"]`.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py -q
# 2 passed, 1 warning

uv run ruff check litellm/rag/ingestion/s3_vectors_ingestion.py tests/test_litellm/proxy/rag_endpoints/test_s3_vectors_ingestion.py
# All checks passed!

git diff --check
# no output
```

Note: `uv run black --check ...` could not be run in my local sparse checkout because `black` was not installed in the resolved environment; CI should still run the repository formatting gate.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Teach `S3VectorsRAGIngestion` to use `vector_store.embedding_model` as the ingest embedding model when no top-level `embedding` config is provided.
- Preserve top-level `ingest_options.embedding` precedence for callers that explicitly set it.
- Add regression coverage proving the selected S3 embedding model is passed to `litellm.aembedding` for both embedding and dimension auto-detection.

## Thermo-nuclear code quality review

The diff keeps the behavior in the S3 vectors ingestion layer where the provider-specific option is already owned, avoids dashboard-specific branching, and adds focused RAG coverage under the proxy RAG endpoint test shard used by upstream CI coverage.