### PR TITLE
fix(proxy): isolate poison spend-log rows so one bad record can't drop the whole batch

### DIFF
--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -67,6 +67,29 @@ class PrismaDBExceptionHandler:
         return False
 
     @staticmethod
+    def is_prisma_data_error(e: Exception) -> bool:
+        """True iff ``e`` is a base prisma ``DataError``: the database processed
+        the statement and refused the data itself (e.g. ``invalid byte sequence
+        for encoding "UTF8": 0x00``), as opposed to a connectivity failure.
+
+        Matched by exact type, not ``isinstance``: the specific data-layer
+        subclasses (``UniqueViolationError``, ``TableNotFoundError``,
+        ``MissingRequiredValueError`` ...) all derive from ``DataError`` but
+        carry their own semantics, and a systemic one like a missing table must
+        not be mistaken for a single poison row and bisected away. A raw
+        Postgres execution error with no prisma P-code surfaces as the base
+        ``DataError``.
+
+        prisma also wraps the P1001 "can't reach database server" outage as a
+        base ``DataError``, so a caller that must not treat an outage as a
+        per-row data rejection has to additionally consult
+        ``is_database_service_unavailable_error`` before acting on a True here.
+        """
+        import prisma
+
+        return type(e) is prisma.errors.DataError
+
+    @staticmethod
     def is_database_transport_error(e: Exception) -> bool:
         """
         Returns True only for transport/connectivity failures where a reconnect

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -23,7 +23,9 @@ from typing import (
     Dict,
     List,
     Literal,
+    Mapping,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
@@ -5194,8 +5196,10 @@ class ProxyUpdateSpend:
                         for j in range(0, len(logs_to_process), BATCH_SIZE):
                             batch = logs_to_process[j : j + BATCH_SIZE]
                             batch_with_dates = [prisma_client.jsonify_object({**entry}) for entry in batch]
-                            await SpendLogsRepository(prisma_client).table.create_many(
-                                data=batch_with_dates, skip_duplicates=True
+                            await _create_spend_logs_with_poison_isolation(
+                                SpendLogsRepository(prisma_client),
+                                batch_with_dates,
+                                MAX_SPEND_LOG_ISOLATION_ATTEMPTS_PER_BATCH,
                             )
                             verbose_proxy_logger.debug(f"Flushed {len(batch)} logs to the DB.")
                             # Explicitly clear batch memory
@@ -5460,6 +5464,65 @@ async def _monitor_spend_logs_queue(
             # Continue monitoring even if there's an error, with exponential backoff
             current_interval = min(current_interval * backoff_multiplier, max_backoff)
             await asyncio.sleep(current_interval)
+
+
+MAX_SPEND_LOG_ISOLATION_ATTEMPTS_PER_BATCH = 256
+
+
+async def _create_spend_logs_with_poison_isolation(
+    repo: SpendLogsRepository,
+    rows: Sequence[Mapping[str, object]],
+    attempts_left: int,
+) -> int:
+    """Write spend-log rows, isolating any row Postgres rejects on its data.
+
+    ``create_many`` writes the whole batch in a single statement, so one row
+    carrying bytes Postgres refuses (a residual NUL byte is the canonical case)
+    fails the entire insert and drops every good row alongside it. On a genuine
+    data-layer rejection the batch is bisected so the good rows still persist
+    and only the offending row is dropped and logged. Transport failures,
+    including the "can't reach database server" outage that prisma mislabels as
+    a ``DataError``, are re-raised unchanged so the caller's connection-retry
+    path still runs.
+
+    ``attempts_left`` is a hard ceiling on the number of ``create_many`` calls
+    the isolation may issue for this batch, so an authenticated caller flooding
+    poisoned rows cannot amplify one failed bulk insert into unbounded failed
+    inserts and log lines. It is checked before any insert (so an exhausted
+    budget never even attempts a write), decremented once per ``create_many``
+    call, and threaded through the recursion so the whole bisection shares one
+    allowance; total inserts are therefore bounded by the initial value
+    regardless of how many rows are poisoned. When it runs out the still-failing
+    remainder is dropped wholesale (the pre-existing drop-the-batch behavior)
+    under one log line. Returns the budget left after this subtree.
+    """
+    if attempts_left <= 0:
+        spend_log_error(
+            "Spend tracking - dropping %d spend log rows without per-row isolation; "
+            "isolation attempt budget exhausted for this flush",
+            len(rows),
+        )
+        return 0
+    try:
+        await repo.table.create_many(data=rows, skip_duplicates=True)
+        return attempts_left - 1
+    except Exception as e:
+        if not PrismaDBExceptionHandler.is_prisma_data_error(e):
+            raise
+        if PrismaDBExceptionHandler.is_database_service_unavailable_error(e):
+            raise
+        if len(rows) == 1:
+            request_id = rows[0].get("request_id")
+            spend_log_error(
+                "Spend tracking - dropping spend log row Postgres rejected. request_id=%s error=%s",
+                request_id,
+                str(e),
+                exc=e,
+            )
+            return attempts_left - 1
+        mid = len(rows) // 2
+        remaining = await _create_spend_logs_with_poison_isolation(repo, rows[:mid], attempts_left - 1)
+        return await _create_spend_logs_with_poison_isolation(repo, rows[mid:], remaining)
 
 
 def _raise_failed_update_spend_exception(e: Exception, start_time: float, proxy_logging_obj: ProxyLogging):

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -148,6 +148,37 @@ def test_is_database_service_unavailable_error_prisma_p1001_masquerades_as_datae
     )
 
 
+def test_is_prisma_data_error_only_true_for_dataerror():
+    """The spend-log poison-row isolation gates on this: only a prisma
+    ``DataError`` (the DB refused the data, e.g. a NUL byte) may be bisected
+    into a per-row drop. A connectivity failure or any non-prisma exception
+    must not be treated as a data rejection, so the whole batch surfaces."""
+    import httpx
+
+    data_error = DataError(data={"user_facing_error": {"message": "invalid byte sequence for encoding UTF8: 0x00"}})
+    assert PrismaDBExceptionHandler.is_prisma_data_error(data_error) is True
+
+    for non_data in (
+        httpx.ConnectError("conn refused"),
+        PrismaError("can't reach database server"),
+        UniqueViolationError(data={"user_facing_error": {"meta": {"table": "t"}}}),
+        RuntimeError("boom"),
+    ):
+        assert PrismaDBExceptionHandler.is_prisma_data_error(non_data) is False
+
+
+def test_is_prisma_data_error_true_for_connection_masquerade_dataerror():
+    """The P1001 outage prisma mislabels as a ``DataError`` is still a
+    ``DataError`` by type, so this returns True; the spend-log helper relies on
+    ``is_database_service_unavailable_error`` (not this check) to keep that
+    outage on the retry path instead of dropping rows."""
+    p1001_as_dataerror = DataError(
+        data={"user_facing_error": {"message": "Can't reach database server at `127.0.0.1`:`5499`"}}
+    )
+    assert PrismaDBExceptionHandler.is_prisma_data_error(p1001_as_dataerror) is True
+    assert PrismaDBExceptionHandler.is_database_service_unavailable_error(p1001_as_dataerror) is True
+
+
 def test_is_database_service_unavailable_error_cached_plan_escapes_as_503():
     """Composes with the cached-plan retry: when that recovery fails and the
     Postgres "cached plan must not change result type" error escapes (raised by

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_proxy_update_spend.py
@@ -231,6 +231,112 @@ async def test_update_spend_logs_failure_raises_after_retries(
         )
 
 
+def _data_error(message: str) -> Any:
+    from prisma.errors import DataError
+
+    return DataError({"user_facing_error": {"message": message}})
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_isolates_poison_row_and_persists_good_rows(
+    mock_prisma_client: Any, make_spend_log_row: Any
+) -> None:
+    """One row Postgres rejects (22P05) must not drop the whole batch.
+
+    The good rows still persist and only the offending row is dropped, with no
+    exception bubbling up. On the unfixed single-shot ``create_many`` the first
+    write raises and the entire batch is lost.
+    """
+    poison_id = "r1"
+    written: List[str] = []
+
+    async def _create_many(*, data: Any, skip_duplicates: bool) -> None:
+        ids = [row["request_id"] for row in data]
+        if poison_id in ids:
+            raise _data_error(
+                "Inconsistent column data: 22P05 invalid byte sequence for encoding UTF8: 0x00"
+            )
+        written.extend(ids)
+
+    mock_prisma_client.db.litellm_spendlogs.create_many = AsyncMock(side_effect=_create_many)
+    proxy_logging = MagicMock()
+    proxy_logging.failure_handler = AsyncMock()
+
+    logs = [make_spend_log_row(request_id=f"r{i}") for i in range(4)]
+    await ProxyUpdateSpend.update_spend_logs(
+        n_retry_times=0,
+        prisma_client=mock_prisma_client,
+        db_writer_client=None,
+        proxy_logging_obj=proxy_logging,
+        logs_to_process=logs,
+    )
+    assert sorted(written) == ["r0", "r2", "r3"]
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_reraises_connection_masquerade_dataerror(
+    mock_prisma_client: Any, make_spend_log_row: Any
+) -> None:
+    """A P1001 "can't reach database server" outage that prisma mislabels as a
+    ``DataError`` is transient, not a poison row: it must propagate so the batch
+    is surfaced/retried rather than bisected into silent per-row drops.
+    """
+    err = _data_error("Can't reach database server at db-host:5432")
+    mock_prisma_client.db.litellm_spendlogs.create_many = AsyncMock(side_effect=err)
+    proxy_logging = MagicMock()
+    proxy_logging.failure_handler = AsyncMock()
+
+    with pytest.raises(type(err)):
+        await ProxyUpdateSpend.update_spend_logs(
+            n_retry_times=0,
+            prisma_client=mock_prisma_client,
+            db_writer_client=None,
+            proxy_logging_obj=proxy_logging,
+            logs_to_process=[
+                make_spend_log_row(request_id="a"),
+                make_spend_log_row(request_id="b"),
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_spend_logs_caps_isolation_attempts_under_poison_flood(
+    mock_prisma_client: Any, make_spend_log_row: Any
+) -> None:
+    """A flood of poisoned rows must not amplify one failed bulk insert into
+    unbounded failed inserts. The per-batch attempt budget hard-caps the number
+    of ``create_many`` calls regardless of how many rows are poisoned, so the DB
+    work stays bounded and well below the input row count, and the helper still
+    completes without raising.
+    """
+    import litellm.proxy.utils as utils_mod
+
+    attempt_cap = utils_mod.MAX_SPEND_LOG_ISOLATION_ATTEMPTS_PER_BATCH
+    # single create_many batch (< BATCH_SIZE) whose row count exceeds the attempt
+    # cap, so the bound bites and attempts stay below the input row count
+    n_rows = attempt_cap * 3
+
+    async def _always_poison(*, data: Any, skip_duplicates: bool) -> None:
+        raise _data_error("invalid byte sequence for encoding UTF8: 0x00")
+
+    mock_prisma_client.db.litellm_spendlogs.create_many = AsyncMock(side_effect=_always_poison)
+    proxy_logging = MagicMock()
+    proxy_logging.failure_handler = AsyncMock()
+    logs = [make_spend_log_row(request_id=f"r{i}") for i in range(n_rows)]
+
+    await ProxyUpdateSpend.update_spend_logs(
+        n_retry_times=0,
+        prisma_client=mock_prisma_client,
+        db_writer_client=None,
+        proxy_logging_obj=proxy_logging,
+        logs_to_process=logs,
+    )
+
+    attempts = mock_prisma_client.db.litellm_spendlogs.create_many.await_count
+    assert attempts <= attempt_cap
+    assert attempts < n_rows
+
+
 def test_disable_spend_updates_reflects_general_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4103

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`update_spend_logs` flushes the queue with a single `create_many` per batch, which Postgres executes as one atomic statement. If a single row carries bytes Postgres refuses, the whole insert fails and every good row in that batch is dropped with it. PR #29515 strips NUL bytes from the JSON columns (`messages`, `response`, `request_tags`, `proxy_server_request`, `metadata`), but the scalar string columns are still written unsanitized, so a NUL byte in the request `user` field reaches the `end_user` column and reproduces the original 22xxx encoding rejection.

Live proxy against real Postgres and a real Anthropic model. A NUL byte cannot travel in a shell argv, so the three requests are sent from a tiny client that injects `chr(0)` into the `user` field of one of them; everything else is observed with psql. Two requests carry a clean `user`, the third carries a NUL byte, and all three land in the same flush batch (`proxy_batch_write_at: 5`).

```python
# fire.py — sends 2 clean + 1 NUL-byte request, then waits one flush interval
import os, sys, time, httpx
KEY = os.environ["LITELLM_MASTER_KEY"]; tag = sys.argv[1]; NUL = chr(0)
users = [("good-A-"+tag, "good-A-"+tag), ("good-B-"+tag, "good-B-"+tag),
         ("poison-"+tag, "poison-"+tag+NUL+"-x")]
with httpx.Client(timeout=60) as c:
    for label, user in users:
        r = c.post("http://127.0.0.1:4103/v1/chat/completions",
            headers={"Authorization": "Bearer "+KEY},
            json={"model": "haiku", "user": user,
                  "messages": [{"role": "user", "content": "say hi in one word"}], "max_tokens": 10})
        print(f"{label} nul_in_user={NUL in user} -> HTTP {r.status_code}")
time.sleep(12)
```

Before the fix, the whole batch is lost. All three responses are 200, but none of the spend logs reach the DB:

```
good-A-unfixed   nul_in_user=False -> HTTP 200
good-B-unfixed   nul_in_user=False -> HTTP 200
poison-unfixed   nul_in_user=True  -> HTTP 200

$ psql -tAc "SELECT count(*) FROM \"LiteLLM_SpendLogs\" WHERE end_user LIKE '%unfixed%';"
0
```

proxy log:

```
prisma.errors.DataError: Error occurred during query execution:
ConnectorError(... QueryError(PostgresError { code: "22021",
message: "invalid byte sequence for encoding \"UTF8\": 0x00", ... }), transient: false )
```

After the fix, the two good rows persist and only the poisoned row is dropped and dead-lettered with its `request_id`:

```
good-A-fixed   nul_in_user=False -> HTTP 200
good-B-fixed   nul_in_user=False -> HTTP 200
poison-fixed   nul_in_user=True  -> HTTP 200

$ psql -tAc "SELECT request_id, end_user FROM \"LiteLLM_SpendLogs\" WHERE end_user LIKE '%fixed%' ORDER BY end_user;"
chatcmpl-6d46f9ce-...|good-A-fixed
chatcmpl-dbaf647e-...|good-B-fixed
-- good=2  poison=0
```

proxy log:

```
LiteLLM Proxy:ERROR: Spend tracking - dropping spend log row Postgres rejected.
request_id=chatcmpl-7685f593-... error=Error occurred during query execution: ...
```

The "Error in spend logs queue monitor" line that fires on the unfixed batch is gone after the fix, since the batch no longer crashes the flush job.

A transient outage must never be treated as a poison row. The "can't reach database server" failure that prisma mislabels as a `DataError` is re-raised unchanged through `is_database_service_unavailable_error`, so it keeps flowing into the existing connection-retry path instead of being bisected into silent per-row drops. This is pinned by `test_update_spend_logs_reraises_connection_masquerade_dataerror`, and the salvage behavior by `test_update_spend_logs_isolates_poison_row_and_persists_good_rows`; both fail on the pre-fix code.

## Type

🐛 Bug Fix

## Changes

`update_spend_logs` now routes each batch through `_create_spend_logs_with_poison_isolation`. On a genuine data-layer rejection it bisects the batch so the good rows still persist and only the offending row is dropped and logged with its `request_id`; the disjoint-halves recursion writes each row at most once and `skip_duplicates` keeps any cross-retry re-attempt idempotent against the `request_id` primary key. Transport failures, including the connection outage prisma surfaces as a `DataError`, are re-raised so the caller's retry/backoff path is unchanged and a blip never becomes data loss.

The classification lives in a new `PrismaDBExceptionHandler.is_prisma_data_error` helper that matches the base `DataError` by exact type, so the specific subclasses (`UniqueViolationError`, `TableNotFoundError`, `MissingRequiredValueError`, ...) are excluded and a systemic failure like a missing table surfaces loudly instead of being bisected into silent per-row drops. Keeping the check there preserves the in-function `prisma` import that module already uses, so `litellm.proxy.utils` stays importable without the proxy extra.

The bisection carries a per-batch attempt budget (`MAX_SPEND_LOG_ISOLATION_ATTEMPTS_PER_BATCH`) that hard-caps how many `create_many` calls the isolation may issue, checked before any insert and decremented per call, so an authenticated caller flooding poisoned rows cannot amplify one failed bulk insert into unbounded failed inserts and log lines. Once the budget is spent the still-failing remainder is dropped wholesale under one log line, which is the pre-existing drop-the-batch behavior, so the isolation salvages the common sparse-poison case while the DB work under abuse stays bounded by the budget regardless of how many rows are poisoned.

This is scoped to the batch-isolation gap that PR #29515 left open; it does not change the NUL-byte stripping or add sanitization for the scalar columns, so whatever still slips through to the write is now contained to its own row instead of taking the batch down.

The isolation covers the in-process Prisma write only. When `SPEND_LOGS_URL` is set the batch is POSTed to an external writer that owns its own atomicity, and the separate `LiteLLM_SpendLogToolIndex` write is already fault-isolated behind its own non-fatal try/except, so neither is in scope here.
