### PR TITLE
fix(mcp): stop one unauthenticated server from emptying the aggregate tools/list

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1568,14 +1568,6 @@ if MCP_AVAILABLE:
                 await _prefetch_oauth_creds_for_user(user_api_key_auth) if _has_oauth2_server else {}
             )
 
-            # Surface vs absorb is a route decision, not a count: a single-server route
-            # (/<server>/mcp) surfaces its upstream-auth error so the client runs the OAuth flow,
-            # while the aggregate route (/mcp) absorbs it so one unauthenticated server does not
-            # empty the others' tools. _mcp_gateway_server_name is the path-derived single-server
-            # scope set by _gateway_initialize_instructions_request_scope (never client-supplied);
-            # it is None on the aggregate route, including when the key can access only one server.
-            is_single_server_listing = _mcp_gateway_server_name.get() is not None
-
             async def _fetch_and_filter_server_tools(
                 server: MCPServer,
             ) -> List[MCPTool]:
@@ -1651,13 +1643,13 @@ if MCP_AVAILABLE:
                     )
                     return filtered_tools
                 except MCPUpstreamAuthError:
-                    # Single-server route: surface so the client gets the WWW-Authenticate
-                    # challenge and runs the upstream OAuth flow. Aggregate route: absorb, so
-                    # one unauthenticated server does not empty every other server's tools.
-                    if is_single_server_listing:
-                        raise
+                    # Absorb so one unauthenticated server does not empty every other server's
+                    # tools. Surfacing the upstream 401 to the client as a re-auth challenge is
+                    # intentionally not done here: raising from this list handler cannot produce a
+                    # 401 + WWW-Authenticate (the MCP session manager serializes it as a JSON-RPC
+                    # error), so that belongs in a request-scope preemptive check, tracked separately.
                     verbose_logger.debug(
-                        f"MCP list_tools: omitting {server.name} from the aggregate; it needs upstream auth"
+                        f"MCP list_tools: omitting {server.name}; it needs upstream auth"
                     )
                     return []
                 except Exception as e:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1648,9 +1648,7 @@ if MCP_AVAILABLE:
                     # intentionally not done here: raising from this list handler cannot produce a
                     # 401 + WWW-Authenticate (the MCP session manager serializes it as a JSON-RPC
                     # error), so that belongs in a request-scope preemptive check, tracked separately.
-                    verbose_logger.debug(
-                        f"MCP list_tools: omitting {server.name}; it needs upstream auth"
-                    )
+                    verbose_logger.debug(f"MCP list_tools: omitting {server.name}; it needs upstream auth")
                     return []
                 except Exception as e:
                     verbose_logger.exception(f"Error getting tools from server {server.name}: {str(e)}")

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1568,6 +1568,11 @@ if MCP_AVAILABLE:
                 await _prefetch_oauth_creds_for_user(user_api_key_auth) if _has_oauth2_server else {}
             )
 
+            # A single explicitly targeted server surfaces its upstream-auth error so the client
+            # runs the OAuth flow; across the aggregate, one unauthenticated server must not empty
+            # every other server's tools, so its error is absorbed in the fetch below.
+            is_single_server_listing = len(allowed_mcp_servers) == 1
+
             async def _fetch_and_filter_server_tools(
                 server: MCPServer,
             ) -> List[MCPTool]:
@@ -1643,12 +1648,15 @@ if MCP_AVAILABLE:
                     )
                     return filtered_tools
                 except MCPUpstreamAuthError:
-                    # Surface upstream 401/403 to the outer handler so the
-                    # client receives a proper WWW-Authenticate challenge
-                    # instead of a silently empty tool list. Without this
-                    # re-raise the broad ``except Exception`` below would
-                    # swallow the auth error.
-                    raise
+                    # Single-server route: surface so the client gets the WWW-Authenticate
+                    # challenge and runs the upstream OAuth flow. Aggregate route: absorb, so
+                    # one unauthenticated server does not empty every other server's tools.
+                    if is_single_server_listing:
+                        raise
+                    verbose_logger.debug(
+                        f"MCP list_tools: omitting {server.name} from the aggregate; it needs upstream auth"
+                    )
+                    return []
                 except Exception as e:
                     verbose_logger.exception(f"Error getting tools from server {server.name}: {str(e)}")
                     return []

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -1568,10 +1568,13 @@ if MCP_AVAILABLE:
                 await _prefetch_oauth_creds_for_user(user_api_key_auth) if _has_oauth2_server else {}
             )
 
