### PR TITLE
fix(caching): handle search call types on cache hit

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -348,6 +348,16 @@ class Cache:
         litellm_param_kwargs = all_litellm_params
         is_semantic_cache = self._is_semantic_cache()
         scope_excluded_params = self._SEMANTIC_CACHE_SCOPE_EXCLUDED_PARAMS if is_semantic_cache else frozenset()
+        # Search requests (litellm.search / litellm.asearch) forward arbitrary
+        # provider-specific optional params (search_provider, max_results,
+        # safesearch, search_depth, exclude_domains, topic, ...) that change the
+        # results but aren't in the fixed LLM-param set. Key every non-litellm
+        # search kwarg regardless of the global
+        # enable_caching_on_provider_specific_optional_params flag; otherwise two
+        # different searches in the same scope would collide on one cached result.
+        # (Transient params like litellm_call_id are in all_litellm_params, so the
+        # `not in litellm_param_kwargs` guard still excludes them.)
+        is_search_request = "search_provider" in kwargs
         for param in kwargs:
             if param in scope_excluded_params:
                 continue
@@ -356,7 +366,7 @@ class Cache:
                 if param_value is not None:
                     cache_key += f"{str(param)}: {str(param_value)}"
             elif param not in litellm_param_kwargs:  # check if user passed in optional param - e.g. top_k
-                if litellm.enable_caching_on_provider_specific_optional_params is True:  # feature flagged for now
+                if litellm.enable_caching_on_provider_specific_optional_params is True or is_search_request:
                     if kwargs[param] is None:
                         continue  # ignore None params
                     param_value = kwargs[param]

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -194,12 +194,22 @@ class LLMCachingHandler:
                     verbose_logger.debug("Cache Hit!")
                     cache_hit = True
                     end_time = datetime.datetime.now()
