### PR TITLE
test(benchmarks): add CodSpeed benchmarks for inference, MCP and A2A hot paths

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - litellm_internal_staging
   pull_request:
     branches:
       - main
+      - litellm_internal_staging
   # Allow CodSpeed to trigger backtest performance analysis
   # in order to generate initial data
   workflow_dispatch:
@@ -48,6 +50,8 @@ jobs:
             uv run --frozen --no-default-groups
             --with pytest==8.3.5
             --with pytest-codspeed==4.3.0
+            --with "mcp>=1.26.0,<2.0"
+            --with "a2a-sdk>=1.1.0,<2.0"
             pytest
             -p pytest_codspeed.plugin
             tests/benchmarks/

--- a/tests/benchmarks/test_a2a_benchmarks.py
+++ b/tests/benchmarks/test_a2a_benchmarks.py
@@ -1,0 +1,76 @@
+"""
+Performance benchmarks for the A2A (agent-to-agent) message-translation hot path.
+
+Both directions are covered: the client direction (litellm.completion talking to
+an upstream A2A agent) converts OpenAI messages into a prompt and extracts text
+from the A2A response, and the proxy server-ingress direction converts an inbound
+A2A message into OpenAI messages before bridging to a completion. All are pure-CPU
+per-request transforms.
+"""
+
+import pytest
+
+from litellm.a2a_protocol.litellm_completion_bridge.transformation import (
+    A2ACompletionBridgeTransformation,
+)
+from litellm.llms.a2a.common_utils import (
+    convert_messages_to_prompt,
+    extract_text_from_a2a_response,
+)
+
+MESSAGES = [
+    {"role": "system", "content": "You are a helpful research assistant."},
+    {"role": "user", "content": "What is the capital of France?"},
+    {"role": "assistant", "content": "The capital of France is Paris."},
+    {"role": "user", "content": "And what is its population?"},
+]
+
+MESSAGE_RESPONSE = {
+    "result": {
+        "kind": "message",
+        "parts": [
+            {"kind": "text", "text": "The population of Paris is about 2.1 million."},
+            {"kind": "text", "text": "The metro area has over 12 million people."},
+        ],
+    }
+}
+
+TASK_RESPONSE = {
+    "result": {
+        "kind": "task",
+        "artifacts": [{"parts": [{"kind": "text", "text": "Paris has a population of about 2.1 million."}]}],
+    }
+}
+
+A2A_INBOUND_MESSAGE = {
+    "role": "user",
+    "parts": [
+        {"kind": "text", "text": "Summarize the latest quarterly report."},
+        {"kind": "text", "text": "Focus on revenue and margins."},
+    ],
+    "messageId": "msg-1",
+}
+
+
+@pytest.mark.benchmark
+def test_convert_messages_to_a2a_prompt():
+    """Benchmark converting OpenAI messages into an A2A prompt string."""
+    convert_messages_to_prompt(messages=MESSAGES)
+
+
+@pytest.mark.benchmark
+def test_extract_text_from_a2a_message_response():
+    """Benchmark extracting text from a direct-message A2A response."""
+    extract_text_from_a2a_response(response_dict=MESSAGE_RESPONSE)
+
+
+@pytest.mark.benchmark
+def test_extract_text_from_a2a_task_response():
+    """Benchmark extracting text from a task-with-artifacts A2A response."""
+    extract_text_from_a2a_response(response_dict=TASK_RESPONSE)
+
+
+@pytest.mark.benchmark
+def test_a2a_inbound_message_to_openai_messages():
+    """Benchmark the proxy converting an inbound A2A message into OpenAI messages."""
+    A2ACompletionBridgeTransformation.a2a_message_to_openai_messages(A2A_INBOUND_MESSAGE)

