### PR TITLE
fix: preserve anthropic streaming cache creation token details across chunks

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -516,11 +516,7 @@ class ChunkProcessor:
         incoming_dict = incoming.model_dump(exclude_none=True)
 
         for key, value in incoming_dict.items():
-            if (
-                isinstance(value, dict)
-                and key in merged
-                and isinstance(merged[key], dict)
-            ):
+            if isinstance(value, dict) and key in merged and isinstance(merged[key], dict):
                 for nested_key, nested_value in value.items():
                     if nested_value is not None:
                         merged[key][nested_key] = nested_value

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -495,6 +495,40 @@ class ChunkProcessor:
             "prompt_tokens_details": prompt_tokens_details,
         }
 
+    def _merge_prompt_tokens_details(
+        self,
+        existing: Optional[PromptTokensDetailsWrapper],
+        incoming: Optional[PromptTokensDetailsWrapper],
+    ) -> Optional[PromptTokensDetailsWrapper]:
+        """
+        Merge streaming prompt token detail snapshots.
+
+        Keep previously observed non-null fields when later chunks omit them
+        (for example Anthropic ``message_start`` may include
+        ``cache_creation_token_details`` while the final usage chunk does not).
+        """
+        if incoming is None:
+            return existing
+        if existing is None:
+            return incoming
+
+        merged = existing.model_dump(exclude_none=True)
+        incoming_dict = incoming.model_dump(exclude_none=True)
+
+        for key, value in incoming_dict.items():
+            if (
+                isinstance(value, dict)
+                and key in merged
+                and isinstance(merged[key], dict)
+            ):
+                for nested_key, nested_value in value.items():
+                    if nested_value is not None:
+                        merged[key][nested_key] = nested_value
+            elif value is not None:
+                merged[key] = value
+
+        return PromptTokensDetailsWrapper(**merged)
+
     def count_reasoning_tokens(self, response: ModelResponse) -> Optional[int]:
         reasoning_tokens: Optional[int] = None
         for choice in response.choices:
@@ -594,7 +628,10 @@ class ChunkProcessor:
                         "web_search_requests",
                     )
 
-                prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
+                prompt_tokens_details = self._merge_prompt_tokens_details(
+                    existing=prompt_tokens_details,
+                    incoming=usage_chunk_dict["prompt_tokens_details"],
+                )
 
         completion_tokens = self._reset_anthropic_cursor_completion_tokens(
             chunks=chunks,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -12,12 +12,14 @@ from litellm import ChatCompletionUsageBlock, stream_chunk_builder
 from litellm.types.utils import GenericStreamingChunk
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
     Delta,
     Function,
     ModelResponseStream,
     PromptTokensDetails,
+    PromptTokensDetailsWrapper,
     ServerToolUse,
     StreamingChoices,
     Usage,
@@ -361,6 +363,94 @@ def test_cache_read_input_tokens_retained_genericstreamingchunk():
     )
 
     assert usage.prompt_tokens_details.cached_tokens == 543
