### PR TITLE
fix(ui): send request id search to logs backend

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -4,6 +4,155 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/budgets/components/budget_modal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/budgets/components/budget_panel.test.tsx": {
+    "unused-imports/no-unused-imports": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/budgets/components/budget_panel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/budgets/components/edit_budget_modal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/components/cache_dashboard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/purity": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/caching/components/cache_health.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/components/cache_settings/CacheFieldRenderer.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/components/cache_settings/RedisTypeSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/caching/components/cache_settings/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/add_margin_form.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/add_provider_form.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/cost_tracking_settings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/how_it_works.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_cost_results.test.tsx": {
+    "unused-imports/no-unused-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_cost_results.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_export_dropdown.test.tsx": {
+    "unused-imports/no-unused-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_export_dropdown.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/use_multi_cost_estimate.ts": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/provider_discount_table.test.tsx": {
+    "unused-imports/no-unused-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/provider_discount_table.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/provider_display_helpers.test.ts": {
+    "unused-imports/no-unused-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/provider_margin_table.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/use_discount_config.ts": {
+    "no-restricted-syntax": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/cost-tracking/components/use_margin_config.ts": {
+    "no-restricted-syntax": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/guardrails-monitor/components/EvaluationSettingsModal.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails-monitor/components/GuardrailsMonitorView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails-monitor/components/ScoreChart.test.tsx": {
+    "react/display-name": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/guardrails-monitor/components/ScoreChart.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/hooks/accessGroups/useAccessGroupDetails.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -164,6 +313,11 @@
       "count": 2
     }
   },
+  "src/app/(dashboard)/memory/components/MemoryView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -203,8 +357,283 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/AgentBuilderView.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 5
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/ChatImageUtils.test.tsx": {
+    "max-nested-callbacks": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 4
+    },
+    "unused-imports/no-unused-imports": {
+      "count": 13
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx": {
+    "no-restricted-syntax": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterTool.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx": {
+    "react-hooks/immutability": {
+      "count": 2
+    },
+    "react-hooks/preserve-manual-memoization": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/compareUI/CompareUI.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/compareUI/components/ModelSelector.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/components/complianceUI/ComplianceUI.tsx": {
+    "react-hooks/preserve-manual-memoization": {
+      "count": 3
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/a2a_send_message.tsx": {
+    "max-params": {
+      "count": 2
+    },
+    "no-restricted-syntax": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/audio_speech.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/audio_transcriptions.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/embeddings_api.tsx": {
+    "max-params": {
+      "count": 1
+    },
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/fetch_agents.tsx": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/image_edits.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/image_generation.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/playground/llm_calls/interactions_api.tsx": {
+    "max-params": {
+      "count": 1
+    },
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/playground/page.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/components/ProjectDetailsPage.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/components/ProjectKeysSection.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/projects/components/ProjectModals/ProjectBaseForm.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/projects/components/ProjectsPage.tsx": {
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/add_prompt_form.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/DeveloperMessageCard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/ModelConfigCard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptCodeSnippets.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptEditorHeader.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptMessagesCard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/PublishModal.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/ToolsCard.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/VersionHistorySidePanel.test.tsx": {
+    "max-nested-callbacks": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/VersionHistorySidePanel.tsx": {
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/MessageInput.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/index.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/useConversation.ts": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_info.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 2
+    }
+  },
+  "src/app/(dashboard)/prompts/components/prompt_table.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/CreateSearchTools.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/set-state-in-effect": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/SearchToolTester.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/SearchToolView.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/search-tools/_components/SearchTools.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "react-hooks/static-components": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/transform-request/TransformRequestPanel.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/ui-theme/UIThemeSettings.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    },
+    "no-restricted-syntax": {
+      "count": 3
+    },
+    "react-hooks/immutability": {
+      "count": 1
+    }
+  },
+  "src/app/(dashboard)/workflows/WorkflowRuns.tsx": {
+    "no-restricted-syntax": {
+      "count": 3
+    },
+    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
@@ -293,81 +722,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-tracking/components/add_margin_form.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/add_provider_form.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/cost_tracking_settings.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/how_it_works.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_cost_results.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_cost_results.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_export_dropdown.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/multi_export_dropdown.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/pricing_calculator/use_multi_cost_estimate.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/provider_discount_table.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/provider_discount_table.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/provider_display_helpers.test.ts": {
-    "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/provider_margin_table.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/use_discount_config.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/cost-tracking/components/use_margin_config.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "src/components/CreateUserButton.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -419,33 +773,8 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/guardrails-monitor/components/EvaluationSettingsModal.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/guardrails-monitor/components/GuardrailsMonitorView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/guardrails-monitor/components/ScoreChart.test.tsx": {
-    "react/display-name": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/guardrails-monitor/components/ScoreChart.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/HelpLink.test.tsx": {
     "unused-imports/no-unused-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/memory/components/MemoryView.tsx": {
-    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   },
@@ -472,26 +801,6 @@
       "count": 4
     }
   },