--- a/tests/benchmarks/test_inference_benchmarks.py
+++ b/tests/benchmarks/test_inference_benchmarks.py
@@ -1,0 +1,113 @@
+"""
+Performance benchmarks for the LLM inference (chat completion) hot path.
+
+The end-to-end cases use ``mock_response`` so the full SDK overhead is exercised
+-- provider resolution, request/response transformation, ``ModelResponse``
+construction, token counting and cost calculation -- without any network I/O. The
+``convert_to_model_response_object`` case isolates the provider-response to
+``ModelResponse`` translation, the single deterministic core every non-streaming
+completion runs.
+"""
+
+import pytest
+
+import litellm
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    convert_to_model_response_object,
+)
+from litellm.types.utils import ModelResponse
+
+SIMPLE_MESSAGES = [{"role": "user", "content": "Hello, how are you?"}]
+
+MULTI_TURN_MESSAGES = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "What is the capital of France?"},
+    {
+        "role": "assistant",
+        "content": "The capital of France is Paris. It is known as the City of Light.",
+    },
+    {"role": "user", "content": "Tell me more about Paris."},
+]
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA",
+                    },
+                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+                },
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+MOCK_RESPONSE = "The capital of France is Paris, the country's largest city and cultural centre."
+
+PROVIDER_RESPONSE = {
+    "id": "chatcmpl-abc123",
+    "object": "chat.completion",
+    "created": 1700000000,
+    "model": "gpt-4o",
+    "choices": [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {"role": "assistant", "content": MOCK_RESPONSE},
+        }
+    ],
+    "usage": {"prompt_tokens": 12, "completion_tokens": 16, "total_tokens": 28},
+}
+
+
+@pytest.mark.benchmark
+def test_completion_simple_message():
+    """Benchmark a single-message completion through the full SDK path."""
+    litellm.completion(model="gpt-4o", messages=SIMPLE_MESSAGES, mock_response=MOCK_RESPONSE)
+
+
+@pytest.mark.benchmark
+def test_completion_multi_turn():
+    """Benchmark a multi-turn completion through the full SDK path."""
+    litellm.completion(model="gpt-4o", messages=MULTI_TURN_MESSAGES, mock_response=MOCK_RESPONSE)
+
+
+@pytest.mark.benchmark
+def test_completion_with_tools():
+    """Benchmark a completion that has to process tool schemas."""
+    litellm.completion(
+        model="gpt-4o",
+        messages=SIMPLE_MESSAGES,
+        tools=TOOL_DEFINITIONS,
+        mock_response=MOCK_RESPONSE,
+    )
+
+
+@pytest.mark.benchmark
+def test_completion_streaming():
+    """Benchmark consuming a full streamed completion (CustomStreamWrapper)."""
+    stream = litellm.completion(
+        model="gpt-4o",
+        messages=SIMPLE_MESSAGES,
+        mock_response=MOCK_RESPONSE,
+        stream=True,
+    )
+    for _ in stream:
+        pass
+
+
+@pytest.mark.benchmark
+def test_response_to_model_response_object():
+    """Benchmark the provider-response to ModelResponse translation core."""
+    convert_to_model_response_object(
+        response_object=PROVIDER_RESPONSE,
+        model_response_object=ModelResponse(),
+    )

--- a/tests/benchmarks/test_mcp_benchmarks.py
+++ b/tests/benchmarks/test_mcp_benchmarks.py
@@ -1,0 +1,84 @@
+"""
+Performance benchmarks for the MCP tool hot path.
+
+Two layers are covered: the client-side translation between MCP and OpenAI
+function-calling formats, and the server-side tool-name prefixing that the proxy
+runs on every list-tools (prefix each tool) and call-tool (strip prefix to route)
+request. Both are pure-CPU and deterministic.
+"""
+
+import pytest
+from mcp.types import Tool as MCPTool
+
+from litellm.experimental_mcp_client.tools import (
+    transform_mcp_tool_to_openai_tool,
+    transform_openai_tool_call_request_to_mcp_tool_call_request,
+)
+from litellm.proxy._experimental.mcp_server.utils import (
+    add_server_prefix_to_name,
+    split_server_prefix_from_name,
+)
+
+
+def _make_tool(index: int) -> MCPTool:
+    return MCPTool(
+        name=f"tool_{index}",
+        description=f"Test tool number {index} that performs an operation",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query"},
+                "limit": {"type": "integer", "description": "Max results"},
+            },
+            "required": ["query"],
+        },
+    )
+
+
+SINGLE_TOOL = _make_tool(0)
+TOOL_LIST = tuple(_make_tool(i) for i in range(20))
+TOOL_NAMES = tuple(t.name for t in TOOL_LIST)
+
+SERVER_NAME = "github_mcp"
+PREFIXED_TOOL_NAME = add_server_prefix_to_name("tool_0", SERVER_NAME)
+
+OPENAI_TOOL_CALL = {
+    "id": "call_abc123",
+    "type": "function",
+    "function": {
+        "name": "tool_0",
+        "arguments": '{"query": "weather in San Francisco", "limit": 5}',
+    },
+}
+
+
+@pytest.mark.benchmark
+def test_transform_single_mcp_tool_to_openai():
+    """Benchmark translating one MCP tool into OpenAI tool format."""
+    transform_mcp_tool_to_openai_tool(mcp_tool=SINGLE_TOOL)
+
+
+@pytest.mark.benchmark
+def test_transform_mcp_tool_list_to_openai():
+    """Benchmark translating a full list-tools response into OpenAI format."""
+    for tool in TOOL_LIST:
+        transform_mcp_tool_to_openai_tool(mcp_tool=tool)
+
+
+@pytest.mark.benchmark
+def test_transform_openai_tool_call_to_mcp():
+    """Benchmark translating an OpenAI tool call into an MCP call request."""
+    transform_openai_tool_call_request_to_mcp_tool_call_request(openai_tool=OPENAI_TOOL_CALL)
+
+
+@pytest.mark.benchmark
+def test_mcp_server_prefix_tool_list():
+    """Benchmark the proxy prefixing every tool name on a list-tools response."""
+    for name in TOOL_NAMES:
+        add_server_prefix_to_name(name, SERVER_NAME)
+
+
+@pytest.mark.benchmark
+def test_mcp_server_strip_prefix_on_call():
+    """Benchmark the proxy stripping the server prefix to route a tool call."""
+    split_server_prefix_from_name(PREFIXED_TOOL_NAME)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

