### PR TITLE
chore: bump litellm to 1.92.0 and litellm-enterprise to 0.1.45

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.44"
+version = "0.1.45"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.44"
+version = "0.1.45"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.26.0,<2.0",
     "litellm-proxy-extras==0.4.74",
-    "litellm-enterprise==0.1.44",
+    "litellm-enterprise==0.1.45",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "polars>=1.38.1,<2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.91.0"
+version = "1.92.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -274,7 +274,7 @@ source-exclude = [
 profile = "black"
 
 [tool.commitizen]
-version = "1.91.0"
+version = "1.92.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-23T00:31:52.495979Z"
+exclude-newer = "2026-06-27T20:21:25.609736Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3274,7 +3274,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.91.0"
+version = "1.92.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -3639,7 +3639,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.44"
+version = "0.1.45"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (n/a: version bump only)
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Version bumps only; no runtime behavior change. The lock resolves cleanly:

```
$ uv lock
Resolved 415 packages
Updated litellm v1.91.0 -> v1.92.0
Updated litellm-enterprise v0.1.44 -> v0.1.45
```

## Type

🚄 Infrastructure

## Changes

Cuts the release versions ahead of the next stable

litellm bumped 1.91.0 -> 1.92.0 (MINOR, via `cz bump --increment MINOR`)

litellm-enterprise bumped 0.1.44 -> 0.1.45 (PATCH, via `cz bump --increment PATCH`); the `enterprise/` workspace member picked up staging-only changes since the last release (email footer wiring in `base_email.py`, and the billable-user/team counting switch to `UserRepository`/`TeamRepository` in `internal_user_endpoints.py`), so it needs a new version. The root `litellm-enterprise==` pin is updated to match

`litellm-proxy-extras` is unchanged between main and staging, so it keeps `0.4.74`

uv.lock rebuilt to reflect the two version bumps
