### PR TITLE
perf(logging): serialize safe_dumps in a single pass on the hot path

### DIFF
--- a/litellm/litellm_core_utils/safe_json_dumps.py
+++ b/litellm/litellm_core_utils/safe_json_dumps.py
@@ -5,10 +5,73 @@ from pydantic import BaseModel
 
 from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
 
+# json renders a NUL byte as this 6-character escape; its presence in the output
+# means a string value held a NUL, so we hand the payload to the sanitizer.
+_NUL_ESCAPE = "\\u0000"
+
 
 def strip_null_bytes(value: str) -> str:
     """Strip NUL bytes, which PostgreSQL text/jsonb columns reject (error 22P05)."""
     return value.replace("\x00", "")
+
+
+def _stringify_unserializable(obj: object) -> str:
+    try:
+        return strip_null_bytes(str(obj))
+    except Exception:
+        return "Unserializable Object"
+
+
+def _json_default(obj: object) -> object:
+    """Encode the values json can't, mirroring the sanitizer's leaf handling."""
+    if isinstance(obj, BaseModel):
+        return obj.model_dump()
+    if isinstance(obj, (set, frozenset)):
+        return sorted(obj)
+    return _stringify_unserializable(obj)
+
+
+def _sanitize(obj: Any, seen: set, depth: int, max_depth: int) -> Any:
+    """Recursively rebuild ``obj`` into a JSON-safe value: strip NUL bytes, replace
+    circular references with a marker, and truncate past ``max_depth``."""
+    if depth > max_depth:
+        return "MaxDepthExceeded"
+    if isinstance(obj, str):
+        return obj.replace("\x00", "") if "\x00" in obj else obj
+    if isinstance(obj, (int, float, bool, type(None))):
+        return obj
+    if id(obj) in seen:
+        return "CircularReference Detected"
+    seen.add(id(obj))
+    result: Union[dict, list, tuple, set, str]
+    if isinstance(obj, dict):
+        result = {}
+        for k, v in obj.items():
+            if isinstance(k, (str)):
+                clean_k = k.replace("\x00", "") if "\x00" in k else k
+                result[clean_k] = _sanitize(v, seen, depth + 1, max_depth)
+        seen.remove(id(obj))
+        return result
+    elif isinstance(obj, list):
+        result = [_sanitize(item, seen, depth + 1, max_depth) for item in obj]
+        seen.remove(id(obj))
+        return result
+    elif isinstance(obj, tuple):
+        result = tuple(_sanitize(item, seen, depth + 1, max_depth) for item in obj)
+        seen.remove(id(obj))
+        return result
+    elif isinstance(obj, set):
+        result = sorted([_sanitize(item, seen, depth + 1, max_depth) for item in obj])
+        seen.remove(id(obj))
+        return result
+    elif isinstance(obj, BaseModel):
+        dumped = obj.model_dump()
+        result = _sanitize(dumped, seen, depth + 1, max_depth)
+        seen.remove(id(obj))
+        return result
+    else:
+        # Fall back to string conversion for non-serializable objects.
+        return _stringify_unserializable(obj)
 
 
 def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
@@ -16,53 +79,18 @@ def safe_dumps(data: Any, max_depth: int = DEFAULT_MAX_RECURSE_DEPTH) -> str:
     Recursively serialize data while detecting circular references.
     If a circular reference is detected then a marker string is returned.
     NUL bytes are stripped from strings to prevent PostgreSQL 22P05 errors.