+
+def test_cache_creation_token_details_carried_forward_from_earlier_stream_chunk():
+    """
+    Anthropic may emit cache_creation_token_details on message_start usage, then omit
+    it from the final usage chunk. Ensure stream usage aggregation preserves it.
+    """
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-anthropic-cache-details",
+        created=1745513206,
+        model="claude-sonnet-4-20250514",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="", role=None),
+                logprobs=None,
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=0,
+            prompt_tokens=2957,
+            total_tokens=2957,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0,
+                text_tokens=12,
+                cache_creation_tokens=2945,
+                cache_creation_token_details=CacheCreationTokenDetails(
+                    ephemeral_5m_input_tokens=2945,
+                    ephemeral_1h_input_tokens=0,
+                ),
+            ),
+            cache_creation_input_tokens=2945,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-anthropic-cache-details",
+        created=1745513207,
+        model="claude-sonnet-4-20250514",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="", role=None),
+                logprobs=None,
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=35,
+            prompt_tokens=2957,
+            total_tokens=2992,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0,
+                text_tokens=12,
+                cache_creation_tokens=2945,
+            ),
+            cache_creation_input_tokens=2945,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    chunks = [chunk1, chunk2]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="claude-sonnet-4-20250514",
+        completion_output="",
+    )
+
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cache_creation_token_details is not None
+    assert (
+        usage.prompt_tokens_details.cache_creation_token_details.ephemeral_5m_input_tokens
+        == 2945
+    )
+    assert (
+        usage.prompt_tokens_details.cache_creation_token_details.ephemeral_1h_input_tokens
+        == 0
+    )
+
 
 def test_stream_chunk_builder_litellm_usage_chunks():
     """


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->
https://github.com/BerriAI/litellm/pull/31651

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->
Before fix: 
The final usage.prompt_tokens_details only has:
`{"cached_tokens":0,"text_tokens":13,"cache_creation_tokens":0}`
So there are no cache_creation_token_details fields present at all.

```
curl -N "http://0.0.0.0:3020/v1/chat/completions" \
  -H "Authorization: Bearer $token" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "anthropic/claude-opus-4-8",
    "stream": true,
    "stream_options": { "include_usage": true },
    "messages": [
      { "role": "user", "content": "Give a short reply." }
    ]
  }'
data: {"id":"chatcmpl-f9ebd7ec-4700-4ac5-ab26-7c6263da67d5","object":"chat.completion.chunk","created":1782770064,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{"role":"assistant","content":"Sure! What's up"}}]}

data: {"id":"chatcmpl-f9ebd7ec-4700-4ac5-ab26-7c6263da67d5","object":"chat.completion.chunk","created":1782770064,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{"content":"? 😊"}}]}

data: {"id":"chatcmpl-f9ebd7ec-4700-4ac5-ab26-7c6263da67d5","object":"chat.completion.chunk","created":1782770064,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: {"id":"chatcmpl-f9ebd7ec-4700-4ac5-ab26-7c6263da67d5","created":1782770064,"model":"anthropic/claude-opus-4-8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":13,"prompt_tokens":13,"total_tokens":26,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":13},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":13,"cache_creation_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}
data: [DONE]
```

After fix:
The final usage chunk includes those nested fields:
`"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}`
This change ensures that if those nested details appear in an earlier chunk and are missing later, they aren’t dropped when calculating the final usage.

```
data: {"id":"chatcmpl-3900ac5c-c405-4990-aa27-e58ea552af34","object":"chat.completion.chunk","created":1782772451,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{"role":"assistant","content":"S"}}]}

data: {"id":"chatcmpl-3900ac5c-c405-4990-aa27-e58ea552af34","object":"chat.completion.chunk","created":1782772451,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{"content":"ure! What would you like to talk about? 😊"}}]}

data: {"id":"chatcmpl-3900ac5c-c405-4990-aa27-e58ea552af34","object":"chat.completion.chunk","created":1782772451,"model":"anthropic/claude-opus-4-8","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: {"id":"chatcmpl-3900ac5c-c405-4990-aa27-e58ea552af34","created":1782772451,"model":"anthropic/claude-opus-4-8","object":"chat.completion.chunk","choices":[{"index":0,"delta":{}}],"usage":{"completion_tokens":18,"prompt_tokens":13,"total_tokens":31,"completion_tokens_details":{"reasoning_tokens":0,"text_tokens":18},"prompt_tokens_details":{"cached_tokens":0,"text_tokens":13,"cache_creation_tokens":0,"cache_creation_token_details":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0}},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}

data: [DONE]
```

## Type
🐛 Bug Fix

## Changes
Description Fix Anthropic streaming usage aggregation so cache‑creation token details (e.g., ephemeral_5m_input_tokens) aren’t lost when later chunks omit those nested fields. Adds a merge helper to preserve non‑null prompt_tokens_details fields across streaming chunks, and a regression test covering the Anthropic message_start → final chunk case.

Before
- When Anthropic streamed usage, the first chunk could include cache_creation_token_details, but the final usage chunk omitted it.
- The stream aggregator replaced prompt_tokens_details with the final chunk’s snapshot, dropping the earlier cache‑creation details.

After
- Streaming usage aggregation merges prompt_tokens_details, keeping previously observed non‑null nested fields when later chunks omit them.
- Added a regression test to ensure cache_creation_token_details persists across chunks.