### PR TITLE
fix(otel): tolerate non-mapping response_obj and skip ended-span writes

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2117,6 +2117,16 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             if standard_logging_payload is None:
                 raise ValueError("standard_logging_object not found in kwargs")
 
+            # response_obj is Optional[Any]: non-LLM call types (e.g. management
+            # list endpoints which return a list, or MCP tool calls which return a
+            # CallToolResult) pass a non-mapping value here. The response-derived
+            # attributes below call response_obj.get(...), which raises
+            # AttributeError on those types and fails the whole tracing callback
+            # (once per such request). Drop it to None so those attributes are
+            # simply skipped instead.
+            if response_obj is not None and not callable(getattr(response_obj, "get", None)):
+                response_obj = None
+
             # https://github.com/open-telemetry/semantic-conventions/blob/main/model/registry/gen-ai.yaml
             # Following Conventions here: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/llm-spans.md
             #############################################
@@ -2464,6 +2474,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         """
         Safely sets an attribute on the span, ensuring the value is a primitive type.
         """
+        # Skip writes to a span that has already ended. The OTel SDK logs a
+        # "Setting attribute on ended span" warning for every such call, which
+        # floods logs (and burns CPU/IO) when async success/failure logging races
+        # the request span's end(). Writing to an ended span is a no-op anyway.
+        if hasattr(span, "is_recording") and not span.is_recording():
+            return
         primitive_value = self._cast_as_primitive_value_type(value)
         span.set_attribute(key, primitive_value)
 

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -50,9 +50,7 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
         }
 
         # Create a kwargs dict with standard_logging_object containing guardrail information
-        kwargs = {
-            "standard_logging_object": {"guardrail_information": [guardrail_info]}
-        }
+        kwargs = {"standard_logging_object": {"guardrail_information": [guardrail_info]}}
 
         # Call the method
         otel._create_guardrail_span(kwargs=kwargs, context=None)
@@ -68,12 +66,8 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
         # Check that the span has the correct attributes set
         mock_span.set_attribute.assert_any_call("guardrail_name", "test_guardrail")
         mock_span.set_attribute.assert_any_call("guardrail_mode", "input")
-        mock_span.set_attribute.assert_any_call(
-            "guardrail_response", safe_dumps("filtered_content")
-        )
-        mock_span.set_attribute.assert_any_call(
-            "masked_entity_count", safe_dumps({"CREDIT_CARD": 2})
-        )
+        mock_span.set_attribute.assert_any_call("guardrail_response", safe_dumps("filtered_content"))
+        mock_span.set_attribute.assert_any_call("masked_entity_count", safe_dumps({"CREDIT_CARD": 2}))
 
         # Verify that the span was ended
         mock_span.end.assert_called_once()
@@ -112,15 +106,11 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
             "start_time": 1609459200.0,
             "end_time": 1609459201.0,
         }
-        kwargs = {
-            "standard_logging_object": {"guardrail_information": [guardrail_info]}
-        }
+        kwargs = {"standard_logging_object": {"guardrail_information": [guardrail_info]}}
 
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        mock_span.set_attribute.assert_any_call(
-            "guardrail_response", safe_dumps(moderation_payload)
-        )
+        mock_span.set_attribute.assert_any_call("guardrail_response", safe_dumps(moderation_payload))
 
     @patch("litellm.integrations.opentelemetry.datetime")
     def test_guardrail_response_none_is_skipped(self, mock_datetime):
@@ -138,15 +128,11 @@ class TestOpenTelemetryGuardrails(unittest.TestCase):
             "start_time": 1609459200.0,
             "end_time": 1609459201.0,
         }
-        kwargs = {
-            "standard_logging_object": {"guardrail_information": [guardrail_info]}
-        }
+        kwargs = {"standard_logging_object": {"guardrail_information": [guardrail_info]}}
 
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        attribute_keys = [
-            call.args[0] for call in mock_span.set_attribute.call_args_list
-        ]
+        attribute_keys = [call.args[0] for call in mock_span.set_attribute.call_args_list]
         self.assertNotIn("guardrail_response", attribute_keys)
 
 
@@ -183,12 +169,8 @@ class TestOpenTelemetryTeamAttributesOnChildSpans(unittest.TestCase):
 
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_id", "team-123"
-        )
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_alias", "my-team"
-        )
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_id", "team-123")
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_alias", "my-team")
 
     @patch.dict(os.environ, {"OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": ""})
     @patch("litellm.turn_off_message_logging", False)
@@ -207,16 +189,10 @@ class TestOpenTelemetryTeamAttributesOnChildSpans(unittest.TestCase):
             "litellm_params": {"metadata": {}},
             "standard_logging_object": {"metadata": self._slo_metadata()},
         }
-        otel._maybe_log_raw_request(
-            kwargs, {}, datetime.now(), datetime.now(), MagicMock()
-        )
+        otel._maybe_log_raw_request(kwargs, {}, datetime.now(), datetime.now(), MagicMock())
 
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_id", "team-123"
-        )
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_alias", "my-team"
-        )
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_id", "team-123")
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_alias", "my-team")
 
     def test_helper_skips_when_team_values_missing(self):
         otel = OpenTelemetry()
@@ -246,12 +222,8 @@ class TestOpenTelemetryTeamAttributesOnChildSpans(unittest.TestCase):
             {"standard_logging_object": {"metadata": self._slo_metadata()}},
         )
 
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_id", "team-123"
-        )
-        mock_span.set_attribute.assert_any_call(
-            "metadata.user_api_key_team_alias", "my-team"
-        )
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_id", "team-123")
+        mock_span.set_attribute.assert_any_call("metadata.user_api_key_team_alias", "my-team")
 
     def test_helper_handles_missing_standard_logging_object(self):
         otel = OpenTelemetry()
@@ -288,9 +260,7 @@ class TestOpenTelemetryTeamAttributesOnChildSpans(unittest.TestCase):
         finished = {s.name: s for s in exporter.get_finished_spans()}
         exception_span = finished["Failed Proxy Server Request"]
         assert exception_span.attributes["metadata.user_api_key_team_id"] == "team-123"
-        assert (
-            exception_span.attributes["metadata.user_api_key_team_alias"] == "my-team"
-        )
+        assert exception_span.attributes["metadata.user_api_key_team_alias"] == "my-team"
 
 
 class TestOpenTelemetryCostBreakdown(unittest.TestCase):
@@ -385,6 +355,82 @@ class TestOpenTelemetryCostBreakdown(unittest.TestCase):
         assert ("gen_ai.cost.original_cost", 0.004) not in call_args_list
 
 
+class TestOpenTelemetryNonMappingResponseObj(unittest.TestCase):
+    """set_attributes is called for every traced call, including non-LLM call
+    types whose response_obj is not a mapping: management list endpoints return
+    a list, MCP tool calls return a CallToolResult. Those have no .get(), so the
+    response-derived attributes used to raise AttributeError and abort the whole
+    tracing callback (once per such request — the flood seen in prod). The
+    response_obj must be tolerated so the rest of the span is still annotated."""
+
+    def _kwargs(self):
+        return {
+            "model": "gpt-4",
+            "optional_params": {},
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": {
+                "id": "std-id-123",
+                "litellm_call_id": "call-id-456",
+                "call_type": "completion",
+                "metadata": {},
+            },
+        }
+
+    def _assert_survives(self, response_obj):
+        otel = OpenTelemetry()
+        span = MagicMock()
+        otel.set_attributes(span=span, kwargs=self._kwargs(), response_obj=response_obj)
+        calls = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args}
+        # litellm.call_id is set AFTER the first response_obj.get(); before the fix
+        # the AttributeError aborted set_attributes before reaching it.
+        assert calls.get("litellm.call_id") == "call-id-456"
+        # response id falls back to the standard logging payload id, not a crash.
+        assert calls.get("gen_ai.response.id") == "std-id-123"
+
+    def test_list_response_obj_does_not_abort_span(self):
+        self._assert_survives([{"team_id": "t1"}, {"team_id": "t2"}])
+
+    def test_non_mapping_object_response_obj_does_not_abort_span(self):
+        class CallToolResultLike:
+            def __init__(self):
+                self.content = "ok"
+
+        self._assert_survives(CallToolResultLike())
+
+    def test_dict_response_obj_still_sets_response_attributes(self):
+        otel = OpenTelemetry()
+        span = MagicMock()
+        otel.set_attributes(
+            span=span,
+            kwargs=self._kwargs(),
+            response_obj={"id": "resp-id", "model": "gpt-4", "choices": []},
+        )
+        calls = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args}
+        # A real dict response still wins over the fallback.
+        assert calls.get("gen_ai.response.id") == "resp-id"
+
+
+class TestOpenTelemetrySafeSetAttributeEndedSpan(unittest.TestCase):
+    """safe_set_attribute must not write to an already-ended span. Async
+    success/failure logging can run after the request span end()s; writing then
+    is a no-op that the OTel SDK logs as a "Setting attribute on ended span"
+    warning, flooding logs (and burning CPU) under load."""
+
+    def test_skips_write_when_span_not_recording(self):
+        otel = OpenTelemetry()
+        span = MagicMock()
+        span.is_recording.return_value = False
+        otel.safe_set_attribute(span=span, key="k", value="v")
+        span.set_attribute.assert_not_called()
+
+    def test_writes_when_span_recording(self):
+        otel = OpenTelemetry()
+        span = MagicMock()
+        span.is_recording.return_value = True
+        otel.safe_set_attribute(span=span, key="k", value="v")
+        span.set_attribute.assert_called_once()
+
+
 class TestOpenTelemetryProviderInitialization(unittest.TestCase):
     """Test suite for verifying provider initialization respects existing providers"""
 
