### PR TITLE
fix(anthropic): fall back to tool-based JSON when schema has unsupported constraints

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -559,7 +559,86 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         return result
 
-    def get_json_schema_from_pydantic_object(self, response_format: Union[Any, Dict, None]) -> Optional[dict]:
+    @staticmethod
+    def _schema_has_unsupported_output_constraints(
+        schema: Union[Dict[str, Any], List[Any], Any]
+    ) -> bool:
+        if not isinstance(schema, (dict, list)):
+            return False
+
+        unsupported_fields = {
+            "maxItems",
+            "minItems",
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "minLength",
+            "maxLength",
+        }
+
+        if isinstance(schema, dict):
+            if any(field in schema for field in unsupported_fields):
+                return True
+            for key, value in schema.items():
+                if key in {"properties", "$defs"} and isinstance(value, dict):
+                    if any(
+                        AnthropicConfig._schema_has_unsupported_output_constraints(
+                            item
+                        )
+                        for item in value.values()
+                    ):
+                        return True
+                elif key == "items" and isinstance(value, dict):
+                    if AnthropicConfig._schema_has_unsupported_output_constraints(
+                        value
+                    ):
+                        return True
+                elif key in {"anyOf", "allOf", "oneOf"} and isinstance(value, list):
+                    if any(
+                        AnthropicConfig._schema_has_unsupported_output_constraints(
+                            item
+                        )
+                        for item in value
+                    ):
+                        return True
+                elif isinstance(value, (dict, list)):
+                    if AnthropicConfig._schema_has_unsupported_output_constraints(
+                        value
+                    ):
+                        return True
+        else:
+            for item in schema:
+                if AnthropicConfig._schema_has_unsupported_output_constraints(item):
+                    return True
+
+        return False
+
+    def _resolve_json_schema_defs(self, json_schema: dict) -> dict:
+        import copy
+
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_defs,
+        )
+
+        resolved_schema = copy.deepcopy(json_schema)
+        defs = resolved_schema.pop("$defs", resolved_schema.pop("definitions", {}))
+        if defs:
+            unpack_defs(resolved_schema, defs)
+        return resolved_schema
+
+    def _response_format_requires_tool_json(
+        self, value: Optional[dict]
+    ) -> bool:
+        json_schema = self._extract_json_schema_from_response_format(value)
+        if json_schema is None:
+            return False
+        resolved_schema = self._resolve_json_schema_defs(json_schema)
+        return self._schema_has_unsupported_output_constraints(resolved_schema)
+
+    def get_json_schema_from_pydantic_object(
+        self, response_format: Union[Any, Dict, None]
+    ) -> Optional[dict]:
         return type_to_response_format_param(
             response_format, ref_template="/$defs/{model}"
         )  # Relevant issue: https://github.com/BerriAI/litellm/issues/7755
@@ -1229,16 +1308,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Resolve $ref/$defs before filtering — Anthropic doesn't support
         # external schema references (e.g., /$defs/CalendarEvent).
-        import copy
-
-        from litellm.litellm_core_utils.prompt_templates.common_utils import (
-            unpack_defs,
-        )
-
-        json_schema = copy.deepcopy(json_schema)
-        defs = json_schema.pop("$defs", json_schema.pop("definitions", {}))
-        if defs:
-            unpack_defs(json_schema, defs)
+        json_schema = self._resolve_json_schema_defs(json_schema)
 
         # Filter out unsupported fields for Anthropic's output_format API
         filtered_schema = self.filter_anthropic_output_schema(json_schema)
@@ -1411,7 +1481,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     output_key=param,
                 )
             elif param == "response_format" and isinstance(value, dict):
