### PR TITLE
fix(anthropic): guard against empty tool_use names in messages adapter

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -47,6 +47,19 @@ def truncate_tool_name(name: str) -> str:
     return f"{name[:TOOL_NAME_PREFIX_LENGTH]}_{name_hash}"
 
 
+def resolve_tool_name(raw_name: Optional[str], fallback: str) -> str:
+    """
+    Return a usable tool name, substituting ``fallback`` when the name is missing or blank.
+
+    OpenAI-compatible backends (e.g. Mistral via vLLM) reject tool calls whose function name
+    is empty, so an Anthropic tool_use block or tool definition without a usable name must be
+    given a non-empty placeholder rather than passed through as an empty string.
+    """
+    if raw_name is not None and str(raw_name).strip():
+        return str(raw_name)
+    return fallback
+
+
 def create_tool_name_mapping(
     tools: List[Dict[str, Any]],
 ) -> Dict[str, str]:
@@ -529,8 +542,8 @@ class LiteLLMAnthropicMessagesAdapter:
                                     has_cache_control_in_text = True
                                 assistant_content_list.append(text_block)
                             elif content.get("type") == "tool_use":
-                                # Truncate tool name for OpenAI's 64-char limit
-                                tool_name = truncate_tool_name(content.get("name", ""))
+                                original_name = resolve_tool_name(content.get("name"), "litellm_unnamed_tool")
+                                tool_name = truncate_tool_name(original_name)
                                 function_chunk: ChatCompletionToolCallFunctionChunk = {
                                     "name": tool_name,
                                     "arguments": json.dumps(content.get("input", {})),
@@ -750,11 +763,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 new_tools.append(tool)  # type: ignore[arg-type]
                 continue
 
-            raw_name = tool.get("name")
-            if raw_name is None or (isinstance(raw_name, str) and not str(raw_name).strip()):
-                original_name = f"litellm_unnamed_tool_{idx}"
-            else:
-                original_name = str(raw_name)
+            original_name = resolve_tool_name(tool.get("name"), f"litellm_unnamed_tool_{idx}")
             truncated_name = truncate_tool_name(original_name)
 
             # Store mapping if name was truncated

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1075,6 +1075,68 @@ def test_translate_anthropic_messages_to_openai_tool_use_with_signature():
     )
 
 
+@pytest.mark.parametrize("tool_use_name", ["", "   ", None])
+def test_translate_anthropic_messages_to_openai_tool_use_without_name(tool_use_name):
+    """Regression test for https://github.com/BerriAI/litellm/issues/30515.
+
+    A tool_use block whose name is missing or blank must not produce an empty OpenAI
+    function name; OpenAI-compatible backends such as Mistral via vLLM reject those.
+    Before the fix an empty name was passed through verbatim and a None name crashed
+    with a TypeError inside truncate_tool_name.
+    """
+    messages = cast(
+        Any,
+        [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": tool_use_name,
+                        "input": {"q": "x"},
+                    }
+                ],
+            },
+        ],
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=messages)
+
+    tool_calls = result[1]["tool_calls"]
+    assert len(tool_calls) == 1
+    function_name = tool_calls[0]["function"]["name"]
+    assert function_name and function_name.strip()
+
+
+def test_translate_anthropic_messages_to_openai_tool_use_preserves_name():
+    """A valid tool_use name must be passed through unchanged."""
+    messages = cast(
+        Any,
+        [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "get_weather",
+                        "input": {"location": "London"},
+                    }
+                ],
+            },
+        ],
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter.translate_anthropic_messages_to_openai(messages=messages)
+
+    assert result[1]["tool_calls"][0]["function"]["name"] == "get_weather"
+
+
 def test_translate_anthropic_messages_to_openai_tool_result_with_multiple_content_items():
     """
     Test that tool_result with multiple content items creates a single tool message


### PR DESCRIPTION
## Relevant issues

Fixes #30515

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The bug lives in `LiteLLMAnthropicMessagesAdapter.translate_anthropic_messages_to_openai`. When an assistant `tool_use` block has a missing or blank name, the adapter emitted an OpenAI tool call with an empty `function.name`, which Mistral via vLLM rejects with `InvalidFunctionCallException` (the error in #30515); a `None` name crashed outright in `truncate_tool_name`.

Reproduction against the adapter (the exact translation the proxy performs before sending to the backend):

```python
from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
    LiteLLMAnthropicMessagesAdapter,
)

def show(name):
    messages = [
        {"role": "user", "content": "hi"},
        {"role": "assistant", "content": [
            {"type": "tool_use", "id": "toolu_1", "name": name, "input": {"q": "x"}},
        ]},
    ]
    out = LiteLLMAnthropicMessagesAdapter().translate_anthropic_messages_to_openai(messages)
    print(repr(name), "->", repr(out[-1]["tool_calls"][0]["function"]["name"]))

show("")            # empty
show(None)          # missing
show("get_weather") # valid
```

Before the fix

```
'' -> ''
None -> TypeError: object of type 'NoneType' has no len()
```

After the fix

```
'' -> 'litellm_unnamed_tool'
None -> 'litellm_unnamed_tool'
'get_weather' -> 'get_weather'
```

A full e2e through the proxy needs an OpenAI-compatible Mistral backend (e.g. vLLM serving a Mistral model) that runs `mistral_common` validation; the snippet above exercises the same translation path that produced the rejected payload.

## Type

🐛 Bug Fix

## Changes

The tool definitions path in this adapter already guarded against missing or blank tool names by substituting `litellm_unnamed_tool_{idx}`, but the assistant `tool_use` path did not, so a tool call without a usable name became an empty function name (or crashed on `None`). This factors that guard into a shared `resolve_tool_name` helper and applies it to both paths, so the two stay consistent. A valid name is always passed through unchanged

Added a parametrized regression test covering empty, whitespace, and `None` tool_use names plus a test asserting valid names are preserved. The regression cases fail before the change (empty name, or `TypeError` for `None`) and pass after