@@ -408,13 +454,9 @@ class TestOpenTelemetryProviderInitialization(unittest.TestCase):
 
         # Assert: The existing provider should still be active
         current_provider = trace.get_tracer_provider()
-        assert (
-            current_provider is existing_provider
-        ), "Existing TracerProvider should be respected and not overridden"
+        assert current_provider is existing_provider, "Existing TracerProvider should be respected and not overridden"
 
-    @patch.dict(
-        os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True
-    )
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
     def test_init_metrics_respects_existing_meter_provider(self):
         """
         Unit test: _init_metrics() should respect existing MeterProvider.
@@ -436,13 +478,9 @@ class TestOpenTelemetryProviderInitialization(unittest.TestCase):
 
         # Assert: The existing provider should still be active
         current_provider = metrics.get_meter_provider()
-        assert (
-            current_provider is existing_provider
-        ), "Existing MeterProvider should be respected and not overridden"
+        assert current_provider is existing_provider, "Existing MeterProvider should be respected and not overridden"
 
-    @patch.dict(
-        os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS": "true"}, clear=True
-    )
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS": "true"}, clear=True)
     def test_init_logs_respects_existing_logger_provider(self):
         """
         Unit test: _init_logs() should respect existing LoggerProvider.
@@ -464,9 +502,7 @@ class TestOpenTelemetryProviderInitialization(unittest.TestCase):
 
         # Assert: The existing provider should still be active
         current_provider = get_logger_provider()
-        assert (
-            current_provider is existing_provider
-        ), "Existing LoggerProvider should be respected and not overridden"
+        assert current_provider is existing_provider, "Existing LoggerProvider should be respected and not overridden"
 
 
 class TestOpenTelemetryDualHandlerIsolation(unittest.TestCase):
@@ -488,9 +524,7 @@ class TestOpenTelemetryDualHandlerIsolation(unittest.TestCase):
 
         fake_existing = SDKTracerProvider()
         own_exporter = InMemorySpanExporter()
-        cfg = OpenTelemetryConfig(
-            exporter="console", service_name="iso-test", skip_set_global=True
-        )
+        cfg = OpenTelemetryConfig(exporter="console", service_name="iso-test", skip_set_global=True)
         with (
             patch.object(trace, "get_tracer_provider", return_value=fake_existing),
             patch.object(trace, "set_tracer_provider") as mock_set,
@@ -580,9 +614,7 @@ class TestOpenTelemetryDualHandlerIsolation(unittest.TestCase):
 
         global_exporter = InMemoryLogExporter()
         fake_existing = SDKLoggerProvider()
-        fake_existing.add_log_record_processor(
-            SimpleLogRecordProcessor(global_exporter)
-        )
+        fake_existing.add_log_record_processor(SimpleLogRecordProcessor(global_exporter))
 
         private_exporter = InMemoryLogExporter()
         cfg = OpenTelemetryConfig(
@@ -594,9 +626,7 @@ class TestOpenTelemetryDualHandlerIsolation(unittest.TestCase):
         with (
             patch.object(_logs, "get_logger_provider", return_value=fake_existing),
             patch.object(_logs, "set_logger_provider"),
-            patch.object(
-                OpenTelemetry, "_get_log_exporter", return_value=private_exporter
-            ),
+            patch.object(OpenTelemetry, "_get_log_exporter", return_value=private_exporter),
             self._wire_span_processor(InMemorySpanExporter()),
         ):
             handler = OpenTelemetry(config=cfg)
@@ -625,9 +655,7 @@ class TestOpenTelemetryDualHandlerIsolation(unittest.TestCase):
 
         # Handler B comes along with the global appearing to be A's provider.
         exporter_b = InMemorySpanExporter()
-        cfg_b = OpenTelemetryConfig(
-            exporter="console", service_name="handler-b", skip_set_global=True
-        )
+        cfg_b = OpenTelemetryConfig(exporter="console", service_name="handler-b", skip_set_global=True)
         with (
             patch.object(trace, "get_tracer_provider", return_value=provider_a),
             patch.object(trace, "set_tracer_provider"),
@@ -666,9 +694,7 @@ class TestOpenTelemetryCaptureMessageContent(unittest.TestCase):
         )
         with patch.dict(os.environ, env_dict):
             handler = OpenTelemetry(
-                config=OpenTelemetryConfig(
-                    exporter="console", capture_message_content=config_value
-                )
+                config=OpenTelemetryConfig(exporter="console", capture_message_content=config_value)
             )
             handler.message_logging = message_logging
             return handler, handler._resolve_capture_mode()
@@ -734,18 +760,12 @@ class TestOpenTelemetryCaptureMessageContent(unittest.TestCase):
 
     def test_two_handlers_can_have_different_modes(self):
         # FIL's stated requirement: one handler strips content, the other keeps it.
-        with patch.dict(
-            os.environ, {"OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": ""}
-        ):
+        with patch.dict(os.environ, {"OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": ""}):
             stripped = OpenTelemetry(
-                config=OpenTelemetryConfig(
-                    exporter="console", capture_message_content="NO_CONTENT"
-                )
+                config=OpenTelemetryConfig(exporter="console", capture_message_content="NO_CONTENT")
             )
             kept = OpenTelemetry(
-                config=OpenTelemetryConfig(
-                    exporter="console", capture_message_content="SPAN_AND_EVENT"
-                )
+                config=OpenTelemetryConfig(exporter="console", capture_message_content="SPAN_AND_EVENT")
             )
         self.assertEqual(stripped._resolve_capture_mode(), "NO_CONTENT")
         self.assertEqual(kept._resolve_capture_mode(), "SPAN_AND_EVENT")
@@ -791,9 +811,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
         self.assertFalse(h._gen_ai_semconv_latest_experimental)
 
     def test_config_field_enables_without_env(self):
-        h = self._make(
-            env="", config_value={OTELSemconvCategory.GEN_AI_LATEST_EXPERIMENTAL}
-        )
+        h = self._make(env="", config_value={OTELSemconvCategory.GEN_AI_LATEST_EXPERIMENTAL})
         self.assertTrue(h._gen_ai_semconv_latest_experimental)
 
     def test_config_field_unions_with_env(self):
@@ -852,10 +870,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
             "n": 3,
         }
         h._set_semconv_request_attributes(span, optional_params)
-        calls = {
-            c.args[0] if c.args else c.kwargs.get("key"): c
-            for c in span.set_attribute.call_args_list
-        }
+        calls = {c.args[0] if c.args else c.kwargs.get("key"): c for c in span.set_attribute.call_args_list}
         self.assertIn("gen_ai.request.frequency_penalty", calls)
         self.assertIn("gen_ai.request.presence_penalty", calls)
         self.assertIn("gen_ai.request.top_k", calls)
@@ -878,16 +893,10 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
             span = MagicMock()
             h._set_semconv_request_attributes(span, {"n": bad_n})
             keys = {c.args[0] for c in span.set_attribute.call_args_list if c.args}
-            self.assertNotIn(
-                "gen_ai.request.choice.count", keys, f"n={bad_n!r} should be omitted"
-            )
+            self.assertNotIn("gen_ai.request.choice.count", keys, f"n={bad_n!r} should be omitted")
 
     def _stream_calls(self, span):
-        return [
-            c
-            for c in span.set_attribute.call_args_list
-            if c.args and c.args[0] == "gen_ai.request.stream"
-        ]
+        return [c for c in span.set_attribute.call_args_list if c.args and c.args[0] == "gen_ai.request.stream"]
 
     def test_semconv_request_stream_emitted_as_bool_when_streaming(self):
         # Conditionally required per spec: present (as bool True) only when streaming.
@@ -911,9 +920,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
         span = MagicMock()
         h._set_semconv_request_attributes(span, {"stop": "STOP_TOKEN"})
         stop_calls = [
-            c
-            for c in span.set_attribute.call_args_list
-            if c.args and c.args[0] == "gen_ai.request.stop_sequences"
+            c for c in span.set_attribute.call_args_list if c.args and c.args[0] == "gen_ai.request.stop_sequences"
         ]
         self.assertEqual(len(stop_calls), 1)
         self.assertEqual(stop_calls[0].args[1], ["STOP_TOKEN"])
@@ -930,9 +937,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
             }
         }
         h._set_semconv_cache_token_attributes(span, std_log)
-        keys = {
-            c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args
-        }
+        keys = {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args}
         self.assertEqual(keys.get("gen_ai.usage.cache_creation.input_tokens"), 12)
         self.assertEqual(keys.get("gen_ai.usage.cache_read.input_tokens"), 34)
 
@@ -975,9 +980,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
         }
         response_obj = {"id": "r", "model": "gpt-4", "choices": []}
         h.set_attributes(span=span, kwargs=kwargs, response_obj=response_obj)
-        return {
-            c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args
-        }
+        return {c.args[0]: c.args[1] for c in span.set_attribute.call_args_list if c.args}
 
     def test_semconv_mode_emits_provider_name_not_system(self):
         # Latest-experimental semconv replaced gen_ai.system with
@@ -1004,15 +1007,11 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
                 os.environ,
                 {"OTEL_SEMCONV_STABILITY_OPT_IN": "gen_ai_latest_experimental"},
             ),
