### PR TITLE
perf(otel): memoize per-request lazy import of otel runtime hooks

### DIFF
--- a/litellm/integrations/otel/runtime.py
+++ b/litellm/integrations/otel/runtime.py
@@ -8,7 +8,23 @@ identity unconditionally.
 """
 
 from contextlib import contextmanager
-from typing import Any, Iterator
+from functools import cache
+from typing import Any, Callable, Iterator, Optional
+
+
+@cache
+def _otel_runtime() -> "Optional[tuple[Callable[[str], Any], Callable[..., None]]]":
+    """Resolve the SDK-backed hooks once and cache the outcome, absence included.
+
+    CPython never caches a failed import, so without this memoization every call
+    site re-attempts the import on each request; when the OTel SDK is not installed
+    that re-scans ``sys.path`` and contends on the import lock on the hot path.
+    """
+    try:
+        from litellm.integrations.otel import logger
+    except Exception:
+        return None
+    return (logger.phase_span, logger.seed_request_identity)
 
 
 @contextmanager
@@ -18,21 +34,17 @@ def phase_span(name: str) -> "Iterator[Any]":
     Yields ``None`` (a plain no-op) when the OTel SDK is unavailable or V2 is not
     the active logger.
     """
-    try:
-        from litellm.integrations.otel.logger import phase_span as _phase_span
-    except Exception:
+    runtime = _otel_runtime()
+    if runtime is None:
         yield None
         return
-    with _phase_span(name) as span:
+    with runtime[0](name) as span:
         yield span
 
 
 def seed_request_identity(user_api_key_dict: Any, model: Any = None) -> None:
     """Seed request-identity Baggage at the auth boundary (no-op without V2)."""
-    try:
-        from litellm.integrations.otel.logger import (
-            seed_request_identity as _seed_request_identity,
-        )
-    except Exception:
+    runtime = _otel_runtime()
+    if runtime is None:
         return
-    _seed_request_identity(user_api_key_dict, model=model)
+    runtime[1](user_api_key_dict, model=model)

--- a/tests/test_litellm/integrations/otel/test_runtime.py
+++ b/tests/test_litellm/integrations/otel/test_runtime.py
@@ -1,0 +1,64 @@
+"""Regression tests for the SDK-free OTel runtime shim.
+
+The proxy auth hot path calls ``phase_span`` and ``seed_request_identity`` on
+every request. These wrappers resolve the SDK-backed implementations with a
+lazy import. CPython never caches a failed import, so before memoization an
+absent OTel SDK made every request re-scan ``sys.path`` and contend on the
+import lock. These tests pin the import to a single resolution.
+"""
+
+import builtins
+
+import litellm.integrations.otel.runtime as runtime
+
+
+def test_logger_not_reimported_after_first_resolution(monkeypatch):
+    runtime._otel_runtime.cache_clear()
+
+    counts = {"n": 0}
+    real_import = builtins.__import__
+
+    def counting_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "litellm.integrations.otel" and fromlist and "logger" in fromlist:
+            counts["n"] += 1
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", counting_import)
+
+    with runtime.phase_span("auth /v1/chat/completions"):
+        pass
+    after_first = counts["n"]
+
+    for _ in range(49):
+        with runtime.phase_span("auth /v1/chat/completions"):
+            pass
+
+    assert counts["n"] == after_first, (
+        f"otel.logger re-imported {counts['n'] - after_first} times after the first "
+        "resolution; it must be memoized so it does not re-scan sys.path per request"
+    )
+
+    runtime._otel_runtime.cache_clear()
+
+
+def test_resolution_is_memoized():
+    runtime._otel_runtime.cache_clear()
+
+    for _ in range(25):
+        with runtime.phase_span("p"):
+            pass
+
+    info = runtime._otel_runtime.cache_info()
+    assert info.misses == 1
+    assert info.hits >= 24
+
+    runtime._otel_runtime.cache_clear()
+
+
+def test_wrappers_no_op_when_runtime_absent(monkeypatch):
+    monkeypatch.setattr(runtime, "_otel_runtime", lambda: None)
+
+    with runtime.phase_span("auth") as span:
+        assert span is None
+
+    assert runtime.seed_request_identity({"token": "sk-x"}, model="gpt-4o") is None


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-4104

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The proxy auth path calls `phase_span()` and `seed_request_identity()` (in `litellm/integrations/otel/runtime.py`) on every request. Each did a `try: from litellm.integrations.otel.logger import ... except Exception` lazy import. `otel.logger` imports the OpenTelemetry SDK at module scope, so when the SDK is not installed (the default) the import raises. CPython never caches a failed import, so every request re-ran a full `find_spec` scan of `sys.path` and contended on the global import lock

