### PR TITLE
feat: add native github_copilot Anthropic Messages provider

### DIFF
--- a/litellm/anthropic_beta_headers_config.json
+++ b/litellm/anthropic_beta_headers_config.json
@@ -184,5 +184,8 @@
     "token-efficient-tools-2025-02-19": "token-efficient-tools-2025-02-19",
     "web-fetch-2025-09-10": "web-fetch-2025-09-10",
     "web-search-2025-03-05": "web-search-2025-03-05"
+  },
+  "provider_aliases": {
+    "github_copilot": "anthropic"
   }
 }

--- a/litellm/llms/github_copilot/messages/transformation.py
+++ b/litellm/llms/github_copilot/messages/transformation.py
@@ -1,0 +1,80 @@
+"""
+GitHub Copilot Anthropic Messages transformation.
+
+Routes ``/v1/messages`` to Copilot's native Anthropic-compatible endpoint
+instead of translating to chat/completions, so native content blocks (notably
+PDF ``document`` blocks) pass through untouched. Auth reuses the shared
+Authenticator + the standard Copilot headers; beta-header handling is inherited
+from ``AnthropicMessagesConfig``.
+"""
+
+from typing import Any, Optional
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+
+from ..authenticator import Authenticator
+from ..common_utils import (
+    DEFAULT_GITHUB_COPILOT_API_BASE,
+    get_copilot_default_headers,
+)
+
+
+class GithubCopilotMessagesConfig(AnthropicMessagesConfig):
+    """Anthropic Messages config for GitHub Copilot's native /v1/messages."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.authenticator = Authenticator()
+
+    @property
+    def custom_llm_provider(self) -> Optional[str]:
+        return "github_copilot"
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        api_key: Optional[str],
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: Optional[bool] = None,
+    ) -> str:
+        base_url = api_base or DEFAULT_GITHUB_COPILOT_API_BASE
+        if base_url.endswith("/v1/messages"):
+            return base_url
+        return f"{base_url.rstrip('/')}/v1/messages"
+
+    def validate_anthropic_messages_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: list[Any],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+    ) -> tuple[dict, Optional[str]]:
+        # Apply the standard Copilot headers (bearer token + editor identity)
+        # unless the caller already supplied auth.
+        has_auth = "authorization" in {k.lower() for k in headers}
+        if not has_auth:
+            token = api_key or self.authenticator.get_api_key()
+            for key, value in get_copilot_default_headers(token).items():
+                headers.setdefault(key, value)
+        # Delegate to the parent for anthropic-version and the feature-driven
+        # anthropic-beta injection (e.g. context_management ->
+        # 'context-management-2025-06-27'), which the Copilot backend requires.
+        # The parent doesn't recognise our capitalized "Authorization", so drop
+        # the api_key to stop it adding a redundant x-api-key alongside it.
+        headers, api_base = super().validate_anthropic_messages_environment(
+            headers=headers,
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+            api_key=None if not has_auth else api_key,
+            api_base=api_base,
+        )
+        return headers, api_base

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -7984,6 +7984,12 @@ class ProviderConfigManager:
             )
 
             return DeepSeekAnthropicMessagesConfig()
+        elif litellm.LlmProviders.GITHUB_COPILOT == provider:
+            from litellm.llms.github_copilot.messages.transformation import (
+                GithubCopilotMessagesConfig,
+            )
+
+            return GithubCopilotMessagesConfig()
         return None
 
     @staticmethod

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -343,7 +343,7 @@ class TestShortCircuitEmitsNativeBlocks:
 
     @pytest.mark.asyncio
     async def test_native_tool_short_circuit_emits_blocks(self):
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(
             logger,
@@ -351,7 +351,7 @@ class TestShortCircuitEmitsNativeBlocks:
             new=AsyncMock(return_value=("Title: x\nURL: y", _make_search_response())),
         ):
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[{"role": "user", "content": "search query"}],
                 tools=[
                     {
@@ -360,7 +360,7 @@ class TestShortCircuitEmitsNativeBlocks:
                         "max_uses": 3,
                     }
                 ],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None
@@ -381,7 +381,7 @@ class TestShortCircuitEmitsNativeBlocks:
     @pytest.mark.asyncio
     async def test_litellm_standard_tool_short_circuit_stays_text_only(self):
         """Non-native tool → existing text-only short-circuit, no regression."""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(
             logger,
@@ -389,7 +389,7 @@ class TestShortCircuitEmitsNativeBlocks:
             new=AsyncMock(return_value=("Title: x\nURL: y", _make_search_response())),
         ):
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[{"role": "user", "content": "search query"}],
                 tools=[
                     {
@@ -401,7 +401,7 @@ class TestShortCircuitEmitsNativeBlocks:
                         },
                     }
                 ],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None
@@ -413,14 +413,14 @@ class TestShortCircuitEmitsNativeBlocks:
         """Search failure on native path: emit blocks with empty results +
         the legacy text-error block, so the client gets a well-formed
         response instead of a malformed half-shape."""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(logger, "_execute_search", side_effect=RuntimeError("boom")):
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[{"role": "user", "content": "search query"}],
                 tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
@@ -24,7 +24,7 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_short_circuits_single_web_search_tool(self):
         """Single web_search_20250305 tool → short-circuit fires"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
