### PR TITLE
ci(lint): generate prisma client before basedpyright type check

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -92,6 +92,10 @@ jobs:
         run: |
           uv run --no-sync python -c "import openai; print(f'OpenAI version: {openai.__version__}')"
 
+      - name: Generate Prisma client
+        run: |
+          uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
+
       - name: Check basedpyright budget (delta vs base)
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}


### PR DESCRIPTION
## Relevant issues

Follow-up from review feedback on #31227 asking why a `# pyright: ignore` was needed on `from prisma import Json`

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The lint workflow installs prisma but never generates the client, so basedpyright type-checks against an ungenerated package where `client.py`, `models.py` and `fields.py` do not exist (they are emitted by `prisma generate`, not shipped by pip). With the client absent, `from prisma import Json` resolves to nothing:

```
$ # generated client removed to mirror the CI environment
$ printf 'from prisma import Json\nx = Json(False)\n' > /tmp/probe.py
$ basedpyright /tmp/probe.py
reportAttributeAccessIssue  "Json" is unknown import symbol
reportUnknownVariableType   Type of "Json" is unknown
```

After `prisma generate --schema litellm/proxy/schema.prisma`, the same import resolves cleanly:

```
$ prisma generate --schema litellm/proxy/schema.prisma
$ basedpyright /tmp/probe.py
0 errors, 0 warnings, 0 notes
```

The generate step here matches what `test-unit-proxy-legacy.yml`, `mutation-test.yml` and the Docker images already do, and the basedpyright budget gate is unaffected: the per-rule deltas from generating the client are tiny (a handful fewer unknown-symbol errors) and the gate compares head against base, both of which now run with the same generated client.

## Type

🚄 Infrastructure

## Changes

Generate the prisma client in the lint workflow before the basedpyright budget gate so the type check sees prisma's real types instead of treating every prisma import as an unknown symbol. This is the root cause behind needing pyright ignores on prisma imports; with the client generated those ignores are no longer required