-            patch.object(
-                _logs, "get_logger_provider", return_value=ProxyLoggerProvider()
-            ),
+            patch.object(_logs, "get_logger_provider", return_value=ProxyLoggerProvider()),
             patch.object(_logs, "set_logger_provider"),
             patch.object(OpenTelemetry, "_get_log_exporter", return_value=log_exporter),
         ):
-            h = OpenTelemetry(
-                config=OpenTelemetryConfig(exporter="console", enable_events=True)
-            )
+            h = OpenTelemetry(config=OpenTelemetryConfig(exporter="console", enable_events=True))
         h.message_logging = True
 
         kwargs = {
@@ -1038,9 +1037,7 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
         # Exactly ONE inference details event, not the legacy per-message/choice pair.
         self.assertEqual(len(records), 1)
         attrs = dict(records[0].attributes or {})
-        self.assertEqual(
-            attrs["event_name"], "gen_ai.client.inference.operation.details"
-        )
+        self.assertEqual(attrs["event_name"], "gen_ai.client.inference.operation.details")
         self.assertEqual(attrs["gen_ai.provider.name"], "openai")
         self.assertEqual(attrs["gen_ai.operation.name"], "chat")
         self.assertIn("gen_ai.input.messages", attrs)
@@ -1057,15 +1054,11 @@ class TestOpenTelemetrySemconvStability(unittest.TestCase):
                 {"OTEL_SEMCONV_STABILITY_OPT_IN": "gen_ai_latest_experimental"},
             ),
             patch("litellm.turn_off_message_logging", True),
-            patch.object(
-                _logs, "get_logger_provider", return_value=ProxyLoggerProvider()
-            ),
+            patch.object(_logs, "get_logger_provider", return_value=ProxyLoggerProvider()),
             patch.object(_logs, "set_logger_provider"),
             patch.object(OpenTelemetry, "_get_log_exporter", return_value=log_exporter),
         ):
-            h = OpenTelemetry(
-                config=OpenTelemetryConfig(exporter="console", enable_events=True)
-            )
+            h = OpenTelemetry(config=OpenTelemetryConfig(exporter="console", enable_events=True))
             h.message_logging = True
 
             kwargs = {
@@ -1132,9 +1125,7 @@ class TestOpenTelemetry(unittest.TestCase):
         self.assertEqual(config.exporter, "otlp_http")
 
         # When exporter is explicitly set to something other than console, should not override
-        config_grpc = OpenTelemetryConfig(
-            exporter="grpc", endpoint="https://otel-collector.example.com:443"
-        )
+        config_grpc = OpenTelemetryConfig(exporter="grpc", endpoint="https://otel-collector.example.com:443")
         self.assertEqual(config_grpc.exporter, "grpc")
 
         # When no endpoint is set, should keep console as default
@@ -1146,11 +1137,7 @@ class TestOpenTelemetry(unittest.TestCase):
         deadline = time.time() + self.POLL_TIMEOUT
         while time.time() < deadline:
             spans = exporter.get_finished_spans()
-            matches = [
-                s
-                for s in spans
-                if s.attributes and any(str(k).startswith(prefix) for k in s.attributes)
-            ]
+            matches = [s for s in spans if s.attributes and any(str(k).startswith(prefix) for k in s.attributes)]
             if matches:
                 return matches
             time.sleep(self.POLL_INTERVAL)
@@ -1212,9 +1199,7 @@ class TestOpenTelemetry(unittest.TestCase):
         }
 
         # Create a kwargs dict with standard_logging_object containing guardrail information
-        kwargs = {
-            "standard_logging_object": {"guardrail_information": [guardrail_info]}
-        }
+        kwargs = {"standard_logging_object": {"guardrail_information": [guardrail_info]}}
 
         # Call the method
         otel._create_guardrail_span(kwargs=kwargs, context=None)
@@ -1230,12 +1215,8 @@ class TestOpenTelemetry(unittest.TestCase):
         # Check that the span has the correct attributes set
         mock_span.set_attribute.assert_any_call("guardrail_name", "test_guardrail")
         mock_span.set_attribute.assert_any_call("guardrail_mode", "input")
-        mock_span.set_attribute.assert_any_call(
-            "guardrail_response", safe_dumps("filtered_content")
-        )
-        mock_span.set_attribute.assert_any_call(
-            "masked_entity_count", safe_dumps({"CREDIT_CARD": 2})
-        )
+        mock_span.set_attribute.assert_any_call("guardrail_response", safe_dumps("filtered_content"))
+        mock_span.set_attribute.assert_any_call("masked_entity_count", safe_dumps({"CREDIT_CARD": 2}))
 
         # Verify that the span was ended
         mock_span.end.assert_called_once()
@@ -1260,9 +1241,7 @@ class TestOpenTelemetry(unittest.TestCase):
 
         # Mock the dynamic header extraction and tracer creation
         with (
-            patch.object(
-                otel, "_get_dynamic_otel_headers_from_kwargs"
-            ) as mock_get_headers,
+            patch.object(otel, "_get_dynamic_otel_headers_from_kwargs") as mock_get_headers,
             patch.object(otel, "_get_tracer_with_dynamic_headers") as mock_get_tracer,
         ):
             # Test case 1: With dynamic headers
@@ -1273,16 +1252,12 @@ class TestOpenTelemetry(unittest.TestCase):
             mock_dynamic_tracer = MagicMock()
             mock_get_tracer.return_value = mock_dynamic_tracer
 
-            kwargs = {
-                "standard_callback_dynamic_params": {"arize_space_key": "test-space"}
-            }
+            kwargs = {"standard_callback_dynamic_params": {"arize_space_key": "test-space"}}
             result = otel.get_tracer_to_use_for_request(kwargs)
 
             # Assertions
             mock_get_headers.assert_called_once_with(kwargs)
-            mock_get_tracer.assert_called_once_with(
-                {"arize-space-id": "test-space", "api_key": "test-key"}
-            )
+            mock_get_tracer.assert_called_once_with({"arize-space-id": "test-space", "api_key": "test-key"})
             self.assertEqual(result, mock_dynamic_tracer)
 
     def test_get_tracer_to_use_for_request_without_dynamic_headers(self):
@@ -1292,9 +1267,7 @@ class TestOpenTelemetry(unittest.TestCase):
         otel.tracer = MagicMock()
 
         # Mock the dynamic header extraction to return None
-        with patch.object(
-            otel, "_get_dynamic_otel_headers_from_kwargs"
-        ) as mock_get_headers:
+        with patch.object(otel, "_get_dynamic_otel_headers_from_kwargs") as mock_get_headers:
             mock_get_headers.return_value = None
 
             kwargs = {}
@@ -1326,12 +1299,8 @@ class TestOpenTelemetry(unittest.TestCase):
             result = otel._get_dynamic_otel_headers_from_kwargs(kwargs)
 
             # Assertions
-            mock_construct.assert_called_once_with(
-                standard_callback_dynamic_params=standard_params
-            )
-            self.assertEqual(
-                result, {"arize-space-id": "test-space", "api_key": "test-key"}
-            )
+            mock_construct.assert_called_once_with(standard_callback_dynamic_params=standard_params)
+            self.assertEqual(result, {"arize-space-id": "test-space", "api_key": "test-key"})
 
             # Test case 2: Without standard_callback_dynamic_params
             kwargs_empty = {}
@@ -1374,21 +1343,15 @@ class TestOpenTelemetry(unittest.TestCase):
             result = otel._get_tracer_with_dynamic_headers(dynamic_headers)
 
             # Assertions
-            mock_get_span_processor.assert_called_once_with(
-                dynamic_headers=dynamic_headers
-            )
-            mock_provider_instance.add_span_processor.assert_called_once_with(
-                mock_span_processor
-            )
+            mock_get_span_processor.assert_called_once_with(dynamic_headers=dynamic_headers)
+            mock_provider_instance.add_span_processor.assert_called_once_with(mock_span_processor)
             mock_provider_instance.get_tracer.assert_called_once_with("litellm")
             self.assertEqual(result, mock_tracer)
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("opentelemetry.sdk.resources.Resource.create")
     @patch("opentelemetry.sdk.resources.OTELResourceDetector")
-    def test_get_litellm_resource_with_defaults(
-        self, mock_detector_cls, mock_resource_create
-    ):
+    def test_get_litellm_resource_with_defaults(self, mock_detector_cls, mock_resource_create):
         """Test _get_litellm_resource with default values when no environment variables are set."""
         # Mock the Resource.create method
         mock_base_resource = MagicMock()
@@ -1429,9 +1392,7 @@ class TestOpenTelemetry(unittest.TestCase):
     )
     @patch("opentelemetry.sdk.resources.Resource.create")
     @patch("opentelemetry.sdk.resources.OTELResourceDetector")
-    def test_get_litellm_resource_with_litellm_env_vars(
-        self, mock_detector_cls, mock_resource_create
-    ):
+    def test_get_litellm_resource_with_litellm_env_vars(self, mock_detector_cls, mock_resource_create):
         """Test _get_litellm_resource with LiteLLM-specific environment variables."""
         # Mock the Resource.create method
         mock_base_resource = MagicMock()
@@ -1471,9 +1432,7 @@ class TestOpenTelemetry(unittest.TestCase):
     )
     @patch("opentelemetry.sdk.resources.Resource.create")
     @patch("opentelemetry.sdk.resources.OTELResourceDetector")
