### PR TITLE
feat(guardrails/headroom): add CCR (compress-cache-retrieve) via agentic loop

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+import json
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple
 
 import httpx
 from fastapi import HTTPException
@@ -18,6 +20,7 @@ from litellm.llms.custom_httpx.http_handler import (
 )
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.guardrails import GuardrailEventHooks, Mode
+from litellm.types.integrations.custom_logger import AgenticLoopPlan, AgenticLoopRequestPatch
 from litellm.types.utils import GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
@@ -25,6 +28,8 @@ if TYPE_CHECKING:
     from litellm.types.proxy.guardrails.guardrail_hooks.base import GuardrailConfigModel
 
 BYPASS_HEADER = "x-headroom-bypass"
+HEADROOM_RETRIEVE_TOOL_NAME = "headroom_retrieve"
+_HASH_PATTERN = re.compile(r"hash=([a-f0-9]{24})")
 
 
 def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
@@ -33,6 +38,124 @@ def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard
 
 def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
     return isinstance(value, list)
+
+
+def extract_hashes_from_messages(messages: list[dict[str, object]]) -> list[str]:
+    hashes: list[str] = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            hashes.extend(_HASH_PATTERN.findall(content))
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        hashes.extend(_HASH_PATTERN.findall(text))
+    return hashes
+
+
+def _build_headroom_retrieve_tool() -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": HEADROOM_RETRIEVE_TOOL_NAME,
+            "description": (
+                "Retrieve original content that was compressed by Headroom. "
+                "Call this when you encounter a compression marker containing a hash."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "type": "string",
+                        "description": "The 24-character hex hash from the compression marker.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional search query for BM25-ranked retrieval.",
+                    },
+                },
+                "required": ["hash"],
+            },
+        },
+    }
+
+
+def has_headroom_retrieve_tool(tools: object) -> bool:
+    if not isinstance(tools, list):
+        return False
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if tool.get("type") == "function" and isinstance(function, dict):
+            if function.get("name") == HEADROOM_RETRIEVE_TOOL_NAME:
+                return True
+    return False
+
+
+def _extract_headroom_tool_calls(
+    response: object,
+) -> list[dict[str, object]]:
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, list) or not choices:
+        return []
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        return []
+    tool_calls = getattr(message, "tool_calls", None)
+    if not isinstance(tool_calls, list):
+        return []
+
+    result: list[dict[str, object]] = []
+    for tc in tool_calls:
+        fn = getattr(tc, "function", None)
+        if fn is None:
+            continue
+        name = getattr(fn, "name", None)
+        if name != HEADROOM_RETRIEVE_TOOL_NAME:
+            continue
+        arguments_str = getattr(fn, "arguments", "{}")
+        try:
+            arguments: dict[str, object] = json.loads(arguments_str)
+        except (json.JSONDecodeError, TypeError):
+            arguments = {}
+        result.append(
+            {
+                "id": getattr(tc, "id", None),
+                "type": "function",
+                "name": name,
+                "arguments": arguments,
+            }
+        )
+    return result
+
+
+def _build_assistant_message_from_response(response: object) -> dict[str, object]:
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, list) or not choices:
+        return {"role": "assistant", "content": None, "tool_calls": []}
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        return {"role": "assistant", "content": None, "tool_calls": []}
+    content = getattr(message, "content", None)
+    tool_calls = getattr(message, "tool_calls", None)
+    raw_tool_calls: list[dict[str, object]] = []
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            fn = getattr(tc, "function", None)
+            raw_tool_calls.append(
+                {
+                    "id": getattr(tc, "id", None),
+                    "type": "function",
+                    "function": {
+                        "name": getattr(fn, "name", None) if fn else None,
+                        "arguments": getattr(fn, "arguments", "{}") if fn else "{}",
+                    },
+                }
+            )
+    return {"role": "assistant", "content": content, "tool_calls": raw_tool_calls}
 
 
 class HeadroomGuardrail(CustomGuardrail):
@@ -77,6 +200,12 @@ class HeadroomGuardrail(CustomGuardrail):
         value = headers.get(BYPASS_HEADER)
         return str(value).lower() == "true"
 
