### PR TITLE
fix(bedrock): drop unmappable Responses tools instead of failing the request (LIT-3858)

### DIFF
--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -58,7 +58,7 @@ def get_supported_openai_params(
             supported_params = list(dict.fromkeys([*supported_params, *base_model_params]))
         return supported_params
 
-    if custom_llm_provider == "bedrock":
+    if custom_llm_provider == "bedrock" or custom_llm_provider == "bedrock_converse":
         return litellm.AmazonConverseConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "meta_llama":
         provider_config = litellm.ProviderConfigManager.get_provider_chat_config(

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -5027,6 +5027,12 @@ def _bedrock_tools_pt(tools: List, model: Optional[str] = None) -> List[BedrockT
             tool_block_list.append(tool)  # type: ignore
             continue
 
+        # Responses built-in tools (web_search, image_generation, namespace, tool_search,
+        # custom) carry neither an OpenAI "function" nor an Anthropic "input_schema" and have
+        # no Bedrock toolSpec equivalent; drop them instead of emitting an empty junk toolSpec.
+        if isinstance(tool, dict) and "function" not in tool and "input_schema" not in tool:
+            continue
+
         # OpenAI function tools, or Anthropic Messages / Claude Code ({name, input_schema, type, ...})
         if isinstance(tool, dict) and "input_schema" in tool and "function" not in tool:
             parameters = copy.deepcopy(tool.get("input_schema") or {"type": "object", "properties": {}})

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -156,6 +156,20 @@ class LiteLLMCompletionResponsesConfig:
         return tool_choice
 
     @staticmethod
+    def _should_drop_derived_web_search_options(model: str, custom_llm_provider: Optional[str]) -> bool:
+        """
+        A Responses ``web_search`` built-in tool is derived into a ``web_search_options`` param.
+        Bedrock Anthropic models have no equivalent (only Nova maps it to a nova_grounding
+        systemTool), so the derived param must be dropped here rather than raising
+        UnsupportedParamsError downstream. Scoped to Bedrock so other providers are untouched.
+        """
+        if custom_llm_provider is None or not custom_llm_provider.startswith("bedrock"):
+            return False
+        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+        return "web_search_options" not in AmazonConverseConfig().get_supported_openai_params(model=model)
+
+    @staticmethod
     def transform_responses_api_request_to_chat_completion_request(
         model: str,
         input: Union[str, ResponseInputParam],
@@ -174,6 +188,11 @@ class LiteLLMCompletionResponsesConfig:
         ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
             responses_api_request.get("tools") or []  # type: ignore
         )
+
+        if web_search_options is not None and LiteLLMCompletionResponsesConfig._should_drop_derived_web_search_options(
+            model=model, custom_llm_provider=custom_llm_provider
+        ):
+            web_search_options = None
 
         response_format = None
         text_param = responses_api_request.get("text")

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -12,6 +12,9 @@ from openai.types.responses.tool_param import FunctionToolParam
 from typing_extensions import TypedDict
 
 from litellm.caching import InMemoryCache
+from litellm.litellm_core_utils.get_supported_openai_params import (
+    get_supported_openai_params,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.responses.litellm_completion_transformation.session_handler import (
     ResponsesSessionHandler,
@@ -159,15 +162,17 @@ class LiteLLMCompletionResponsesConfig:
     def _should_drop_derived_web_search_options(model: str, custom_llm_provider: Optional[str]) -> bool:
         """
         A Responses ``web_search`` built-in tool is derived into a ``web_search_options`` param.
-        Bedrock Anthropic models have no equivalent (only Nova maps it to a nova_grounding
-        systemTool), so the derived param must be dropped here rather than raising
-        UnsupportedParamsError downstream. Scoped to Bedrock so other providers are untouched.
-        """
-        if custom_llm_provider is None or not custom_llm_provider.startswith("bedrock"):
-            return False
-        from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+        When the resolved provider/model does not support it (e.g. Bedrock Anthropic, where only
+        Nova maps it to a nova_grounding systemTool), the derived param is dropped here instead of
+        raising UnsupportedParamsError downstream. Providers that support it keep it untouched.
 
-        return "web_search_options" not in AmazonConverseConfig().get_supported_openai_params(model=model)
+        Support is read from each provider's own ``get_supported_openai_params`` so this bridge
+        stays provider-agnostic; an unmapped provider (``None``) is treated as "keep".
+        """
+        supported_params: Optional[List[str]] = get_supported_openai_params(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+        return supported_params is not None and "web_search_options" not in supported_params
 
     @staticmethod
     def transform_responses_api_request_to_chat_completion_request(

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -1553,6 +1553,69 @@ def test_bedrock_tools_pt_does_not_handle_system_tool():
     assert tool_spec["name"] == "get_weather"
 
 
+def test_bedrock_tools_pt_drops_unmappable_responses_builtin_tools():
+    """
+    Regression for LIT-3858: Responses built-in tools (image_generation, namespace,
+    tool_search, custom) have no Bedrock toolSpec equivalent. They must be dropped, not
+    emitted as junk ``litellm_unnamed_tool_N`` toolSpecs the model can hallucinate calls to.
+    Mappable ``function`` and Anthropic ``input_schema`` tools must survive untouched.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "noop",
+                "description": "x",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        },
+        {"type": "image_generation", "output_format": "png"},
+        {"type": "namespace", "name": "grp", "description": "g", "tools": []},
+        {"type": "custom", "name": "free_form"},
+    ]
+
+    result = _bedrock_tools_pt(
+        tools=tools, model="anthropic.claude-sonnet-4-5-20250929-v1:0"
+    )
+
+    names = [block["toolSpec"]["name"] for block in result if "toolSpec" in block]
+    assert names == ["noop"]
+    assert not any(name.startswith("litellm_unnamed_tool_") for name in names)
+
+
+def test_bedrock_tools_pt_keeps_anthropic_input_schema_tools():
+    """
+    The drop guard for unmappable tools must not regress Anthropic Messages format tools,
+    which carry an ``input_schema`` instead of an OpenAI ``function`` key.
+    """
+    from litellm.litellm_core_utils.prompt_templates.factory import _bedrock_tools_pt
+
+    tools = [
+        {
+            "type": "image_generation",
+            "output_format": "png",
+        },
+        {
+            "name": "lookup",
+            "description": "look something up",
+            "input_schema": {
+                "type": "object",
+                "properties": {"q": {"type": "string"}},
+                "required": ["q"],
+            },
+        },
+    ]
+
+    result = _bedrock_tools_pt(
+        tools=tools, model="anthropic.claude-sonnet-4-5-20250929-v1:0"
+    )
+
+    names = [block["toolSpec"]["name"] for block in result if "toolSpec" in block]
+    assert names == ["lookup"]
+
+
 def test_convert_to_anthropic_tool_result_image_with_cache_control():
     """
     Test that cache_control is properly applied to image content in tool results.

--- a/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_supported_openai_params.py
@@ -146,3 +146,33 @@ def test_sambanova_embeddings_request_returns_list_not_none():
     )
 
     assert embedding_params == []
+
+
+def test_bedrock_converse_alias_resolves_like_bedrock():
+    """The ``bedrock_converse`` invocation alias must resolve through AmazonConverseConfig
+    just like ``bedrock`` (the codebase already pairs them, e.g. ``_strip_model_name``).
+    Before this mapping it returned ``None`` (unmapped), so callers gating on supported
+    params saw no Bedrock capabilities for a Converse model invoked via the alias."""
+    anthropic_model = "bedrock/converse/us.anthropic.claude-sonnet-4-6"
+
+    via_alias = get_supported_openai_params(
+        model=anthropic_model, custom_llm_provider="bedrock_converse"
+    )
+
+    assert via_alias is not None
+    assert via_alias == get_supported_openai_params(
+        model=anthropic_model, custom_llm_provider="bedrock"
+    )
+    assert "web_search_options" not in via_alias
+    assert "tools" in via_alias
+
+
+def test_bedrock_converse_alias_keeps_nova_web_search_options():
+    """Nova on the ``bedrock_converse`` alias still advertises web_search_options, proving the
+    alias routes through the model-aware config rather than a blanket Bedrock default."""
+    nova_params = get_supported_openai_params(
+        model="amazon.nova-pro-v1:0", custom_llm_provider="bedrock_converse"
+    )
+
+    assert nova_params is not None
+    assert "web_search_options" in nova_params

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1411,7 +1411,7 @@ class TestToolTransformation:
         """
         Regression for LIT-3858: a Responses web_search tool becomes a derived
         web_search_options param. Bedrock Anthropic models do not support it, so on the
-        Bedrock chat-completion bridge it must be dropped (so litellm doesn't raise
+        chat-completion bridge it must be dropped (so litellm doesn't raise
         UnsupportedParamsError) without the caller setting drop_params.
         """
         responses_api_request = {
@@ -1442,8 +1442,8 @@ class TestToolTransformation:
 
         assert result.get("web_search_options") is not None
 
-    def test_non_bedrock_keeps_derived_web_search_options(self):
-        """The drop is scoped to Bedrock; other providers keep the derived param untouched."""
+    def test_supported_provider_keeps_derived_web_search_options(self):
+        """A provider whose config lists web_search_options (e.g. OpenAI) keeps it untouched."""
         responses_api_request = {
             "tools": [{"type": "web_search", "search_context_size": "high"}],
         }
@@ -1456,6 +1456,25 @@ class TestToolTransformation:
         )
 
         assert result.get("web_search_options") is not None
+
+    def test_unsupported_non_bedrock_provider_drops_derived_web_search_options(self):
+        """
+        The drop is provider-agnostic, not hardcoded to Bedrock: any provider whose config
+        does not list web_search_options (e.g. Cohere) drops the derived param. This fails if
+        the drop is ever re-scoped to a single provider.
+        """
+        responses_api_request = {
+            "tools": [{"type": "web_search", "search_context_size": "high"}],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="command-r",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="cohere",
+        )
+
+        assert "web_search_options" not in result
 
     def test_bedrock_anthropic_responses_tools_yield_only_function_toolspec(self):
         """

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1427,6 +1427,25 @@ class TestToolTransformation:
 
         assert "web_search_options" not in result
 
+    def test_bedrock_converse_provider_drops_derived_web_search_options(self):
+        """
+        Regression for the ``bedrock_converse`` alias: routing a Bedrock Converse model resolves
+        to custom_llm_provider='bedrock_converse' with model='bedrock/converse/...'. The derived
+        web_search_options must still be dropped on this route, not just the bare 'bedrock' one.
+        """
+        responses_api_request = {
+            "tools": [{"type": "web_search", "external_web_access": False}],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="bedrock/converse/us.anthropic.claude-sonnet-4-6",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="bedrock_converse",
+        )
+
+        assert "web_search_options" not in result
+
     def test_bedrock_nova_keeps_derived_web_search_options(self):
         """Nova models map web_search_options to a nova_grounding systemTool, so keep it."""
         responses_api_request = {

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -1407,6 +1407,100 @@ class TestToolTransformation:
             == "string"
         )
 
+    def test_bedrock_anthropic_drops_derived_web_search_options(self):
+        """
+        Regression for LIT-3858: a Responses web_search tool becomes a derived
+        web_search_options param. Bedrock Anthropic models do not support it, so on the
+        Bedrock chat-completion bridge it must be dropped (so litellm doesn't raise
+        UnsupportedParamsError) without the caller setting drop_params.
+        """
+        responses_api_request = {
+            "tools": [{"type": "web_search", "external_web_access": False}],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="anthropic.claude-sonnet-4-5-20250929-v1:0",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="bedrock",
+        )
+
+        assert "web_search_options" not in result
+
+    def test_bedrock_nova_keeps_derived_web_search_options(self):
+        """Nova models map web_search_options to a nova_grounding systemTool, so keep it."""
+        responses_api_request = {
+            "tools": [{"type": "web_search", "search_context_size": "high"}],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="amazon.nova-pro-v1:0",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="bedrock",
+        )
+
+        assert result.get("web_search_options") is not None
+
+    def test_non_bedrock_keeps_derived_web_search_options(self):
+        """The drop is scoped to Bedrock; other providers keep the derived param untouched."""
+        responses_api_request = {
+            "tools": [{"type": "web_search", "search_context_size": "high"}],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model="gpt-4o",
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="openai",
+        )
+
+        assert result.get("web_search_options") is not None
+
+    def test_bedrock_anthropic_responses_tools_yield_only_function_toolspec(self):
+        """
+        End-to-end (no network) of the LIT-3858 acceptance criterion: the mixed tools array
+        is transformed for a Bedrock Anthropic model, then fed through the Bedrock tool layer.
+        The derived web_search_options is dropped, and toolConfig contains only the function
+        tool, never the web_search/image_generation/namespace built-ins as junk toolSpecs.
+        """
+        from litellm.litellm_core_utils.prompt_templates.factory import (
+            _bedrock_tools_pt,
+        )
+
+        model = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+        responses_api_request = {
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "noop",
+                    "description": "x",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                {"type": "web_search", "external_web_access": False},
+                {"type": "image_generation", "output_format": "png"},
+                {"type": "namespace", "name": "grp", "description": "g", "tools": []},
+            ],
+        }
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_request_to_chat_completion_request(
+            model=model,
+            input="hi",
+            responses_api_request=responses_api_request,
+            custom_llm_provider="bedrock",
+        )
+
+        assert "web_search_options" not in result
+
+        bedrock_tool_blocks = _bedrock_tools_pt(tools=result["tools"], model=model)
+        names = [
+            block["toolSpec"]["name"]
+            for block in bedrock_tool_blocks
+            if "toolSpec" in block
+        ]
+        assert names == ["noop"]
+        assert not any(name.startswith("litellm_unnamed_tool_") for name in names)
+
 
 class TestUsageTransformation:
     """Test cases for usage transformation from Chat Completion to Responses API format"""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3858

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified end to end against a real litellm proxy (own venv, random port, DB-less) configured with a single Bedrock Converse Sonnet model (`bedrock/converse/us.anthropic.claude-sonnet-4-6`, `us-east-1`) hitting real AWS Bedrock, with `litellm.drop_params` left at its default of `False`. The same Responses request was run against the base commit and against the fix; only the git checkout changed between the two runs

### Before (base commit `20dabb78`)

```bash
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://127.0.0.1:$PORT/v1/responses \
  -H 'content-type: application/json' -H 'authorization: Bearer sk-qa-lit3858' \
  -d '{
    "model": "bedrock-converse-sonnet-4-6",
    "input": "Reply with the single word: hello",
    "tools": [
      {"type":"function","name":"noop","description":"x","parameters":{"type":"object","properties":{}}},
      {"type":"web_search","external_web_access":false},
      {"type":"image_generation","output_format":"png"},
      {"type":"namespace","name":"grp","description":"g","tools":[]}
    ]
  }'
```

```
{"error":{"message":"litellm.UnsupportedParamsError: bedrock does not support parameters: ['web_search_options'], for model=converse/us.anthropic.claude-sonnet-4-6. To drop these, set `litellm.drop_params=True` or for proxy:\n\n`litellm_settings:\n drop_params: true`\n. \n If you want to use these params dynamically send allowed_openai_params=['web_search_options'] in your request.. Received Model Group=bedrock-converse-sonnet-4-6\nAvailable Model Group Fallbacks=None","type":"None","param":null,"code":"400"}}
HTTP_STATUS:400
```

### After (fix, commit `20863dae`)

Identical request, identical config, fix checked out

```bash
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' http://127.0.0.1:$PORT/v1/responses \
  -H 'content-type: application/json' -H 'authorization: Bearer sk-qa-lit3858' \
  -d '{
    "model": "bedrock-converse-sonnet-4-6",
    "input": "Reply with the single word: hello",
    "tools": [
      {"type":"function","name":"noop","description":"x","parameters":{"type":"object","properties":{}}},
      {"type":"web_search","external_web_access":false},
      {"type":"image_generation","output_format":"png"},
      {"type":"namespace","name":"grp","description":"g","tools":[]}
    ]
  }'
```

```
{"id":"resp_nAPjxIAGnEUly28q...redacted...","created_at":1782782347,"error":null,"model":"bedrock-converse-sonnet-4-6","object":"response","output":[{"type":"message","id":"chatcmpl-69f46685-74d7-43b7-8f6f-550ad9a28f9b","status":"completed","role":"assistant","content":[{"type":"output_text","text":"hello","annotations":[]}]}],"parallel_tool_calls":false,"tool_choice":"auto","tools":[],"status":"completed","usage":{"input_tokens":549,"output_tokens":4,"total_tokens":553}}
HTTP_STATUS:200
```

The `--detailed_debug` log for the after run confirms only the `function` tool reached Bedrock. The outgoing Bedrock request body carried just the `noop` toolSpec, with zero `litellm_unnamed_tool_` entries and `web_search_options` resolved to `None` rather than raising

```
"toolConfig": {"tools": [{"toolSpec": {"inputSchema": {"json": {"type": "object", "properties": {}, "required": []}}, "name": "noop", "description": "x", "strict": false}}]}
```

## Type

🐛 Bug Fix

## Changes

When an OpenAI Responses request is routed to a Bedrock Converse Anthropic model, litellm translates the Responses `tools` array into Bedrock `toolConfig`. Responses built-in tool types beyond `function` (`web_search`, `image_generation`, `namespace`, `tool_search`, `custom`) have no Bedrock equivalent, and on current main this caused two failures that this PR fixes

A `web_search` tool is derived into a `web_search_options` param. Bedrock Anthropic models do not list `web_search_options` in `get_supported_openai_params`, so the request raised `UnsupportedParamsError` (HTTP 400) even though it never needed web search. The derived param is now dropped on the chat-completion bridge whenever the resolved provider/model does not support it. Support is read from each provider's own `get_supported_openai_params`, so the bridge stays provider-agnostic and Bedrock capability knowledge lives in the Bedrock config that already owns it, instead of hardcoding a `startswith("bedrock")` branch and a Bedrock import in the generic Responses transformer. Bedrock Anthropic drops the param, while Bedrock Nova keeps it (it maps the param to a `nova_grounding` systemTool) and providers whose config lists the param, such as OpenAI, keep it. It happens by default; the caller does not need to set `drop_params`. Because the Responses bridge is the only place that derives this param from a built-in tool, dropping it here does not change `drop_params` semantics for genuinely user-supplied chat-completion params

The remaining non-`function` tools reached `_bedrock_tools_pt` and were emitted as junk `litellm_unnamed_tool_N` toolSpecs with empty schemas, polluting `toolConfig` with tools the model could hallucinate calls to. They are now dropped because they carry neither an OpenAI `function` nor an Anthropic `input_schema`, while mappable `function` and Anthropic `input_schema` tools survive untouched. The filtering lives entirely in the Bedrock-specific layer, so OpenAI and Anthropic, which natively support these built-in tools, keep their current behavior

Net effect for the acceptance scenario: a Responses request to a Bedrock Converse Anthropic model carrying a `function` tool plus `web_search`, `image_generation`, and `namespace` tools now goes from HTTP 400 to HTTP 200 with `litellm.drop_params` at its default, and the outgoing Bedrock `toolConfig` contains only the `function` tool

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Responses bridging and Bedrock tool formatting; behavior changes for mixed-tool requests but is gated on provider capability lists and covered by regression tests.
> 
> **Overview**
> Fixes **LIT-3858** so mixed OpenAI Responses `tools` on **Bedrock Converse Anthropic** no longer 400 with `UnsupportedParamsError` or send junk `toolConfig` entries.
> 
> On the Responses → chat-completion bridge, **`web_search`** is still derived to **`web_search_options`**, but that param is **cleared** when the resolved provider/model’s `get_supported_openai_params` does not list it (Bedrock Anthropic and `bedrock_converse`, Cohere, etc.). **Nova** and providers like **OpenAI** keep it. **`bedrock_converse`** now resolves supported params the same way as **`bedrock`**.
> 
> In **`_bedrock_tools_pt`**, built-in tools with neither OpenAI **`function`** nor Anthropic **`input_schema`** are **skipped** instead of becoming empty `litellm_unnamed_tool_N` toolSpecs; mappable function and `input_schema` tools are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9d57c9cf939a8e50291a3ede65679ef29f7e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->