### PR TITLE
fix(databricks): split parallel tool calls so each tool message follows tool_calls

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -40,10 +40,13 @@ from litellm.types.llms.databricks import (
 )
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionAssistantMessage,
+    ChatCompletionAssistantToolCall,
     ChatCompletionRedactedThinkingBlock,
     ChatCompletionThinkingBlock,
     ChatCompletionToolChoiceFunctionParam,
     ChatCompletionToolChoiceObjectParam,
+    ChatCompletionToolMessage,
     ChatCompletionToolParam,
 )
 from litellm.types.utils import (
@@ -90,6 +93,58 @@ def _sanitize_empty_content(message_dict: dict[str, Any]) -> None:
             message_dict.pop("content")
         else:
             message_dict["content"] = filtered
+
+
+def _split_parallel_tool_calls(messages: List[AllMessageValues]) -> List[AllMessageValues]:
+    """
+    Databricks (OpenAI-compatible serving) rejects a ``tool`` message unless the
+    message immediately before it carries ``tool_calls``. A single assistant turn
+    with parallel tool calls is followed by one ``tool`` message per call, so every
+    result after the first is preceded by another ``tool`` message and 400s. Re-emit
+    each result right after an assistant message holding only its matching call:
+    ``assistant(tool_calls=[A, B]), tool(A), tool(B)`` becomes
+    ``assistant(tool_calls=[A]), tool(A), assistant(tool_calls=[B]), tool(B)``.
+
+    Left untouched (no-op) when the turn is already valid or the history is
+    malformed, so no tool call is ever dropped.
+    """
+
+    def _expand(
+        assistant: ChatCompletionAssistantMessage,
+        calls_by_id: dict[Optional[str], ChatCompletionAssistantToolCall],
+        tool_messages: List[ChatCompletionToolMessage],
+    ) -> Iterator[AllMessageValues]:
+        for position, tool_message in enumerate(tool_messages):
+            matched_call = calls_by_id[tool_message["tool_call_id"]]
+            if position == 0:
+                yield cast(AllMessageValues, {**assistant, "tool_calls": [matched_call]})
+            else:
+                yield ChatCompletionAssistantMessage(role="assistant", tool_calls=[matched_call])
+            yield tool_message
+
+    def _generate() -> Iterator[AllMessageValues]:
+        index = 0
+        while index < len(messages):
+            message = messages[index]
+            tool_calls = message.get("tool_calls") if message["role"] == "assistant" else None
+            if not tool_calls or len(tool_calls) < 2:
+                yield message
+                index += 1
+                continue
+            end = index + 1
+            while end < len(messages) and messages[end]["role"] == "tool":
+                end += 1
+            tool_messages = cast(List[ChatCompletionToolMessage], messages[index + 1 : end])
+            calls_by_id = {call["id"]: call for call in tool_calls}
+            result_ids = {tool_message["tool_call_id"] for tool_message in tool_messages}
+            if len(tool_messages) == len(tool_calls) and set(calls_by_id) == result_ids:
+                yield from _expand(cast(ChatCompletionAssistantMessage, message), calls_by_id, tool_messages)
+                index = end
+            else:
+                yield message
+                index += 1
+
+    return list(_generate())
 
 
 if TYPE_CHECKING:
@@ -384,6 +439,9 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
                 _message = self._move_cache_control_into_string_content_block(_message)
             _sanitize_empty_content(cast(dict[str, Any], _message))
             new_messages.append(_message)
+
+        if "claude" not in model:
+            new_messages = _split_parallel_tool_calls(cast(List[AllMessageValues], new_messages))
 
         if is_async:
             return super()._transform_messages(messages=new_messages, model=model, is_async=cast(Literal[True], True))

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -95,7 +95,7 @@ def _sanitize_empty_content(message_dict: dict[str, Any]) -> None:
             message_dict["content"] = filtered
 
 
-def _split_parallel_tool_calls(messages: List[AllMessageValues]) -> List[AllMessageValues]:
+def _split_parallel_tool_calls(messages: list[AllMessageValues]) -> list[AllMessageValues]:
     """
     Databricks (OpenAI-compatible serving) rejects a ``tool`` message unless the
     message immediately before it carries ``tool_calls``. A single assistant turn
@@ -112,7 +112,7 @@ def _split_parallel_tool_calls(messages: List[AllMessageValues]) -> List[AllMess
     def _expand(
         assistant: ChatCompletionAssistantMessage,
         calls_by_id: dict[Optional[str], ChatCompletionAssistantToolCall],
-        tool_messages: List[ChatCompletionToolMessage],
+        tool_messages: list[ChatCompletionToolMessage],
     ) -> Iterator[AllMessageValues]:
         for position, tool_message in enumerate(tool_messages):
             matched_call = calls_by_id[tool_message["tool_call_id"]]
@@ -134,7 +134,7 @@ def _split_parallel_tool_calls(messages: List[AllMessageValues]) -> List[AllMess
             end = index + 1
             while end < len(messages) and messages[end]["role"] == "tool":
                 end += 1
-            tool_messages = cast(List[ChatCompletionToolMessage], messages[index + 1 : end])
+            tool_messages = cast(list[ChatCompletionToolMessage], messages[index + 1 : end])
             calls_by_id = {call["id"]: call for call in tool_calls}
             result_ids = {tool_message["tool_call_id"] for tool_message in tool_messages}
             if len(tool_messages) == len(tool_calls) and set(calls_by_id) == result_ids:
@@ -441,7 +441,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             new_messages.append(_message)
 
         if "claude" not in model:
-            new_messages = _split_parallel_tool_calls(cast(List[AllMessageValues], new_messages))
+            new_messages = _split_parallel_tool_calls(cast(list[AllMessageValues], new_messages))
 
         if is_async:
             return super()._transform_messages(messages=new_messages, model=model, is_async=cast(Literal[True], True))

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -5,9 +5,7 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 from unittest.mock import MagicMock, patch
 
 from litellm.llms.databricks.chat.transformation import (
@@ -255,8 +253,166 @@ def test_transform_messages_sanitizes_empty_content():
         {"role": "user", "content": [{"type": "text", "text": ""}]},
         {"role": "user", "content": "Hi"},
     ]
-    result = config._transform_messages(
-        messages=messages, model="databricks-claude", is_async=False
-    )
+    result = config._transform_messages(messages=messages, model="databricks-claude", is_async=False)
     assert "content" not in result[0]
     assert result[1]["content"] == "Hi"
+
+
+def _parallel_tool_calls():
+    return [
+        {
+            "id": "call_A",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+        },
+        {
+            "id": "call_B",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'},
+        },
+    ]
+
+
+def _assert_every_tool_message_follows_tool_calls(messages):
+    for index, message in enumerate(messages):
+        if message.get("role") == "tool":
+            previous = messages[index - 1] if index > 0 else {}
+            assert previous.get("role") == "assistant" and previous.get("tool_calls"), (
+                f"tool message at index {index} is not preceded by an assistant message with tool_calls: {messages}"
+            )
+
+
+def _declared_tool_call_ids(messages):
+    return sorted(
+        call["id"]
+        for message in messages
+        if message.get("role") == "assistant" and message.get("tool_calls")
+        for call in message["tool_calls"]
+    )
+
+
+def test_transform_request_splits_parallel_tool_calls_for_gpt():
+    """Regression for LIT-3984: Databricks 400s with 'messages with role tool must
+    be a response to a preceeding message with tool_calls' because parallel tool
+    calls send consecutive tool messages. Each result must be re-paired with an
+    assistant tool_calls message holding only its matching call."""
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "weather in SF and NYC?"},
+        {"role": "assistant", "content": "checking", "tool_calls": _parallel_tool_calls()},
+        {"role": "tool", "tool_call_id": "call_A", "content": "sunny"},
+        {"role": "tool", "tool_call_id": "call_B", "content": "rainy"},
+    ]
+
+    result = config.transform_request(
+        model="gpt-5.4-mini",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )["messages"]
+
+    _assert_every_tool_message_follows_tool_calls(result)
+    assert _declared_tool_call_ids(result) == ["call_A", "call_B"]
+    assistant_tool_call_messages = [m for m in result if m.get("role") == "assistant" and m.get("tool_calls")]
+    assert all(len(m["tool_calls"]) == 1 for m in assistant_tool_call_messages), (
+        "each split assistant message must declare exactly one tool call"
+    )
+    tool_messages = [m for m in result if m.get("role") == "tool"]
+    assert [m["tool_call_id"] for m in tool_messages] == ["call_A", "call_B"]
+    for tool_message, assistant_message in zip(tool_messages, assistant_tool_call_messages):
+        assert assistant_message["tool_calls"][0]["id"] == tool_message["tool_call_id"]
+
+
+def test_transform_request_pairs_out_of_order_parallel_results():
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": "checking", "tool_calls": _parallel_tool_calls()},
+        {"role": "tool", "tool_call_id": "call_B", "content": "rainy"},
+        {"role": "tool", "tool_call_id": "call_A", "content": "sunny"},
+    ]
+
+    result = config.transform_request(
+        model="gpt-5.4-mini",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )["messages"]
+
+    _assert_every_tool_message_follows_tool_calls(result)
+    for index, message in enumerate(result):
+        if message.get("role") == "tool":
+            assert result[index - 1]["tool_calls"][0]["id"] == message["tool_call_id"]
+
+
+def test_transform_request_leaves_single_tool_call_untouched():
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_A",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_A", "content": "sunny"},
+    ]
+
+    result = config.transform_request(
+        model="gpt-5.4-mini",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )["messages"]
+
+    assert len(result) == 3
+    _assert_every_tool_message_follows_tool_calls(result)
+    assert _declared_tool_call_ids(result) == ["call_A"]
+
+
+def test_transform_request_does_not_drop_tool_calls_on_incomplete_results():
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": "checking", "tool_calls": _parallel_tool_calls()},
+        {"role": "tool", "tool_call_id": "call_A", "content": "sunny"},
+        {"role": "user", "content": "thanks"},
+    ]
+
+    result = config.transform_request(
+        model="gpt-5.4-mini",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )["messages"]
+
+    assert _declared_tool_call_ids(result) == ["call_A", "call_B"]
+
+
+def test_transform_request_keeps_parallel_tool_calls_for_claude():
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": "checking", "tool_calls": _parallel_tool_calls()},
+        {"role": "tool", "tool_call_id": "call_A", "content": "sunny"},
+        {"role": "tool", "tool_call_id": "call_B", "content": "rainy"},
+    ]
+
+    result = config.transform_request(
+        model="databricks-claude-3-7-sonnet",
+        messages=messages,
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )["messages"]
+
+    assert len([m for m in result if m.get("role") == "assistant"]) == 1


### PR DESCRIPTION
## Relevant issues

Reported by a customer via support: tool/function calling against Databricks-hosted OpenAI-compatible GPT models 400s in any multi-turn agentic loop.

## Linear ticket

Resolves LIT-3984

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live against a real Databricks workspace endpoint (`databricks-gpt-oss-120b`), real tokens spent. The payload is one assistant turn with two parallel `get_weather` tool calls followed by both tool results, then a follow-up user message; `parallel.json` holds exactly that.

1. The failure, sent straight to Databricks (this is what LiteLLM emitted before the fix, passed through untouched):

```
$ curl -s "$DATABRICKS_HOST/serving-endpoints/chat/completions" \
    -H "Authorization: Bearer $DATABRICKS_TOKEN" -H "Content-Type: application/json" \
    -d @parallel.json
{"error_code":"BAD_REQUEST","message":"Multiple tool calls are not supported.\n"}
# HTTP 400
```

The customer's backend phrased the same rejection as `Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'`; both are Databricks refusing parallel tool calls.

2. The same payload through the LiteLLM proxy on this branch:

```
$ curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d @parallel.json
{"id":"chatcmpl_...","model":"databricks-gpt-oss-120b","object":"chat.completion",
 "choices":[{"finish_reason":"stop","index":0,"message":{
   "content":"San Francisco is sunny at 65 °F, while New York is cloudy at 50 °F.","role":"assistant"}}],
 "usage":{"completion_tokens":69,"prompt_tokens":244,"total_tokens":313}}
# HTTP 200
```

3. What LiteLLM actually POSTed to Databricks (`--detailed_debug`), confirming the split that makes the difference:

```
messages:
  user("What's the weather in SF and NYC?")
  assistant(tool_calls=[call_sf])
  tool(call_sf, "San Francisco: 65F, sunny")
  assistant(tool_calls=[call_nyc])
  tool(call_nyc, "New York: 50F, cloudy")
  user("Summarize both in one sentence.")
```

The client's single `assistant(tool_calls=[call_sf, call_nyc])` was rewritten into two single-call assistant turns, each immediately followed by its own result.

## Type

🐛 Bug Fix

## Changes

```
Before (400):
user:      "Weather in SF and NYC?"
assistant: tool_calls=[A: get_weather(SF), B: get_weather(NYC)]
tool:      (A) "65°F sunny"
tool:      (B) "50°F cloudy"          <- Databricks rejects: this tool msg
                                          follows a tool msg, not tool_calls
```

```
After (200):
user:      "Weather in SF and NYC?"
assistant: tool_calls=[A: get_weather(SF)]
tool:      (A) "65°F sunny"
assistant: tool_calls=[B: get_weather(NYC)]
tool:      (B) "50°F cloudy"          <- now each tool msg follows its own tool_calls
```

Databricks' OpenAI-compatible serving validates that every `tool` message is immediately preceded by a message carrying `tool_calls`, and it does not support parallel function calling. When an assistant turn makes parallel tool calls, the OpenAI wire shape is one `assistant` message holding all `tool_calls` followed by one `tool` message per result, so every result after the first is preceded by another `tool` message and gets rejected. LiteLLM's Databricks request transform passed the sequence through untouched.

`_split_parallel_tool_calls` (called from `DatabricksConfig._transform_messages` for non-Claude models) re-emits each result right after an assistant message carrying only its matching `tool_call`, turning `assistant(tool_calls=[A, B]), tool(A), tool(B)` into `assistant(tool_calls=[A]), tool(A), assistant(tool_calls=[B]), tool(B)`. It is a no-op when the turn is already valid (single call), when the result group is incomplete, or when ids don't line up, so no tool call is ever dropped. Claude on Databricks supports parallel calls natively and is translated server-side, so it is left on the existing path.

Tests live in `tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py`: the split for parallel calls and the out-of-order pairing both fail before the fix and pass after; three guards cover the no-op paths (single call untouched, incomplete results not dropped, Claude not split).

The same customer report also included an unrelated OpenTelemetry `TypeError: unhashable type: 'list'` in guardrail-span dedup; that was already fixed in #31262 and is out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound chat message shape for Databricks non-Claude models only; logic is guarded with no-op paths, but incorrect splitting could break multi-turn tool conversations.
> 
> **Overview**
> Fixes **LIT-3984**: Databricks OpenAI-compatible GPT endpoints reject multi-turn agentic tool loops when one assistant turn has **parallel** `tool_calls` followed by multiple `tool` messages—the second and later `tool` messages are not immediately after an assistant with `tool_calls`, causing HTTP 400.
> 
> Adds **`_split_parallel_tool_calls`** in the Databricks chat transform and runs it from **`_transform_messages`** for models whose name does **not** include `"claude"`. Valid parallel turns are rewritten to alternating single-call assistant + tool pairs (e.g. `assistant([A,B]), tool(A), tool(B)` → `assistant([A]), tool(A), assistant([B]), tool(B)`), including when tool results arrive out of order. The helper is a **no-op** for a single tool call, mismatched/incomplete tool result groups, or malformed history so tool calls are not dropped. **Claude** on Databricks is unchanged and keeps parallel tool-call wire format.
> 
> Tests in **`test_databricks_chat_transformation.py`** cover the split, out-of-order pairing, single-call passthrough, incomplete results, and Claude exclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93246fc642768011b12a1e9ec01a2823151b61cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