@@ -35,14 +35,14 @@ class TestTryShortCircuitSearch:
             )
 
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[
                     {"role": "user", "content": "Search for Claude Code releases"}
                 ],
                 tools=[
                     {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
                 ],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None
@@ -63,16 +63,16 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_does_not_short_circuit_mixed_tools(self):
         """Mix of web_search and other tools → NOT short-circuited"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         result = await logger.try_short_circuit_search(
-            model="github_copilot/claude-sonnet-4",
+            model="gemini/gemini-2.0-flash",
             messages=[{"role": "user", "content": "Do something"}],
             tools=[
                 {"type": "web_search_20250305", "name": "web_search", "max_uses": 8},
                 {"name": "Read", "description": "Read a file", "input_schema": {}},
             ],
-            custom_llm_provider="github_copilot",
+            custom_llm_provider="gemini",
         )
 
         assert result is None
@@ -80,13 +80,13 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_does_not_short_circuit_no_tools(self):
         """No tools → NOT short-circuited"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         result = await logger.try_short_circuit_search(
-            model="github_copilot/claude-sonnet-4",
+            model="gemini/gemini-2.0-flash",
             messages=[{"role": "user", "content": "Hello"}],
             tools=None,
-            custom_llm_provider="github_copilot",
+            custom_llm_provider="gemini",
         )
 
         assert result is None
@@ -94,13 +94,13 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_does_not_short_circuit_empty_tools(self):
         """Empty tools list → NOT short-circuited"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         result = await logger.try_short_circuit_search(
-            model="github_copilot/claude-sonnet-4",
+            model="gemini/gemini-2.0-flash",
             messages=[{"role": "user", "content": "Hello"}],
             tools=[],
-            custom_llm_provider="github_copilot",
+            custom_llm_provider="gemini",
         )
 
         assert result is None
@@ -111,12 +111,12 @@ class TestTryShortCircuitSearch:
         logger = WebSearchInterceptionLogger(enabled_providers=["bedrock"])
 
         result = await logger.try_short_circuit_search(
-            model="github_copilot/claude-sonnet-4",
+            model="gemini/gemini-2.0-flash",
             messages=[{"role": "user", "content": "Search for something"}],
             tools=[
                 {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
             ],
-            custom_llm_provider="github_copilot",
+            custom_llm_provider="gemini",
         )
 
         assert result is None
@@ -130,7 +130,7 @@ class TestTryShortCircuitSearch:
         The short-circuit must not fire for them.
         """
         logger = WebSearchInterceptionLogger(
-            enabled_providers=["bedrock", "github_copilot"]
+            enabled_providers=["bedrock", "gemini"]
         )
 
         result = await logger.try_short_circuit_search(
@@ -147,15 +147,15 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_does_not_short_circuit_no_messages(self):
         """Empty messages → NOT short-circuited"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         result = await logger.try_short_circuit_search(
-            model="github_copilot/claude-sonnet-4",
+            model="gemini/gemini-2.0-flash",
             messages=[],
             tools=[
                 {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
             ],
-            custom_llm_provider="github_copilot",
+            custom_llm_provider="gemini",
         )
 
         assert result is None
@@ -163,7 +163,7 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_search_failure_returns_error_text(self):
         """Search failure → response with error message, not exception"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
@@ -171,12 +171,12 @@ class TestTryShortCircuitSearch:
             mock_search.side_effect = RuntimeError("Tavily API error")
 
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[{"role": "user", "content": "Search for something"}],
                 tools=[
                     {"type": "web_search_20250305", "name": "web_search", "max_uses": 8}
                 ],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None
@@ -186,7 +186,7 @@ class TestTryShortCircuitSearch:
     @pytest.mark.asyncio
     async def test_response_has_valid_structure(self):
         """Synthetic response has all required AnthropicMessagesResponse fields"""
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
 
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
@@ -194,10 +194,10 @@ class TestTryShortCircuitSearch:
             mock_search.return_value = ("search results here", None)
 
             result = await logger.try_short_circuit_search(
-                model="github_copilot/claude-sonnet-4",
+                model="gemini/gemini-2.0-flash",
                 messages=[{"role": "user", "content": "Search query"}],
                 tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
             )
 
         assert result is not None
@@ -206,7 +206,7 @@ class TestTryShortCircuitSearch:
         assert result["id"].startswith("msg_")
         assert result["type"] == "message"
         assert result["role"] == "assistant"
-        assert result["model"] == "github_copilot/claude-sonnet-4"
+        assert result["model"] == "gemini/gemini-2.0-flash"
         assert result["stop_reason"] == "end_turn"
         assert result["stop_sequence"] is None
         assert "usage" in result
@@ -238,7 +238,7 @@ class TestShortCircuitEntryPoint:
                 model="test",
                 messages=[],
                 tools=[],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
                 stream=False,
             )
         assert result is None