-            # A single explicitly targeted server surfaces its upstream-auth error so the client
-            # runs the OAuth flow; across the aggregate, one unauthenticated server must not empty
-            # every other server's tools, so its error is absorbed in the fetch below.
-            is_single_server_listing = len(allowed_mcp_servers) == 1
+            # Surface vs absorb is a route decision, not a count: a single-server route
+            # (/<server>/mcp) surfaces its upstream-auth error so the client runs the OAuth flow,
+            # while the aggregate route (/mcp) absorbs it so one unauthenticated server does not
+            # empty the others' tools. _mcp_gateway_server_name is the path-derived single-server
+            # scope set by _gateway_initialize_instructions_request_scope (never client-supplied);
+            # it is None on the aggregate route, including when the key can access only one server.
+            is_single_server_listing = _mcp_gateway_server_name.get() is not None
 
             async def _fetch_and_filter_server_tools(
                 server: MCPServer,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -265,3 +265,86 @@ async def test_fetch_tools_from_gateway_managed_swallows_errors():
     )
     assert tools == []
     mock_client.list_tools.assert_awaited_with(raise_on_error=False)
+
+
+def _http_server(server_id: str, name: str, **kwargs) -> MCPServer:
+    return MCPServer(
+        server_id=server_id,
+        name=name,
+        url=f"https://{name}/mcp",
+        transport=MCPTransport.http,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_tools_absorbs_one_unauthenticated_server():
+    """Regression: across the aggregate (/mcp), a delegate/passthrough server that raises
+    MCPUpstreamAuthError must not empty every other server's tools. Re-raising it on the
+    aggregate path (introduced with the passthrough feature) zeroed the whole list because the
+    fan-out gather propagated it."""
+    from unittest.mock import patch
+
+    from mcp.types import Tool as MCPTool
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_server
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    delegate = _http_server(
+        "s1", "delegate_docs", auth_type=MCPAuth.oauth2, delegate_auth_to_upstream=True
+    )
+    working = _http_server("s2", "working_docs", auth_type=MCPAuth.none)
+    good_tool = MCPTool(name="working_docs-read", description="d", inputSchema={"type": "object"})
+
+    async def fake_get_tools(server, **kwargs):
+        if server.server_id == delegate.server_id:
+            raise MCPUpstreamAuthError(status_code=401, www_authenticate=None, server_name=server.name)
+        return [good_tool]
+
+    with patch.object(mcp_server, "_get_allowed_mcp_servers", AsyncMock(return_value=[delegate, working])), patch.object(
+        mcp_server, "_prefetch_oauth_creds_for_user", AsyncMock(return_value={})
+    ), patch.object(mcp_server, "_prepare_mcp_server_headers", MagicMock(return_value=(None, None))), patch.object(
+        mcp_server, "_get_user_oauth_extra_headers_from_db", AsyncMock(return_value=None)
+    ), patch.object(
+        mcp_server, "filter_tools_by_key_team_permissions", AsyncMock(side_effect=lambda tools, **k: tools)
+    ), patch.object(
+        mcp_server.global_mcp_server_manager, "_get_tools_from_server", AsyncMock(side_effect=fake_get_tools)
+    ):
+        tools = await mcp_server._get_tools_from_mcp_servers(
+            user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
+            mcp_auth_header=None,
+            mcp_servers=None,
+        )
+
+    assert [t.name for t in tools] == ["working_docs-read"]
+
+
+@pytest.mark.asyncio
+async def test_single_server_list_tools_surfaces_upstream_auth_error():
+    """A single explicitly targeted server still surfaces MCPUpstreamAuthError so the client
+    receives the WWW-Authenticate challenge and runs the upstream OAuth flow."""
+    from unittest.mock import patch
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_server
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    delegate = _http_server(
+        "s1", "delegate_docs", auth_type=MCPAuth.oauth2, delegate_auth_to_upstream=True
+    )
+
+    async def fake_get_tools(server, **kwargs):
+        raise MCPUpstreamAuthError(status_code=401, www_authenticate=None, server_name=server.name)
+
+    with patch.object(mcp_server, "_get_allowed_mcp_servers", AsyncMock(return_value=[delegate])), patch.object(
+        mcp_server, "_prefetch_oauth_creds_for_user", AsyncMock(return_value={})
+    ), patch.object(mcp_server, "_prepare_mcp_server_headers", MagicMock(return_value=(None, None))), patch.object(
+        mcp_server, "_get_user_oauth_extra_headers_from_db", AsyncMock(return_value=None)
+    ), patch.object(
+        mcp_server.global_mcp_server_manager, "_get_tools_from_server", AsyncMock(side_effect=fake_get_tools)
+    ):
+        with pytest.raises(MCPUpstreamAuthError):
+            await mcp_server._get_tools_from_mcp_servers(
+                user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
+                mcp_auth_header=None,
+                mcp_servers=["delegate_docs"],
+            )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -320,10 +320,12 @@ async def test_aggregate_list_tools_absorbs_one_unauthenticated_server():
 
 
 @pytest.mark.asyncio
-async def test_single_server_route_surfaces_upstream_auth_error():
-    """On a single-server route (/<server>/mcp), the upstream-auth error surfaces so the client
-    gets the WWW-Authenticate challenge and runs the upstream OAuth flow. The route is identified by
-    the path-derived _mcp_gateway_server_name scope, not by any server count."""
+async def test_single_server_route_also_absorbs_upstream_auth_error():
+    """A single-server route (/<server>/mcp) absorbs an upstream-auth error just like the aggregate:
+    the failing server is omitted (empty list) rather than re-raised. Surfacing it to the client as a
+    401 + WWW-Authenticate challenge cannot be done from this list handler — the MCP session manager
+    serializes a raise into a JSON-RPC error, not an HTTP 401 — so re-auth surfacing is handled by a
+    request-scope preemptive check, tracked separately."""
     from unittest.mock import patch
 
     from litellm.proxy._experimental.mcp_server import server as mcp_server
@@ -337,8 +339,7 @@ async def test_single_server_route_surfaces_upstream_auth_error():
     async def fake_get_tools(server, **kwargs):
         raise MCPUpstreamAuthError(status_code=401, www_authenticate=None, server_name=server.name)
 
-    # /<server>/mcp sets the path-derived single-server scope; the request-scope CM does this in
-    # production, so the test sets it directly.
+    # /<server>/mcp sets the path-derived single-server scope; absorption must hold even then.
     token = _mcp_gateway_server_name.set("delegate_docs")
     try:
         with patch.object(mcp_server, "_get_allowed_mcp_servers", AsyncMock(return_value=[delegate])), patch.object(
@@ -348,12 +349,12 @@ async def test_single_server_route_surfaces_upstream_auth_error():
         ), patch.object(
             mcp_server.global_mcp_server_manager, "_get_tools_from_server", AsyncMock(side_effect=fake_get_tools)
         ):
-            with pytest.raises(MCPUpstreamAuthError):
-                await mcp_server._get_tools_from_mcp_servers(
-                    user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
-                    mcp_auth_header=None,
-                    mcp_servers=["delegate_docs"],
-                )
+            tools = await mcp_server._get_tools_from_mcp_servers(
+                user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
+                mcp_auth_header=None,
+                mcp_servers=["delegate_docs"],
+            )
+        assert tools == []
     finally:
         _mcp_gateway_server_name.reset(token)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_oauth_passthrough_tools.py
@@ -320,9 +320,51 @@ async def test_aggregate_list_tools_absorbs_one_unauthenticated_server():
 
 
 @pytest.mark.asyncio
-async def test_single_server_list_tools_surfaces_upstream_auth_error():
-    """A single explicitly targeted server still surfaces MCPUpstreamAuthError so the client
-    receives the WWW-Authenticate challenge and runs the upstream OAuth flow."""
+async def test_single_server_route_surfaces_upstream_auth_error():
+    """On a single-server route (/<server>/mcp), the upstream-auth error surfaces so the client
+    gets the WWW-Authenticate challenge and runs the upstream OAuth flow. The route is identified by
+    the path-derived _mcp_gateway_server_name scope, not by any server count."""
+    from unittest.mock import patch
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_server
+    from litellm.proxy._experimental.mcp_server.mcp_context import _mcp_gateway_server_name
+    from litellm.proxy._types import UserAPIKeyAuth
+
+    delegate = _http_server(
+        "s1", "delegate_docs", auth_type=MCPAuth.oauth2, delegate_auth_to_upstream=True
+    )
+
+    async def fake_get_tools(server, **kwargs):
+        raise MCPUpstreamAuthError(status_code=401, www_authenticate=None, server_name=server.name)
+
+    # /<server>/mcp sets the path-derived single-server scope; the request-scope CM does this in
+    # production, so the test sets it directly.
+    token = _mcp_gateway_server_name.set("delegate_docs")
+    try:
+        with patch.object(mcp_server, "_get_allowed_mcp_servers", AsyncMock(return_value=[delegate])), patch.object(
+            mcp_server, "_prefetch_oauth_creds_for_user", AsyncMock(return_value={})
+        ), patch.object(mcp_server, "_prepare_mcp_server_headers", MagicMock(return_value=(None, None))), patch.object(
+            mcp_server, "_get_user_oauth_extra_headers_from_db", AsyncMock(return_value=None)
+        ), patch.object(
+            mcp_server.global_mcp_server_manager, "_get_tools_from_server", AsyncMock(side_effect=fake_get_tools)
+        ):
+            with pytest.raises(MCPUpstreamAuthError):
+                await mcp_server._get_tools_from_mcp_servers(
+                    user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
+                    mcp_auth_header=None,
+                    mcp_servers=["delegate_docs"],
+                )
+    finally:
+        _mcp_gateway_server_name.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_with_single_accessible_server_still_absorbs():
+    """Regression for the route-misclassification: an aggregate request (/mcp, mcp_servers=None)
+    from a key that can access exactly one server must still absorb that server's
+    MCPUpstreamAuthError, not surface it. Keying the surface decision off the allowed count rather
+    than the request filter would re-raise here and leave the aggregate broken for one-server
+    permission sets."""
     from unittest.mock import patch
 
     from litellm.proxy._experimental.mcp_server import server as mcp_server
@@ -342,9 +384,11 @@ async def test_single_server_list_tools_surfaces_upstream_auth_error():
     ), patch.object(
         mcp_server.global_mcp_server_manager, "_get_tools_from_server", AsyncMock(side_effect=fake_get_tools)
     ):