+    def _request_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.headroom_api_key:
+            headers["Authorization"] = f"Bearer {self.headroom_api_key}"
+        return headers
+
     async def _call_compress(
         self,
         messages: list[dict[str, object]],
@@ -86,15 +215,11 @@ class HeadroomGuardrail(CustomGuardrail):
         if model:
             payload["model"] = model
 
-        request_headers: dict[str, str] = {"Content-Type": "application/json"}
-        if self.headroom_api_key:
-            request_headers["Authorization"] = f"Bearer {self.headroom_api_key}"
-
         try:
             raw_response: HttpxResponse | None = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]
                 url=f"{self.headroom_api_base}/v1/compress",
                 json=payload,
-                headers=request_headers,
+                headers=self._request_headers(),
             )
         except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError) as e:
             raise HTTPException(
@@ -168,6 +293,46 @@ class HeadroomGuardrail(CustomGuardrail):
         )
         return filtered
 
+    async def _call_retrieve(self, hash_value: str, query: str | None = None) -> str:
+        params: dict[str, str] = {}
+        if query:
+            params["query"] = query
+
+        try:
+            raw_response: HttpxResponse | None = await self.async_handler.get(  # pyright: ignore[reportUnknownMemberType]
+                url=f"{self.headroom_api_base}/v1/retrieve/{hash_value}",
+                params=params,
+                headers=self._request_headers(),
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError) as e:
+            verbose_proxy_logger.warning(
+                "Headroom: retrieve failed for hash=%s: %s", hash_value, e
+            )
+            return f"[Headroom: retrieval failed for hash={hash_value}]"
+
+        if raw_response is None or raw_response.status_code == 404:
+            return f"[Headroom: hash={hash_value} not found or expired]"
+
+        if raw_response.status_code != 200:
+            verbose_proxy_logger.warning(
+                "Headroom: retrieve returned %s for hash=%s",
+                raw_response.status_code,
+                hash_value,
+            )
+            return f"[Headroom: retrieval error {raw_response.status_code} for hash={hash_value}]"
+
+        try:
+            body: object = raw_response.json()
+        except Exception:
+            return raw_response.text
+
+        if _is_str_object_dict(body):
+            original_content = body.get("original_content")
+            if isinstance(original_content, str):
+                return original_content
+
+        return str(body)
+
     @log_guardrail_information
     async def apply_guardrail(
         self,
@@ -199,7 +364,111 @@ class HeadroomGuardrail(CustomGuardrail):
             model=model if isinstance(model, str) else None,
         )
 
-        return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
+        hashes = extract_hashes_from_messages(compressed)
+        if not hashes:
+            return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
+
+        existing_tools = inputs.get("tools")
+        retrieve_tool = _build_headroom_retrieve_tool()
+        if isinstance(existing_tools, list) and not has_headroom_retrieve_tool(existing_tools):
+            merged_tools: list[object] = list(existing_tools) + [retrieve_tool]
+        elif existing_tools is None:
+            merged_tools = [retrieve_tool]
+        else:
+            merged_tools = list(existing_tools) if isinstance(existing_tools, list) else [retrieve_tool]
+
+        return {**inputs, "structured_messages": compressed, "tools": merged_tools}  # pyright: ignore[reportReturnType]
+
+    async def async_should_run_agentic_loop(
+        self,
+        response: Any,
+        model: str,
+        messages: List[Dict],
+        tools: Optional[List[Dict]],
+        stream: bool,
+        custom_llm_provider: str,
+        kwargs: Dict,
+    ) -> Tuple[bool, Dict]:
+        if not has_headroom_retrieve_tool(tools):
+            return False, {}
+
+        tool_calls = _extract_headroom_tool_calls(response)
+        if not tool_calls:
+            return False, {}
+
+        return True, {"tool_calls": tool_calls}
+
+    async def async_build_agentic_loop_plan(
+        self,
+        tools: Dict,
+        model: str,
+        messages: List[Dict],
+        response: Any,
+        anthropic_messages_provider_config: Any,
+        anthropic_messages_optional_request_params: Dict,
+        logging_obj: Any,
+        stream: bool,
+        kwargs: Dict,
+    ) -> AgenticLoopPlan:
+        tool_calls: list[dict[str, object]] = tools.get("tool_calls", [])  # type: ignore[assignment]
+
+        tool_results: list[dict[str, object]] = []
+        for tc in tool_calls:
+            arguments = tc.get("arguments", {})
+            hash_value = arguments.get("hash", "") if isinstance(arguments, dict) else ""
+            query = arguments.get("query") if isinstance(arguments, dict) else None
+            content = await self._call_retrieve(
+                hash_value=str(hash_value),
+                query=str(query) if query else None,
+            )
+            verbose_proxy_logger.debug(
+                "Headroom CCR: retrieved hash=%s (%d chars)", hash_value, len(content)
+            )
+            tool_results.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": tc.get("id"),
+                    "content": content,
+                }
+            )
+
+        assistant_message = _build_assistant_message_from_response(response)
+        follow_up_messages = list(messages) + [assistant_message] + tool_results
+
+        max_tokens: Optional[int] = (
+            anthropic_messages_optional_request_params.get("max_tokens")
+            or kwargs.get("max_tokens")
+        )
+        optional_params_without_max_tokens = {
+            k: v
+            for k, v in anthropic_messages_optional_request_params.items()
+            if k != "max_tokens"
+        }
+
+        full_model_name = model
+        if logging_obj is not None:
+            agentic_params = getattr(logging_obj, "model_call_details", {}).get(
+                "agentic_loop_params", {}
+            )
+            candidate = agentic_params.get("model", model)
+            if isinstance(candidate, str) and candidate:
+                full_model_name = candidate
+
+        return AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(
+                model=full_model_name,
+                messages=follow_up_messages,
+                max_tokens=max_tokens,
+                optional_params=optional_params_without_max_tokens,
+                kwargs={
+                    k: v
+                    for k, v in kwargs.items()
+                    if not k.startswith("_headroom") and k != "litellm_logging_obj"
+                },
+            ),
+            metadata={"tool_type": "headroom_ccr"},
+        )
 
     @staticmethod
     def get_config_model() -> type[GuardrailConfigModel[object]] | None:

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -165,15 +165,10 @@ class HeadroomGuardrail(CustomGuardrail):
         api_key: str | None = None,
         model: str | None = None,
         guardrail_name: str | None = None,
