### PR TITLE
chore(release): backport #31733 to stable/1.89.x

### DIFF
--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.logging_worker import GLOBAL_LOGGING_WORKER
 from litellm.llms.base_llm.realtime.transformation import BaseRealtimeConfig
 from litellm.types.llms.openai import (
     OpenAIRealtimeEvents,
@@ -268,8 +269,10 @@ class RealTimeStreaming:
                     self.tool_calls
                 )
             ## ASYNC LOGGING
-            # Create an event loop for the new thread
-            asyncio.create_task(self.logging_obj.async_success_handler(self.messages))
+            # Route through the bounded logging worker (per-coroutine timeout +
+            # concurrency cap) instead of a bare create_task, so a slow callback
+            # can't leave suspended tasks pinning each call's response in memory.
+            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(self.logging_obj.async_success_handler(self.messages))
             ## SYNC LOGGING
             executor.submit(self.logging_obj.success_handler(self.messages))
 

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -2110,3 +2110,26 @@ async def test_deferred_setup_caps_non_audio_buffered_bytes(monkeypatch):
     assert (
         streaming._pending_messages_byte_total <= RealTimeStreaming._MAX_BUFFERED_BYTES
     )
+
+
+@pytest.mark.asyncio
+async def test_log_messages_routes_async_logging_through_bounded_worker():
+    """Realtime success logging must go through GLOBAL_LOGGING_WORKER (bounded
+    queue + per-coroutine timeout), not a bare asyncio.create_task. A bare task
+    has no timeout/concurrency cap, so when a logging callback is slow every
+    realtime turn leaves a suspended task pinning its response in memory -> an
+    unbounded leak. Regression for that fix."""
+    logging_obj = MagicMock()
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), logging_obj)
+    streaming.messages = [{"type": "session.created"}]
+
+    with (
+        patch("litellm.litellm_core_utils.realtime_streaming.GLOBAL_LOGGING_WORKER") as mock_worker,
+        patch("litellm.litellm_core_utils.realtime_streaming.asyncio.create_task") as mock_create_task,
+        patch("litellm.litellm_core_utils.realtime_streaming.executor.submit"),
+    ):
+        await streaming.log_messages()
+
+        mock_worker.ensure_initialized_and_enqueue.assert_called_once()
+        # the bare create_task path must no longer be used for success logging
+        mock_create_task.assert_not_called()


### PR DESCRIPTION
## Relevant issues

Backports #31733 onto stable/1.89.x. RealTimeStreaming.log_messages dispatched the realtime success handler with a bare asyncio.create_task, bypassing GLOBAL_LOGGING_WORKER (the bounded logging worker that provides a per-coroutine timeout and a concurrency cap). On a long-lived realtime websocket a slow logging callback left one suspended task per logged turn, each pinning that turn's assembled response, accumulating without bound (~12-15k in-flight under load in a repro) until the proxy ran out of memory. Routing realtime success logging through the bounded worker caps in-flight logging and cancels a hung callback at the worker timeout

No version bump. The line tip is already at 1.89.5 (bumped by the prior backport and not yet released), so this pick rides the pending 1.89.5

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## What is included

- #31733 fix(logging): route realtime success logging through the bounded worker (cherry-picked from d4c33b2)

Originally requested alongside #31519, but #31519 was dropped from this line. #31519 is built on top of #30960, a large realtime restructure that is not on stable/1.89.x, so #31519's changes reference machinery (the setup-vs-content send loop and the renamed guardrail helper) that this line does not have. Backporting #31519 here would mean also backporting that restructure, which is out of scope for this patch; #31733 is independent of it and stands alone

## Adaptation notes

#31733 is ADAPTED (context-only, no logic change). The fix's own lines are byte-identical to the source commit; two divergences come from this line predating the realtime restructure:

1. In litellm/litellm_core_utils/realtime_streaming.py the added import and the one-line change in log_messages apply verbatim; only the surrounding context differs (the line's typing import does not include Protocol, and model_call_details is formatted at the older width)
2. In tests/test_litellm/litellm_core_utils/test_realtime_streaming.py the new regression test test_log_messages_routes_async_logging_through_bounded_worker is appended after this line's last test rather than after the source's anchor test (which is not on this line). The added test body is byte-identical, and a name-equality check confirms the resolved file adds exactly the source's added test and nothing else

## Known noise on this line

None. The targeted test set was green at baseline (112 passed, 0 failed) before any pick

## Screenshots / Proof of Fix

Live proxy on localhost, hitting the real OpenAI API (sanity floor, judged as a delta against the pre-pick baseline):

```
# baseline (before pick)
$ curl -sf "localhost:4001/health/liveliness?_bp=bp-realtime-0630-base"
"I'm alive!"
$ curl -s localhost:4001/v1/chat/completions -d '{"model":"gpt-4o",...}'
CONTENT: Baseline backport approved.   USAGE: total_tokens=22

# after pick
$ curl -sf "localhost:4001/health/liveliness?_bp=bp-realtime-0630-post"
"I'm alive!"
$ curl -s localhost:4001/v1/chat/completions -d '{"model":"gpt-4o",...}'
CONTENT: Backport successfully completed.   USAGE: total_tokens=21
```

The bug itself is a memory leak on long-lived realtime (Gemini Live) websockets under load, which is not reproducible with a single curl. The behavioral proof is the regression test, which is mutation-checked: with the fix in place test_log_messages_routes_async_logging_through_bounded_worker passes; reverting the one-line change back to the bare asyncio.create_task makes it fail. Targeted test delta: 112 passed at baseline, 113 passed after the pick (the +1 is the new regression test), 0 new failures

Gauntlet (behavioral, universal): SURVIVED. All three sub-claims held; every identifier the pick references resolves on this line, the new regression test passes as a clean +1 delta, and the sole production caller of log_messages is structurally unaffected. Five investigator lenses (including two tasked as refuters) converged with no verified refutation; the only artifact surfaced was a benign pre-existing RuntimeWarning under certain test orderings that fails no test and is not introduced by this pick

## Type

🐛 Bug Fix

## Changes

Routes realtime success logging through GLOBAL_LOGGING_WORKER so in-flight logging on realtime websockets is bounded
