### PR TITLE
fix(prometheus): bound per-request budget metric emission with a timeout

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import sys
 from datetime import datetime, timedelta
@@ -73,14 +74,17 @@ def _get_budget_metrics_per_request_timeout() -> float:
     if raw is None:
         return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
     try:
-        return float(raw)
+        parsed = float(raw)
     except ValueError:
+        parsed = None
+    if parsed is None or not math.isfinite(parsed) or parsed <= 0:
         verbose_logger.debug(
             "[Non-Blocking] Prometheus: invalid PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT=%r; using default %ss.",
             raw,
             _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT,
         )
         return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+    return parsed
 
 
 class PrometheusLogger(CustomLogger):

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -65,6 +65,23 @@ if TYPE_CHECKING:
 else:
     AsyncIOScheduler = Any
 
+_DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT = 5.0
+
+
+def _get_budget_metrics_per_request_timeout() -> float:
+    raw = os.getenv("PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT")
+    if raw is None:
+        return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+    try:
+        return float(raw)
+    except ValueError:
+        verbose_logger.debug(
+            "[Non-Blocking] Prometheus: invalid PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT=%r; using default %ss.",
+            raw,
+            _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT,
+        )
+        return _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+
 
 class PrometheusLogger(CustomLogger):
     # Class variables or attributes
@@ -1542,7 +1559,15 @@ class PrometheusLogger(CustomLogger):
         _user_spend = _metadata.get("user_api_key_user_spend", None)
         _user_max_budget = _metadata.get("user_api_key_user_max_budget", None)
 
