### PR TITLE
fix(passthrough): drop top-level additional_drop_params on /v1/messages

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -673,7 +673,9 @@ class LiteLLMAnthropicMessagesAdapter:
         Returns:
             Dict with either 'thinking' or 'reasoning_effort' key
         """
-        if LiteLLMAnthropicMessagesAdapter.is_anthropic_claude_model(model):
+        if LiteLLMAnthropicMessagesAdapter.is_anthropic_claude_model(
+            model
+        ) or LiteLLMAnthropicMessagesAdapter.is_bedrock_arn_model(model):
             return {"thinking": thinking}
         else:
             reasoning_effort = LiteLLMAnthropicMessagesAdapter.translate_anthropic_thinking_to_reasoning_effort(
@@ -965,7 +967,7 @@ class LiteLLMAnthropicMessagesAdapter:
             return
 
         model = new_kwargs.get("model", "")
-        if self.is_anthropic_claude_model(model):
+        if self.is_anthropic_claude_model(model) or self.is_bedrock_arn_model(model):
             new_kwargs["thinking"] = thinking  # type: ignore
             return
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1998,16 +1998,11 @@ class BaseLLMHTTPHandler:
             custom_llm_provider=custom_llm_provider,
         )
 
-        # Apply additional_drop_params for nested field removal
-        additional_drop_params = litellm_params.get("additional_drop_params")
+        additional_drop_params: list[str] = litellm_params.get("additional_drop_params") or []
         if additional_drop_params:
-            from litellm.litellm_core_utils.dot_notation_indexing import (
-                delete_nested_value,
-                is_nested_path,
-            )
+            from litellm.litellm_core_utils.dot_notation_indexing import delete_nested_value
 
-            nested_paths = [p for p in additional_drop_params if is_nested_path(p)]
-            for path in nested_paths:
+            for path in additional_drop_params:
                 anthropic_messages_optional_request_params = delete_nested_value(
                     anthropic_messages_optional_request_params, path
                 )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1508,6 +1508,44 @@ def test_cache_control_fix_does_not_broaden_claude_detection():
     )
 
 
+def test_thinking_preserved_for_bedrock_arn_inference_profile():
+    """
+    Regression: opaque Bedrock Application Inference Profile ARNs hide the underlying
+    Claude model name, so on /v1/messages a `thinking` param must be preserved as
+    `thinking` (not rewritten to `reasoning_effort`). Otherwise `additional_drop_params:
+    ["thinking"]` runs after the rewrite and has nothing left to drop, and the Bedrock
+    Converse body re-expands reasoning_effort back into additionalModelRequestFields.thinking.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    thinking = {"type": "enabled", "budget_tokens": 1024}
+
+    new_kwargs = {"model": CACHE_CONTROL_BEDROCK_ARN_MODEL}
+    adapter._translate_thinking_to_openai(cast(Any, {"thinking": thinking}), cast(Any, new_kwargs))
+
+    assert new_kwargs["thinking"] == thinking
+    assert "reasoning_effort" not in new_kwargs
+
+    assert LiteLLMAnthropicMessagesAdapter.translate_thinking_for_model(thinking, CACHE_CONTROL_BEDROCK_ARN_MODEL) == {
+        "thinking": thinking
+    }
+
+
+def test_thinking_still_translated_to_reasoning_effort_for_non_claude_model():
+    """
+    The bedrock-ARN gate must not broaden to every model: a genuine non-Claude model
+    still has `thinking` converted to `reasoning_effort` so it does not hit an
+    UnsupportedParamsError downstream.
+    """
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    thinking = {"type": "enabled", "budget_tokens": 1024}
+
+    new_kwargs = {"model": CACHE_CONTROL_NON_ANTHROPIC_MODEL}
+    adapter._translate_thinking_to_openai(cast(Any, {"thinking": thinking}), cast(Any, new_kwargs))
+
+    assert "thinking" not in new_kwargs
+    assert new_kwargs["reasoning_effort"] == "low"
+
+
 def test_cache_control_preserved_in_image_content_for_claude():
     """Cache control should be preserved in image content for Claude models."""
     anthropic_messages = [

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -645,6 +645,85 @@ async def test_async_anthropic_messages_handler_header_priority():
         assert captured_headers["X-Provider-Only"] == "keep-this-too"
 
 
+@pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_drops_top_level_and_nested_params():
+    """
+    Regression for LIT-3988 / GitHub #25931: on the /v1/messages path,
+    additional_drop_params must strip plain top-level keys (e.g. `thinking`,
+    `context_management`) before the provider transform runs, not only nested
+    dotted paths. Bedrock rejects these fields, so leaving them in produces a 400.
+    """
+    handler = BaseLLMHTTPHandler()
+
+    mock_config = Mock()
+    mock_config.validate_anthropic_messages_environment = Mock(
+        return_value=({"x-api-key": "test-key"}, "https://api.anthropic.com")
+    )
+
+    captured = {}
+
+    def capture_transform(*args, **kwargs):
+        captured["optional_params"] = kwargs["anthropic_messages_optional_request_params"]
+        return {"model": "claude-opus-4-7", "messages": []}
+
+    mock_config.transform_anthropic_messages_request = capture_transform
+
+    mock_client = AsyncMock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "id": "msg_123",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello!"}],
+        "model": "claude-opus-4-7",
+        "stop_reason": "end_turn",
+    }
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.update_from_kwargs = Mock()
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.stream = False
+
+    optional_params = {
+        "max_tokens": 1024,
+        "thinking": {"type": "enabled", "budget_tokens": 2048},
+        "context_management": {"edits": [{"type": "clear_thinking_20251015"}]},
+        "metadata": {"user_id": "u1", "drop_me": "x"},
+    }
+
+    with patch(
+        "litellm.litellm_core_utils.get_provider_specific_headers.ProviderSpecificHeaderUtils.get_provider_specific_headers"
+    ) as mock_provider_headers:
+        mock_provider_headers.return_value = None
+        try:
+            await handler.async_anthropic_messages_handler(
+                model="claude-opus-4-7",
+                messages=[{"role": "user", "content": "Hello"}],
+                anthropic_messages_provider_config=mock_config,
+                anthropic_messages_optional_request_params=optional_params,
+                custom_llm_provider="bedrock",
+                litellm_params=GenericLiteLLMParams(
+                    additional_drop_params=[
+                        "thinking",
+                        "context_management",
+                        "metadata.drop_me",
+                    ]
+                ),
+                logging_obj=mock_logging_obj,
+                client=mock_client,
+            )
+        except Exception:
+            pass  # drop runs before the mocked sign_request; the capture is what we assert on
+
+    transformed = captured["optional_params"]
+    assert "thinking" not in transformed
+    assert "context_management" not in transformed
+    assert transformed["max_tokens"] == 1024
+    assert transformed["metadata"] == {"user_id": "u1"}
+
+
 def test_google_genai_streaming_hidden_params_model_info_and_router_fallback():
     logging_obj = Mock()
     logging_obj.get_router_model_id = Mock(return_value="router-model-id")