-  "src/app/(dashboard)/projects/components/ProjectDetailsPage.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/projects/components/ProjectKeysSection.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/projects/components/ProjectModals/ProjectBaseForm.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/projects/components/ProjectsPage.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/components/SCIM.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -502,32 +811,6 @@
   },
   "src/components/SSOModals.tsx": {
     "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/search-tools/_components/CreateSearchTools.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/search-tools/_components/SearchToolTester.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/search-tools/_components/SearchToolView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/search-tools/_components/SearchTools.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/static-components": {
       "count": 1
     }
   },
@@ -750,7 +1033,7 @@
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
-      "count": 2
+      "count": 1
     }
   },
   "src/components/agents/add_agent_form.tsx": {
@@ -790,61 +1073,7 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/budgets/components/budget_modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/budgets/components/budget_panel.test.tsx": {
-    "unused-imports/no-unused-imports": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/budgets/components/budget_panel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/budgets/components/edit_budget_modal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/components/bulk_create_users_button.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/caching/components/cache_dashboard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/purity": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/caching/components/cache_health.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/caching/components/cache_settings/CacheFieldRenderer.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/caching/components/cache_settings/RedisTypeSelector.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/caching/components/cache_settings/index.tsx": {
     "no-restricted-imports": {
       "count": 1
     },
@@ -1140,6 +1369,16 @@
   },
   "src/components/key_value_input.tsx": {
     "no-restricted-imports": {
+      "count": 1
+    }
+  },
+  "src/components/llm_calls/chat_completion.tsx": {
+    "max-params": {
+      "count": 1
+    }
+  },
+  "src/components/llm_calls/responses_api.tsx": {
+    "max-params": {
       "count": 1
     }
   },
@@ -1469,132 +1708,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/playground/components/chat_ui/AdditionalModelSettings.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/AgentBuilderView.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 5
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/ChatImageUtils.test.tsx": {
-    "max-nested-callbacks": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 4
-    },
-    "unused-imports/no-unused-imports": {
-      "count": 13
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterOutput.tsx": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/CodeInterpreterTool.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx": {
-    "react-hooks/immutability": {
-      "count": 2
-    },
-    "react-hooks/preserve-manual-memoization": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/components/compareUI/CompareUI.tsx": {
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/components/compareUI/components/ModelSelector.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/components/complianceUI/ComplianceUI.tsx": {
-    "react-hooks/preserve-manual-memoization": {
-      "count": 3
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/a2a_send_message.tsx": {
-    "max-params": {
-      "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/anthropic_messages.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/audio_speech.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/audio_transcriptions.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/components/llm_calls/chat_completion.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/embeddings_api.tsx": {
-    "max-params": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/fetch_agents.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/image_edits.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/image_generation.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/playground/llm_calls/interactions_api.tsx": {
-    "max-params": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/components/llm_calls/responses_api.tsx": {
-    "max-params": {
-      "count": 1
-    }
-  },
   "src/components/policies/add_attachment_form.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -1708,87 +1821,6 @@
   "src/components/price_data_reload.tsx": {
     "react-hooks/immutability": {
       "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/components/add_prompt_form.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/DeveloperMessageCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/ModelConfigCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptCodeSnippets.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptEditorHeader.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/PromptMessagesCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/PublishModal.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/ToolsCard.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/VersionHistorySidePanel.test.tsx": {
-    "max-nested-callbacks": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/VersionHistorySidePanel.tsx": {
-    "react-hooks/immutability": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/MessageInput.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_editor_view/conversation_panel/useConversation.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_info.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 2
-    }
-  },
-  "src/app/(dashboard)/prompts/components/prompt_table.tsx": {
-    "no-restricted-imports": {
-      "count": 1
     }
   },
   "src/components/public_model_hub.tsx": {
@@ -1916,22 +1948,6 @@
       "count": 1
     },
     "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/transform-request/TransformRequestPanel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/ui-theme/UIThemeSettings.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 3
-    },
-    "react-hooks/immutability": {
       "count": 1
     }
   },
@@ -2081,14 +2097,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/workflows/WorkflowRuns.tsx": {
-    "no-restricted-syntax": {
-      "count": 3
-    },
-    "react-hooks/set-state-in-effect": {
-      "count": 1
-    }
-  },
   "src/contexts/AuthContext.tsx": {
     "react-hooks/set-state-in-effect": {
       "count": 1
@@ -2165,14 +2173,6 @@
       "count": 1
     },
     "react/display-name": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/prompts/components/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    },
-    "react-hooks/set-state-in-effect": {
       "count": 1
     }
   }

--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import moment from "moment";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import { uiSpendLogsCall } from "../networking";
 import { useLogFilterLogic } from "./log_filter_logic";
 
 const mockHandleFilterResetFromHook = vi.fn();
+const mockHandleFilterChangeFromHook = vi.fn();
 vi.mock("./log_filter_logic", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./log_filter_logic")>();
   return {
@@ -16,7 +17,7 @@ vi.mock("./log_filter_logic", async (importOriginal) => {
       logsQuery: { isLoading: false, isFetching: false, refetch: vi.fn() },
       filteredLogs: { data: [], total: 0, page: 1, page_size: 50, total_pages: 1 },
       allTeams: [],
-      handleFilterChange: vi.fn(),
+      handleFilterChange: mockHandleFilterChangeFromHook,
       handleFilterReset: mockHandleFilterResetFromHook,
     })),
   };
@@ -56,6 +57,16 @@ describe("SpendLogsTable", () => {
     vi.clearAllMocks();
     // Clear sessionStorage to avoid isLiveTail state from previous tests
     sessionStorage.clear();
+  });
+
+  it("should route the Request ID search box through handleFilterChange", async () => {
+    renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search by Request ID"), { target: { value: "req-123" } });
+
+    await waitFor(() => {
+      expect(mockHandleFilterChangeFromHook).toHaveBeenCalledWith({ "Request ID": "req-123" });
+    });
   });
 
   it("should call handleFilterResetFromHook when Reset Filters is clicked", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -12,7 +12,7 @@ import AuditLogs from "./audit_logs";
 import { createColumns, LogEntry, type LogsSortField } from "./columns";
 import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
 import { getLogFilterOptions } from "./filter_options";
-import { useLogFilterLogic, defaultFilters, type LogFilterState } from "./log_filter_logic";
+import { useLogFilterLogic, defaultFilters, FILTER_KEYS, type LogFilterState } from "./log_filter_logic";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
 import { LogsTableToolbar } from "./LogsTableToolbar";
 import { DataTable } from "./table";
@@ -27,7 +27,6 @@ interface SpendLogsTableProps {
 }
 
 export default function SpendLogsTable({ accessToken, token, userRole, userID, premiumUser }: SpendLogsTableProps) {
-  const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(50);
 
@@ -134,13 +133,9 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
 
   const filteredData = useMemo(() => {
     const searchedLogs = filteredLogs.data.filter((log) => {
-      const matchesSearch =
-        !searchTerm ||
-        log.request_id.includes(searchTerm) ||
-        log.model.includes(searchTerm) ||
-        (log.user && log.user.includes(searchTerm));
+      const requestIdSearchTerm = filters[FILTER_KEYS.REQUEST_ID];
+      const matchesSearch = !requestIdSearchTerm || log.request_id.includes(requestIdSearchTerm);
 
-      // No need for additional filtering since we're now handling this in the API call
       return matchesSearch;
     });
 
@@ -200,7 +195,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           return sessionRepresentativeMap.get(log.session_id)?.requestId === log.request_id;
         })
     );
-  }, [filteredLogs.data, searchTerm]);
+  }, [filteredLogs.data, filters]);
 
   // Keep the Fetch button busy until the table has actually committed the new
   // rows. `keepPreviousData` leaves logsQuery.isLoading false on refetch, so