-    def test_get_litellm_resource_with_otel_resource_attributes(
-        self, mock_detector_cls, mock_resource_create
-    ):
+    def test_get_litellm_resource_with_otel_resource_attributes(self, mock_detector_cls, mock_resource_create):
         """Test _get_litellm_resource with OTEL_RESOURCE_ATTRIBUTES environment variable."""
         # Mock the Resource.create method to simulate the actual behavior
         # In reality, Resource.create() would parse OTEL_RESOURCE_ATTRIBUTES and merge it
@@ -1602,13 +1561,9 @@ class TestOpenTelemetry(unittest.TestCase):
         # ─── minimal input / output for a chat call ──────────────────────────────
         start = datetime.utcnow()
         end = start + timedelta(seconds=1)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")) as f:
             kwargs = json.load(f)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")) as f:
             response_obj = json.load(f)
 
         # ─── exercise the hook ───────────────────────────────────────────────────
@@ -1624,10 +1579,7 @@ class TestOpenTelemetry(unittest.TestCase):
         #     "litellm_request span missing",
         # )
         # model attribute should be on that span
-        found = any(
-            s.attributes and s.attributes.get("gen_ai.request.model") == self.MODEL
-            for s in spans
-        )
+        found = any(s.attributes and s.attributes.get("gen_ai.request.model") == self.MODEL for s in spans)
         self.assertTrue(found, "expected gen_ai.request.model on span attributes")
 
         # no metrics recorded
@@ -1639,9 +1591,7 @@ class TestOpenTelemetry(unittest.TestCase):
         logs = log_exporter.get_finished_logs()
         self.assertFalse(logs, "Did not expect any logs")
 
-    @patch.dict(
-        os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True
-    )
+    @patch.dict(os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True)
     def test_handle_success_spans_and_metrics(self):
         # ─── build in‐memory OTEL providers/exporters ─────────────────────────────
         span_exporter = InMemorySpanExporter()
@@ -1665,13 +1615,9 @@ class TestOpenTelemetry(unittest.TestCase):
         # ─── minimal input / output for a chat call ──────────────────────────────
         start = datetime.utcnow()
         end = start + timedelta(seconds=1)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")) as f:
             kwargs = json.load(f)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")) as f:
             response_obj = json.load(f)
 
         # ─── exercise the hook ───────────────────────────────────────────────────
@@ -1682,24 +1628,15 @@ class TestOpenTelemetry(unittest.TestCase):
         self.assertTrue(spans, "Expected at least one span")
 
         # ─── assert metrics ──────────────────────────────────────────────────────
-        duration_metric = self.wait_for_metric(
-            metric_reader, "gen_ai.client.operation.duration"
-        )
+        duration_metric = self.wait_for_metric(metric_reader, "gen_ai.client.operation.duration")
         self.assertIsNotNone(duration_metric, "duration histogram was not recorded")
         # model attribute should be present on a data point
         found_dp = False
-        if (
-            duration_metric
-            and hasattr(duration_metric, "data")
-            and hasattr(duration_metric.data, "data_points")
-        ):
+        if duration_metric and hasattr(duration_metric, "data") and hasattr(duration_metric.data, "data_points"):
             found_dp = any(
-                dp.attributes.get("gen_ai.request.model") == self.MODEL
-                for dp in duration_metric.data.data_points
+                dp.attributes.get("gen_ai.request.model") == self.MODEL for dp in duration_metric.data.data_points
             )
-        self.assertTrue(
-            found_dp, "expected gen_ai.request.model attribute on a data point"
-        )
+        self.assertTrue(found_dp, "expected gen_ai.request.model attribute on a data point")
 
         # ─── no events when only metrics enabled ─────────────────────────────────
         logs = log_exporter.get_finished_logs()
@@ -1738,14 +1675,10 @@ class TestOpenTelemetry(unittest.TestCase):
         otel._to_ns = MagicMock(return_value=1234567890)
 
         kwargs = {"litellm_params": {"metadata": {}}}
-        otel._maybe_log_raw_request(
-            kwargs, {}, datetime.now(), datetime.now(), MagicMock()
-        )
+        otel._maybe_log_raw_request(kwargs, {}, datetime.now(), datetime.now(), MagicMock())
 
         mock_tracer.start_span.assert_called_once()
-        self.assertEqual(
-            mock_tracer.start_span.call_args[1]["name"], RAW_REQUEST_SPAN_NAME
-        )
+        self.assertEqual(mock_tracer.start_span.call_args[1]["name"], RAW_REQUEST_SPAN_NAME)
 
     @patch("litellm.turn_off_message_logging", True)
     def test_maybe_log_raw_request_skips_when_logging_disabled(self):
@@ -1755,9 +1688,7 @@ class TestOpenTelemetry(unittest.TestCase):
         otel.get_tracer_to_use_for_request = MagicMock(return_value=mock_tracer)
 
         kwargs = {"litellm_params": {"metadata": {}}}
-        otel._maybe_log_raw_request(
-            kwargs, {}, datetime.now(), datetime.now(), MagicMock()
-        )
+        otel._maybe_log_raw_request(kwargs, {}, datetime.now(), datetime.now(), MagicMock())
 
         mock_tracer.start_span.assert_not_called()
 
@@ -1802,9 +1733,7 @@ class TestOpenTelemetryHeaderSplitting(unittest.TestCase):
         otel = OpenTelemetry()
         headers = "api-key=value1=part2,config=setting=enabled"
         result = otel._get_headers_dictionary(headers)
-        self.assertEqual(
-            result, {"api-key": "value1=part2", "config": "setting=enabled"}
-        )
+        self.assertEqual(result, {"api-key": "value1=part2", "config": "setting=enabled"})
 
 
 class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
@@ -1813,17 +1742,13 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
     def test_normalize_traces_endpoint_from_logs_path(self):
         """Test normalizing endpoint with /v1/logs to /v1/traces"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/logs", "traces"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/logs", "traces")
         self.assertEqual(result, "http://collector:4318/v1/traces")
 
     def test_normalize_traces_endpoint_from_metrics_path(self):
         """Test normalizing endpoint with /v1/metrics to /v1/traces"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/metrics", "traces"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/metrics", "traces")
         self.assertEqual(result, "http://collector:4318/v1/traces")
 
     def test_normalize_traces_endpoint_from_base_url(self):
@@ -1841,25 +1766,19 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
     def test_normalize_traces_endpoint_already_correct(self):
         """Test endpoint already ending with /v1/traces remains unchanged"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/traces", "traces"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/traces", "traces")
         self.assertEqual(result, "http://collector:4318/v1/traces")
 
     def test_normalize_metrics_endpoint_from_traces_path(self):
         """Test normalizing endpoint with /v1/traces to /v1/metrics"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/traces", "metrics"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/traces", "metrics")
         self.assertEqual(result, "http://collector:4318/v1/metrics")
 
     def test_normalize_metrics_endpoint_from_logs_path(self):
         """Test normalizing endpoint with /v1/logs to /v1/metrics"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/logs", "metrics"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/logs", "metrics")
         self.assertEqual(result, "http://collector:4318/v1/metrics")
 
     def test_normalize_metrics_endpoint_from_base_url(self):
@@ -1871,25 +1790,19 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
     def test_normalize_metrics_endpoint_already_correct(self):
         """Test endpoint already ending with /v1/metrics remains unchanged"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/metrics", "metrics"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/metrics", "metrics")
         self.assertEqual(result, "http://collector:4318/v1/metrics")
 
     def test_normalize_logs_endpoint_from_traces_path(self):
         """Test normalizing endpoint with /v1/traces to /v1/logs"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/traces", "logs"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/traces", "logs")
         self.assertEqual(result, "http://collector:4318/v1/logs")
 
     def test_normalize_logs_endpoint_from_metrics_path(self):
         """Test normalizing endpoint with /v1/metrics to /v1/logs"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/v1/metrics", "logs"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/v1/metrics", "logs")
         self.assertEqual(result, "http://collector:4318/v1/logs")
 
     def test_normalize_logs_endpoint_from_base_url(self):
@@ -1930,9 +1843,7 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
             ),
         ]
     )
