### PR TITLE
fix: skip health check for semantic auto_router deployments

### DIFF
--- a/litellm/proxy/health_check.py
+++ b/litellm/proxy/health_check.py
@@ -43,14 +43,10 @@ MINIMAL_DISPLAY_PARAMS = ["model", "mode_error"]
 # endpoints that reject unknown fields with 400 "Unknown parameter:
 # 'max_tokens'". Allow-list so new modes are safe by default.
 # Per-deployment override: `model_info.health_check_supports_max_tokens`.
-_MAX_TOKEN_SUPPORT_MODES: frozenset[str] = frozenset(
-    {"chat", "completion", "responses"}
-)
+_MAX_TOKEN_SUPPORT_MODES: frozenset[str] = frozenset({"chat", "completion", "responses"})
 
 
-def _resolve_health_check_mode(
-    model_info: Mapping[str, object], litellm_params: Mapping[str, object]
-) -> str | None:
+def _resolve_health_check_mode(model_info: Mapping[str, object], litellm_params: Mapping[str, object]) -> str | None:
     """
     Effective mode for a deployment's health-check probe.
 
@@ -72,9 +68,7 @@ def _resolve_health_check_mode(
         return None
 
 
-def _should_inject_health_check_max_tokens(
-    model_info: Mapping[str, object], mode: str | None
-) -> bool:
+def _should_inject_health_check_max_tokens(model_info: Mapping[str, object], mode: str | None) -> bool:
     """
     Whether the health-check probe should include `max_tokens`.
 
