### PR TITLE
fix(anthropic): drop unsignable thinking blocks and allow null signature in logging (LIT-4007)

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2319,6 +2319,28 @@ def sanitize_messages_for_tool_calling(
     return sanitized_messages
 
 
+def _is_unsignable_thinking_block(
+    block: Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock, Dict[str, Any]],
+) -> bool:
+    """A `thinking` block that Anthropic cannot accept on input.
+
+    Anthropic verifies the thinking signature cryptographically, so a block whose
+    signature is null, empty, or missing (e.g. from an open-source reasoning model)
+    is rejected with a 400 and must be dropped rather than blanked or repaired.
+    `redacted_thinking` blocks carry no signature and are always kept.
+    """
+    if not isinstance(block, dict) or block.get("type") != "thinking":
+        return False
+    signature = block.get("signature")
+    return not (isinstance(signature, str) and len(signature) > 0)
+
+
+def _drop_unsignable_thinking_blocks(
+    thinking_blocks: List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
+) -> List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]:
+    return [block for block in thinking_blocks if not _is_unsignable_thinking_block(block)]
+
+
 def anthropic_messages_pt(
     messages: List[AllMessageValues],
     model: str,
@@ -2507,7 +2529,12 @@ def anthropic_messages_pt(
                     # Add compaction blocks at the beginning of assistant content : https://platform.claude.com/docs/en/build-with-claude/compaction
                     assistant_content.extend(_compaction_blocks)  # type: ignore
 
-            thinking_blocks = assistant_content_block.get("thinking_blocks", None)
+            _raw_thinking_blocks = assistant_content_block.get("thinking_blocks", None)
+            thinking_blocks = (
+                _drop_unsignable_thinking_blocks(_raw_thinking_blocks)
+                if _raw_thinking_blocks is not None
+                else None
+            )
 
             # Check if tool_calls contain server tool calls (web search, etc.)
             # If so, we need to interleave thinking blocks with tool call groups
@@ -2671,7 +2698,9 @@ def anthropic_messages_pt(
                         thinking_block = cast(str, m.get("thinking", ""))
                         text_block = cast(str, m.get("text", ""))
                         if (
-                            m.get("type", "") == "thinking" and len(thinking_block) > 0
+                            m.get("type", "") == "thinking"
+                            and len(thinking_block) > 0
+                            and not _is_unsignable_thinking_block(m)
                         ):  # don't pass empty text blocks. anthropic api raises errors.
                             anthropic_message: Union[
                                 ChatCompletionThinkingBlock,

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2319,9 +2319,7 @@ def sanitize_messages_for_tool_calling(
     return sanitized_messages
 
 
-def _is_unsignable_thinking_block(
-    block: Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock, Dict[str, Any]],
-) -> bool:
+def _is_unsignable_thinking_block(block: object) -> bool:
     """A `thinking` block that Anthropic cannot accept on input.
 
     Anthropic verifies the thinking signature cryptographically, so a block whose
@@ -2336,8 +2334,8 @@ def _is_unsignable_thinking_block(
 
 
 def _drop_unsignable_thinking_blocks(
-    thinking_blocks: List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
-) -> List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]:
+    thinking_blocks: list[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]],
+) -> list[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]:
     return [block for block in thinking_blocks if not _is_unsignable_thinking_block(block)]
 
 
@@ -2531,9 +2529,7 @@ def anthropic_messages_pt(
 
             _raw_thinking_blocks = assistant_content_block.get("thinking_blocks", None)
             thinking_blocks = (
-                _drop_unsignable_thinking_blocks(_raw_thinking_blocks)
-                if _raw_thinking_blocks is not None
-                else None
+                _drop_unsignable_thinking_blocks(_raw_thinking_blocks) if _raw_thinking_blocks is not None else None
             )
 
             # Check if tool_calls contain server tool calls (web search, etc.)

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -533,7 +533,7 @@ class ChatCompletionCachedContent(TypedDict):
 class ChatCompletionThinkingBlock(TypedDict, total=False):
     type: Required[Literal["thinking"]]
     thinking: str
-    signature: str
+    signature: Optional[str]
     cache_control: Optional[Union[dict, ChatCompletionCachedContent]]
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -181,6 +181,79 @@ def test_bedrock_converse_assistant_with_empty_thinking_block_and_tool_calls():
     assert len(tool_use_blocks) == 2
 
 
+@pytest.mark.parametrize(
+    "thinking_block",
+    [
+        {"type": "thinking", "thinking": "oss reasoning", "signature": None},
+        {"type": "thinking", "thinking": "oss reasoning", "signature": ""},
+        {"type": "thinking", "thinking": "oss reasoning"},
+    ],
+    ids=["null_signature", "empty_signature", "missing_signature"],
+)
+def test_anthropic_messages_pt_drops_unsignable_thinking_block(thinking_block):
+    """Open-source reasoning models (DeepSeek-R1, Qwen, etc.) emit thinking blocks
+    with no Anthropic signature. Anthropic verifies the signature cryptographically,
+    so replaying a null/empty/missing-signature thinking block is rejected with
+    400 ... thinking.signature.str: Input should be a valid string.
+    anthropic_messages_pt must drop the unsignable thinking block while preserving
+    the assistant's answer text. Regression for LIT-4007.
+    """
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "content": "2+2 equals 4.",
+            "thinking_blocks": [thinking_block],
+        },
+        {"role": "user", "content": "Now what is 3+3?"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+    )
+
+    assistant = next(m for m in result if m["role"] == "assistant")
+    content = assistant["content"]
+    assert all(
+        block.get("type") != "thinking" for block in content
+    ), f"unsignable thinking block must be dropped, got {content!r}"
+    assert any(
+        block.get("type") == "text" and block.get("text") == "2+2 equals 4."
+        for block in content
+    ), f"assistant answer text must be preserved, got {content!r}"
+
+
+def test_anthropic_messages_pt_keeps_signed_thinking_block():
+    """A genuine Anthropic round-trip still holds its original signature, so that
+    thinking block must be forwarded unchanged (we only drop unsignable blocks).
+    Regression for LIT-4007.
+    """
+    signed_block = {
+        "type": "thinking",
+        "thinking": "genuine anthropic reasoning",
+        "signature": "ErcBCkgIValidSignatureBytes",
+    }
+    messages = [
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "content": "2+2 equals 4.",
+            "thinking_blocks": [signed_block],
+        },
+        {"role": "user", "content": "Now what is 3+3?"},
+    ]
+
+    result = anthropic_messages_pt(
+        messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+    )
+
+    assistant = next(m for m in result if m["role"] == "assistant")
+    thinking_blocks = [b for b in assistant["content"] if b.get("type") == "thinking"]
+    assert len(thinking_blocks) == 1
+    assert thinking_blocks[0]["signature"] == "ErcBCkgIValidSignatureBytes"
+    assert thinking_blocks[0]["thinking"] == "genuine anthropic reasoning"
+
+
 def test_convert_to_azure_openai_messages():
     """Test coverting image_url to azure_openai spec"""
 

--- a/tests/test_litellm/types/test_types_utils.py
+++ b/tests/test_litellm/types/test_types_utils.py
@@ -371,3 +371,48 @@ def test_delta_maps_reasoning_to_reasoning_content():
     # When neither is present, reasoning_content is not set (OpenAI spec)
     delta4 = Delta(content="hello")
     assert not hasattr(delta4, "reasoning_content")
+
+
+def test_message_accepts_thinking_block_with_null_signature():
+    """Open-source reasoning models (DeepSeek-R1, Qwen, etc.) emit thinking blocks
+    without an Anthropic-style signature. Message must accept signature=None so the
+    success-logging handler can build the StandardLoggingObject instead of silently
+    dropping the log record. Regression for LIT-4007.
+    """
+    from litellm.types.utils import Choices, Message
+
+    thinking_blocks = [
+        {"type": "thinking", "thinking": "step by step reasoning", "signature": None}
+    ]
+
+    message = Message(
+        content="the answer is 4", role="assistant", thinking_blocks=thinking_blocks
+    )
+    assert message.thinking_blocks is not None
+    assert message.thinking_blocks[0]["signature"] is None
+    assert message.thinking_blocks[0]["thinking"] == "step by step reasoning"
+
+    validated = Message.model_validate(
+        {
+            "role": "assistant",
+            "content": "the answer is 4",
+            "thinking_blocks": thinking_blocks,
+        }
+    )
+    dumped = validated.model_dump()
+    assert dumped["thinking_blocks"][0]["signature"] is None
+    assert dumped["thinking_blocks"][0]["thinking"] == "step by step reasoning"
+
+    choice = Choices.model_validate(
+        {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "the answer is 4",
+                "thinking_blocks": thinking_blocks,
+            },
+        }
+    )
+    assert choice.message.thinking_blocks is not None
+    assert choice.message.thinking_blocks[0]["signature"] is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -21922,7 +21922,7 @@ export interface components {
                 [key: string]: unknown;
             } | components["schemas"]["ChatCompletionCachedContent"] | null;
             /** Signature */
-            signature?: string;
+            signature?: string | null;
             /** Thinking */
             thinking?: string;
             /**


### PR DESCRIPTION
## Relevant issues

Open-source reasoning models (DeepSeek-R1 and its distills, Qwen3/QwQ, IBM Granite 3.2, served via vLLM/Ollama/OpenRouter/DeepSeek) return `reasoning_content` with no Anthropic-style encrypted signature. LiteLLM represents that as a thinking block with a null signature, which broke two paths for a customer running an autorouter that replays prior reasoning turns to a real Anthropic model.

The first failure is a silent success-log loss. `ChatCompletionThinkingBlock.signature` was typed as a required `str`, so when the success-logging handler built the `StandardLoggingObject`, Pydantic validation of `Message` rejected `signature=None` and the log record was dropped while the request still returned 200. The wrapped error looked like `[Non-Blocking] LiteLLM.Success_Call Error: ... validation errors for Message ... thinking_blocks.0.ChatCompletionThinkingBlock.signature  Input should be a valid string [input_value=None]`

The second failure is a hard 400. The outbound Anthropic conversion in `anthropic_messages_pt()` forwarded null-signature thinking blocks unchanged, so replaying a prior open-source thinking turn to Anthropic returned `400 ... messages.N.content.0.thinking.signature.str: Input should be a valid string`. Anthropic verifies the signature cryptographically, so null, empty, and missing all 400 identically and an open-source thinking block carries no signature to repair; the only correct move is to drop the unsignable block while keeping the assistant's answer text. `litellm/types/llms/anthropic.py` already types the equivalent signature as `Optional[str]`, which is why a null value legitimately reaches this code.

## Linear ticket

Resolves LIT-4007

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proxy run on a randomly chosen free port `49734`, against real provider APIs (no mocks):

```
python litellm/proxy/proxy_cli.py --config lit4007_config.yaml --port 49734 --detailed_debug 2>&1 | tee litellm.log
```

Config exposes `claude-sonnet-4-6` (anthropic/claude-sonnet-4-6) and `deepseek-reasoner` (deepseek/deepseek-reasoner).

### Bug 2 (outbound Anthropic 400) -> real claude-sonnet-4-6

BEFORE (unfixed staging code): replaying an assistant turn whose thinking block has `signature: null` returns a real Anthropic 400

```
curl -sS -w "\nHTTP_STATUS:%{http_code}\n" http://127.0.0.1:49734/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -d '{
    "model": "claude-sonnet-4-6",
    "max_tokens": 4096,
    "thinking": {"type": "enabled", "budget_tokens": 1024},
    "messages": [
      {"role": "user", "content": "What is 2+2? Think briefly."},
      {"role": "assistant", "content": "2+2 equals 4.", "thinking_blocks": [{"type": "thinking", "thinking": "The user asked for 2+2, which is 4.", "signature": null}]},
      {"role": "user", "content": "Great. Now what is 3+3?"}
    ]
  }'
```

```
{"error":{"message":"litellm.BadRequestError: AnthropicException - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"messages.1.content.0.thinking.signature.str: Input should be a valid string\"},\"request_id\":\"req_011CcYMAvkhaTKeRt8urSzpN\"}. Received Model Group=claude-sonnet-4-6\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

AFTER (this PR): same request returns 200. The unsignable thinking block is dropped, the assistant text is preserved, and Anthropic returns a fresh, properly signed thinking block

```
{"id":"chatcmpl-49c14504-2735-4e7b-98be-5eb8c0485384","created":1782773018,"model":"claude-sonnet-4-6","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"3+3 equals 6.","role":"assistant","reasoning_content":"6","thinking_blocks":[{"type":"thinking","thinking":"6","signature":"EsgBCmUIDxgCKkCN...<redacted-anthropic-signature>"}]}}], ...}
HTTP_STATUS:200
```

### Bug 1 (success-logging validation) -> real Message validation

The available `deepseek-reasoner` returns `reasoning_content` as a plain string (not a coerced null-signature thinking block), and it still returns 200 with a clean success log on the fixed proxy, so the live `Success_Call Error` could not be triggered end-to-end through the proxy with the keys available. To keep this proof honest I reproduced the exact internal validation the success-logging handler performs, directly on the real `Message`/`Choices` models, on both the unfixed and fixed code.

BEFORE (unfixed staging code):

```
python -c "
from litellm.types.utils import Message
Message(content='hi', role='assistant', thinking_blocks=[{'type':'thinking','thinking':'reasoning...','signature':None}])
"
```

```
2 validation errors for Message
thinking_blocks.0.ChatCompletionThinkingBlock.signature
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
thinking_blocks.0.ChatCompletionRedactedThinkingBlock.type
  Input should be 'redacted_thinking' [type=literal_error, input_value='thinking', input_type=str]
```

AFTER (this PR):

```
python -c "
from litellm.types.utils import Message, Choices
tb=[{'type':'thinking','thinking':'reasoning...','signature':None}]
print(Message(content='hi', role='assistant', thinking_blocks=tb).thinking_blocks[0]['signature'])
print(Choices.model_validate({'index':0,'finish_reason':'stop','message':{'role':'assistant','content':'hi','thinking_blocks':tb}}).message.thinking_blocks[0]['signature'])
"
```

```
None
None
```

## Type

🐛 Bug Fix

## Changes

`litellm/types/llms/openai.py` relaxes `ChatCompletionThinkingBlock.signature` from `str` to `Optional[str]` so a null signature no longer fails internal `Message` validation during success logging.

`litellm/litellm_core_utils/prompt_templates/factory.py` adds `_is_unsignable_thinking_block` and `_drop_unsignable_thinking_blocks`, and `anthropic_messages_pt()` now filters out thinking blocks whose signature is null, empty, or missing while preserving the assistant text and keeping genuinely signed blocks and `redacted_thinking` blocks. The filter is applied both where the assistant `thinking_blocks` field is read and on inline thinking blocks inside list content.

Tests extend the mapped files. `tests/test_litellm/types/test_types_utils.py` asserts `Message` and `Choices` now accept and round-trip a null-signature thinking block. `tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py` asserts `anthropic_messages_pt()` drops null/empty/missing-signature thinking blocks while preserving the answer text, and keeps a validly signed block unchanged. All four added tests fail on the pre-fix code and pass after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted prompt-template and typing changes with regression tests; behavior only affects unsignable thinking blocks on outbound Anthropic conversion and internal message validation.
> 
> **Overview**
> Fixes **LIT-4007** when open-source reasoning models produce thinking blocks without an Anthropic cryptographic signature and those turns are logged or replayed to Claude.
> 
> `ChatCompletionThinkingBlock.signature` is now **`Optional[str]`**, so `Message` / success logging no longer fail validation on `signature=None`. **`anthropic_messages_pt()`** drops `thinking` blocks with null, empty, or missing signatures (via `_is_unsignable_thinking_block` / `_drop_unsignable_thinking_blocks`) on both assistant `thinking_blocks` and inline list content, while keeping assistant text, signed thinking blocks, and `redacted_thinking` unchanged. Dashboard OpenAPI types mirror the nullable signature. New tests cover drop vs keep behavior and `Message`/`Choices` round-trip with null signatures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a74ca51b18e63a907c4dddc4f8110013d7dee9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->