### PR TITLE
fix(gemini/realtime): don't append `model` query param to the Gemini Live WS URL

### DIFF
--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5683,6 +5683,12 @@ class BaseLLMHTTPHandler:
         parsed = urlparse(url)
         existing = dict(parse_qsl(parsed.query))
         extras = {k: v for k, v in query_params.items() if k not in existing}
+        # Gemini Live's BidiGenerateContent endpoint has no `model` query field (the
+        # model belongs in the setup message). Appending it makes Google close the
+        # socket with WS 1007 "Invalid JSON payload ... Unknown name \"model\":
+        # Cannot bind query parameter", so the realtime session yields zero events.
+        if "BidiGenerateContent" in url:
+            extras.pop("model", None)
         if not extras:
             return url
         new_query = parsed.query + ("&" if parsed.query else "") + urlencode(extras)

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -2409,6 +2409,36 @@ class TestNativeWebSocketUrlConstruction:
             "2024-05-01"
         ], f"existing param lost: {captured_urls[0]}"
 
+    def test_gemini_live_ws_url_omits_model(self):
+        """Gemini Live's BidiGenerateContent endpoint rejects a `model` query
+        param (WS 1007), so _append_query_params must drop it there while keeping
+        other params — and keep `model` for non-Gemini realtime URLs."""
+        from urllib.parse import parse_qs, urlparse
+
+        from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+
+        gemini_url = (
+            "wss://generativelanguage.googleapis.com/ws/"
+            "google.ai.generativelanguage.v1beta.GenerativeService."
+            "BidiGenerateContent?key=test-key"
+        )
+        out = BaseLLMHTTPHandler._append_query_params(
+            gemini_url,
+            {"model": "gemini-2.5-flash-native-audio", "intent": "transcription"},
+        )
+        qs = parse_qs(urlparse(out).query)
+        assert "model" not in qs, f"model must be dropped for Gemini Live: {out}"
+        assert qs.get("key") == ["test-key"], f"existing param lost: {out}"
+        assert qs.get("intent") == ["transcription"], f"non-model param dropped: {out}"
+
+        # Non-Gemini realtime URLs keep the model param (OpenAI convention).
+        openai_out = BaseLLMHTTPHandler._append_query_params(
+            "wss://api.openai.com/v1/realtime", {"model": "gpt-4o-realtime-preview"}
+        )
+        assert parse_qs(urlparse(openai_out).query).get("model") == [
+            "gpt-4o-realtime-preview"
+        ], f"model must be preserved for non-Gemini: {openai_out}"
+
     @pytest.mark.asyncio
     async def test_ws_passes_litellm_params_to_get_websocket_url(self):
         """Deployment api_version must reach get_websocket_url (Azure WS URL)."""


### PR DESCRIPTION
## What

`_append_query_params` (used by the realtime/responses WebSocket handler in `llms/custom_httpx/llm_http_handler.py`) appends every `RealtimeQueryParams` entry — including `model` — to the **backend** WebSocket URL.

That matches OpenAI's realtime/responses convention (`wss://.../v1/realtime?model=...`), but Google's Gemini Live endpoint `...GenerativeService.BidiGenerateContent` has **no** `model` query field — the model is sent in the `setup` message. Google therefore closes the socket immediately with:

```
1007 (invalid frame payload data) Invalid JSON payload received.
Unknown name "model": Cannot bind query parameter. Field 'model' could not be found in request.
```

So a `gemini/*` model configured with `model_info: { mode: realtime }` connects upstream but produces **zero** realtime events — the session is silent and then closes. (Seen in `realtime_streaming.py` `backend_to_client_send_messages`.)

## Fix

Drop the `model` query param **only** when the target URL is the Gemini Live `BidiGenerateContent` endpoint. Every other provider/param is untouched, so the OpenAI/Azure realtime paths keep the `?model=` they require.

```python
extras = {k: v for k, v in query_params.items() if k not in existing}
if "BidiGenerateContent" in url:
    extras.pop("model", None)
```

## Repro

Configure a Gemini Live model for realtime:

```yaml
model_list:
  - model_name: gemini-live
    litellm_params:
      model: gemini/gemini-2.5-flash-native-audio-latest
      api_key: os.environ/GEMINI_API_KEY
    model_info:
      mode: realtime
litellm_settings:
  gemini_live_defer_setup: true
```

Connect via `ws://<proxy>/v1/realtime?model=gemini-live` and send a `session.update` → the upstream closes with the 1007 above and no events reach the client. With this change the Gemini Live session connects and streams events normally.

## Notes

The `?model=` backend-URL append is required by OpenAI's realtime/responses WebSocket; this change only excludes the Gemini Live (`BidiGenerateContent`) endpoint, which rejects it. Happy to add a unit test alongside `tests/test_litellm/responses/test_responses_websocket_all_providers.py` if useful.
