### PR TITLE
fix(proxy): hydrate MCP server registry from DB on startup when store_model_in_db is false

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6311,6 +6311,10 @@ class ProxyConfig:
                 "litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db - {}".format(str(e))
             )
 
+    async def init_mcp_servers_from_db(self) -> None:
+        if self._should_load_db_object(object_type="mcp"):
+            await self._init_mcp_servers_in_db()
+
     async def _init_agents_in_db(self, prisma_client: PrismaClient):
         from litellm.proxy.agent_endpoints.agent_registry import (
             global_agent_registry as AGENT_REGISTRY,
@@ -7557,6 +7561,9 @@ class ProxyStartupEvent:
                 misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
             )
             await proxy_config.get_credentials(prisma_client=prisma_client)
+
+        if store_model_in_db is not True:
+            await proxy_config.init_mcp_servers_from_db()
 
         await cls._initialize_slack_alerting_jobs(
             scheduler=scheduler,

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -754,6 +754,66 @@ async def test_initialize_scheduled_jobs_credentials(monkeypatch):
         assert len(mock_scheduler_calls) > 0
 
 
+@pytest.mark.asyncio
+async def test_initialize_scheduled_jobs_hydrates_mcp_when_store_model_in_db_false(monkeypatch):
+    """
+    Regression (LIT-4128): MCP servers created via the UI are persisted to the DB
+    regardless of store_model_in_db, but the in-memory registry that GET
+    /v1/mcp/server reads is hydrated from the DB only by the store_model_in_db
+    model-sync loop (add_deployment). On a DB-backed proxy with store_model_in_db
+    unset the registry must still be hydrated on startup so previously-added
+    servers survive a restart instead of showing an empty list until a write.
+    """
+    monkeypatch.delenv("DISABLE_PRISMA_SCHEMA_UPDATE", raising=False)
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+    from litellm.proxy.utils import ProxyLogging
+
+    mock_prisma_client = MagicMock()
+    mock_proxy_logging = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging.slack_alerting_instance = MagicMock()
+    mock_proxy_config = AsyncMock()
+
+    with (
+        patch("litellm.proxy.proxy_server.proxy_config", mock_proxy_config),
+        patch("litellm.proxy.proxy_server.store_model_in_db", False),
+    ):
+        await ProxyStartupEvent.initialize_scheduled_background_jobs(
+            general_settings={},
+            prisma_client=mock_prisma_client,
+            proxy_budget_rescheduler_min_time=1,
+            proxy_budget_rescheduler_max_time=2,
+            proxy_batch_write_at=5,
+            proxy_logging_obj=mock_proxy_logging,
+        )
+
+    mock_proxy_config.add_deployment.assert_not_called()
+    mock_proxy_config.init_mcp_servers_from_db.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_init_mcp_servers_from_db_respects_supported_db_objects(monkeypatch):
+    """
+    init_mcp_servers_from_db hydrates MCP from the DB by default but skips it when
+    an explicit supported_db_objects allowlist omits "mcp".
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    config = ProxyConfig()
+    with patch.object(config, "_init_mcp_servers_in_db", new=AsyncMock()) as mock_init:
+        monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+        await config.init_mcp_servers_from_db()
+        mock_init.assert_awaited_once()
+
+        mock_init.reset_mock()
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.general_settings",
+            {"supported_db_objects": ["models"]},
+        )
+        await config.init_mcp_servers_from_db()
+        mock_init.assert_not_awaited()
+
+
 def test_update_config_fields_deep_merge_db_wins():
     from litellm.proxy.proxy_server import ProxyConfig
 


### PR DESCRIPTION
## Relevant issues

Resolves LIT-4128

Reported internally: MCP servers added through the UI disappear from the MCP Servers page after a single-instance restart, and only reappear once a new server is added

## Linear ticket

[LIT-4128](https://linear.app/litellm-ai/issue/LIT-4128)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## This is a backend fix (no dashboard changes)

The symptom looks like a UI problem, but the dashboard is not at fault. The MCP Servers page already fetches the list on mount through a React Query hook (`useMCPServers`) and re-fetches after every write, so an empty page reflects what `GET /v1/mcp/server` actually returned rather than stale client state. On a cold start the endpoint itself returned an empty list even though the rows were still in the database, so a client-side change (a different hook, a hard refresh) would just re-fetch the same empty result. The fix is entirely server side in `litellm/proxy/proxy_server.py`; there are no frontend edits

## Root cause

MCP servers created through the UI are written straight to the database (`LiteLLM_MCPServerTable`) and are independent of `store_model_in_db`, but `GET /v1/mcp/server` reads only from the in-memory registry on `global_mcp_server_manager`, never from the database. That registry is hydrated from the database on startup exclusively through `add_deployment -> _init_non_llm_objects_in_db -> _init_mcp_servers_in_db -> reload_servers_from_database`, and the initial `add_deployment` call plus its polling job run only inside the `if store_model_in_db is True:` guard in `ProxyStartupEvent.initialize_scheduled_background_jobs`

Config-yaml servers load unconditionally on startup, but database servers ride the `store_model_in_db` model-sync loop. So on a DB-backed single-instance proxy where `store_model_in_db` is not set, a restart leaves the registry empty, and the page stays empty until any MCP write endpoint (add, edit, delete, approve, reject) calls `reload_servers_from_database` and rebuilds the registry from the database. That write side effect is why adding one server makes every previously-added server reappear

## Fix

Hydrate the MCP registry from the database on startup regardless of `store_model_in_db`, so it matches how config servers already behave. A new public `ProxyConfig.init_mcp_servers_from_db` wraps the existing loader and honors `supported_db_objects`; `initialize_scheduled_background_jobs` calls it when `store_model_in_db` is not `True` (when it is `True`, the existing model-sync loop already handles hydration, so nothing changes for those deployments)

## Screenshots / Proof of Fix

Single-instance proxy, Postgres attached, `store_model_in_db` unset (default `False`), started with `python litellm/proxy/proxy_cli.py --config config.yaml`

1. Add an MCP server through the API the UI uses, which persists it to the database and lists it while the proxy is up

```
curl -s -X POST http://localhost:4000/v1/mcp/server \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"server_name":"deepwiki_mcp","transport":"http","auth_type":"none","url":"https://mcp.deepwiki.com/mcp"}'
# {"server_id":"66c447aa-4fff-435a-945a-099072303a23","server_name":"deepwiki_mcp", ...}

curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer $KEY" | jq '{count: length, servers: [.[].server_name]}'
# { "count": 1, "servers": ["deepwiki_mcp"] }
```

2. Restart against the same database on the current release (before this change); the list is empty even though the row is still in the database

```
curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer $KEY" | jq '{count: length, servers: [.[].server_name]}'
# { "count": 0, "servers": [] }

# the row is still there:
psql -tAc 'SELECT server_id, server_name FROM "LiteLLM_MCPServerTable";'
# 66c447aa-4fff-435a-945a-099072303a23|deepwiki_mcp
```

3. Restart against the same database with this change; the server is listed after the restart with no write

```
curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer $KEY" | jq '{count: length, servers: [{name: .[].server_name, url: .[].url}]}'
# { "count": 1, "servers": [ { "name": "deepwiki_mcp", "url": "https://mcp.deepwiki.com/mcp" } ] }
```

The same is visible in the dashboard at `http://localhost:4000/ui/?page=mcp-servers`: empty after a restart before this change, populated after a restart with it

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/proxy_server.py`: added `ProxyConfig.init_mcp_servers_from_db` and a startup call to it in `initialize_scheduled_background_jobs` for the `store_model_in_db` is not `True` path

`tests/test_litellm/proxy/test_proxy_server.py`: a regression test asserting the startup path hydrates MCP servers when `store_model_in_db` is `False` (and does not run `add_deployment`), plus a test that `init_mcp_servers_from_db` honors `supported_db_objects`
