### PR TITLE
fix: emit server_tool_use block on agentic-loop web search path

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -705,11 +705,25 @@ class WebSearchInterceptionLogger(CustomLogger):
         tool_calls: List[Dict],
         structured_results: List[Optional[SearchResponse]],
     ) -> List[Dict[str, Any]]:
-        """Build one ``web_search_tool_result`` block per tool_call."""
+        """Build a ``server_tool_use`` + ``web_search_tool_result`` pair per tool_call.
+
+        Native clients need both blocks (sharing a ``tool_use_id``) to render
+        web search citations.
+        """
         blocks: List[Dict[str, Any]] = []
         for i, tool_call in enumerate(tool_calls):
             tool_use_id = tool_call.get("id") or ""
+            tool_input = tool_call.get("input") or {}
+            query = tool_input.get("query") if isinstance(tool_input, dict) else None
             structured = structured_results[i] if i < len(structured_results) else None
+            blocks.append(
+                {
+                    "type": "server_tool_use",
+                    "id": tool_use_id,
+                    "name": "web_search",
+                    "input": {"query": query} if query is not None else {},
+                }
+            )
             blocks.append(
                 WebSearchTransformation.build_web_search_tool_result_block(
                     tool_use_id=tool_use_id,

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -224,10 +224,17 @@ class TestBuildPlanAttachesBlocks:
 
         blocks = plan.metadata.get(WEBSEARCH_NATIVE_BLOCKS_METADATA_KEY)
         assert isinstance(blocks, list)
-        assert len(blocks) == 1
-        assert blocks[0]["type"] == "web_search_tool_result"
-        assert blocks[0]["tool_use_id"] == "toolu_one"
-        assert blocks[0]["content"][0]["url"] == "https://docs.litellm.ai/"
+        # Each tool_call yields a paired server_tool_use + web_search_tool_result.
+        assert len(blocks) == 2
+        assert blocks[0]["type"] == "server_tool_use"
+        assert blocks[0]["id"] == "toolu_one"
+        assert blocks[0]["name"] == "web_search"
+        assert blocks[0]["input"] == {"query": "what is litellm"}
+        assert blocks[1]["type"] == "web_search_tool_result"
+        assert blocks[1]["tool_use_id"] == "toolu_one"
+        assert blocks[1]["content"][0]["url"] == "https://docs.litellm.ai/"
+        # server_tool_use.id must match web_search_tool_result.tool_use_id.
+        assert blocks[0]["id"] == blocks[1]["tool_use_id"]
 
     @pytest.mark.asyncio
     async def test_metadata_does_not_carry_blocks_when_flag_absent(self):
@@ -479,6 +486,9 @@ class TestLegacyPathMatchesNewPath:
                 kwargs={WEBSEARCH_EMIT_NATIVE_BLOCKS_KEY: True},
             )
 
-        assert out["content"][0]["type"] == "web_search_tool_result"
-        assert out["content"][0]["tool_use_id"] == "toolu_legacy"
-        assert out["content"][1]["type"] == "text"
+        assert out["content"][0]["type"] == "server_tool_use"
+        assert out["content"][0]["id"] == "toolu_legacy"
+        assert out["content"][0]["input"] == {"query": "q"}
+        assert out["content"][1]["type"] == "web_search_tool_result"
+        assert out["content"][1]["tool_use_id"] == "toolu_legacy"
+        assert out["content"][2]["type"] == "text"


### PR DESCRIPTION
## Relevant issues

Follow-up to #27886, which added native `server_tool_use` + `web_search_tool_result` blocks on the **short-circuit** web search path. This PR brings the **agentic-loop** path to parity.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🐛 Bug Fix

## Changes

`WebSearchInterceptionLogger._build_native_result_blocks` (used by the agentic-loop path for providers that have native Anthropic Messages support — `anthropic`, `bedrock`, `vertex_ai`, `azure_ai`) emitted only a `web_search_tool_result` block per tool call, **omitting the paired `server_tool_use` block**.

Anthropic-native clients (Claude Code, Claude Desktop, the Anthropic SDK) require both blocks to render citation cards. Without the `server_tool_use` block the client reports **"Did 0 searches"** even though the search ran and results were returned.

The short-circuit path already emits the pair (added in #27886). This makes the two paths consistent: each `web_search_tool_result` is now preceded by a `server_tool_use` block carrying the query, with a matching `tool_use_id`.

```diff
 for i, tool_call in enumerate(tool_calls):
     tool_use_id = tool_call.get("id") or ""
+    tool_input = tool_call.get("input") or {}
+    query = tool_input.get("query") if isinstance(tool_input, dict) else None
     structured = structured_results[i] if i < len(structured_results) else None
+    blocks.append({
+        "type": "server_tool_use", "id": tool_use_id,
+        "name": "web_search",
+        "input": {"query": query} if query is not None else {},
+    })
     blocks.append(WebSearchTransformation.build_web_search_tool_result_block(...))
```

## Tests

Updated `test_websearch_native_blocks.py` to assert the paired shape on both the plan path and the legacy path, including that `server_tool_use.id == web_search_tool_result.tool_use_id`.

```
pytest tests/test_litellm/integrations/websearch_interception/ -q
99 passed, 2 skipped
```

## Proof of fix

Running a proxy that routes Claude requests through the agentic-loop web search path, a `web_search_20250305` request now returns the full native shape:

```
content block types: ['server_tool_use', 'web_search_tool_result', 'text']
```

Before this fix the same request returned only `['web_search_tool_result', 'text']`, and Claude Code showed "Did 0 searches" with no citation card. After, the client renders citation cards normally.