-        event_hook: GuardrailEventHooks
-        | list[GuardrailEventHooks]
-        | Mode
-        | None = None,
+        event_hook: GuardrailEventHooks | list[GuardrailEventHooks] | Mode | None = None,
         default_on: bool = False,
     ):
-        self.headroom_api_base = (
-            api_base or get_secret_str("HEADROOM_API_BASE") or ""
-        ).rstrip("/")
+        self.headroom_api_base = (api_base or get_secret_str("HEADROOM_API_BASE") or "").rstrip("/")
         if not self.headroom_api_base:
             raise ValueError(
                 "Headroom guardrail requires an API base URL. "
@@ -305,9 +300,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 headers=self._request_headers(),
             )
         except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError) as e:
-            verbose_proxy_logger.warning(
-                "Headroom: retrieve failed for hash=%s: %s", hash_value, e
-            )
+            verbose_proxy_logger.warning("Headroom: retrieve failed for hash=%s: %s", hash_value, e)
             return f"[Headroom: retrieval failed for hash={hash_value}]"
 
         if raw_response is None or raw_response.status_code == 404:
@@ -345,9 +338,7 @@ class HeadroomGuardrail(CustomGuardrail):
             return inputs
 
         if self._should_bypass(request_data):
-            verbose_proxy_logger.debug(
-                "Headroom: %s header set; skipping compression", BYPASS_HEADER
-            )
+            verbose_proxy_logger.debug("Headroom: %s header set; skipping compression", BYPASS_HEADER)
             return inputs
 
         structured_messages = inputs.get("structured_messages")
@@ -421,9 +412,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 hash_value=str(hash_value),
                 query=str(query) if query else None,
             )
