### PR TITLE
feat(proxy): optionally preserve unknown OpenAI request parameters for Provider mapping

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -225,7 +225,7 @@ token: Optional[str] = (
 telemetry = True
 max_tokens: int = DEFAULT_MAX_TOKENS  # OpenAI Defaults
 drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
-passthrough_unknown_openai_params = False
+passthrough_unknown_openai_params = bool(os.getenv("LITELLM_PASSTHROUGH_UNKNOWN_OPENAI_PARAMS", False))
 modify_params = bool(os.getenv("LITELLM_MODIFY_PARAMS", False))
 use_chat_completions_url_for_anthropic_messages: bool = bool(
     os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", False)

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -225,6 +225,7 @@ token: Optional[str] = (
 telemetry = True
 max_tokens: int = DEFAULT_MAX_TOKENS  # OpenAI Defaults
 drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
+passthrough_unknown_openai_params = False
 modify_params = bool(os.getenv("LITELLM_MODIFY_PARAMS", False))
 use_chat_completions_url_for_anthropic_messages: bool = bool(
     os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", False)

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -225,7 +225,7 @@ token: Optional[str] = (
 telemetry = True
 max_tokens: int = DEFAULT_MAX_TOKENS  # OpenAI Defaults
 drop_params = bool(os.getenv("LITELLM_DROP_PARAMS", False))
-passthrough_unknown_openai_params = bool(os.getenv("LITELLM_PASSTHROUGH_UNKNOWN_OPENAI_PARAMS", False))
+passthrough_unknown_openai_params = os.getenv("LITELLM_PASSTHROUGH_UNKNOWN_OPENAI_PARAMS", "").lower() in ("1", "true", "yes")
 modify_params = bool(os.getenv("LITELLM_MODIFY_PARAMS", False))
 use_chat_completions_url_for_anthropic_messages: bool = bool(
     os.getenv("LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES", False)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3818,7 +3818,10 @@ def get_optional_params(
                     unsupported_params[k] = non_default_params[k]
 
         if unsupported_params:
-            if litellm.drop_params is True or (drop_params is not None and drop_params is True):
+            if litellm.passthrough_unknown_openai_params:
+                # Preserve unknown params in non_default_params for provider-specific handling.
+                return
+            elif litellm.drop_params is True or (drop_params is not None and drop_params is True):
                 for k in unsupported_params.keys():
                     non_default_params.pop(k, None)
             else:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3889,6 +3889,108 @@ class TestGetOptionalParamsDeepSeek:
         assert result.get("thinking") == {"type": "enabled"}
 
 
+class TestPassthroughUnknownOpenaiParams:
+    """Tests for litellm.passthrough_unknown_openai_params.
+
+    Replicate intentionally doesn't advertise `logprobs` in its supported
+    params, making it a reliable regression target: the param is listed in
+    DEFAULT_CHAT_COMPLETION_PARAM_VALUES so it reaches `_check_valid_arg`.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _reset_globals(self):
+        passthrough_old = litellm.passthrough_unknown_openai_params
+        drop_old = litellm.drop_params
+        yield
+        litellm.passthrough_unknown_openai_params = passthrough_old
+        litellm.drop_params = drop_old
+
+    def test_default_rejects_provider_unsupported_param(self):
+        from litellm.exceptions import UnsupportedParamsError
+        from litellm.utils import get_optional_params
+
+        litellm.passthrough_unknown_openai_params = False
+
+        with pytest.raises(UnsupportedParamsError):
+            get_optional_params(
+                model="meta/llama",
+                custom_llm_provider="replicate",
+                logprobs=True,
+            )
+
+    def test_passthrough_does_not_raise(self):
+        from litellm.utils import get_optional_params
+
+        litellm.passthrough_unknown_openai_params = True
+
+        result = get_optional_params(
+            model="meta/llama",
+            custom_llm_provider="replicate",
+            logprobs=True,
+        )
+        assert isinstance(result, dict)
+
+    def _capture_non_default_params(self, monkeypatch):
+        """Monkeypatch ReplicateConfig.map_openai_params to capture non_default_params.
+
+        Returns a dict that will be populated with the non_default_params
+        the Provider receives. The stub does not call the real implementation
+        so this remains a unit test of the Proxy → Provider handoff, not
+        an integration test of Replicate's request transformation.
+        """
+        import litellm.llms.replicate.chat.transformation as replicate_mod
+
+        captured = {}
+
+        def _capturing_map(self, non_default_params, optional_params, **kw):
+            captured.update(non_default_params)
+            return optional_params
+
+        monkeypatch.setattr(
+            replicate_mod.ReplicateConfig,
+            "map_openai_params",
+            _capturing_map,
+            raising=True,
+        )
+
+        return captured
+
+    def test_provider_receives_unsupported_param_in_non_default_params(self, monkeypatch):
+        from litellm.utils import get_optional_params
+
+        litellm.passthrough_unknown_openai_params = True
+
+        captured = self._capture_non_default_params(monkeypatch)
+
+        get_optional_params(
+            model="meta/llama",
+            custom_llm_provider="replicate",
+            logprobs=True,
+        )
+
+        assert "logprobs" in captured
+        assert captured["logprobs"] is True
+
+    def test_passthrough_takes_priority_over_drop_params(self, monkeypatch):
+        """passthrough must take priority over drop_params to preserve
+        unknown params for the provider rather than silently dropping them."""
+        from litellm.utils import get_optional_params
+
+        litellm.drop_params = True
+        litellm.passthrough_unknown_openai_params = True
+
+        captured = self._capture_non_default_params(monkeypatch)
+
+        get_optional_params(
+            model="meta/llama",
+            custom_llm_provider="replicate",
+            logprobs=True,
+        )
+
+        assert "logprobs" in captured
+        assert captured["logprobs"] is True
+
+
 class TestIsStreamingRequest:
     def test_stream_true_in_kwargs(self):
         assert (


### PR DESCRIPTION
````markdown
## Summary

Introduce an optional Proxy/runtime setting:

```yaml
litellm_settings:
  passthrough_unknown_openai_params: true
````

When enabled, LiteLLM no longer rejects OpenAI-compatible request parameters that are unknown to LiteLLM itself. Instead, they are preserved in `non_default_params` and passed to the Provider's `map_openai_params()` implementation for Provider-specific handling.

By default (`false`), behavior is unchanged.

---

## Motivation

LiteLLM is commonly deployed as an OpenAI-compatible API Gateway in front of multiple LLM Providers.

Many Providers expose request parameters that intentionally extend the OpenAI Chat Completions schema, for example:

* Anthropic: `thinking`
* OpenRouter: `provider`
* Gemini: provider-specific generation options
* Future Provider-specific request extensions

Today these parameters are validated by `_check_valid_arg()` before the Provider receives them.

As a result, requests like:

```json
{
  "model": "anthropic/claude-sonnet",
  "messages": [...],
  "thinking": {
    "budget_tokens": 1024
  }
}
```

fail with:

```
UnsupportedParamsError: thinking
```

even though the downstream Provider supports the parameter.

This makes LiteLLM Proxy stricter than many downstream Providers.

---

## Proposed change

Add a new global configuration:

```python
litellm.passthrough_unknown_openai_params = True
```

or

```yaml
litellm_settings:
  passthrough_unknown_openai_params: true
```

When enabled:

* unknown OpenAI request parameters are **not rejected**
* unknown parameters remain available in `non_default_params`
* Providers decide whether to consume or ignore them

When disabled (default):

* existing validation behavior is preserved
* `UnsupportedParamsError` continues to be raised

---

## Design

Current flow:

```
request
    ↓
_check_valid_arg()
    ↓
UnsupportedParamsError
```

New flow (optional):

```
request
    ↓
_check_valid_arg()
    ↓
non_default_params
    ↓
Provider.map_openai_params(...)
    ↓
Provider decides whether to consume the parameter
```

This change intentionally **does not**:

* modify `optional_params`
* inject unknown parameters into outgoing HTTP requests
* change Provider implementations

Instead, it simply defers Provider-specific parameter interpretation to the Provider layer, which already owns protocol adaptation.

---

## Why not `allowed_openai_params`?

`allowed_openai_params` requires LiteLLM itself to recognize every Provider-specific request extension.

However, downstream Providers frequently introduce new request parameters independently of LiteLLM releases.

This feature allows Gateway deployments to forward those request extensions immediately without waiting for LiteLLM to add explicit support.

---

## Backward compatibility

Default value:

```python
litellm.passthrough_unknown_openai_params = False
```

Therefore:

* existing applications behave exactly as before
* existing validation behavior is unchanged
* the feature is entirely opt-in

---

## Interaction with `drop_params`

If both are enabled:

```python
litellm.drop_params = True
litellm.passthrough_unknown_openai_params = True
```

`passthrough_unknown_openai_params` takes precedence.

This preserves unknown parameters for Provider-specific handling rather than silently dropping them.

---

## Example

### Before

```http
POST /v1/chat/completions
```

```json
{
  "model": "anthropic/claude-sonnet",
  "messages": [...],
  "thinking": {
    "budget_tokens": 1024
  }
}
```

↓

```
UnsupportedParamsError: thinking
```

---

### After

```yaml
litellm_settings:
  passthrough_unknown_openai_params: true
```

```
thinking
    ↓
non_default_params
    ↓
Provider.map_openai_params(...)
    ↓
Provider decides whether to consume it
```

If the Provider supports the parameter (for example Anthropic's `thinking`), it can process it normally.

---

## Tests

Added regression tests covering:

* default behavior still raises `UnsupportedParamsError`
* passthrough mode no longer raises
* unknown parameters are preserved in `non_default_params`
* Providers receive unknown parameters during `map_openai_params()`
* `passthrough_unknown_openai_params` takes precedence over `drop_params`

---

## Scope

This PR intentionally only changes Chat Completions parameter validation.

It does **not** modify:

* Embeddings
* Images
* Audio / Transcriptions
* Provider request transformation logic

Those endpoints can be evaluated independently if similar Gateway requirements arise.

## Maintainer note

This PR intentionally keeps the implementation minimal.

Rather than introducing a generic parameter forwarding mechanism or modifying Provider request bodies, it only relaxes validation at the Proxy layer. Existing Provider implementations remain solely responsible for interpreting Provider-specific request parameters.

This keeps the change low-risk, fully backward compatible, and aligned with LiteLLM's existing Provider mapping architecture.
````