-    def test_normalize_traces_nonstandard_otlp_ingest_urls_unchanged(
-        self, input_url: str, expected: str
-    ) -> None:
+    def test_normalize_traces_nonstandard_otlp_ingest_urls_unchanged(self, input_url: str, expected: str) -> None:
         """Splunk-style /v2/trace/otlp endpoints must not get /v1/traces appended."""
         otel = OpenTelemetry()
         self.assertEqual(
@@ -1969,24 +1880,18 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
             call_args = mock_warning.call_args[0]
             self.assertIn("Invalid signal_type", call_args[0])
             self.assertEqual(call_args[1], "invalid")  # signal_type parameter
-            self.assertEqual(
-                call_args[2], {"traces", "metrics", "logs"}
-            )  # valid_signals parameter
+            self.assertEqual(call_args[2], {"traces", "metrics", "logs"})  # valid_signals parameter
 
     def test_normalize_endpoint_https(self):
         """Test normalization works with https URLs"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "https://collector.example.com:4318", "logs"
-        )
+        result = otel._normalize_otel_endpoint("https://collector.example.com:4318", "logs")
         self.assertEqual(result, "https://collector.example.com:4318/v1/logs")
 
     def test_normalize_endpoint_with_path_prefix(self):
         """Test normalization works with URLs that have path prefixes"""
         otel = OpenTelemetry()
-        result = otel._normalize_otel_endpoint(
-            "http://collector:4318/otel/v1/traces", "logs"
-        )
+        result = otel._normalize_otel_endpoint("http://collector:4318/otel/v1/traces", "logs")
         # Should replace the final /traces with /logs
         self.assertEqual(result, "http://collector:4318/otel/v1/logs")
 
@@ -2034,9 +1939,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         )
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-        config = OpenTelemetryConfig(
-            exporter="otlp_http", endpoint="http://collector:4318"
-        )
+        config = OpenTelemetryConfig(exporter="otlp_http", endpoint="http://collector:4318")
         otel = OpenTelemetry(config=config)
 
         processor = otel._get_span_processor()
@@ -2054,9 +1957,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         )
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-        config = OpenTelemetryConfig(
-            exporter="otlp_grpc", endpoint="http://collector:4317"
-        )
+        config = OpenTelemetryConfig(exporter="otlp_grpc", endpoint="http://collector:4317")
         otel = OpenTelemetry(config=config)
 
         processor = otel._get_span_processor()
@@ -2092,9 +1993,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         )
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-        config = OpenTelemetryConfig(
-            exporter="http/protobuf", endpoint="http://collector:4318"
-        )
+        config = OpenTelemetryConfig(exporter="http/protobuf", endpoint="http://collector:4318")
         otel = OpenTelemetry(config=config)
 
         processor = otel._get_span_processor()
@@ -2127,9 +2026,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         """Test that otlp_http protocol uses HTTP OTLPLogExporter"""
         from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 
-        config = OpenTelemetryConfig(
-            exporter="otlp_http", endpoint="http://collector:4318", enable_events=True
-        )
+        config = OpenTelemetryConfig(exporter="otlp_http", endpoint="http://collector:4318", enable_events=True)
         otel = OpenTelemetry(config=config)
 
         exporter = otel._get_log_exporter()
@@ -2144,9 +2041,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         """Test that otlp_grpc protocol uses gRPC OTLPLogExporter"""
         from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 
-        config = OpenTelemetryConfig(
-            exporter="otlp_grpc", endpoint="http://collector:4317", enable_events=True
-        )
+        config = OpenTelemetryConfig(exporter="otlp_grpc", endpoint="http://collector:4317", enable_events=True)
         otel = OpenTelemetry(config=config)
 
         exporter = otel._get_log_exporter()
@@ -2161,9 +2056,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         """Test that 'grpc' protocol alias uses gRPC OTLPLogExporter"""
         from opentelemetry.exporter.otlp.proto.grpc._log_exporter import OTLPLogExporter
 
-        config = OpenTelemetryConfig(
-            exporter="grpc", endpoint="http://collector:4317", enable_events=True
-        )
+        config = OpenTelemetryConfig(exporter="grpc", endpoint="http://collector:4317", enable_events=True)
         otel = OpenTelemetry(config=config)
 
         exporter = otel._get_log_exporter()
@@ -2309,9 +2202,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
 
     def test_http_exporter_endpoint_normalization_for_traces(self):
         """Test that HTTP trace exporter gets properly normalized endpoint"""
-        config = OpenTelemetryConfig(
-            exporter="otlp_http", endpoint="http://collector:4318"
-        )
+        config = OpenTelemetryConfig(exporter="otlp_http", endpoint="http://collector:4318")
         otel = OpenTelemetry(config=config)
 
         processor = otel._get_span_processor()
@@ -2323,9 +2214,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
 
     def test_grpc_exporter_endpoint_normalization_for_traces(self):
         """Test that gRPC trace exporter gets properly normalized endpoint"""
-        config = OpenTelemetryConfig(
-            exporter="otlp_grpc", endpoint="http://collector:4317"
-        )
+        config = OpenTelemetryConfig(exporter="otlp_grpc", endpoint="http://collector:4317")
         otel = OpenTelemetry(config=config)
 
         processor = otel._get_span_processor()
@@ -2337,9 +2226,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
             self.assertIn("collector:4317", processor.span_exporter._endpoint)  # type: ignore[attr-defined]
             # The endpoint should have been normalized with /v1/traces before being passed to gRPC exporter
             # We verify this by checking the normalization function was called correctly
-            normalized = otel._normalize_otel_endpoint(
-                "http://collector:4317", "traces"
-            )
+            normalized = otel._normalize_otel_endpoint("http://collector:4317", "traces")
             self.assertEqual(normalized, "http://collector:4317/v1/traces")
 
     def test_http_log_exporter_endpoint_normalization_for_logs(self):
@@ -2376,9 +2263,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
             self.assertIn("collector:4317", exporter._endpoint)  # type: ignore[attr-defined]
             # The endpoint should have been normalized with /v1/logs before being passed to gRPC exporter
             # We verify this by checking the normalization function was called correctly
-            normalized = otel._normalize_otel_endpoint(
-                "http://collector:4317/v1/traces", "logs"
-            )
+            normalized = otel._normalize_otel_endpoint("http://collector:4317/v1/traces", "logs")
             self.assertEqual(normalized, "http://collector:4317/v1/logs")
 
     def test_get_metric_reader_uses_http_exporter_for_http_protobuf(self):
@@ -2388,9 +2273,7 @@ class TestOpenTelemetryProtocolSelection(unittest.TestCase):
         )
         from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
-        config = OpenTelemetryConfig(
-            exporter="http/protobuf", endpoint="http://collector:4318"
-        )
+        config = OpenTelemetryConfig(exporter="http/protobuf", endpoint="http://collector:4318")
         otel = OpenTelemetry(config=config)
 
         reader = otel._get_metric_reader()
@@ -2429,14 +2312,10 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
 
     def _create_test_kwargs_and_response(self):
         """Load test data from JSON files"""
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")) as f:
             kwargs = json.load(f)
 
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")) as f:
             response_obj = json.load(f)
 
         return kwargs, response_obj
@@ -2511,9 +2390,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
 
         # Should have external_parent_span
         parent_spans = self._get_spans_by_name("external_parent_span")
-        self.assertEqual(
-            len(parent_spans), 1, "Should have exactly one external_parent_span"
-        )
+        self.assertEqual(len(parent_spans), 1, "Should have exactly one external_parent_span")
 
         # Verify LiteLLM set attributes on external parent span
         parent_span_finished = parent_spans[0]
@@ -2683,9 +2560,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
 
         # Should have the external parent span
         parent_spans = self._get_spans_by_name("external_parent_span")
-        self.assertEqual(
-            len(parent_spans), 1, "Should have exactly one external_parent_span"
-        )
+        self.assertEqual(len(parent_spans), 1, "Should have exactly one external_parent_span")
 
         # Verify LiteLLM set attributes on external parent span
         parent_span_finished = parent_spans[0]
@@ -2724,9 +2599,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
 
             # Verify the span is in global context
             current_span = trace.get_current_span()
-            self.assertEqual(
-                current_span, parent_span, "Span should be in global context"
-            )
+            self.assertEqual(current_span, parent_span, "Span should be in global context")
 
             # Make completion call
             start_time = datetime.utcnow()
@@ -2760,9 +2633,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
         """
         # Initialize OpenTelemetry
         otel = OpenTelemetry(tracer_provider=self.tracer_provider)
-        otel.message_logging = (
-            True  # Enable message logging to get raw_gen_ai_request spans
-        )
+        otel.message_logging = True  # Enable message logging to get raw_gen_ai_request spans
 
         # Load test data
         kwargs, response_obj = self._create_test_kwargs_and_response()
@@ -2849,9 +2720,7 @@ class TestOpenTelemetryExternalSpan(unittest.TestCase):
 
         # Should have external_parent_span
         parent_spans = self._get_spans_by_name("external_parent_span")
-        self.assertEqual(
-            len(parent_spans), 1, "Should have exactly one external_parent_span"
-        )
+        self.assertEqual(len(parent_spans), 1, "Should have exactly one external_parent_span")
 
         # Verify LiteLLM set attributes on external parent span even on failure
         parent_span_finished = parent_spans[0]
@@ -2879,15 +2748,11 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
     def setUp(self):
         # Insulate from a shell-set OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT
         # so these tests exercise the legacy default path (message_logging=True).
-        self._prev = os.environ.pop(
-            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", None
-        )
+        self._prev = os.environ.pop("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", None)
 
     def tearDown(self):
         if self._prev is not None:
-            os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-                self._prev
-            )
+            os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = self._prev
 
     def test_input_messages_uses_parts_structure(self):
         """
@@ -2927,9 +2792,7 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         # Find the call that set gen_ai.input.messages
         input_messages_calls = [
-            call
-            for call in mock_span.set_attribute.call_args_list
-            if call[0][0] == "gen_ai.input.messages"
+            call for call in mock_span.set_attribute.call_args_list if call[0][0] == "gen_ai.input.messages"
         ]
         self.assertEqual(
             len(input_messages_calls),
@@ -2986,9 +2849,7 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         # Find the call that set gen_ai.output.messages
         output_messages_calls = [
-            call
-            for call in mock_span.set_attribute.call_args_list
-            if call[0][0] == "gen_ai.output.messages"
+            call for call in mock_span.set_attribute.call_args_list if call[0][0] == "gen_ai.output.messages"
         ]
         self.assertEqual(
             len(output_messages_calls),
@@ -3084,9 +2945,7 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         # Find the call that set gen_ai.response.finish_reasons
         finish_reasons_calls = [
-            call
-            for call in mock_span.set_attribute.call_args_list
-            if call[0][0] == "gen_ai.response.finish_reasons"
+            call for call in mock_span.set_attribute.call_args_list if call[0][0] == "gen_ai.response.finish_reasons"
         ]
         self.assertEqual(
             len(finish_reasons_calls),
@@ -3131,9 +2990,7 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
         mock_span.set_attribute.assert_any_call("gen_ai.operation.name", "chat")
 
     @parameterized.expand([("_handle_success",), ("_handle_failure",)])
-    def test_handle_success_failure_nulls_parent_span_if_ignore_context_propagation(
-        self, handle_method: str
-    ):
+    def test_handle_success_failure_nulls_parent_span_if_ignore_context_propagation(self, handle_method: str):
         """
         If ignore_context_propagation is True, _handle_success should ignore any parent span
         and create a root-level span. This could be useful for langfuse_otel where
