### PR TITLE
fix(anthropic): prevent content rehydration when tool/function calls present

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2319,9 +2319,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if json_extra_content:
             merged_text = merged_text + json_extra_content if merged_text else json_extra_content
 
+        message_content: Optional[str] = merged_text or None
+        if tool_calls_for_message:
+            # OpenAI chat completions require content to be null when tool_calls exist.
+            message_content = None
         _message = litellm.Message(
             tool_calls=tool_calls_for_message,
-            content=merged_text or None,
+            content=message_content,
             provider_specific_fields=provider_specific_fields,
             thinking_blocks=thinking_blocks,
             reasoning_content=reasoning_content,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8425,7 +8425,8 @@ def stream_chunk_builder(
             and chunk["choices"][0]["delta"]["tool_calls"] is not None
         ]
 
-        if len(tool_call_chunks) > 0:
+        has_tool_calls = len(tool_call_chunks) > 0
+        if has_tool_calls:
             tool_calls_list = processor.get_combined_tool_content(tool_call_chunks)
             _choice = cast(Choices, response.choices[0])
             _choice.message.content = None
@@ -8439,7 +8440,8 @@ def stream_chunk_builder(
             and chunk["choices"][0]["delta"]["function_call"] is not None
         ]
 
-        if len(function_call_chunks) > 0:
+        has_function_calls = len(function_call_chunks) > 0
+        if has_function_calls:
             _choice = cast(Choices, response.choices[0])
             _choice.message.content = None
             _choice.message.function_call = processor.get_combined_function_call_content(function_call_chunks)
@@ -8452,8 +8454,10 @@ def stream_chunk_builder(
             and chunk["choices"][0]["delta"]["content"] is not None
         ]
 
-        if len(content_chunks) > 0:
-            response["choices"][0]["message"]["content"] = processor.get_combined_content(content_chunks)
+        if len(content_chunks) > 0 and not has_tool_calls and not has_function_calls:
+            response["choices"][0]["message"]["content"] = (
+                processor.get_combined_content(content_chunks)
+            )
 
         thinking_blocks = [
             chunk

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -629,6 +629,57 @@ def test_stream_chunk_builder_accepts_dict_snapshot_chunks():
     assert response.choices[0].message.content == "Hello world"
 
 
+def test_stream_chunk_builder_tool_calls_nulls_content():
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-123",
+        created=1,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="Let me check.", role="assistant"),
+            )
+        ],
+    )
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-123",
+        created=2,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="tool_calls",
+                index=0,
+                delta=Delta(
+                    content=None,
+                    role=None,
+                    tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id="call_1",
+                            function=Function(
+                                arguments='{"city":"Toronto"}',
+                                name="get_weather",
+                            ),
+                            type="function",
+                            index=0,
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+
+    response = stream_chunk_builder(chunks=[chunk1, chunk2])
+
+    assert response is not None
+    message = response.choices[0].message
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.content is None
+
+
 def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     chunk = ModelResponseStream(
         id="chatcmpl-123",

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3068,12 +3068,8 @@ def test_code_execution_tool_results_extraction():
     assert editor_result["tool_use_id"] == "srvtoolu_01DEF"
     assert editor_result["content"]["is_file_update"] is False
 
-    # Verify text content is properly concatenated
-    assert (
-        "I'll calculate that for you."
-        in transformed_response.choices[0].message.content
-    )
-    assert "Done!" in transformed_response.choices[0].message.content
+    # Tool calls should null content per OpenAI contract
+    assert transformed_response.choices[0].message.content is None
 
 
 def test_code_execution_tool_results_in_hidden_params():
@@ -3189,6 +3185,53 @@ def test_tool_search_tool_result_not_in_tool_results():
     # Verify tool_search_tool_result is NOT in tool_results
     provider_fields = transformed_response.choices[0].message.provider_specific_fields
     assert provider_fields.get("tool_results") is None
+
+
+def test_tool_call_preamble_sets_content_none():
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AnthropicConfig()
+
+    mock_anthropic_response = {
+        "id": "msg_01XYZ",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [
+            {"type": "text", "text": "Let me call a tool."},
+            {
+                "type": "tool_use",
+                "id": "toolu_01ABC",
+                "name": "get_weather",
+                "input": {"city": "Toronto"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 12, "output_tokens": 7},
+    }
+
+    mock_raw_response = MagicMock(spec=httpx.Response)
+    mock_raw_response.json.return_value = mock_anthropic_response
+    mock_raw_response.status_code = 200
+    mock_raw_response.headers = {}
+
+    model_response = ModelResponse()
+
+    transformed_response = config.transform_parsed_response(
+        completion_response=mock_anthropic_response,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+
+    message = transformed_response.choices[0].message
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.content is None
 
 
 def test_web_search_tool_result_backwards_compatibility():

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4532,4 +4532,3 @@ def test_aws_bedrock_project_id_excluded_from_bedrock_optional_params():
 
     assert "aws_bedrock_project_id" not in result
     assert result["aws_region_name"] == "us-east-1"
-


### PR DESCRIPTION
## Relevant issues

When Anthropic streaming responses include both content and tool calls, the stream builder incorrectly rehydrates content into the final message alongside tool calls, producing a payload that Anthropic rejects.

Related: https://github.com/BerriAI/litellm/pull/31719




## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before fix: 
```
{
  "choices": [
    {
      "finish_reason": "tool_calls",
      "index": 0,
      "logprobs": null,
      "message": {
        "content": "I'll check the weather for you. Let me get that information.",
        "reasoning_content": null,
        "refusal": null,
        "role": "assistant",
        "tool_calls": [
          {
            "function": {
              "arguments": "{\"city\": \"London\"}",
              "name": "get_weather"
            },
            "id": "toolu_0189ia2YjKYX7ZqcwnzeZMps",
            "type": "function"
          }
```

After fix: 
```
{
  "choices": [
    {
      "finish_reason": "tool_calls",
      "index": 0,
      "logprobs": null,
      "message": {
        "content": null,
        "reasoning_content": null,
        "refusal": null,
        "role": "assistant",
        "tool_calls": [
          {
            "function": {
              "arguments": "{\"city\": \"London\"}",
              "name": "get_weather"
            },
            "id": "toolu_011XHKjxYd8qV2aq5hX9nz89",
            "type": "function"
          }
        ]
      }
    }
  ],
```

## Type
🐛 Bug Fix

## Changes
Updated Anthropic chat response mapping so tool calls always null out content, matching OpenAI’s mutual-exclusivity contract, and ensured streaming assembly won’t overwrite that with preamble text. Added unit coverage for both parsed and streaming paths.

Changes:
- Enforce content=None when tool_calls exist in AnthropicConfig.transform_parsed_response.
- Guard stream_chunk_builder from rehydrating content when tool/function calls are present.
- Added tests covering preamble+tool_use in parsed responses and streaming.
- Anthropic response shaping: litellm/llms/anthropic/chat/transformation.py now forces message.content = None when tool calls are present, even after JSON-mode handling, to match the OpenAI tool-calls contract.
- Streaming assembly behavior: litellm/main.py now tracks whether tool or function calls are present in the stream and prevents any later content chunks from repopulating message.content when tool/function calls exist.
- Anthropic tests updated/added: tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py now asserts that tool-call responses should have content=None, and adds coverage for “tool call preamble” responses where text precedes a tool call.
- Streaming tests added: tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py adds a test that ensures streamed tool calls null out message content in the aggregated response.


