### PR TITLE
test(e2e): add vertex_ai passthrough spend-log coverage

### DIFF
--- a/tests/e2e/llm_translation/LLM_TRANSLATION_COVERAGE_MATRIX.md
+++ b/tests/e2e/llm_translation/LLM_TRANSLATION_COVERAGE_MATRIX.md
@@ -28,7 +28,7 @@ Status: `covered` / `partial` / `gap`.
 |----------|---------------|-----------|------------|-------------|--------|
 | Gemini (`/gemini/v1beta/models/{m}:generateContent` / `:streamGenerateContent`) | live | live | live | live | **covered** |
 | Anthropic (`/anthropic/v1/messages`) | live | live | live | live | **covered** |
-| Vertex AI (`/vertex_ai/...`) | - | - | - | - | gap (gcloud auth) |
+| Vertex AI (`/vertex_ai/v1/projects/{p}/locations/{loc}/.../models/{m}:generateContent`) | live | - | - | live | **partial** |
 | OpenAI / Bedrock / Cohere / Mistral / VLLM | - | - | - | - | gap |
 
 Each covered cell asserts: `call_type == "pass_through_endpoint"`, `spend > 0`,
@@ -60,11 +60,21 @@ most likely to silently break and the one a mock can't prove works.
 | `test_anthropic_passthrough_nonstreaming_logs_cost` | anthropic native, non-stream, cost |
 | `test_anthropic_passthrough_streaming_logs_cost` | anthropic native, stream, cost |
 | `test_anthropic_passthrough_tool_call_logs_cost` | anthropic native, tool call, cost |
+| `test_vertex_passthrough_via_managed_model_logs_cost` | vertex_ai native, non-stream, cost |
+
+Vertex keeps the credential on the proxy like gemini/anthropic, but the deployment is
+added at runtime instead of declared in the gateway config: the test POSTs `/model/new`
+with `use_in_pass_through`, so the proxy registers that deployment's service account for
+the `/vertex_ai` route, then deletes it on teardown. The passthrough call sends only its
+litellm virtual key (`x-litellm-api-key`), no upstream bearer, and the proxy mints the
+Vertex token itself. Credentials (`VERTEXAI_PROJECT` / `VERTEXAI_CREDENTIALS`) are read
+from the same env the proxy uses, so the test never mints a token.
 
 ## Gaps
 
-- Vertex / OpenAI / Bedrock / Cohere passthrough (same shape; add once the
-  provider credential is configured; Vertex is closest - route exists, auth stale).
+- Vertex streaming / tool-call passthrough (non-streaming + cost now covered).
+- OpenAI / Bedrock / Cohere passthrough (same shape; add once the provider
+  credential is configured).
 - Non-passthrough tool calls over `/chat/completions` end to end with cost.
 - Image / audio / rerank / responses / realtime translation + cost.
 - Streaming cost-injection (`include_cost_in_streaming_usage`); passthrough on

--- a/tests/e2e/llm_translation/passthrough_client.py
+++ b/tests/e2e/llm_translation/passthrough_client.py
@@ -48,6 +48,16 @@ class AnthropicHeaders(Headers):
     tags: str | None = None
 
 
+class VertexHeaders(Headers):
+    # Only the litellm virtual key; the /vertex_ai passthrough mints the Vertex token
+    # from the proxy's own service account (the deployment marked use_in_pass_through),
+    # so no upstream Authorization bearer is sent from the client.
+    x_litellm_api_key: str = Field(serialization_alias="x-litellm-api-key")
+    content_type: str = Field(
+        default="application/json", serialization_alias="Content-Type"
+    )
+
+
 class AltSseParams(BaseModel):
     alt: str = "sse"
 
@@ -130,6 +140,23 @@ class PassthroughClient:
             ),
             params=AltSseParams(),
             stream=True,
+        )
+
+    # ---- Vertex AI native passthrough (/vertex_ai/v1/projects/...) -------
+
+    def vertex_generate(
+        self, key: str, project: str, location: str, model: str, text: str
+    ) -> StreamingResponse:
+        path = (
+            f"/vertex_ai/v1/projects/{project}/locations/{location}"
+            f"/publishers/google/models/{model}:generateContent"
+        )
+        return self.gateway.transport.send(
+            path,
+            headers=VertexHeaders(x_litellm_api_key=key),
+            json=GeminiGenerateBody(
+                contents=[GeminiContent(parts=[GeminiPart(text=text)])]
+            ),
         )
 
     # ---- Anthropic native passthrough (/anthropic/v1/messages) ----------

