### PR TITLE
fix: constraints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,8 @@ RUN apk add --no-cache \
     npm \
     libsndfile
 
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    UV_PROJECT_ENVIRONMENT=/app/.venv \
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
-    XDG_CACHE_HOME=/app/.cache \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -94,11 +92,14 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile supervi
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    XDG_CACHE_HOME=/app/.cache \
-    PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
+# Prisma binaries live in $HOME/.cache (default prisma-python location),
+# which is /root/.cache here. Copy them from the builder so they survive
+# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
+# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
+COPY --from=builder /root/.cache /root/.cache
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete

--- a/docker/Dockerfile.database
+++ b/docker/Dockerfile.database
@@ -26,10 +26,8 @@ RUN apk add --no-cache \
     npm \
     libsndfile
 
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    UV_PROJECT_ENVIRONMENT=/app/.venv \
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     UV_LINK_MODE=copy \
-    XDG_CACHE_HOME=/app/.cache \
     PATH="/app/.venv/bin:${PATH}"
 
 # Copy dependency metadata first for layer caching
@@ -92,11 +90,14 @@ RUN apk add --no-cache bash openssl tzdata nodejs npm python3 libsndfile supervi
     { apk del --no-cache npm 2>/dev/null || true; }
 
 WORKDIR /app
-ENV PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    XDG_CACHE_HOME=/app/.cache \
-    PATH="/app/.venv/bin:${PATH}"
+ENV PATH="/app/.venv/bin:${PATH}"
 
 COPY --from=builder /app /app
+# Prisma binaries live in $HOME/.cache (default prisma-python location),
+# which is /root/.cache here. Copy them from the builder so they survive
+# deployments that volume-mount /app/.cache (e.g. readOnlyRootFilesystem
+# + emptyDir) — otherwise the mount would shadow the baked-in query engine.
+COPY --from=builder /root/.cache /root/.cache
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
     find /app/.venv -type d -path "*/tornado/test" -delete

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -508,6 +508,40 @@ class ChunkProcessor:
             "prompt_tokens_details": prompt_tokens_details,
         }
 
+    def _merge_prompt_tokens_details(
+        self,
+        existing: Optional[PromptTokensDetailsWrapper],
+        incoming: Optional[PromptTokensDetailsWrapper],
+    ) -> Optional[PromptTokensDetailsWrapper]:
+        """
+        Merge streaming prompt token detail snapshots.
+
+        Keep previously observed non-null fields when later chunks omit them
+        (for example Anthropic ``message_start`` may include
+        ``cache_creation_token_details`` while the final usage chunk does not).
+        """
+        if incoming is None:
+            return existing
+        if existing is None:
+            return incoming
+
+        merged = existing.model_dump(exclude_none=True)
+        incoming_dict = incoming.model_dump(exclude_none=True)
+
+        for key, value in incoming_dict.items():
+            if (
+                isinstance(value, dict)
+                and key in merged
+                and isinstance(merged[key], dict)
+            ):
+                for nested_key, nested_value in value.items():
+                    if nested_value is not None:
+                        merged[key][nested_key] = nested_value
+            elif value is not None:
+                merged[key] = value
+
+        return PromptTokensDetailsWrapper(**merged)
+
     def count_reasoning_tokens(self, response: ModelResponse) -> Optional[int]:
         reasoning_tokens: Optional[int] = None
         for choice in response.choices:
@@ -602,7 +636,10 @@ class ChunkProcessor:
                         "web_search_requests",
                     )
 