-        results = await asyncio.gather(
+        # Bound the per-request budget-metric emission so that slow Redis/DB
+        # lookups under load cannot consume the whole LoggingWorker watchdog
+        # (LOGGING_WORKER_MAX_TIME_PER_COROUTINE, default 20s) and get the entire
+        # success-logging event cancelled. Budget gauges are also refreshed by the
+        # periodic cron every PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES,
+        # so dropping one slow per-request emission only loses sub-cron real-time
+        # detail, not correctness.
+        budget_metrics_timeout = _get_budget_metrics_per_request_timeout()
+        gather_coro = asyncio.gather(
             self._set_api_key_budget_metrics_after_api_request(
                 user_api_key=user_api_key,
                 user_api_key_alias=user_api_key_alias,
@@ -1569,6 +1594,16 @@ class PrometheusLogger(CustomLogger):
             ),
             return_exceptions=True,
         )
+        try:
+            results = await asyncio.wait_for(gather_coro, timeout=budget_metrics_timeout)
+        except asyncio.TimeoutError:
+            verbose_logger.debug(
+                "[Non-Blocking] Prometheus: per-request budget metric emission "
+                "exceeded %ss under load; skipping (values are refreshed by the "
+                "periodic budget-metrics cron job).",
+                budget_metrics_timeout,
+            )
+            return
         for i, r in enumerate(results):
             if isinstance(r, Exception):
                 verbose_logger.debug(

--- a/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
+++ b/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from prometheus_client import REGISTRY
 
-from litellm.integrations.prometheus import PrometheusLogger
+from litellm.integrations.prometheus import (
+    PrometheusLogger,
+    _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT,
+    _get_budget_metrics_per_request_timeout,
+)
 
 TIMEOUT_ENV = "PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT"
 
@@ -112,6 +116,31 @@ async def test_invalid_timeout_env_falls_back_to_default(prometheus_logger, monk
 
     assert prometheus_logger._set_api_key_budget_metrics_after_api_request.await_count == 1
     assert prometheus_logger._set_org_budget_metrics_after_api_request.await_count == 1
+
+
+@pytest.mark.parametrize("value", ["not-a-number", "0", "-1", "nan", "inf", "-inf"])
+def test_unusable_timeout_env_falls_back_to_default(value, monkeypatch):
+    """Values that parse but disable or unbound the timeout (0, negative, nan,
+    inf) must fall back to the default instead of being used; otherwise they
+    either skip every emission or recreate the unbounded-wait failure mode."""
+    monkeypatch.setenv(TIMEOUT_ENV, value)
+
+    assert _get_budget_metrics_per_request_timeout() == _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
+
+
+@pytest.mark.parametrize("value,expected", [("0.05", 0.05), ("5.0", 5.0), ("30", 30.0)])
+def test_valid_timeout_env_is_used(value, expected, monkeypatch):
+    """A finite positive value is parsed and returned unchanged."""
+    monkeypatch.setenv(TIMEOUT_ENV, value)
+
+    assert _get_budget_metrics_per_request_timeout() == expected
+
+
+def test_missing_timeout_env_uses_default(monkeypatch):
+    """With the env unset the default is returned."""
+    monkeypatch.delenv(TIMEOUT_ENV, raising=False)
+
+    assert _get_budget_metrics_per_request_timeout() == _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
+++ b/tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the per-request budget-metric emission timeout in
+PrometheusLogger._increment_remaining_budget_metrics.
+
+A slow Redis/DB lookup in one of the budget branches must not let the gather run
+unbounded; it is wrapped in asyncio.wait_for so the success-logging coroutine
+cannot exceed the LoggingWorker watchdog and get the whole event cancelled.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.integrations.prometheus import PrometheusLogger
+
+TIMEOUT_ENV = "PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def prometheus_logger():
+    return PrometheusLogger()
+
+
+def _call_increment(logger: PrometheusLogger):
+    return logger._increment_remaining_budget_metrics(
+        user_api_team="team-1",
+        user_api_team_alias="team-alias",
+        user_api_key="key-1",
+        user_api_key_alias="key-alias",
+        litellm_params={"metadata": {}},
+        response_cost=0.01,
+        user_id="user-1",
+        user_api_key_org_id="org-1",
+    )
+
+
+def _skip_logged(debug_mock) -> bool:
+    return any("skipping" in str(call.args[0]) for call in debug_mock.call_args_list if call.args)
+
+
+@pytest.mark.asyncio
+async def test_budget_metric_emission_skips_on_timeout(prometheus_logger, monkeypatch):
+    """A branch slower than the timeout is skipped without propagating, and the
+    skip is logged instead of cancelling the success-logging event."""
+    monkeypatch.setenv(TIMEOUT_ENV, "0.05")
+
+    async def _slow_branch(**kwargs):
+        await asyncio.sleep(30)
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = _slow_branch
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    with patch("litellm.integrations.prometheus.verbose_logger") as mock_logger:
+        await _call_increment(prometheus_logger)
+
+    assert _skip_logged(mock_logger.debug)
+
+
+@pytest.mark.asyncio
+async def test_budget_metric_emission_completes_within_timeout(prometheus_logger, monkeypatch):
+    """With a generous timeout every branch is awaited and no skip is logged."""
+    monkeypatch.setenv(TIMEOUT_ENV, "5.0")
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    with patch("litellm.integrations.prometheus.verbose_logger") as mock_logger:
+        await _call_increment(prometheus_logger)
+
+    assert prometheus_logger._set_api_key_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_team_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_user_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_org_budget_metrics_after_api_request.await_count == 1
+    assert not _skip_logged(mock_logger.debug)
+
+
+@pytest.mark.asyncio
+async def test_invalid_timeout_env_falls_back_to_default(prometheus_logger, monkeypatch):
+    """A malformed timeout env value must not raise (which would recreate the
+    failure mode); it falls back to the default and every branch still runs."""
+    monkeypatch.setenv(TIMEOUT_ENV, "not-a-number")
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    await _call_increment(prometheus_logger)
+
+    assert prometheus_logger._set_api_key_budget_metrics_after_api_request.await_count == 1
+    assert prometheus_logger._set_org_budget_metrics_after_api_request.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_still_propagates(prometheus_logger, monkeypatch):
+    """Only asyncio.TimeoutError is swallowed; an outer cancellation (cooperative
+    shutdown / watchdog) injected while awaiting must still propagate."""
+    monkeypatch.setenv(TIMEOUT_ENV, "30")
+
+    started = asyncio.Event()
+
+    async def _slow_branch(**kwargs):
+        started.set()
+        await asyncio.sleep(30)
+
+    prometheus_logger._set_api_key_budget_metrics_after_api_request = _slow_branch
+    prometheus_logger._set_team_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_user_budget_metrics_after_api_request = AsyncMock()
+    prometheus_logger._set_org_budget_metrics_after_api_request = AsyncMock()
+
+    task = asyncio.create_task(_call_increment(prometheus_logger))
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Relevant issues

N/A

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Deterministic, self-contained reproduction — **no Redis/DB, no live load**. It calls the patched method directly and captures `verbose_logger` into an in-memory buffer, exercising both the timeout branch and the happy path. Run from the repo root.

**Why `timeout=0.0` is a reliable trigger:** on CPython, `asyncio.wait_for(coro, timeout)` short-circuits when `timeout <= 0` and raises `TimeoutError` immediately, *before* the coroutine runs. So `PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT=0.0` deterministically forces the timeout branch on every call — simulating an "infinitely slow Redis" with zero real load. Production default is `5.0s`.

```bash
for T in 0.0 5.0; do echo "===== timeout=$T ====="; uv run --no-sync python -c "
import os, asyncio, logging, io
os.environ['PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT'] = '$T'
from litellm._logging import verbose_logger
buf = io.StringIO()
h = logging.StreamHandler(buf); h.setLevel(logging.DEBUG)
verbose_logger.addHandler(h); verbose_logger.setLevel(logging.DEBUG)
from litellm.integrations.prometheus import PrometheusLogger
pl = PrometheusLogger()
raised = None
async def main():
    global raised
    try:
        await pl._increment_remaining_budget_metrics(
            user_api_team=None, user_api_team_alias=None,
            user_api_key=None, user_api_key_alias=None,
            litellm_params={}, response_cost=0.0,
            user_id=None, user_api_key_org_id=None)
    except BaseException as e:
        raised = repr(e)
asyncio.run(main())
out = buf.getvalue()
print('Exception raised?:', raised, '(expected: None)')
print('Skip line present?:', 'budget metric emission exceeded' in out)
"; done
```

Output:

```
===== timeout=0.0 =====
LiteLLM:DEBUG: prometheus.py:1670 - [Non-Blocking] Prometheus: per-request budget metric emission exceeded 0.0s under load; skipping (values are refreshed by the periodic budget-metrics cron job).
Exception raised?: None (expected: None)   # returns clean, does NOT propagate TimeoutError/CancelledError
Skip line present?: True                   # patched branch executed

===== timeout=5.0 =====
Exception raised?: None (expected: None)
Skip line present?: False                  # happy path unchanged, no regression
```

| Criterion | Expected | Observed |
|---|---|---|
| Under timeout (0.0): no exception propagated | none | `raised = None` ✅ |
| Under timeout (0.0): skips and logs | line present | `True` ✅ |
| No timeout (5.0): completes normally | no skip line | `False` ✅ |
| No timeout (5.0): no exception | none | `raised = None` ✅ |

The two cases together prove the exact patch behavior: when budget emission exceeds the timeout it is dropped in isolation and silently, **without tearing down the whole success-logging event** (the original failure mode); when it doesn't exceed, nothing changes. The `5.0` case is the control proving the wrapper adds no regression on the happy path.

## Type

🐛 Bug Fix

## Changes

### Problem

`PrometheusLogger._increment_remaining_budget_metrics` awaits an `asyncio.gather` over the key/team/user/org budget branches with no timeout. Each branch reads the Redis cache and the Prisma DB. Under load these reads stall, the gather is awaited unbounded, and the success-logging coroutine exceeds the `LoggingWorker` watchdog (`LOGGING_WORKER_MAX_TIME_PER_COROUTINE`, default 20s). The watchdog then cancels the whole event, so every metric emitted after this await (latency, cache, total requests) is dropped too, not only the budget gauges

Requests still return 200, but the Prometheus gauges go incomplete and the logs fill with `LoggingWorker error` / `CancelledError`

### Fix

Bound only the budget-metric gather with its own `asyncio.wait_for`. The branches are already non-blocking (`return_exceptions=True`); on timeout we log and return, letting `async_log_success_event` keep emitting the remaining metrics instead of being cancelled wholesale. The budget gauges are independently refreshed by the periodic cron, so a skipped per-request emission only loses sub-cron real-time detail, not correctness

The bound is configurable via a new env var `PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT` (default 5.0s, well below the 20s watchdog). Only `asyncio.TimeoutError` is caught so an injected `CancelledError` (cooperative shutdown / outer watchdog) still propagates. The env value is validated to be a finite positive number; anything else (a typo, `0`, a negative, `nan`, or `inf`) falls back to the default instead of being used, so a bad value cannot silently disable emission (`<= 0` skips every call) or reintroduce the unbounded wait (`inf`)

### Tests

`tests/test_litellm/integrations/test_prometheus_budget_metrics_timeout.py` covers the behaviors: a branch slower than the timeout is skipped without propagating and the skip is logged; with a generous timeout every branch is awaited and nothing is skipped; the env parser returns a finite positive value as-is and falls back to the default for unusable inputs (`not-a-number`, `0`, `-1`, `nan`, `inf`, `-inf`) and when unset; an outer cancellation while awaiting still propagates instead of being swallowed
