### PR TITLE
ci(linting): generate prisma client before basedpyright typecheck

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -48,7 +48,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --frozen
+          uv sync --frozen --group proxy-dev
+
+      # basedpyright resolves Prisma's generated client (litellm/proxy/schema.prisma)
+      # only after `prisma generate` writes prisma/client.py et al. Without this the
+      # DB wrappers typed against the generated client would degrade to Unknown.
+      - name: Generate Prisma client
+        env:
+          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
+        run: |
+          uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Check ruff format
         env:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

## Linear ticket

Resolves PERF-16

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The basedpyright typecheck in `test-linting.yml` previously ran against an environment where Prisma's client had never been generated, so `prisma/client.py` (and `models`, `partials`, `types`, ...) did not exist on disk. `from prisma import Prisma` therefore resolved to nothing and every DB type degraded to Unknown, which is why the DB wrappers had no generated types to land on. The unit-test workflows already generate the client (`_test-unit-base.yml` has a "Generate Prisma client" step); the lint workflow did not

This adds the same generation step, and pulls `prisma` into the lint job (it lives in the `proxy-dev` group, not the base deps) so the CLI is present. Local run of the exact command:

```
$ uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
✔ Generated Prisma Client Python (v0.11.0) to ./.venv/lib/python3.12/site-packages/prisma in 828ms
```

The basedpyright budget gate is delta-based (head vs merge-base in the same environment), so generating the client does not move any per-rule count for this change on its own; it is the prerequisite that lets the typed-wrapper refactor in PERF-15 resolve against the real generated client instead of Unknown

## Type

Infrastructure

## Changes

`test-linting.yml` now installs the `proxy-dev` group and runs `prisma generate --schema litellm/proxy/schema.prisma` right after dependency install, before the basedpyright budget check

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C0B13QZPM8B/p1782781184188889?thread_ts=1782781184.188889&cid=C0B13QZPM8B)

<div><a href="https://cursor.com/agents/bc-85c4b8c8-9c56-5645-8fad-f1051f77900e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85c4b8c8-9c56-5645-8fad-f1051f77900e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

