### PR TITLE
feat(provider): add iFlytek Spark chat provider

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -289,6 +289,7 @@ novita_api_key: Optional[str] = None
 snowflake_key: Optional[str] = None
 gradient_ai_api_key: Optional[str] = None
 nebius_key: Optional[str] = None
+iflytek_key: Optional[str] = None
 wandb_key: Optional[str] = None
 heroku_key: Optional[str] = None
 cometapi_key: Optional[str] = None
@@ -626,6 +627,7 @@ llama_models: Set = set()
 nscale_models: Set = set()
 nebius_models: Set = set()
 nebius_embedding_models: Set = set()
+iflytek_models: Set = set()
 aiml_models: Set = set()
 deepgram_models: Set = set()
 elevenlabs_models: Set = set()
@@ -1123,6 +1125,7 @@ models_by_provider: dict = {
     "sambanova": sambanova_models | sambanova_embedding_models,
     "novita": novita_models,
     "nebius": nebius_models | nebius_embedding_models,
+    "iflytek": iflytek_models,
     "aiml": aiml_models,
     "assemblyai": assemblyai_models,
     "jina_ai": jina_ai_models,
@@ -1948,6 +1951,7 @@ if TYPE_CHECKING:
         GigaChatEmbeddingConfig as GigaChatEmbeddingConfig,
     )
     from .llms.nebius.chat.transformation import NebiusConfig as NebiusConfig
