### PR TITLE
fix(responses): coerce None content to empty string in output_text

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -1933,7 +1933,7 @@ class LiteLLMCompletionResponsesConfig:
 
         return OutputText(
             type="output_text",
-            text=message.content,
+            text=message.content if message.content is not None else "",
             annotations=transformed_annotations,
         )
 

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2853,3 +2853,42 @@ def test_streaming_function_call_tool_id_for_degenerate_call_id():
 
     assert stream_tool_id("fc_unique_abc123", "call_0") == "fc_unique_abc123"
     assert stream_tool_id("fc_2", "call_tokyo") == "call_tokyo"
+
+def test_none_content_in_assistant_message_produces_empty_string_text():
+    """
+    Regression test for issue #31696.
+
+    When a provider (e.g. Gemini via Vertex AI) returns an assistant message with
+    tool_calls but content=None, the back-translation to Responses API should emit
+    text="" (empty string), not text=None. The OpenAI Responses API spec defines
+    ResponseOutputText.text as a required, non-nullable str field.
+    """
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+    from litellm.types.utils import Message
+
+    # Simulate a Gemini assistant message: content is None, tool_calls present
+    message = Message(
+        role="assistant",
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_abc123",
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"location": "Paris"}',
+                },
+            }
+        ],
+    )
+
+    result = LiteLLMCompletionResponsesConfig._transform_chat_message_to_response_output_text(
+        message
+    )
+
+    assert result.text is not None, "text should not be None"
+    assert result.text == "", "text should be empty string when content is None"
+    assert result.type == "output_text"
+


### PR DESCRIPTION
When a provider returns an assistant message with tool_calls but no text content (content=None), the back-translation to the Responses API emits "text": null in the output_text content block. The OpenAI Responses API spec defines ResponseOutputText.text as a required, non-nullable str field. This causes downstream consumers that trust the spec (e.g. langchain-openai's _get_output_text) to crash with TypeError when joining content items.

This happens routinely with Gemini models on Vertex AI when the model invokes a tool: it emits a blank text block alongside the function_call block, and the assistant message's content field is None.

The production realtime handler (litellm/llms/openai/realtime/handler.py) already handles this correctly via _get_ssl_config, and the streaming iterator (streaming_iterator.py:435) uses text="" for the same reason. The non-streaming back-translation path was inconsistent.

Fix: coerce None to empty string in _transform_chat_message_to_response_output_text.

Added a regression test that constructs an assistant message with content=None and tool_calls, then asserts the resulting OutputText.text is an empty string, not None.

Fixes #31696