@@ -250,17 +250,17 @@ class TestShortCircuitEntryPoint:
             _try_websearch_short_circuit,
         )
 
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
         ) as mock_search:
             mock_search.return_value = ("results", None)
             with patch("litellm.callbacks", [logger]):
                 result = await _try_websearch_short_circuit(
-                    model="github_copilot/claude-sonnet-4",
+                    model="gemini/gemini-2.0-flash",
                     messages=[{"role": "user", "content": "search query"}],
                     tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                    custom_llm_provider="github_copilot",
+                    custom_llm_provider="gemini",
                     stream=False,
                 )
 
@@ -278,17 +278,17 @@ class TestShortCircuitEntryPoint:
             _try_websearch_short_circuit,
         )
 
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
         ) as mock_search:
             mock_search.return_value = ("streaming results", None)
             with patch("litellm.callbacks", [logger]):
                 result = await _try_websearch_short_circuit(
-                    model="github_copilot/claude-sonnet-4",
+                    model="gemini/gemini-2.0-flash",
                     messages=[{"role": "user", "content": "search query"}],
                     tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                    custom_llm_provider="github_copilot",
+                    custom_llm_provider="gemini",
                     stream=True,
                 )
 
@@ -323,7 +323,7 @@ class TestShortCircuitEntryPoint:
                 model="test",
                 messages=[{"role": "user", "content": "search"}],
                 tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                custom_llm_provider="github_copilot",
+                custom_llm_provider="gemini",
                 stream=False,
             )
         assert result is None
@@ -343,7 +343,7 @@ class TestShortCircuitEntryPoint:
             _try_websearch_short_circuit,
         )
 
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
         ) as mock_search:
@@ -353,10 +353,10 @@ class TestShortCircuitEntryPoint:
                 # is passed to the short-circuit, even though the hook would have
                 # already converted stream to False in request_kwargs.
                 result = await _try_websearch_short_circuit(
-                    model="github_copilot/claude-sonnet-4",
+                    model="gemini/gemini-2.0-flash",
                     messages=[{"role": "user", "content": "search query"}],
                     tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                    custom_llm_provider="github_copilot",
+                    custom_llm_provider="gemini",
                     stream=True,  # original_stream, NOT the hook-converted value
                 )
 
@@ -373,7 +373,7 @@ class TestShortCircuitEntryPoint:
             _try_websearch_short_circuit,
         )
 
-        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+        logger = WebSearchInterceptionLogger(enabled_providers=["gemini"])
         with patch.object(
             logger, "_execute_search", new_callable=AsyncMock
         ) as mock_search:
@@ -382,10 +382,10 @@ class TestShortCircuitEntryPoint:
                 # Simulate the caller having derived custom_llm_provider from
                 # the model string before calling _try_websearch_short_circuit
                 result = await _try_websearch_short_circuit(
-                    model="github_copilot/claude-sonnet-4",
+                    model="gemini/gemini-2.0-flash",
                     messages=[{"role": "user", "content": "search query"}],
                     tools=[{"type": "web_search_20250305", "name": "web_search"}],
-                    custom_llm_provider="github_copilot",
+                    custom_llm_provider="gemini",
                     stream=False,
                 )
 

