### PR TITLE
fix(policy): reject empty specific attachments

### DIFF
--- a/litellm/types/proxy/policy_engine/policy_types.py
+++ b/litellm/types/proxy/policy_engine/policy_types.py
@@ -31,7 +31,7 @@ Key concepts:
 
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from litellm.types.proxy.policy_engine.pipeline_types import GuardrailPipeline
 
@@ -292,6 +292,19 @@ class PolicyAttachment(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_scope_has_selector(self) -> "PolicyAttachment":
+        if self.scope == "*":
+            return self
+
+        if any((self.teams, self.keys, self.models, self.tags)):
+            return self
+
+        raise ValueError(
+            "Specific policy attachments must include at least one non-empty selector "
+            "(teams, keys, models, or tags). Use scope='*' for global attachments."
+        )
 
     def is_global(self) -> bool:
         """Check if this is a global attachment (scope='*')."""

--- a/litellm/types/proxy/policy_engine/resolver_types.py
+++ b/litellm/types/proxy/policy_engine/resolver_types.py
@@ -8,7 +8,7 @@ the final guardrails list.
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class PolicyMatchContext(BaseModel):
@@ -301,6 +301,19 @@ class PolicyAttachmentCreateRequest(BaseModel):
         default=None,
         description="Tag patterns this attachment applies to. Supports wildcards (e.g., health-*).",
     )
+
+    @model_validator(mode="after")
+    def validate_scope_has_selector(self) -> "PolicyAttachmentCreateRequest":
+        if self.scope == "*":
+            return self
+
+        if any((self.teams, self.keys, self.models, self.tags)):
+            return self
+
+        raise ValueError(
+            "Specific policy attachments must include at least one non-empty selector "
+            "(teams, keys, models, or tags). Use scope='*' for global attachments."
+        )
 
 
 class PolicyAttachmentDBResponse(BaseModel):

--- a/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
+++ b/tests/test_litellm/proxy/policy_engine/test_attachment_registry.py
@@ -362,23 +362,15 @@ class TestMatchAttribution:
         )
         assert registry.get_attached_policies(context_no_tag) == []
 
-    def test_attachment_with_no_scope_matches_everything(self):
-        """Test that an attachment with no scope/teams/keys/models/tags
-        matches everything because teams/keys/models default to ['*']."""
+    def test_attachment_with_no_scope_is_rejected(self):
+        """Test that empty config attachments must use explicit global scope."""
         registry = AttachmentRegistry()
-        registry.load_attachments(
-            [
-                {"policy": "catch-all"},
-            ]
-        )
-
-        context = PolicyMatchContext(
-            team_alias="any-team",
-            key_alias="any-key",
-            model="gpt-4",
-        )
-        attached = registry.get_attached_policies(context)
-        assert "catch-all" in attached
+        with pytest.raises(ValueError, match="at least one non-empty selector"):
+            registry.load_attachments(
+                [
+                    {"policy": "catch-all"},
+                ]
+            )
 
 
 class TestAttachmentRegistrySingleton:

--- a/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
+++ b/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
@@ -3,8 +3,10 @@ Tests for pipeline field on policy CRUD types (resolver_types.py).
 """
 
 import pytest
+from pydantic import ValidationError
 
 from litellm.types.proxy.policy_engine.resolver_types import (
+    PolicyAttachmentCreateRequest,
     PolicyCreateRequest,
     PolicyDBResponse,
     PolicyUpdateRequest,
@@ -100,3 +102,33 @@ def test_policy_create_request_roundtrip():
     dumped = req.model_dump()
     restored = PolicyCreateRequest(**dumped)
     assert restored.pipeline == pipeline_data
+
+
+def test_policy_attachment_create_request_rejects_empty_specific_scope():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachmentCreateRequest(policy_name="pii-policy")
+
+
+def test_policy_attachment_create_request_rejects_empty_selector_list():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachmentCreateRequest(policy_name="pii-policy", teams=[])
+
+
+def test_policy_attachment_create_request_allows_explicit_global_scope():
+    request = PolicyAttachmentCreateRequest(
+        policy_name="pii-policy",
+        scope="*",
+    )
+
+    assert request.scope == "*"
+
+
+@pytest.mark.parametrize("selector_field", ["teams", "keys", "models", "tags"])
+def test_policy_attachment_create_request_allows_selector_scope(selector_field):
+    selector_value = f"{selector_field}-a"
+    request = PolicyAttachmentCreateRequest(
+        policy_name="pii-policy",
+        **{selector_field: [selector_value]},
+    )
+
+    assert getattr(request, selector_field) == [selector_value]

--- a/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
+++ b/tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
@@ -11,6 +11,7 @@ from litellm.types.proxy.policy_engine.resolver_types import (
     PolicyDBResponse,
     PolicyUpdateRequest,
 )
+from litellm.types.proxy.policy_engine.policy_types import PolicyAttachment
 
 
 def test_policy_create_request_with_pipeline():
@@ -132,3 +133,30 @@ def test_policy_attachment_create_request_allows_selector_scope(selector_field):
     )
 
     assert getattr(request, selector_field) == [selector_value]
+
+
+def test_policy_attachment_rejects_config_empty_specific_scope():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachment(policy="pii-policy")
+
+
+def test_policy_attachment_rejects_config_empty_selector_list():
+    with pytest.raises(ValidationError, match="at least one non-empty selector"):
+        PolicyAttachment(policy="pii-policy", teams=[])
+
+
+def test_policy_attachment_allows_config_explicit_global_scope():
+    attachment = PolicyAttachment(policy="pii-policy", scope="*")
+
+    assert attachment.scope == "*"
+
+
+@pytest.mark.parametrize("selector_field", ["teams", "keys", "models", "tags"])
+def test_policy_attachment_allows_config_selector_scope(selector_field):
+    selector_value = f"{selector_field}-a"
+    attachment = PolicyAttachment(
+        policy="pii-policy",
+        **{selector_field: [selector_value]},
+    )
+
+    assert getattr(attachment, selector_field) == [selector_value]


### PR DESCRIPTION
## Relevant issues

Fixes #28904
Replaces closed PR #28921, which could not be reopened because the prior fork/head branch no longer existed.

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/test_litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/test_litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR passes the relevant unit tests for this isolated policy resolver change: `uv run --extra proxy pytest tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py -q` (13 passed)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem
- [x] I requested a Greptile review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## CI (LiteLLM team)

> **CI status guideline:**
>
> - 50-55 passing tests: main is stable with minor issues.
> - 45-49 passing tests: acceptable but needs attention
> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.

- [ ] **Branch creation CI run**  
       Link:

- [ ] **CI run for the last commit**  
       Link:

- [ ] **Merge / cherry-pick CI run**  
       Links:

## Screenshots / Proof of Fix

Before this change, a policy attachment with `scope="specific"` but no selectors could be treated as matching broadly. That made an invalid specific attachment behave like a global attachment.

After this change, specific attachments with no selected users/teams/organizations/keys are rejected during policy attachment resolution.

Validated locally:

```bash
uv run --extra proxy pytest tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py -q
# 13 passed

uv run ruff check litellm/types/proxy/policy_engine/resolver_types.py tests/test_litellm/types/proxy/policy_engine/test_resolver_types.py
# All checks passed!

git diff --check
# no output
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Reject empty `specific` policy attachments instead of allowing them to resolve without selectors.
- Add policy resolver regression coverage for the empty-specific-attachment case.