### PR TITLE
fix(deepinfra): strip only trailing /openai from rerank api_base

### DIFF
--- a/litellm/llms/deepinfra/rerank/transformation.py
+++ b/litellm/llms/deepinfra/rerank/transformation.py
@@ -52,8 +52,12 @@ class DeepinfraRerankConfig(BaseRerankConfig):
                 "Deepinfra API Base is required. api_base=None. Set in call or via `DEEPINFRA_API_BASE` env var."
             )
 
-        # Remove 'openai' from the base if present
-        api_base_clean = api_base.replace("openai", "") if "openai" in api_base else api_base
+        # Strip only a trailing '/openai' segment (DeepInfra's OpenAI-compatible base
+        # ends in '/openai'); a plain str.replace would also corrupt an api_base that
+        # contains 'openai' elsewhere, e.g. in the host or a proxy path.
+        api_base_clean = api_base.rstrip("/")
+        if api_base_clean.endswith("/openai"):
+            api_base_clean = api_base_clean[: -len("/openai")]
 
         # Remove any trailing slashes for consistency, then add one
         api_base_clean = api_base_clean.rstrip("/") + "/"

--- a/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank_transformation.py
+++ b/tests/test_litellm/llms/deepinfra/test_deepinfra_rerank_transformation.py
@@ -43,6 +43,23 @@ class TestDeepinfraRerankTransform:
         with pytest.raises(ValueError, match="Deepinfra API Base is required"):
             self.config.get_complete_url(None, model)
 
+    def test_get_complete_url_preserves_openai_in_host(self):
+        """Regression: only a trailing '/openai' segment should be stripped.
+
+        A plain str.replace("openai", "") corrupted any api_base that contained
+        'openai' elsewhere (e.g. a gateway host or proxy path), producing a
+        malformed URL. The host/path must be preserved.
+        """
+        model = "Qwen/Qwen3-Reranker-0.6B"
+
+        # 'openai' in the host, with a trailing '/openai' segment to strip
+        url = self.config.get_complete_url("https://openai-gw.mycorp.com/v1/openai", model)
+        assert url == "https://openai-gw.mycorp.com/v1/inference/Qwen/Qwen3-Reranker-0.6B"
+
+        # 'openai' in the host, no trailing '/openai' segment to strip
+        url = self.config.get_complete_url("https://my-openai-proxy.example.com/v1", model)
+        assert url == "https://my-openai-proxy.example.com/v1/inference/Qwen/Qwen3-Reranker-0.6B"
+
     def test_map_cohere_rerank_params_basic(self):
         """Test basic parameter mapping for DeepInfra rerank."""
         params = self.config.map_cohere_rerank_params(
@@ -166,9 +183,7 @@ class TestDeepinfraRerankTransform:
         assert result._hidden_params["model"] == self.model
 
         # Verify logging was called
-        mock_logging.post_call.assert_called_once_with(
-            original_response=mock_response.text
-        )
+        mock_logging.post_call.assert_called_once_with(original_response=mock_response.text)
 
     def test_transform_rerank_response_minimal(self):
         """Test response transformation with minimal data."""
@@ -245,12 +260,8 @@ class TestDeepinfraRerankTransform:
                 query="query1",
                 documents=documents,
             )
-            assert (
-                params["queries"] == expected_queries
-            ), f"Failed for {len(documents)} documents"
-            assert len(params["queries"]) == len(
-                documents
-            ), "Queries length must match documents length"
+            assert params["queries"] == expected_queries, f"Failed for {len(documents)} documents"
+            assert len(params["queries"]) == len(documents), "Queries length must match documents length"
 
     def test_get_error_class_basic(self):
         """Test error class generation for basic error."""


### PR DESCRIPTION
## Relevant issues

None; found while auditing provider `get_complete_url` implementations for unsafe path handling

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`DeepinfraRerankConfig.get_complete_url` strips DeepInfra's OpenAI-compatible `/openai` suffix with `api_base.replace("openai", "")`, which removes the substring from anywhere in the URL. An api_base that contains `openai` outside the trailing segment is silently corrupted.

Before the fix:

```
https://openai-gw.mycorp.com/v1/openai   ->  https://-gw.mycorp.com/v1/inference/<model>   # host mangled
https://my-openai-proxy.example.com/v1   ->  https://my--proxy.example.com/v1/inference/<model>
```

After the fix:

```
https://openai-gw.mycorp.com/v1/openai   ->  https://openai-gw.mycorp.com/v1/inference/<model>
https://my-openai-proxy.example.com/v1   ->  https://my-openai-proxy.example.com/v1/inference/<model>
https://api.deepinfra.com/v1/openai      ->  https://api.deepinfra.com/v1/inference/<model>   # default, unchanged
```

The new regression test `test_get_complete_url_preserves_openai_in_host` fails on the current code and passes with the fix; the existing `test_get_complete_url` (default DeepInfra bases) still passes.

```
tests/test_litellm/llms/deepinfra/test_deepinfra_rerank_transformation.py  15 passed
```

## Type

🐛 Bug Fix

## Changes

Replaced the substring `api_base.replace("openai", "")` with a guard that strips only a trailing `/openai` path segment, so an api_base containing `openai` in the host or elsewhere in the path is preserved. Added a regression test covering gateway hosts that contain `openai`