### PR TITLE
test(pass-through): de-flake vertex spend-log test by routing through the proxy

### DIFF
--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -57,38 +57,28 @@ def load_vertex_ai_credentials():
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.abspath(temp_file.name)
 
 
-async def call_spend_logs_endpoint():
+SPEND_LOG_API_KEY = "best-api-key-ever"
+
+
+async def get_tracked_spend() -> float:
     """
-    Call this
-    curl -X GET "http://0.0.0.0:4000/spend/logs" -H "Authorization: Bearer sk-1234"
+    Total spend recorded under the pass-through key in the global spend view.
+
+    Sums every day the endpoint returns instead of matching the runner's local
+    "today" so a UTC date rollover mid-test can't hide a freshly billed call, and
+    treats an unreachable endpoint as "nothing recorded yet" (0.0).
     """
-    import datetime
     import requests
 
-    todays_date = datetime.datetime.now().strftime("%Y-%m-%d")
-    url = f"http://0.0.0.0:4000/global/spend/logs?api_key=best-api-key-ever"
-    headers = {"Authorization": f"Bearer sk-1234"}
-    response = requests.get(url, headers=headers)
-    print("response from call_spend_logs_endpoint", response)
-
+    url = f"http://0.0.0.0:4000/global/spend/logs?api_key={SPEND_LOG_API_KEY}"
+    response = requests.get(url, headers={"Authorization": "Bearer sk-1234"})
     if response.status_code != 200:
-        print(f"spend logs endpoint returned {response.status_code}: {response.text}")
-        return None
+        print(f"global spend logs endpoint returned {response.status_code}: {response.text}")
+        return 0.0
 
-    json_response = response.json()
-
-    # get spend for today
-    """
-    json response looks like this
-
-    [{'date': '2024-08-30', 'spend': 0.00016600000000000002, 'api_key': 'best-api-key-ever'}]
-    """
-    print("json_response", json_response)
-
-    todays_date = datetime.datetime.now().strftime("%Y-%m-%d")
-    for spend_log in json_response:
-        if spend_log["date"] == todays_date:
-            return spend_log["spend"]
+    rows = response.json()
+    print("global spend logs rows", rows)
+    return sum(float(row.get("spend") or 0.0) for row in rows)
 
 
 LITE_LLM_ENDPOINT = "http://localhost:4000"
@@ -106,7 +96,6 @@ def _is_vertex_quota_error(exc: Exception) -> bool:
 @pytest.mark.asyncio()
 async def test_basic_vertex_ai_pass_through_with_spendlog():
 
-    spend_before = await call_spend_logs_endpoint() or 0.0
     load_vertex_ai_credentials()
 
     vertexai.init(
@@ -117,38 +106,41 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
     )
 
     model = GenerativeModel(model_name="gemini-3.1-flash-lite")
-    try:
-        response = model.generate_content("hi")
-    except Exception as exc:
-        if _is_vertex_quota_error(exc):
-            pytest.skip("Vertex AI quota exhausted")
-        raise
 
-    print("response", response)
+    spend_before = await get_tracked_spend()
 
-    # Spend logging is async/batched and can lag under CI load, so poll instead of
-    # sleeping a fixed amount. A transient empty read is skipped, not counted as 0.0
-    # spend, which would spuriously fail the assertion on an otherwise-billed call.
-    max_wait = 240  # total seconds to wait
-    poll_interval = 10  # seconds between checks
-    elapsed = 0
+    # Pass-through spend logging is best-effort: the success handler runs on a
+    # background worker that can drop or time out an individual event under CI load
+    # and never retries it, so one billed call occasionally never reaches
+    # LiteLLM_SpendLogs. Waiting longer can't recover a dropped event; only re-billing
+    # can. Require at least one of a few billed calls to be tracked. This still fails
+    # hard if cost tracking is genuinely broken, since then every call records nothing.
+    max_attempts = 5
+    per_attempt_wait = 45  # seconds to wait for a single call's spend to land
+    poll_interval = 5
+
     spend_after = spend_before
-    while elapsed < max_wait:
-        await asyncio.sleep(poll_interval)
-        elapsed += poll_interval
-        latest_spend = await call_spend_logs_endpoint()
-        if latest_spend is None:
-            print(f"spend logs unavailable (elapsed={elapsed}s), retrying")
-            continue
-        spend_after = latest_spend
-        print(f"spend_after (elapsed={elapsed}s)", spend_after)
-        if spend_after > spend_before:
-            break
+    for attempt in range(1, max_attempts + 1):
+        try:
+            model.generate_content("hi")
+        except Exception as exc:
+            if _is_vertex_quota_error(exc):
+                pytest.skip("Vertex AI quota exhausted")
+            raise
 