@@ -264,8 +259,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
                 />
                 <div className="bg-white rounded-lg shadow w-full max-w-full box-border">
                   <LogsTableToolbar
-                    searchTerm={searchTerm}
-                    onSearchChange={setSearchTerm}
+                    searchTerm={filters[FILTER_KEYS.REQUEST_ID]}
+                    onSearchChange={(value) => handleFilterChange({ [FILTER_KEYS.REQUEST_ID]: value })}
                     startTime={startTime}
                     onStartTimeChange={setStartTime}
                     endTime={endTime}

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -131,9 +131,10 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     [sortBy, sortOrder, handleSortChange],
   );
 
+  const requestIdSearchTerm = filters[FILTER_KEYS.REQUEST_ID];
+
   const filteredData = useMemo(() => {
     const searchedLogs = filteredLogs.data.filter((log) => {
-      const requestIdSearchTerm = filters[FILTER_KEYS.REQUEST_ID];
       const matchesSearch = !requestIdSearchTerm || log.request_id.includes(requestIdSearchTerm);
 
       return matchesSearch;
@@ -195,7 +196,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           return sessionRepresentativeMap.get(log.session_id)?.requestId === log.request_id;
         })
     );
-  }, [filteredLogs.data, filters]);
+  }, [filteredLogs.data, requestIdSearchTerm]);
 
   // Keep the Fetch button busy until the table has actually committed the new
   // rows. `keepPreviousData` leaves logsQuery.isLoading false on refetch, so
