### PR TITLE
feat(proxy): audit default user settings updates

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -189,6 +189,7 @@ class LitellmTableNames(str, enum.Enum):
     TOOL_TABLE_NAME = "LiteLLM_ToolTable"
     CACHE_CONFIG_TABLE_NAME = "LiteLLM_CacheConfig"
     CONFIG_OVERRIDES_TABLE_NAME = "LiteLLM_ConfigOverrides"
+    CONFIG_TABLE_NAME = "LiteLLM_Config"
 
 
 class Litellm_EntityType(enum.Enum):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14208,11 +14208,20 @@ def _redact_general_setting_value(field_name: str, value: JsonValue, is_full_adm
 
 
 def _dump_redacted_config(value: Optional[JsonValue], *, redact_all_values: bool = False) -> Optional[str]:
+    # `default=str` matches the sibling audit-log serializers in
+    # team_endpoints.py and the LiteLLM_AuditLogs validator, so a YAML-loaded
+    # value with a non-JSON-native leaf (datetime, custom object) cannot turn
+    # an audit write into a 500.
     if value is None:
         return None
-    if redact_all_values and isinstance(value, dict):
-        return json.dumps({key: "REDACTED" for key in value})
-    return json.dumps(_redact_secret_values_in_obj(value))
+    if redact_all_values:
+        if isinstance(value, dict):
+            return json.dumps({key: "REDACTED" for key in value}, default=str)
+        # Defensive fallback if a future caller stores this section as a
+        # non-dict: redact wholesale rather than silently leaking through the
+        # key-name matcher below.
+        return json.dumps("REDACTED")
+    return json.dumps(_redact_secret_values_in_obj(value), default=str)
 
 
 async def create_config_audit_log(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -14214,13 +14214,8 @@ def _dump_redacted_config(value: Optional[JsonValue], *, redact_all_values: bool
     # an audit write into a 500.
     if value is None:
         return None
-    if redact_all_values:
-        if isinstance(value, dict):
-            return json.dumps({key: "REDACTED" for key in value}, default=str)
-        # Defensive fallback if a future caller stores this section as a
-        # non-dict: redact wholesale rather than silently leaking through the
-        # key-name matcher below.
-        return json.dumps("REDACTED")
+    if redact_all_values and isinstance(value, dict):
+        return json.dumps({key: "REDACTED" for key in value}, default=str)
     return json.dumps(_redact_secret_values_in_obj(value), default=str)
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -425,7 +425,10 @@ from litellm.proxy.management_endpoints.user_agent_analytics_endpoints import (
 from litellm.proxy.management_endpoints.workflow_management_endpoints import (
     router as workflow_management_router,
 )
-from litellm.proxy.management_helpers.audit_logs import create_audit_log_for_update
+from litellm.proxy.management_helpers.audit_logs import (
+    create_audit_log_for_update,
+    create_object_audit_log,
+)
 from litellm.proxy.memory.memory_endpoints import router as memory_router
 from litellm.proxy.plugin_routes import (
     router as plugin_router,
@@ -14202,6 +14205,43 @@ def _redact_general_setting_value(field_name: str, value: JsonValue, is_full_adm
     if isinstance(value, (dict, list)):
         return _redact_secret_values_in_obj(value)
     return value
+
+
+def _dump_redacted_config(value: Optional[JsonValue], *, redact_all_values: bool = False) -> Optional[str]:
+    if value is None:
+        return None
+    if redact_all_values and isinstance(value, dict):
+        return json.dumps({key: "REDACTED" for key in value})
+    return json.dumps(_redact_secret_values_in_obj(value))
+
+
+async def create_config_audit_log(
+    param_name: str,
+    action: AUDIT_ACTIONS,
+    before_value: Optional[JsonValue],
+    after_value: Optional[JsonValue],
+    user_api_key_dict: UserAPIKeyAuth,
+    table_name: LitellmTableNames = LitellmTableNames.CONFIG_TABLE_NAME,
+) -> None:
+    """Record a system-wide settings change in LiteLLM_AuditLog.
+
+    Secret leaves are redacted before the row is written. environment_variables
+    hold arbitrary credentials under non-secret-looking uppercase keys (e.g.
+    DATABASE_URL), so every value in that section is redacted rather than
+    relying on key-name matching; other sections reuse the same matcher
+    /config/field/info applies for non-admins.
+    """
+    redact_all_values = param_name == "environment_variables"
+    await create_object_audit_log(
+        object_id=param_name,
+        action=action,
+        table_name=table_name,
+        before_value=_dump_redacted_config(before_value, redact_all_values=redact_all_values),
+        after_value=_dump_redacted_config(after_value, redact_all_values=redact_all_values),
+        user_api_key_dict=user_api_key_dict,
+        litellm_changed_by=None,
+        litellm_proxy_admin_name=LITELLM_PROXY_ADMIN_NAME,
+    )
 
 
 @router.get(

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -553,6 +553,7 @@ async def _update_litellm_setting(
     settings: Union[DefaultInternalUserParams, DefaultTeamSSOParams, MCPSemanticFilterSettings],
     settings_key: str,
     success_message: str,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ):
     """
     Common utility function to update `litellm_settings` in both memory and config.
@@ -561,8 +562,15 @@ async def _update_litellm_setting(
         settings: The settings object to update
         settings_key: The key in litellm_settings to update
         success_message: Message to return on success
+        user_api_key_dict: The acting admin, recorded as the audit-log actor.
+            Optional today so callers that have not been wired for auditing
+            keep working; the audit row is only written when an actor is passed.
     """
-    from litellm.proxy.proxy_server import proxy_config, store_model_in_db
+    from litellm.proxy.proxy_server import (
+        create_config_audit_log,
+        proxy_config,
+        store_model_in_db,
+    )
 
     if store_model_in_db is not True:
         raise HTTPException(
@@ -576,6 +584,7 @@ async def _update_litellm_setting(
     # because get_config() may overwrite litellm.<key> with stale DB values
     # via LITELLM_SETTINGS_SAFE_DB_OVERRIDES.
     config = await proxy_config.get_config()
+    before_value = config.get("litellm_settings", {}).get(settings_key)
 
     # Update the in-memory settings (after get_config to avoid stale override)
     setattr(litellm, settings_key, in_memory_var)
@@ -588,6 +597,15 @@ async def _update_litellm_setting(
 
     # Save the updated config
     await proxy_config.save_config(new_config=config)
+
+    if user_api_key_dict is not None:
+        await create_config_audit_log(
+            param_name=settings_key,
+            action="updated",
+            before_value=before_value,
+            after_value=in_memory_var,
+            user_api_key_dict=user_api_key_dict,
+        )
 
     return {
         "message": success_message,
@@ -619,6 +637,7 @@ async def update_internal_user_settings(
         settings=settings,
         settings_key="default_internal_user_params",
         success_message="Internal user settings updated successfully",
+        user_api_key_dict=user_api_key_dict,
     )
 
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -1,4 +1,5 @@
 #### CRUD ENDPOINTS for UI Settings #####
+import asyncio
 import json
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 from urllib.parse import urlparse
@@ -599,12 +600,18 @@ async def _update_litellm_setting(
     await proxy_config.save_config(new_config=config)
 
     if user_api_key_dict is not None:
-        await create_config_audit_log(
-            param_name=settings_key,
-            action="updated",
-            before_value=before_value,
-            after_value=in_memory_var,
-            user_api_key_dict=user_api_key_dict,
+        # Fire-and-forget so an audit-log failure (transient DB blip, etc.)
+        # never surfaces as a 500 after save_config has already committed,
+        # matching the create_object_audit_log pattern used elsewhere
+        # (e.g. model_management_endpoints).
+        asyncio.create_task(
+            create_config_audit_log(
+                param_name=settings_key,
+                action="updated",
+                before_value=before_value,
+                after_value=in_memory_var,
+                user_api_key_dict=user_api_key_dict,
+            )
         )
 
     return {

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8756,13 +8756,3 @@ def test_dump_redacted_config_serializes_non_json_native_values():
     restored = json.loads(out)
     assert "2026-06-30" in restored["updated_at"]
 
-
-def test_dump_redacted_config_redacts_non_dict_when_redact_all_values():
-    """The redact_all_values branch must not silently fall through to the
-    key-name matcher for non-dict inputs, or a future caller storing the
-    section as a list/scalar would leak plaintext."""
-    from litellm.proxy.proxy_server import _dump_redacted_config
-
-    list_value = ["DATABASE_URL=postgresql://u:p@db/x"]
-    assert _dump_redacted_config(list_value, redact_all_values=True) == '"REDACTED"'
-    assert _dump_redacted_config("postgresql://u:p@db/x", redact_all_values=True) == '"REDACTED"'

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8650,3 +8650,93 @@ def test_config_field_info_returns_raw_secrets_for_full_admin(monkeypatch):
         )
     finally:
         app.dependency_overrides.clear()
+
+
+def _fake_prisma_with_config(existing_param_value):
+    """MagicMock prisma whose litellm_config row returns existing_param_value and
+    whose litellm_auditlog.create records the written audit row."""
+    fake = MagicMock()
+    config_row = MagicMock()
+    config_row.param_value = existing_param_value
+    fake.db.litellm_config.find_first = AsyncMock(return_value=config_row)
+    fake.db.litellm_config.upsert = AsyncMock(return_value=config_row)
+    fake.db.litellm_auditlog.create = AsyncMock()
+    return fake
+
+
+def test_dump_redacted_config_redacts_secret_leaves():
+    from litellm.proxy.proxy_server import _dump_redacted_config
+
+    assert _dump_redacted_config(None) is None
+
+    restored = json.loads(
+        _dump_redacted_config(
+            {
+                "api_key": "sk-leak",
+                "model": "gpt-4",
+                "nested": {"aws_secret_access_key": "abc", "region": "us-east-1"},
+            }
+        )
+    )
+    assert restored["api_key"] == "REDACTED"
+    assert restored["model"] == "gpt-4"
+    assert restored["nested"]["aws_secret_access_key"] == "REDACTED"
+    assert restored["nested"]["region"] == "us-east-1"
+
+
+@pytest.mark.asyncio
+async def test_create_config_audit_log_writes_redacted_entry(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import LitellmTableNames
+    from litellm.proxy.proxy_server import create_config_audit_log
+
+    fake = _fake_prisma_with_config({})
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+
+    caller = UserAPIKeyAuth(api_key="hashed-key-abc", user_id="admin-7")
+    await create_config_audit_log(
+        "router_settings",
+        "updated",
+        {"routing_strategy": "simple-shuffle", "api_key": "sk-old"},
+        {"routing_strategy": "latency-based", "api_key": "sk-new"},
+        caller,
+    )
+
+    fake.db.litellm_auditlog.create.assert_awaited_once()
+    written = fake.db.litellm_auditlog.create.call_args.kwargs["data"]
+    assert written["table_name"] == LitellmTableNames.CONFIG_TABLE_NAME.value
+    assert written["object_id"] == "router_settings"
+    assert written["action"] == "updated"
+    assert written["changed_by"] == "admin-7"
+    assert written["changed_by_api_key"] == "hashed-key-abc"
+
+    before = json.loads(written["before_value"])
+    after = json.loads(written["updated_values"])
+    assert before["routing_strategy"] == "simple-shuffle"
+    assert after["routing_strategy"] == "latency-based"
+    assert "sk-old" not in written["before_value"]
+    assert "sk-new" not in written["updated_values"]
+    assert before["api_key"] != "sk-old"
+    assert after["api_key"] != "sk-new"
+
+
+@pytest.mark.asyncio
+async def test_create_config_audit_log_noop_when_store_audit_logs_disabled(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy.proxy_server import create_config_audit_log
+
+    fake = _fake_prisma_with_config({})
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", False)
+
+    await create_config_audit_log(
+        "router_settings",
+        "updated",
+        {},
+        {"a": 1},
+        UserAPIKeyAuth(api_key="k", user_id="u"),
+    )
+    fake.db.litellm_auditlog.create.assert_not_called()

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -8740,3 +8740,29 @@ async def test_create_config_audit_log_noop_when_store_audit_logs_disabled(monke
         UserAPIKeyAuth(api_key="k", user_id="u"),
     )
     fake.db.litellm_auditlog.create.assert_not_called()
+
+
+def test_dump_redacted_config_serializes_non_json_native_values():
+    """YAML-loaded config can contain datetime/date/custom values that plain
+    json.dumps refuses. Without default=str the audit write turns into a 500
+    after the config change has already committed; the sibling audit-log
+    serializers in team_endpoints.py use default=str for the same reason."""
+    from datetime import datetime, timezone
+
+    from litellm.proxy.proxy_server import _dump_redacted_config
+
+    out = _dump_redacted_config({"updated_at": datetime(2026, 6, 30, tzinfo=timezone.utc)})
+    assert out is not None
+    restored = json.loads(out)
+    assert "2026-06-30" in restored["updated_at"]
+
+
+def test_dump_redacted_config_redacts_non_dict_when_redact_all_values():
+    """The redact_all_values branch must not silently fall through to the
+    key-name matcher for non-dict inputs, or a future caller storing the
+    section as a list/scalar would leak plaintext."""
+    from litellm.proxy.proxy_server import _dump_redacted_config
+
+    list_value = ["DATABASE_URL=postgresql://u:p@db/x"]
+    assert _dump_redacted_config(list_value, redact_all_values=True) == '"REDACTED"'
+    assert _dump_redacted_config("postgresql://u:p@db/x", redact_all_values=True) == '"REDACTED"'

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1869,3 +1869,56 @@ class TestProxySettingEndpoints:
         assert "field_schema" in data
         assert "properties" in data["field_schema"]
         assert "role_mappings" in data["field_schema"]["properties"]
+
+
+def test_update_internal_user_settings_writes_audit_log(mock_proxy_config, monkeypatch):
+    """Regression for the reported scenario: an admin changes Default User
+    Settings from the dashboard, which issues PATCH /update/internal_user_settings
+    (NOT /config/update). An audit row must record who changed it and what
+    changed."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    audit_create = AsyncMock()
+    fake_prisma = MagicMock()
+    fake_prisma.db.litellm_auditlog.create = audit_create
+
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake_prisma)
+    monkeypatch.setattr(proxy_server_module, "premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "store_audit_logs", True)
+    monkeypatch.setattr(litellm, "default_internal_user_params", {})
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/internal_user_settings",
+            json={"max_budget": 999.0, "models": ["gpt-4"]},
+        )
+        assert resp.status_code == 200, resp.text
+
+        audit_create.assert_awaited_once()
+        written = audit_create.await_args.kwargs["data"]
+        assert written["object_id"] == "default_internal_user_params"
+        assert written["action"] == "updated"
+        assert written["table_name"] == "LiteLLM_Config"
+        assert written["changed_by"] == "audit-admin"
+        assert written["changed_by_api_key"] == "hashed-admin-key"
+
+        before = json.loads(written["before_value"])
+        after = json.loads(written["updated_values"])
+        assert before["max_budget"] == 100.0
+        assert after["max_budget"] == 999.0
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)

--- a/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
+++ b/tests/test_litellm/proxy/ui_crud_endpoints/test_proxy_setting_endpoints.py
@@ -1922,3 +1922,41 @@ def test_update_internal_user_settings_writes_audit_log(mock_proxy_config, monke
         assert after["max_budget"] == 999.0
     finally:
         app.dependency_overrides.pop(user_api_key_auth, None)
+
+
+def test_update_internal_user_settings_returns_200_when_audit_write_raises(
+    mock_proxy_config, monkeypatch
+):
+    """The settings change is already committed by save_config, so an
+    audit-log failure must never surface as a 500. Scheduling via
+    asyncio.create_task keeps the audit call off the request path; this
+    test asserts that contract by making the audit helper raise."""
+    import litellm
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+    monkeypatch.setattr(litellm, "default_internal_user_params", {})
+
+    async def _raise(**_kwargs):
+        raise RuntimeError("audit prisma blip")
+
+    monkeypatch.setattr(proxy_server_module, "create_config_audit_log", _raise)
+
+    async def _admin_auth():
+        return UserAPIKeyAuth(
+            user_id="audit-admin",
+            api_key="hashed-admin-key",
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+        )
+
+    app.dependency_overrides[user_api_key_auth] = _admin_auth
+    try:
+        resp = client.patch(
+            "/update/internal_user_settings", json={"max_budget": 42.0}
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "success"
+    finally:
+        app.dependency_overrides.pop(user_api_key_auth, None)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3839

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This PR closes the customer-impacting path: an admin changes Default User Settings from the dashboard and the change is recorded with who did it and what changed. The dashboard hits `PATCH /update/internal_user_settings`, NOT `/config/update`, and today that path writes nothing to `LiteLLM_AuditLog`.

Reproduced live against a local proxy on `:4010` with `store_audit_logs: true` and an enterprise license, backed by a real Postgres.

Before (current behavior on `litellm_internal_staging`):

```bash
$ curl -X PATCH localhost:4010/update/internal_user_settings -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"max_budget":999.0,"models":["gpt-4.1-mini"]}'
{"message":"Internal user settings updated successfully","status":"success", ...}

$ psql -tAc 'SELECT count(*) FROM "LiteLLM_AuditLog";'
0    # nothing recorded
```

After (this PR):

```bash
$ curl -X PATCH localhost:4010/update/internal_user_settings ... \
    -d '{"max_budget":999.0,"models":["gpt-4.1-mini"]}'
{"message":"Internal user settings updated successfully","status":"success", ...}
```

Audit row written:
```json
{
  "action": "updated",
  "table_name": "LiteLLM_Config",
  "object_id": "default_internal_user_params",
  "changed_by": "default_user_id",
  "changed_by_api_key": "litellm_proxy_master_key",
  "before": {"user_role":"internal_user_viewer","max_budget":100.0,"models":["gpt-3.5-turbo","gpt-4"]},
  "after":  {"user_role":"internal_user_viewer","max_budget":999.0,"models":["gpt-4.1-mini"]}
}
```

`changed_by` records the acting user and `changed_by_api_key` records the key hash, so a UI/SSO admin edit (session token) is distinguishable from a direct API call (master or virtual key).

## Type

🆕 New Feature

## Changes

Adds audit logging for the customer-impacting path: `PATCH /update/internal_user_settings`. The dashboard's Default User Settings page hits this route, and there is no record today of who changed what.

Introduces the small framework that future system-wide settings audits will share: a `LitellmTableNames.CONFIG_TABLE_NAME` enum value, a `create_config_audit_log` helper that reuses the existing `create_object_audit_log` path (so `store_audit_logs` and the enterprise gate still apply), and a `_dump_redacted_config` helper that strips secret leaves from the snapshots using the same matcher `/config/field/info` applies for non-admins. `environment_variables` is special-cased to redact every value, since it carries credentials under non-secret-looking uppercase keys (e.g. `DATABASE_URL`).

Only `update_internal_user_settings` is wired up in this change. Coverage for the other `LiteLLM_Config` writers (the generic `/config/*` endpoints, `default_team_settings`, `mcp_semantic_filter`, allowed-IP add/delete, `sso_settings`, `ui_theme_settings`, `ui_settings`) is the follow-up so each can be verified live against the credential-bearing fields it actually carries. The follow-up is open against this branch as the broader-scope PR.

The audit-actor parameter on `_update_litellm_setting` is optional in this PR so non-audited callers keep working unchanged; the follow-up will make it required once every caller is wired up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy config persistence and audit storage with credential redaction logic; scope is narrow (one UI route) and audit is fire-and-forget after commit.
> 
> **Overview**
> Dashboard **Default User Settings** changes via `PATCH /update/internal_user_settings` now write **`LiteLLM_AuditLog`** rows (table `LiteLLM_Config`, object id `default_internal_user_params`) with actor, before/after snapshots, and existing `store_audit_logs` / enterprise gating.
> 
> Adds shared helpers: **`create_config_audit_log`** (via **`create_object_audit_log`**), **`_dump_redacted_config`** (secret-key redaction aligned with `/config/field/info`; **`environment_variables`** values fully redacted), and **`LitellmTableNames.CONFIG_TABLE_NAME`**. **`_update_litellm_setting`** accepts an optional admin actor and schedules audit writes **after** `save_config` so audit failures cannot 500 the request.
> 
> Only **`update_internal_user_settings`** is wired in this PR; other config writers remain for follow-up. Tests cover redaction, audit row shape, disabled audit logs, and 200 on audit failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5053fca094a0d80bf04ecfffd3108c8b22c80b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->