### PR TITLE
fix(proxy): emit x-litellm-response-cost header on /messages and /generateContent (LIT-4076)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1384,6 +1384,10 @@ class Logging(LiteLLMLoggingBaseClass):
         if cache_hit is True:
             return 0.0
 
+        transformed_result = self._generate_content_result_as_model_response(result)
+        if transformed_result is not None:
+            result = transformed_result
+
         if isinstance(result, BaseModel) and hasattr(result, "_hidden_params"):
             hidden_params = getattr(result, "_hidden_params", {})
             if (
@@ -1462,6 +1466,39 @@ class Logging(LiteLLMLoggingBaseClass):
             self.model_call_details["response_cost_failure_debug_information"] = debug_info
 
         return None
+
+    def _generate_content_result_as_model_response(self, result: object) -> Optional[ModelResponse]:
+        """
+        Native Google :generateContent bodies report token usage under
+        ``usageMetadata``, which the cost calculator does not read, so a raw body
+        always costs 0. The async success path already transforms it into a
+        ``ModelResponse`` before costing; do the same transformation here so the
+        synchronously-built ``x-litellm-response-cost`` header carries the real
+        cost. Returns ``None`` (leaving the original result untouched) for other
+        call types, for already-transformed ``ModelResponse`` results, and on any
+        transformation failure.
+        """
+        if self.call_type not in (
+            CallTypes.generate_content.value,
+            CallTypes.agenerate_content.value,
+        ):
+            return None
+        if isinstance(result, ModelResponse) or not isinstance(result, (BaseModel, dict)):
+            return None
+        try:
+            import httpx
+
+            completion_response = result.model_dump(by_alias=True) if isinstance(result, BaseModel) else dict(result)
+            return litellm.VertexGeminiConfig()._transform_google_generate_content_to_openai_model_response(
+                completion_response=completion_response,
+                model_response=ModelResponse(),
+                model=self.model or "",
+                logging_obj=self,
+                raw_response=httpx.Response(status_code=200, headers={}),
+            )
+        except Exception as e:
+            verbose_logger.debug(f"generate_content response cost normalization failed: {e}")
+            return None
 
     async def _response_cost_calculator_async(
         self,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1496,7 +1496,7 @@ class Logging(LiteLLMLoggingBaseClass):
                 logging_obj=self,
                 raw_response=httpx.Response(status_code=200, headers={}),
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - cost normalization must never break the response path
             verbose_logger.debug(f"generate_content response cost normalization failed: {e}")
             return None
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1184,6 +1184,25 @@ class ProxyBaseLLMRequestProcessing:
             model_id = model_info.get("id", "") or ""
         return model_id
 
+    @staticmethod
+    def _response_cost_from_logging_obj(
+        *,
+        response: Any,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> float | str:
+        """
+        Recover the response cost for TypedDict results (Anthropic /v1/messages,
+        Google :generateContent) that cannot hold ``_hidden_params``. For those
+        results ``ResponseMetadata.apply()`` drops the computed cost, so the cost
+        is read back from the logging object instead, recomputing from the same
+        calculator only when it has not been stored yet.
+        """
+        stored_cost = logging_obj.model_call_details.get("response_cost")
+        if isinstance(stored_cost, (int, float)):
+            return float(stored_cost)
+        recomputed_cost = logging_obj._response_cost_calculator(result=response)
+        return recomputed_cost if isinstance(recomputed_cost, (int, float)) else ""
+
     def _debug_log_request_payload(self) -> None:
         """Log request payload at DEBUG level, truncating if too large."""
         if not verbose_proxy_logger.isEnabledFor(logging.DEBUG):
@@ -1687,6 +1706,12 @@ class ProxyBaseLLMRequestProcessing:
         hidden_params = getattr(response, "_hidden_params", {}) or {}  # get any updated response headers
         additional_headers = hidden_params.get("additional_headers", {}) or {}
 
+        response_cost_for_headers = (
+            self._response_cost_from_logging_obj(response=response, logging_obj=logging_obj)
+            if (not response_cost and not hasattr(response, "_hidden_params"))
+            else response_cost
+        )
+
         fastapi_response.headers.update(
             ProxyBaseLLMRequestProcessing.get_custom_headers(
                 user_api_key_dict=user_api_key_dict,
@@ -1695,7 +1720,7 @@ class ProxyBaseLLMRequestProcessing:
                 cache_key=cache_key,
                 api_base=api_base,
                 version=version,
-                response_cost=response_cost,
+                response_cost=response_cost_for_headers,
                 model_region=getattr(user_api_key_dict, "allowed_model_region", ""),
                 fastest_response_batch_completion=fastest_response_batch_completion,
                 request_data=self.data,

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -1191,11 +1191,12 @@ class ProxyBaseLLMRequestProcessing:
         logging_obj: LiteLLMLoggingObj,
     ) -> float | str:
         """
-        Recover the response cost for TypedDict results (Anthropic /v1/messages,
-        Google :generateContent) that cannot hold ``_hidden_params``. For those
-        results ``ResponseMetadata.apply()`` drops the computed cost, so the cost
-        is read back from the logging object instead, recomputing from the same
-        calculator only when it has not been stored yet.
+        Recover the response cost when the response never recorded one in its
+        ``_hidden_params``: Anthropic /v1/messages returns a TypedDict that cannot
+        hold the attribute at all, and Google :generateContent carries
+        ``_hidden_params`` but no synchronously-populated ``response_cost``. In both
+        cases the cost is read back from the logging object instead, recomputing from
+        the same calculator only when it has not been stored yet.
         """
         stored_cost = logging_obj.model_call_details.get("response_cost")
         if isinstance(stored_cost, (int, float)):
@@ -1706,9 +1707,10 @@ class ProxyBaseLLMRequestProcessing:
         hidden_params = getattr(response, "_hidden_params", {}) or {}  # get any updated response headers
         additional_headers = hidden_params.get("additional_headers", {}) or {}
 
+        recover_response_cost = not response_cost and hidden_params.get("response_cost") is None
         response_cost_for_headers = (
-            self._response_cost_from_logging_obj(response=response, logging_obj=logging_obj)
-            if (not response_cost and not hasattr(response, "_hidden_params"))
+            self._response_cost_from_logging_obj(response=response, logging_obj=logging_obj) or ""
+            if recover_response_cost
             else response_cost
         )
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -1424,6 +1424,71 @@ def test_response_cost_calculator_with_response_cost_in_hidden_params(logging_ob
     assert response_cost > 100
 
 
+def test_response_cost_calculator_native_generate_content_body_uses_usage_metadata():
+    """
+    Regression for LIT-4076: a native Google :generateContent body reports tokens
+    under ``usageMetadata`` rather than ``usage``, so the cost calculator read 0
+    tokens and returned 0.0 synchronously. The calculator now transforms the native
+    body (as the async logging path does) so the cost is the real non-zero amount.
+    """
+    from litellm.types.llms.vertex_ai import GenerateContentResponseBody
+    from litellm.types.utils import ModelResponse, Usage
+
+    logging_obj = LitellmLogging(
+        model="gemini-2.5-flash",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="agenerate_content",
+        start_time=time.time(),
+        litellm_call_id="lit4076",
+        function_id="lit4076",
+    )
+    logging_obj.model_call_details["custom_llm_provider"] = "gemini"
+    logging_obj.optional_params = {}
+
+    native_body = GenerateContentResponseBody(
+        candidates=[{"content": {"parts": [{"text": "hi"}], "role": "model"}, "finishReason": "STOP"}],
+        usageMetadata={
+            "promptTokenCount": 1000,
+            "candidatesTokenCount": 500,
+            "totalTokenCount": 1500,
+        },
+    )
+
+    expected_cost = litellm.completion_cost(
+        completion_response=ModelResponse(
+            model="gemini-2.5-flash",
+            usage=Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500),
+        ),
+        model="gemini-2.5-flash",
+        custom_llm_provider="gemini",
+    )
+    assert expected_cost > 0
+
+    cost = logging_obj._response_cost_calculator(result=native_body)
+    assert cost == pytest.approx(expected_cost)
+
+
+def test_response_cost_calculator_does_not_transform_non_generate_content_dict():
+    """The native-body transform must only run for generate_content call types, so a
+    plain dict on a chat completion call is left untouched (no spurious Gemini cost)."""
+    logging_obj = LitellmLogging(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="acompletion",
+        start_time=time.time(),
+        litellm_call_id="lit4076-2",
+        function_id="lit4076-2",
+    )
+    logging_obj.optional_params = {}
+
+    cost = logging_obj._response_cost_calculator(
+        result={"usageMetadata": {"promptTokenCount": 1000, "candidatesTokenCount": 500}}
+    )
+    assert not cost
+
+
 def test_sentry_event_scrubber_initialization(monkeypatch):
     # Step 1: Create a fake sentry_sdk.scrubber module
     mock_event_scrubber_instance = MagicMock()

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4066,3 +4066,167 @@ class TestAllmPassthroughStreamingProviderGate:
         streamed = [chunk async for chunk in result.body_iterator]
         assert streamed == chunks
         mock_handler.assert_not_awaited()
+
+
+class TestResponseCostHeaderForTypedDictResponses:
+    """
+    Regression for LIT-4076. Anthropic /v1/messages and Google :generateContent
+    return TypedDict results that are plain dicts at runtime and therefore cannot
+    hold _hidden_params. ResponseMetadata.apply() drops the computed response_cost
+    for those results, so x-litellm-response-cost went missing on those two routes
+    even though it appeared on /chat/completions and /responses. The non-streaming
+    header build now recovers the cost from the logging object for such results,
+    while leaving object responses (ModelResponse etc.) untouched.
+    """
+
+    def _build_logging_obj(self, *, model_call_details, response_cost_calculator):
+        logging_obj = MagicMock()
+        logging_obj.litellm_call_id = "call-lit4076"
+        logging_obj.cost_breakdown = None
+        logging_obj.model_call_details = model_call_details
+        logging_obj._response_cost_calculator = response_cost_calculator
+        logging_obj._enqueue_deferred_logging = None
+        logging_obj._on_deferred_stream_complete = None
+        return logging_obj
+
+    async def _drive_non_streaming(self, *, monkeypatch, response, logging_obj, route_type):
+        import litellm.proxy.common_request_processing as crp
+        from litellm.proxy._types import UserAPIKeyAuth as RealUserAPIKeyAuth
+
+        async def fake_route_request(**kwargs):
+            async def _llm_call():
+                return response
+
+            return _llm_call()
+
+        monkeypatch.setattr(crp, "route_request", fake_route_request)
+
+        async def fake_post_call_success_hook(data, user_api_key_dict, response):
+            return response
+
+        proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        proxy_logging_obj.during_call_hook = AsyncMock(return_value=None)
+        proxy_logging_obj.update_request_status = AsyncMock(return_value=None)
+        proxy_logging_obj.post_call_response_headers_hook = AsyncMock(return_value={})
+        proxy_logging_obj.post_call_success_hook = fake_post_call_success_hook
+
+        fastapi_response = Response()
+        processing_obj = ProxyBaseLLMRequestProcessing(data={"litellm_logging_obj": logging_obj})
+
+        with patch.object(
+            ProxyBaseLLMRequestProcessing,
+            "_has_post_call_guardrails",
+            return_value=False,
+        ):
+            await processing_obj.base_process_llm_request(
+                request=MagicMock(spec=Request, headers={}),
+                fastapi_response=fastapi_response,
+                user_api_key_dict=RealUserAPIKeyAuth(api_key="sk-test"),
+                route_type=route_type,
+                proxy_logging_obj=proxy_logging_obj,
+                general_settings={},
+                proxy_config=MagicMock(spec=ProxyConfig),
+                select_data_generator=None,
+                llm_router=None,
+                skip_pre_call_logic=True,
+            )
+        return fastapi_response
+
+    @pytest.mark.asyncio
+    async def test_messages_typeddict_emits_cost_header_from_stored_cost(self, monkeypatch):
+        from litellm.types.utils import AnthropicMessagesResponse
+
+        response = AnthropicMessagesResponse(
+            id="msg_1",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": "hi"}],
+            model="claude-haiku-4-5",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        recompute = MagicMock(return_value=999.0)
+        logging_obj = self._build_logging_obj(
+            model_call_details={"response_cost": 0.00123},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="anthropic_messages",
+        )
+
+        assert fastapi_response.headers["x-litellm-response-cost"] == "0.00123"
+        recompute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_content_typeddict_emits_cost_header_via_recompute(self, monkeypatch):
+        from litellm.types.llms.vertex_ai import GenerateContentResponseBody
+
+        response = GenerateContentResponseBody(
+            candidates=[{"content": {"parts": [{"text": "hi"}], "role": "model"}}],
+            usageMetadata={
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5,
+                "totalTokenCount": 15,
+            },
+        )
+        recompute = MagicMock(return_value=0.00456)
+        logging_obj = self._build_logging_obj(
+            model_call_details={},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="agenerate_content",
+        )
+
+        assert fastapi_response.headers["x-litellm-response-cost"] == "0.00456"
+        recompute.assert_called_once()
+        assert recompute.call_args.kwargs["result"] is response
+
+    @pytest.mark.asyncio
+    async def test_object_response_with_hidden_params_is_unaffected(self, monkeypatch):
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(_hidden_params={"response_cost": 0.009})
+        recompute = MagicMock(side_effect=AssertionError("must not recompute for object responses"))
+        logging_obj = self._build_logging_obj(
+            model_call_details={"response_cost": 123.0},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="acompletion",
+        )
+
+        assert fastapi_response.headers["x-litellm-response-cost"] == "0.009"
+        recompute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_object_response_zero_cost_drops_header_like_chat_completions(self, monkeypatch):
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(_hidden_params={"response_cost": 0.0})
+        recompute = MagicMock(side_effect=AssertionError("must not recompute for object responses"))
+        logging_obj = self._build_logging_obj(
+            model_call_details={"response_cost": 0.00789},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="acompletion",
+        )
+
+        assert "x-litellm-response-cost" not in fastapi_response.headers
+        recompute.assert_not_called()

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4191,6 +4191,63 @@ class TestResponseCostHeaderForTypedDictResponses:
         assert recompute.call_args.kwargs["result"] is response
 
     @pytest.mark.asyncio
+    async def test_generate_content_emits_real_nonzero_cost_header_from_usage_metadata(self, monkeypatch):
+        """
+        End-to-end regression for LIT-4076 using the real cost calculator (not a
+        mock). A native :generateContent body reports tokens under usageMetadata,
+        which the cost calculator did not read, so the synchronously-recovered
+        cost was 0.0 and the header was dropped even though the async logging path
+        billed a real non-zero amount. The header must now carry the true cost.
+        """
+        from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+        from litellm.types.llms.vertex_ai import GenerateContentResponseBody
+        from litellm.types.utils import ModelResponse, Usage
+
+        response = GenerateContentResponseBody(
+            candidates=[{"content": {"parts": [{"text": "hi"}], "role": "model"}, "finishReason": "STOP"}],
+            usageMetadata={
+                "promptTokenCount": 1000,
+                "candidatesTokenCount": 500,
+                "totalTokenCount": 1500,
+            },
+        )
+
+        real_logging = LiteLLMLoggingObj(
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            call_type="agenerate_content",
+            start_time=None,
+            litellm_call_id="call-lit4076-real",
+            function_id="fn",
+        )
+        real_logging.model_call_details["custom_llm_provider"] = "gemini"
+        real_logging.optional_params = {}
+
+        logging_obj = self._build_logging_obj(
+            model_call_details={},
+            response_cost_calculator=real_logging._response_cost_calculator,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="agenerate_content",
+        )
+
+        expected_cost = litellm.completion_cost(
+            completion_response=ModelResponse(
+                model="gemini-2.5-flash",
+                usage=Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500),
+            ),
+            model="gemini-2.5-flash",
+            custom_llm_provider="gemini",
+        )
+        assert expected_cost > 0
+        assert float(fastapi_response.headers["x-litellm-response-cost"]) == pytest.approx(expected_cost)
+
+    @pytest.mark.asyncio
     async def test_generate_content_with_hidden_params_emits_cost_header(self, monkeypatch):
         """
         Models the real :generateContent response: it DOES carry a _hidden_params

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -4070,13 +4070,14 @@ class TestAllmPassthroughStreamingProviderGate:
 
 class TestResponseCostHeaderForTypedDictResponses:
     """
-    Regression for LIT-4076. Anthropic /v1/messages and Google :generateContent
-    return TypedDict results that are plain dicts at runtime and therefore cannot
-    hold _hidden_params. ResponseMetadata.apply() drops the computed response_cost
-    for those results, so x-litellm-response-cost went missing on those two routes
-    even though it appeared on /chat/completions and /responses. The non-streaming
-    header build now recovers the cost from the logging object for such results,
-    while leaving object responses (ModelResponse etc.) untouched.
+    Regression for LIT-4076. x-litellm-response-cost went missing on Anthropic
+    /v1/messages and Google :generateContent even though it appeared on
+    /chat/completions and /responses. /v1/messages returns a TypedDict that cannot
+    hold _hidden_params at all, and :generateContent carries _hidden_params but no
+    synchronously-populated response_cost. In both cases the raw response_cost is
+    empty at header-build time. The non-streaming header build now recovers the cost
+    from the logging object whenever the response itself never recorded one, while
+    leaving object responses (ModelResponse etc.) untouched.
     """
 
     def _build_logging_obj(self, *, model_call_details, response_cost_calculator):
@@ -4188,6 +4189,70 @@ class TestResponseCostHeaderForTypedDictResponses:
         assert fastapi_response.headers["x-litellm-response-cost"] == "0.00456"
         recompute.assert_called_once()
         assert recompute.call_args.kwargs["result"] is response
+
+    @pytest.mark.asyncio
+    async def test_generate_content_with_hidden_params_emits_cost_header(self, monkeypatch):
+        """
+        Models the real :generateContent response: it DOES carry a _hidden_params
+        attribute (which is why x-litellm-model-group / x-litellm-model-api-base
+        appear), but no response_cost is populated synchronously at header-build
+        time. The cost is only available on the logging object. The previous
+        ``not hasattr(response, "_hidden_params")`` guard skipped recovery here, so
+        x-litellm-response-cost went missing even though the cost was computed.
+        """
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(
+            _hidden_params={
+                "additional_headers": {"x-litellm-model-group": "gemini-2.5-flash"},
+            }
+        )
+        recompute = MagicMock(return_value=999.0)
+        logging_obj = self._build_logging_obj(
+            model_call_details={"response_cost": 0.0004521},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="agenerate_content",
+        )
+
+        assert fastapi_response.headers["x-litellm-response-cost"] == "0.0004521"
+        assert fastapi_response.headers["x-litellm-model-group"] == "gemini-2.5-flash"
+        recompute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_content_with_hidden_params_zero_cost_drops_header(self, monkeypatch):
+        """
+        A recovered cost of 0 must normalize to a dropped header, exactly like
+        /chat/completions, so :generateContent does not start emitting
+        x-litellm-response-cost: 0.0 where nothing was emitted before.
+        """
+        from types import SimpleNamespace
+
+        response = SimpleNamespace(
+            _hidden_params={
+                "additional_headers": {"x-litellm-model-group": "gemini-2.5-flash"},
+            }
+        )
+        recompute = MagicMock(return_value=999.0)
+        logging_obj = self._build_logging_obj(
+            model_call_details={"response_cost": 0.0},
+            response_cost_calculator=recompute,
+        )
+
+        fastapi_response = await self._drive_non_streaming(
+            monkeypatch=monkeypatch,
+            response=response,
+            logging_obj=logging_obj,
+            route_type="agenerate_content",
+        )
+
+        assert "x-litellm-response-cost" not in fastapi_response.headers
+        recompute.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_object_response_with_hidden_params_is_unaffected(self, monkeypatch):


### PR DESCRIPTION
## Relevant issues

The proxy returns `x-litellm-response-cost` on `/v1/chat/completions` and `/v1/responses`, but it was missing on the Anthropic `/v1/messages` endpoint and the Google native `:generateContent` endpoint. The other `x-litellm-*` headers (call-id, model-id, version) were present on those two routes; only the cost header was absent

## Linear ticket

Resolves LIT-4076

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a live proxy started from this branch on a random free port with a DB-less minimal config (`claude-haiku-4-5` mapped to `anthropic/claude-haiku-4-5` and `gemini-flash` mapped to `gemini/gemini-2.5-flash`), making real Anthropic and real Gemini calls. `grep -i x-litellm` prints every litellm header so the sibling headers stay visible and only `x-litellm-response-cost` changes between before and after

### Before (base `26ee5dd5`)

Anthropic `/v1/messages`

```bash
curl -sS -D - -o /dev/null http://127.0.0.1:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}]}' \
  | grep -i x-litellm
```

```
x-litellm-call-id: d4b2d281-614e-49c4-b526-e5af0b552f1e
x-litellm-model-id: df10618a6a8a6ca747bc99722c87255728c8a24b79e3326ca370aa40faf389db
x-litellm-version: 1.91.0
x-litellm-response-cost-original: 5.9000000000000004e-05
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-key-spend: 0.0
```

Google `:generateContent`

```bash
curl -sS -D - -o /dev/null "http://127.0.0.1:4000/v1beta/models/gemini-flash:generateContent" \
  -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"say hi in 3 words"}]}]}' \
  | grep -i x-litellm
```

```
x-litellm-call-id: bb2959f7-300a-42c9-991c-ce1383148b92
x-litellm-model-id: 669e6bac2eee2ab76d36577adef65e58d234bfaf998942cb0133ced83f200aaf
x-litellm-model-api-base: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
x-litellm-version: 1.91.0
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-key-spend: 0.0
x-litellm-response-duration-ms: 3770.48
x-litellm-callback-duration-ms: 0.0
x-litellm-model-group: gemini-flash
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

Both routes return HTTP 200 with the sibling headers present, but `x-litellm-response-cost` is absent on each

### After (fix `f4824e20`)

Anthropic `/v1/messages`

```bash
curl -sS -D - -o /dev/null http://127.0.0.1:4000/v1/messages \
  -H "Authorization: Bearer sk-1234" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
  -d '{"model":"claude-haiku-4-5","max_tokens":64,"messages":[{"role":"user","content":"say hi in 3 words"}]}' \
  | grep -i x-litellm
```

```
x-litellm-call-id: 8240f65d-d16c-4f13-b88e-3d24dfd4788e
x-litellm-model-id: df10618a6a8a6ca747bc99722c87255728c8a24b79e3326ca370aa40faf389db
x-litellm-version: 1.91.0
x-litellm-response-cost: 5.4000000000000005e-05
x-litellm-response-cost-original: 5.4000000000000005e-05
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-key-spend: 5.4000000000000005e-05
```

Google `:generateContent`

```bash
curl -sS -D - -o /dev/null "http://127.0.0.1:4000/v1beta/models/gemini-flash:generateContent" \
  -H "Authorization: Bearer sk-1234" -H "content-type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"say hi in 3 words"}]}]}' \
  | grep -i x-litellm
```

```
x-litellm-call-id: 86c187d6-9f22-463d-a9e4-48a6be3e338b
x-litellm-model-id: 669e6bac2eee2ab76d36577adef65e58d234bfaf998942cb0133ced83f200aaf
x-litellm-model-api-base: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
x-litellm-version: 1.91.0
x-litellm-response-cost: 0.0005121
x-litellm-response-cost-original: 0.0005121
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
x-litellm-key-spend: 0.0005121
x-litellm-response-duration-ms: 1521.769
x-litellm-callback-duration-ms: 0.0
x-litellm-model-group: gemini-flash
x-litellm-attempted-retries: 0
x-litellm-attempted-fallbacks: 0
```

`x-litellm-response-cost` is now present with a real non-zero value on both routes. Repeating each call confirms the value is stable and genuinely computed rather than a flaky zero: a second Anthropic call returned `x-litellm-response-cost: 6.4e-05` and a second Gemini call returned `x-litellm-response-cost: 0.0005496`, each tracking the response's own token usage

### Also verified on a modern Gemini model (`gemini-3.5-flash`)

To confirm the `usageMetadata` fix is not specific to the 2.5 family, the same before/after was repeated on `gemini-3.5-flash` (the current GA flash tier, newer than 2.5, priced in litellm at input `1.5e-06` / output `9e-06`), on a separate live proxy on a random free port hitting the real Gemini API via the native `:generateContent` route

```bash
curl -sS -D - -X POST "http://127.0.0.1:61612/v1beta/models/gemini-3.5-flash:generateContent" \
  -H "Content-Type: application/json" -H "Authorization: Bearer sk-1234" \
  -d '{"contents":[{"parts":[{"text":"Reply with just: hi"}]}]}' | grep -i x-litellm
```

Before (base `26ee5dd5`): HTTP 200 with the sibling headers present (`x-litellm-call-id`, `x-litellm-model-id`, `x-litellm-model-api-base`, `x-litellm-version: 1.91.0`, `x-litellm-model-group: gemini-3.5-flash`) and `x-litellm-response-cost-original: 0.0`, but `x-litellm-response-cost` absent

After (fix `f4824e20`), two runs:

```
x-litellm-response-cost: 0.0009884999999999998
x-litellm-response-cost: 0.0008895
```

Each value matches the independently computed gemini-3.5-flash cost exactly (prompt tokens x `1.5e-06` + output tokens x `9e-06`), confirming the header carries the true cost computed against the modern model's price entry rather than a fallback or a flaky zero

## Type

🐛 Bug Fix

## Changes

Both routes flow through `ProxyBaseLLMRequestProcessing.base_process_llm_request` and share the same `get_custom_headers` builder, so no new header builder is needed. The two routes lose the cost header for related but distinct reasons. `/v1/messages` returns an `AnthropicMessagesResponse`, a `TypedDict` that is a plain dict at runtime and cannot hold a `_hidden_params` attribute at all, so `ResponseMetadata.apply()` has nowhere to write the computed `response_cost` back and it is discarded. `:generateContent` returns an object whose token usage lives under `usageMetadata` and whose `response_cost` is not populated synchronously at header-build time. In both cases the capture in `base_process_llm_request` collapses to `""` and `get_custom_headers` filters the cost header out while still emitting call-id, model-id and version

The header build recovers the cost from the logging object whenever the response itself never recorded one, that is when the captured `response_cost` is empty and the response's `_hidden_params` carries no `response_cost`. It prefers the value already stored in `model_call_details["response_cost"]` and recomputes through the same `_response_cost_calculator` only when it has not been stored yet, then normalizes a recovered `0` back to a dropped header with the same `or ""` semantics `/chat/completions` already uses. Object responses such as `ModelResponse` and `ResponsesAPIResponse` record their own `response_cost` in `_hidden_params` (even when it is `0`), so they keep their existing path and `/chat/completions`, `/responses`, and the Anthropic error path that intentionally emits a zero cost are all unaffected

Recovering the cost was necessary but not sufficient for `:generateContent`. The recomputed value came back as a genuine `0.0`: a native generate-content body reports tokens under `usageMetadata`, while `litellm.completion_cost` only reads `usage`, so the synchronous calculation saw zero tokens. The async success/logging path already sidesteps this by transforming the native body into a `ModelResponse` (via `VertexGeminiConfig._transform_google_generate_content_to_openai_model_response`) before costing, which is why the deferred async callback billed the correct non-zero amount a moment after the headers had already flushed. `_response_cost_calculator` now applies that same transformation up front for `generate_content` / `agenerate_content` results that are still in native-body form, so the cost is the real non-zero value at header-build time. Results that are already a `ModelResponse` (the async-logging and adapter paths) and every other call type are left untouched, so this changes nothing for existing providers

Streaming is intentionally out of scope. For streaming requests the headers are emitted at the start of the stream, before the response is consumed and the cost is known, which is the same reason `/chat/completions` streaming does not carry the cost header at stream start

Tests live in `tests/test_litellm/proxy/test_common_request_processing.py` and `tests/test_litellm/litellm_core_utils/test_litellm_logging.py`. The proxy tests drive `base_process_llm_request` end to end and assert the header is present with the recovered cost for a real `AnthropicMessagesResponse` and for a `GenerateContentResponseBody`, including a regression that wires the real `_response_cost_calculator` to a `gemini-2.5-flash` response with a populated `usageMetadata` and asserts the header carries the true non-zero per-token cost rather than `0`. They also assert that an object response with a non-zero cost still uses its own hidden-params cost without consulting the logging object, that a zero-cost object response keeps the header dropped exactly as `/chat/completions` does today, and that a recovered `0` cost on `:generateContent` drops the header too. The logging-core tests cover `_response_cost_calculator` directly: a native generate-content body now costs the real non-zero amount, while a plain dict on a chat-completion call is left untouched. The new generate-content cost tests fail on the prior revision (where the synchronous cost was `0`) and pass with this fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy billing headers and shared cost calculation for specific routes; behavior is gated and well-tested, but incorrect costing or header logic could affect spend visibility for Anthropic messages and Gemini generateContent.
> 
> **Overview**
> Restores **`x-litellm-response-cost`** on non-streaming Anthropic **`/v1/messages`** and Google **`:generateContent`** proxy routes (LIT-4076), where other `x-litellm-*` headers already appeared but the main cost header was omitted.
> 
> **Proxy header build:** When the captured `response_cost` is empty and the response’s `_hidden_params` has no `response_cost`, the non-streaming path now pulls cost from the logging object—preferring `model_call_details["response_cost"]`, otherwise calling `_response_cost_calculator`—and still drops the header when the recovered value is zero, matching `/chat/completions` behavior. Responses that already set `response_cost` on `_hidden_params` (e.g. `ModelResponse`) are unchanged.
> 
> **Synchronous costing for Gemini:** `_response_cost_calculator` now converts native `generate_content` / `agenerate_content` bodies (dict/`BaseModel` with `usageMetadata`) into a `ModelResponse` via `VertexGeminiConfig._transform_google_generate_content_to_openai_model_response` before costing, mirroring the async logging path so token usage is not read as zero. The transform is limited to those call types; failures are caught so responses are not broken.
> 
> Regression tests cover the logging calculator and end-to-end proxy header behavior for TypedDict/object responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf2e333869637c274ff488e5f84aa771c9b2b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->