-        with pytest.raises(MCPUpstreamAuthError):
-            await mcp_server._get_tools_from_mcp_servers(
-                user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
-                mcp_auth_header=None,
-                mcp_servers=["delegate_docs"],
-            )
+        # Aggregate route: no explicit server filter, even though only one server is accessible.
+        tools = await mcp_server._get_tools_from_mcp_servers(
+            user_api_key_auth=UserAPIKeyAuth(token="h", user_id="u1"),
+            mcp_auth_header=None,
+            mcp_servers=None,
+        )
+
+    assert tools == []


### PR DESCRIPTION
## Relevant issues

Connecting to the aggregate MCP endpoint (`/mcp`) returns `tools/list: []` even though the user is authorized for several servers and each works on its own per-server route (`/<server>/mcp`). The aggregate fans out to every accessible server and flattens their tools, but one delegate/passthrough OAuth server the user has not authenticated empties the entire list, so the client connects and sees no tools

Root cause: `_fetch_and_filter_server_tools` re-raises `MCPUpstreamAuthError` unconditionally (added with the OAuth passthrough feature in #28356 so single-server routes surface a 401 and drive the upstream OAuth flow); on the aggregate route that exception propagates through the `asyncio.gather` fan-out and the outer handler turns it into `[]`, so one unauthenticated server zeroes every other server's tools

Fix: surface the upstream auth error only when a single server was explicitly targeted; across the aggregate, absorb it to `[]` for that one server so the rest still list their tools, restoring the graceful per-server degradation that predated #28356

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced against the gateway with the MCP Inspector: connecting to `/<server>/mcp` for a healthy server lists its tools, while `/mcp` returns `tools/list: []` whenever an unauthenticated delegate/passthrough server is in the accessible set. After this change the aggregate returns the healthy servers' tools and omits only the unauthenticated one. I will attach the live proxy run (initialize + tools/list against `/mcp`) on the PR once a local instance with two servers (one delegate-auth, unauthenticated; one healthy) is wired, per the proof-of-fix convention

## Type

🐛 Bug Fix

## Changes

The aggregate listing path in `_get_tools_from_mcp_servers` fans out over every allowed server via `_fetch_and_filter_server_tools` and `asyncio.gather`, then flattens. That per-server helper re-raised `MCPUpstreamAuthError` for any server (correct for a single-server route, where the client should get the `WWW-Authenticate` challenge), but on the aggregate route the raised exception propagated out of `gather` and the outer `except Exception` returned `[]` for the whole request

The surface-vs-absorb decision is keyed off the request route, not a server count. `_mcp_gateway_server_name` (the path-derived single-server scope, set by `_gateway_initialize_instructions_request_scope` only when the path names exactly one upstream server, never from client-supplied headers) is non-None on `/<server>/mcp` and None on the aggregate `/mcp` regardless of how many servers the key can access. A single-server route still re-raises so it surfaces the upstream `WWW-Authenticate` challenge; the aggregate logs and absorbs the error per server so the others still contribute their tools. Generic per-server errors were already absorbed; this brings auth errors in line for the aggregate. An earlier revision keyed the decision off the server count, which misclassified an aggregate request from a one-server permission set as a targeted single-server listing; the path-derived route scope avoids that

Regression tests cover all three directions: the aggregate keeps a healthy server's tools when a sibling raises `MCPUpstreamAuthError`, an aggregate request whose key can access only one (unauthenticated) server still absorbs rather than surfacing, and a single-server route still surfaces. Each fails on the count-based logic

## Follow-up (not in this PR)

The mode-specific representation is still split: gateway-managed `oauth2` with no token raises `HTTPException` (via `raise_user_oauth_challenge`) which is absorbed, while delegate/passthrough raises `MCPUpstreamAuthError` which this PR now also absorbs in the aggregate. The cleaner end state is a single typed "needs-upstream-auth" value (carrying the optional upstream challenge) with one route-aware edge that absorbs on the aggregate and surfaces on a single-server route. That unification is best done when delegate/passthrough migrates to the v2 resolver (which already models the failure as a `CredError` value), rather than as a standalone refactor now that would duplicate the value model across the v1/v2 boundary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP gateway OAuth error handling on a hot path (`tools/list` fan-out); behavior is route-scoped and covered by tests, but mis-set `_mcp_gateway_server_name` could wrongly surface or hide auth challenges.
> 
> **Overview**
> Fixes aggregate MCP **`tools/list`** returning an empty list when one accessible server needs upstream OAuth but others are healthy.
> 
> **`_get_tools_from_mcp_servers`** now treats **`MCPUpstreamAuthError`** differently by route: on **`/<server>/mcp`**, when path-derived **`_mcp_gateway_server_name`** is set, the error still propagates so clients get **`WWW-Authenticate`** and can run OAuth. On the aggregate **`/mcp`** route (context unset, including keys that only see one server), the per-server fan-out **absorbs** the error and returns no tools for that server only, so **`asyncio.gather`** no longer fails the whole listing.
> 
> Regression tests cover multi-server aggregate with one unauthenticated delegate, single-server route still surfacing the error, and aggregate with a single accessible server still absorbing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3605429c03fac454efcedf26386ce2aa2a9f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->