-                    model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                        model=model,
-                        custom_llm_provider=kwargs.get("custom_llm_provider", None),
-                        api_base=kwargs.get("api_base", None),
-                        api_key=kwargs.get("api_key", None),
-                    )
+                    # Search call types carry a search-tool name in `model` (e.g.
+                    # "tavily-search"), not an LLM model name, so get_llm_provider()
+                    # would raise "LLM Provider NOT provided". Skip provider
+                    # resolution for them and keep the search-tool name as-is.
+                    if original_function.__name__ in (
+                        CallTypes.asearch.value,
+                        CallTypes.search.value,
+                    ):
+                        custom_llm_provider = kwargs.get("custom_llm_provider", None)
+                    else:
+                        model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                            model=model,
+                            custom_llm_provider=kwargs.get("custom_llm_provider", None),
+                            api_base=kwargs.get("api_base", None),
+                            api_key=kwargs.get("api_key", None),
+                        )
                     cache_duration_ms = (cache_check_end_time - cache_check_start_time) * 1000
                     self._update_litellm_logging_obj_environment(
                         logging_obj=logging_obj,
@@ -319,20 +329,28 @@ class LLMCachingHandler:
                     # LOG SUCCESS
                     cache_hit = True
                     end_time = datetime.datetime.now()
-                    (
-                        model,
-                        custom_llm_provider,
-                        dynamic_api_key,
-                        api_base,
-                    ) = litellm.get_llm_provider(
-                        model=model or "",
-                        custom_llm_provider=kwargs.get("custom_llm_provider", None),
-                        api_base=kwargs.get("api_base", None),
-                        api_key=kwargs.get("api_key", None),
-                    )
+                    # Search call types carry a search-tool name in `model` (e.g.
+                    # "tavily-search"), not an LLM model name, so get_llm_provider()
+                    # would raise "LLM Provider NOT provided". Skip provider
+                    # resolution for them.
+                    if call_type in (CallTypes.asearch.value, CallTypes.search.value):
+                        logged_model = model
+                    else:
+                        (
+                            model,
+                            custom_llm_provider,
+                            dynamic_api_key,
+                            api_base,
+                        ) = litellm.get_llm_provider(
+                            model=model or "",
+                            custom_llm_provider=kwargs.get("custom_llm_provider", None),
+                            api_base=kwargs.get("api_base", None),
+                            api_key=kwargs.get("api_key", None),
+                        )
+                        logged_model = f"{custom_llm_provider}/{model}"
                     self._update_litellm_logging_obj_environment(
                         logging_obj=logging_obj,
-                        model=f"{custom_llm_provider}/{model}",
+                        model=logged_model,
                         kwargs=kwargs,
                         cached_result=cached_result,
                         is_async=False,
@@ -872,6 +890,12 @@ class LLMCachingHandler:
                     )
                 else:
                     cached_result = response_obj
+        elif (call_type == CallTypes.asearch.value or call_type == CallTypes.search.value) and isinstance(
+            cached_result, dict
+        ):
+            from litellm.llms.base_llm.search.transformation import SearchResponse
+
+            cached_result = SearchResponse(**cached_result)
 
         if (
             hasattr(cached_result, "_hidden_params")

--- a/tests/test_litellm/caching/test_search_caching.py
+++ b/tests/test_litellm/caching/test_search_caching.py
@@ -1,0 +1,150 @@
+"""
+Regression tests for caching of the Search API (`litellm.search` / `litellm.asearch`).
+
+Search call types were wired into the cache write/gate path (CallTypes.search /
+CallTypes.asearch are valid `supported_call_types`, and both functions are
+`@client`-decorated), but the cache *read* path was incomplete:
+
+  1. On a cache hit, the wrapper unconditionally called `litellm.get_llm_provider(model=...)`.
+     For a search the `model` is a search-tool name (e.g. "tavily-search"), which has no
+     LLM provider, so the second (cached) call raised
+     "LLM Provider NOT provided ... Received Model Group=tavily-search".
+  2. `_convert_cached_result_to_model_response` had no `search`/`asearch` branch, so a
+     cached search dict was never rebuilt into a `SearchResponse`.
+
+These tests confirm a second, identical search is served from cache as a proper
+`SearchResponse` without re-hitting the provider.
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import pytest
+
+import litellm
+from litellm.caching.caching import Cache, LiteLLMCacheType
+from litellm.llms.base_llm.search.transformation import SearchResponse, SearchResult
+from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+
+def _make_search_response() -> SearchResponse:
+    resp = SearchResponse(
+        results=[
+            SearchResult(
+                title="LiteLLM Caching",
+                url="https://docs.litellm.ai/docs/proxy/caching",
+                snippet="How to cache responses in LiteLLM.",
+            )
+        ],
+        object="search",
+    )
+    resp._hidden_params = {"response_cost": 0.0}
+    return resp
+
+
+def _patch_provider_search():
+    return patch.object(
+        BaseLLMHTTPHandler,
+        "search",
+        return_value=_make_search_response(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _search_cache():
+    os.environ["TAVILY_API_KEY"] = "sk-test-tavily"
+    # Search is not in the default supported_call_types, so opt it in (this is
+    # exactly what a user must do in cache_params to cache search). Completion is
+    # included too so the non-search cache-hit path (provider resolution) is
+    # exercised alongside it.
+    litellm.cache = Cache(
+        type=LiteLLMCacheType.LOCAL,
+        supported_call_types=["search", "asearch", "completion", "acompletion"],
+    )
+    yield
+    litellm.cache = None
+
+
+@pytest.mark.asyncio
+async def test_asearch_second_call_served_from_cache():
+    """A repeated async search must hit the cache and not re-call the provider."""
+    with _patch_provider_search() as mock_search:
+        first = await litellm.asearch(query="litellm cache test", search_provider="tavily")
+        second = await litellm.asearch(query="litellm cache test", search_provider="tavily")
+
+    # Provider hit exactly once: the second call came from cache.
+    assert mock_search.call_count == 1
+    # Regression: the second call previously raised get_llm_provider() on "tavily-search".
+    assert isinstance(second, SearchResponse)
+    assert second.object == "search"
+    assert [r.url for r in second.results] == [r.url for r in first.results]
+
+
+def test_search_second_call_served_from_cache():
+    """Same guarantee for the synchronous entrypoint."""
+    with _patch_provider_search() as mock_search:
+        first = litellm.search(query="litellm cache test", search_provider="tavily")
+        second = litellm.search(query="litellm cache test", search_provider="tavily")
+
+    assert mock_search.call_count == 1
+    assert isinstance(second, SearchResponse)
+    assert [r.url for r in second.results] == [r.url for r in first.results]
+
+
+# The search guard added an `else` branch around the existing get_llm_provider()
+# call on the cache-hit path. These confirm a normal (non-search) completion
+# cache hit still resolves its provider through that branch and is unaffected.
+_COMPLETION_KWARGS = dict(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "hi"}],
+    mock_response="hello",
+    caching=True,
+)
+
+
+@pytest.mark.asyncio
+async def test_acompletion_cache_hit_still_resolves_provider():
+    await litellm.acompletion(**_COMPLETION_KWARGS)
+    # async set_cache runs as a background task; let it settle before re-reading.
+    await asyncio.sleep(0.5)
+    second = await litellm.acompletion(**_COMPLETION_KWARGS)
+    assert second._hidden_params.get("cache_hit") is True
+
+
+def test_completion_cache_hit_still_resolves_provider():
+    litellm.completion(**_COMPLETION_KWARGS)
+    second = litellm.completion(**_COMPLETION_KWARGS)
+    assert second._hidden_params.get("cache_hit") is True
+
+
+def test_search_cache_key_distinguishes_provider_and_options():
+    """Different search provider/options must not collide on one cached result.
+
+    `query` is already part of the key, but the provider and search options were
+    omitted, so e.g. tavily vs perplexity, different max_results/country, or an
+    arbitrary provider-specific param like safesearch=off vs strict for the same
+    query would have shared a single cached SearchResponse.
+    """
+    cache = Cache(type=LiteLLMCacheType.LOCAL)
+    base = dict(query="x", search_provider="tavily", model="tavily-search")
+    key = cache.get_cache_key(**base)
+    assert key != cache.get_cache_key(**{**base, "search_provider": "perplexity"})
+    assert key != cache.get_cache_key(**{**base, "max_results": 5})
+    assert key != cache.get_cache_key(**{**base, "country": "DE"})
+    # a provider-specific optional param (not in any fixed search param set) must
+    # still affect the key — search keys all non-litellm kwargs, not a fixed list.
+    assert key != cache.get_cache_key(**{**base, "safesearch": "strict"})
+
+
+def test_search_cache_key_excludes_transient_litellm_params():
+    """Per-request litellm params must NOT enter the search key, or every search
+    would be a cache miss."""
+    cache = Cache(type=LiteLLMCacheType.LOCAL)
+    base = dict(query="x", search_provider="tavily", model="tavily-search")
+    key = cache.get_cache_key(**base)
+    assert key == cache.get_cache_key(**{**base, "litellm_call_id": "abc-123"})
+    assert key == cache.get_cache_key(**{**base, "litellm_call_id": "different-id"})


### PR DESCRIPTION
## Relevant issues

N/A — bug found while enabling `/v1/search` response caching.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review and received a Confidence Score ≥ 4/5 (got 5/5)

## Type

🐛 Bug Fix

## Changes

Search responses (`litellm.search` / `litellm.asearch`, i.e. `POST /v1/search/...`)
are written to the cache when `search`/`asearch` are in
`cache_params.supported_call_types`, but the cache **read** path didn't handle them:

1. On a cache hit the wrapper called `get_llm_provider(model=...)`. A search carries a
   search-tool name (e.g. `tavily-search`) in `model`, which has no LLM provider → the
   **second** (cached) call raised `LLM Provider NOT provided` (surfaced as
   `Received Model Group=tavily-search`).
2. `_convert_cached_result_to_model_response` had no search branch, so a cached search
   dict was never rebuilt into a `SearchResponse`.
3. The cache **key** omitted `search_provider` and search options (`max_results`,
   `safesearch`, …), so two different searches in the same scope could collide on one
   cached result.

Fixes:
- Skip provider resolution for `search`/`asearch` on the sync + async cache-hit paths;
  reconstruct cached results as `SearchResponse`.
- `Cache.get_cache_key` now keys every non-litellm search kwarg (provider + options) for
  search requests. Transient params (`litellm_call_id`, …) stay excluded via
  `all_litellm_params`, so caching still works.

Tests (`tests/test_litellm/caching/test_search_caching.py`): sync + async cache hit served
as `SearchResponse` (provider hit once), non-search completion cache hit still resolves its
provider, and cache-key differentiation (provider/options change the key; `litellm_call_id`
does not).

## Screenshots / Proof of Fix

End-to-end against the real Tavily Search API (no mocks) — stock image vs. this branch,
identical request twice, only the 2nd (cache-hit) call differs.

Config (local cache, so no external deps):

```yaml
litellm_settings:
  cache: true
  cache_params:
    type: local
    supported_call_types: ["search", "asearch"]
search_tools:
  - search_tool_name: tavily-search
    litellm_params:
      search_provider: tavily
      api_key: os.environ/TAVILY_API_KEY
```

```bash
req() { curl -s localhost:$PORT/v1/search/tavily-search -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"query":"litellm cache test","max_results":3}'; }
# called twice against each image
```

**Before** (`ghcr.io/berriai/litellm:main-stable`) — 2nd (cached) call 500s:

```
== BEFORE 1st ==
{"object":"search","err":null}
== BEFORE 2nd ==
{"object":null,"err":"litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=\n Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers. Received Model Group=tavily-search\nAvailable Model Group Fallbacks=None"}
```

**After** (this branch) — 2nd call served from cache as a `SearchResponse`:

```
== AFTER 1st ==
{"object":"search","err":null}
== AFTER 2nd ==
{"object":"search","err":null}
```