-            verbose_proxy_logger.debug(
-                "Headroom CCR: retrieved hash=%s (%d chars)", hash_value, len(content)
-            )
+            verbose_proxy_logger.debug("Headroom CCR: retrieved hash=%s (%d chars)", hash_value, len(content))
             tool_results.append(
                 {
                     "role": "tool",
@@ -435,21 +424,16 @@ class HeadroomGuardrail(CustomGuardrail):
         assistant_message = _build_assistant_message_from_response(response)
         follow_up_messages = list(messages) + [assistant_message] + tool_results
 
-        max_tokens: Optional[int] = (
-            anthropic_messages_optional_request_params.get("max_tokens")
-            or kwargs.get("max_tokens")
+        max_tokens: Optional[int] = anthropic_messages_optional_request_params.get("max_tokens") or kwargs.get(
+            "max_tokens"
         )
         optional_params_without_max_tokens = {
-            k: v
-            for k, v in anthropic_messages_optional_request_params.items()
-            if k != "max_tokens"
+            k: v for k, v in anthropic_messages_optional_request_params.items() if k != "max_tokens"
         }
 
         full_model_name = model
         if logging_obj is not None:
-            agentic_params = getattr(logging_obj, "model_call_details", {}).get(
-                "agentic_loop_params", {}
-            )
+            agentic_params = getattr(logging_obj, "model_call_details", {}).get("agentic_loop_params", {})
             candidate = agentic_params.get("model", model)
             if isinstance(candidate, str) and candidate:
                 full_model_name = candidate
@@ -462,9 +446,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 max_tokens=max_tokens,
                 optional_params=optional_params_without_max_tokens,
                 kwargs={
-                    k: v
-                    for k, v in kwargs.items()
-                    if not k.startswith("_headroom") and k != "litellm_logging_obj"
+                    k: v for k, v in kwargs.items() if not k.startswith("_headroom") and k != "litellm_logging_obj"
                 },
             ),
             metadata={"tool_type": "headroom_ccr"},

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -98,37 +98,59 @@ def has_headroom_retrieve_tool(tools: object) -> bool:
 def _extract_headroom_tool_calls(
     response: object,
 ) -> list[dict[str, object]]:
-    choices = getattr(response, "choices", None)
-    if not isinstance(choices, list) or not choices:
-        return []
-    message = getattr(choices[0], "message", None)
-    if message is None:
-        return []
-    tool_calls = getattr(message, "tool_calls", None)
-    if not isinstance(tool_calls, list):
-        return []
-
     result: list[dict[str, object]] = []
-    for tc in tool_calls:
-        fn = getattr(tc, "function", None)
-        if fn is None:
-            continue
-        name = getattr(fn, "name", None)
-        if name != HEADROOM_RETRIEVE_TOOL_NAME:
-            continue
-        arguments_str = getattr(fn, "arguments", "{}")
-        try:
-            arguments: dict[str, object] = json.loads(arguments_str)
-        except (json.JSONDecodeError, TypeError):
-            arguments = {}
-        result.append(
-            {
-                "id": getattr(tc, "id", None),
-                "type": "function",
-                "name": name,
-                "arguments": arguments,
-            }
-        )
+
+    # OpenAI chat completions format: choices[0].message.tool_calls
+    choices = getattr(response, "choices", None)
+    if isinstance(choices, list) and choices:
+        message = getattr(choices[0], "message", None)
+        tool_calls = getattr(message, "tool_calls", None) if message else None
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                fn = getattr(tc, "function", None)
+                if fn is None:
+                    continue
+                name = getattr(fn, "name", None)
+                if name != HEADROOM_RETRIEVE_TOOL_NAME:
+                    continue
+                arguments_str = getattr(fn, "arguments", "{}")
+                try:
+                    arguments: dict[str, object] = json.loads(arguments_str)
+                except (json.JSONDecodeError, TypeError):
+                    arguments = {}
+                result.append(
+                    {
+                        "id": getattr(tc, "id", None),
+                        "type": "function",
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                )
+            return result
+
+    # Anthropic messages format: content blocks with type=tool_use
+    content = getattr(response, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            block_type = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
+            block_name = block.get("name") if isinstance(block, dict) else getattr(block, "name", None)
+            if block_type != "tool_use" or block_name != HEADROOM_RETRIEVE_TOOL_NAME:
+                continue
+            if isinstance(block, dict):
+                raw_input: object = block.get("input", {})
+                block_id: object = block.get("id")
+            else:
+                raw_input = getattr(block, "input", {})
+                block_id = getattr(block, "id", None)
+            result.append(
+                {
+                    "id": block_id,
+                    "type": "function",
+                    "name": block_name,
+                    "arguments": raw_input if isinstance(raw_input, dict) else {},
+                }
+            )
+
     return result
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -8,15 +8,24 @@ Tests cover:
 - response-type input is passed through unchanged
 - /v1/compress HTTP error raises HTTPException
 - /v1/compress returning malformed JSON raises HTTPException
+- CCR: headroom_retrieve tool injected when compressed messages contain hashes
+- CCR: async_should_run_agentic_loop returns True when response has headroom_retrieve tool calls
+- CCR: async_build_agentic_loop_plan calls retrieve endpoint and builds follow-up messages
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from fastapi import HTTPException
 
-from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import HeadroomGuardrail
+from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import (
+    HeadroomGuardrail,
+    extract_hashes_from_messages,
+    has_headroom_retrieve_tool,
+    HEADROOM_RETRIEVE_TOOL_NAME,
+)
 from litellm.types.utils import GenericGuardrailAPIInputs
 
 FAKE_API_BASE = "https://headroom.example.com"
@@ -29,6 +38,13 @@ ORIGINAL_MESSAGES = [
 COMPRESSED_MESSAGES = [
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "A" * 500},
+]
+COMPRESSED_MESSAGES_WITH_HASH = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {
+        "role": "user",
+        "content": "Summary. Retrieve more: hash=b573993006976af767214fac",
+    },
 ]
 
 
@@ -55,6 +71,38 @@ def _make_compress_response(messages: list, status: int = 200) -> MagicMock:
     }
     mock.text = ""
     return mock
+
+
+def _make_retrieve_response(original_content: str, status: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status
+    mock.json.return_value = {"original_content": original_content}
+    mock.text = original_content
+    return mock
+
+
+def _make_openai_response_with_tool_call(
+    tool_name: str, arguments: dict, tool_id: str = "call_abc123"
+) -> MagicMock:
+    fn = MagicMock()
+    fn.name = tool_name
+    fn.arguments = json.dumps(arguments)
+
+    tc = MagicMock()
+    tc.id = tool_id
+    tc.type = "function"
+    tc.function = fn
+
+    message = MagicMock()
+    message.content = None
+    message.tool_calls = [tc]
+
+    choice = MagicMock()
+    choice.message = message
+
+    response = MagicMock()
+    response.choices = [choice]
+    return response
 
 
 @pytest.fixture
@@ -85,6 +133,296 @@ async def test_apply_guardrail_compresses_and_returns_structured_messages(
         )
 
     assert result.get("structured_messages") == COMPRESSED_MESSAGES
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_injects_retrieve_tool_when_hashes_present(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES_WITH_HASH)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    tools = result.get("tools")
+    assert tools is not None
+    assert has_headroom_retrieve_tool(tools)
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_no_tool_injected_when_no_hashes(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    tools = result.get("tools")
+    assert not has_headroom_retrieve_tool(tools or [])
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_preserves_existing_tools_when_injecting(
+    guardrail: HeadroomGuardrail,
+):
+    existing_tool = {"type": "function", "function": {"name": "my_tool", "parameters": {}}}
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+        tools=[existing_tool],
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES_WITH_HASH)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    tools = result.get("tools")
+    assert tools is not None
+    assert isinstance(tools, list)
+    assert any(
+        isinstance(t, dict) and t.get("function", {}).get("name") == "my_tool"
+        for t in tools
+    )
+    assert has_headroom_retrieve_tool(tools)
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_returns_true_for_retrieve_call(
+    guardrail: HeadroomGuardrail,
+):
+    retrieve_tool_def = [{"type": "function", "function": {"name": HEADROOM_RETRIEVE_TOOL_NAME}}]
+    response = _make_openai_response_with_tool_call(
+        tool_name=HEADROOM_RETRIEVE_TOOL_NAME,
+        arguments={"hash": "b573993006976af767214fac"},
+    )
+
+    should_run, ctx = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="gpt-4o",
+        messages=[],
+        tools=retrieve_tool_def,
+        stream=False,
+        custom_llm_provider="openai",
+        kwargs={},
+    )
+
+    assert should_run is True
+    assert len(ctx["tool_calls"]) == 1
+    assert ctx["tool_calls"][0]["arguments"]["hash"] == "b573993006976af767214fac"
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_returns_false_without_retrieve_tool(
+    guardrail: HeadroomGuardrail,
+):
+    other_tools = [{"type": "function", "function": {"name": "other_tool"}}]
+    response = _make_openai_response_with_tool_call(
+        tool_name="other_tool",
+        arguments={},
+    )
+
+    should_run, _ = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="gpt-4o",
+        messages=[],
+        tools=other_tools,
+        stream=False,
+        custom_llm_provider="openai",
+        kwargs={},
+    )
+
+    assert should_run is False
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_returns_false_when_no_retrieve_calls(
+    guardrail: HeadroomGuardrail,
+):
+    retrieve_tool_def = [{"type": "function", "function": {"name": HEADROOM_RETRIEVE_TOOL_NAME}}]
+    response = _make_openai_response_with_tool_call(
+        tool_name="some_other_function",
+        arguments={},
+    )
+
+    should_run, _ = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="gpt-4o",
+        messages=[],
+        tools=retrieve_tool_def,
+        stream=False,
+        custom_llm_provider="openai",
+        kwargs={},
+    )
+
+    assert should_run is False
+
+
+@pytest.mark.asyncio
+async def test_async_build_agentic_loop_plan_calls_retrieve_and_builds_messages(
+    guardrail: HeadroomGuardrail,
+):
+    original_content = "This is the full compressed content."
+    mock_retrieve = _make_retrieve_response(original_content)
+
+    tool_calls = [
+        {
+            "id": "call_abc123",
+            "type": "function",
+            "name": HEADROOM_RETRIEVE_TOOL_NAME,
+            "arguments": {"hash": "b573993006976af767214fac"},
+        }
+    ]
+    response = _make_openai_response_with_tool_call(
+        tool_name=HEADROOM_RETRIEVE_TOOL_NAME,
+        arguments={"hash": "b573993006976af767214fac"},
+        tool_id="call_abc123",
+    )
+    messages = [{"role": "user", "content": "What does it say? hash=b573993006976af767214fac"}]
+
+    with patch.object(
+        guardrail.async_handler,
+        "get",
+        new_callable=AsyncMock,
+        return_value=mock_retrieve,
+    ) as mock_get:
+        plan = await guardrail.async_build_agentic_loop_plan(
+            tools={"tool_calls": tool_calls},
+            model="gpt-4o",
+            messages=messages,
+            response=response,
+            anthropic_messages_provider_config=None,
+            anthropic_messages_optional_request_params={},
+            logging_obj=None,
+            stream=False,
+            kwargs={},
+        )
+
+    assert plan.run_agentic_loop is True
+    assert plan.request_patch is not None
+
+    follow_up = plan.request_patch.messages
+    assert follow_up is not None
+
+    tool_result_message = next(
+        (m for m in follow_up if m.get("role") == "tool"), None
+    )
+    assert tool_result_message is not None
+    assert tool_result_message["content"] == original_content
+    assert tool_result_message["tool_call_id"] == "call_abc123"
+
+    mock_get.assert_called_once()
+    call_url = mock_get.call_args.kwargs.get("url") or mock_get.call_args.args[0]
+    assert "b573993006976af767214fac" in call_url
+
+
+@pytest.mark.asyncio
+async def test_async_build_agentic_loop_plan_handles_retrieve_404(
+    guardrail: HeadroomGuardrail,
+):
+    mock_retrieve = MagicMock()
+    mock_retrieve.status_code = 404
+
+    tool_calls = [
+        {
+            "id": "call_xyz",
+            "type": "function",
+            "name": HEADROOM_RETRIEVE_TOOL_NAME,
+            "arguments": {"hash": "deadbeef000000000000dead"},
+        }
+    ]
+    response = _make_openai_response_with_tool_call(
+        tool_name=HEADROOM_RETRIEVE_TOOL_NAME,
+        arguments={"hash": "deadbeef000000000000dead"},
+        tool_id="call_xyz",
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "get",
+        new_callable=AsyncMock,
+        return_value=mock_retrieve,
+    ):
+        plan = await guardrail.async_build_agentic_loop_plan(
+            tools={"tool_calls": tool_calls},
+            model="gpt-4o",
+            messages=[],
+            response=response,
+            anthropic_messages_provider_config=None,
+            anthropic_messages_optional_request_params={},
+            logging_obj=None,
+            stream=False,
+            kwargs={},
+        )
+
+    follow_up = plan.request_patch.messages  # type: ignore[union-attr]
+    tool_result = next((m for m in follow_up if m.get("role") == "tool"), None)
+    assert tool_result is not None
+    assert "not found" in tool_result["content"] or "expired" in tool_result["content"]
+
+
+def test_extract_hashes_from_messages_finds_hashes():
+    messages = [
+        {"role": "user", "content": "Retrieve more: hash=b573993006976af767214fac"},
+        {"role": "assistant", "content": "Also: hash=aabbccdd001122334455aabb"},
+    ]
+    hashes = extract_hashes_from_messages(messages)
+    assert "b573993006976af767214fac" in hashes
+    assert "aabbccdd001122334455aabb" in hashes
+
+
+def test_extract_hashes_from_messages_ignores_short_hashes():
+    messages = [{"role": "user", "content": "hash=tooshort"}]
+    hashes = extract_hashes_from_messages(messages)
+    assert not hashes
+
+
+def test_extract_hashes_from_list_content_blocks():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "hash=b573993006976af767214fac found here"},
+            ],
+        }
+    ]
+    hashes = extract_hashes_from_messages(messages)
+    assert "b573993006976af767214fac" in hashes
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -81,9 +81,7 @@ def _make_retrieve_response(original_content: str, status: int = 200) -> MagicMo
     return mock
 
 