--- a/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
@@ -87,7 +87,9 @@ class _ModelDeleteBody(BaseModel):
     id: str
 
 
-def _add_vertex_passthrough_model(client: PassthroughClient, model_name: str, project: str, credentials: str) -> str:
+def _add_vertex_passthrough_model(
+    client: PassthroughClient, model_name: str, project: str, credentials: str
+) -> str:
     return unwrap(
         client.gateway.transport.post(
             "/model/new",

--- a/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
@@ -1,0 +1,161 @@
+"""Live e2e: a native Vertex AI generateContent call over the proxy's /vertex_ai
+passthrough is forwarded to Vertex and still logged as a costed SpendLogs row.
+
+Ports the de-flake of the SDK-based spend test (#31689). That test configured the
+vertexai SDK with an api_endpoint override pointing at the proxy, but the SDK
+intermittently ignored the override and billed the public Vertex endpoint directly,
+so the request never reached LiteLLM and no spend was recorded; the bypass, not
+logging lag, was the flake. Driving raw HTTP through the shared transport always
+reaches the proxy, which the harness already guarantees, so the only residual
+nondeterminism is the ~60s async spend flush the poll absorbs.
+
+The vertex deployment is added at runtime through the management endpoint rather than
+declared in the gateway config: the test POSTs /model/new with use_in_pass_through so
+the proxy registers that deployment's service account for the /vertex_ai route, then
+deletes it on teardown. The credential is the one the proxy already holds (read from
+the same VERTEXAI_CREDENTIALS the deployment uses), so the passthrough call sends only
+its litellm virtual key in x-litellm-api-key and no upstream bearer, and the proxy
+mints the Vertex token itself. The test never mints a token.
+
+Asserts both sides of the promise: the forward succeeds (2xx with a candidate) and
+the costed row lands (call_type pass_through_endpoint, vertex_ai provider, a gemini
+model, spend > 0), correlated by the x-litellm-call-id header.
+"""
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from e2e_config import unique_marker
+from e2e_http import NoBody, require_successful_call, unwrap
+from lifecycle import ResourceManager
+from models import SpendLogRow
+from passthrough_client import PassthroughClient
+
+pytestmark = pytest.mark.e2e
+
+VERTEX_MODEL = "gemini-2.5-flash"
+# The added deployment's region and the passthrough URL's region are the same constant,
+# so they always agree; the proxy registers passthrough credentials per project+region.
+VERTEX_LOCATION = os.environ.get("VERTEXAI_LOCATION", "us-central1")
+
+
+@pytest.fixture(scope="session")
+def vertex_project() -> str:
+    """The Vertex project to bill, read from the same VERTEXAI_PROJECT the proxy uses.
+    Skip when unset, since that is an environment gap rather than a behavior failure."""
+    project = os.environ.get("VERTEXAI_PROJECT")
+    if not project:
+        pytest.skip("set VERTEXAI_PROJECT (the project the vertex deployment bills)")
+    return project
+
+
+@pytest.fixture(scope="session")
+def vertex_credentials() -> str:
+    """The service-account JSON the added deployment authenticates with, the same
+    VERTEXAI_CREDENTIALS the proxy holds. Skip when unset."""
+    credentials = os.environ.get("VERTEXAI_CREDENTIALS")
+    if not credentials:
+        pytest.skip("set VERTEXAI_CREDENTIALS (the vertex service-account JSON)")
+    return credentials
+
+
+class _VertexDeploymentParams(BaseModel):
+    model: str
+    vertex_project: str
+    vertex_location: str
+    vertex_credentials: str
+    use_in_pass_through: bool
+
+
+class _ModelInfoId(BaseModel):
+    id: str
+
+
+class _ModelNewBody(BaseModel):
+    model_name: str
+    litellm_params: _VertexDeploymentParams
+    model_info: _ModelInfoId
+
+
+class _ModelNewResponse(BaseModel):
+    model_id: str
+
+
+class _ModelDeleteBody(BaseModel):
+    id: str
+
+
+def _add_vertex_passthrough_model(client: PassthroughClient, model_name: str, project: str, credentials: str) -> str:
+    return unwrap(
+        client.gateway.transport.post(
+            "/model/new",
+            headers=client.gateway.transport.master,
+            json=_ModelNewBody(
+                model_name=model_name,
+                litellm_params=_VertexDeploymentParams(
+                    model=f"vertex_ai/{VERTEX_MODEL}",
+                    vertex_project=project,
+                    vertex_location=VERTEX_LOCATION,
+                    vertex_credentials=credentials,
+                    use_in_pass_through=True,
+                ),
+                model_info=_ModelInfoId(id=model_name),
+            ),
+            response_type=_ModelNewResponse,
+        )
+    ).model_id
+
+
+def _delete_model(client: PassthroughClient, model_id: str) -> None:
+    _ = client.gateway.transport.post(
+        "/model/delete",
+        headers=client.gateway.transport.master,
+        json=_ModelDeleteBody(id=model_id),
+        response_type=NoBody,
+    )
+
+
+def _costed_row(client: PassthroughClient, call_id: str | None) -> SpendLogRow:
+    """The passthrough call's SpendLogs row, polled until it carries a cost.
+
+    A 2xx passthrough call that produced no costed row is a hard failure, not a skip:
+    a billed Vertex call that LiteLLM did not track is the exact regression #31689
+    guards against."""
+    assert call_id, "vertex passthrough response had no x-litellm-call-id header"
+    rows = client.gateway.poll_logs_for_request_id(call_id, predicate=lambda rs: (rs[0].spend or 0) > 0)
+    assert rows, f"no SpendLogs row for vertex passthrough call_id {call_id}"
+    row = rows[0]
+    assert row.call_type == "pass_through_endpoint", f"unexpected call_type: {row}"
+    assert (row.spend or 0) > 0, f"vertex passthrough call was not costed: {row}"
+    assert row.status == "success", f"unexpected status: {row}"
+    return row
+
+
+class TestVertexPassthroughSpendTracking:
+    def test_vertex_passthrough_via_managed_model_logs_cost(
+        self,
+        client: PassthroughClient,
+        scoped_key: str,
+        resources: ResourceManager,
+        vertex_project: str,
+        vertex_credentials: str,
+    ) -> None:
+        model_name = f"e2e-vertex-pt-{unique_marker()}"
+        model_id = _add_vertex_passthrough_model(client, model_name, vertex_project, vertex_credentials)
+        resources.defer(lambda: _delete_model(client, model_id))
+
+        result = client.vertex_generate(
+            key=scoped_key,
+            project=vertex_project,
+            location=VERTEX_LOCATION,
+            model=VERTEX_MODEL,
+            text=f"reply with one word {unique_marker()}",
+        )
+        require_successful_call(result)
+        assert '"candidates"' in result.body, f"vertex passthrough returned no candidates: {result.body[:300]}"
+
+        row = _costed_row(client, result.call_id)
+        assert row.custom_llm_provider == "vertex_ai", f"passthrough spend logged under the wrong provider: {row}"
+        assert "gemini" in (row.model or ""), f"unexpected model in spend log: {row}"

--- a/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
+++ b/tests/e2e/llm_translation/test_vertex_passthrough_e2e.py
@@ -126,7 +126,10 @@ def _costed_row(client: PassthroughClient, call_id: str | None) -> SpendLogRow:
     a billed Vertex call that LiteLLM did not track is the exact regression #31689
     guards against."""
     assert call_id, "vertex passthrough response had no x-litellm-call-id header"
-    rows = client.gateway.poll_logs_for_request_id(call_id, predicate=lambda rs: (rs[0].spend or 0) > 0)
+    rows = client.gateway.poll_logs_for_request_id(
+        call_id,
+        predicate=lambda rs: (rs[0].spend or 0) > 0,
+    )
     assert rows, f"no SpendLogs row for vertex passthrough call_id {call_id}"
     row = rows[0]
     assert row.call_type == "pass_through_endpoint", f"unexpected call_type: {row}"


### PR DESCRIPTION
## Relevant issues

Companion to #31689, which de-flakes `tests/pass_through_tests/test_vertex_ai.py::test_basic_vertex_ai_pass_through_with_spendlog` by driving the pass-through over HTTP instead of the vertexai SDK. That SDK-bypass flake is why Vertex was the lone gap in the live passthrough matrix (`tests/e2e/llm_translation/LLM_TRANSLATION_COVERAGE_MATRIX.md`). This closes the non-streaming + cost cell with a real e2e test in that harness, where driving HTTP through the shared transport is the default and the SDK bypass cannot happen

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Against a live proxy hitting the real Vertex AI API and costing real dollars. The deployment is added through the management endpoint, not the config; the proxy registers its service account for the `/vertex_ai` route, so the passthrough call sends only its litellm virtual key and no `Authorization` bearer

```
# nothing registered yet -> passthrough is rejected
$ curl -s -o /dev/null -w "%{http_code}\n" -X POST \
    ".../vertex_ai/v1/projects/$VERTEXAI_PROJECT/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent" \
    -H "x-litellm-api-key: sk-1234" -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}'
401

# add the deployment via the management endpoint with use_in_pass_through
$ curl -s -X POST .../model/new -H "Authorization: Bearer sk-1234" -d '{
    "model_name":"e2e-vertex-pt",
    "litellm_params":{"model":"vertex_ai/gemini-2.5-flash","vertex_project":"'"$VERTEXAI_PROJECT"'",
      "vertex_location":"us-central1","vertex_credentials":"<service account json>","use_in_pass_through":true},
    "model_info":{"id":"e2e-vertex-pt"}}' | jq .model_id
"e2e-vertex-pt"

# the same passthrough call now works: only the litellm key, no bearer
$ curl -sS -D - -X POST ".../vertex_ai/.../gemini-2.5-flash:generateContent" \
    -H "x-litellm-api-key: sk-1234" -d '{"contents":[{"role":"user","parts":[{"text":"reply with one word"}]}]}'
HTTP/1.1 200 OK
x-litellm-call-id: bcdd6a21-7106-4fd6-87a2-6ae3d3a5ecfd

$ curl -s ".../spend/logs?request_id=bcdd6a21-7106-4fd6-87a2-6ae3d3a5ecfd" -H "Authorization: Bearer sk-1234" | jq '.[0]'
{
  "model": "gemini-2.5-flash",
  "custom_llm_provider": "vertex_ai",
  "spend": 9.12e-05,
  "call_type": "pass_through_endpoint",
  "status": "success"
}
```

The test asserts both sides: the forward returns 2xx with a candidate, and that specific call's `SpendLogs` row lands with `custom_llm_provider == "vertex_ai"`, a gemini model, `spend > 0`, `call_type == "pass_through_endpoint"`, and `status == "success"`. The 401-before / 200-after above is the non-vacuity: without the registered deployment the passthrough is rejected

## Type

✅ Test

## Changes

`tests/e2e/llm_translation/test_vertex_passthrough_e2e.py` adds a vertex deployment at runtime through `/model/new` with `use_in_pass_through`, drives a native `generateContent` request through `/vertex_ai/...`, asserts the costed `SpendLogs` row, and deletes the deployment on teardown. Adding it through the management endpoint keeps the gateway config untouched; `use_in_pass_through` is what makes the proxy register the deployment's service account for the passthrough route and mint the Vertex token itself, so the call carries only `x-litellm-api-key` and no upstream bearer. The credential is the one the proxy already holds, read from the same `VERTEXAI_CREDENTIALS` / `VERTEXAI_PROJECT` env, so the test never mints a token

`passthrough_client.py` gains a typed `VertexHeaders` model (just the litellm key) and a `vertex_generate` route on `PassthroughClient`. The matrix marks the Vertex non-streaming + cost cell covered

Deploy note: the service account needs `roles/aiplatform.user`, and any environment that runs this test needs `VERTEXAI_PROJECT` / `VERTEXAI_CREDENTIALS` set (the same secret the proxy uses); the test skips cleanly when they are absent

The change is test-only; no production behavior, performance, or contract changes
