### PR TITLE
fix(token_counter): count legacy function_call.arguments (VERIA-492)

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -431,9 +431,11 @@ def _count_function_call_tokens(
             function_arguments = tool_call["function"].get("arguments", "")
             total += count_function(str(function_arguments))
         return total
-    if not isinstance(value, Mapping):
-        raise ValueError(f"Unsupported type {type(value)} for key function_call in message {message}")
-    return count_function(str(value.get("arguments", "")))
+    if key == "function_call":
+        if not isinstance(value, Mapping):
+            raise ValueError(f"Unsupported type {type(value)} for key function_call in message {message}")
+        return count_function(str(value.get("arguments", "")))
+    raise ValueError(f"Unexpected key {key!r}; expected 'tool_calls' or 'function_call'")
 
 
 def _count_messages(

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -407,6 +407,35 @@ def token_counter(
     return num_tokens
 
 
+def _count_function_call_tokens(
+    key: str,
+    value: Any,
+    message: Mapping[str, Any],
+    count_function: TokenCounterFunction,
+) -> int:
+    """
+    Count tokens contributed by an assistant message's tool/function call payload.
+
+    Handles both the modern `tool_calls` list and the legacy OpenAI
+    `function_call` dict. Only the `arguments` string is counted (matching the
+    existing tool_calls behavior); names are accounted for elsewhere via the
+    tool/function definitions and `tool_choice`.
+    """
+    if key == "tool_calls":
+        if not isinstance(value, List):
+            raise ValueError(f"Unsupported type {type(value)} for key tool_calls in message {message}")
+        total = 0
+        for tool_call in value:
+            if "function" not in tool_call:
+                raise ValueError(f"Unsupported tool call {tool_call} must contain a function key")
+            function_arguments = tool_call["function"].get("arguments", "")
+            total += count_function(str(function_arguments))
+        return total
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Unsupported type {type(value)} for key function_call in message {message}")
+    return count_function(str(value.get("arguments", "")))
+
+
 def _count_messages(
     params: _MessageCountParams,
     messages: List[AllMessageValues],
@@ -430,16 +459,8 @@ def _count_messages(
         for key, value in message.items():
             if value is None:
                 pass
-            elif key == "tool_calls":
-                if isinstance(value, List):
-                    for tool_call in value:
-                        if "function" in tool_call:
-                            function_arguments = tool_call["function"].get("arguments", [])
-                            num_tokens += params.count_function(str(function_arguments))
-                        else:
-                            raise ValueError(f"Unsupported tool call {tool_call} must contain a function key")
-                else:
-                    raise ValueError(f"Unsupported type {type(value)} for key tool_calls in message {message}")
+            elif key in ("tool_calls", "function_call"):
+                num_tokens += _count_function_call_tokens(key, value, message, params.count_function)
             elif isinstance(value, str):
                 num_tokens += params.count_function(value)
                 if key == "name":

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -97,6 +97,50 @@ def test_token_counter_normal_plus_function_calling():
 # test_token_counter_normal_plus_function_calling()
 
 
+def test_token_counter_legacy_function_call_counts_arguments():
+    """
+    Regression for VERIA-492 (Token-counter function_call bypass).
+
+    The legacy OpenAI assistant `function_call` field carries arbitrary text in
+    `arguments`. Before the fix, `_count_messages` had no branch for
+    `function_call` and fell through to the unsupported-key `continue`, so an
+    assistant turn could smuggle unlimited text past `token_counter` and the
+    proxy `/utils/token_counter` endpoint (and downstream pre-call budget /
+    `get_modified_max_tokens` math). After the fix it must be counted the
+    same as the equivalent `tool_calls` payload.
+    """
+    long_arg = "A" * 4000
+    fc_messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "function_call": {"name": "search", "arguments": long_arg},
+        },
+    ]
+    tc_messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": long_arg},
+                }
+            ],
+        },
+    ]
+    fc_tokens = token_counter(model="gpt-3.5-turbo", messages=fc_messages)
+    tc_tokens = token_counter(model="gpt-3.5-turbo", messages=tc_messages)
+    assert fc_tokens == tc_tokens, (
+        f"function_call arguments must count like tool_calls arguments; "
+        f"got function_call={fc_tokens}, tool_calls={tc_tokens}"
+    )
+    assert fc_tokens > 500, f"4000-char arguments payload must contribute real tokens, got {fc_tokens}"
+
+
 @pytest.mark.parametrize(
     "message_count_pair",
     MESSAGES_TEXT,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves VERIA-492

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`token_counter` already handles the modern `tool_calls` field on assistant messages, but `_count_messages` had no branch for the legacy OpenAI `function_call` payload. The value is a dict (`{"name", "arguments"}`), so it skipped every special-cased branch and fell through to the unsupported-key `continue`. The entire `arguments` string was excluded from the count.

That undercount flows everywhere `token_counter` is used: the proxy `/utils/token_counter` endpoint, `get_modified_max_tokens`, and any pre-call budget/limit math that prices input messages.

Live proxy on this branch, model `openai/gpt-4.1-mini` mapped as `gpt-3.5-turbo`, master key `sk-1234`, 4000 char payload.

Before the fix:

```
$ curl -sS -X POST http://localhost:4001/utils/token_counter \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":"AAAA...x4000"}]}'
{"total_tokens": 512, ...}

$ curl ... -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":null,"function_call":{"name":"search","arguments":"AAAA...x4000"}}]}'
{"total_tokens": 12, ...}     # smuggled

$ curl ... -d '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"hi"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"search","arguments":"AAAA...x4000"}}]}]}'
{"total_tokens": 512, ...}     # counted correctly via the modern field
```

After the fix:

```
$ curl ... -d '...content...'
{"total_tokens": 512, ...}

$ curl ... -d '...function_call...'
{"total_tokens": 512, ...}     # bypass closed

$ curl ... -d '...tool_calls...'
{"total_tokens": 512, ...}     # unchanged

$ curl ... -d '...function_call: null'
{"total_tokens": 12, ...}      # null guard preserved

$ curl ... -d '...function_call: {"arguments": ""}'
{"total_tokens": 12, ...}      # empty args, no error
```

## Type

🐛 Bug Fix

## Changes

`_count_messages` now treats `tool_calls` and the legacy `function_call` field through a shared helper, `_count_function_call_tokens`, that counts only the `arguments` string (matching the existing tool_calls behavior; names are accounted for elsewhere via the tool/function definitions and `tool_choice`).

The regression test in `tests/test_litellm/litellm_core_utils/test_token_counter.py` asserts a `function_call` payload counts identically to the equivalent `tool_calls` payload and that a 4000-char payload contributes real tokens (it fails on unfixed code: 12 vs 512).

Notable adjacent change: the default for a missing `arguments` key on a `tool_calls` entry shifts from `[]` (which `str()` rendered as `"[]"` and added ~1 token) to `""` (0 tokens). The previous default was a latent oversight; no existing test relies on the old behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a budget/limit bypass in shared token counting used before calls; behavior change is small but touches pre-call sizing paths across the proxy and core utils.
> 
> **Overview**
> Closes a **token undercount** where assistant messages using the legacy OpenAI **`function_call`** field ignored the entire **`arguments`** payload, while equivalent **`tool_calls`** were counted correctly. That gap affected **`token_counter`**, the proxy **`/utils/token_counter`** route, and any logic (e.g. **`get_modified_max_tokens`**) that sizes requests from priced input messages.
> 
> **`_count_messages`** now routes **`tool_calls`** and **`function_call`** through a shared **`_count_function_call_tokens`** helper that tokenizes only **`arguments`** (names stay covered via tool definitions / **`tool_choice`**). Missing **`arguments`** on **`tool_calls`** entries default to **`""`** instead of **`[]`**, avoiding a stray **`"[]"`** token from **`str()`**.
> 
> A regression test asserts **`function_call`** and **`tool_calls`** produce identical counts for a large arguments string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db2941a83ad3567c56daa458c2cb1307574ad895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->