### PR TITLE
refactor(e2e): drop inline imports and the DB-truncate teardown

### DIFF
--- a/tests/e2e/budgets/test_spend_counter_reseed_e2e.py
+++ b/tests/e2e/budgets/test_spend_counter_reseed_e2e.py
@@ -20,18 +20,15 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier
-from typing import TYPE_CHECKING
 
 import pytest
+import redis
+from redis.cluster import RedisCluster
 
 from budget_client import BudgetClient
 from e2e_config import unique_marker
 from e2e_http import StreamingResponse
 from lifecycle import ResourceManager
-
-if TYPE_CHECKING:
-    import redis
-    from redis.cluster import RedisCluster
 
 pytestmark = pytest.mark.e2e
 
@@ -47,13 +44,11 @@ def _redis() -> "redis.Redis[str] | RedisCluster[str]":
     """The proxy's Redis. The deployed runner sets REDIS_HOST to the serverless
     ElastiCache, which is always TLS + cluster-mode; without it, fall back to a
     local standalone redis for docker-compose runs."""
-    import redis
-
     host = os.getenv("REDIS_HOST")
     if not host:
-        return redis.Redis(host="localhost", port=6380, decode_responses=True, socket_connect_timeout=2)
-
-    from redis.cluster import RedisCluster
+        return redis.Redis(
+            host="localhost", port=6380, decode_responses=True, socket_connect_timeout=2
+        )
 
     return RedisCluster(
         host=host,
@@ -64,14 +59,14 @@ def _redis() -> "redis.Redis[str] | RedisCluster[str]":
     )
 
 
-def _spend_counter(rds: "redis.Redis[str] | RedisCluster[str]", key: str) -> float | None:
+def _spend_counter(
+    rds: "redis.Redis[str] | RedisCluster[str]", key: str
+) -> float | None:
     """The shared spend counter for `key`, or None if it is cold. A cluster client
     can't run a keyspace SCAN that spans shards, so read the key directly - the stage
     gateway sets no cache namespace, so the key is the bare ``spend:key:{sha256(key)}``.
     A standalone client matches by suffix, so the local cache namespace (litellm.caching)
     need not be hard-coded here."""
-    from redis.cluster import RedisCluster
-
     digest = hashlib.sha256(key.encode()).hexdigest()
     suffix = f"spend:key:{digest}"
     if isinstance(rds, RedisCluster):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,8 +14,6 @@ shared fixtures build on it.
 """
 
 import functools
-import sys
-from pathlib import Path
 from typing import Iterator
 
 import pytest
@@ -23,9 +21,6 @@ import requests
 
 from e2e_config import CONTROL_PLANE_BASE_URL, PROXY_BASE_URL
 from lifecycle import GatewayProvider, ResourceManager
-
-
-_E2E_TEST_RAN = pytest.StashKey[bool]()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -68,40 +63,6 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
     reason = _proxy_skip_reason()
     if reason is not None:
         pytest.skip(reason)
-
-
-def pytest_runtest_call(item: pytest.Item) -> None:
-    """Mark that an e2e test body actually ran (not skipped at setup). Skipped
-    sessions never reach this hook, so the session-finish cleanup can use it as a
-    guard before truncating the spend-log DB. Tests under `tests/e2e/` without the
-    `e2e` marker (pure unit coverage for the harness itself) never hit the proxy,
-    so they must not arm the destructive DB truncate."""
-    if item.get_closest_marker("e2e") is None:
-        return
-    item.session.stash[_E2E_TEST_RAN] = True
-
-
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Once the whole e2e session is done (all suites), truncate the spend logs so
-    the DB doesn't accumulate test rows. Skipped sessions (no live proxy, no test
-    actually executed) leave the DB alone so a `DATABASE_URL` pointing at a shared
-    instance is never wiped without an e2e run. Best-effort: a cleanup failure (no
-    DB reachable) must not fail the run. The spend_tracking dir goes on sys.path
-    only for this import and is removed after, so a broader `pytest tests/` run is
-    not left with a mutated path."""
-    if not session.stash.get(_E2E_TEST_RAN, False):
-        return
-    spend_dir = str(Path(__file__).parent / "spend_tracking")
-    sys.path.insert(0, spend_dir)
-    try:
-        from spend_e2e_client import reset_spend_logs  # pyright: ignore
-
-        reset_spend_logs()
-    except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
-        print(f"spend-log cleanup skipped: {exc}")
-    finally:
-        if spend_dir in sys.path:
-            sys.path.remove(spend_dir)
 
 
 @pytest.fixture

--- a/tests/e2e/spend_tracking/spend_e2e_client.py
+++ b/tests/e2e/spend_tracking/spend_e2e_client.py
@@ -11,7 +11,6 @@ helpers from one place.
 
 from __future__ import annotations
 
-import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -43,30 +42,12 @@ from models import (
 __all__ = [
     "SpendClient",
     "build_client",
-    "reset_spend_logs",
     "unique_marker",
     "unwrap",
     "is_ok",
     "SpendLogRow",
     "ProbeResult",
 ]
-
-
-def reset_spend_logs() -> None:
-    """Truncate LiteLLM_SpendLogs for a clean slate. No proxy endpoint deletes
-    spend logs (/global/spend/reset keeps them), so go to the DB directly. Uses
-    DATABASE_URL (default: the local docker postgres on its mapped host port; note
-    the in-container `@db` host isn't resolvable from the host, so default to
-    localhost).
-    """
-    import psycopg
-
-    url = os.environ.get(
-        "DATABASE_URL",
-        "postgresql://llmproxy:dbpassword9090@localhost:5432/litellm",
-    )
-    with psycopg.connect(url) as conn:
-        _ = conn.execute('TRUNCATE TABLE "LiteLLM_SpendLogs"')
 
 
 def _chat_body(


### PR DESCRIPTION
The e2e suite is a black-box HTTP client against the proxy, but two spots reached around it with function-level imports. Hoist the budgets reseed test's redis imports to module top (redis is a declared suite dep), so nothing imports inside a function anymore.

Remove the spend-log truncate teardown entirely: it imported psycopg inline to TRUNCATE the SpendLogs table directly, a DB side-channel with no proxy route that was a no-op in the deployed runner (no psycopg) and unnecessary since tests isolate their rows with unique_marker. This drops the sys.path hack, the sessionfinish/runtest_call hooks, and the reset_spend_logs helper.

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