-def _make_openai_response_with_tool_call(
-    tool_name: str, arguments: dict, tool_id: str = "call_abc123"
-) -> MagicMock:
+def _make_openai_response_with_tool_call(tool_name: str, arguments: dict, tool_id: str = "call_abc123") -> MagicMock:
     fn = MagicMock()
     fn.name = tool_name
     fn.arguments = json.dumps(arguments)
@@ -215,10 +213,7 @@ async def test_apply_guardrail_preserves_existing_tools_when_injecting(
     tools = result.get("tools")
     assert tools is not None
     assert isinstance(tools, list)
-    assert any(
-        isinstance(t, dict) and t.get("function", {}).get("name") == "my_tool"
-        for t in tools
-    )
+    assert any(isinstance(t, dict) and t.get("function", {}).get("name") == "my_tool" for t in tools)
     assert has_headroom_retrieve_tool(tools)
 
 
@@ -339,9 +334,7 @@ async def test_async_build_agentic_loop_plan_calls_retrieve_and_builds_messages(
     follow_up = plan.request_patch.messages
     assert follow_up is not None
 
-    tool_result_message = next(
-        (m for m in follow_up if m.get("role") == "tool"), None
-    )
+    tool_result_message = next((m for m in follow_up if m.get("role") == "tool"), None)
     assert tool_result_message is not None
     assert tool_result_message["content"] == original_content
     assert tool_result_message["tool_call_id"] == "call_abc123"
@@ -435,9 +428,7 @@ async def test_apply_guardrail_bypass_header_skips_compression(
     )
     request_data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "true"}}}
 