+    from .llms.iflytek.chat.transformation import IFlytekConfig as IFlytekConfig
     from .llms.wandb.chat.transformation import WandbConfig as WandbConfig
     from .llms.dashscope.chat.transformation import (
         DashScopeChatConfig as DashScopeChatConfig,

--- a/litellm/_lazy_imports_registry.py
+++ b/litellm/_lazy_imports_registry.py
@@ -301,6 +301,7 @@ LLM_CONFIG_NAMES = (
     "ManusResponsesAPIConfig",
     "GithubCopilotEmbeddingConfig",
     "NebiusConfig",
+    "IFlytekConfig",
     "WandbConfig",
     "GigaChatConfig",
     "GigaChatEmbeddingConfig",
@@ -1148,6 +1149,7 @@ _LLM_CONFIGS_IMPORT_MAP = {
         "ChatGPTResponsesAPIConfig",
     ),
     "NebiusConfig": (".llms.nebius.chat.transformation", "NebiusConfig"),
+    "IFlytekConfig": (".llms.iflytek.chat.transformation", "IFlytekConfig"),
     "WandbConfig": (".llms.wandb.chat.transformation", "WandbConfig"),
     "GigaChatConfig": (".llms.gigachat.chat.transformation", "GigaChatConfig"),
     "GigaChatEmbeddingConfig": (

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -550,6 +550,7 @@ LITELLM_CHAT_PROVIDERS = [
     "lemonade",
     "docker_model_runner",
     "amazon_nova",
+    "iflytek",
 ]
 
 LITELLM_EMBEDDING_PROVIDERS_SUPPORTING_INPUT_ARRAY_OF_TOKENS = [
@@ -714,6 +715,7 @@ openai_compatible_endpoints: List = [
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
     "https://pinstripes.io/v1",
+    "https://spark-api-open.xf-yun.com/v1",
 ]
 
 
@@ -779,6 +781,7 @@ openai_compatible_providers: List = [
     "ragflow",
     "pinstripes",  # Pinstripes - JSON-configured provider
     "darkbloom",
+    "iflytek",
 ]
 openai_text_completion_compatible_providers: List = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -274,6 +274,9 @@ def get_llm_provider(
                     elif endpoint == "api.deepseek.com/v1":
                         custom_llm_provider = "deepseek"
                         dynamic_api_key = get_secret_str("DEEPSEEK_API_KEY")
+                    elif endpoint == "https://spark-api-open.xf-yun.com/v1":
+                        custom_llm_provider = "iflytek"
+                        dynamic_api_key = get_secret_str("IFLYTEK_API_KEY")
                     elif endpoint == "ollama.com":
                         custom_llm_provider = "ollama"
                         dynamic_api_key = get_secret_str("OLLAMA_API_KEY")
@@ -608,6 +611,9 @@ def _get_openai_compatible_provider_info(
     elif custom_llm_provider == "nebius":
         api_base = api_base or get_secret("NEBIUS_API_BASE") or "https://api.studio.nebius.ai/v1"  # type: ignore
         dynamic_api_key = api_key or get_secret_str("NEBIUS_API_KEY")
+    elif custom_llm_provider == "iflytek":
+        api_base = api_base or get_secret("IFLYTEK_API_BASE") or "https://spark-api-open.xf-yun.com/v1"  # type: ignore
+        dynamic_api_key = api_key or get_secret_str("IFLYTEK_API_KEY")
     elif custom_llm_provider == "ollama":
         api_base = api_base or get_secret("OLLAMA_API_BASE") or "http://localhost:11434"  # type: ignore
         dynamic_api_key = api_key or get_secret_str("OLLAMA_API_KEY")

--- a/litellm/litellm_core_utils/get_supported_openai_params.py
+++ b/litellm/litellm_core_utils/get_supported_openai_params.py
@@ -159,6 +159,9 @@ def get_supported_openai_params(
     elif custom_llm_provider == "nebius":
         if request_type == "chat_completion":
             return litellm.NebiusConfig().get_supported_openai_params(model=model)
+    elif custom_llm_provider == "iflytek":
+        if request_type == "chat_completion":
+            return litellm.IFlytekConfig().get_supported_openai_params(model=model)
     elif custom_llm_provider == "wandb":
         if request_type == "chat_completion":
             return litellm.WandbConfig().get_supported_openai_params(model=model)

--- a/litellm/llms/iflytek/chat/transformation.py
+++ b/litellm/llms/iflytek/chat/transformation.py
@@ -1,0 +1,29 @@
+"""
+iFlytek Spark Chat Completions API - Transformation
+
+iFlytek Spark exposes an OpenAI-compatible `/v1/chat/completions` endpoint
+(https://spark-api-open.xf-yun.com/v1), so no request/response translation is
+required beyond the standard OpenAI-compatible handling.
+"""
+
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+
+
+class IFlytekConfig(OpenAIGPTConfig):
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        """
+        map max_completion_tokens param to max_tokens
+        """
+        supported_openai_params = self.get_supported_openai_params(model=model)
+        for param, value in non_default_params.items():
+            if param == "max_completion_tokens":
+                optional_params["max_tokens"] = value
+            elif param in supported_openai_params:
+                optional_params[param] = value
+        return optional_params

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5467,6 +5467,7 @@ def completion(  # type: ignore
             or custom_llm_provider == "openai"
             or custom_llm_provider == "together_ai"
             or custom_llm_provider == "nebius"
+            or custom_llm_provider == "iflytek"
             or custom_llm_provider == "wandb"
             or custom_llm_provider == "clarifai"
             or custom_llm_provider in litellm.openai_compatible_providers

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -761,6 +761,24 @@
         "interactions": true
       }
     },
+    "iflytek": {
+      "display_name": "iFlytek Spark (`iflytek`)",
+      "url": "https://docs.litellm.ai/docs/providers/iflytek",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": true,
+        "interactions": true
+      }
+    },
     "duckduckgo": {
       "display_name": "DuckDuckGo (`duckduckgo`)",
       "url": "https://docs.litellm.ai/docs/search/duckduckgo",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3315,6 +3315,7 @@ class LlmProviders(str, Enum):
     LM_STUDIO = "lm_studio"
     GALADRIEL = "galadriel"
     NEBIUS = "nebius"
+    IFLYTEK = "iflytek"
     INFINITY = "infinity"
     DEEPGRAM = "deepgram"
     ELEVENLABS = "elevenlabs"

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4238,6 +4238,13 @@ def get_optional_params(
             model=model,
             drop_params=(drop_params if drop_params is not None and isinstance(drop_params, bool) else False),
         )
+    elif custom_llm_provider == "iflytek":
+        optional_params = litellm.IFlytekConfig().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=model,
+            drop_params=(drop_params if drop_params is not None and isinstance(drop_params, bool) else False),
+        )
     elif custom_llm_provider == "nebius":
         optional_params = litellm.NebiusConfig().map_openai_params(
             non_default_params=non_default_params,
@@ -4726,6 +4733,9 @@ def get_api_key(llm_provider: str, dynamic_api_key: Optional[str]):
         api_key = (
             api_key or litellm.togetherai_api_key or get_secret("TOGETHERAI_API_KEY") or get_secret("TOGETHER_AI_TOKEN")
         )
+    # iflytek
+    elif llm_provider == "iflytek":
+        api_key = api_key or litellm.iflytek_key or get_secret("IFLYTEK_API_KEY")
     # nebius
     elif llm_provider == "nebius":
         api_key = api_key or litellm.nebius_key or get_secret("NEBIUS_API_KEY")
@@ -7653,6 +7663,7 @@ class ProviderConfigManager:
             LlmProviders.FEATHERLESS_AI: (lambda: litellm.FeatherlessAIConfig(), False),
             LlmProviders.NOVITA: (lambda: litellm.NovitaConfig(), False),
             LlmProviders.NEBIUS: (lambda: litellm.NebiusConfig(), False),
+            LlmProviders.IFLYTEK: (lambda: litellm.IFlytekConfig(), False),
             LlmProviders.WANDB: (lambda: litellm.WandbConfig(), False),
             LlmProviders.DASHSCOPE: (lambda: litellm.DashScopeChatConfig(), False),
             LlmProviders.MODELSCOPE: (lambda: litellm.ModelScopeChatConfig(), False),

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -814,6 +814,24 @@
         "interactions": true
       }
     },
+    "iflytek": {
+      "display_name": "iFlytek Spark (`iflytek`)",
+      "url": "https://docs.litellm.ai/docs/providers/iflytek",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": true,
+        "interactions": true
+      }
+    },
     "duckduckgo": {
       "display_name": "DuckDuckGo (`duckduckgo`)",
       "url": "https://docs.litellm.ai/docs/search/duckduckgo",

--- a/tests/test_litellm/llms/iflytek/test_iflytek_chat_transformation.py
+++ b/tests/test_litellm/llms/iflytek/test_iflytek_chat_transformation.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for the iFlytek Spark configuration.
+
+iFlytek Spark is an OpenAI-compatible provider; these tests validate the
+provider routing, default API base, reverse endpoint detection and the
+IFlytekConfig param mapping.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import pytest
+
+import litellm
+from litellm import completion, get_llm_provider
+from litellm.llms.iflytek.chat.transformation import IFlytekConfig
+
+IFLYTEK_API_BASE = "https://spark-api-open.xf-yun.com/v1"
+
+
+class TestIFlytekRouting:
+    def test_provider_prefix_routing(self):
+        model, provider, dynamic_api_key, api_base = get_llm_provider(
+            model="iflytek/4.0Ultra", api_key="fake-iflytek-key"
+        )
+        assert model == "4.0Ultra"
+        assert provider == "iflytek"
+        assert api_base == IFLYTEK_API_BASE
+
+    def test_reverse_endpoint_detection(self):
+        _, provider, _, api_base = get_llm_provider(model="generalv3.5", api_base=IFLYTEK_API_BASE)
+        assert provider == "iflytek"
+        assert api_base == IFLYTEK_API_BASE
+
+    def test_api_base_env_override(self, monkeypatch):
+        monkeypatch.setenv("IFLYTEK_API_BASE", "https://custom.spark.example/v1")
+        _, provider, _, api_base = get_llm_provider(model="iflytek/lite", api_key="fake-iflytek-key")
+        assert provider == "iflytek"
+        assert api_base == "https://custom.spark.example/v1"
+
+
+class TestIFlytekConfig:
+    def test_map_max_completion_tokens(self):
+        mapped = IFlytekConfig().map_openai_params(
+            non_default_params={"max_completion_tokens": 50, "temperature": 0.3},
+            optional_params={},
+            model="4.0Ultra",
+            drop_params=False,
+        )
+        assert mapped["max_tokens"] == 50
+        assert mapped["temperature"] == 0.3
+        assert "max_completion_tokens" not in mapped
+
+    @pytest.mark.respx()
+    def test_iflytek_completion_uses_default_base(self, respx_mock):
+        """
+        With no api_base passed, the request must go to the iFlytek Spark default
+        endpoint with the provided key. This fails if the default-base routing or
+        the openai-compatible wiring is broken.
+        """
+        litellm.disable_aiohttp_transport = True
+
+        api_key = "fake-iflytek-key"
+        route = respx_mock.post(f"{IFLYTEK_API_BASE}/chat/completions").respond(
+            json={
+                "id": "chatcmpl-spark-1",
+                "object": "chat.completion",
+                "created": 1677652288,
+                "model": "4.0Ultra",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "你好,来自 LiteLLM"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 9, "completion_tokens": 6, "total_tokens": 15},
+            },
+            status_code=200,
+        )
+
+        response = completion(
+            model="iflytek/4.0Ultra",
+            messages=[{"role": "user", "content": "say hi"}],
+            api_key=api_key,
+        )
+
+        assert route.called
+        sent = route.calls.last.request
+        assert sent.headers["authorization"] == f"Bearer {api_key}"
+        assert response.choices[0].message.content == "你好,来自 LiteLLM"


### PR DESCRIPTION
## Relevant issues

None

## Linear ticket

None

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

iFlytek Spark is an OpenAI-compatible chat endpoint, so once the provider is registered it behaves like any other openai-compatible provider. The SDK path works directly

```python
from litellm import completion

# IFLYTEK_API_KEY = the Spark HTTP API password from the iFlytek open platform console
resp = completion(
    model="iflytek/4.0Ultra",
    messages=[{"role": "user", "content": "用一句话介绍你自己"}],
)
print(resp.choices[0].message.content)
```

On the proxy, register the model in `config.yaml` like any other provider and call it by its `model_name`

```yaml
model_list:
  - model_name: spark-4-ultra
    litellm_params:
      model: iflytek/4.0Ultra
      api_key: os.environ/IFLYTEK_API_KEY
```

```bash
curl http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model": "spark-4-ultra", "messages": [{"role": "user", "content": "say hi"}]}'
```

I do not have a paid Spark key to attach a live run; the routing, default base url, reverse endpoint detection and param mapping are covered by `tests/test_litellm/llms/iflytek/test_iflytek_chat_transformation.py`, including a mocked completion that asserts the request lands on `https://spark-api-open.xf-yun.com/v1/chat/completions` with the bearer key

## Type

🆕 New Feature

## Changes

Adds iFlytek Spark as a first-class openai-compatible provider. Models are addressed as `iflytek/<model>` (for example `iflytek/4.0Ultra`, `iflytek/generalv3.5`, `iflytek/lite`), the default api base is `https://spark-api-open.xf-yun.com/v1` and the key is read from `IFLYTEK_API_KEY`

`IFlytekConfig` extends `OpenAIGPTConfig` and maps `max_completion_tokens` to `max_tokens`, matching how the other openai-compatible providers behave. The provider is registered in the chat provider list, the openai-compatible provider and endpoint lists, the lazy import registry, the `LlmProviders` enum, provider routing and reverse endpoint detection, supported-params and param-mapping dispatch, `ProviderConfigManager`, and the provider endpoints support manifest

The change is intentionally minimal and does not add model pricing or embedding support; pricing entries can follow once confirmed, and Spark's embedding API is not openai-compatible in the same way