-                if any(
+                use_native_output_format = any(
                     substring in model
                     for substring in {
                         "sonnet-4.5",
@@ -1429,8 +1499,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "sonnet_4.6",
                         "sonnet_4_6",
                     }
+                )
+                if use_native_output_format and self._response_format_requires_tool_json(
+                    value
                 ):
-                    _output_format = self.map_response_format_to_anthropic_output_format(value)
+                    use_native_output_format = False
+                if use_native_output_format:
+                    _output_format = (
+                        self.map_response_format_to_anthropic_output_format(value)
+                    )
                     if _output_format is not None:
                         optional_params["output_format"] = _output_format
                 else:

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1039,6 +1039,41 @@ def test_non_structured_output_model_uses_tool_workaround():
     assert "tool_choice" in optional_params
 
 
+def test_structured_output_with_constraints_uses_tool_workaround():
+    """
+    Test that models with native structured outputs fall back to the tool-based
+    workaround when the schema includes unsupported constraints.
+    """
+    config = AnthropicConfig()
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "age": {"type": "integer", "minimum": 0},
+                },
+                "required": ["name", "age"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    optional_params = config.map_openai_params(
+        non_default_params={"response_format": response_format},
+        optional_params={},
+        model="claude-opus-4-6-20250918",
+        drop_params=False,
+    )
+
+    assert "output_format" not in optional_params
+    assert "tools" in optional_params
+    assert "tool_choice" in optional_params
+
+
 # ============ Tool Search Tests ============
 
 


### PR DESCRIPTION

## Relevant issues

Anthropic's native `output_format` (structured outputs) doesn't support JSON Schema constraints like `minItems`, `maxItems`, `minimum`, `maximum`, `minLength`, `maxLength`, `exclusiveMinimum`, `exclusiveMaximum`. When these are present, the request fails instead of falling back to the tool-based JSON approach.

Related: https://github.com/BerriAI/litellm/pull/31737

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
Before fix: 
```
curl -sS http://localhost:4010/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer sk-test" \
  -d '{
    "model": "anthropic/claude-opus-4-5",
    "messages": [
      {"role": "system", "content": "Return JSON only."},
      {"role": "user", "content": "Give me a short person record."}
    ],
    "response_format": {
      "type": "json_schema",
      "json_schema": {
        "name": "person",
        "schema": {
          "type": "object",
          "properties": {
            "name": {"type": "string", "minLength": 5},
            "age": {"type": "integer", "minimum": 21}
          },
          "required": ["name", "age"],
          "additionalProperties": false
        }
      }
    }
  }'

Final returned optional params: {'output_format': {'type': 'json_schema', 'schema': {'type': 'object', 'properties': {'name': {'description': 'Note: minimum length: 5.', 'type': 'string'}, 'age': {'description': 'Note: minimum value: 21.', 'type': 'integer'}}, 'required': ['name', 'age'], 'additionalProperties': False}}, 'json_mode': True}

POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/messages \
... 'output_format': {'type': 'json_schema', 'schema': {'type': 'object', 'properties': {'name': {'description': 'Note: minimum length: 5.', 'type': 'string'}, 'age': {'description': 'Note: minimum value: 21.', 'type': 'integer'}}, 'required': ['name', 'age'], 'additionalProperties': False}} ...
```

Final params had output_format.
Constraints were stripped and turned into notes (advisory only).
Evidence:
```
Final returned optional params: {
  'output_format': {
    'schema': {
      'properties': {
        'name': {'description': 'Note: minimum length: 5.'},
        'age': {'description': 'Note: minimum value: 21.'}
      }
    }
  }
}
```
Meaning: Anthropic only saw notes, not hard rules.

After fix: 
```
Final returned optional params: {'tool_choice': {'name': 'json_tool_call', 'type': 'tool'}, 'tools': [{'name': 'json_tool_call', 'input_schema': {'type': 'object', 'properties': {'name': {'type': 'string', 'minLength': 5}, 'age': {'type': 'integer', 'minimum': 21}}, 'required': ['name', 'age'], 'additionalProperties': False}}], 'json_mode': True}

POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/messages \
... 'tool_choice': {'name': 'json_tool_call', 'type': 'tool'}, 'tools': [...]
```
Final params had tools + tool_choice.
Constraints stayed in the schema (hard rules).
Evidence:
```
Final returned optional params: {
  'tool_choice': {...},
  'tools': [{'input_schema': {'properties': {'name': {'minLength': 5}, 'age': {'minimum': 21}}}}],
  'json_mode': True
}
```
Summary
- Before: native output_format → constraints removed → model can ignore them.
- After: tool‑based JSON → constraints preserved → model is forced to comply.

## Type
🐛 Bug Fix

## Changes
Before
- For Claude Sonnet/Opus 4.5–4.7, response_format always went to native output_format.
- That path strips hard constraints (minLength, maxLength, minItems, minimum, etc.) and only adds advisory “Note:” text.
- LiteLLM does not validate-and-retry against the original schema, so those constraints become effectively unenforced → degraded JSON reliability.

After

- If the schema contains any unsupported constraints, we avoid native output_format and instead use the tool-based JSON mode.
- The tool-based mode keeps the original schema intact, so hard constraints are still enforceable.
- If the schema has no unsupported constraints, we still use native output_format.

What changed
- Added schema inspection + $defs resolution to detect unsupported constraints.
- Routing logic now falls back to tool JSON mode when constraints are present.
- Added a test to lock this behavior.

Net effect: reliability is restored for constrained schemas without needing a validate‑and‑retry loop.