-                prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
+                prompt_tokens_details = self._merge_prompt_tokens_details(
+                    existing=prompt_tokens_details,
+                    incoming=usage_chunk_dict["prompt_tokens_details"],
+                )
 
         return UsagePerChunk(
             prompt_tokens=prompt_tokens,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -248,6 +248,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         return params
 
+    _OUTPUT_FORMAT_UNSUPPORTED_FIELDS = {
+        "maxItems",
+        "minItems",
+        "minimum",
+        "maximum",
+        "exclusiveMinimum",
+        "exclusiveMaximum",
+        "minLength",
+        "maxLength",
+    }
+
     @staticmethod
     def filter_anthropic_output_schema(schema: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -278,16 +289,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             return schema
 
         # All numeric/string/array constraints not supported by Anthropic
-        unsupported_fields = {
-            "maxItems",
-            "minItems",  # array constraints
-            "minimum",
-            "maximum",  # numeric constraints
-            "exclusiveMinimum",
-            "exclusiveMaximum",  # numeric constraints
-            "minLength",
-            "maxLength",  # string constraints
-        }
+        unsupported_fields = AnthropicConfig._OUTPUT_FORMAT_UNSUPPORTED_FIELDS
 
         # Build description additions from removed constraints
         constraint_descriptions: list = []
@@ -369,16 +371,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if not isinstance(schema, (dict, list)):
             return False
 
-        unsupported_fields = {
-            "maxItems",
-            "minItems",
-            "minimum",
-            "maximum",
-            "exclusiveMinimum",
-            "exclusiveMaximum",
-            "minLength",
-            "maxLength",
-        }
+        unsupported_fields = AnthropicConfig._OUTPUT_FORMAT_UNSUPPORTED_FIELDS
 
         if isinstance(schema, dict):
             if any(field in schema for field in unsupported_fields):
@@ -432,12 +425,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
     def _response_format_requires_tool_json(
         self, value: Optional[dict]
-    ) -> bool:
+    ) -> Tuple[bool, Optional[dict]]:
         json_schema = self._extract_json_schema_from_response_format(value)
         if json_schema is None:
-            return False
+            return False, None
         resolved_schema = self._resolve_json_schema_defs(json_schema)
-        return self._schema_has_unsupported_output_constraints(resolved_schema)
+        return (
+            self._schema_has_unsupported_output_constraints(resolved_schema),
+            resolved_schema,
+        )
 
     def get_json_schema_from_pydantic_object(
         self, response_format: Union[Any, Dict, None]
@@ -917,17 +913,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         return json_schema
 
     def map_response_format_to_anthropic_output_format(
-        self, value: Optional[dict]
+        self, value: Optional[dict], resolved_schema: Optional[dict] = None
     ) -> Optional[AnthropicOutputSchema]:
-        json_schema: Optional[dict] = self._extract_json_schema_from_response_format(
-            value
-        )
+        json_schema: Optional[dict] = resolved_schema
         if json_schema is None:
-            return None
+            json_schema = self._extract_json_schema_from_response_format(value)
+            if json_schema is None:
+                return None
 
-        # Resolve $ref/$defs before filtering — Anthropic doesn't support
-        # external schema references (e.g., /$defs/CalendarEvent).
-        json_schema = self._resolve_json_schema_defs(json_schema)
+            # Resolve $ref/$defs before filtering — Anthropic doesn't support
+            # external schema references (e.g., /$defs/CalendarEvent).
+            json_schema = self._resolve_json_schema_defs(json_schema)
 
         # Filter out unsupported fields for Anthropic's output_format API
         filtered_schema = self.filter_anthropic_output_schema(json_schema)
@@ -1124,13 +1120,17 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "sonnet_4_6",
                     }
                 )
-                if use_native_output_format and self._response_format_requires_tool_json(
-                    value
-                ):
+                (
+                    requires_tool_json,
+                    resolved_schema,
+                ) = self._response_format_requires_tool_json(value)
+                if use_native_output_format and requires_tool_json:
                     use_native_output_format = False
                 if use_native_output_format:
                     _output_format = (
-                        self.map_response_format_to_anthropic_output_format(value)
+                        self.map_response_format_to_anthropic_output_format(
+                            value, resolved_schema=resolved_schema
+                        )
                     )
                     if _output_format is not None:
                         optional_params["output_format"] = _output_format

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1927,9 +1927,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             tool_calls,
         )
 