@@ -3188,14 +3045,12 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         self.assertTrue(child_spans, "Expected at least one child span")
         for span in child_spans:
-            assert (
-                span.parent is None or span.parent.span_id in child_span_ids
-            ), f"if ignore_context_propagation is True, span should not have parent from other providers, but got parent: {span.parent}"
+            assert span.parent is None or span.parent.span_id in child_span_ids, (
+                f"if ignore_context_propagation is True, span should not have parent from other providers, but got parent: {span.parent}"
+            )
 
     @parameterized.expand([("_handle_success",), ("_handle_failure",)])
-    def test_handle_success_failure_default_preserves_parent_span(
-        self, handle_method: str
-    ):
+    def test_handle_success_failure_default_preserves_parent_span(self, handle_method: str):
         """
         For default otel callbacks, _handle_success should use parent spans normally.
         (symmetric with _handle_failure)
@@ -3243,14 +3098,12 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         self.assertTrue(child_spans, "Expected at least one child span")
         for span in child_spans:
-            assert (
-                span.parent is not None
-            ), f"By default parent span should be preserved, but got None parent for span: {span.name}"
+            assert span.parent is not None, (
+                f"By default parent span should be preserved, but got None parent for span: {span.name}"
+            )
 
     @parameterized.expand([("_handle_success",), ("_handle_failure",)])
-    def test_handle_success_failure_with_context_propagation_preserves_parent_span(
-        self, handle_method: str
-    ):
+    def test_handle_success_failure_with_context_propagation_preserves_parent_span(self, handle_method: str):
         """
         For otel callbacks with context propagation enabled, _handle_success should
         use parent spans normally. (symmetric with _handle_failure)
@@ -3301,9 +3154,9 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
 
         self.assertTrue(child_spans, "Expected at least one child span")
         for span in child_spans:
-            assert (
-                span.parent is not None
-            ), f"If ignore_context_propagation is False, parent span should be preserved, but got None parent for span: {span.name}"
+            assert span.parent is not None, (
+                f"If ignore_context_propagation is False, parent span should be preserved, but got None parent for span: {span.name}"
+            )
 
     def test_handle_failure_hasattr_guard_on_parent_name(self):
         """
@@ -3338,9 +3191,7 @@ class TestOpenTelemetrySemanticConventions138(unittest.TestCase):
         try:
             otel._handle_failure(kwargs, None, start, end)
         except AttributeError as e:
-            self.fail(
-                f"_handle_failure raised AttributeError on parent span without 'name': {e}"
-            )
+            self.fail(f"_handle_failure raised AttributeError on parent span without 'name': {e}")
 
     def test_handle_failure_creates_error_span(self):
         """
@@ -3402,9 +3253,7 @@ class TestRawSpanAttributeIsolation(unittest.TestCase):
             "litellm_params": {"custom_llm_provider": "vertex_ai"},
             "optional_params": {"temperature": 0.7},
             "original_response": '{"predictions": [1,2,3]}',
-            "additional_args": {
-                "complete_input_dict": {"instances": [{"content": "hello"}]}
-            },
+            "additional_args": {"complete_input_dict": {"instances": [{"content": "hello"}]}},
             "standard_logging_object": {
                 "id": "test-id",
                 "call_type": "embedding",
@@ -3451,13 +3300,9 @@ class TestNoParentSpanDuplication(unittest.TestCase):
 
         otel = OpenTelemetry(tracer_provider=tracer_provider)
 
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")) as f:
             kwargs = json.load(f)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")) as f:
             response_obj = json.load(f)
 
         # Simulate proxy flow: create a parent proxy span
@@ -3651,9 +3496,7 @@ class TestResponseIdFallback(unittest.TestCase):
         otel.set_attributes(mock_span, kwargs, response_obj)
 
         # Should use provider response ID, not litellm call ID
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.response.id", "chatcmpl-provider-id-456"
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.response.id", "chatcmpl-provider-id-456")
 
     def test_response_id_fallback_for_embeddings(self):
         """When response_obj has no id (embeddings), fallback to
@@ -3682,9 +3525,7 @@ class TestResponseIdFallback(unittest.TestCase):
         otel.set_attributes(mock_span, kwargs, response_obj)
 
         # Should fallback to litellm call ID
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.response.id", "litellm-embed-call-789"
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.response.id", "litellm-embed-call-789")
 
     def test_response_id_fallback_for_image_gen(self):
         """When response_obj has no id (image gen), fallback to
@@ -3711,9 +3552,7 @@ class TestResponseIdFallback(unittest.TestCase):
         otel.set_attributes(mock_span, kwargs, response_obj)
 
         # Should fallback to litellm call ID
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.response.id", "litellm-img-call-101"
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.response.id", "litellm-img-call-101")
 
     def test_litellm_call_id_emitted_as_span_attribute(self):
         """litellm.call_id must be set on the span from standard_logging_payload."""
@@ -3793,11 +3632,7 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
 
     def _get_attr(self, mock_span, attr_name):
         """Extract the value set for a specific attribute name, or None."""
-        calls = [
-            call
-            for call in mock_span.set_attribute.call_args_list
-            if call[0][0] == attr_name
-        ]
+        calls = [call for call in mock_span.set_attribute.call_args_list if call[0][0] == attr_name]
         if not calls:
             return None
         return calls[0][0][1]
@@ -3848,9 +3683,7 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
         raw = self._get_attr(mock_span, "gen_ai.output.messages")
         parsed = json.loads(raw)
@@ -3877,9 +3710,7 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
         raw = self._get_attr(mock_span, "gen_ai.output.messages")
         parsed = json.loads(raw)
@@ -3916,9 +3747,7 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
         raw = self._get_attr(mock_span, "gen_ai.output.messages")
         parsed = json.loads(raw)
@@ -3945,15 +3774,11 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
         # No output messages should be set since the text is empty
         raw = self._get_attr(mock_span, "gen_ai.output.messages")
-        self.assertIsNone(
-            raw, "Empty output text should not produce gen_ai.output.messages"
-        )
+        self.assertIsNone(raw, "Empty output text should not produce gen_ai.output.messages")
 
     def test_choices_still_work(self):
         """Existing choices-based responses must still work (no regression)."""
@@ -4061,9 +3886,7 @@ class TestOpenTelemetryResponsesAPI(unittest.TestCase):
         otel = OpenTelemetry()
         mock_span = MagicMock()
 
-        kwargs = self._base_kwargs(
-            system_instructions=[{"role": "system", "content": "Be concise."}]
-        )
+        kwargs = self._base_kwargs(system_instructions=[{"role": "system", "content": "Be concise."}])
         response_obj = self._responses_api_response_obj()
 
         otel.set_attributes(span=mock_span, kwargs=kwargs, response_obj=response_obj)
@@ -4235,11 +4058,7 @@ class TestSystemInstructionsPrecedence(unittest.TestCase):
     """Tests for the is-not-None precedence in system_instructions coalescing."""
 
     def _get_attr(self, mock_span, attr_name):
-        calls = [
-            call
-            for call in mock_span.set_attribute.call_args_list
-            if call[0][0] == attr_name
-        ]
+        calls = [call for call in mock_span.set_attribute.call_args_list if call[0][0] == attr_name]
         if not calls:
             return None
         return calls[0][0][1]
@@ -4316,24 +4135,16 @@ class TestResponsesAPIToolCallSpanAttributes(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
         # Verify per-tool-call attributes were set (same format as choices branch)
         attr_names = [call[0][0] for call in mock_span.set_attribute.call_args_list]
         tool_call_attrs = [a for a in attr_names if "function_call" in a]
-        self.assertTrue(
-            len(tool_call_attrs) > 0, "Per-tool-call span attributes should be emitted"
-        )
+        self.assertTrue(len(tool_call_attrs) > 0, "Per-tool-call span attributes should be emitted")
 
         # Verify the name attribute specifically
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.completion.0.function_call.name", "get_weather"
-        )
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.completion.0.function_call.arguments", '{"location": "SF"}'
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.completion.0.function_call.name", "get_weather")
+        mock_span.set_attribute.assert_any_call("gen_ai.completion.0.function_call.arguments", '{"location": "SF"}')
 
     def test_multiple_tool_calls_indexed(self):
         """Multiple function_call items should be indexed correctly."""
@@ -4360,16 +4171,10 @@ class TestResponsesAPIToolCallSpanAttributes(unittest.TestCase):
             ],
         }
 
