### PR TITLE
fix(gemini): ensure finish_reason is null on intermediate tool call streaming chunks

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1914,8 +1914,12 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _check_finish_reason(
         chat_completion_message: Optional[ChatCompletionResponseMessage],
         finish_reason: Optional[str],
-    ) -> OpenAIChatCompletionFinishReason:
+        is_streaming: bool = False,
+    ) -> Optional[OpenAIChatCompletionFinishReason]:
         from litellm.litellm_core_utils.core_helpers import map_finish_reason
+
+        if is_streaming and not finish_reason:
+            return None
 
         if chat_completion_message and chat_completion_message.get("function_call"):
             return "function_call"
@@ -2005,7 +2009,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # create a streaming choice object
         choice = StreamingChoices(
             finish_reason=VertexGeminiConfig._check_finish_reason(
-                chat_completion_message, candidate.get("finishReason")
+                chat_completion_message, candidate.get("finishReason"), is_streaming=True
             ),
             index=candidate.get("index", idx),
             delta=Delta(
@@ -3167,7 +3171,9 @@ class ModelResponseIterator:
                     if self.has_seen_tool_calls:
                         mapped_finish_reason = "tool_calls"
                     else:
-                        mapped_finish_reason = VertexGeminiConfig._check_finish_reason(None, finish_reason_str)
+                        mapped_finish_reason = VertexGeminiConfig._check_finish_reason(
+                            None, finish_reason_str, is_streaming=True
+                        )
                 choice = StreamingChoices(
                     finish_reason=mapped_finish_reason,
                     index=candidate.get("index", 0),

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_streaming_tool_call_finish_reason.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_gemini_streaming_tool_call_finish_reason.py
@@ -78,7 +78,7 @@ def test_streaming_tool_call_finish_reason_is_tool_calls():
     assert response1 is not None
     assert len(response1.choices) == 1
     assert response1.choices[0].delta.tool_calls is not None
-    assert response1.choices[0].finish_reason == "tool_calls"
+    assert response1.choices[0].finish_reason is None
     assert iterator.has_seen_tool_calls is True
 
     # Process chunk 2 (final chunk)
@@ -133,6 +133,7 @@ def test_streaming_no_tool_calls_finish_reason_is_stop():
     assert response1 is not None
     assert len(response1.choices) == 1
     assert iterator.has_seen_tool_calls is False
+    assert response1.choices[0].finish_reason is None
 
     # Process chunk 2
     response2 = iterator.chunk_parser(chunk_with_finish_reason)
@@ -196,7 +197,9 @@ def test_streaming_multiple_tool_calls_finish_reason():
 
     response1 = iterator.chunk_parser(chunk_tool_1)
     assert response1 is not None
+    assert len(response1.choices) == 1
     assert iterator.has_seen_tool_calls is True
+    assert response1.choices[0].finish_reason is None
 
     response2 = iterator.chunk_parser(chunk_finish)
     assert response2 is not None
@@ -295,6 +298,7 @@ def test_streaming_tool_call_finish_reason_with_empty_content_in_final_chunk():
     assert len(response1.choices) == 1
     assert response1.choices[0].delta.tool_calls is not None
     assert iterator.has_seen_tool_calls is True
+    assert response1.choices[0].finish_reason is None
 
     # Process chunk 2 (final chunk with empty content)
     response2 = iterator.chunk_parser(chunk_with_empty_content_and_finish)
@@ -338,3 +342,22 @@ def test_streaming_metadata_only_chunk_does_not_yield_empty_choices():
     assert len(response.choices) == 1
     assert response.choices[0].finish_reason is None
     assert response.choices[0].delta.content is None
+
+
+def test_check_finish_reason_streaming_returns_none_when_no_finish_reason():
+    """
+    Ensure _check_finish_reason returns None when is_streaming=True and finish_reason is None or empty,
+    even if chat_completion_message contains tool_calls or function_call.
+    """
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    msg_with_tool_calls = {
+        "role": "assistant",
+        "tool_calls": [{"id": "call_123", "type": "function", "function": {"name": "foo", "arguments": "{}"}}],
+    }
+    assert VertexGeminiConfig._check_finish_reason(msg_with_tool_calls, None, is_streaming=True) is None
+    assert VertexGeminiConfig._check_finish_reason(msg_with_tool_calls, "", is_streaming=True) is None
+    # When not streaming, should still return "tool_calls" per contract
+    assert VertexGeminiConfig._check_finish_reason(msg_with_tool_calls, None, is_streaming=False) == "tool_calls"


### PR DESCRIPTION
## Relevant issues

Fixes premature finish_reason in Gemini tool call streaming

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real end-to-end proof hitting live Google AI Studio API (`gemini/gemini-3.1-flash-lite-preview`) with tool calls via LiteLLM streaming:

Command run against real Google AI Studio endpoint using streaming tool calls:
```bash
python -c '
import os, litellm
tools = [{
    "type": "function",
    "function": {
        "name": "get_current_weather",
        "description": "Get weather",
        "parameters": {
            "type": "object",
            "properties": {"location": {"type": "string"}},
            "required": ["location"]
        }
    }
}]
response = litellm.completion(
    model="gemini/gemini-3.1-flash-lite-preview",
    messages=[{"role": "user", "content": "What is the weather in Boston?"}],
    tools=tools,
    stream=True
)
for idx, chunk in enumerate(response):
    print(f"--- Chunk {idx} ---")
    print(chunk.model_dump_json(indent=2))
'
```

Real output logs demonstrating `finish_reason: null` on intermediate tool call chunks and `finish_reason: "tool_calls"` on the final chunk:
```json
--- Chunk 0 ---
{
  "id": "285Casb7KsWDjMcPgv2P-A4",
  "created": 1782763228,
  "model": "gemini-3.1-flash-lite-preview",
  "object": "chat.completion.chunk",
  "choices": [
    {
      "finish_reason": null,
      "index": 0,
      "delta": {
        "role": "assistant",
        "tool_calls": [
          {
            "id": "q2gHA8k1__thought__EjQKMgEMOdbH2lqftE9WRXxuOZ/AHYz2FPFd77GLllV4c32Gs874GAyXT9DULzrFwpss2cA4",
            "function": {
              "arguments": "{\"location\": \"Boston\"}",
              "name": "get_current_weather"
            },
            "type": "function",
            "index": 0
          }
        ]
      }
    }
  ]
}
--- Chunk 1 ---
{
  "id": "285Casb7KsWDjMcPgv2P-A4",
  "created": 1782763228,
  "model": "gemini-3.1-flash-lite-preview",
  "object": "chat.completion.chunk",
  "choices": [
    {
      "finish_reason": "tool_calls",
      "index": 0,
      "delta": {
        "content": null,
        "role": null,
        "tool_calls": null
      }
    }
  ]
}
```

Explanation of end-to-end behavior:
Before this fix, on Chunk 0 where `delta.tool_calls` is first yielded, LiteLLM evaluated `_check_finish_reason` unconditionally on the presence of tool calls and returned `"finish_reason": "tool_calls"`. When downstream clients observe any non-null `finish_reason`, they immediately close the streaming connection, truncating intermediate tool call arguments. With this fix, Chunk 0 maintains `"finish_reason": null` while tool call arguments stream, and only Chunk 1 sets `"finish_reason": "tool_calls"` once the stream completes.

## Type

🐛 Bug Fix

## Changes

According to OpenAI streaming specification, intermediate streaming chunks must keep finish_reason unassigned (null) while tool call arguments stream across chunks, and only the final chunk should assign finish_reason as tool_calls. Previously, _check_finish_reason evaluated chat_completion_message for tool_calls without considering whether the chunk contained a finish_reason candidate field during streaming, causing intermediate chunks to prematurely report tool_calls. This change introduces an is_streaming check inside _check_finish_reason so intermediate streaming chunks without a candidate finishReason remain null, while the final chunk correctly reports tool_calls
