### PR TITLE
fix(proxy): reject non-finite budget_limits windows on /key/generate (LIT-4094)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -576,15 +576,20 @@ def _check_budget_limits_delegation_ceiling(
     is_ui_session_team_key: bool,
 ) -> None:
     """
-    Enforce the delegation ceiling on every per-window budget entry.
+    Enforce two invariants on `budget_limits`:
 
-    The single-value `max_budget` check upstream guards the all-time budget;
-    `budget_limits` lets a key carry independent concurrent windows and was
-    bypassing the ceiling entirely, so a non-admin caller could mint a key
-    with a window budget far above their own authority.
+    - Every `budget_limits[*].max_budget` must be a finite number; applies
+      to every caller including proxy admin.
+    - Non-admin callers may not set a window above their delegation ceiling.
     """
     if not budget_limits:
         return
+    non_finite = next((w for w in budget_limits if not math.isfinite(w.max_budget)), None)
+    if non_finite is not None:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": (f"budget_limits entry max_budget ({non_finite.max_budget}) must be a finite number.")},
+        )
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
         return
     if is_ui_session_team_key:

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -12855,6 +12855,64 @@ async def test_budget_limits_admin_unrestricted(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+async def test_budget_limits_window_non_finite_rejected_for_non_admin(monkeypatch, non_finite):
+    """A non-admin caller submitting a non-finite `budget_limits` window
+    gets 400. The finite-number invariant applies before role / ceiling
+    checks."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=10.0,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": non_finite}],
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "finite" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf"), float("-inf")])
+async def test_budget_limits_window_non_finite_rejected_for_admin(monkeypatch, non_finite):
+    """The finite-number invariant applies to every caller including
+    proxy admin."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": non_finite}],
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=admin,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "finite" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_permissions_field_rejected_for_non_admin(monkeypatch):
     """A non-admin caller may not set the `permissions` field on a key
     they create."""


### PR DESCRIPTION
## Relevant issues

Stacked on top of #31469 (VERIA-392). Closes Cursor Bugbot's finding 1 on the parent PR.

## Linear ticket

Resolves LIT-4094

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Enforce that every `budget_limits[*].max_budget` is a finite number on `/key/generate`. The check lives at the top of `_check_budget_limits_delegation_ceiling`, before the role and ceiling early returns, so the invariant applies to every caller including proxy admin

Six parametrized regression tests cover the rejection across the three non-finite float values (`NaN`, `+inf`, `-inf`) for both non-admin and admin callers. Mutation-killed against the parent commit (`c1495448d03`)

## Screenshots / Proof of Fix

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":NaN}]}'
```

```json
{"error":{"message":"{'error': 'budget_limits entry max_budget (nan) must be a finite number.'}","code":"400"}}
```

Control: finite values within the caller's ceiling still pass

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":5}]}'
```

```json
{"key":"sk-...","budget_limits":[{"budget_duration":"1d","max_budget":5.0,"reset_at":"..."}]}
```

## Follow-up

LIT-4095 lands as the next PR in this stack

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input validation on key generation with no auth or persistence changes beyond rejecting invalid budgets.
> 
> **Overview**
> **`/key/generate`** now rejects API key requests whose `budget_limits` entries use non-finite `max_budget` values (`NaN`, `+inf`, `-inf`) with HTTP 400.
> 
> The validation is added at the start of `_check_budget_limits_delegation_ceiling`, **before** proxy-admin and delegation-ceiling bypasses, so every caller—including admins—must submit finite window budgets. Existing ceiling checks for non-admins are unchanged.
> 
> Six parametrized tests assert this behavior for both internal users and proxy admins via `_common_key_generation_helper`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00a82980e187031217e0b7977fa48edc5f3cdb0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->