### PR TITLE
feat(proxy): support object_permission in default_key_generate_params

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -783,22 +783,6 @@ async def _common_key_generation_helper(
                 setattr(data, key, litellm.default_key_generate_params.get(key, []))
             elif key == "metadata" and value == {}:
                 setattr(data, key, litellm.default_key_generate_params.get(key, {}))
-            elif key == "object_permission":
-                _default_object_permission = litellm.default_key_generate_params.get("object_permission")
-                if _default_object_permission is not None:
-                    if value is None:
-                        setattr(
-                            data,
-                            key,
-                            LiteLLM_ObjectPermissionBase(**_default_object_permission),
-                        )
-                    else:
-                        for (
-                            _op_field,
-                            _op_default_value,
-                        ) in _default_object_permission.items():
-                            if getattr(value, _op_field, None) is None:
-                                setattr(value, _op_field, _op_default_value)
 
     # check if user set upperbound key/generate params on config.yaml
     _enforce_upperbound_key_params(data, fill_defaults=True)
@@ -980,6 +964,23 @@ async def _common_key_generation_helper(
         team_obj=team_table,
         is_proxy_admin=_is_proxy_admin_caller,
     )
+
+    # Merge default_key_generate_params.object_permission in *after* the team-scope
+    # checks above, so an admin-configured default (e.g. vector_stores, search_tools)
+    # is never mistaken for a caller-requested permission and rejected by those
+    # non-admin/no-team checks. Only fields the caller left unset are filled in.
+    _default_object_permission = (
+        litellm.default_key_generate_params.get("object_permission")
+        if litellm.default_key_generate_params is not None
+        else None
+    )
+    if isinstance(_default_object_permission, dict):
+        _caller_object_permission = data_json.get("object_permission")
+        if _caller_object_permission is None:
+            data_json["object_permission"] = dict(_default_object_permission)
+        elif isinstance(_caller_object_permission, dict):
+            for _op_field, _op_default_value in _default_object_permission.items():
+                _caller_object_permission.setdefault(_op_field, _op_default_value)
 
     data_json = await _set_object_permission(
         data_json=data_json,

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -783,6 +783,22 @@ async def _common_key_generation_helper(
                 setattr(data, key, litellm.default_key_generate_params.get(key, []))
             elif key == "metadata" and value == {}:
                 setattr(data, key, litellm.default_key_generate_params.get(key, {}))
+            elif key == "object_permission":
+                _default_object_permission = litellm.default_key_generate_params.get("object_permission")
+                if _default_object_permission is not None:
+                    if value is None:
+                        setattr(
+                            data,
+                            key,
+                            LiteLLM_ObjectPermissionBase(**_default_object_permission),
+                        )
+                    else:
+                        for (
+                            _op_field,
+                            _op_default_value,
+                        ) in _default_object_permission.items():
+                            if getattr(value, _op_field, None) is None:
+                                setattr(value, _op_field, _op_default_value)
 
     # check if user set upperbound key/generate params on config.yaml
     _enforce_upperbound_key_params(data, fill_defaults=True)

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -7789,7 +7789,6 @@ async def test_default_key_generate_params_object_permission_applied_when_absent
     doesn't specify object_permission at all.
     """
     import litellm
-    from litellm.proxy._types import LiteLLM_ObjectPermissionBase
 
     mock_prisma_client = AsyncMock()
     mock_insert_data = AsyncMock(
@@ -7837,8 +7836,8 @@ async def test_default_key_generate_params_object_permission_applied_when_absent
             team_table=None,
         )
 
-        assert isinstance(request.object_permission, LiteLLM_ObjectPermissionBase)
-        assert request.object_permission.vector_stores == ["default-vs"]
+        created_data = mock_prisma_client.db.litellm_objectpermissiontable.create.call_args.kwargs["data"]
+        assert created_data["vector_stores"] == ["default-vs"]
     finally:
         litellm.default_key_generate_params = original_value
 
@@ -7902,8 +7901,9 @@ async def test_default_key_generate_params_object_permission_merges_partial(
             team_table=None,
         )
 
-        assert request.object_permission.agents == ["agent-1"]
-        assert request.object_permission.vector_stores == ["default-vs"]
+        created_data = mock_prisma_client.db.litellm_objectpermissiontable.create.call_args.kwargs["data"]
+        assert created_data["agents"] == ["agent-1"]
+        assert created_data["vector_stores"] == ["default-vs"]
     finally:
         litellm.default_key_generate_params = original_value
 
@@ -7968,7 +7968,73 @@ async def test_default_key_generate_params_object_permission_does_not_override_e
             team_table=None,
         )
 
-        assert request.object_permission.vector_stores == ["explicit-vs"]
+        created_data = mock_prisma_client.db.litellm_objectpermissiontable.create.call_args.kwargs["data"]
+        assert created_data["vector_stores"] == ["explicit-vs"]
+    finally:
+        litellm.default_key_generate_params = original_value
+
+
+async def test_default_key_generate_params_object_permission_not_rejected_for_non_admin_personal_key(
+    monkeypatch,
+):
+    """
+    Regression test: a default_key_generate_params.object_permission containing
+    a team-scoped field (vector_stores) must not turn ordinary non-admin
+    personal key creation into a 403. The default is merged in *after* the
+    caller-scope validation, so it is never mistaken for a caller-requested
+    permission.
+    """
+    import litellm
+
+    mock_prisma_client = AsyncMock()
+    mock_insert_data = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.insert_data = mock_insert_data
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.db.litellm_objectpermissiontable = MagicMock()
+    mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
+        return_value=MagicMock(object_permission_id="objperm-4")
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    original_value = litellm.default_key_generate_params
+    litellm.default_key_generate_params = {
+        "object_permission": {"vector_stores": ["default-vs"]}
+    }
+
+    try:
+        request = GenerateKeyRequest(user_id="alice")  # No object_permission specified
+        response = await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.INTERNAL_USER,
+                api_key="sk-alice",
+                user_id="alice",
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+
+        assert response is not None
+        created_data = mock_prisma_client.db.litellm_objectpermissiontable.create.call_args.kwargs["data"]
+        assert created_data["vector_stores"] == ["default-vs"]
     finally:
         litellm.default_key_generate_params = original_value
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -7781,6 +7781,198 @@ async def test_default_key_generate_params_duration(monkeypatch):
         litellm.default_key_generate_params = original_value
 
 
+async def test_default_key_generate_params_object_permission_applied_when_absent(
+    monkeypatch,
+):
+    """
+    default_key_generate_params.object_permission is applied to a key that
+    doesn't specify object_permission at all.
+    """
+    import litellm
+    from litellm.proxy._types import LiteLLM_ObjectPermissionBase
+
+    mock_prisma_client = AsyncMock()
+    mock_insert_data = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.insert_data = mock_insert_data
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.db.litellm_objectpermissiontable = MagicMock()
+    mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
+        return_value=MagicMock(object_permission_id="objperm-1")
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    original_value = litellm.default_key_generate_params
+    litellm.default_key_generate_params = {
+        "object_permission": {"vector_stores": ["default-vs"]}
+    }
+
+    try:
+        request = GenerateKeyRequest()  # No object_permission specified
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+
+        assert isinstance(request.object_permission, LiteLLM_ObjectPermissionBase)
+        assert request.object_permission.vector_stores == ["default-vs"]
+    finally:
+        litellm.default_key_generate_params = original_value
+
+
+async def test_default_key_generate_params_object_permission_merges_partial(
+    monkeypatch,
+):
+    """
+    default_key_generate_params.object_permission fills only the fields the
+    caller left unset - an explicitly supplied field (agents here) is
+    preserved alongside the defaulted field (vector_stores).
+    """
+    import litellm
+    from litellm.proxy._types import LiteLLM_ObjectPermissionBase
+
+    mock_prisma_client = AsyncMock()
+    mock_insert_data = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.insert_data = mock_insert_data
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.db.litellm_objectpermissiontable = MagicMock()
+    mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
+        return_value=MagicMock(object_permission_id="objperm-2")
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    original_value = litellm.default_key_generate_params
+    litellm.default_key_generate_params = {
+        "object_permission": {"vector_stores": ["default-vs"]}
+    }
+
+    try:
+        request = GenerateKeyRequest(
+            object_permission=LiteLLM_ObjectPermissionBase(agents=["agent-1"])
+        )
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+
+        assert request.object_permission.agents == ["agent-1"]
+        assert request.object_permission.vector_stores == ["default-vs"]
+    finally:
+        litellm.default_key_generate_params = original_value
+
+
+async def test_default_key_generate_params_object_permission_does_not_override_explicit(
+    monkeypatch,
+):
+    """
+    A field the caller explicitly set on object_permission must win over the
+    same field in default_key_generate_params.
+    """
+    import litellm
+    from litellm.proxy._types import LiteLLM_ObjectPermissionBase
+
+    mock_prisma_client = AsyncMock()
+    mock_insert_data = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.insert_data = mock_insert_data
+    mock_prisma_client.db = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken = MagicMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.update = AsyncMock(
+        return_value=MagicMock(
+            token="hashed_token_123", litellm_budget_table=None, object_permission=None
+        )
+    )
+    mock_prisma_client.db.litellm_objectpermissiontable = MagicMock()
+    mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
+        return_value=MagicMock(object_permission_id="objperm-3")
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    original_value = litellm.default_key_generate_params
+    litellm.default_key_generate_params = {
+        "object_permission": {"vector_stores": ["default-vs"]}
+    }
+
+    try:
+        request = GenerateKeyRequest(
+            object_permission=LiteLLM_ObjectPermissionBase(
+                vector_stores=["explicit-vs"]
+            )
+        )
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN,
+                api_key="sk-1234",
+                user_id="1234",
+            ),
+            litellm_changed_by=None,
+            team_table=None,
+        )
+
+        assert request.object_permission.vector_stores == ["explicit-vs"]
+    finally:
+        litellm.default_key_generate_params = original_value
+
+
 @pytest.mark.asyncio
 async def test_build_key_filter_member_team_service_accounts():
     """


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy against a real Postgres DB, config with `litellm_settings.default_key_generate_params.object_permission.vector_stores: ["default-proof-vs"]`:

Key generated (as proxy admin) with no `object_permission` in the request picks up the default:

```console
$ curl -s -X POST http://localhost:4000/key/generate \
    -H "Authorization: Bearer sk-1234" -d '{}' | jq -r .key
sk-...

$ curl -s "http://localhost:4000/key/info?key=$KEY" -H "Authorization: Bearer sk-1234" \
    | jq '.info.object_permission | {vector_stores, agents}'
{
  "vector_stores": ["default-proof-vs"],
  "agents": []
}
```

Key generated with a partial `object_permission` (only `agents` set) keeps the caller's explicit field and still gets the defaulted field merged in, instead of the default replacing the whole object:

```console
$ curl -s -X POST http://localhost:4000/key/generate \
    -H "Authorization: Bearer sk-1234" \
    -d '{"object_permission": {"agents": ["explicit-agent"]}}' | jq -r .key
sk-...

$ curl -s "http://localhost:4000/key/info?key=$KEY" -H "Authorization: Bearer sk-1234" \
    | jq '.info.object_permission | {vector_stores, agents}'
{
  "vector_stores": ["default-proof-vs"],
  "agents": ["explicit-agent"]
}
```

A non-admin (`alice`, `internal_user`) creating her own personal key with no `object_permission` in the request is not rejected (the default is only merged in after the caller-scope validation, so it's never mistaken for a caller-requested team-scoped permission):

```console
$ curl -s -X POST http://localhost:4000/key/generate \
    -H "Authorization: Bearer $ALICE_KEY" -d '{}' -o /dev/null -w '%{http_code}\n'
200

$ curl -s "http://localhost:4000/key/info?key=$NEW_KEY" -H "Authorization: Bearer sk-1234" \
    | jq '.info.object_permission.vector_stores'
["default-proof-vs"]
```

## Type

🆕 New Feature

## Changes

`default_key_generate_params` (config.yaml `litellm_settings.default_key_generate_params`) filled a fixed whitelist of scalar fields plus a full-replace for `models`/`metadata`, but never touched `object_permission` at all, so there was no way for an admin to set a default `object_permission` value (e.g. `vector_stores`, and once #31486 lands, `mcp_tool_search_enabled`) applied to every new key.

`_common_key_generation_helper` in `key_management_endpoints.py` now merges the default `object_permission` into `data_json` field by field, after `validate_key_mcp_servers_against_team` / `validate_key_search_tools_against_team` / `validate_key_vector_stores_against_team` run. Doing the merge after those checks (rather than earlier on the request object) matters: those checks reject team-scoped fields like `vector_stores` on a personal key from a non-admin caller, and an admin-configured default merged in *before* the checks would look exactly like a caller-requested permission, turning ordinary non-admin personal key creation into a 403. If the caller didn't set `object_permission`, the default is applied wholesale; if the caller set a partial `object_permission`, only the fields they left unset are filled from the default, so an explicit field (e.g. `mcp_servers`) is never clobbered.

Caught by Greptile review (missing `isinstance` guard on a config-sourced value) and Codex review (the ordering issue described above) - both addressed in a follow-up commit with a regression test for the non-admin case.