### PR TITLE
fix(vertex_ai): correct gemma-4-26b-a4b-it-maas context window to 262144

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -35897,7 +35897,7 @@
     "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-openai_models",
-        "max_input_tokens": 256000,
+        "max_input_tokens": 262144,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -36102,7 +36102,7 @@
     "vertex_ai/google/gemma-4-26b-a4b-it-maas": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-openai_models",
-        "max_input_tokens": 256000,
+        "max_input_tokens": 262144,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gemma/test_vertex_ai_gemma_global_endpoint.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/gemma/test_vertex_ai_gemma_global_endpoint.py
@@ -206,6 +206,27 @@ def test_gemma_maas_supports_vision():
         )
 
 
+def test_gemma_maas_local_cost_map_matches_google_model_card(monkeypatch):
+    """Guard the shipped cost-map entry against the official Vertex AI model card.
+
+    The Google model card lists a 262,144-token context window and a 128,000-token
+    max output at $0.15/1M input and $0.60/1M output. This loads the packaged local
+    cost map (not the remote one) so a regression in the JSON file is caught here,
+    including the earlier 256000 context-window approximation.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    local_cost_map = litellm.get_model_cost_map(url="")
+    entry = local_cost_map["vertex_ai/google/gemma-4-26b-a4b-it-maas"]
+
+    assert entry["max_input_tokens"] == 262144
+    assert entry["max_output_tokens"] == 128000
+    assert entry["max_tokens"] == 128000
+    assert entry["input_cost_per_token"] == 1.5e-07
+    assert entry["output_cost_per_token"] == 6e-07
+    assert entry["supports_function_calling"] is True
+    assert entry["supports_vision"] is True
+
+
 # ---------------------------------------------------------------------------
 # Integration tests: verify payloads reach the global OpenAI endpoint
 #


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Relevant issues

## Linear ticket

Resolves LIT-4117

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Context

The Vertex AI MaaS model `vertex_ai/google/gemma-4-26b-a4b-it-maas` is already wired up and working: it lives in the cost map, routes through the OpenAI-compatible partner-models path via the `google/gemma-` prefix, and is covered by tests. The one inaccuracy was its context window

The cost map carried `max_input_tokens: 256000`, a rounded approximation. Google's official Vertex AI model card lists the context length as 262,144 tokens (256K) with a 128,000 max output. Sibling Vertex MaaS entries such as `vertex_ai/openai/gpt-oss-120b-maas` already set `max_input_tokens` to the full context window, so this aligns gemma-4 with both the model card and the existing convention. The undercount silently truncated callers that gate on `get_model_info`, rejecting valid 256K-token prompts

## Changes

Set `max_input_tokens` to `262144` for `vertex_ai/google/gemma-4-26b-a4b-it-maas` in both `model_prices_and_context_window.json` and the packaged `litellm/model_prices_and_context_window_backup.json`. Added a regression test that loads the local cost map and asserts the entry matches the model card (context window, max output, input/output cost, function-calling and vision flags), which fails on the old 256000 value

## Type

🐛 Bug Fix

## Screenshots / Proof of Fix

No GCP credentials are available in this environment, so a live Gemma inference call against Vertex was not possible. Since this is a cost-map metadata correction, the end-user-visible surface is the model info the proxy reports. Ran a live proxy with the local cost map and queried it

```
$ export LITELLM_LOCAL_MODEL_COST_MAP=True
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
# config.yaml model: vertex_ai/google/gemma-4-26b-a4b-it-maas

$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234"
{
  "model_name": "gemma-4-26b",
  "litellm_model": "vertex_ai/google/gemma-4-26b-a4b-it-maas",
  "max_input_tokens": 262144,
  "max_output_tokens": 128000,
  "input_cost_per_token": 1.5e-07,
  "output_cost_per_token": 6e-07,
  "supports_vision": true,
  "supports_function_calling": true
}
```

Before the fix the same endpoint returned `"max_input_tokens": 256000`

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://berriaillm.slack.com/archives/C09MMPFRN7M/p1782846657901239?thread_ts=1782846657.901239&cid=C09MMPFRN7M)

<div><a href="https://cursor.com/agents/bc-6ed9c854-ad25-5462-a393-61e8f5316ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ed9c854-ad25-5462-a393-61e8f5316ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