-        otel.set_attributes(
-            span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj
-        )
+        otel.set_attributes(span=mock_span, kwargs=self._base_kwargs(), response_obj=response_obj)
 
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.completion.0.function_call.name", "get_weather"
-        )
-        mock_span.set_attribute.assert_any_call(
-            "gen_ai.completion.1.function_call.name", "get_time"
-        )
+        mock_span.set_attribute.assert_any_call("gen_ai.completion.0.function_call.name", "get_weather")
+        mock_span.set_attribute.assert_any_call("gen_ai.completion.1.function_call.name", "get_time")
 
 
 class TestOpenTelemetryProxyParentSpanChildEmission(unittest.TestCase):
@@ -4440,17 +4245,11 @@ class TestOpenTelemetryProxyParentSpanChildEmission(unittest.TestCase):
         litellm_spans = [s for s in spans if s.name == LITELLM_REQUEST_SPAN_NAME]
         proxy_spans = [s for s in spans if s.name == LITELLM_PROXY_REQUEST_SPAN_NAME]
 
-        self.assertEqual(
-            len(litellm_spans), 1, "Exactly one litellm_request span must be emitted"
-        )
-        self.assertEqual(
-            len(proxy_spans), 1, "Proxy span should be closed exactly once"
-        )
+        self.assertEqual(len(litellm_spans), 1, "Exactly one litellm_request span must be emitted")
+        self.assertEqual(len(proxy_spans), 1, "Proxy span should be closed exactly once")
 
         litellm_span = litellm_spans[0]
-        self.assertIsNotNone(
-            litellm_span.parent, "litellm_request must have a parent (not root)"
-        )
+        self.assertIsNotNone(litellm_span.parent, "litellm_request must have a parent (not root)")
         self.assertEqual(
             litellm_span.parent.span_id,
             proxy_spans[0].context.span_id,
@@ -4477,9 +4276,7 @@ class TestOpenTelemetryProxyParentSpanChildEmission(unittest.TestCase):
         }
         otel._end_proxy_span_from_kwargs(kwargs, end_time=datetime.utcnow())
 
-        self.assertFalse(
-            proxy_span.is_recording(), "Proxy span should be closed by helper"
-        )
+        self.assertFalse(proxy_span.is_recording(), "Proxy span should be closed by helper")
 
     def test_end_proxy_span_from_kwargs_does_not_close_external_span(self):
         """Spans not named LITELLM_PROXY_REQUEST_SPAN_NAME must not be closed —
@@ -4660,9 +4457,7 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         )
         self.assertFalse(otel._emit_once(kwargs, "success"))
         self.assertFalse(otel._emit_once(kwargs, "failure"))
-        self.assertFalse(
-            otel._emit_once(kwargs, "guardrail", "block-code", 1.0, "pre_call")
-        )
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "block-code", 1.0, "pre_call"))
 
     def test_emit_once_separate_handlers_each_emit(self):
         """Two distinct handler instances must each emit exactly once for the
@@ -4697,9 +4492,7 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         dedupe key. Pre-fix, this call crashed inside ``dict.get``."""
         otel = OpenTelemetry()
         kwargs = self._build_kwargs()
-        self.assertTrue(
-            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"])
-        )
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"]))
         self.assertFalse(
             otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"]),
             "Same list scope must dedupe to False on the second call",
@@ -4717,9 +4510,7 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
             "Distinct list scopes must produce distinct dedupe keys",
         )
         self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call"]))
-        self.assertFalse(
-            otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"])
-        )
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"]))
 
     def test_emit_once_accepts_dict_and_set_scope_parts(self):
         """``guardrail_mode`` can also arrive as a ``GuardrailMode`` TypedDict
@@ -4727,12 +4518,8 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         through the same normalization. Both must hash without raising."""
         otel = OpenTelemetry()
         kwargs = self._build_kwargs()
-        self.assertTrue(
-            otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]})
-        )
-        self.assertFalse(
-            otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]})
-        )
+        self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]}))
+        self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]}))
         self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"a", "b"}))
 
     def test_emit_once_handles_self_referential_scope_without_recursion_error(self):
@@ -4783,14 +4570,11 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         otel._create_guardrail_span(kwargs=kwargs, context=None)
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        guardrail_spans = [
-            s for s in span_exporter.get_finished_spans() if s.name == "guardrail"
-        ]
+        guardrail_spans = [s for s in span_exporter.get_finished_spans() if s.name == "guardrail"]
         self.assertEqual(
             len(guardrail_spans),
             1,
-            "List-valued guardrail_mode must emit exactly one guardrail span "
-            "across repeated lifecycle entrypoints",
+            "List-valued guardrail_mode must emit exactly one guardrail span across repeated lifecycle entrypoints",
         )
 
     def test_handle_success_emits_single_litellm_request_span_on_double_call(self):
@@ -4903,16 +4687,12 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
 
         otel._create_guardrail_span(kwargs=kwargs, context=None)
         # Mutate the entry between calls — proxy enriches the response.
-        guardrail_entry["guardrail_response"] = [
-            {"type": "code_block", "action_taken": "block"}
-        ]
+        guardrail_entry["guardrail_response"] = [{"type": "code_block", "action_taken": "block"}]
         guardrail_entry["end_time"] = 3.0
         otel._create_guardrail_span(kwargs=kwargs, context=None)
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        guardrail_spans = [
-            s for s in span_exporter.get_finished_spans() if s.name == "guardrail"
-        ]
+        guardrail_spans = [s for s in span_exporter.get_finished_spans() if s.name == "guardrail"]
         self.assertEqual(
             len(guardrail_spans),
             1,
@@ -4950,9 +4730,7 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         otel._create_guardrail_span(kwargs=kwargs, context=None)
         otel._create_guardrail_span(kwargs=kwargs, context=None)
 
-        guardrail_spans = [
-            s for s in span_exporter.get_finished_spans() if s.name == "guardrail"
-        ]
+        guardrail_spans = [s for s in span_exporter.get_finished_spans() if s.name == "guardrail"]
         self.assertEqual(
             len(guardrail_spans),
             2,
@@ -5208,9 +4986,7 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
             },
         )
         attrs = self._attr(span, exp)
-        self.assertAlmostEqual(
-            attrs["litellm.preprocessing.duration_ms"], 250.0, places=1
-        )
+        self.assertAlmostEqual(attrs["litellm.preprocessing.duration_ms"], 250.0, places=1)
 
     def test_failure_shape_request_data(self):
         # failure path: request_data with first_api_call_start_time lifted
@@ -5229,24 +5005,18 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
             },
         )
         attrs = self._attr(span, exp)
-        self.assertAlmostEqual(
-            attrs["litellm.preprocessing.duration_ms"], 30.0, places=1
-        )
+        self.assertAlmostEqual(attrs["litellm.preprocessing.duration_ms"], 30.0, places=1)
 
     def test_missing_received_at_omits(self):
         otel = OpenTelemetry()
         span, exp = self._span()
-        otel.set_preprocessing_duration_attribute(
-            span, {"first_api_call_start_time": datetime(2026, 1, 1)}
-        )
+        otel.set_preprocessing_duration_attribute(span, {"first_api_call_start_time": datetime(2026, 1, 1)})
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
 
     def test_missing_handoff_omits(self):
         otel = OpenTelemetry()
         span, exp = self._span()
-        otel.set_preprocessing_duration_attribute(
-            span, {"metadata": {"litellm_received_at": datetime(2026, 1, 1)}}
-        )
+        otel.set_preprocessing_duration_attribute(span, {"metadata": {"litellm_received_at": datetime(2026, 1, 1)}})
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
 
     def test_negative_duration_omitted(self):
@@ -5263,9 +5033,7 @@ class TestOpenTelemetryPreprocessingDuration(unittest.TestCase):
         assert "litellm.preprocessing.duration_ms" not in self._attr(span, exp)
 
     def test_none_span_is_noop(self):
-        OpenTelemetry().set_preprocessing_duration_attribute(
-            None, {"first_api_call_start_time": datetime(2026, 1, 1)}
-        )
+        OpenTelemetry().set_preprocessing_duration_attribute(None, {"first_api_call_start_time": datetime(2026, 1, 1)})
 
     def test_non_dict_container_is_noop(self):
         otel = OpenTelemetry()
@@ -5311,9 +5079,7 @@ class TestGetSpanContextLitellmMetadataFallback(unittest.TestCase):
 
         kwargs = {
             "litellm_params": {
-                "metadata": {
-                    "user_id": "test-user"
-                },  # Anthropic native metadata, no span
+                "metadata": {"user_id": "test-user"},  # Anthropic native metadata, no span
                 "litellm_metadata": {"litellm_parent_otel_span": mock_span},
             }
         }
@@ -5328,16 +5094,12 @@ class TestGetSpanContextLitellmMetadataFallback(unittest.TestCase):
         span_from_metadata = MagicMock(name="span_from_metadata")
         span_from_metadata.get_span_context.return_value = MagicMock(is_valid=True)
         span_from_litellm_metadata = MagicMock(name="span_from_litellm_metadata")
-        span_from_litellm_metadata.get_span_context.return_value = MagicMock(
-            is_valid=True
-        )
+        span_from_litellm_metadata.get_span_context.return_value = MagicMock(is_valid=True)
 
         kwargs = {
             "litellm_params": {
                 "metadata": {"litellm_parent_otel_span": span_from_metadata},
-                "litellm_metadata": {
-                    "litellm_parent_otel_span": span_from_litellm_metadata
-                },
+                "litellm_metadata": {"litellm_parent_otel_span": span_from_litellm_metadata},
             }
         }
 
@@ -5452,9 +5214,7 @@ class TestOpenTelemetryInferenceIdentityAttributes(unittest.TestCase):
         }
 
     def _otel_with_team_metadata_keys(self, keys):
-        return OpenTelemetry(
-            config=OpenTelemetryConfig(baggage_team_metadata_keys=keys)
-        )
+        return OpenTelemetry(config=OpenTelemetryConfig(baggage_team_metadata_keys=keys))
 
     def test_all_identity_attributes_stamped(self):
         otel = self._otel_with_team_metadata_keys(["tier", "cost_center"])
@@ -5483,9 +5243,7 @@ class TestOpenTelemetryInferenceIdentityAttributes(unittest.TestCase):
         otel = self._otel_with_team_metadata_keys(["tier"])
         span, exp = self._span()
         otel.set_attributes(span, self._kwargs(), {"model": "azure/gpt-4o"})
-        assert json.loads(self._attr(span, exp)["litellm.team.metadata"]) == {
-            "tier": "gold"
-        }
+        assert json.loads(self._attr(span, exp)["litellm.team.metadata"]) == {"tier": "gold"}
 
     def test_team_metadata_allowlist_from_config_yaml_kwarg(self):
         """callback_settings.otel.baggage_team_metadata_keys arrives as a kwarg