-    with patch.object(
-        guardrail.async_handler, "post", new_callable=AsyncMock
-    ) as mock_post:
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data=request_data,
@@ -457,9 +448,7 @@ async def test_apply_guardrail_response_type_passthrough(
         structured_messages=ORIGINAL_MESSAGES,
     )
 
-    with patch.object(
-        guardrail.async_handler, "post", new_callable=AsyncMock
-    ) as mock_post:
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={},
@@ -476,9 +465,7 @@ async def test_apply_guardrail_empty_structured_messages_passthrough(
 ):
     inputs = GenericGuardrailAPIInputs(texts=["hello"])
 
-    with patch.object(
-        guardrail.async_handler, "post", new_callable=AsyncMock
-    ) as mock_post:
+    with patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post:
         result = await guardrail.apply_guardrail(
             inputs=inputs,
             request_data={},
@@ -615,9 +602,7 @@ def test_bypass_header_case_insensitive():
     guardrail = _make_guardrail()
 
     for header_value in ("true", "True", "TRUE"):
-        data = {
-            "proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}
-        }
+        data = {"proxy_server_request": {"headers": {"x-headroom-bypass": header_value}}}
         assert guardrail._should_bypass(data) is True
 
     data = {"proxy_server_request": {"headers": {"x-headroom-bypass": "false"}}}

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -667,3 +667,35 @@ async def test_apply_guardrail_sends_model_from_request_data_when_no_config_mode
     call_kwargs = mock_post.call_args
     sent_payload = call_kwargs.kwargs.get("json") or call_kwargs.args[1]
     assert sent_payload.get("model") == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_detects_anthropic_content_block_format(
+    guardrail: HeadroomGuardrail,
+):
+    retrieve_tool_def = [{"type": "function", "function": {"name": HEADROOM_RETRIEVE_TOOL_NAME}}]
+
+    response = MagicMock()
+    response.choices = None
+    response.content = [
+        {
+            "type": "tool_use",
+            "id": "toolu_abc",
+            "name": HEADROOM_RETRIEVE_TOOL_NAME,
+            "input": {"hash": "b573993006976af767214fac"},
+        }
+    ]
+
+    should_run, ctx = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="claude-sonnet-4-6",
+        messages=[],
+        tools=retrieve_tool_def,
+        stream=False,
+        custom_llm_provider="anthropic",
+        kwargs={},
+    )
+
+    assert should_run is True
+    assert len(ctx["tool_calls"]) == 1
+    assert ctx["tool_calls"][0]["arguments"]["hash"] == "b573993006976af767214fac"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting \`@greptileai\` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Headroom sidecar running at https://headroom-mock.onrender.com.

Run the proxy:

```bash
python litellm/proxy/proxy_cli.py --config headroom_ccr_test.yaml --port 4000 --detailed_debug
```

Config (`headroom_ccr_test.yaml`):

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

guardrails:
  - guardrail_name: headroom
    litellm_params:
      guardrail: headroom
      api_base: https://headroom-mock.onrender.com
      mode: pre_call
      default_on: true
```