+        message_content: Optional[str] = text_content or None
+        if tool_calls:
+            # OpenAI chat completions require content to be null when tool_calls exist.
+            message_content = None
         _message = litellm.Message(
             tool_calls=tool_calls,
-            content=text_content or None,
+            content=message_content,
             provider_specific_fields=provider_specific_fields,
             thinking_blocks=thinking_blocks,
             reasoning_content=reasoning_content,

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -362,6 +362,83 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         return result
 
+    @staticmethod
+    def _schema_has_unsupported_output_constraints(
+        schema: Union[Dict[str, Any], List[Any], Any]
+    ) -> bool:
+        if not isinstance(schema, (dict, list)):
+            return False
+
+        unsupported_fields = {
+            "maxItems",
+            "minItems",
+            "minimum",
+            "maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "minLength",
+            "maxLength",
+        }
+
+        if isinstance(schema, dict):
+            if any(field in schema for field in unsupported_fields):
+                return True
+            for key, value in schema.items():
+                if key in {"properties", "$defs"} and isinstance(value, dict):
+                    if any(
+                        AnthropicConfig._schema_has_unsupported_output_constraints(
+                            item
+                        )
+                        for item in value.values()
+                    ):
+                        return True
+                elif key == "items" and isinstance(value, dict):
+                    if AnthropicConfig._schema_has_unsupported_output_constraints(
+                        value
+                    ):
+                        return True
+                elif key in {"anyOf", "allOf", "oneOf"} and isinstance(value, list):
+                    if any(
+                        AnthropicConfig._schema_has_unsupported_output_constraints(
+                            item
+                        )
+                        for item in value
+                    ):
+                        return True
+                elif isinstance(value, (dict, list)):
+                    if AnthropicConfig._schema_has_unsupported_output_constraints(
+                        value
+                    ):
+                        return True
+        else:
+            for item in schema:
+                if AnthropicConfig._schema_has_unsupported_output_constraints(item):
+                    return True
+
+        return False
+
+    def _resolve_json_schema_defs(self, json_schema: dict) -> dict:
+        import copy
+
+        from litellm.litellm_core_utils.prompt_templates.common_utils import (
+            unpack_defs,
+        )
+
+        resolved_schema = copy.deepcopy(json_schema)
+        defs = resolved_schema.pop("$defs", resolved_schema.pop("definitions", {}))
+        if defs:
+            unpack_defs(resolved_schema, defs)
+        return resolved_schema
+
+    def _response_format_requires_tool_json(
+        self, value: Optional[dict]
+    ) -> bool:
+        json_schema = self._extract_json_schema_from_response_format(value)
+        if json_schema is None:
+            return False
+        resolved_schema = self._resolve_json_schema_defs(json_schema)
+        return self._schema_has_unsupported_output_constraints(resolved_schema)
+
     def get_json_schema_from_pydantic_object(
         self, response_format: Union[Any, Dict, None]
     ) -> Optional[dict]:
@@ -850,16 +927,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Resolve $ref/$defs before filtering — Anthropic doesn't support
         # external schema references (e.g., /$defs/CalendarEvent).
-        import copy
-
-        from litellm.litellm_core_utils.prompt_templates.common_utils import (
-            unpack_defs,
-        )
-
-        json_schema = copy.deepcopy(json_schema)
-        defs = json_schema.pop("$defs", json_schema.pop("definitions", {}))
-        if defs:
-            unpack_defs(json_schema, defs)
+        json_schema = self._resolve_json_schema_defs(json_schema)
 
         # Filter out unsupported fields for Anthropic's output_format API
         filtered_schema = self.filter_anthropic_output_schema(json_schema)
@@ -1037,7 +1105,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             elif param == "top_p":
                 optional_params["top_p"] = value
             elif param == "response_format" and isinstance(value, dict):
-                if any(
+                use_native_output_format = any(
                     substring in model
                     for substring in {
                         "sonnet-4.5",
@@ -1055,7 +1123,12 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         "sonnet_4.6",
                         "sonnet_4_6",
                     }
+                )
+                if use_native_output_format and self._response_format_requires_tool_json(
+                    value
                 ):
+                    use_native_output_format = False
+                if use_native_output_format:
                     _output_format = (
                         self.map_response_format_to_anthropic_output_format(value)
                     )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7481,7 +7481,8 @@ def stream_chunk_builder(  # noqa: PLR0915
             and chunk["choices"][0]["delta"]["tool_calls"] is not None
         ]
 
-        if len(tool_call_chunks) > 0:
+        has_tool_calls = len(tool_call_chunks) > 0
+        if has_tool_calls:
             tool_calls_list = processor.get_combined_tool_content(tool_call_chunks)
             _choice = cast(Choices, response.choices[0])
             _choice.message.content = None
@@ -7495,7 +7496,8 @@ def stream_chunk_builder(  # noqa: PLR0915
             and chunk["choices"][0]["delta"]["function_call"] is not None
         ]
 
-        if len(function_call_chunks) > 0:
+        has_function_calls = len(function_call_chunks) > 0
+        if has_function_calls:
             _choice = cast(Choices, response.choices[0])
             _choice.message.content = None
             _choice.message.function_call = (
@@ -7510,7 +7512,7 @@ def stream_chunk_builder(  # noqa: PLR0915
             and chunk["choices"][0]["delta"]["content"] is not None
         ]
 
-        if len(content_chunks) > 0:
+        if len(content_chunks) > 0 and not has_tool_calls and not has_function_calls:
             response["choices"][0]["message"]["content"] = (
                 processor.get_combined_content(content_chunks)
             )

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -679,6 +679,57 @@ def test_stream_chunk_builder_accepts_dict_snapshot_chunks():
     assert response.choices[0].message.content == "Hello world"
 
 
+def test_stream_chunk_builder_tool_calls_nulls_content():
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-123",
+        created=1,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="Let me check.", role="assistant"),
+            )
+        ],
+    )
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-123",
+        created=2,
+        model="claude-sonnet-4-5-20250929",
+        object="chat.completion.chunk",
+        choices=[
+            StreamingChoices(
+                finish_reason="tool_calls",
+                index=0,
+                delta=Delta(
+                    content=None,
+                    role=None,
+                    tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id="call_1",
+                            function=Function(
+                                arguments='{"city":"Toronto"}',
+                                name="get_weather",
+                            ),
+                            type="function",
+                            index=0,
+                        )
+                    ],
+                ),
+            )
+        ],
+    )
+
+    response = stream_chunk_builder(chunks=[chunk1, chunk2])
+
+    assert response is not None
+    message = response.choices[0].message
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.content is None
+
+
 def test_stream_chunk_builder_dict_snapshot_preserves_hidden_provider_fields():
     chunk = ModelResponseStream(
         id="chatcmpl-123",

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -11,12 +11,14 @@ sys.path.insert(
 from litellm import stream_chunk_builder
 from litellm.litellm_core_utils.streaming_chunk_builder_utils import ChunkProcessor
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionDeltaToolCall,
     ChatCompletionMessageToolCall,
     Delta,
     Function,
     ModelResponseStream,
     PromptTokensDetails,
+    PromptTokensDetailsWrapper,
     ServerToolUse,
     StreamingChoices,
     Usage,
@@ -323,6 +325,94 @@ def test_cache_read_input_tokens_retained():
     assert usage.cache_creation_input_tokens == 4
     assert usage.cache_read_input_tokens == 11775
     assert usage.prompt_tokens_details.cached_tokens == 11775
+
+
+def test_cache_creation_token_details_carried_forward_from_earlier_stream_chunk():
+    """
+    Anthropic may emit cache_creation_token_details on message_start usage, then omit
+    it from the final usage chunk. Ensure stream usage aggregation preserves it.
+    """
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-anthropic-cache-details",
+        created=1745513206,
+        model="claude-sonnet-4-20250514",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="", role=None),
+                logprobs=None,
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=0,
+            prompt_tokens=2957,
+            total_tokens=2957,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0,
+                text_tokens=12,
+                cache_creation_tokens=2945,
+                cache_creation_token_details=CacheCreationTokenDetails(
+                    ephemeral_5m_input_tokens=2945,
+                    ephemeral_1h_input_tokens=0,
+                ),
+            ),
+            cache_creation_input_tokens=2945,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-anthropic-cache-details",
+        created=1745513207,
+        model="claude-sonnet-4-20250514",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content="", role=None),
+                logprobs=None,
+            )
+        ],
+        stream_options={"include_usage": True},
+        usage=Usage(
+            completion_tokens=35,
+            prompt_tokens=2957,
+            total_tokens=2992,
+            prompt_tokens_details=PromptTokensDetailsWrapper(
+                cached_tokens=0,
+                text_tokens=12,
+                cache_creation_tokens=2945,
+            ),
+            cache_creation_input_tokens=2945,
+            cache_read_input_tokens=0,
+        ),
+    )
+
+    chunks = [chunk1, chunk2]
+    processor = ChunkProcessor(chunks=chunks)
+
+    usage = processor.calculate_usage(
+        chunks=chunks,
+        model="claude-sonnet-4-20250514",
+        completion_output="",
+    )
+
+    assert usage.prompt_tokens_details is not None
+    assert usage.prompt_tokens_details.cache_creation_token_details is not None
+    assert (
+        usage.prompt_tokens_details.cache_creation_token_details.ephemeral_5m_input_tokens
+        == 2945
+    )
+    assert (
+        usage.prompt_tokens_details.cache_creation_token_details.ephemeral_1h_input_tokens
+        == 0
+    )
 
 
 def test_stream_chunk_builder_litellm_usage_chunks():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -969,6 +969,41 @@ def test_non_structured_output_model_uses_tool_workaround():
     assert "tool_choice" in optional_params
 
 
