### PR TITLE
fix(proxy): hard-reject CLI session token personal-key budget_limits (LIT-4095)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -574,12 +574,16 @@ def _check_budget_limits_delegation_ceiling(
     delegation_ceiling: Optional[float],
     user_api_key_dict: UserAPIKeyAuth,
     is_ui_session_team_key: bool,
+    team_table: Optional[LiteLLM_TeamTableCachedObj],
 ) -> None:
     """
-    Enforce two invariants on `budget_limits`:
+    Enforce three invariants on `budget_limits`:
 
     - Every `budget_limits[*].max_budget` must be a finite number; applies
       to every caller including proxy admin.
+    - A CLI session token caller may not set `budget_limits` on a personal
+      key (one with no `team_id`); mirrors the scalar `max_budget` guard in
+      `_common_key_generation_helper`.
     - Non-admin callers may not set a window above their delegation ceiling.
     """
     if not budget_limits:
@@ -594,6 +598,13 @@ def _check_budget_limits_delegation_ceiling(
         return
     if is_ui_session_team_key:
         return
+    if user_api_key_dict.is_session_token and team_table is None:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": ("budget_limits cannot be set without specifying team_id when using a CLI session token.")
+            },
+        )
     if delegation_ceiling is None:
         return
     over_ceiling = next((w for w in budget_limits if w.max_budget > delegation_ceiling), None)
@@ -811,6 +822,7 @@ async def _common_key_generation_helper(
         delegation_ceiling=delegation_ceiling,
         user_api_key_dict=user_api_key_dict,
         is_ui_session_team_key=is_ui_session_team_key,
+        team_table=team_table,
     )
     _check_permissions_caller_permission(
         permissions=data.permissions,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -12913,6 +12913,129 @@ async def test_budget_limits_window_non_finite_rejected_for_admin(monkeypatch, n
 
 
 @pytest.mark.asyncio
+async def test_budget_limits_session_token_personal_key_rejected(monkeypatch):
+    """A CLI session token caller may not set `budget_limits` on a
+    personal key (no `team_id`). Mirrors the scalar `max_budget` guard."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        is_session_token=True,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 400
+    assert "session token" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_session_token_team_key_uses_team_ceiling(monkeypatch):
+    """A CLI session token acting on a team key uses the team's
+    `max_budget` as the ceiling; values within it are permitted."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    team = LiteLLM_TeamTableCachedObj(team_id="team-1", max_budget=50.0)
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        team_id="team-1",
+        is_session_token=True,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 25.0}],
+        team_id="team-1",
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "user-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=team,
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_session_token_team_key_over_team_budget_rejected(monkeypatch):
+    """Same shape, but window exceeds the team's `max_budget`."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    team = LiteLLM_TeamTableCachedObj(team_id="team-1", max_budget=50.0)
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        team_id="team-1",
+        is_session_token=True,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+        team_id="team-1",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=team,
+        )
+    assert exc_info.value.status_code == 400
+    assert "cannot exceed" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_budget_limits_session_token_personal_key_admin_unaffected(monkeypatch):
+    """A proxy admin using a session token is exempt from the personal-key
+    reject; the role short-circuit runs first."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        user_id="admin-1",
+        is_session_token=True,
+    )
+    request = GenerateKeyRequest(
+        budget_limits=[{"budget_duration": "1d", "max_budget": 1_000_000.0}],
+    )
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints.generate_key_helper_fn",
+        new_callable=AsyncMock,
+        return_value={"key": "sk-test", "expires": None, "user_id": "admin-1"},
+    ):
+        result = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=admin,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert result is not None
+
+
+@pytest.mark.asyncio
 async def test_permissions_field_rejected_for_non_admin(monkeypatch):
     """A non-admin caller may not set the `permissions` field on a key
     they create."""


### PR DESCRIPTION
## Relevant issues

Stacked on top of #31630 (LIT-4094), which is stacked on #31469 (VERIA-392). Closes the "Session token skips budget_limits guard" finding Cursor Bugbot flagged on the original PR.

After this PR merges, VERIA-392 + both Cursor Bugbot findings on the original parent PR are closed end-to-end.

## Linear ticket

Resolves LIT-4095

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`_check_budget_limits_delegation_ceiling` short-circuits when `delegation_ceiling` is `None`. For a CLI session token caller on a personal key (no `team_id`), the ceiling resolves to `None` because the token deliberately carries `max_budget=None` and there is no team budget to fall back to. The helper returns early and any submitted `budget_limits` window slips through

The scalar `max_budget` guard in `_common_key_generation_helper` already encodes the policy: a CLI session token cannot delegate budget for a personal key because there is no team budget to enforce against at request time. Mirror that on the per-window check

Pass `team_table` into the helper so it can detect the session-token + no-team case explicitly. Insert a hard reject before the `delegation_ceiling is None` early return. Counter-tests pin the other paths: the session-token + team-key case still works (uses team budget as the ceiling), and a proxy admin who happens to be using a session token is unaffected because the role short-circuit runs first

Four new regression tests in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`. Mutation-killed against the LIT-4094 base

## Screenshots / Proof of Fix

CLI session token + personal key + budget_limits = 400

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $SESSION_TOKEN" -H "Content-Type: application/json" \
  -d '{"budget_limits":[{"budget_duration":"1d","max_budget":1000000}]}'
```

```json
{"error":{"message":"{'error': 'budget_limits cannot be set without specifying team_id when using a CLI session token.'}","code":"400"}}
```

Session token + team-key path still works within the team budget

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $SESSION_TOKEN" -H "Content-Type: application/json" \
  -d '{"team_id":"team-1","budget_limits":[{"budget_duration":"1d","max_budget":25}]}'
```

```json
{"key":"sk-...","team_id":"team-1","budget_limits":[{"budget_duration":"1d","max_budget":25.0,"reset_at":"..."}]}
```

Session token + team key + window over team budget = 400 (regular ceiling error, not session-token error)

```
curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer $SESSION_TOKEN" -H "Content-Type: application/json" \
  -d '{"team_id":"team-1","budget_limits":[{"budget_duration":"1d","max_budget":1000000}]}'
```

```json
{"error":{"message":"{'error': \"budget_limits entry max_budget (1000000.0) cannot exceed the caller's own max_budget (50.0).\"}","code":"400"}}
```

## Stack

When all three land in order: VERIA-392 + Cursor Bugbot finding 1 (NaN) + Cursor Bugbot finding 2 (session-token) are all closed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authorization on proxy key generation for session tokens; behavior change is intentional but affects a security-sensitive path.
> 
> **Overview**
> Fixes a gap where **`budget_limits`** on key generation could bypass delegation checks for **CLI session tokens** creating **personal keys** (no `team_id`). When `delegation_ceiling` is `None`, `_check_budget_limits_delegation_ceiling` used to return early, so arbitrary per-window budgets could slip through even though scalar **`max_budget`** already blocks that case in `_common_key_generation_helper`.
> 
> The helper now takes **`team_table`** and, before the `delegation_ceiling is None` short-circuit, **hard-rejects** `is_session_token` callers with no team context (400: must specify `team_id`). **Team keys** still use the team budget as the ceiling; **proxy admins** on session tokens remain exempt via the existing role short-circuit.
> 
> Four async tests cover personal-key rejection, team-key within/over ceiling, and admin unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f27ef244b55119d58ab799e1d234520796c4257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->