@@ -5493,9 +5251,7 @@ class TestOpenTelemetryInferenceIdentityAttributes(unittest.TestCase):
         otel = OpenTelemetry(baggage_team_metadata_keys=["cost_center"])
         span, exp = self._span()
         otel.set_attributes(span, self._kwargs(), {"model": "azure/gpt-4o"})
-        assert json.loads(self._attr(span, exp)["litellm.team.metadata"]) == {
-            "cost_center": "42"
-        }
+        assert json.loads(self._attr(span, exp)["litellm.team.metadata"]) == {"cost_center": "42"}
 
     def test_provider_model_falls_back_to_payload_model(self):
         """Without hidden_params.litellm_model_name the dispatched model is
@@ -5535,9 +5291,7 @@ class TestOpenTelemetryInferenceIdentityAttributes(unittest.TestCase):
         # no allowlisted key present -> dropped, not a useless "{}"
         assert OpenTelemetry._team_metadata_json({"c": 1}, keys) is None
         # only allowlisted sub-keys survive
-        assert json.loads(
-            OpenTelemetry._team_metadata_json({"a": 1, "c": 2}, keys)
-        ) == {"a": 1}
+        assert json.loads(OpenTelemetry._team_metadata_json({"a": 1, "c": 2}, keys)) == {"a": 1}
 
 
 class TestOpenTelemetryTeamMetadataKeysConfig(unittest.TestCase):
@@ -5602,13 +5356,9 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
     RETAINED_LOW_CARDINALITY_KEY = "gen_ai.request.model"
 
     def _load_fixtures(self):
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_kwargs.json")) as f:
             kwargs = json.load(f)
-        with open(
-            os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")
-        ) as f:
+        with open(os.path.join(self.HERE, "open_telemetry", "data", "captured_response.json")) as f:
             response_obj = json.load(f)
         return kwargs, response_obj
 
@@ -5619,9 +5369,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
         tracer_provider = TracerProvider()
         tracer_provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
         otel = OpenTelemetry(
-            config=OpenTelemetryConfig(
-                exporter="console", enable_metrics=True, attributes=attributes
-            ),
+            config=OpenTelemetryConfig(exporter="console", enable_metrics=True, attributes=attributes),
             tracer_provider=tracer_provider,
             meter_provider=meter_provider,
         )
@@ -5643,10 +5391,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
                     for sm in rm.scope_metrics:
                         for m in sm.metrics:
                             if m.name == metric_name:
-                                return [
-                                    set(dp.attributes.keys())
-                                    for dp in m.data.data_points
-                                ]
+                                return [set(dp.attributes.keys()) for dp in m.data.data_points]
             time.sleep(self.POLL_INTERVAL)
         return None
 
@@ -5655,9 +5400,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
         cardinality. With exclude_list set, none of them reach any data point,
         while the retained low-cardinality model attribute survives. Asserted
         on both the duration and token-usage histograms."""
-        reader = self._record(
-            OTELMetricAttributeFilter(exclude_list=list(self.HIGH_CARDINALITY_KEYS))
-        )
+        reader = self._record(OTELMetricAttributeFilter(exclude_list=list(self.HIGH_CARDINALITY_KEYS)))
         excluded = set(self.HIGH_CARDINALITY_KEYS)
 
         for metric_name in (self.DURATION_METRIC, self.TOKEN_METRIC):
@@ -5719,9 +5462,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             metric_reader = InMemoryMetricReader()
             meter_provider = MeterProvider(metric_readers=[metric_reader])
             tracer_provider = TracerProvider()
-            tracer_provider.add_span_processor(
-                SimpleSpanProcessor(InMemorySpanExporter())
-            )
+            tracer_provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
             otel = OpenTelemetry(
                 config=OpenTelemetryConfig(exporter="console", enable_metrics=True),
                 tracer_provider=tracer_provider,
@@ -5729,16 +5470,10 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             )
             otel.tracer = tracer_provider.get_tracer(__name__)
             # The proxy sets this only after the logger already exists.
-            litellm.callback_settings = {
-                "otel": {
-                    "attributes": {"exclude_list": list(self.HIGH_CARDINALITY_KEYS)}
-                }
-            }
+            litellm.callback_settings = {"otel": {"attributes": {"exclude_list": list(self.HIGH_CARDINALITY_KEYS)}}}
             kwargs, response_obj = self._load_fixtures()
             start = datetime.utcnow()
-            otel._handle_success(
-                kwargs, response_obj, start, start + timedelta(seconds=1)
-            )
+            otel._handle_success(kwargs, response_obj, start, start + timedelta(seconds=1))
         finally:
             litellm.callback_settings = previous
 
@@ -5774,9 +5509,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             with self.assertRaises(ValueError):
                 otel._filter_metric_attributes(attrs)
 
-            litellm.callback_settings = {
-                "otel": {"attributes": {"exclude_list": ["hidden_params"]}}
-            }
+            litellm.callback_settings = {"otel": {"attributes": {"exclude_list": ["hidden_params"]}}}
             filtered = otel._filter_metric_attributes(attrs)
         finally:
             litellm.callback_settings = previous
@@ -5800,9 +5533,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             OpenTelemetry(
                 config=OpenTelemetryConfig(
                     exporter="console",
-                    attributes=OTELMetricAttributeFilter(
-                        include_list=["not.a.real.attribute"]
-                    ),
+                    attributes=OTELMetricAttributeFilter(include_list=["not.a.real.attribute"]),
                 )
             )
 
@@ -5811,9 +5542,7 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             OpenTelemetry(
                 config=OpenTelemetryConfig(
                     exporter="console",
-                    attributes=OTELMetricAttributeFilter(
-                        exclude_list=["metadata.does_not_exist"]
-                    ),
+                    attributes=OTELMetricAttributeFilter(exclude_list=["metadata.does_not_exist"]),
                 )
             )
 
@@ -5847,8 +5576,4 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
             OTELMetricAttributeFilter(include_list=["gen_ai.token.type"]),
         ):
             with self.assertRaises(ValueError):
-                OpenTelemetry(
-                    config=OpenTelemetryConfig(
-                        exporter="console", attributes=attributes
-                    )
-                )
+                OpenTelemetry(config=OpenTelemetryConfig(exporter="console", attributes=attributes))


### PR DESCRIPTION
## Relevant issues

OpenTelemetry tracing aborts on non-LLM calls and floods logs under load

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two independent bugs in the OpenTelemetry integration, both observed in production pod logs during a traffic burst

`set_attributes` reads `response_obj.get("id")` assuming a dict, but non-LLM call types pass a non-mapping value. Management list endpoints (`/team/list`, `/key/list`, `/organization/list`, `/models`) return a list and MCP tool calls return a `CallToolResult`, so each such traced request raised `AttributeError: 'list' object has no attribute 'get'` and aborted the whole tracing callback. In the production capture this fired 63 times with full tracebacks, alongside 120 matching Arize/OpenInference attribute errors of the same shape

`safe_set_attribute` wrote unconditionally, so async success/failure logging that runs after the request span has already `end()`ed produced an `opentelemetry.sdk.trace` "Setting attribute on ended span" warning per attribute. In the same capture that was about 5,590 lines, roughly 75% of all log output during the burst, and it scaled linearly with request volume rather than being a one-off

In that capture a client presenting a deactivated user's key against management endpoints turned ~90 log lines/min into ~1,200/min, almost entirely these OTel span-lifecycle warnings

To reproduce manually: enable an OTel callback, send any request to a list-returning management endpoint (e.g. `GET /v1/models`) under load, and observe the `set_attributes` `AttributeError` and the "ended span" warning flood disappear with this change

## Type

🐛 Bug Fix

## Changes

- `litellm/integrations/opentelemetry.py`: drop a non-mapping `response_obj` to `None` in `set_attributes` so the response-derived attributes are skipped instead of crashing; guard `safe_set_attribute` with `span.is_recording()` so writes to an already-ended span are skipped
- `tests/test_litellm/integrations/test_opentelemetry.py`: regression tests for list and `CallToolResult` responses (and that a dict response still wins), and for skipping ended-span writes