+def test_structured_output_with_constraints_uses_tool_workaround():
+    """
+    Test that models with native structured outputs fall back to the tool-based
+    workaround when the schema includes unsupported constraints.
+    """
+    config = AnthropicConfig()
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test_schema",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "age": {"type": "integer", "minimum": 0},
+                },
+                "required": ["name", "age"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    optional_params = config.map_openai_params(
+        non_default_params={"response_format": response_format},
+        optional_params={},
+        model="claude-opus-4-6-20250918",
+        drop_params=False,
+    )
+
+    assert "output_format" not in optional_params
+    assert "tools" in optional_params
+    assert "tool_choice" in optional_params
+
+
 # ============ Tool Search Tests ============
 
 

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2521,6 +2521,53 @@ def test_tool_search_tool_result_not_in_tool_results():
     assert provider_fields.get("tool_results") is None
 
 
+def test_tool_call_preamble_sets_content_none():
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AnthropicConfig()
+
+    mock_anthropic_response = {
+        "id": "msg_01XYZ",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-sonnet-4-5-20250929",
+        "content": [
+            {"type": "text", "text": "Let me call a tool."},
+            {
+                "type": "tool_use",
+                "id": "toolu_01ABC",
+                "name": "get_weather",
+                "input": {"city": "Toronto"},
+            },
+        ],
+        "stop_reason": "tool_use",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 12, "output_tokens": 7},
+    }
+
+    mock_raw_response = MagicMock(spec=httpx.Response)
+    mock_raw_response.json.return_value = mock_anthropic_response
+    mock_raw_response.status_code = 200
+    mock_raw_response.headers = {}
+
+    model_response = ModelResponse()
+
+    transformed_response = config.transform_parsed_response(
+        completion_response=mock_anthropic_response,
+        raw_response=mock_raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+
+    message = transformed_response.choices[0].message
+    assert message.tool_calls is not None
+    assert len(message.tool_calls) == 1
+    assert message.content is None
+
+
 def test_web_search_tool_result_backwards_compatibility():
     """
     Test that web_search_tool_result continues to be stored in web_search_results

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2398,12 +2398,8 @@ def test_code_execution_tool_results_extraction():
     assert editor_result["tool_use_id"] == "srvtoolu_01DEF"
     assert editor_result["content"]["is_file_update"] is False
 
-    # Verify text content is properly concatenated
-    assert (
-        "I'll calculate that for you."
-        in transformed_response.choices[0].message.content
-    )
-    assert "Done!" in transformed_response.choices[0].message.content
+    # Tool calls should null content per OpenAI contract
+    assert transformed_response.choices[0].message.content is None
 
 
 def test_code_execution_tool_results_in_hidden_params():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1002,6 +1002,9 @@ def test_structured_output_with_constraints_uses_tool_workaround():
     assert "output_format" not in optional_params
     assert "tools" in optional_params
     assert "tool_choice" in optional_params
+    tool_schema = optional_params["tools"][0]["input_schema"]["properties"]
+    assert tool_schema["name"]["minLength"] == 1
+    assert tool_schema["age"]["minimum"] == 0
 
 
 # ============ Tool Search Tests ============


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes
Before
- filter_anthropic_output_schema and _schema_has_unsupported_output_constraints each had their own copy of the unsupported‑constraints set.
- → Risk: if one got updated and the other didn’t, the router would send a constraint‑bearing schema down native output_format, and those constraints would get stripped again.
- _response_format_requires_tool_json resolved $defs (deepcopy + unpack) to check constraints, then map_response_format_to_anthropic_output_format did the same resolution again on the common path.
- → Extra per‑request cost for large schemas.
- The test only checked routing, not that the constraints survived in the tool schema.

After
- Single source of truth for unsupported constraints:
- _OUTPUT_FORMAT_UNSUPPORTED_FIELDS is used by both methods, preventing drift.
- Resolved schema reused:
- _response_format_requires_tool_json returns (requires_tool_json, resolved_schema) and the resolved schema is passed into map_response_format_to_anthropic_output_format, avoiding a second deepcopy/unpack.
- Test now asserts constraints are preserved in the tool schema (minLength, minimum).

Net effect
- Safer routing (no constraint‑set drift).
- Less per‑request overhead on native structured output path.
- Stronger test coverage proving constraints survive the tool‑based path.