--- a/tests/test_litellm/llms/github_copilot/messages/test_github_copilot_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/messages/test_github_copilot_anthropic_messages_transformation.py
@@ -1,0 +1,105 @@
+import litellm
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
+from litellm.llms.github_copilot.messages.transformation import (
+    GithubCopilotMessagesConfig,
+)
+from litellm.utils import ProviderConfigManager
+
+
+def test_github_copilot_provider_uses_messages_config():
+    config = ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="claude-opus-4.8",
+        provider=litellm.LlmProviders.GITHUB_COPILOT,
+    )
+
+    assert isinstance(config, GithubCopilotMessagesConfig)
+    assert config.custom_llm_provider == "github_copilot"
+
+
+def test_anthropic_provider_keeps_default_config_for_claude_model():
+    config = ProviderConfigManager.get_provider_anthropic_messages_config(
+        model="claude-opus-4.8",
+        provider=litellm.LlmProviders.ANTHROPIC,
+    )
+
+    assert isinstance(config, AnthropicMessagesConfig)
+    assert not isinstance(config, GithubCopilotMessagesConfig)
+
+
+def test_github_copilot_messages_url_targets_native_endpoint():
+    config = GithubCopilotMessagesConfig()
+
+    for api_base in (
+        None,
+        "https://api.githubcopilot.com",
+        "https://api.githubcopilot.com/",
+        "https://api.githubcopilot.com/v1/messages",
+    ):
+        assert (
+            config.get_complete_url(
+                api_base=api_base,
+                api_key=None,
+                model="claude-opus-4.8",
+                optional_params={},
+                litellm_params={},
+            )
+            == "https://api.githubcopilot.com/v1/messages"
+        )
+
+
+def test_github_copilot_messages_headers_use_bearer_not_x_api_key():
+    config = GithubCopilotMessagesConfig()
+
+    # Pass api_key so the shared Authenticator is not invoked.
+    headers, _ = config.validate_anthropic_messages_environment(
+        headers={},
+        model="claude-opus-4.8",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="copilot-token",
+    )
+
+    # Copilot authenticates with a bearer token + editor identity headers.
+    assert headers["Authorization"] == "Bearer copilot-token"
+    assert headers["editor-version"]
+    assert headers["copilot-integration-id"] == "vscode-chat"
+    assert headers["anthropic-version"] == "2023-06-01"
+    # The bearer header is authoritative; no redundant x-api-key.
+    assert "x-api-key" not in headers
+
+
+def test_github_copilot_messages_injects_context_management_beta_header():
+    config = GithubCopilotMessagesConfig()
+
+    headers, _ = config.validate_anthropic_messages_environment(
+        headers={},
+        model="claude-opus-4.8",
+        messages=[],
+        optional_params={
+            "context_management": {"edits": [{"type": "clear_tool_uses_20250919"}]}
+        },
+        litellm_params={},
+        api_key="copilot-token",
+    )
+
+    # context_management requires this beta header or the Copilot backend 400s.
+    assert "context-management-2025-06-27" in headers.get("anthropic-beta", "")
+
+
+def test_github_copilot_messages_preserves_caller_authorization():
+    config = GithubCopilotMessagesConfig()
+
+    headers, _ = config.validate_anthropic_messages_environment(
+        headers={"authorization": "Bearer caller-supplied"},
+        model="claude-opus-4.8",
+        messages=[],
+        optional_params={},
+        litellm_params={},
+        api_key="copilot-token",
+    )
+
+    assert headers["authorization"] == "Bearer caller-supplied"
+    assert "Authorization" not in headers


### PR DESCRIPTION
## Relevant issues

Adds native `github_copilot` provider support for the Anthropic Messages API (`/v1/messages`).

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review

## Type

🆕 New Feature

## What

Lets the `github_copilot` provider serve the Anthropic Messages API natively, so callers can route Claude requests as `github_copilot/claude-*` instead of pointing the `anthropic/` provider at `api_base=https://api.githubcopilot.com` and wiring a custom auth callback.

GitHub Copilot exposes an Anthropic-compatible `/v1/messages` endpoint for its Claude models. Routing there (instead of translating to chat/completions) preserves native content blocks the OpenAI-style path drops — most notably PDF `document` blocks.

## How

New `GithubCopilotMessagesConfig` (extends `AnthropicMessagesConfig`), overriding only what differs for Copilot:

- **`get_complete_url`** — targets `https://api.githubcopilot.com/v1/messages`.
- **`validate_anthropic_messages_environment`** — applies the standard Copilot headers (reusing the existing `get_copilot_default_headers` helper + the shared `Authenticator`), then defers to the parent for `anthropic-version` and the feature-driven `anthropic-beta` injection. request/response/streaming transforms are inherited unchanged.

Two small wiring changes:
- Register the config in `ProviderConfigManager.get_provider_anthropic_messages_config`.
- Alias `github_copilot -> anthropic` in `anthropic_beta_headers_config.json` so the beta-header filter forwards feature betas (e.g. `context_management -> context-management-2025-06-27`) that the Copilot backend requires — without the alias the filter drops them and the backend 400s.

## Tests

`tests/test_litellm/llms/github_copilot/messages/test_github_copilot_anthropic_messages_transformation.py` (6 tests): provider resolution, URL building across api_base shapes, bearer-vs-x-api-key header behaviour, context_management beta-header injection, and caller-supplied auth pass-through.

```
pytest tests/test_litellm/llms/github_copilot/messages/ -q
6 passed
```

## Proof of fix

Running a proxy with `model: github_copilot/claude-opus-4.8`, a `/v1/messages` request (including Claude Code's `context_management` parameter) returns 200 with the response streamed back from Copilot's native endpoint, and PDF `document` blocks are parsed correctly — neither of which works through the chat/completions translation path.
