### PR TITLE
feat(ui): add token endpoint auth method selector to MCP OAuth forms

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.test.tsx
@@ -91,6 +91,47 @@ describe("OAuthFormFields", () => {
     });
   });
 
+  describe("token endpoint auth method selector", () => {
+    it("renders directly below the Token URL field in interactive mode", () => {
+      render(
+        <WithForm>
+          <OAuthFormFields isM2M={false} />
+        </WithForm>,
+      );
+      const tokenUrlLabel = screen.getByText("Token URL (optional)");
+      const authMethodLabel = screen.getByText("Token Endpoint Auth Method (optional)");
+      expect(tokenUrlLabel.compareDocumentPosition(authMethodLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("renders directly below the Token URL field in M2M mode", () => {
+      render(
+        <WithForm>
+          <OAuthFormFields isM2M={true} />
+        </WithForm>,
+      );
+      const tokenUrlLabel = screen.getByText("Token URL");
+      const authMethodLabel = screen.getByText("Token Endpoint Auth Method (optional)");
+      expect(tokenUrlLabel.compareDocumentPosition(authMethodLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it("offers client_secret_basic and client_secret_post options", async () => {
+      render(
+        <WithForm>
+          <OAuthFormFields isM2M={false} />
+        </WithForm>,
+      );
+      const authMethodLabel = screen.getByText("Token Endpoint Auth Method (optional)");
+      const selector = authMethodLabel.closest(".ant-form-item")!.querySelector(".ant-select-selector")!;
+      await act(async () => {
+        fireEvent.mouseDown(selector);
+      });
+      await waitFor(() => {
+        expect(screen.getByText("Client Secret Basic")).toBeInTheDocument();
+        expect(screen.getByText("Client Secret Post")).toBeInTheDocument();
+      });
+    });
+  });
+
   // ── token_validation_json inline JSON validator ──────────────────────────────
 
   describe("token_validation_json validation", () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/OAuthFormFields.tsx
@@ -3,6 +3,7 @@ import { Form, Input, InputNumber, Select, Tooltip } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
 import { OAUTH_FLOW } from "./types";
+import TokenEndpointAuthMethodField from "./TokenEndpointAuthMethodField";
 
 interface OAuthFlowStatus {
   startOAuthFlow: () => void;
@@ -101,6 +102,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
           >
             <TextInput placeholder="https://auth.example.com/oauth/token" className={fieldClassName} />
           </Form.Item>
+          <TokenEndpointAuthMethodField isEditing={isEditing} />
           <Form.Item
             label={
               <FieldLabel
@@ -182,6 +184,7 @@ const OAuthFormFields: React.FC<OAuthFormFieldsProps> = ({
           >
             <TextInput placeholder="https://example.com/oauth/token" className={fieldClassName} />
           </Form.Item>
+          <TokenEndpointAuthMethodField isEditing={isEditing} />
           <Form.Item
             label={
               <FieldLabel

--- a/ui/litellm-dashboard/src/components/mcp_tools/TokenEndpointAuthMethodField.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/TokenEndpointAuthMethodField.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Form, Select, Tooltip } from "antd";
+import { InfoCircleOutlined } from "@ant-design/icons";
+
+const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
+  { value: "client_secret_basic", label: "Client Secret Basic" },
+  { value: "client_secret_post", label: "Client Secret Post" },
+];
+
+interface TokenEndpointAuthMethodFieldProps {
+  isEditing?: boolean;
+}
+
+const TokenEndpointAuthMethodField: React.FC<TokenEndpointAuthMethodFieldProps> = ({ isEditing = false }) => (
+  <Form.Item
+    label={
+      <span className="text-sm font-medium text-gray-700 flex items-center">
+        Token Endpoint Auth Method (optional)
+        <Tooltip title="How the proxy authenticates to the upstream OAuth token endpoint. Client Secret Basic sends the client credentials in an HTTP Basic Authorization header; leave blank to use the default, Client Secret Post, which sends them in the request body.">
+          <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+        </Tooltip>
+      </span>
+    }
+    name={["credentials", "token_endpoint_auth_method"]}
+  >
+    <Select
+      allowClear
+      placeholder={
+        isEditing ? "Leave blank to keep existing (default Client Secret Post)" : "Default (Client Secret Post)"
+      }
+      className="rounded-lg"
+      size="large"
+      options={TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS}
+    />
+  </Form.Item>
+);
+
+export default TokenEndpointAuthMethodField;

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as networking from "../networking";
 import { setToken } from "@/utils/mcpTokenStore";
 import CreateMCPServer from "./create_mcp_server";
+import { selectAntOption } from "./testUtils";
 
 vi.mock("../networking", () => ({
   createMCPServer: vi.fn(),
@@ -87,45 +88,6 @@ const defaultProps = {
 
 /** Helper: get the server_name input by its Ant Form id */
 const getServerNameInput = () => document.getElementById("server_name") as HTMLInputElement;
-
-/** Helper: select a dropdown option by opening a select near a label and clicking an option */
-async function selectAntOption(labelText: string, optionText: string) {
-  const label = screen.getByText(labelText);
-  // First try to find a .ant-form-item ancestor (standard form fields)
-  let select: Element | null = null;
-  const formItem = label.closest(".ant-form-item");
-  if (formItem) {
-    select = formItem.querySelector(".ant-select");
-  }
-  // If not found, try .ant-collapse-content ancestor (auth type is inside a Collapse panel)
-  if (!select) {
-    const collapseContent = label.closest(".ant-collapse-item");
-    if (collapseContent) {
-      select = collapseContent.querySelector(".ant-select");
-    }
-  }
-  // Fallback: look for a sibling or nearby select
-  if (!select) {
-    const parent = label.closest("div");
-    select = parent?.querySelector(".ant-select") ?? null;
-  }
-  act(() => {
-    fireEvent.mouseDown(select!.querySelector(".ant-select-selector")!);
-  });
-
-  await waitFor(() => {
-    const options = document.querySelectorAll(".ant-select-item-option");
-    expect(options.length).toBeGreaterThan(0);
-  });
-
-  const option = Array.from(document.querySelectorAll(".ant-select-item-option")).find((el) =>
-    el.textContent?.includes(optionText),
-  );
-  expect(option).toBeTruthy();
-  act(() => {
-    fireEvent.click(option!);
-  });
-}
 
 describe("CreateMCPServer", () => {
   beforeEach(() => {
@@ -532,6 +494,84 @@ describe("CreateMCPServer", () => {
 
       const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
       expect(payload.token_validation).toBeUndefined();
+    });
+
+    it("includes credentials.token_endpoint_auth_method in payload when client_secret_basic is selected", async () => {
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "new-server-oauth",
+        server_name: "OAuth_Server",
+        alias: "OAuth_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "oauth2",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      await setupOAuthInteractive();
+
+      const nameInput = document.getElementById("server_name") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(nameInput, { target: { value: "OAuth_Server" } });
+      });
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
+      });
+
+      await selectAntOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
+
+      const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(networking.createMCPServer).toHaveBeenCalledTimes(1);
+      });
+
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials?.token_endpoint_auth_method).toBe("client_secret_basic");
+    });
+
+    it("omits token_endpoint_auth_method from credentials when left blank", async () => {
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "new-server-oauth",
+        server_name: "OAuth_Server",
+        alias: "OAuth_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "oauth2",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      await setupOAuthInteractive();
+
+      const nameInput = document.getElementById("server_name") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(nameInput, { target: { value: "OAuth_Server" } });
+      });
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await act(async () => {
+        fireEvent.change(urlInput, { target: { value: "https://example.com/mcp" } });
+      });
+
+      const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(networking.createMCPServer).toHaveBeenCalledTimes(1);
+      });
+
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.credentials?.token_endpoint_auth_method).toBeUndefined();
     });
 
     it("persists access + refresh token to the DB on submit for OBO mode", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, fireEvent, act } from "@testing-library/react"
 import MCPServerEdit from "./mcp_server_edit";
 import * as networking from "../networking";
 import NotificationsManager from "../molecules/notifications_manager";
+import { selectAntOption } from "./testUtils";
 
 vi.mock("../networking", () => ({
   updateMCPServer: vi.fn(),
@@ -504,6 +505,68 @@ describe("MCPServerEdit (interactive OAuth)", () => {
 
     const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
     expect(payload.token_validation).toEqual({ organization: "my-org" });
+  });
+
+  it("includes credentials.token_endpoint_auth_method in update payload when client_secret_basic is selected", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(interactiveOAuthServer);
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Token Endpoint Auth Method (optional)")).toBeInTheDocument();
+    });
+
+    await selectAntOption("Token Endpoint Auth Method (optional)", "Client Secret Basic");
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.credentials?.token_endpoint_auth_method).toBe("client_secret_basic");
+  });
+
+  it("omits token_endpoint_auth_method from the update payload when the selector is left blank", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue(interactiveOAuthServer);
+
+    render(
+      <MCPServerEdit
+        mcpServer={interactiveOAuthServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Token Endpoint Auth Method (optional)")).toBeInTheDocument();
+    });
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.credentials?.token_endpoint_auth_method).toBeUndefined();
   });
 
   it("does not include token_validation in payload when field is empty and server had none", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -20,6 +20,7 @@ import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
 import MCPLogoSelector from "./MCPLogoSelector";
 import EnvVarsSection from "./EnvVarsSection";
+import TokenEndpointAuthMethodField from "./TokenEndpointAuthMethodField";
 import { validateMCPServerUrl, validateMCPServerName, normalizeEnvVars } from "./utils";
 import NotificationsManager from "../molecules/notifications_manager";
 import { useMcpOAuthFlow } from "@/hooks/useMcpOAuthFlow";
@@ -996,6 +997,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                     className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
                   />
                 </Form.Item>
+                <TokenEndpointAuthMethodField isEditing />
                 <Form.Item
                   label={
                     <span className="text-sm font-medium text-gray-700 flex items-center">

--- a/ui/litellm-dashboard/src/components/mcp_tools/testUtils.ts
+++ b/ui/litellm-dashboard/src/components/mcp_tools/testUtils.ts
@@ -1,0 +1,27 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { expect } from "vitest";
+
+export async function selectAntOption(labelText: string, optionText: string) {
+  const label = screen.getByText(labelText);
+  const select =
+    label.closest(".ant-form-item")?.querySelector(".ant-select") ??
+    label.closest(".ant-collapse-item")?.querySelector(".ant-select") ??
+    label.closest("div")?.querySelector(".ant-select") ??
+    null;
+
+  act(() => {
+    fireEvent.mouseDown(select!.querySelector(".ant-select-selector")!);
+  });
+
+  await waitFor(() => {
+    expect(document.querySelectorAll(".ant-select-item-option").length).toBeGreaterThan(0);
+  });
+
+  const option = Array.from(document.querySelectorAll(".ant-select-item-option")).find((el) =>
+    el.textContent?.includes(optionText),
+  );
+  expect(option).toBeTruthy();
+  act(() => {
+    fireEvent.click(option!);
+  });
+}


### PR DESCRIPTION
## Relevant issues

Follow-up to #31635, which added the backend support

## Linear ticket

Relates to LIT-4091 (resolved by #31635 on the backend); this completes it in the dashboard

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
<img width="1163" height="266" alt="Screenshot 2026-06-30 at 12 35 38 PM" src="https://github.com/user-attachments/assets/21fc7978-b671-4a98-a7f3-43bd8dd9dcde" />

This is a dashboard-only change with no backend behavior change, so the proof is the new field in the create and edit forms. Run the proxy and open the dashboard, then:

1. go to http://localhost:4000/ui/?page=mcp-servers and click "Add New MCP Server"
2. set Transport Type to "Streamable HTTP", enter any MCP Server URL
3. under Authentication, select "OAuth"
4. confirm a new "Token Endpoint Auth Method (optional)" dropdown shows directly under the Token URL field, defaulting to blank with placeholder "Default (Client Secret Post)", offering "Client Secret Basic" and "Client Secret Post"
5. pick "Client Secret Basic" and create the server
6. open the server's edit view; the same selector shows under "Token URL Override (optional)" with placeholder "Leave blank to keep existing (default Client Secret Post)"

To confirm the value round-trips into the credentials the gateway reads, after step 5 check the stored row:

```
curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.[] | select(.alias=="<your_alias>") | {alias, auth_type}'
```

then exercise the upstream token exchange against an IdP registered for `client_secret_basic` (same setup as #31635) and confirm the gateway sends `Authorization: Basic ...` instead of credentials in the body

## Type

🆕 New Feature

## Changes

PR #31635 added a per-server `token_endpoint_auth_method` (`client_secret_basic` or `client_secret_post`) that controls how the gateway authenticates to an upstream OAuth token endpoint, but the only way to set it was hand-editing the stored credentials JSON; the dashboard had no control for it

This adds an optional "Token Endpoint Auth Method" selector directly under the Token URL field in both MCP server forms: the create form (`OAuthFormFields`, in both the M2M and interactive flows) and the edit form (`mcp_server_edit`). A small shared `TokenEndpointAuthMethodField` component renders the field in all three spots so the markup stays in one place

The field binds to `credentials.token_endpoint_auth_method`, which is exactly what the backend already reads, so no API change is needed. It is write-only by design: the credentials blob is redacted before servers are returned to the dashboard (same reason client id/secret cannot be pre-filled today), so the dropdown opens blank. Leaving it blank omits the key from the request, which preserves whatever is already stored and keeps the `client_secret_post` default; choosing a value overrides it. Because nothing is sent when blank, an edit that does not touch the field never disturbs the existing setting

Tests cover the create form (selecting `client_secret_basic` puts it in the create payload under `credentials`; leaving it blank omits it), the edit form (selecting it puts it in the update payload), and `OAuthFormFields` (the selector renders directly below Token URL in both M2M and interactive flows and offers both options). The selector tests fail on the pre-change code