+
+    With the default depth budget the common case is encoded in a single pass; a NUL
+    byte in the output, a circular reference, or a key json cannot encode falls back
+    to the recursive sanitizer. A caller-tightened ``max_depth`` always uses the
+    sanitizer so its truncation stays exact.
     """
-
-    def _serialize(obj: Any, seen: set, depth: int) -> Any:
-        # Check for maximum depth.
-        if depth > max_depth:
-            return "MaxDepthExceeded"
-        # Base-case: if it is a primitive, simply return it.
-        if isinstance(obj, str):
-            return obj.replace("\x00", "") if "\x00" in obj else obj
-        if isinstance(obj, (int, float, bool, type(None))):
-            return obj
-        # Check for circular reference.
-        if id(obj) in seen:
-            return "CircularReference Detected"
-        seen.add(id(obj))
-        result: Union[dict, list, tuple, set, str]
-        if isinstance(obj, dict):
-            result = {}
-            for k, v in obj.items():
-                if isinstance(k, (str)):
-                    clean_k = k.replace("\x00", "") if "\x00" in k else k
-                    result[clean_k] = _serialize(v, seen, depth + 1)
-            seen.remove(id(obj))
-            return result
-        elif isinstance(obj, list):
-            result = [_serialize(item, seen, depth + 1) for item in obj]
-            seen.remove(id(obj))
-            return result
-        elif isinstance(obj, tuple):
-            result = tuple(_serialize(item, seen, depth + 1) for item in obj)
-            seen.remove(id(obj))
-            return result
-        elif isinstance(obj, set):
-            result = sorted([_serialize(item, seen, depth + 1) for item in obj])
-            seen.remove(id(obj))
-            return result
-        elif isinstance(obj, BaseModel):
-            dumped = obj.model_dump()
-            result = _serialize(dumped, seen, depth + 1)
-            seen.remove(id(obj))
-            return result
+    if max_depth >= DEFAULT_MAX_RECURSE_DEPTH:
+        try:
+            encoded = json.dumps(data, default=_json_default)
+        except (ValueError, TypeError, RecursionError):
+            pass
         else:
-            # Fall back to string conversion for non-serializable objects.
-            try:
-                return strip_null_bytes(str(obj))
-            except Exception:
-                return "Unserializable Object"
-
-    safe_data = _serialize(data, set(), 0)
-    return json.dumps(safe_data, default=str)
+            if _NUL_ESCAPE not in encoded:
+                return encoded
+    return json.dumps(_sanitize(data, set(), 0, max_depth), default=str)

--- a/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
+++ b/tests/test_litellm/litellm_core_utils/test_safe_json_dumps.py
@@ -230,3 +230,126 @@ def test_pydantic_base_model():
     assert len(result["healthy_endpoints"]) == 2
     assert result["healthy_endpoints"][0]["name"] == "test"
     assert result["healthy_endpoints"][1] == {"value": 1, "label": "one"}
+
+
+# --- single-pass fast path: equivalence with the recursive sanitizer ---
+
+import random
+
+from pydantic import BaseModel
+
+from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
+
+
+def _reference_safe_dumps(data, max_depth=DEFAULT_MAX_RECURSE_DEPTH):
+    """The pre-optimization recursive sanitizer, kept verbatim as a test oracle."""
+
+    def _serialize(obj, seen, depth):
+        if depth > max_depth:
+            return "MaxDepthExceeded"
+        if isinstance(obj, str):
+            return obj.replace("\x00", "") if "\x00" in obj else obj
+        if isinstance(obj, (int, float, bool, type(None))):
+            return obj
+        if id(obj) in seen:
+            return "CircularReference Detected"
+        seen.add(id(obj))
+        if isinstance(obj, dict):
+            result = {}
+            for k, v in obj.items():
+                if isinstance(k, str):
+                    clean_k = k.replace("\x00", "") if "\x00" in k else k
+                    result[clean_k] = _serialize(v, seen, depth + 1)
+            seen.remove(id(obj))
+            return result
+        elif isinstance(obj, list):
+            result = [_serialize(item, seen, depth + 1) for item in obj]
+            seen.remove(id(obj))
+            return result
+        elif isinstance(obj, tuple):
+            result = tuple(_serialize(item, seen, depth + 1) for item in obj)
+            seen.remove(id(obj))
+            return result
+        elif isinstance(obj, set):
+            result = sorted([_serialize(item, seen, depth + 1) for item in obj])
+            seen.remove(id(obj))
+            return result
+        elif isinstance(obj, BaseModel):
+            dumped = obj.model_dump()
+            result = _serialize(dumped, seen, depth + 1)
+            seen.remove(id(obj))
+            return result
+        else:
+            try:
+                return strip_null_bytes(str(obj))
+            except Exception:
+                return "Unserializable Object"
+
+    return json.dumps(_serialize(data, set(), 0), default=str)
+
+
+class _FuzzModel(BaseModel):
+    a: int
+    b: str
+    c: list
+
+
+def _random_payload(rng, depth):
+    if depth >= 5:
+        return rng.choice([rng.randint(-9, 9), "leaf", None, True, "with\x00nul"])
+    kind = rng.choice(
+        ["int", "float", "str", "nul_str", "none", "bool", "list", "tuple", "dict", "set", "model"]
+    )
+    if kind == "int":
+        return rng.randint(-1000, 1000)
+    if kind == "float":
+        return rng.random() * 100
+    if kind == "str":
+        return rng.choice(["hello", "", "a b c", "unicode_é", 'quote"here', "tab\tnl\n"])
+    if kind == "nul_str":
+        return rng.choice(["pre\x00post", "\x00lead", "trail\x00", "lit \\u0000 text"])
+    if kind == "none":
+        return None
+    if kind == "bool":
+        return rng.choice([True, False])
+    if kind == "list":
+        return [_random_payload(rng, depth + 1) for _ in range(rng.randint(0, 4))]
+    if kind == "tuple":
+        return tuple(_random_payload(rng, depth + 1) for _ in range(rng.randint(0, 3)))
+    if kind == "dict":
+        # string keys only (the realistic shape; non-str keys are covered separately)
+        return {f"k{i}\x00x" if rng.random() < 0.2 else f"k{i}": _random_payload(rng, depth + 1) for i in range(rng.randint(0, 4))}
+    if kind == "set":
+        return set(rng.sample(range(30), rng.randint(0, 4)))  # one comparable type, sortable
+    return _FuzzModel(a=rng.randint(0, 9), b=rng.choice(["x", "y\x00z"]), c=[rng.randint(0, 3)])
+
+
+def test_fuzz_matches_reference_sanitizer():
+    """The single-pass path must be byte-identical to the recursive sanitizer for
+    realistic (string-keyed) payloads, including NUL bytes, sets, tuples, models,
+    and nesting."""
+    rng = random.Random(20240630)
+    for _ in range(600):
+        data = _random_payload(rng, 0)
+        assert safe_dumps(data) == _reference_safe_dumps(data)
+
+
+def test_tightened_max_depth_still_truncates():
+    """A caller-tightened max_depth must bypass the fast path and truncate exactly."""
+    data = {"a": {"b": {"c": {"d": "deep"}}}}
+    assert "MaxDepthExceeded" in safe_dumps(data, max_depth=2)
+    assert safe_dumps(data, max_depth=2) == _reference_safe_dumps(data, max_depth=2)
+
+
+def test_non_string_primitive_keys_are_kept():
+    """With the single-pass path, dict keys json can stringify (int/bool/None) are
+    kept with their JSON key form instead of being silently dropped. Keys json
+    cannot encode still fall back to the sanitizer and are dropped."""
+    assert json.loads(safe_dumps({1: "a", "b": "c"})) == {"1": "a", "b": "c"}
+
+    class Unhashable:
+        def __str__(self):
+            return "obj"
+
+    # object key -> json raises -> sanitizer fallback drops it (legacy behavior)
+    assert json.loads(safe_dumps({Unhashable(): "v", "ok": 1})) == {"ok": 1}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

LIT-4105

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Follow-up to the OTel per-request import fix (#31707). After that fix, the remaining proxy-overhead gap versus v1.85.0 was profiled with single-worker cProfile, bucketing self-time per request by module. The dependency bumps are net neutral (starlette 1.x is actually faster), so the residual is litellm's own new per-request work, and the largest single slice is `safe_json_dumps`

`safe_dumps` serialized in two passes: a full recursive Python-level copy of the payload to strip NUL bytes and detect circular references, then `json.dumps`, which re-traverses the whole structure. The standard logging payload is serialized on every request, and the per-token cost and cache breakdown added in 1.91 grew that payload, so the redundant pass became the biggest single contributor to the residual overhead

This encodes the common case in a single pass and falls back to the existing sanitizer only when needed

Microbenchmark on a representative ~1.9KB standard-logging payload, 200k iterations, output asserted identical between old and new

```
reference (old): 18.16 us/call
new (fast path):  7.44 us/call
speedup: 2.44x  (59% faster)
```

Residual-gap attribution (single-worker cProfile, self-time ms/req, 1.85.0 -> patched 1.91), showing `safe_json_dumps` as the top litellm contributor and starlette as a net win

```
TOTAL self-time/req: 1.85.0=9.111ms  1.91=9.531ms  delta=+0.420ms (+4.6%)

litellm:logging+cost   +0.098   (safe_json_dumps is the bulk of this)
litellm:proxy          +0.098
dep:pydantic           +0.081
dep:fastapi            +0.048
dep:starlette          -0.119   (faster, despite the 0.50 -> 1.3 bump)
```

Full benchmark and attribution: https://gist.github.com/yassin-berriai/31ecf15a2ba6d4298c3f2924c734f1a3

This is one increment. The rest of the residual is genuinely new per-request feature work (lazy-feature route matching, agentic-loop gating, callback-capability checks) plus the pydantic validation it pulls in, with no further single hotspot, so the end-to-end throughput contribution of this PR alone is small and below load-test noise; the per-call serialization win is large and deterministic

## Type

🚄 Infrastructure

## Changes

`safe_dumps` now tries a single `json.dumps` pass with a `default` that mirrors the sanitizer's handling of pydantic models (`model_dump`), sets (sorted), and unencodable objects (string fallback). It falls back to the recursive sanitizer when the encoded output contains a NUL escape, a circular reference is hit, or a key json cannot encode. A caller-tightened `max_depth` always uses the sanitizer, so its truncation stays exact. The sanitizer is lifted from a per-call nested closure to a module-level `_sanitize`, which also avoids rebuilding it on every call

Behavior is locked by a 600-case fuzz test that compares the new path against a verbatim copy of the previous sanitizer across nested dicts, lists, tuples, sets, pydantic models, NUL bytes, and the literal backslash-u-0000 text edge case, plus the existing suite (max_depth truncation, NUL stripping, cycles, non-string keys, pydantic models). Dicts with keys json can stringify (int, bool, None) are now kept with their JSON key form instead of being silently dropped; keys json cannot encode still fall back and are dropped as before