### PR DESCRIPTION
## Relevant issues

Fixes #25931

## Linear ticket

LIT-3988

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two live-proxy runs against real AWS Bedrock, each before (staging HEAD `971a1bedc7`, no fix) and after (this PR, `f50966084d`). Account id and inference-profile id are redacted to `<acct>` / `<id>`

### Converse opaque inference-profile ARN (the reported case): HTTP 400 -> 200

1. Point a model at an opaque application-inference-profile ARN on the converse route and drop `thinking`:
   ```yaml
   model_list:
     - model_name: probe
       litellm_params:
         model: bedrock/converse/arn:aws:bedrock:us-west-2:<acct>:application-inference-profile/<id>
         aws_region_name: us-west-2
         additional_drop_params: ["thinking"]
       model_info:
         base_model: claude-opus-4-7
         litellm_provider: bedrock
         mode: chat
   general_settings:
     master_key: sk-e2e-1234
   ```
2. Run the proxy: `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`
3. Send a request with `thinking` enabled:
   ```
   curl -sS -w '\n%{http_code}\n' -X POST http://localhost:4000/v1/messages \
     -H 'content-type: application/json' -H 'x-api-key: sk-e2e-1234' \
     -H 'anthropic-version: 2023-06-01' \
     -d '{"model":"probe","max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":1024},"messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
   ```

Before (`additional_drop_params` is a no-op, so `thinking` reaches Bedrock and is rejected):
```
{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: \\\"thinking.type.enabled\\\" is not supported for this model. Use \\\"thinking.type.adaptive\\\" and \\\"output_config.effort\\\" to control thinking behavior.\"}. Received Model Group=probe\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
400
```

After (`thinking` is preserved, then actually dropped):
```
{"id":"chatcmpl-7b8ad6d0-5ffc-48ac-99fa-3db61ca2b1d0","type":"message","role":"assistant","model":"probe","stop_sequence":null,"usage":{"input_tokens":21,"output_tokens":6},"content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn"}
200
```

With the same fixed code but no `additional_drop_params`, the request 400s again with the identical `thinking.type.enabled` error, confirming `thinking` is exactly the param the drop removes. The outgoing Bedrock Converse body after the fix carries no `thinking` and no `additionalModelRequestFields`:
```
{"messages": [{"role": "user", "content": [{"text": "Reply with the single word: pong"}]}], "inferenceConfig": {"maxTokens": 2048}}
```

### Invoke path: outgoing body delta (stays HTTP 200 both ways)

1. Point a model at the invoke route and drop `thinking` + `context_management`:
   ```yaml
   model_list:
     - model_name: probe
       litellm_params:
         model: bedrock/invoke/us.anthropic.claude-opus-4-7
         aws_region_name: us-west-2
         additional_drop_params: ["thinking", "context_management"]
       model_info:
         base_model: claude-opus-4-7
         litellm_provider: bedrock
         mode: chat
   general_settings:
     master_key: sk-e2e-1234
   ```