@@ -90,9 +84,7 @@ def _should_inject_health_check_max_tokens(
 
 
 # Health-check modes that forward `reasoning_effort` to the provider (chat-style calls).
-_HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT = frozenset(
-    (None, "chat", "completion")
-)
+_HEALTH_CHECK_MODES_SUPPORTING_REASONING_EFFORT = frozenset((None, "chat", "completion"))
 
 
 def _get_process_rss_mb() -> Optional[float]:
@@ -190,9 +182,32 @@ async def run_with_timeout(task, timeout):
         return {"error": "Timeout exceeded", "exception": timeout_exception}
 
 
+def _is_semantic_auto_router_deployment(litellm_params: dict) -> bool:
+    """
+    True for semantic auto_router deployments (auto_router/<name>) that are not
+    sub-strategies (complexity_router, adaptive_router, quality_router).
+
+    These are meta-routers that select among real LLM deployments at request time;
+    they have no LLM endpoint to health-check.
+    """
+    model: object = litellm_params.get("model", "")
+    if not isinstance(model, str):
+        return False
+    if not model.startswith("auto_router/"):
+        return False
+    for sub_strategy in ("complexity_router", "adaptive_router", "quality_router"):
+        if model.startswith(f"auto_router/{sub_strategy}"):
+            return False
+    return True
+
+
 async def _run_model_health_check(model: dict):
     litellm_params = model["litellm_params"]
     model_info = model.get("model_info", {})
+
+    if _is_semantic_auto_router_deployment(litellm_params):
+        return {}
+
     mode = _resolve_health_check_mode(
         model_info,
         litellm_params,  # any-ok: untyped router config dict
@@ -211,9 +226,7 @@ async def _run_model_health_check(model: dict):
     )
 
 
-async def _run_health_checks_with_bounded_concurrency(
-    models: list, concurrency_limit: int
-) -> tuple[list, int]:
+async def _run_health_checks_with_bounded_concurrency(models: list, concurrency_limit: int) -> tuple[list, int]:
     """
     Run health checks with at most `concurrency_limit` active tasks.
     Preserves result ordering to match `models`.
@@ -274,13 +287,9 @@ async def _perform_health_check(
     peak_in_flight = 0
     if isinstance(max_concurrency, int) and max_concurrency > 0:
         dispatch_mode = "bounded"
-        results, peak_in_flight = await _run_health_checks_with_bounded_concurrency(
-            model_list, max_concurrency
-        )
+        results, peak_in_flight = await _run_health_checks_with_bounded_concurrency(model_list, max_concurrency)
     else:
-        tasks = [
-            asyncio.create_task(_run_model_health_check(model)) for model in model_list
-        ]
+        tasks = [asyncio.create_task(_run_model_health_check(model)) for model in model_list]
         peak_in_flight = len(tasks)
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -330,9 +339,7 @@ async def _perform_health_check(
                 cleaned["model_id"] = _model_id
                 if isinstance(is_healthy, Exception):
                     exceptions_by_model_id[_model_id] = is_healthy
-                    cleaned["exception_status"] = getattr(
-                        is_healthy, "status_code", 500
-                    )
+                    cleaned["exception_status"] = getattr(is_healthy, "status_code", 500)
             unhealthy_endpoints.append(cleaned)
 
     return healthy_endpoints, unhealthy_endpoints, exceptions_by_model_id
@@ -389,9 +396,7 @@ def _health_check_deployment_is_wildcard(litellm_params: dict) -> bool:
     return "*" in _deployment_model_string_for_health_check(litellm_params)
 
 
-def _resolve_health_check_max_tokens(
-    model_info: dict, litellm_params: dict
-) -> Optional[int]:
+def _resolve_health_check_max_tokens(model_info: dict, litellm_params: dict) -> Optional[int]:
     """
     Pick max_tokens for the health check request.
 
@@ -418,9 +423,7 @@ def _resolve_health_check_max_tokens(
         except Exception:
             is_reasoning = False
         tokens_reasoning = model_info.get("health_check_max_tokens_reasoning", None)
-        tokens_non_reasoning = model_info.get(
-            "health_check_max_tokens_non_reasoning", None
-        )
+        tokens_non_reasoning = model_info.get("health_check_max_tokens_non_reasoning", None)
         if tokens_reasoning is not None or tokens_non_reasoning is not None:
             if is_reasoning and tokens_reasoning is not None:
                 return int(tokens_reasoning)
@@ -438,9 +441,7 @@ def _resolve_health_check_max_tokens(
     return None
 
 
-def _update_litellm_params_for_health_check(
-    model_info: dict, litellm_params: dict
-) -> dict:
+def _update_litellm_params_for_health_check(model_info: dict, litellm_params: dict) -> dict:
     """
     Update the litellm params for health check.
 
@@ -463,9 +464,7 @@ def _update_litellm_params_for_health_check(
         model_info,
         mode,  # any-ok: untyped router config dict
     ):
-        _resolved_max_tokens = _resolve_health_check_max_tokens(
-            model_info, litellm_params
-        )
+        _resolved_max_tokens = _resolve_health_check_max_tokens(model_info, litellm_params)
         if _resolved_max_tokens is not None:
             litellm_params["max_tokens"] = _resolved_max_tokens
 
@@ -556,9 +555,7 @@ async def perform_health_check(
 
     if not model_list:
         if cli_model:
-            model_list = [
-                {"model_name": cli_model, "litellm_params": {"model": cli_model}}
-            ]
+            model_list = [{"model_name": cli_model, "litellm_params": {"model": cli_model}}]
         else:
             if instrumentation_enabled:
                 logger.debug(
@@ -573,26 +570,18 @@ async def perform_health_check(
 
     # Filter by model_id first so a single deployment is checked when id is specified
     if model_id is not None:
-        _by_id = [
-            x for x in model_list if (x.get("model_info") or {}).get("id") == model_id
-        ]
+        _by_id = [x for x in model_list if (x.get("model_info") or {}).get("id") == model_id]
         if _by_id:
             model_list = _by_id
     elif model is not None:
-        _new_model_list = [
-            x for x in model_list if x["litellm_params"]["model"] == model
-        ]
+        _new_model_list = [x for x in model_list if x["litellm_params"]["model"] == model]
         if _new_model_list == []:
             _new_model_list = [x for x in model_list if x["model_name"] == model]
         model_list = _new_model_list
 
     if health_check_skip_disabled_background_models:
         model_list = [
-            x
-            for x in model_list
-            if not (x.get("model_info") or {}).get(
-                "disable_background_health_check", False
-            )
+            x for x in model_list if not (x.get("model_info") or {}).get("disable_background_health_check", False)
         ]
     if not model_list:
         if instrumentation_enabled:

--- a/tests/test_litellm/proxy/test_health_check_max_tokens.py
+++ b/tests/test_litellm/proxy/test_health_check_max_tokens.py
@@ -5,6 +5,7 @@ import pytest
 from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
 from litellm.proxy import health_check as hc_module
 from litellm.proxy.health_check import (
+    _is_semantic_auto_router_deployment,
     _resolve_health_check_max_tokens,
     _resolve_health_check_mode,
     _update_litellm_params_for_health_check,
@@ -300,9 +301,7 @@ def test_no_mode_still_injects_max_tokens():
 
 @pytest.mark.parametrize("mode", ["chat", "completion", "responses"])
 def test_chat_style_modes_inject_max_tokens(mode):
-    updated = _update_litellm_params_for_health_check(
-        {"mode": mode}, {"model": f"openai/dummy-{mode}"}
-    )
+    updated = _update_litellm_params_for_health_check({"mode": mode}, {"model": f"openai/dummy-{mode}"})
 
     assert updated["max_tokens"] == 16
 
@@ -323,9 +322,7 @@ def test_chat_style_modes_inject_max_tokens(mode):
     ],
 )
 def test_non_chat_modes_skip_max_tokens(mode):
-    updated = _update_litellm_params_for_health_check(
-        {"mode": mode}, {"model": f"openai/dummy-{mode}"}
-    )
+    updated = _update_litellm_params_for_health_check({"mode": mode}, {"model": f"openai/dummy-{mode}"})
 
     assert "max_tokens" not in updated
 
@@ -361,35 +358,25 @@ def test_update_litellm_params_health_check_reasoning_effort():
     assert out.get("reasoning_effort") == "low"
 
     model_info = {"mode": "chat", "health_check_reasoning_effort": "none"}
-    out = _update_litellm_params_for_health_check(
-        model_info, {"model": "openai/gpt-5", "api_key": "x"}
-    )
+    out = _update_litellm_params_for_health_check(model_info, {"model": "openai/gpt-5", "api_key": "x"})
     assert out.get("reasoning_effort") == "none"
 
     model_info = {"mode": "completion", "health_check_reasoning_effort": "low"}
-    out = _update_litellm_params_for_health_check(
-        model_info, {"model": "openai/gpt-5", "api_key": "x"}
-    )
+    out = _update_litellm_params_for_health_check(model_info, {"model": "openai/gpt-5", "api_key": "x"})
     assert out.get("reasoning_effort") == "low"
 
     model_info = {
         "health_check_reasoning_effort": {"effort": "none", "summary": "auto"},
     }
-    out = _update_litellm_params_for_health_check(
-        model_info, {"model": "openai/gpt-5.1", "api_key": "x"}
-    )
+    out = _update_litellm_params_for_health_check(model_info, {"model": "openai/gpt-5.1", "api_key": "x"})
     assert out.get("reasoning_effort") == {"effort": "none", "summary": "auto"}
 
     model_info = {"mode": "embedding", "health_check_reasoning_effort": "low"}
-    out = _update_litellm_params_for_health_check(
-        model_info, {"model": "text-embedding-3-small", "api_key": "x"}
-    )
+    out = _update_litellm_params_for_health_check(model_info, {"model": "text-embedding-3-small", "api_key": "x"})
     assert "reasoning_effort" not in out
 
     model_info = {}
-    out = _update_litellm_params_for_health_check(
-        model_info, {"model": "openai/gpt-4o", "api_key": "x"}
-    )
+    out = _update_litellm_params_for_health_check(model_info, {"model": "openai/gpt-4o", "api_key": "x"})
     assert "reasoning_effort" not in out
 
 
@@ -413,9 +400,7 @@ def test_update_litellm_params_health_check_reasoning_effort():
         ("bedrock/us.cohere.embed-v4:0", "us.cohere.embed-v4:0"),
     ],
 )
-def test_bedrock_embedding_without_explicit_mode_skips_max_tokens(
-    deployment_model, expected_request_model
-):
+def test_bedrock_embedding_without_explicit_mode_skips_max_tokens(deployment_model, expected_request_model):
     """Embedding mode auto-detected from model cost map -> no max_tokens, provider pinned."""
     assert _resolve_health_check_mode({}, {"model": deployment_model}) == "embedding"
 
@@ -428,19 +413,11 @@ def test_bedrock_embedding_without_explicit_mode_skips_max_tokens(
 
 def test_resolve_health_check_mode_prefers_explicit_model_info_mode():
     """An operator-set mode wins over model-cost lookup."""
-    assert (
-        _resolve_health_check_mode(
-            {"mode": "chat"}, {"model": "bedrock/amazon.titan-embed-text-v2:0"}
-        )
-        == "chat"
-    )
+    assert _resolve_health_check_mode({"mode": "chat"}, {"model": "bedrock/amazon.titan-embed-text-v2:0"}) == "chat"
 
 
 def test_resolve_health_check_mode_unknown_model_returns_none():
-    assert (
-        _resolve_health_check_mode({}, {"model": "bedrock/not-a-real-model-xyz"})
-        is None
-    )
+    assert _resolve_health_check_mode({}, {"model": "bedrock/not-a-real-model-xyz"}) is None
     assert _resolve_health_check_mode({}, {}) is None
 
 
@@ -516,3 +493,53 @@ def test_autodetected_embedding_skips_reasoning_effort():
 
     assert "reasoning_effort" not in updated
     assert "max_tokens" not in updated
+
+
+# ---------------------------------------------------------------------------
+# auto_router (semantic router) deployments must be skipped by health checks.
+#
+# These are meta-routers that select among real LLM deployments at request
+# time. They have no LLM endpoint to probe. Before this fix, the health check
+# passed model="auto_router/router_1" to get_llm_provider(), which raised
+# BadRequestError: "Unmapped LLM provider for this endpoint" because
+# auto_router is not a real LLM provider.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        ("auto_router/router_1", True),
+        ("auto_router/my_router", True),
+        ("auto_router/complexity_router", False),
+        ("auto_router/adaptive_router", False),
+        ("auto_router/quality_router", False),
+        ("auto_router/adaptive_router/subpath", False),
+        ("gpt-4", False),
+        ("openai/gpt-4", False),
+        ("bedrock/claude", False),
+    ],
+)
+def test_is_semantic_auto_router_deployment(model, expected):
+    assert _is_semantic_auto_router_deployment({"model": model}) == expected
+
+
+@pytest.mark.asyncio
+async def test_run_model_health_check_skips_auto_router_deployment():
+    """auto_router deployments return {} (healthy) without calling ahealth_check."""
+    fake_ahealth_check = AsyncMock(return_value={})
+    model = {
+        "litellm_params": {
+            "model": "auto_router/router_1",
+            "auto_router_config": '{"routes": []}',
+            "auto_router_default_model": "gpt-4o-mini",
+            "auto_router_embedding_model": "text-embedding-3-small",
+        },
+        "model_info": {},
+    }
+
+    with patch.object(hc_module.litellm, "ahealth_check", fake_ahealth_check):
+        result = await hc_module._run_model_health_check(model)
+
+    fake_ahealth_check.assert_not_called()
+    assert result == {}


### PR DESCRIPTION
## Relevant issues

Customer report: adding an auto_router deployment causes it to always appear unhealthy in /health, and curl requests hang.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

Bug Fix

## Changes

`auto_router/<name>` deployments are semantic meta-routers that select among real LLM deployments at request time. They have no LLM endpoint to probe. The health check was passing `model=auto_router/router_1` into `litellm.ahealth_check()`, which calls `get_llm_provider()` — that raises `BadRequestError: Unmapped LLM provider for this endpoint` because `auto_router` is not a real LLM provider.

Fix: added `_is_semantic_auto_router_deployment()` in `litellm/proxy/health_check.py`. When detected, `_run_model_health_check` returns `{}` immediately (healthy, no probe). Sub-strategies (`complexity_router`, `adaptive_router`, `quality_router`) are excluded from this path and continue to be health-checked normally.

## Screenshots / Proof of Fix

### Before (bug reproduced)

Config with an `auto_router/router_1` deployment + real OpenAI models. The auto_router deployment shows as `unhealthy` with the exact error from the customer report:

```
$ curl -s http://localhost:4001/health -H "Authorization: Bearer sk-test-1234"

{
  "unhealthy_endpoints": [
    {
      "model": "auto_router/router_1",
      "error": "litellm.BadRequestError: Unmapped LLM provider for this endpoint. You passed model=router_1, custom_llm_provider=auto_router. Check supported provider and route: https://docs.litellm.ai/docs/providers\nstack trace: ...",
      "exception_status": 400
    }
  ],
  "healthy_count": 0,
  "unhealthy_count": 1
}
```

### After (fixed)

Same config, proxy running from this branch. All 3 deployments healthy, `auto_router/router_1` in `healthy_endpoints`, `unhealthy_count: 0`:

```
$ curl -s http://localhost:4002/health -H "Authorization: Bearer sk-test-1234" | python3 -m json.tool

{
    "healthy_endpoints": [
        {
            "model": "openai/gpt-4o-mini",
            "x-ratelimit-remaining-requests": "29999",
            "x-ratelimit-remaining-tokens": "149999992",
            "model_id": "gpt-4o-mini-id"
        },
        {
            "auto_router_config": "{\"routes\":[{\"name\":\"gpt-4o-mini\",\"utterances\":[\"how to code\",\"explain this code\"],\"description\":\"coding\",\"score_threshold\":0.5}]}",
            "auto_router_default_model": "gpt-4o-mini",
            "auto_router_embedding_model": "text-embedding-3-small",
            "model": "auto_router/router_1",
            "model_id": "auto-router-router1-id"
        },
        {
            "model": "openai/text-embedding-3-small",
            "model_id": "text-embedding-3-small-id"
        }
    ],
    "unhealthy_endpoints": [],
    "healthy_count": 3,
    "unhealthy_count": 0
}
```

Proxy config used:

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: gpt-4o-mini-id

  - model_name: router_1
    litellm_params:
      model: auto_router/router_1
      auto_router_config: '{"routes":[{"name":"gpt-4o-mini","utterances":["how to code","explain this code"],"description":"coding","score_threshold":0.5}]}'
      auto_router_default_model: gpt-4o-mini
      auto_router_embedding_model: text-embedding-3-small
    model_info:
      id: auto-router-router1-id

  - model_name: text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: text-embedding-3-small-id

general_settings:
  master_key: sk-test-1234
```