### PR TITLE
feat(e2e): single-source gateway config via mountable ConfigMap

### DIFF
--- a/helm/litellm/templates/_helpers.tpl
+++ b/helm/litellm/templates/_helpers.tpl
@@ -19,6 +19,25 @@ Common naming + label helpers shared by gateway, backend, and ui templates.
 {{- printf "%s-gateway" (include "litellm.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Gateway proxy config. The gateway + backend mount config.yaml when the chart
+renders it from gateway.config.proxy_config (config.create) OR an existing
+ConfigMap is supplied (config.existingConfigMap, e.g. one a gitops overlay
+renders from the upstream litellm-config.yml). configMapName resolves to
+whichever applies.
+*/}}
+{{- define "litellm.gateway.config.enabled" -}}
+{{- if or .Values.gateway.config.create .Values.gateway.config.existingConfigMap -}}true{{- end -}}
+{{- end -}}
+
+{{- define "litellm.gateway.config.configMapName" -}}
+{{- if .Values.gateway.config.existingConfigMap -}}
+{{- .Values.gateway.config.existingConfigMap -}}
+{{- else -}}
+{{- include "litellm.gateway.fullname" . }}-config
+{{- end -}}
+{{- end -}}
+
 {{- define "litellm.backend.fullname" -}}
 {{- printf "%s-backend" (include "litellm.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -40,12 +40,12 @@ spec:
               protocol: TCP
           env:
             {{- include "litellm.serverEnv" (dict "root" $ "component" .Values.backend) | nindent 12 }}
-            {{- if .Values.gateway.config.create }}
+            {{- if include "litellm.gateway.config.enabled" . }}
             - name: CONFIG_FILE_PATH
               value: /app/config/config.yaml
             {{- end }}
           {{- include "litellm.envFrom" .Values.backend | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if include "litellm.gateway.config.enabled" . }}
           volumeMounts:
             - name: gateway-config
               mountPath: /app/config/config.yaml
@@ -61,11 +61,11 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if include "litellm.gateway.config.enabled" . }}
       volumes:
         - name: gateway-config
           configMap:
-            name: {{ include "litellm.gateway.fullname" . }}-config
+            name: {{ include "litellm.gateway.config.configMapName" . }}
       {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/templates/gateway/configmap.yaml
+++ b/helm/litellm/templates/gateway/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.config.create }}
+{{- if and .Values.gateway.config.create (not .Values.gateway.config.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               protocol: TCP
           env:
             {{- include "litellm.serverEnv" (dict "root" $ "component" .Values.gateway) | nindent 12 }}
-            {{- if .Values.gateway.config.create }}
+            {{- if include "litellm.gateway.config.enabled" . }}
             - name: CONFIG_FILE_PATH
               value: /app/config/config.yaml
             {{- end }}
@@ -47,7 +47,7 @@ spec:
               value: {{ .Values.gateway.numWorkers | quote }}
             {{- end }}
           {{- include "litellm.envFrom" .Values.gateway | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if include "litellm.gateway.config.enabled" . }}
           volumeMounts:
             - name: gateway-config
               mountPath: /app/config/config.yaml
@@ -63,11 +63,11 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if include "litellm.gateway.config.enabled" . }}
       volumes:
         - name: gateway-config
           configMap:
-            name: {{ include "litellm.gateway.fullname" . }}-config
+            name: {{ include "litellm.gateway.config.configMapName" . }}
       {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -127,6 +127,11 @@ gateway:
   config:
     create: true
     proxy_config: {}
+    # Mount an existing ConfigMap (key config.yaml) as the gateway+backend config
+    # instead of rendering one from proxy_config. Set create:false alongside this
+    # to let a gitops overlay own the config (e.g. one rendered from the upstream
+    # litellm-config.yml). When empty, the chart renders its own from proxy_config.
+    existingConfigMap: ""
   image:
     repository: ghcr.io/berriai/litellm-gateway
     tag: ""              # defaults to .Chart.AppVersion

--- a/tests/e2e/gateway/kustomization.yaml
+++ b/tests/e2e/gateway/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Renders this directory's litellm proxy config into the litellm-gateway-config
+# ConfigMap the deployed gateway mounts as /app/config.yaml. A gitops overlay
+# (e.g. litellm-ops) points an ArgoCD source at this path so the live model_list
+# and the rest of the proxy config track litellm-config.yml directly, instead of
+# a hand-mirrored copy. Redis connection is intentionally env-driven in the
+# config (REDIS_HOST or REDIS_CLUSTER_NODES), so the same ConfigMap serves every
+# environment.
+namespace: litellm
+
+configMapGenerator:
+  - name: litellm-gateway-config
+    files:
+      - config.yaml=litellm-config.yml
+
+# The gateway Deployment mounts a fixed ConfigMap name, so don't append the
+# content-hash suffix kustomize adds by default.
+generatorOptions:
+  disableNameSuffixHash: true

--- a/tests/e2e/gateway/litellm-config.yml
+++ b/tests/e2e/gateway/litellm-config.yml
@@ -46,11 +46,12 @@ litellm_settings:
   json_logs: true
   store_audit_logs: True
   cache: true
+  # Redis connection is supplied per environment via env vars, not pinned here, so
+  # one config serves every consumer: REDIS_HOST/REDIS_PORT for a standalone redis
+  # (local docker-compose), REDIS_CLUSTER_NODES + REDIS_SSL for cluster-mode
+  # ElastiCache (stage). litellm reads these when host is absent from cache_params.
   cache_params:
     type: redis
-    host: redis
-    port: 6379
-    password: os.environ/REDIS_PASSWORD
     namespace: litellm.caching
     ttl: 16600
   # max_budget: 1000000000.0 # (float) sets max budget in dollars across the entire proxy across all API keys. Note, the budget does not apply to the master key. That is the only exception.


### PR DESCRIPTION
## What and why

The deployed gateway's `model_list` was hand-mirrored into the stage ops overlay and had drifted (8 of 19 models, plus a stale `openai-realtime` entry). This makes `tests/e2e/gateway/litellm-config.yml` the single source a gitops overlay can mount directly, so the live config tracks this file instead of a copy.

Two pieces:

Render the config into a ConfigMap. A new `tests/e2e/gateway/kustomization.yaml` runs `configMapGenerator` to produce the `litellm-gateway-config` ConfigMap (key `config.yaml`, fixed name, `litellm` namespace) from `litellm-config.yml`. A gitops overlay points at this directory and mounts the result.

Env-drive redis so one config serves every environment. The hard-coded `cache_params.host/port/password` are dropped from `litellm-config.yml`. litellm already falls back to env when `host` is absent from `cache_params`: `RedisCache.__init__` only forwards host/port/password when they are not None (`litellm/caching/redis_cache.py`), and `_get_redis_client_logic` seeds from `_redis_kwargs_from_environment()` and reads `REDIS_CLUSTER_NODES` (`litellm/_redis.py`, `litellm/caching/caching.py`). So a local standalone redis comes from `REDIS_HOST`/`REDIS_PORT` and stage's cluster-mode ElastiCache from `REDIS_CLUSTER_NODES` + `REDIS_SSL`, with no per-environment edit to the file.

Support mounting that ConfigMap in the chart. `helm/litellm` only mounted `config.yaml` when it rendered the ConfigMap itself from `gateway.config.proxy_config` (`config.create`); `create: false` dropped the mount entirely, so an overlay had no way to supply its own. This adds `gateway.config.existingConfigMap`: when set, the gateway and backend mount that ConfigMap and the chart skips rendering its own. The mount is gated on `create OR existingConfigMap`. Default behavior is unchanged.

## Proof

Config-only change, so the proof is the renders.

`kubectl kustomize tests/e2e/gateway` produces one ConfigMap:

```
kind: ConfigMap | name: litellm-gateway-config | ns: litellm
model_list entries: 19
cache_params: {'type': 'redis', 'namespace': 'litellm.caching', 'ttl': 16600}
```

`helm template helm/litellm` in both modes:

```
default (create:true):
  own ConfigMap rendered: True
  litellm-gateway  mounts ['litellm-gateway-config']
  litellm-backend  mounts ['litellm-gateway-config']

create:false + existingConfigMap=litellm-gateway-config:
  own ConfigMap rendered: False
  litellm-gateway  mounts ['litellm-gateway-config'] | mount /app/config/config.yaml | CONFIG_FILE_PATH True
  litellm-backend  mounts ['litellm-gateway-config'] | mount /app/config/config.yaml | CONFIG_FILE_PATH True
```

## Follow-ups

The stage overlay (litellm-ops) consumes this: an ArgoCD source renders this ConfigMap into the cluster, the gateway sets `config.create: false` + `existingConfigMap: litellm-gateway-config`, and `REDIS_CLUSTER_NODES` + `REDIS_SSL` move to the gateway env. The local docker-compose proxy (on a separate branch) needs `REDIS_HOST`/`REDIS_PORT` set once it picks up the neutralized config.

## Type

New Feature