2. Run the proxy with `--detailed_debug`
3. Send a request carrying both keys and read the outgoing `/invoke` body in the proxy log:
   ```
   curl -sS -X POST http://localhost:4000/v1/messages \
     -H 'content-type: application/json' -H 'x-api-key: sk-e2e-1234' \
     -H 'anthropic-version: 2023-06-01' -H 'anthropic-beta: context-management-2025-06-27' \
     -d '{"model":"probe","max_tokens":2048,"thinking":{"type":"enabled","budget_tokens":1024},"context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[{"role":"user","content":"Reply with the single word: pong"}]}'
   ```

Before (top-level `thinking` leaks into the InvokeModel body):
```
POST https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-opus-4-7/invoke
-d '{'messages': [{'role': 'user', 'content': 'Reply with the single word: pong'}], 'max_tokens': 2048, 'thinking': {'type': 'adaptive'}, 'output_config': {'effort': 'low'}, 'anthropic_version': 'bedrock-2023-05-31'}'
HTTP 200
```

After (top-level `thinking` is dropped):
```
POST https://bedrock-runtime.us-west-2.amazonaws.com/model/us.anthropic.claude-opus-4-7/invoke
-d '{'messages': [{'role': 'user', 'content': 'Reply with the single word: pong'}], 'max_tokens': 2048, 'anthropic_version': 'bedrock-2023-05-31'}'
HTTP 200
```

The invoke path stays 200 either way because its InvokeModel transform already rewrites `thinking: {type: enabled}` to the model-accepted `{type: adaptive}` and strips `context_management`, so the leaked top-level `thinking` was harmless on this provider. The fix removes that leaked key for correctness; the user-visible 400 -> 200 flip is the converse case above

## Type

🐛 Bug Fix

## Changes

The Anthropic Messages pass-through path (`async_anthropic_messages_handler` in `litellm/llms/custom_httpx/llm_http_handler.py`) only stripped nested dotted `additional_drop_params` entries via an `is_nested_path` filter, so plain top-level keys such as `thinking` and `context_management` were never removed and got forwarded to the provider. `delete_nested_value` already handles plain top-level fields, so this routes every drop param through it and removes the nested-only filter, making `additional_drop_params` on `/v1/messages` behave like it does on `/chat/completions`.

Added `test_async_anthropic_messages_handler_drops_top_level_and_nested_params` which drives the handler with `["thinking", "context_management", "metadata.drop_me"]`, captures what reaches `transform_anthropic_messages_request`, and asserts the top-level and nested keys are gone while `max_tokens` survives. Reverting the source flips it red

This now also fixes the opaque Bedrock application-inference-profile converse case, where `additional_drop_params: ["thinking"]` was previously a no-op. The adapter receives the model as `converse/arn:aws:bedrock:...:application-inference-profile/<id>`, a string that contains neither "anthropic" nor "claude", so `is_anthropic_claude_model` returned False and the thinking-translation path in `litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py` rewrote `thinking` to `reasoning_effort='low'` before `additional_drop_params` ran. With nothing named `thinking` left to drop, the Bedrock Converse transform re-expanded `reasoning_effort` back into `additionalModelRequestFields.thinking` and the request 400'd. v1.90.0 already added `is_bedrock_arn_model` and wired it into the cache_control preservation path, but the thinking-translation gates were never updated; this extends both of those gates (`_translate_thinking_to_openai` and the `translate_thinking_for_model` helper) to also accept bedrock ARNs, mirroring the cache_control fix, so `thinking` is preserved and `additional_drop_params` can drop it. The readable model-id form (`bedrock/converse/global.anthropic.claude-opus-4-7`) already worked because it contains "claude"

Added `test_thinking_preserved_for_bedrock_arn_inference_profile`, which asserts that for an opaque application-inference-profile ARN the adapter keeps `thinking` as `thinking` rather than converting it to `reasoning_effort`, plus `test_thinking_still_translated_to_reasoning_effort_for_non_claude_model` so the ARN gate does not broaden to genuine non-Claude models. Both fail before the gate change and pass after

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request shaping on the `/v1/messages` Bedrock path (param dropping and thinking translation); mis-scoping could affect non-Bedrock models, though tests guard the non-Claude translation path.
> 
> **Overview**
> Fixes **Bedrock 400s** on `POST /v1/messages` when `additional_drop_params` was configured but ineffective.
> 
> On the Anthropic Messages HTTP path, **`additional_drop_params` now removes plain top-level keys** (e.g. `thinking`, `context_management`) as well as dotted nested paths—previously only nested entries were filtered and dropped, so Bedrock still received unsupported fields.
> 
> For **opaque Bedrock application-inference-profile ARNs**, the pass-through adapter **keeps `thinking` as `thinking`** (via `is_bedrock_arn_model`, matching the existing cache-control behavior) instead of rewriting it to `reasoning_effort` first. That rewrite made `additional_drop_params: ["thinking"]` a no-op and let Converse re-inject thinking into the request body.
> 
> Regression tests cover handler param stripping and ARN vs non-Claude thinking translation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50966084d22c65047e2f9a72d79125ce08f274b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