These are CodSpeed micro-benchmarks, not a runtime behavior change, so the proof is that the new suite collects and runs green under the exact command the CI job uses. Run from the repo root in an isolated env that installs only the base dependency set the benchmark job uses (`--no-default-groups`) plus the benchmark extras:

```
env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
  uv run --frozen --no-default-groups \
  --with pytest==8.3.5 \
  --with pytest-codspeed==4.3.0 \
  --with "mcp>=1.26.0,<2.0" \
  --with "a2a-sdk>=1.1.0,<2.0" \
  pytest -p pytest_codspeed.plugin tests/benchmarks/ --codspeed
```

Output (trimmed to the new benchmarks):

```
tests/benchmarks/test_a2a_benchmarks.py ....                             [ 13%]
tests/benchmarks/test_benchmarks.py ................                     [ 66%]
tests/benchmarks/test_inference_benchmarks.py .....                      [ 83%]
tests/benchmarks/test_mcp_benchmarks.py .....                            [100%]

│ test_a2a_inbound_message_to_openai_messages │   0ns │  0.7% │  2.90s │ 1,74… │
│              test_completion_simple_message │ 1.67… │  2.2% │  2.95s │ 11,0… │
│                  test_completion_multi_turn │ 1.70… │  2.6% │  2.98s │ 10,9… │
│                  test_completion_with_tools │ 1.75… │  1.5% │  2.98s │ 10,7… │
│                   test_completion_streaming │ 460.… │ 11.6% │  3.00s │   594 │
│      test_response_to_model_response_object │  20ns │  6.9% │  2.99s │ 96,0… │
│    test_transform_single_mcp_tool_to_openai │   0ns │  8.1% │  2.50s │ 1,51… │
│      test_transform_mcp_tool_list_to_openai │   1ns │  2.0% │  3.02s │ 456,… │
│      test_transform_openai_tool_call_to_mcp │   0ns │  1.2% │  2.83s │ 1,21… │
│            test_mcp_server_prefix_tool_list │   1ns │  1.2% │  2.92s │ 584,… │
│        test_mcp_server_strip_prefix_on_call │   0ns │  1.1% │  2.86s │ 2,14… │

================== 30 passed, 2 warnings in 122.96s (0:02:02) ==================
```

The sub-nanosecond transforms read as 0ns only in CodSpeed's local walltime mode; the CI run uses instrumentation mode, which counts CPU instructions and gives them a meaningful, stable number to diff against the base branch

## Type

✅ Test

## Changes

This adds CodSpeed benchmarks for the three areas of interest so perf regressions in their per-request hot paths surface on every commit going forward. Everything is designed to be lightweight and deterministic: each benchmark is pure in-process CPU work with zero network I/O (a hard requirement of CodSpeed's simulation mode, which counts CPU instructions), and the targets are the transformation functions rather than the full FastAPI proxy, so they import under the constrained dependency set the benchmark job installs

Inference (`tests/benchmarks/test_inference_benchmarks.py`) exercises the full SDK overhead through `litellm.completion(..., mock_response=...)` for simple, multi-turn, with-tools and streaming calls, which walks provider resolution, request/response transformation, `ModelResponse` construction, token counting and cost calculation without hitting a provider. It also benchmarks `convert_to_model_response_object` directly as a deterministic anchor for the provider-response to `ModelResponse` core that every non-streaming completion runs

MCP (`tests/benchmarks/test_mcp_benchmarks.py`) covers the client-side MCP to OpenAI tool translation (a single tool, a 20-tool list mirroring list-tools, and a tool-call dispatch) plus the proxy server-side tool-name prefix round-trip, `add_server_prefix_to_name` over a tool list and `split_server_prefix_from_name` on a call, which is the real per-request CPU cost on the MCP endpoint

A2A (`tests/benchmarks/test_a2a_benchmarks.py`) covers the client direction (`convert_messages_to_prompt` for the request and `extract_text_from_a2a_response` for message and task-artifact response shapes) and the proxy server-ingress `A2ACompletionBridgeTransformation.a2a_message_to_openai_messages` that runs on every inbound A2A request

The workflow change adds the `mcp` and `a2a-sdk` packages to the benchmark run since those transform modules need them at import time, and broadens the push and pull_request triggers to include `litellm_internal_staging` so the internal branch flow, where contributors open PRs against staging rather than `main`, is benchmarked too