Benchmark is locust against a real litellm proxy, 750 concurrent users, spawn 100/s, 60s, 4 worker processes, `/v1/chat/completions` only, Postgres and Redis both connected. The upstream is a static mock OpenAI server on purpose so the proxy's own per-request overhead dominates the measurement rather than provider latency; real-provider latency would swamp the signal this PR is about. Same config for every version, proxy run with `--num_workers 4`

Launch and sanity check

```
DATABASE_URL=postgresql://.../litellm DISABLE_SCHEMA_UPDATE=True \
  litellm --config config.yaml --port 4111 --num_workers 4

curl -s -X POST http://127.0.0.1:4111/v1/chat/completions \
  -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
  -d '{"model":"mock-gpt-4o","messages":[{"role":"user","content":"hi"}]}' -w "\nHTTP %{http_code}\n"
# -> HTTP 200
```

Load test

```
locust -f locustfile.py --headless --host http://127.0.0.1:4111/v1 \
  -u 750 -r 100 -t 60s --processes 4 --tags completion
```

Controlled interleaved A/B (185, 191-unpatched, 191-patched), 2 runs each, constant background load

| Version | Avg RPS | Median | p95 | Error rate | vs 1.85.0 |
| --- | --- | --- | --- | --- | --- |
| 1.85.0 | 724.7 | ~715ms | ~2550ms | 0% | baseline |
| 1.91 unpatched | 636.5 | ~820ms | ~2850ms | 0% | -12.2% |
| 1.91 patched (this PR) | 705.8 | ~755ms | ~2500ms | 0% | -2.6% |

The fix closes about 79% of the gap. The single-worker cProfile run (cleanest apples-to-apples CPU comparison, no multi-worker scheduling noise) reads 116.2 rps patched vs 117.0 for 1.85.0 vs 105.1 unpatched, so per-request overhead is back to baseline. The residual ~2.6% under 4-worker load sits inside 1.85.0's own run-to-run variance and traces to genuinely new per-request features (per-token cost and cache breakdown, overhead-latency metric) plus a FastAPI/starlette bump, not this code path

Direct evidence of the cause and the fix, captured by instrumenting `PathFinder.find_spec`

```
BEFORE (over ~1977 requests, unpatched):       AFTER (over ~2325 requests, patched):
  4424  opentelemetry                             5  opentelemetry
  4420  litellm.integrations.otel.logger          (otel.logger no longer scanned per request)
```

Full load-test CSVs, the find_spec probe output, and the cProfile diff: https://gist.github.com/yassin-berriai/c4a5be8099c6467d7e8330e9e82ec0e2

## Type

🐛 Bug Fix

## Changes

Resolve the SDK-backed OTel hooks once and memoize the outcome, absence included, with `functools.cache` in `litellm/integrations/otel/runtime.py`, so the lazy import is attempted a single time instead of on every request. Public behavior is unchanged: the wrappers still no-op when the SDK is absent or V2 is not the active logger, and still nest spans when it is

Added `tests/test_litellm/integrations/otel/test_runtime.py`, which counts import attempts across 50 calls and asserts the resolution happens at most once, asserts the `functools.cache` is memoized, and checks the SDK-absent path still no-ops without raising. The test fails on the pre-fix code (one import attempt per call) and passes with the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized performance fix in the OTel shim with unchanged public no-op/span behavior and targeted regression tests.
> 
> **Overview**
> Fixes a **proxy auth hot-path regression** where `phase_span` and `seed_request_identity` in `litellm/integrations/otel/runtime.py` attempted a lazy `otel.logger` import on **every request**. When the OpenTelemetry SDK is not installed, that import fails and CPython does not cache failures, so each call re-scanned `sys.path` and hit the import lock.
> 
> The change adds a **`@cache`-memoized `_otel_runtime()`** that resolves `phase_span` and `seed_request_identity` once (including caching `None` when the SDK is missing). `phase_span` and `seed_request_identity` delegate to that tuple; **behavior is unchanged**—still no-op without the SDK/V2 logger, still nest spans when OTel is active.
> 
> Adds **`tests/test_litellm/integrations/otel/test_runtime.py`** to assert at most one logger import across many calls, `functools.cache` hit/miss behavior, and no-op wrappers when runtime is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b48de1555ed7f268d76b6c8b3732b78b1cabcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->