Send a request with a large message (above the CCR compression threshold):

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{
    "model": "gpt-4o-mini",
    "messages": [{"role":"user","content":"<27000 char system context...> What is 2+2?"}],
    "max_tokens": 30
  }'
```

Proxy logs showing the full CCR loop:

```
19:42:05 - LiteLLM Proxy:DEBUG: headroom.py:305 - Headroom: compressed 5078 tokens -> 519 tokens (ratio 0.10)
# ^^ apply_guardrail calls POST /v1/compress, gets compressed messages with CCR hash marker,
#    injects headroom_retrieve tool into the LLM request

19:42:05 - Final returned optional params: {'tools': [{'function': {'name': 'headroom_retrieve', ...}}]}
# ^^ LLM receives compressed message + headroom_retrieve tool

19:42:06 - LiteLLM Proxy:DEBUG: headroom.py:437 - Headroom CCR: retrieved hash=7636d481e56ee5e3d855a6fd (18313 chars)
# ^^ LLM called headroom_retrieve; async_build_agentic_loop_plan called
#    GET /v1/retrieve/7636d481e56ee5e3d855a6fd and got back 18313 chars of original content

19:42:06 - litellm.acompletion(model='openai/gpt-4o-mini', messages=[...full context injected as tool_result...])
# ^^ LLM replayed with full context as tool_result message
```

Response (LLM answered correctly with retrieved full context):

```json
{"choices":[{"message":{"content":"2 + 2 equals 4."}}]}
```

The full CCR round-trip: 5078 tokens compressed to 519, LLM retrieved 18313 chars of original content via the agentic loop, answered correctly.

## Type

New Feature

## Changes

Extends the existing HeadroomGuardrail with CCR (Compress-Cache-Retrieve) support via LiteLLM's agentic loop infrastructure.

**How it works:**

1. apply_guardrail calls /v1/compress. If the compressed response contains hash=([a-f0-9]{24}) markers, it injects a headroom_retrieve function tool into the outbound request.
2. async_should_run_agentic_loop detects when the LLM calls headroom_retrieve in its response (handles both OpenAI choices format and Anthropic content block format).
3. async_build_agentic_loop_plan calls GET {api_base}/v1/retrieve/{hash} on the Headroom sidecar, builds an assistant + tool-result message pair, and returns an AgenticLoopPlan that replays the LLM with the retrieved content. All transparent to the caller.

The Headroom sidecar must run on the same host as LiteLLM (Headroom's loopback-only restriction on /v1/retrieve in production). Configure it as a guardrail:

```yaml
guardrails:
  - guardrail_name: headroom
    litellm_params:
      guardrail: headroom
      api_base: http://localhost:8787
      mode: pre_call
      default_on: true
```

**API surface coverage:**
- /v1/chat/completions: full support via async_should_run_agentic_loop + async_build_agentic_loop_plan
- /v1/messages (Anthropic pass-through): supported; _extract_headroom_tool_calls handles Anthropic content block format
- /v1/responses: supported; routes through same shared handler

**New public helpers:**
- extract_hashes_from_messages(messages) — scans message content for CCR hash markers
- has_headroom_retrieve_tool(tools) — checks if the headroom_retrieve tool is present