### PR TITLE
feat(proxy): audit log system-wide settings updates

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -190,6 +190,8 @@ class LitellmTableNames(str, enum.Enum):
     CACHE_CONFIG_TABLE_NAME = "LiteLLM_CacheConfig"
     CONFIG_OVERRIDES_TABLE_NAME = "LiteLLM_ConfigOverrides"
     CONFIG_TABLE_NAME = "LiteLLM_Config"
+    SSO_CONFIG_TABLE_NAME = "LiteLLM_SSOConfig"
+    UI_SETTINGS_TABLE_NAME = "LiteLLM_UISettings"
 
 
 class Litellm_EntityType(enum.Enum):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -189,6 +189,7 @@ class LitellmTableNames(str, enum.Enum):
     TOOL_TABLE_NAME = "LiteLLM_ToolTable"
     CACHE_CONFIG_TABLE_NAME = "LiteLLM_CacheConfig"
     CONFIG_OVERRIDES_TABLE_NAME = "LiteLLM_ConfigOverrides"
+    CONFIG_TABLE_NAME = "LiteLLM_Config"
 
 
 class Litellm_EntityType(enum.Enum):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -425,7 +425,10 @@ from litellm.proxy.management_endpoints.user_agent_analytics_endpoints import (
 from litellm.proxy.management_endpoints.workflow_management_endpoints import (
     router as workflow_management_router,
 )
-from litellm.proxy.management_helpers.audit_logs import create_audit_log_for_update
+from litellm.proxy.management_helpers.audit_logs import (
+    create_audit_log_for_update,
+    create_object_audit_log,
+)
 from litellm.proxy.memory.memory_endpoints import router as memory_router
 from litellm.proxy.plugin_routes import (
     router as plugin_router,
@@ -13935,6 +13938,7 @@ async def update_config(
         # effect of auto-enabling slack alerting.
         if config_info.general_settings is not None:
             existing = await _read_section("general_settings")
+            before_general_settings = copy.deepcopy(existing)
             updates = config_info.general_settings.dict(exclude_none=True)
             for k, v in updates.items():
                 if k == "alert_to_webhook_url":
@@ -13944,6 +13948,9 @@ async def update_config(
                         existing["alerting"].append("slack")
                 existing[k] = v
             await _upsert_section("general_settings", existing)
+            await _create_config_audit_log(
+                "general_settings", "updated", before_general_settings, existing, user_api_key_dict
+            )
 
         # environment_variables: idempotently encrypt the request values
         # (plaintext on first write, OR ciphertext the UI read back via
@@ -13952,10 +13959,14 @@ async def update_config(
         # their stored ciphertext byte-for-byte.
         if config_info.environment_variables is not None:
             existing = await _read_section("environment_variables")
+            before_environment_variables = copy.deepcopy(existing)
             existing.update(
                 proxy_config._encrypt_env_variables_for_db(environment_variables=config_info.environment_variables)
             )
             await _upsert_section("environment_variables", existing)
+            await _create_config_audit_log(
+                "environment_variables", "updated", before_environment_variables, existing, user_api_key_dict
+            )
 
         # litellm_settings: merge existing + request, request wins (matching
         # router_settings semantics — the caller's value for any given key is
@@ -13967,6 +13978,7 @@ async def update_config(
         # entries that delete_callback (lowercase lookup) cannot find.
         if config_info.litellm_settings is not None:
             existing = await _read_section("litellm_settings")
+            before_litellm_settings = copy.deepcopy(existing)
             updated_litellm_settings = dict(config_info.litellm_settings)
 
             incoming_cb = updated_litellm_settings.get("success_callback")
@@ -13988,12 +14000,20 @@ async def update_config(
                     merged["success_callback"] = list(set(incoming_cb))
 
             await _upsert_section("litellm_settings", merged)
+            await _create_config_audit_log(
+                "litellm_settings", "updated", before_litellm_settings, merged, user_api_key_dict
+            )
 
         # router_settings: merge existing + request, request wins.
         if config_info.router_settings is not None:
             existing = await _read_section("router_settings")
+            before_router_settings = copy.deepcopy(existing)
             updates = config_info.router_settings.dict(exclude_none=True)
-            await _upsert_section("router_settings", {**existing, **updates})
+            new_router_settings = {**existing, **updates}
+            await _upsert_section("router_settings", new_router_settings)
+            await _create_config_audit_log(
+                "router_settings", "updated", before_router_settings, new_router_settings, user_api_key_dict
+            )
 
         await proxy_config.add_deployment(prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj)
 
@@ -14125,6 +14145,8 @@ async def update_config_general_settings(
     else:
         general_settings = dict(db_general_settings.param_value)
 
+    before_general_settings = copy.deepcopy(general_settings)
+
     ## update db
 
     field_value = data.field_value
@@ -14144,6 +14166,9 @@ async def update_config_general_settings(
         },
     )
     await invalidate_config_param("general_settings")
+    await _create_config_audit_log(
+        "general_settings", "updated", before_general_settings, general_settings, user_api_key_dict
+    )
 
     if data.field_name == "plugins":
         register_plugins_from_config(general_settings)
@@ -14202,6 +14227,42 @@ def _redact_general_setting_value(field_name: str, value: JsonValue, is_full_adm
     if isinstance(value, (dict, list)):
         return _redact_secret_values_in_obj(value)
     return value
+
+
+def _dump_redacted_config(value: Optional[JsonValue], *, redact_all_values: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    if redact_all_values and isinstance(value, dict):
+        return json.dumps({key: "REDACTED" for key in value})
+    return json.dumps(_redact_secret_values_in_obj(value))
+
+
+async def _create_config_audit_log(
+    param_name: str,
+    action: AUDIT_ACTIONS,
+    before_value: Optional[JsonValue],
+    after_value: Optional[JsonValue],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """Record a system-wide settings change in LiteLLM_AuditLog.
+
+    Secret leaves are redacted before the row is written. environment_variables
+    hold arbitrary credentials under non-secret-looking uppercase keys (e.g.
+    DATABASE_URL), so every value in that section is redacted rather than
+    relying on key-name matching; other sections reuse the same matcher
+    /config/field/info applies for non-admins.
+    """
+    redact_all_values = param_name == "environment_variables"
+    await create_object_audit_log(
+        object_id=param_name,
+        action=action,
+        table_name=LitellmTableNames.CONFIG_TABLE_NAME,
+        before_value=_dump_redacted_config(before_value, redact_all_values=redact_all_values),
+        after_value=_dump_redacted_config(after_value, redact_all_values=redact_all_values),
+        user_api_key_dict=user_api_key_dict,
+        litellm_changed_by=user_api_key_dict.user_id,
+        litellm_proxy_admin_name=LITELLM_PROXY_ADMIN_NAME,
+    )
 
 
 @router.get(
@@ -14487,6 +14548,8 @@ async def delete_config_general_settings(
     else:
         general_settings = dict(db_general_settings.param_value)
 
+    before_general_settings = copy.deepcopy(general_settings)
+
     ## update db
 
     general_settings.pop(data.field_name, None)
@@ -14502,6 +14565,9 @@ async def delete_config_general_settings(
         },
     )
     await invalidate_config_param("general_settings")
+    await _create_config_audit_log(
+        "general_settings", "deleted", before_general_settings, general_settings, user_api_key_dict
+    )
 
     return response
 
@@ -14559,6 +14625,8 @@ async def delete_callback(
                 detail={"error": f"Callback '{callback_name}' not found in active configuration"},
             )
 
+        before_success_callbacks = list(success_callbacks)
+
         # Remove callback from success_callback list
         success_callbacks.remove(callback_name)
         config.setdefault("litellm_settings", {})["success_callback"] = success_callbacks
@@ -14568,6 +14636,14 @@ async def delete_callback(
 
         # Restart the proxy to apply changes
         await proxy_config.add_deployment(prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj)
+
+        await _create_config_audit_log(
+            "litellm_settings",
+            "deleted",
+            {"success_callback": before_success_callbacks},
+            {"success_callback": success_callbacks},
+            user_api_key_dict,
+        )
 
         return {
             "message": f"Successfully deleted callback: {callback_name}",

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13948,7 +13948,7 @@ async def update_config(
                         existing["alerting"].append("slack")
                 existing[k] = v
             await _upsert_section("general_settings", existing)
-            await _create_config_audit_log(
+            await create_config_audit_log(
                 "general_settings", "updated", before_general_settings, existing, user_api_key_dict
             )
 
@@ -13964,7 +13964,7 @@ async def update_config(
                 proxy_config._encrypt_env_variables_for_db(environment_variables=config_info.environment_variables)
             )
             await _upsert_section("environment_variables", existing)
-            await _create_config_audit_log(
+            await create_config_audit_log(
                 "environment_variables", "updated", before_environment_variables, existing, user_api_key_dict
             )
 
@@ -14000,7 +14000,7 @@ async def update_config(
                     merged["success_callback"] = list(set(incoming_cb))
 
             await _upsert_section("litellm_settings", merged)
-            await _create_config_audit_log(
+            await create_config_audit_log(
                 "litellm_settings", "updated", before_litellm_settings, merged, user_api_key_dict
             )
 
@@ -14011,7 +14011,7 @@ async def update_config(
             updates = config_info.router_settings.dict(exclude_none=True)
             new_router_settings = {**existing, **updates}
             await _upsert_section("router_settings", new_router_settings)
-            await _create_config_audit_log(
+            await create_config_audit_log(
                 "router_settings", "updated", before_router_settings, new_router_settings, user_api_key_dict
             )
 
@@ -14166,7 +14166,7 @@ async def update_config_general_settings(
         },
     )
     await invalidate_config_param("general_settings")
-    await _create_config_audit_log(
+    await create_config_audit_log(
         "general_settings", "updated", before_general_settings, general_settings, user_api_key_dict
     )
 
@@ -14237,12 +14237,13 @@ def _dump_redacted_config(value: Optional[JsonValue], *, redact_all_values: bool
     return json.dumps(_redact_secret_values_in_obj(value))
 
 
-async def _create_config_audit_log(
+async def create_config_audit_log(
     param_name: str,
     action: AUDIT_ACTIONS,
     before_value: Optional[JsonValue],
     after_value: Optional[JsonValue],
     user_api_key_dict: UserAPIKeyAuth,
+    table_name: LitellmTableNames = LitellmTableNames.CONFIG_TABLE_NAME,
 ) -> None:
     """Record a system-wide settings change in LiteLLM_AuditLog.
 
@@ -14256,11 +14257,11 @@ async def _create_config_audit_log(
     await create_object_audit_log(
         object_id=param_name,
         action=action,
-        table_name=LitellmTableNames.CONFIG_TABLE_NAME,
+        table_name=table_name,
         before_value=_dump_redacted_config(before_value, redact_all_values=redact_all_values),
         after_value=_dump_redacted_config(after_value, redact_all_values=redact_all_values),
         user_api_key_dict=user_api_key_dict,
-        litellm_changed_by=user_api_key_dict.user_id,
+        litellm_changed_by=None,
         litellm_proxy_admin_name=LITELLM_PROXY_ADMIN_NAME,
     )
 
@@ -14565,7 +14566,7 @@ async def delete_config_general_settings(
         },
     )
     await invalidate_config_param("general_settings")
-    await _create_config_audit_log(
+    await create_config_audit_log(
         "general_settings", "deleted", before_general_settings, general_settings, user_api_key_dict
     )
 
@@ -14634,7 +14635,7 @@ async def delete_callback(
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)
 
-        await _create_config_audit_log(
+        await create_config_audit_log(
             "litellm_settings",
             "deleted",
             {"success_callback": before_success_callbacks},

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14634,9 +14634,6 @@ async def delete_callback(
         # Save the updated configuration
         await proxy_config.save_config(new_config=config)
 
-        # Restart the proxy to apply changes
-        await proxy_config.add_deployment(prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj)
-
         await _create_config_audit_log(
             "litellm_settings",
             "deleted",
@@ -14644,6 +14641,9 @@ async def delete_callback(
             {"success_callback": success_callbacks},
             user_api_key_dict,
         )
+
+        # Restart the proxy to apply changes
+        await proxy_config.add_deployment(prisma_client=prisma_client, proxy_logging_obj=proxy_logging_obj)
 
         return {
             "message": f"Successfully deleted callback: {callback_name}",

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -418,7 +418,7 @@ async def delete_allowed_ip(
 
     await create_config_audit_log(
         param_name="general_settings",
-        action="updated",
+        action="deleted",
         before_value={"allowed_ips": before_allowed_ips},
         after_value={"allowed_ips": config["general_settings"]["allowed_ips"]},
         user_api_key_dict=user_api_key_dict,
@@ -582,7 +582,7 @@ async def _update_litellm_setting(
     settings: Union[DefaultInternalUserParams, DefaultTeamSSOParams, MCPSemanticFilterSettings],
     settings_key: str,
     success_message: str,
-    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+    user_api_key_dict: UserAPIKeyAuth,
 ):
     """
     Common utility function to update `litellm_settings` in both memory and config.
@@ -591,8 +591,7 @@ async def _update_litellm_setting(
         settings: The settings object to update
         settings_key: The key in litellm_settings to update
         success_message: Message to return on success
-        user_api_key_dict: The acting admin, used for the audit log. When omitted
-            (internal callers) no audit row is written.
+        user_api_key_dict: The acting admin, recorded as the audit-log actor.
     """
     from litellm.proxy.proxy_server import (
         create_config_audit_log,
@@ -626,14 +625,13 @@ async def _update_litellm_setting(
     # Save the updated config
     await proxy_config.save_config(new_config=config)
 
-    if user_api_key_dict is not None:
-        await create_config_audit_log(
-            param_name=settings_key,
-            action="updated",
-            before_value=before_value,
-            after_value=in_memory_var,
-            user_api_key_dict=user_api_key_dict,
-        )
+    await create_config_audit_log(
+        param_name=settings_key,
+        action="updated",
+        before_value=before_value,
+        after_value=in_memory_var,
+        user_api_key_dict=user_api_key_dict,
+    )
 
     return {
         "message": success_message,

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -322,8 +322,12 @@ async def get_allowed_ips():
     tags=["Budget & Spend Tracking"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def add_allowed_ip(ip_address: IPAddress):
+async def add_allowed_ip(
+    ip_address: IPAddress,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     from litellm.proxy.proxy_server import (
+        create_config_audit_log,
         general_settings,
         prisma_client,
         proxy_config,
@@ -355,10 +359,19 @@ async def add_allowed_ip(ip_address: IPAddress):
     if "allowed_ips" not in config["general_settings"]:
         config["general_settings"]["allowed_ips"] = []
 
+    before_allowed_ips = list(config["general_settings"]["allowed_ips"])
     if ip_address.ip not in config["general_settings"]["allowed_ips"]:
         config["general_settings"]["allowed_ips"].append(ip_address.ip)
 
     await proxy_config.save_config(new_config=config)
+
+    await create_config_audit_log(
+        param_name="general_settings",
+        action="updated",
+        before_value={"allowed_ips": before_allowed_ips},
+        after_value={"allowed_ips": config["general_settings"]["allowed_ips"]},
+        user_api_key_dict=user_api_key_dict,
+    )
 
     return {
         "message": f"IP {ip_address.ip} address added successfully",
@@ -371,8 +384,15 @@ async def add_allowed_ip(ip_address: IPAddress):
     tags=["Budget & Spend Tracking"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def delete_allowed_ip(ip_address: IPAddress):
-    from litellm.proxy.proxy_server import general_settings, proxy_config
+async def delete_allowed_ip(
+    ip_address: IPAddress,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        general_settings,
+        proxy_config,
+    )
 
     _allowed_ips: List = general_settings.get("allowed_ips", [])
     if ip_address.ip in _allowed_ips:
@@ -390,10 +410,19 @@ async def delete_allowed_ip(ip_address: IPAddress):
     if "allowed_ips" not in config["general_settings"]:
         config["general_settings"]["allowed_ips"] = []
 
+    before_allowed_ips = list(config["general_settings"]["allowed_ips"])
     if ip_address.ip in config["general_settings"]["allowed_ips"]:
         config["general_settings"]["allowed_ips"].remove(ip_address.ip)
 
     await proxy_config.save_config(new_config=config)
+
+    await create_config_audit_log(
+        param_name="general_settings",
+        action="updated",
+        before_value={"allowed_ips": before_allowed_ips},
+        after_value={"allowed_ips": config["general_settings"]["allowed_ips"]},
+        user_api_key_dict=user_api_key_dict,
+    )
 
     return {"message": f"IP {ip_address.ip} deleted successfully", "status": "success"}
 
@@ -553,6 +582,7 @@ async def _update_litellm_setting(
     settings: Union[DefaultInternalUserParams, DefaultTeamSSOParams, MCPSemanticFilterSettings],
     settings_key: str,
     success_message: str,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ):
     """
     Common utility function to update `litellm_settings` in both memory and config.
@@ -561,8 +591,14 @@ async def _update_litellm_setting(
         settings: The settings object to update
         settings_key: The key in litellm_settings to update
         success_message: Message to return on success
+        user_api_key_dict: The acting admin, used for the audit log. When omitted
+            (internal callers) no audit row is written.
     """
-    from litellm.proxy.proxy_server import proxy_config, store_model_in_db
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        proxy_config,
+        store_model_in_db,
+    )
 
     if store_model_in_db is not True:
         raise HTTPException(
@@ -576,6 +612,7 @@ async def _update_litellm_setting(
     # because get_config() may overwrite litellm.<key> with stale DB values
     # via LITELLM_SETTINGS_SAFE_DB_OVERRIDES.
     config = await proxy_config.get_config()
+    before_value = config.get("litellm_settings", {}).get(settings_key)
 
     # Update the in-memory settings (after get_config to avoid stale override)
     setattr(litellm, settings_key, in_memory_var)
@@ -588,6 +625,15 @@ async def _update_litellm_setting(
 
     # Save the updated config
     await proxy_config.save_config(new_config=config)
+
+    if user_api_key_dict is not None:
+        await create_config_audit_log(
+            param_name=settings_key,
+            action="updated",
+            before_value=before_value,
+            after_value=in_memory_var,
+            user_api_key_dict=user_api_key_dict,
+        )
 
     return {
         "message": success_message,
@@ -619,6 +665,7 @@ async def update_internal_user_settings(
         settings=settings,
         settings_key="default_internal_user_params",
         success_message="Internal user settings updated successfully",
+        user_api_key_dict=user_api_key_dict,
     )
 
 
@@ -627,7 +674,10 @@ async def update_internal_user_settings(
     tags=["SSO Settings"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def update_default_team_settings(settings: DefaultTeamSSOParams):
+async def update_default_team_settings(
+    settings: DefaultTeamSSOParams,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Update the default team parameters for SSO users.
     These settings will be applied to new teams created from SSO.
@@ -636,6 +686,7 @@ async def update_default_team_settings(settings: DefaultTeamSSOParams):
         settings=settings,
         settings_key="default_team_params",
         success_message="Default team settings updated successfully",
+        user_api_key_dict=user_api_key_dict,
     )
 
 
@@ -746,7 +797,10 @@ async def get_sso_settings():
     tags=["SSO Settings"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def update_sso_settings(sso_config: SSOConfig):
+async def update_sso_settings(
+    sso_config: SSOConfig,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Update SSO configuration by saving to the dedicated SSO table.
     """
@@ -754,6 +808,7 @@ async def update_sso_settings(sso_config: SSOConfig):
     import os
 
     from litellm.proxy.proxy_server import (
+        create_config_audit_log,
         prisma_client,
         proxy_config,
         store_model_in_db,
@@ -857,6 +912,15 @@ async def update_sso_settings(sso_config: SSOConfig):
             detail={"error": f"Error updating environment_variables: {str(e)}"},
         )
 
+    await create_config_audit_log(
+        param_name="sso_config",
+        action="updated",
+        before_value=None,
+        after_value=sso_data,
+        user_api_key_dict=user_api_key_dict,
+        table_name=LitellmTableNames.SSO_CONFIG_TABLE_NAME,
+    )
+
     return {
         "message": "SSO settings updated successfully",
         "status": "success",
@@ -917,14 +981,21 @@ def _validate_public_image_url(value: Optional[str], field_name: str) -> None:
     tags=["UI Theme Settings"],
     dependencies=[Depends(user_api_key_auth)],
 )
-async def update_ui_theme_settings(theme_config: UIThemeConfig):
+async def update_ui_theme_settings(
+    theme_config: UIThemeConfig,
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+):
     """
     Update UI theme configuration.
     Updates logo settings for the admin UI.
     """
     import os
 
-    from litellm.proxy.proxy_server import proxy_config, store_model_in_db
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        proxy_config,
+        store_model_in_db,
+    )
 
     _validate_public_image_url(theme_config.logo_url, "logo_url")
     _validate_public_image_url(theme_config.favicon_url, "favicon_url")
@@ -937,6 +1008,7 @@ async def update_ui_theme_settings(theme_config: UIThemeConfig):
 
     # Load existing config
     config = await proxy_config.get_config()
+    before_theme = config.get("litellm_settings", {}).get("ui_theme_config")
 
     # Update config with UI theme settings
     if "general_settings" not in config:
@@ -1003,6 +1075,14 @@ async def update_ui_theme_settings(theme_config: UIThemeConfig):
     # Save the updated config
     await proxy_config.save_config(new_config=stored_config)
 
+    await create_config_audit_log(
+        param_name="ui_theme_config",
+        action="updated",
+        before_value=before_theme,
+        after_value=theme_data,
+        user_api_key_dict=user_api_key_dict,
+    )
+
     return {
         "message": "UI theme settings updated successfully.",
         "status": "success",
@@ -1057,6 +1137,7 @@ async def update_mcp_semantic_filter_settings(
         settings=settings,
         settings_key="mcp_semantic_tool_filter",
         success_message="MCP Semantic Filter settings updated successfully. Changes will be applied across all pods within 10 seconds.",
+        user_api_key_dict=user_api_key_dict,
     )
     try:
         from litellm.proxy.proxy_server import prisma_client, proxy_config
@@ -1174,7 +1255,11 @@ async def update_ui_settings(
     Update UI-specific configuration flags.
     Only proxy admins are allowed to modify these settings.
     """
-    from litellm.proxy.proxy_server import prisma_client, store_model_in_db
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        prisma_client,
+        store_model_in_db,
+    )
 
     if user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN:
         raise HTTPException(status_code=403, detail="Only proxy admins can update UI settings.")
@@ -1255,6 +1340,15 @@ async def update_ui_settings(
 
     sanitized = {k: v for k, v in ui_settings.items() if k in ALLOWED_UI_SETTINGS_FIELDS}
     await user_api_key_cache.async_set_cache(key=UI_SETTINGS_CACHE_KEY, value=sanitized, ttl=UI_SETTINGS_CACHE_TTL)
+
+    await create_config_audit_log(
+        param_name="ui_settings",
+        action="updated",
+        before_value=existing,
+        after_value=ui_settings,
+        user_api_key_dict=user_api_key_dict,
+        table_name=LitellmTableNames.UI_SETTINGS_TABLE_NAME,
+    )
 
     return {
         "message": "UI settings updated successfully",

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -877,6 +877,15 @@ async def update_sso_settings(
         },
     )
 
+    await create_config_audit_log(
+        param_name="sso_config",
+        action="updated",
+        before_value=None,
+        after_value=sso_data,
+        user_api_key_dict=user_api_key_dict,
+        table_name=LitellmTableNames.SSO_CONFIG_TABLE_NAME,
+    )
+
     # Remove SSO-related env vars from config.environment_variables
     try:
         env_var_entry = await ConfigRepository(prisma_client).table.find_unique(
@@ -909,15 +918,6 @@ async def update_sso_settings(
             status_code=500,
             detail={"error": f"Error updating environment_variables: {str(e)}"},
         )
-
-    await create_config_audit_log(
-        param_name="sso_config",
-        action="updated",
-        before_value=None,
-        after_value=sso_data,
-        user_api_key_dict=user_api_key_dict,
-        table_name=LitellmTableNames.SSO_CONFIG_TABLE_NAME,
-    )
 
     return {
         "message": "SSO settings updated successfully",

--- a/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/scim/test_scim_v2_endpoints.py
@@ -258,6 +258,7 @@ async def test_scim_create_user_respects_default_role_set_via_ui(mocker, monkeyp
     )
 
     import litellm
+    from litellm.proxy._types import UserAPIKeyAuth
 
     settings = DefaultInternalUserParams(
         user_role=LitellmUserRoles.INTERNAL_USER,
@@ -266,6 +267,7 @@ async def test_scim_create_user_respects_default_role_set_via_ui(mocker, monkeyp
         settings=settings,
         settings_key="default_internal_user_params",
         success_message="ok",
+        user_api_key_dict=UserAPIKeyAuth(user_id="test-admin"),
     )
 
     # Verify the in-memory variable was actually updated

--- a/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_default_params.py
@@ -426,6 +426,7 @@ class TestUpdateLitellmSettingOrdering:
             settings=new_settings,
             settings_key="default_team_params",
             success_message="Updated",
+            user_api_key_dict=UserAPIKeyAuth(user_id="test-admin"),
         )
 
         # In-memory value should be the NEW value, not the stale one
@@ -459,6 +460,7 @@ class TestUpdateLitellmSettingOrdering:
                 settings=DefaultTeamSSOParams(max_budget=100.0),
                 settings_key="default_team_params",
                 success_message="Updated",
+                user_api_key_dict=UserAPIKeyAuth(user_id="test-admin"),
             )
 
         assert exc_info.value.status_code == 500

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8688,7 +8688,7 @@ def test_dump_redacted_config_redacts_secret_leaves():
 async def test_create_config_audit_log_writes_redacted_entry(monkeypatch):
     import litellm.proxy.proxy_server as proxy_server_module
     from litellm.proxy._types import LitellmTableNames
-    from litellm.proxy.proxy_server import _create_config_audit_log
+    from litellm.proxy.proxy_server import create_config_audit_log
 
     fake = _fake_prisma_with_config({})
     monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
@@ -8696,7 +8696,7 @@ async def test_create_config_audit_log_writes_redacted_entry(monkeypatch):
     monkeypatch.setattr(litellm, "store_audit_logs", True)
 
     caller = UserAPIKeyAuth(api_key="hashed-key-abc", user_id="admin-7")
-    await _create_config_audit_log(
+    await create_config_audit_log(
         "router_settings",
         "updated",
         {"routing_strategy": "simple-shuffle", "api_key": "sk-old"},
@@ -8725,14 +8725,14 @@ async def test_create_config_audit_log_writes_redacted_entry(monkeypatch):
 @pytest.mark.asyncio
 async def test_create_config_audit_log_noop_when_store_audit_logs_disabled(monkeypatch):
     import litellm.proxy.proxy_server as proxy_server_module
-    from litellm.proxy.proxy_server import _create_config_audit_log
+    from litellm.proxy.proxy_server import create_config_audit_log
 
     fake = _fake_prisma_with_config({})
     monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
     monkeypatch.setattr(proxy_server_module, "premium_user", True)
     monkeypatch.setattr(litellm, "store_audit_logs", False)
 
-    await _create_config_audit_log(
+    await create_config_audit_log(
         "router_settings",
         "updated",
         {},

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8650,3 +8650,306 @@ def test_config_field_info_returns_raw_secrets_for_full_admin(monkeypatch):
         )
     finally:
         app.dependency_overrides.clear()
+
+
+def _fake_prisma_with_config(existing_param_value):
+    """MagicMock prisma whose litellm_config row returns existing_param_value and
+    whose litellm_auditlog.create records the written audit row."""
+    fake = MagicMock()
+    config_row = MagicMock()
+    config_row.param_value = existing_param_value
+    fake.db.litellm_config.find_first = AsyncMock(return_value=config_row)
+    fake.db.litellm_config.upsert = AsyncMock(return_value=config_row)
+    fake.db.litellm_auditlog.create = AsyncMock()
+    return fake
+
+
+def test_dump_redacted_config_redacts_secret_leaves():
+    from litellm.proxy.proxy_server import _dump_redacted_config
+
+    assert _dump_redacted_config(None) is None
+
+    restored = json.loads(
+        _dump_redacted_config(
+            {
+                "api_key": "sk-leak",
+                "model": "gpt-4",
+                "nested": {"aws_secret_access_key": "abc", "region": "us-east-1"},
+            }
+        )
+    )
+    assert restored["api_key"] == "REDACTED"
+    assert restored["model"] == "gpt-4"
+    assert restored["nested"]["aws_secret_access_key"] == "REDACTED"
+    assert restored["nested"]["region"] == "us-east-1"
+
+
+@pytest.mark.asyncio
+async def test_create_config_audit_log_writes_redacted_entry(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import LitellmTableNames
+    from litellm.proxy.proxy_server import _create_config_audit_log
+
+    fake = _fake_prisma_with_config({})
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    caller = UserAPIKeyAuth(api_key="hashed-key-abc", user_id="admin-7")
+    await _create_config_audit_log(
+        "router_settings",
+        "updated",
+        {"routing_strategy": "simple-shuffle", "api_key": "sk-old"},
+        {"routing_strategy": "latency-based", "api_key": "sk-new"},
+        caller,
+    )
+
+    fake.db.litellm_auditlog.create.assert_awaited_once()
+    written = fake.db.litellm_auditlog.create.call_args.kwargs["data"]
+    assert written["table_name"] == LitellmTableNames.CONFIG_TABLE_NAME.value
+    assert written["object_id"] == "router_settings"
+    assert written["action"] == "updated"
+    assert written["changed_by"] == "admin-7"
+    assert written["changed_by_api_key"] == "hashed-key-abc"
+
+    before = json.loads(written["before_value"])
+    after = json.loads(written["updated_values"])
+    assert before["routing_strategy"] == "simple-shuffle"
+    assert after["routing_strategy"] == "latency-based"
+    assert "sk-old" not in written["before_value"]
+    assert "sk-new" not in written["updated_values"]
+    assert before["api_key"] != "sk-old"
+    assert after["api_key"] != "sk-new"
+
+
+@pytest.mark.asyncio
+async def test_create_config_audit_log_noop_when_store_audit_logs_disabled(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.proxy_server import _create_config_audit_log
+
+    fake = _fake_prisma_with_config({})
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", False)
+
+    await _create_config_audit_log(
+        "router_settings",
+        "updated",
+        {},
+        {"a": 1},
+        UserAPIKeyAuth(api_key="k", user_id="u"),
+    )
+    fake.db.litellm_auditlog.create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_config_general_settings_emits_audit_log(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import ConfigFieldUpdate
+    from litellm.proxy.proxy_server import update_config_general_settings
+
+    existing = {"max_parallel_requests": 5, "some_api_key": "sk-stored-secret"}
+    fake = _fake_prisma_with_config(existing)
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    admin = UserAPIKeyAuth(
+        api_key="hashed-admin",
+        user_id="admin-1",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="max_parallel_requests",
+            field_value=42,
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+
+    fake.db.litellm_auditlog.create.assert_awaited_once()
+    written = fake.db.litellm_auditlog.create.call_args.kwargs["data"]
+    assert written["table_name"] == "LiteLLM_Config"
+    assert written["object_id"] == "general_settings"
+    assert written["action"] == "updated"
+    assert written["changed_by"] == "admin-1"
+
+    before = json.loads(written["before_value"])
+    after = json.loads(written["updated_values"])
+    assert before["max_parallel_requests"] == 5
+    assert after["max_parallel_requests"] == 42
+    assert "sk-stored-secret" not in written["before_value"]
+    assert "sk-stored-secret" not in written["updated_values"]
+    assert before["some_api_key"] != "sk-stored-secret"
+
+
+@pytest.mark.asyncio
+async def test_delete_config_general_settings_emits_deleted_audit_log(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import ConfigFieldDelete
+    from litellm.proxy.proxy_server import delete_config_general_settings
+
+    existing = {"max_parallel_requests": 5}
+    fake = _fake_prisma_with_config(existing)
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    admin = UserAPIKeyAuth(
+        api_key="hashed-admin",
+        user_id="admin-1",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    await delete_config_general_settings(
+        data=ConfigFieldDelete(
+            field_name="max_parallel_requests", config_type="general_settings"
+        ),
+        user_api_key_dict=admin,
+    )
+
+    fake.db.litellm_auditlog.create.assert_awaited_once()
+    written = fake.db.litellm_auditlog.create.call_args.kwargs["data"]
+    assert written["object_id"] == "general_settings"
+    assert written["action"] == "deleted"
+    before = json.loads(written["before_value"])
+    after = json.loads(written["updated_values"])
+    assert before["max_parallel_requests"] == 5
+    assert "max_parallel_requests" not in after
+
+
+def test_update_config_audits_every_written_section(_update_config_setup, monkeypatch):
+    """/config/update must emit one audit row per section it writes, so each
+    of the four call sites (general_settings, environment_variables,
+    litellm_settings, router_settings) is mutation-protected. litellm_settings
+    is the row that holds default_internal_user_params ("default user settings")."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    client, prisma, restore = _update_config_setup(
+        initial_rows={"litellm_settings": {"drop_params": True}}
+    )
+    audit_create = AsyncMock()
+    prisma.db.litellm_auditlog.create = audit_create
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    try:
+        resp = client.post(
+            "/config/update",
+            json={
+                "general_settings": {"store_prompts_in_spend_logs": True},
+                "environment_variables": {"FOO": "bar"},
+                "litellm_settings": {
+                    "default_internal_user_params": {"max_budget": 10}
+                },
+                "router_settings": {"routing_strategy": "latency-based-routing"},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        audited = {
+            call.kwargs["data"]["object_id"]: call.kwargs["data"]["action"]
+            for call in audit_create.await_args_list
+        }
+        assert audited == {
+            "general_settings": "updated",
+            "environment_variables": "updated",
+            "litellm_settings": "updated",
+            "router_settings": "updated",
+        }
+        for call in audit_create.await_args_list:
+            assert call.kwargs["data"]["table_name"] == "LiteLLM_Config"
+            assert call.kwargs["data"]["changed_by"] == "test_admin"
+
+        ls_call = next(
+            c
+            for c in audit_create.await_args_list
+            if c.kwargs["data"]["object_id"] == "litellm_settings"
+        )
+        after = json.loads(ls_call.kwargs["data"]["updated_values"])
+        assert after["default_internal_user_params"] == {"max_budget": 10}
+    finally:
+        restore()
+
+
+def test_delete_callback_audits_litellm_settings_deletion(
+    _update_config_setup, monkeypatch
+):
+    """/config/callback/delete must emit a deleted audit row for litellm_settings
+    capturing the success_callback list before and after removal."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    client, prisma, restore = _update_config_setup()
+    audit_create = AsyncMock()
+    prisma.db.litellm_auditlog.create = audit_create
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    from litellm.proxy.proxy_server import proxy_config as real_proxy_config
+
+    monkeypatch.setattr(
+        real_proxy_config,
+        "get_config",
+        AsyncMock(
+            return_value={
+                "litellm_settings": {"success_callback": ["langfuse", "datadog"]}
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        real_proxy_config, "save_config", AsyncMock(return_value=None)
+    )
+    try:
+        resp = client.post(
+            "/config/callback/delete", json={"callback_name": "datadog"}
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "litellm_settings"
+        assert written["action"] == "deleted"
+        before = json.loads(written["before_value"])
+        after = json.loads(written["updated_values"])
+        assert before["success_callback"] == ["langfuse", "datadog"]
+        assert after["success_callback"] == ["langfuse"]
+    finally:
+        restore()
+
+
+def test_update_config_redacts_all_environment_variable_values(
+    _update_config_setup, monkeypatch
+):
+    """environment_variables hold credentials under arbitrary uppercase keys
+    (DATABASE_URL) that key-name secret matching misses, so every value in the
+    section must be redacted before the audit row is written; a plaintext
+    secret must never reach LiteLLM_AuditLog."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    client, prisma, restore = _update_config_setup()
+    audit_create = AsyncMock()
+    prisma.db.litellm_auditlog.create = audit_create
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    try:
+        resp = client.post(
+            "/config/update",
+            json={
+                "environment_variables": {
+                    "DATABASE_URL": "postgresql://u:p@db.internal:5432/litellm",
+                    "LOG_LEVEL": "debug",
+                }
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        env_call = next(
+            c
+            for c in audit_create.await_args_list
+            if c.kwargs["data"]["object_id"] == "environment_variables"
+        )
+        after = json.loads(env_call.kwargs["data"]["updated_values"])
+        assert after == {"DATABASE_URL": "REDACTED", "LOG_LEVEL": "REDACTED"}
+        assert "postgresql://" not in env_call.kwargs["data"]["updated_values"]
+        assert "db.internal" not in env_call.kwargs["data"]["updated_values"]
+    finally:
+        restore()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8916,6 +8916,48 @@ def test_delete_callback_audits_litellm_settings_deletion(
         restore()
 
 
+def test_delete_callback_audits_before_reload_failure(_update_config_setup, monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    client, prisma, restore = _update_config_setup()
+    audit_create = AsyncMock()
+    prisma.db.litellm_auditlog.create = audit_create
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    from litellm.proxy.proxy_server import proxy_config as real_proxy_config
+
+    monkeypatch.setattr(
+        real_proxy_config,
+        "get_config",
+        AsyncMock(
+            return_value={
+                "litellm_settings": {"success_callback": ["langfuse", "datadog"]}
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        real_proxy_config, "save_config", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        real_proxy_config,
+        "add_deployment",
+        AsyncMock(side_effect=RuntimeError("reload failed")),
+    )
+    try:
+        resp = client.post(
+            "/config/callback/delete", json={"callback_name": "datadog"}
+        )
+        assert resp.status_code == 500, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "litellm_settings"
+        assert written["action"] == "deleted"
+    finally:
+        restore()
+
+
 def test_update_config_redacts_all_environment_variable_values(
     _update_config_setup, monkeypatch
 ):

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8925,7 +8925,15 @@ def test_update_config_redacts_all_environment_variable_values(
     secret must never reach LiteLLM_AuditLog."""
     import litellm.proxy.proxy_server as proxy_server_module
 
-    client, prisma, restore = _update_config_setup()
+    # DATABASE_URL is the bug class: an uppercase env key that key-name secret
+    # matching does NOT flag, so only whole-section value redaction protects it.
+    client, prisma, restore = _update_config_setup(
+        initial_rows={
+            "environment_variables": {
+                "DATABASE_URL": "enc:postgresql://OLDsecret@old.host:5432/db"
+            }
+        }
+    )
     audit_create = AsyncMock()
     prisma.db.litellm_auditlog.create = audit_create
     monkeypatch.setattr(proxy_server_module, "premium_user", True)
@@ -8947,9 +8955,18 @@ def test_update_config_redacts_all_environment_variable_values(
             for c in audit_create.await_args_list
             if c.kwargs["data"]["object_id"] == "environment_variables"
         )
-        after = json.loads(env_call.kwargs["data"]["updated_values"])
+        data = env_call.kwargs["data"]
+
+        # the pre-existing secret must be redacted in the before snapshot
+        before = json.loads(data["before_value"])
+        assert before == {"DATABASE_URL": "REDACTED"}
+        assert "OLDsecret" not in data["before_value"]
+        assert "old.host" not in data["before_value"]
+
+        # the newly-written values must be redacted in the after snapshot
+        after = json.loads(data["updated_values"])
         assert after == {"DATABASE_URL": "REDACTED", "LOG_LEVEL": "REDACTED"}
-        assert "postgresql://" not in env_call.kwargs["data"]["updated_values"]
-        assert "db.internal" not in env_call.kwargs["data"]["updated_values"]
+        assert "postgresql://" not in data["updated_values"]
+        assert "db.internal" not in data["updated_values"]
     finally:
         restore()

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1869,3 +1869,160 @@ class TestProxySettingEndpoints:
         assert "field_schema" in data
         assert "properties" in data["field_schema"]
         assert "role_mappings" in data["field_schema"]["properties"]
+
+
+def test_update_internal_user_settings_writes_audit_log(mock_proxy_config, monkeypatch):
+    """Regression for the reported scenario: an admin changes Default User
+    Settings from the dashboard, which issues PATCH /update/internal_user_settings
+    (NOT /config/update). An audit row must record who changed it and what
+    changed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    monkeypatch.setattr(litellm, "default_internal_user_params", {})
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/internal_user_settings",
+            json={"max_budget": 999.0, "models": ["gpt-4"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "default_internal_user_params"
+        assert written["action"] == "updated"
+        assert written["table_name"] == "LiteLLM_Config"
+        assert written["changed_by"] == "audit-admin"
+        assert written["changed_by_api_key"] == "hashed-admin-key"
+
+        before = json.loads(written["before_value"])
+        after = json.loads(written["updated_values"])
+        assert before["max_budget"] == 100.0
+        assert after["max_budget"] == 999.0
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_update_sso_settings_writes_redacted_audit_log(mock_proxy_config, monkeypatch):
+    """Updating SSO settings must write an audit row to the SSO config table
+    with the client secret redacted."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+    fake_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+    fake_prisma.db.litellm_config.find_unique = AsyncMock(return_value=None)
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    monkeypatch.setattr(
+        proxy_server_module.proxy_config,
+        "_encrypt_env_variables",
+        lambda environment_variables: environment_variables,
+    )
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/sso_settings",
+            json={
+                "google_client_id": "client-id-123",
+                "google_client_secret": "super-secret-xyz",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "sso_config"
+        assert written["table_name"] == "LiteLLM_SSOConfig"
+        assert written["changed_by"] == "audit-admin"
+
+        after = json.loads(written["updated_values"])
+        assert after["google_client_id"] == "client-id-123"
+        assert after["google_client_secret"] == "REDACTED"
+        assert "super-secret-xyz" not in written["updated_values"]
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_add_allowed_ip_writes_audit_log(mock_proxy_config, monkeypatch):
+    """Adding an allowed IP is a system-wide security setting change and must
+    be audited with the before and after IP list."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(proxy_server_module, "general_settings", {})
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.post("/add/allowed_ip", json={"ip": "203.0.113.77"})
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "general_settings"
+        assert written["action"] == "updated"
+        assert written["changed_by"] == "audit-admin"
+
+        before = json.loads(written["before_value"])
+        after = json.loads(written["updated_values"])
+        assert "203.0.113.77" not in before["allowed_ips"]
+        assert "203.0.113.77" in after["allowed_ips"]
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -2026,3 +2026,155 @@ def test_add_allowed_ip_writes_audit_log(mock_proxy_config, monkeypatch):
         assert "203.0.113.77" in after["allowed_ips"]
     finally:
         app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_delete_allowed_ip_writes_deleted_audit_log(monkeypatch):
+    """Removing an allowed IP must be audited as a deletion, symmetric with the
+    add path."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+
+    config = {"general_settings": {"allowed_ips": ["203.0.113.77", "198.51.100.1"]}}
+
+    async def _get_config():
+        return config
+
+    async def _save_config(new_config=None):
+        nonlocal config
+        if new_config is not None:
+            config = new_config
+        return config
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(
+        proxy_server_module, "general_settings", {"allowed_ips": ["203.0.113.77"]}
+    )
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    monkeypatch.setattr(proxy_server_module.proxy_config, "get_config", _get_config)
+    monkeypatch.setattr(proxy_server_module.proxy_config, "save_config", _save_config)
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.post("/delete/allowed_ip", json={"ip": "203.0.113.77"})
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "general_settings"
+        assert written["action"] == "deleted"
+        before = json.loads(written["before_value"])
+        after = json.loads(written["updated_values"])
+        assert "203.0.113.77" in before["allowed_ips"]
+        assert "203.0.113.77" not in after["allowed_ips"]
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_update_ui_theme_settings_writes_audit_log(mock_proxy_config, monkeypatch):
+    """Updating the UI theme must be audited under ui_theme_config."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    monkeypatch.setattr(
+        proxy_server_module.proxy_config,
+        "_encrypt_env_variables",
+        lambda environment_variables: environment_variables,
+    )
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/ui_theme_settings",
+            json={"logo_url": "https://example.com/logo.png"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "ui_theme_config"
+        assert written["action"] == "updated"
+        assert written["changed_by"] == "audit-admin"
+        after = json.loads(written["updated_values"])
+        assert after["logo_url"] == "https://example.com/logo.png"
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_update_ui_settings_writes_audit_log(monkeypatch):
+    """Updating UI settings must be audited under the UI settings table."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+    fake_prisma.db.litellm_uisettings.find_unique = AsyncMock(return_value=None)
+    fake_prisma.db.litellm_uisettings.upsert = AsyncMock()
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/ui_settings", json={"disable_custom_api_keys": True}
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "ui_settings"
+        assert written["table_name"] == "LiteLLM_UISettings"
+        assert written["changed_by"] == "audit-admin"
+        after = json.loads(written["updated_values"])
+        assert after["disable_custom_api_keys"] is True
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -466,6 +466,61 @@ class TestProxySettingEndpoints:
         create_sso_settings = json.loads(create_data["sso_settings"])
         assert create_sso_settings["google_client_id"] == "new_google_client_id"
 
+    def test_update_sso_settings_audits_when_env_cleanup_fails(
+        self, mock_proxy_config, mock_auth, monkeypatch
+    ):
+        import json
+        from unittest.mock import AsyncMock, MagicMock
+
+        monkeypatch.setenv("LITELLM_SALT_KEY", "test_salt_key")
+        monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+        mock_prisma = MagicMock()
+        mock_prisma.db.litellm_ssoconfig.upsert = AsyncMock()
+        mock_prisma.db.litellm_config = MagicMock()
+        mock_prisma.db.litellm_config.find_unique = AsyncMock(
+            side_effect=ValueError("cleanup failed")
+        )
+        mock_prisma.db.litellm_config.update = AsyncMock()
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+
+        from litellm.proxy.proxy_server import proxy_config
+
+        monkeypatch.setattr(
+            proxy_config,
+            "_encrypt_env_variables",
+            lambda environment_variables: environment_variables,
+        )
+
+        create_config_audit_log = AsyncMock()
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.create_config_audit_log",
+            create_config_audit_log,
+        )
+
+        response = client.patch(
+            "/update/sso_settings",
+            json={"google_client_id": "new_google_client_id"},
+        )
+
+        assert response.status_code == 500
+        assert mock_prisma.db.litellm_ssoconfig.upsert.called
+        create_config_audit_log.assert_awaited_once()
+        audit_log_kwargs = create_config_audit_log.await_args.kwargs
+        assert audit_log_kwargs["param_name"] == "sso_config"
+        assert (
+            audit_log_kwargs["after_value"]["google_client_id"]
+            == "new_google_client_id"
+        )
+        assert (
+            json.loads(
+                mock_prisma.db.litellm_ssoconfig.upsert.call_args.kwargs["data"][
+                    "create"
+                ]["sso_settings"]
+            )["google_client_id"]
+            == "new_google_client_id"
+        )
+
     def test_update_sso_settings_with_null_values_clears_env_vars(
         self, mock_proxy_config, mock_auth, monkeypatch
     ):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3839

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

litellm already writes `LiteLLM_AuditLog` rows for key, team, user, model and org changes, but system-wide settings (the `LiteLLM_Config` rows an admin edits from the UI Settings pages) had no audit trail, so there was no way to see who changed default user settings, router settings, or general settings, or whether the change came from the UI or the API

Reproduced live against a local proxy on `:4010` with `store_audit_logs: true` and an enterprise license, backed by a real Postgres. The customer's reported path is the Default User Settings page on the dashboard, which hits `PATCH /update/internal_user_settings`, NOT `/config/update`. Each of the 9 admin endpoints below writes one `LiteLLM_AuditLog` row capturing actor, action, the affected setting, and a redacted before/after snapshot.

### 1) Customer scenario: PATCH /update/internal_user_settings

```bash
$ curl -X PATCH .../update/internal_user_settings -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"max_budget":999.0,"models":["gpt-4.1-mini"]}'
{"message":"Internal user settings updated successfully","status":"success",
 "settings":{"user_role":"internal_user_viewer","max_budget":999.0,"models":["gpt-4.1-mini"]}}
```

Audit row:
```json
{
  "action": "updated",
  "table_name": "LiteLLM_Config",
  "object_id": "default_internal_user_params",
  "changed_by": "default_user_id",
  "changed_by_api_key": "litellm_proxy_master_key",
  "before": {"user_role":"internal_user_viewer","max_budget":100.0,"models":["gpt-3.5-turbo","gpt-4"]},
  "after":  {"user_role":"internal_user_viewer","max_budget":999.0,"models":["gpt-4.1-mini"]}
}
```

`changed_by` records the acting user and `changed_by_api_key` records the key hash, so a UI/SSO admin edit (session token) is distinguishable from a direct API call (master or virtual key)

### 2) PATCH /update/default_team_settings

```bash
$ curl -X PATCH .../update/default_team_settings ... -d '{"max_budget":50.0,"tpm_limit":200}'
{"message":"Default team settings updated successfully","status":"success", ...}
```
Audit row: `action=updated, table_name=LiteLLM_Config, object_id=default_team_params`, before/after captured

### 3) PATCH /update/mcp_semantic_filter_settings

```bash
$ curl -X PATCH .../update/mcp_semantic_filter_settings ... -d '{"enabled":true,"top_k":5}'
{"message":"MCP Semantic Filter settings updated successfully ...","status":"success", ...}
```
Audit row: `action=updated, object_id=mcp_semantic_tool_filter`

### 4) PATCH /update/ui_theme_settings

```bash
$ curl -X PATCH .../update/ui_theme_settings ... -d '{"logo_url":"https://example.com/logo.png"}'
{"message":"UI theme settings updated successfully.","status":"success", ...}
```
Audit row: `action=updated, object_id=ui_theme_config`, before/after captured

### 5) PATCH /update/ui_settings

```bash
$ curl -X PATCH .../update/ui_settings ... -d '{"disable_custom_api_keys":true}'
{"message":"UI settings updated successfully","status":"success","settings":{"disable_custom_api_keys":true}}
```
Audit row: `action=updated, table_name=LiteLLM_UISettings, object_id=ui_settings`

### 6) PATCH /update/sso_settings (secret redaction)

```bash
$ curl -X PATCH .../update/sso_settings ... \
    -d '{"google_client_id":"client-id-public","google_client_secret":"sk-SUPERSECRET-PLAINTEXT"}'
{"message":"SSO settings updated successfully","status":"success", ...}
```
Audit row (`table_name=LiteLLM_SSOConfig`, `object_id=sso_config`):
```json
{"google_client_id":"client-id-public","google_client_secret":"REDACTED",
 "generic_client_secret":"REDACTED","microsoft_client_secret":"REDACTED", ...}
```
Plaintext check against the live audit row: `PASS: plaintext absent (redacted)`

### 7) POST /config/callback/delete (audit fires before reload)

```bash
$ curl -X POST .../config/callback/delete ... -d '{"callback_name":"datadog"}'
{"message":"Successfully deleted callback: datadog","removed_callback":"datadog","remaining_callbacks":[], ...}
```
Audit row: `action=deleted, object_id=litellm_settings, before={"success_callback":["datadog"]}, after={"success_callback":[]}`. The audit is now recorded before the proxy reload, so it persists even if the reload throws.

### 8) DATABASE_URL wholesale env-var redaction

The earlier review flagged that uppercase env-var keys (e.g. `DATABASE_URL`) escaped key-name secret matching. Every value in the `environment_variables` section is now redacted before the audit row is written.

```bash
$ curl -X POST .../config/update ... \
    -d '{"environment_variables":{"DATABASE_URL":"postgresql://AUDIT_USER:AUDIT_PASSWORD@db.internal:5432/litellm","LOG_LEVEL":"debug"}}'
{"message":"Config updated successfully"}
```
Audit row: `action=updated, object_id=environment_variables, after={"DATABASE_URL":"REDACTED","LOG_LEVEL":"REDACTED", ...}`. Plaintext check: `PASS: plaintext absent (redacted)` — neither `AUDIT_PASSWORD` nor `db.internal` appears in the audit row.

### 9) POST /add/allowed_ip (run last; allowlist mode then forbids further loopback calls)

```bash
$ curl -X POST .../add/allowed_ip ... -d '{"ip":"203.0.113.77"}'
{"message":"IP 203.0.113.77 address added successfully","status":"success"}
```
Audit row: `action=updated, object_id=general_settings, before={"allowed_ips":[]}, after={"allowed_ips":["203.0.113.77"]}`. `POST /delete/allowed_ip` is also wired (mutation-tested) but cannot be verified live in the same session because adding an entry flips the proxy into allowlist mode and forbids the loopback caller.

### Before/after summary

Same proxy on the unfixed code wrote `LiteLLM_AuditLog` count = 0 for the same set of changes. On this PR the same set writes one redacted audit row per endpoint, captured above.

## Type

🆕 New Feature

## Changes

Audit logging now fires on every admin endpoint that writes proxy-wide settings, recording the actor, the API key hash, the action, the affected config section, and a redacted before/after snapshot through the shared `create_config_audit_log` helper, which reuses the existing `create_object_audit_log` path so it honors `store_audit_logs` and the enterprise gate

The generic config API: `/config/update` (general_settings, environment_variables, litellm_settings, router_settings), `/config/field/update`, `/config/field/delete`, and `/config/callback/delete`

The dedicated settings endpoints in `proxy_setting_endpoints.py` that the admin dashboard uses, which do not route through `/config/update`: `/update/internal_user_settings` (default user settings), `/update/default_team_settings`, `/update/mcp_semantic_filter_settings` (all via the shared `_update_litellm_setting`), `/add/allowed_ip` and `/delete/allowed_ip`, `/update/sso_settings`, `/update/ui_theme_settings`, and `/update/ui_settings`. SSO and UI settings rows are tagged with their own table names

New `LitellmTableNames` values (`CONFIG_TABLE_NAME`, `SSO_CONFIG_TABLE_NAME`, `UI_SETTINGS_TABLE_NAME`) identify the rows. A small `_dump_redacted_config` helper strips secret leaves from the snapshots using the same matcher `/config/field/info` applies for non-admins, covering config secrets such as `database_url`, pass-through `Authorization` headers, and webhook URLs that the audit model's narrower masker does not catch; `environment_variables` values are redacted wholesale since they carry credentials under arbitrary uppercase keys

`object_id` is the logical setting being changed, which for the dedicated endpoints is the `litellm_settings` sub-key (`default_internal_user_params`, `default_team_params`, `mcp_semantic_tool_filter`, `ui_theme_config`) rather than the row name, so it reads naturally for an auditor looking for a specific setting

Operational config writers that are not admin settings edits (the model-cost-map reload and anthropic-beta-header reload endpoints, plus internal background reloads) are intentionally out of scope

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive settings (SSO, IP allowlists, env vars) across many admin code paths; mitigated by redaction and existing audit gates, but mis-redaction or missed call sites would be high impact.
> 
> **Overview**
> Adds an audit trail for **proxy-wide settings** that previously updated `LiteLLM_Config` (and related tables) without writing `LiteLLM_AuditLog` rows.
> 
> A shared **`create_config_audit_log`** helper records actor, action, logical setting id, and **redacted** before/after JSON via the existing `create_object_audit_log` path (respecting `store_audit_logs` / enterprise gating). **`environment_variables`** snapshots redact **every** value; other sections use the same secret masking as config field reads. New **`LitellmTableNames`** values tag config, SSO, and UI settings rows.
> 
> **Wiring** covers bulk `/config/update` sections, `/config/field/update` and `/config/field/delete`, `/config/callback/delete` (audit **before** reload so a failed `add_deployment` still leaves a trail), and dashboard paths in `proxy_setting_endpoints` (default user/team settings, MCP filter, allowed IPs, SSO, UI theme, UI flags). Endpoints now pass **`UserAPIKeyAuth`** into `_update_litellm_setting` for the acting admin.
> 
> **Ordering fixes**: SSO audit runs right after the SSO table upsert (even if env cleanup fails); callback delete audits before deployment reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210fe5a215537b5f8e9cf4ef4e493fbdd10f1d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

