### PR TITLE
feat(gemini/realtime): surface barge-in as input_audio_buffer.speech_started

### DIFF
--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -1226,6 +1226,23 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
 
         server_content = json_message.get("serverContent")
         if isinstance(server_content, dict):
+            # Surface Gemini's native barge-in. Gemini emits
+            # ``serverContent.interrupted`` when the user interrupts the model;
+            # mapping it only to ``response.done`` loses that signal. Emit the
+            # OpenAI-realtime ``input_audio_buffer.speech_started`` too, so clients
+            # that flush playback / cancel on speech-start actually interrupt.
+            if server_content.get("interrupted"):
+                returned_message.append(
+                    cast(
+                        OpenAIRealtimeEvents,
+                        {
+                            "type": "input_audio_buffer.speech_started",
+                            "event_id": "event_{}".format(uuid.uuid4()),
+                            "audio_start_ms": 0,
+                            "item_id": "item_{}".format(uuid.uuid4()),
+                        },
+                    )
+                )
             input_tx = server_content.get("inputTranscription")
             if isinstance(input_tx, dict) and input_tx.get("text"):
                 returned_message.append(

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -162,6 +162,47 @@ def test_gemini_realtime_transformation_content_delta():
     assert len(set(output_item_ids)) == 1
 
 
+def test_gemini_realtime_interrupted_emits_speech_started():
+    """``serverContent.interrupted`` should also surface
+    ``input_audio_buffer.speech_started`` so OpenAI-Realtime clients can barge-in,
+    while keeping the existing ``interrupted -> response.done`` mapping."""
+    config = GeminiRealtimeConfig()
+
+    session_configuration_request_str = json.dumps(
+        {
+            "setup": {
+                "model": "gemini-2.5-flash-native-audio",
+                "generationConfig": {"responseModalities": ["AUDIO"]},
+            }
+        }
+    )
+
+    result = config.transform_realtime_response(
+        json.dumps({"serverContent": {"interrupted": True}}),
+        "gemini-2.5-flash-native-audio",
+        MagicMock(),
+        realtime_response_transform_input={
+            "session_configuration_request": session_configuration_request_str,
+            "current_output_item_id": "my-output-item-id",
+            "current_response_id": "my-response-id",
+            "current_conversation_id": None,
+            "current_delta_chunks": [],
+            "current_item_chunks": [],
+            "current_delta_type": "audio",
+        },
+    )
+
+    types = [event["type"] for event in result["response"] if "type" in event]
+    # Barge-in is surfaced for clients that flush playback on speech-start.
+    assert "input_audio_buffer.speech_started" in types
+    # The existing interrupted -> response.done mapping is preserved.
+    assert "response.done" in types
+    # speech-start precedes response.done (flush/cancel, then lifecycle reset).
+    assert types.index("input_audio_buffer.speech_started") < types.index(
+        "response.done"
+    )
+
+
 def test_gemini_model_turn_event_mapping():
     from litellm.types.llms.openai import OpenAIRealtimeEventTypes
 


### PR DESCRIPTION
## What

The Gemini Live realtime transformation maps `serverContent.interrupted` only to `response.done` (via `MAP_GEMINI_FIELD_TO_OPENAI_EVENT`). Gemini emits `serverContent.interrupted` when the user **barges in** (interrupts the model mid-utterance), but collapsing it to a plain `response.done` loses that signal.

OpenAI-Realtime clients implement barge-in by reacting to `input_audio_buffer.speech_started` (flush the locally-buffered/queued model audio + cancel the active response). Since the Gemini path never emits that event, such clients never interrupt — the already-buffered model audio keeps playing even though Gemini has stopped generating. (OpenAI's server-VAD path emits `input_audio_buffer.speech_started`, so this aligns the two providers.)

## Fix

When `serverContent.interrupted` is truthy, also emit `input_audio_buffer.speech_started` (in addition to the existing `interrupted → response.done`). The client then receives speech-start (flush/cancel) followed by `response.done` (lifecycle reset).

```python
if isinstance(server_content, dict):
    if server_content.get("interrupted"):
        returned_message.append(cast(OpenAIRealtimeEvents, {
            "type": "input_audio_buffer.speech_started",
            "event_id": "event_{}".format(uuid.uuid4()),
            "audio_start_ms": 0,
            "item_id": "item_{}".format(uuid.uuid4()),
        }))
    ...
```

This reuses the existing `cast` / `uuid` / `OpenAIRealtimeEvents` imports in the module (right next to where input transcription events are synthesized), and leaves the `interrupted → response.done` mapping intact.

## Notes

Purely additive — it emits one extra event on interruption frames and changes nothing else. Builds on #31708 (the `?model=` fix needed to reach a working Gemini Live realtime session in the first place).