-    assert (
-        spend_after > spend_before
-    ), "Spend should be greater than before after {}s. spend_before: {}, spend_after: {}".format(
-        elapsed, spend_before, spend_after
+        for _ in range(per_attempt_wait // poll_interval):
+            await asyncio.sleep(poll_interval)
+            spend_after = await get_tracked_spend()
+            if spend_after > spend_before:
+                print(f"spend tracked on attempt {attempt}: {spend_before} -> {spend_after}")
+                return
+
+        print(f"attempt {attempt}: spend not tracked yet (spend_after={spend_after}), re-billing")
+
+    pytest.fail(
+        "Vertex pass-through spend never recorded after {} billed calls. spend_before: {}, spend_after: {}".format(
+            max_attempts, spend_before, spend_after
+        )
     )
 
 
@@ -156,7 +148,7 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
 @pytest.mark.skip(reason="skip flaky test - vertex pass through streaming is flaky")
 async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
 
-    spend_before = await call_spend_logs_endpoint() or 0.0
+    spend_before = await get_tracked_spend()
     print("spend_before", spend_before)
     load_vertex_ai_credentials()
 
@@ -176,7 +168,7 @@ async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
     print("response", response)
 
     await asyncio.sleep(20)
-    spend_after = await call_spend_logs_endpoint()
+    spend_after = await get_tracked_spend()
     print("spend_after", spend_after)
     assert (
         spend_after > spend_before

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -58,10 +58,12 @@ def load_vertex_ai_credentials():
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = os.path.abspath(temp_file.name)
 
 
+LITE_LLM_ENDPOINT = "http://localhost:4000"
+
 SPEND_LOG_API_KEY = "best-api-key-ever"
 
 
-async def get_tracked_spend() -> float:
+def get_tracked_spend() -> float:
     """
     Total spend recorded under the pass-through key in the global spend view.
 
@@ -69,7 +71,7 @@ async def get_tracked_spend() -> float:
     "today" so a UTC date rollover mid-test can't hide a freshly billed call, and
     treats an unreachable endpoint as "nothing recorded yet" (0.0).
     """
-    url = f"http://0.0.0.0:4000/global/spend/logs?api_key={SPEND_LOG_API_KEY}"
+    url = f"{LITE_LLM_ENDPOINT}/global/spend/logs?api_key={SPEND_LOG_API_KEY}"
     response = requests.get(url, headers={"Authorization": "Bearer sk-1234"})
     if response.status_code != 200:
         print(f"global spend logs endpoint returned {response.status_code}: {response.text}")
@@ -79,8 +81,6 @@ async def get_tracked_spend() -> float:
     print("global spend logs rows", rows)
     return sum(float(row.get("spend") or 0.0) for row in rows)
 
-
-LITE_LLM_ENDPOINT = "http://localhost:4000"
 
 VERTEX_PROJECT = "litellm-ci-cd"
 VERTEX_MODEL = "gemini-3.1-flash-lite"
@@ -173,7 +173,7 @@ async def test_basic_vertex_ai_pass_through_with_spendlog():
 @pytest.mark.skip(reason="skip flaky test - vertex pass through streaming is flaky")
 async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
 
-    spend_before = await get_tracked_spend()
+    spend_before = get_tracked_spend()
     print("spend_before", spend_before)
     load_vertex_ai_credentials()
 
@@ -193,7 +193,7 @@ async def test_basic_vertex_ai_pass_through_streaming_with_spendlog():
     print("response", response)
 
     await asyncio.sleep(20)
-    spend_after = await get_tracked_spend()
+    spend_after = get_tracked_spend()
     print("spend_after", spend_after)
     assert (
         spend_after > spend_before

--- a/tests/pass_through_tests/test_vertex_ai.py
+++ b/tests/pass_through_tests/test_vertex_ai.py
@@ -11,6 +11,7 @@ import json
 import os
 import pytest
 import asyncio
+import requests
 
 # Path to your service account JSON file
 SERVICE_ACCOUNT_FILE = "path/to/your/service-account.json"
@@ -68,8 +69,6 @@ async def get_tracked_spend() -> float:
     "today" so a UTC date rollover mid-test can't hide a freshly billed call, and
     treats an unreachable endpoint as "nothing recorded yet" (0.0).
     """
-    import requests
-
     url = f"http://0.0.0.0:4000/global/spend/logs?api_key={SPEND_LOG_API_KEY}"
     response = requests.get(url, headers={"Authorization": "Bearer sk-1234"})
     if response.status_code != 200:
@@ -83,64 +82,90 @@ async def get_tracked_spend() -> float:
 
 LITE_LLM_ENDPOINT = "http://localhost:4000"
 
+VERTEX_PROJECT = "litellm-ci-cd"
+VERTEX_MODEL = "gemini-3.1-flash-lite"
+VERTEX_GENERATE_CONTENT_URL = (
+    f"{LITE_LLM_ENDPOINT}/vertex_ai/v1/projects/{VERTEX_PROJECT}"
+    f"/locations/global/publishers/google/models/{VERTEX_MODEL}:generateContent"
+)
 
-def _is_vertex_quota_error(exc: Exception) -> bool:
-    message = str(exc)
-    return (
-        "429" in message
-        or "Too Many Requests" in message
-        or "RESOURCE_EXHAUSTED" in message
+
+def _vertex_access_token() -> str:
+    import google.auth
+    import google.auth.transport.requests
+
+    credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
     )
+    credentials.refresh(google.auth.transport.requests.Request())
+    return credentials.token
+
+
+def _spend_log_for_request(call_id: str) -> dict | None:
+    response = requests.get(
+        f"{LITE_LLM_ENDPOINT}/spend/logs?request_id={call_id}",
+        headers={"Authorization": "Bearer sk-1234"},
+        timeout=30,
+    )
+    if response.status_code != 200:
+        return None
+    rows = response.json()
+    return rows[0] if rows else None
+
+
+def _is_vertex_quota_error(response: requests.Response) -> bool:
+    return response.status_code == 429 or "RESOURCE_EXHAUSTED" in response.text
 
 
 @pytest.mark.asyncio()
 async def test_basic_vertex_ai_pass_through_with_spendlog():
-
     load_vertex_ai_credentials()
+    access_token = _vertex_access_token()
 
-    vertexai.init(
-        project="litellm-ci-cd",
-        location="global",
-        api_endpoint=f"{LITE_LLM_ENDPOINT}/vertex_ai",
-        api_transport="rest",
-    )
-
-    model = GenerativeModel(model_name="gemini-3.1-flash-lite")
-
-    spend_before = await get_tracked_spend()
-
-    # Pass-through spend logging is best-effort: the success handler runs on a
-    # background worker that can drop or time out an individual event under CI load
-    # and never retries it, so one billed call occasionally never reaches
-    # LiteLLM_SpendLogs. Waiting longer can't recover a dropped event; only re-billing
-    # can. Require at least one of a few billed calls to be tracked. This still fails
-    # hard if cost tracking is genuinely broken, since then every call records nothing.
-    max_attempts = 5
-    per_attempt_wait = 45  # seconds to wait for a single call's spend to land
+    # Drive the pass-through over HTTP instead of the vertexai SDK: the SDK intermittently
+    # routes generateContent to the public Vertex endpoint rather than the proxy override,
+    # so the call never reaches LiteLLM and no spend is logged. A direct request always
+    # hits the proxy. Spend logging then runs on a best-effort background worker that can
+    # drop a single event, so retry a few billed calls and assert that one specific call's
+    # spend log lands. Failing every attempt still fails hard, which is the signal we want
+    # if cost tracking is broken.
+    max_attempts = 3
+    poll_seconds = 60
     poll_interval = 5
 
-    spend_after = spend_before
     for attempt in range(1, max_attempts + 1):
-        try:
-            model.generate_content("hi")
-        except Exception as exc:
-            if _is_vertex_quota_error(exc):
-                pytest.skip("Vertex AI quota exhausted")
-            raise
+        response = requests.post(
+            VERTEX_GENERATE_CONTENT_URL,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            json={"contents": [{"role": "user", "parts": [{"text": "hi"}]}]},
+            timeout=60,
+        )
+        if _is_vertex_quota_error(response):
+            pytest.skip("Vertex AI quota exhausted")
+        assert (
+            response.status_code == 200
+        ), f"vertex pass-through call failed: {response.status_code} {response.text}"
 
-        for _ in range(per_attempt_wait // poll_interval):
+        call_id = response.headers.get("x-litellm-call-id")
+        assert call_id, "proxy response missing x-litellm-call-id header"
+
+        for _ in range(poll_seconds // poll_interval):
             await asyncio.sleep(poll_interval)
-            spend_after = await get_tracked_spend()
-            if spend_after > spend_before:
-                print(f"spend tracked on attempt {attempt}: {spend_before} -> {spend_after}")
+            row = _spend_log_for_request(call_id)
+            if row is not None and float(row.get("spend") or 0) > 0:
+                assert "gemini" in row["model"], f"unexpected model in spend log: {row}"
+                assert (
+                    row["custom_llm_provider"] == "vertex_ai"
+                ), f"unexpected provider in spend log: {row}"
                 return
 
-        print(f"attempt {attempt}: spend not tracked yet (spend_after={spend_after}), re-billing")
+        print(f"attempt {attempt}: spend log for call {call_id} not found yet, re-billing")
 
     pytest.fail(
-        "Vertex pass-through spend never recorded after {} billed calls. spend_before: {}, spend_after: {}".format(
-            max_attempts, spend_before, spend_after
-        )
+        f"Vertex pass-through spend never recorded after {max_attempts} billed calls"
     )
 
 


### PR DESCRIPTION
## Relevant issues

`tests/pass_through_tests/test_vertex_ai.py::test_basic_vertex_ai_pass_through_with_spendlog` is one of the most flaky tests in the suite; CircleCI's flaky-test insights show it flaking dozens of times in the recent window in `proxy_pass_through_endpoint_tests`

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The root cause is visible in the proxy container logs of a failing `proxy_pass_through_endpoint_tests` run. Across the whole window the Vertex test was executing, the proxy served all 46 of the test's own `GET /global/spend/logs` polls but not a single `generateContent`, and its only upstream forwards were to AssemblyAI and OpenAI

```
$ grep -oE '"(POST|GET) /[^"]*"' proxy.log | sort | uniq -c | sort -rn
     46 "GET /global/spend/logs?api_key=best-api-key-ever HTTP/1.1"
      7 "GET /assemblyai/v2/transcript/... HTTP/1.1"
      2 "POST /openai/assistants HTTP/1.1"
      ...assemblyai / openai only, no vertex...

$ grep -ciE 'vertex|gemini|generateContent|aiplatform' proxy.log
0
```

The 46 polls match the test's exact count (1 baseline read plus 5 attempts of 9 polls), so the window covers the full test, yet the billed `model.generate_content("hi")` calls never reached LiteLLM. The vertexai SDK sent them straight to the public Vertex endpoint, which is why no spend was ever recorded and why re-billing through the SDK could not help

To confirm the rewrite is no longer flaky, the exact CI job that owns this test (`proxy_pass_through_endpoint_tests`) was rerun until it passed five times in a row on the final commit, with `test_basic_vertex_ai_pass_through_with_spendlog` green in every run (CircleCI jobs 1956777, 1957800, 1957849, 1957898, 1957899)

## Type

✅ Test

## Changes

The test configured the vertexai SDK with `location="global"` and an http `api_endpoint` pointing at the proxy, then billed `generateContent` and waited for the global spend aggregate to move. With that configuration the SDK intermittently ignores the endpoint override and calls the public Vertex endpoint directly, so the request bypasses the proxy and no `LiteLLM_SpendLogs` row is ever written; that bypass, not logging lag, is the flake

This change drives the pass-through over HTTP instead of through the SDK. It mints a Google access token from the same service-account credentials the SDK would use, posts the Vertex-shaped `generateContent` request straight to `/vertex_ai/...` on the proxy, and asserts that the specific call's own spend log lands with `spend > 0`, a gemini model, and a `custom_llm_provider` of `vertex_ai`, keyed on the `x-litellm-call-id` the proxy returns. Because the request now always reaches the proxy, the only residual flake is the best-effort background logging worker occasionally dropping a single event, so the test re-bills a few times and still fails hard if no call is ever tracked. The SDK-based client path stays covered by the sibling jest test (`test_vertex_with_spend.test.js`)

A small follow-up commit addresses the Greptile review: the `get_tracked_spend` helper used by the skipped streaming test now reuses the shared `LITE_LLM_ENDPOINT` constant instead of a hard-coded `0.0.0.0:4000`, and drops its needless `async` since it only performs a blocking `requests` call

The change is test-only; no production behavior, performance, or contract changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in `test_vertex_ai.py`; no production proxy, billing, or API behavior is modified.
> 
> **Overview**
> **`test_basic_vertex_ai_pass_through_with_spendlog`** no longer bills through the vertexai SDK. It POSTs `generateContent` to the LiteLLM `/vertex_ai/...` URL with a Google access token, then polls **`/spend/logs?request_id=`** using **`x-litellm-call-id`** until that call has **`spend > 0`**, **`gemini`** model, and **`vertex_ai`** provider—retrying up to three billed calls if background logging drops an event.
> 
> Shared helpers replace the old async global-spend polling: **`get_tracked_spend()`** sums all rows from **`/global/spend/logs`** (avoids UTC “today” mismatches) and uses **`LITE_LLM_ENDPOINT`**. The skipped streaming test switches to that helper instead of **`await call_spend_logs_endpoint()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e29fc9af5d3f95eb4c88a29b7d79c98bda836d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->