### PR TITLE
fix(router): stamp failed_deployment_id on the /v1/messages path so enable_weighted_failover composes

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4819,6 +4819,7 @@ class Router:
 
         passthrough_on_no_deployment = kwargs.pop("passthrough_on_no_deployment", False)
         function_name = "_ageneric_api_call_with_fallbacks"
+        deployment: Optional[dict] = None
         try:
             parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             try:
@@ -4906,6 +4907,8 @@ class Router:
             )
             if model is not None:
                 self.fail_calls[model] += 1
+            if deployment is not None:
+                self._set_failed_deployment_id_on_exception(e, deployment)
             raise e
 
     async def _aresponses_with_streaming_fallbacks(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4819,7 +4819,7 @@ class Router:
 
         passthrough_on_no_deployment = kwargs.pop("passthrough_on_no_deployment", False)
         function_name = "_ageneric_api_call_with_fallbacks"
-        deployment: Optional[dict] = None
+        selected_deployment: Optional[dict] = None
         try:
             parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             try:
@@ -4834,6 +4834,7 @@ class Router:
                     return await original_generic_function(model=model, **kwargs)
                 raise e
 
+            selected_deployment = deployment
             self._update_kwargs_with_deployment(
                 deployment=deployment, kwargs=kwargs, function_name=function_name
             )
@@ -4907,8 +4908,8 @@ class Router:
             )
             if model is not None:
                 self.fail_calls[model] += 1
-            if deployment is not None:
-                self._set_failed_deployment_id_on_exception(e, deployment)
+            if selected_deployment is not None:
+                self._set_failed_deployment_id_on_exception(e, selected_deployment)
             raise e
 
     async def _aresponses_with_streaming_fallbacks(

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -13,9 +13,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import litellm
 from litellm import Router
 from litellm.utils import _get_excluded_filtered_deployments
-
 
 # ---------------------------------------------------------------------------
 # Unit tests for _get_excluded_filtered_deployments
@@ -98,6 +98,63 @@ def test_set_failed_deployment_id_on_exception():
     assert getattr(exc, "failed_deployment_id", None) == "dep-a"
     router._set_failed_deployment_id_on_exception(exc, _make_dep("dep-b"))
     assert exc.failed_deployment_id == "dep-a"
+
+
+@pytest.mark.asyncio
+async def test_ageneric_api_call_stamps_failed_deployment_id_on_failure():
+    """The /v1/messages (generic) path must stamp failed_deployment_id on a
+    deployment failure, like /chat/completions does. Without it weighted
+    failover has nothing to exclude and the request escapes to a cross-group
+    fallback instead of trying a healthy sibling in the same group."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key"},
+                "model_info": {"id": "dep-a"},
+            }
+        ],
+        routing_strategy="simple-shuffle",
+        enable_weighted_failover=True,
+    )
+
+    async def failing_call(**kwargs):
+        raise litellm.RateLimitError(
+            message="boom", llm_provider="openai", model="gpt-4o"
+        )
+
+    with pytest.raises(litellm.RateLimitError) as exc_info:
+        await router._ageneric_api_call_with_fallbacks_helper(
+            model="test-model",
+            original_generic_function=failing_call,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert getattr(exc_info.value, "failed_deployment_id", None) == "dep-a"
+
+
+@pytest.mark.asyncio
+async def test_ageneric_api_call_no_stamp_when_deployment_selection_fails():
+    """When no deployment was selected, the helper re-raises without a
+    failed_deployment_id and without a NameError on the unbound deployment."""
+    router = Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {"model": "gpt-4o", "api_key": "key"},
+                "model_info": {"id": "dep-a"},
+            }
+        ],
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await router._ageneric_api_call_with_fallbacks_helper(
+            model="does-not-exist",
+            original_generic_function=AsyncMock(),
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert getattr(exc_info.value, "failed_deployment_id", None) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Fixes #31678

## Type

🐛 Bug Fix

## Changes

enable_weighted_failover is meant to keep a failed request inside its model group by retrying a healthy sibling before any cross-group fallback. It does this on /chat/completions but not on /v1/messages. On the Anthropic path a single failing provider in a Claude group sends the request straight to the cross-group GPT fallback instead of the healthy Bedrock or Anthropic sibling. The request still returns 200, so dashboards stay green and the skipped in-group failover goes unnoticed. The same config on /chat/completions behaves correctly, which makes this hard to spot.

The cause is narrow. Weighted failover only triggers when the failing exception carries failed_deployment_id. The chat path sets that attribute on failure. The generic path that serves /v1/messages never did, so weighted failover saw nothing to fail over from and gave up. This change sets it there too, reusing the existing idempotent setter, so both request formats behave the same.

The only critical detail is that the failed deployment is already known at the point of failure, so this is a small change guarded on a deployment having actually been selected.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on the mapped file (tests/test_litellm/test_router_weighted_failover.py)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Live proxy reproduction, no real keys needed because the failing deployment is forced with mock_response. config.yaml:

```yaml
model_list:
  - model_name: claude-sonnet-test
    litellm_params:
      model: anthropic/claude-sonnet-4-5
      mock_response: "litellm.RateLimitError"
      api_key: sk-fake
    model_info:
      id: dep-anthropic
  - model_name: claude-sonnet-test
    litellm_params:
      model: bedrock/anthropic.claude-sonnet-4-5
      mock_response: "served by the healthy sibling"
    model_info:
      id: dep-bedrock
  - model_name: gpt-fallback
    litellm_params:
      model: openai/gpt-4o
      mock_response: "served by the cross-group fallback"

router_settings:
  routing_strategy: simple-shuffle
  enable_weighted_failover: true
  fallbacks: [{"claude-sonnet-test": ["gpt-fallback"]}]
```

Run the proxy and send an Anthropic-format request a few times so the failing deployment is picked first:

```bash
litellm --config config.yaml --detailed_debug

for i in 1 2 3 4 5; do
  curl -s http://localhost:4000/v1/messages \
    -H "content-type: application/json" \
    -H "x-api-key: sk-1234" \
    -d '{"model": "claude-sonnet-test", "max_tokens": 64, "messages": [{"role": "user", "content": "hi"}]}'
  echo
done
```

Before this change the reply comes from gpt-fallback (the cross-group fallback). After it, the reply comes from the healthy dep-bedrock sibling in the same group. The same request on /chat/completions already reroutes to dep-bedrock, which isolates the difference to the request path.

## Changes

Set failed_deployment_id in the failure path of _ageneric_api_call_with_fallbacks_helper, matching what _completion and _acompletion already do. Added two regression tests in the mapped test file: one asserts a failure on this path stamps the id, the other asserts that when no deployment was selected the helper re-raises cleanly without it.
