### PR TITLE
fix(email): apply EMAIL_SIGNATURE to budget alert emails

### DIFF
--- a/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
+++ b/enterprise/litellm_enterprise/enterprise_callbacks/send_emails/base_email.py
@@ -239,6 +239,7 @@ class BaseEmailLogger(CustomLogger):
             max_budget_info=max_budget_info,
             base_url=email_params.base_url,
             email_support_contact=email_params.support_contact,
+            email_footer=email_params.signature,
         )
         await self.send_email(
             from_email=self.DEFAULT_LITELLM_EMAIL,
@@ -311,6 +312,7 @@ class BaseEmailLogger(CustomLogger):
             max_budget_info=max_budget_info,
             base_url=email_params.base_url,
             email_support_contact=email_params.support_contact,
+            email_footer=email_params.signature,
         )
 
         # Send email to all recipients
@@ -379,6 +381,7 @@ class BaseEmailLogger(CustomLogger):
                 alert_threshold=alert_threshold_str,
                 base_url=email_params.base_url,
                 email_support_contact=email_params.support_contact,
+                email_footer=email_params.signature,
             )
             await self.send_email(
                 from_email=self.DEFAULT_LITELLM_EMAIL,
@@ -403,6 +406,7 @@ class BaseEmailLogger(CustomLogger):
                 alert_threshold=alert_threshold_str,
                 base_url=email_params.base_url,
                 email_support_contact=email_params.support_contact,
+                email_footer=email_params.signature,
             )
             await self.send_email(
                 from_email=self.DEFAULT_LITELLM_EMAIL,

--- a/litellm/integrations/email_templates/templates.py
+++ b/litellm/integrations/email_templates/templates.py
@@ -81,8 +81,7 @@ SOFT_BUDGET_ALERT_EMAIL_TEMPLATE = """
 
                     If you have any questions, please send an email to {email_support_contact} <br /> <br />
 
-                    Best, <br />
-                    The LiteLLM team <br />
+                    {email_footer}
 """
 
 TEAM_SOFT_BUDGET_ALERT_EMAIL_TEMPLATE = """
@@ -105,8 +104,7 @@ TEAM_SOFT_BUDGET_ALERT_EMAIL_TEMPLATE = """
 
                     If you have any questions, please send an email to {email_support_contact} <br /> <br />
 
-                    Best, <br />
-                    The LiteLLM team <br />
+                    {email_footer}
 """
 
 MAX_BUDGET_ALERT_EMAIL_TEMPLATE = """
@@ -129,6 +127,5 @@ MAX_BUDGET_ALERT_EMAIL_TEMPLATE = """
 
                     If you have any questions, please send an email to {email_support_contact} <br /> <br />
 
-                    Best, <br />
-                    The LiteLLM team <br />
+                    {email_footer}
 """

--- a/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
+++ b/tests/test_litellm/enterprise/enterprise_callbacks/send_emails/test_base_email.py
@@ -1112,3 +1112,133 @@ async def test_no_map_preserves_old_single_threshold(
         # Old path cache key has no threshold percentage
         cache_key = mock_cache.async_set_cache.call_args[1]["key"]
         assert cache_key == "email_budget_alerts:max_budget_alert:test_user"
+
+
+CUSTOM_SIGNATURE = "<div>Best,<br/>The Acme Platform Team</div>"
+
+
+@pytest.mark.asyncio
+async def test_send_soft_budget_alert_email_uses_custom_signature(
+    base_email_logger, mock_send_email, mock_lookup_user_email
+):
+    """Soft budget alert honors EMAIL_SIGNATURE for premium users."""
+    event = WebhookEvent(
+        user_id="test_user",
+        user_email="test@example.com",
+        event_group=Litellm_EntityType.USER,
+        event="soft_budget_crossed",
+        event_message="Soft Budget Crossed",
+        spend=105.0,
+        max_budget=200.0,
+        soft_budget=100.0,
+    )
+    with mock.patch.dict(
+        os.environ,
+        {"PROXY_BASE_URL": "http://test.com", "EMAIL_SIGNATURE": CUSTOM_SIGNATURE},
+    ), patch("litellm.proxy.proxy_server.premium_user", True):
+        await base_email_logger.send_soft_budget_alert_email(event)
+
+        html_body = mock_send_email.call_args[1]["html_body"]
+        assert CUSTOM_SIGNATURE in html_body
+        assert "The LiteLLM team" not in html_body
+
+
+@pytest.mark.asyncio
+async def test_send_team_soft_budget_alert_email_uses_custom_signature(
+    base_email_logger, mock_send_email, mock_lookup_user_email
+):
+    """Team soft budget alert honors EMAIL_SIGNATURE for premium users."""
+    event = WebhookEvent(
+        user_id="test_user",
+        event_group=Litellm_EntityType.TEAM,
+        event="soft_budget_crossed",
+        event_message="Team Soft Budget Crossed",
+        spend=105.0,
+        max_budget=200.0,
+        soft_budget=100.0,
+        team_alias="Acme",
+        alert_emails=["teamlead@example.com"],
+    )
+    with mock.patch.dict(
+        os.environ,
+        {"PROXY_BASE_URL": "http://test.com", "EMAIL_SIGNATURE": CUSTOM_SIGNATURE},
+    ), patch("litellm.proxy.proxy_server.premium_user", True):
+        await base_email_logger.send_team_soft_budget_alert_email(event)
+
+        html_body = mock_send_email.call_args[1]["html_body"]
+        assert CUSTOM_SIGNATURE in html_body
+        assert "The LiteLLM team" not in html_body
+
+
+@pytest.mark.asyncio
+async def test_send_max_budget_alert_email_single_recipient_uses_custom_signature(
+    base_email_logger, mock_send_email, mock_lookup_user_email
+):
+    """Max budget alert (single-recipient path) honors EMAIL_SIGNATURE."""
+    event = WebhookEvent(
+        user_id="test_user",
+        user_email="test@example.com",
+        event_group=Litellm_EntityType.USER,
+        event="max_budget_alert",
+        event_message="Max Budget Alert",
+        spend=165.0,
+        max_budget=200.0,
+    )
+    with mock.patch.dict(
+        os.environ,
+        {"PROXY_BASE_URL": "http://test.com", "EMAIL_SIGNATURE": CUSTOM_SIGNATURE},
+    ), patch("litellm.proxy.proxy_server.premium_user", True):
+        await base_email_logger.send_max_budget_alert_email(event)
+
+        html_body = mock_send_email.call_args[1]["html_body"]
+        assert CUSTOM_SIGNATURE in html_body
+        assert "The LiteLLM team" not in html_body
+
+
+@pytest.mark.asyncio
+async def test_send_max_budget_alert_email_multi_recipient_uses_custom_signature(
+    base_email_logger, mock_send_email, mock_lookup_user_email
+):
+    """Max budget alert (multi-threshold/recipient path) honors EMAIL_SIGNATURE."""
+    event = WebhookEvent(
+        user_id="test_user",
+        user_email="owner@example.com",
+        event_group=Litellm_EntityType.USER,
+        event="max_budget_alert",
+        event_message="Max Budget Alert",
+        spend=165.0,
+        max_budget=200.0,
+    )
+    with mock.patch.dict(
+        os.environ,
+        {"PROXY_BASE_URL": "http://test.com", "EMAIL_SIGNATURE": CUSTOM_SIGNATURE},
+    ), patch("litellm.proxy.proxy_server.premium_user", True):
+        await base_email_logger.send_max_budget_alert_email(
+            event, threshold_pct=75, recipient_emails=["a@example.com", "b@example.com"]
+        )
+
+        html_body = mock_send_email.call_args[1]["html_body"]
+        assert CUSTOM_SIGNATURE in html_body
+        assert "The LiteLLM team" not in html_body
+
+
+@pytest.mark.asyncio
+async def test_send_soft_budget_alert_email_default_footer_when_no_signature(
+    base_email_logger, mock_send_email, mock_lookup_user_email
+):
+    """Without EMAIL_SIGNATURE, budget alert falls back to the default EMAIL_FOOTER."""
+    event = WebhookEvent(
+        user_id="test_user",
+        user_email="test@example.com",
+        event_group=Litellm_EntityType.USER,
+        event="soft_budget_crossed",
+        event_message="Soft Budget Crossed",
+        spend=105.0,
+        max_budget=200.0,
+        soft_budget=100.0,
+    )
+    with mock.patch.dict(os.environ, {"PROXY_BASE_URL": "http://test.com"}):
+        await base_email_logger.send_soft_budget_alert_email(event)
+
+        html_body = mock_send_email.call_args[1]["html_body"]
+        assert EMAIL_FOOTER in html_body


### PR DESCRIPTION
## Relevant issues

N/A (no public GitHub issue)

## Linear ticket

Resolves LIT-3748

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (CircleCI pending on push)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Budget alert emails ignored `EMAIL_SIGNATURE`. Rendered footer of a soft budget alert with a premium license and `EMAIL_SIGNATURE` set, before and after the change

Before

```
If you have any questions, please send an email to support@berri.ai
Best, <br />
The LiteLLM team <br />
```

After

```
If you have any questions, please send an email to support@berri.ai
<div>Best,<br/>The Acme Platform Team</div>
```

All three budget alert types (soft, team soft, max) and both max budget code paths render the configured signature; with no `EMAIL_SIGNATURE` they fall back to the standard `EMAIL_FOOTER`, consistent with every other email type. A live end-to-end send needs an enterprise license plus SMTP plus an actual budget crossing, so verification asserts the rendered email body directly through the unit tests and a render harness exercising all four call sites

## Type

🐛 Bug Fix

## Changes

The three budget alert templates (soft budget, team soft budget, max budget) hardcoded the `Best, / The LiteLLM team` signature and had no `{email_footer}` placeholder, and the four budget `.format()` calls in `base_email.py` never passed `email_footer=email_params.signature`. So the `EMAIL_SIGNATURE` override (and the default `EMAIL_FOOTER`) reached invitation and key emails but was silently dropped on every budget alert

This adds the `{email_footer}` placeholder to the three budget templates and passes `email_footer=email_params.signature` at all four budget call sites; the max budget path has two branches (single recipient and multi-threshold) and both are updated. `email_params.signature` already resolves to the custom `EMAIL_SIGNATURE` for premium instances and the default `EMAIL_FOOTER` otherwise, so budget alerts now match the behavior of the other email types. Five regression tests cover the four paths plus the default-footer fallback; they fail on the pre-fix code and pass with it
