### PR TITLE
fix(azure): drop max_tokens when max_completion_tokens is set (#31614)

### DIFF
--- a/litellm/llms/azure/chat/gpt_transformation.py
+++ b/litellm/llms/azure/chat/gpt_transformation.py
@@ -245,6 +245,8 @@ class AzureOpenAIConfig(BaseConfig):
                 optional_params["tools"].extend(value)
             elif param in supported_openai_params:
                 optional_params[param] = value
+        if "max_completion_tokens" in optional_params:
+            optional_params.pop("max_tokens", None)
         return optional_params
 
     def transform_request(

--- a/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_chat_gpt_transformation.py
@@ -1,10 +1,9 @@
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
-)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../..")))
 
+import litellm
 from litellm.llms.azure.chat.gpt_transformation import AzureOpenAIConfig
 
 
@@ -51,6 +50,67 @@ def test_map_openai_params_with_preview_api_version():
     model = "azure/gpt-4-1"
     drop_params = False
     api_version = "preview"
-    assert config.map_openai_params(
-        non_default_params, optional_params, model, drop_params, api_version
-    )
+    assert config.map_openai_params(non_default_params, optional_params, model, drop_params, api_version)
+
+
+class TestAzureMaxTokensConflict:
+    """Azure rejects requests carrying both max_tokens and max_completion_tokens.
+
+    Regression coverage for https://github.com/BerriAI/litellm/issues/31614 -
+    map_openai_params must never emit both; max_completion_tokens is preferred.
+    """
+
+    def _map(self, non_default_params, optional_params=None):
+        return AzureOpenAIConfig().map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params if optional_params is not None else {},
+            model="azure/gpt-4.1",
+            drop_params=False,
+        )
+
+    def test_max_tokens_alone_is_preserved(self):
+        result = self._map({"max_tokens": 100})
+        assert result["max_tokens"] == 100
+        assert "max_completion_tokens" not in result
+
+    def test_max_completion_tokens_alone_is_preserved(self):
+        result = self._map({"max_completion_tokens": 100})
+        assert result["max_completion_tokens"] == 100
+        assert "max_tokens" not in result
+
+    def test_both_in_non_default_params_keeps_only_max_completion_tokens(self):
+        result = self._map({"max_tokens": 50, "max_completion_tokens": 100})
+        assert result["max_completion_tokens"] == 100
+        assert "max_tokens" not in result
+
+    def test_preseeded_max_tokens_is_dropped_when_max_completion_tokens_present(self):
+        result = self._map({"max_completion_tokens": 100}, optional_params={"max_tokens": 50})
+        assert result["max_completion_tokens"] == 100
+        assert "max_tokens" not in result
+
+    def test_max_completion_tokens_wins_even_when_smaller(self):
+        result = self._map({"max_tokens": 1000, "max_completion_tokens": 5})
+        assert result["max_completion_tokens"] == 5
+        assert "max_tokens" not in result
+
+
+class TestAzureMaxTokensConflictGetOptionalParams:
+    """End-to-end coverage through the public get_optional_params entrypoint."""
+
+    def _get(self, **kwargs):
+        return litellm.utils.get_optional_params(model="gpt-4.1", custom_llm_provider="azure", **kwargs)
+
+    def test_max_tokens_alone_does_not_add_max_completion_tokens(self):
+        result = self._get(max_tokens=100)
+        assert result["max_tokens"] == 100
+        assert "max_completion_tokens" not in result
+
+    def test_max_completion_tokens_alone_does_not_add_max_tokens(self):
+        result = self._get(max_completion_tokens=100)
+        assert result["max_completion_tokens"] == 100
+        assert "max_tokens" not in result
+
+    def test_both_keeps_only_max_completion_tokens(self):
+        result = self._get(max_tokens=50, max_completion_tokens=100)
+        assert result["max_completion_tokens"] == 100
+        assert "max_tokens" not in result


### PR DESCRIPTION
## Relevant issues

Fixes #31614

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Azure rejects chat-completion requests that carry both `max_tokens` and `max_completion_tokens` with "Setting 'max_tokens' and 'max_completion_tokens' at the same time is not supported". LiteLLM could send both, so the request never reached the model

Live real-Azure verification was not possible because no accessible GPT-4.x Azure deployment was available; a personal Microsoft account hit AADSTS50020, a school account is RBAC-locked, and gpt-4o/gpt-4.1 are deprecated or undeployable in the available regions. GPT-5 was not used as a substitute because it routes through a different LiteLLM config path and neither reproduces the bug nor exercises this fix. Instead I verified through the running proxy using curl and detailed-debug logs against an Azure-compatible endpoint, plus a before/after capture of the exact outbound JSON

Primary proof, curl through the proxy with `--detailed_debug`, the same request both times with both token fields set

Before the fix, the outbound request body to Azure carries both fields

```
Final returned optional params: {'stream': False, 'max_tokens': 50, 'max_completion_tokens': 50, 'extra_body': {}}
POST Request Sent from LiteLLM:
-d '{'model': 'gpt-4o', 'messages': [...], 'stream': False, 'max_tokens': 50, 'max_completion_tokens': 50, 'extra_body': {}}'
```

After the fix, only `max_completion_tokens` is sent

```
Final returned optional params: {'stream': False, 'max_completion_tokens': 50, 'extra_body': {}}
POST Request Sent from LiteLLM:
-d '{'model': 'gpt-4o', 'messages': [...], 'stream': False, 'max_completion_tokens': 50, 'extra_body': {}}'
```

Supporting proof, capturing the exact request body via an injected httpx transport so it does not depend on Azure credentials

```
BEFORE: {"model":"gpt-4o", ..., "max_completion_tokens":50, "max_tokens":50}   max_tokens present: True
AFTER:  {"model":"gpt-4o", ..., "max_completion_tokens":50}                    max_tokens present: False
```

Regression tests: `11 passed`. Mutation-checked, reverting the two-line normalization makes exactly the four conflict tests fail

## Type

🐛 Bug Fix

## Changes

`AzureOpenAIConfig.map_openai_params` advertised both `max_tokens` and `max_completion_tokens` as supported and passed through whatever it was given, so a request that set both reached Azure and was rejected. This adds a final normalization in `map_openai_params` that drops `max_tokens` when `max_completion_tokens` is present, keeping the canonical field. It is placed at the end of the method rather than inside the param loop so it also covers a pre-seeded `optional_params`, and `get_supported_openai_params` is unchanged since each field remains valid on its own. GPT-5 and o-series are untouched because they resolve to their own config classes before this one