@@ -259,7 +260,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
                 />
                 <div className="bg-white rounded-lg shadow w-full max-w-full box-border">
                   <LogsTableToolbar
-                    searchTerm={filters[FILTER_KEYS.REQUEST_ID]}
+                    searchTerm={requestIdSearchTerm}
                     onSearchChange={(value) => handleFilterChange({ [FILTER_KEYS.REQUEST_ID]: value })}
                     startTime={startTime}
                     onStartTimeChange={setStartTime}


### PR DESCRIPTION
## Relevant issues

Fixes #31695

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before this fix, typing `chatcmpl-8193f644` or `chatcmpl-195fc2da` into `Search by Request ID` did not send `request_id` to `/spend/logs/ui`. The browser request only loaded the current page, so the search filtered the 50 rows already in memory

```bash
curl 'http://localhost:4000/spend/logs/ui?start_date=2026-06-01+00:00:00&end_date=2026-06-30+23:59:59&page=1&page_size=50' \
  -H 'Authorization: Bearer sk-...'
```

Actual response excerpt from the unfiltered page 1 data

```json
{
  "total": 72,
  "page": 1,
  "page_size": 50,
  "total_pages": 2,
  "data": [
    { "request_id": "chatcmpl-30401f3d" },
    { "request_id": "chatcmpl-a189cc66" },
    { "request_id": "chatcmpl-49469a98" },
    { "request_id": "chatcmpl-ceda92fa" },
    { "request_id": "chatcmpl-f178f4dd" }
  ]
}
```

Neither `chatcmpl-8193f644` nor `chatcmpl-195fc2da` is present in that first page response, so the old browser-only filter showed no matching rows

After this fix, the same search input updates the shared logs filter state, so the UI request includes `request_id`

```bash
curl 'http://localhost:4000/spend/logs/ui?start_date=2026-06-01+00:00:00&end_date=2026-06-30+23:59:59&page=1&page_size=50&request_id=chatcmpl-8193f644' \
  -H 'Authorization: Bearer sk-...'
```

Actual response excerpt

```json
{
  "total": 1,
  "page": 1,
  "page_size": 50,
  "total_pages": 1,
  "data": [
    {
      "request_id": "chatcmpl-8193f644",
      "model": "GLM-4.7-Flash-6bit",
      "status": "success",
      "spend": 0.0,
      "total_tokens": 27,
      "startTime": "2026-06-29T09:58:59.284000",
      "endTime": "2026-06-29T09:59:00.420000",
      "call_type": "acompletion"
    }
  ]
}
```

Second verified request ID

```bash
curl 'http://localhost:4000/spend/logs/ui?start_date=2026-06-01+00:00:00&end_date=2026-06-30+23:59:59&page=1&page_size=50&request_id=chatcmpl-195fc2da' \
  -H 'Authorization: Bearer sk-...'
```

Actual response excerpt

```json
{
  "total": 1,
  "page": 1,
  "page_size": 50,
  "total_pages": 1,
  "data": [
    {
      "request_id": "chatcmpl-195fc2da",
      "model": "GLM-4.7-Flash-6bit",
      "status": "success",
      "spend": 0.0,
      "total_tokens": 27,
      "startTime": "2026-06-29T09:58:51.537000",
      "endTime": "2026-06-29T09:58:52.809000",
      "call_type": "acompletion"
    }
  ]
}
```

After the fix, the new and existing tests pass with no regressions:

​`$ npm run test -- run src/components/view_logs Test Files  22 passed (22) Tests  225 passed (225)`

## Type

🐛 Bug Fix

## Changes

The Request Logs page now routes `Search by Request ID` through the shared log filter state instead of a local client-only search value
That reuses the existing backend `request_id` filter on `/spend/logs/ui`, which fixes searches for logs that are not already loaded in the current page
A regression test was added to verify the toolbar search input calls the shared filter handler
`ui/litellm-dashboard/eslint-suppressions.json` was pruned so `npm run lint:metrics` passes again
