### PR TITLE
fix(logging): route realtime success logging through the bounded worker

### DIFF
--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union, ca
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.types.llms.openai import (
     OpenAIRealtimeEvents,
@@ -315,8 +316,10 @@ class RealTimeStreaming:
                 self.logging_obj.model_call_details["realtime_tools"] = self.session_tools
                 self.logging_obj.model_call_details["realtime_tool_calls"] = self.tool_calls
             ## ASYNC LOGGING
-            # Create an event loop for the new thread
-            asyncio.create_task(self.logging_obj.async_success_handler(self.messages))
+            # Route through the bounded logging worker (per-coroutine timeout +
+            # concurrency cap) instead of a bare create_task, so a slow callback
+            # can't leave suspended tasks pinning each call's response in memory.
+            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(self.logging_obj.async_success_handler(self.messages))
             ## SYNC LOGGING
             executor.submit(self.logging_obj.success_handler(self.messages))
 

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -2945,3 +2945,26 @@ def test_non_bidi_setup_left_untouched_for_followup_capable_providers():
         assert streaming._maybe_inject_guardrail_auto_response_disable(msg) == msg
     finally:
         litellm.callbacks = []
+
+
+@pytest.mark.asyncio
+async def test_log_messages_routes_async_logging_through_bounded_worker():
+    """Realtime success logging must go through GLOBAL_LOGGING_WORKER (bounded
+    queue + per-coroutine timeout), not a bare asyncio.create_task. A bare task
+    has no timeout/concurrency cap, so when a logging callback is slow every
+    realtime turn leaves a suspended task pinning its response in memory -> an
+    unbounded leak. Regression for that fix."""
+    logging_obj = MagicMock()
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), logging_obj)
+    streaming.messages = [{"type": "session.created"}]
+
+    with (
+        patch("litellm.litellm_core_utils.realtime_streaming.GLOBAL_LOGGING_WORKER") as mock_worker,
+        patch("litellm.litellm_core_utils.realtime_streaming.asyncio.create_task") as mock_create_task,
+        patch("litellm.litellm_core_utils.realtime_streaming.executor.submit"),
+    ):
+        await streaming.log_messages()
+
+        mock_worker.ensure_initialized_and_enqueue.assert_called_once()
+        # the bare create_task path must no longer be used for success logging
+        mock_create_task.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Streaming and realtime success logging accumulates unbounded suspended tasks when a logging callback is slow

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Streaming, realtime api success logging dispatch the success handler with a bare `asyncio.create_task`, which bypasses `GLOBAL_LOGGING_WORKER`. The non-streaming path already routes through that worker for a per-coroutine timeout and a concurrency cap. When a configured callback is slow (e.g. an external sink that lags), the bare task has neither bound, so each streamed or realtime turn leaves one suspended task pinning that turn's assembled response, and they accumulate without bound until the process OOMs

Reproduced against a live proxy (single worker) driving sustained streaming load through a deliberately slow success callback (a `CustomLogger` whose `async_log_success_event` hangs), comparing the patched and unpatched images. Mock responses were used so the measurement isolates the logging path rather than upstream latency. In-flight success-logging calls were counted in-process:

```
unfixed:  in-flight climbed to 14,710 and was still rising when load stopped; RSS +300 MB, not recovered after 90s idle
fixed:    in-flight capped at 100 (the worker concurrency); a hung callback is cancelled at the worker timeout
```

Note: a follow-up will additionally bound the worker's queue (drop-on-full with a counter) to cap the second-order buffer under sustained slow-sink load. This PR addresses the unbounded in-flight task accumulation, which is the primary leak

## Type

🐛 Bug Fix

## Changes

- route the bare `create_task` success-logging dispatches through `GLOBAL_LOGGING_WORKER` in `litellm/litellm_core_utils/realtime_streaming.py`, `litellm/litellm_core_utils/streaming_handler.py`, and 
- `tests/test_litellm/litellm_core_utils/test_realtime_streaming.py`: regression test asserting realtime success logging routes through the bounded worker and not a bare `create_task`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime success-logging dispatch under sustained load; mis-routing could drop or delay spend/audit callbacks, but scope is limited to the logging enqueue path with a targeted regression test.
> 
> **Overview**
> Fixes **unbounded memory growth** when realtime sessions use slow async success logging callbacks (e.g. lagging external sinks).
> 
> **`RealTimeStreaming.log_messages`** no longer schedules `async_success_handler` with a bare **`asyncio.create_task`**. It now enqueues that coroutine on **`GLOBAL_LOGGING_WORKER`**, matching the non-streaming path so success logging gets a **concurrency cap** and **per-coroutine timeout** instead of piling up suspended tasks that keep each turn’s assembled response in memory.
> 
> A regression test asserts realtime success logging goes through the worker and does **not** call `asyncio.create_task` for that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb6fc7d6f6ad0bec1726ea9a77548930f013da24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->