### PR TITLE
feat(ui): add openapi-react-query $api bound to schema.d.ts

### DIFF
--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -24,6 +24,8 @@
         "moment": "2.30.1",
         "next": "16.2.6",
         "openai": "4.104.0",
+        "openapi-fetch": "^0.17.0",
+        "openapi-react-query": "^0.5.4",
         "papaparse": "5.5.3",
         "react": "18.3.1",
         "react-copy-to-clipboard": "5.1.1",
@@ -10005,6 +10007,28 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-react-query": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/openapi-react-query/-/openapi-react-query-0.5.4.tgz",
+      "integrity": "sha512-V9lRiozjHot19/BYSgXYoyznDxDJQhEBSdi26+SJ0UqjMANLQhkni4XG+Z7e3Ag7X46ZLMrL9VxYkghU3QvbWg==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.0",
+        "openapi-fetch": "^0.17.0"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -10025,6 +10049,12 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
     },
     "node_modules/openapi-typescript/node_modules/supports-color": {
       "version": "10.2.2",

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -40,6 +40,8 @@
     "moment": "2.30.1",
     "next": "16.2.6",
     "openai": "4.104.0",
+    "openapi-fetch": "^0.17.0",
+    "openapi-react-query": "^0.5.4",
     "papaparse": "5.5.3",
     "react": "18.3.1",
     "react-copy-to-clipboard": "5.1.1",

--- a/ui/litellm-dashboard/src/lib/http/api.test.tsx
+++ b/ui/litellm-dashboard/src/lib/http/api.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { $api } from "@/lib/http/api";
+
+function UserCount() {
+  const { data, isPending } = $api.useQuery("get", "/user/list");
+  if (isPending) return <span>loading</span>;
+  return <span>users: {(data as { users?: unknown[] })?.users?.length ?? 0}</span>;
+}
+
+function renderWithClient(ui: ReactNode) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+describe("$api (openapi-fetch + openapi-react-query)", () => {
+  it("drives a schema-typed GET /user/list through the query client", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ users: [{ user_id: "u1" }, { user_id: "u2" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    renderWithClient(<UserCount />);
+
+    await waitFor(() => expect(screen.getByText("users: 2")).toBeInTheDocument());
+    const requested = fetchSpy.mock.calls[0]?.[0];
+    const requestedUrl = requested instanceof Request ? requested.url : String(requested);
+    expect(requestedUrl).toContain("/user/list");
+  });
+
+  it("surfaces a non-2xx response as an ApiError in the query error state", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ detail: "boom" }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    function Status() {
+      const { error, isError } = $api.useQuery("get", "/user/list");
+      return <span>{isError ? `error: ${(error as Error).message}` : "ok"}</span>;
+    }
+
+    renderWithClient(<Status />);
+    await waitFor(() => expect(screen.getByText("error: boom")).toBeInTheDocument());
+  });
+});

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -1,0 +1,43 @@
+/**
+ * Typed API surface generated from schema.d.ts via openapi-fetch + openapi-react-query.
+ * Coexists with the legacy hand-rolled client/networking during the migration: new
+ * data access should use `$api`; call sites move over endpoint by endpoint.
+ */
+import createFetchClient, { type Middleware } from "openapi-fetch";
+import createQueryClient from "openapi-react-query";
+
+import type { paths } from "@/lib/http/schema";
+import { ApiError, deriveErrorMessage } from "@/lib/http/client";
+import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+import { getCookie } from "@/utils/cookieUtils";
+
+const authAndErrors: Middleware = {
+  onRequest({ request }) {
+    const token = typeof document !== "undefined" ? getCookie("token") : null;
+    if (token) {
+      request.headers.set(getGlobalLitellmHeaderName(), `Bearer ${token}`);
+    }
+    return request;
+  },
+  async onResponse({ response }) {
+    if (response.ok) return response;
+    const raw = await response.clone().text();
+    let body: unknown = raw;
+    let message: string;
+    try {
+      body = JSON.parse(raw);
+      message = deriveErrorMessage(body);
+    } catch {
+      message = raw || `HTTP ${response.status}`;
+    }
+    throw new ApiError(message, response.status, body);
+  },
+};
+
+const fetchClient = createFetchClient<paths>({
+  baseUrl: getProxyBaseUrl(),
+  fetch: (request) => globalThis.fetch(request),
+});
+fetchClient.use(authAndErrors);
+
+export const $api = createQueryClient(fetchClient);


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a foundation change with no user-facing behavior, so there is nothing to curl or screenshot yet; the first migrated endpoint will carry the real proof. Verification here is that `$api.useQuery("get", "/user/list")` typechecks against the 620 paths in the generated `schema.d.ts`, and the included test exercises the full chain: a typed GET resolving to data, and a 500 response surfacing as an `ApiError` in the query error state. Nothing in the existing client or networking is touched, so the 272 current calls behave exactly as before

## Type

🚄 Infrastructure

## Changes

Stands up a typed data layer generated from the proxy OpenAPI spec as the foundation for migrating off the hand-rolled `networking.tsx`, which today carries roughly 272 call functions and 39 response types in a single 8000-line module. openapi-fetch gives a client typed against the paths already in `src/lib/http/schema.d.ts`, and openapi-react-query wraps it as `$api`, so a call becomes `$api.useQuery("get", "/user/list")` with the response, params, and query key all derived from the schema instead of hand-written

It coexists with the existing client and networking by design. The migration happens endpoint by endpoint in later PRs; new data access uses `$api`, and call sites move over as they are touched. Auth and error handling run as openapi-fetch middleware that reuses the existing `ApiError` and `deriveErrorMessage`, so non-2xx responses keep surfacing as an `ApiError`, and the token is injected per request from the same cookie the dashboard already reads

The added test doubles as the usage example, and there is a companion standalone reference (FastAPI server plus a Next client wired the same way) kept outside the repo for anyone who wants to feel the end-to-end pattern before the migration ramps up
