### PR TITLE
fix(responses-api): raise APIError on in-stream error events; widen ErrorEventError.param to accept dict

### DIFF
--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -47,6 +47,17 @@ def _log_background_task_failure(task: "asyncio.Task[Any]", *, task_name: str) -
         verbose_logger.error("%s failed: %s", task_name, exception)
 
 
+_CLIENT_ERROR_CODES: frozenset[str] = frozenset(
+    (
+        "invalid_request_error",
+        "context_length_exceeded",
+        "insufficient_quota",
+        "content_policy_violation",
+        "model_not_found",
+    )
+)
+
+
 class BaseResponsesAPIStreamingIterator:
     """
     Base class for streaming iterators that process responses from the Responses API.
@@ -335,6 +346,47 @@ class BaseResponsesAPIStreamingIterator:
         )
         self._handle_failure(exception)
 
+    def _maybe_raise_for_error_event(self, result: object) -> None:
+        chunk_type = getattr(result, "type", None)
+        if chunk_type not in ("error", "response.failed"):
+            return
+
+        error_obj: object = (
+            getattr(getattr(result, "response", None), "error", None)
+            if chunk_type == "response.failed"
+            else getattr(result, "error", None)
+        )
+
+        if error_obj is not None and hasattr(error_obj, "message"):
+            error_message = str(getattr(error_obj, "message", "Response API in-stream error"))
+        elif error_obj is not None and isinstance(error_obj, dict):
+            error_message = str(error_obj.get("message", "Response API in-stream error"))
+        else:
+            error_message = "Response API in-stream error"
+
+        if isinstance(error_obj, dict):
+            raw = error_obj.get("code")
+            error_code: Optional[str] = raw if isinstance(raw, str) else None
+        elif error_obj is not None:
+            raw_attr = getattr(error_obj, "code", None)
+            error_code = raw_attr if isinstance(raw_attr, str) else None
+        else:
+            error_code = None
+
+        if error_code is not None and error_code.startswith("rate_limit"):
+            status_code = 429
+        elif error_code in _CLIENT_ERROR_CODES:
+            status_code = 400
+        else:
+            status_code = 500
+
+        raise litellm.APIError(
+            status_code=status_code,
+            message=error_message,
+            llm_provider=self.custom_llm_provider or "",
+            model=self.model or "",
+        )
+
     def _get_completed_response_object(self) -> Optional[Any]:
         openai_types = _get_openai_response_types()
         completed_response = self.completed_response
@@ -608,6 +660,7 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                 if self.finished:
                     raise StopAsyncIteration
                 elif result is not None:
+                    self._maybe_raise_for_error_event(result)
                     # Await hook directly instead of run_async_function
                     # (which spawns a thread + event loop per call)
                     result = await self._call_post_streaming_deployment_hook(
@@ -682,6 +735,7 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
                 if self.finished:
                     raise StopIteration
                 elif result is not None:
+                    self._maybe_raise_for_error_event(result)
                     # Sync path: use run_async_function for the hook
                     result = run_async_function(
                         async_function=self._call_post_streaming_deployment_hook,

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -1717,7 +1717,7 @@ class ErrorEventError(BaseLiteLLMOpenAIResponseObject):
     type: str  # e.g., 'invalid_request_error'
     code: str  # e.g., 'context_length_exceeded'
     message: str
-    param: Optional[str] = None
+    param: Optional[Union[str, Dict[str, Any]]] = None
 
 
 class ErrorEvent(BaseLiteLLMOpenAIResponseObject):

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -17,18 +17,21 @@ import os
 import sys
 from datetime import datetime
 from typing import Any, Dict, Optional
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 sys.path.insert(0, os.path.abspath("../.."))
 
+import litellm
 from litellm.constants import STREAM_SSE_DONE_STRING
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.responses.utils import ResponsesAPIRequestUtils
 from litellm.types.llms.openai import (
+    ErrorEvent,
+    ErrorEventError,
     ResponseCompletedEvent,
     ResponseFailedEvent,
     ResponseIncompleteEvent,
@@ -643,3 +646,118 @@ class TestBaseResponsesAPIStreamingIterator:
             # Failure handlers should NOT have been called
             mock_logging_obj.async_failure_handler.assert_not_called()
             mock_logging_obj.failure_handler.assert_not_called()
+
+
+class TestMaybeRaiseForErrorEvent:
+    """Regression tests for _maybe_raise_for_error_event."""
+
+    def _make_iterator(self) -> BaseResponsesAPIStreamingIterator:
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+        mock_response = Mock()
+        mock_response.headers = {}
+        return BaseResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            custom_llm_provider="openai",
+        )
+
+    def _make_error_chunk(self, code: str, message: str = "err") -> ErrorEvent:
+        error_obj = ErrorEventError(
+            type="rate_limit_error" if code.startswith("rate_limit") else "invalid_request_error",
+            code=code,
+            message=message,
+        )
+        return ErrorEvent(
+            type=ResponsesAPIStreamEvents.ERROR, sequence_number=0, error=error_obj
+        )
+
+    def test_raises_api_error_on_error_type(self):
+        iterator = self._make_iterator()
+        chunk = self._make_error_chunk("internal_error", "something went wrong")
+        with pytest.raises(litellm.APIError) as exc_info:
+            iterator._maybe_raise_for_error_event(chunk)
+        assert exc_info.value.status_code == 500
+
+    def test_maps_rate_limit_to_429(self):
+        iterator = self._make_iterator()
+        chunk = self._make_error_chunk("rate_limit_exceeded", "Too many requests")
+        with pytest.raises(litellm.APIError) as exc_info:
+            iterator._maybe_raise_for_error_event(chunk)
+        assert exc_info.value.status_code == 429
+
+    def test_maps_invalid_request_to_400(self):
+        iterator = self._make_iterator()
+        chunk = self._make_error_chunk("invalid_request_error", "bad request")
+        with pytest.raises(litellm.APIError) as exc_info:
+            iterator._maybe_raise_for_error_event(chunk)
+        assert exc_info.value.status_code == 400
+
+    def test_maps_context_length_exceeded_to_400(self):
+        iterator = self._make_iterator()
+        chunk = self._make_error_chunk("context_length_exceeded", "max tokens exceeded")
+        with pytest.raises(litellm.APIError) as exc_info:
+            iterator._maybe_raise_for_error_event(chunk)
+        assert exc_info.value.status_code == 400
+
+    def test_passes_through_normal_chunk(self):
+        iterator = self._make_iterator()
+        chunk = Mock()
+        chunk.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+        iterator._maybe_raise_for_error_event(chunk)  # must not raise
+
+    def test_error_event_error_param_accepts_dict(self):
+        error_obj = ErrorEventError(
+            type="invalid_request_error",
+            code="context_length_exceeded",
+            message="too long",
+            param={"field": "messages", "index": 0},
+        )
+        assert isinstance(error_obj.param, dict)
+
+    @pytest.mark.asyncio
+    async def test_async_iterator_raises_api_error_on_error_event(self):
+        from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+
+        error_payload = {
+            "type": "error",
+            "error": {
+                "type": "rate_limit_error",
+                "code": "rate_limit_exceeded",
+                "message": "rate limited",
+            },
+        }
+        sse_bytes = f"data: {json.dumps(error_payload)}\n\n".encode()
+
+        async def mock_aiter_bytes():
+            yield sse_bytes
+
+        mock_response = Mock()
+        mock_response.headers = {}
+        mock_response.aiter_bytes = mock_aiter_bytes
+        mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+        mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+        error_obj = ErrorEventError(
+            type="rate_limit_error", code="rate_limit_exceeded", message="rate limited"
+        )
+        mock_config.transform_streaming_response.return_value = ErrorEvent(
+            type=ResponsesAPIStreamEvents.ERROR, sequence_number=0, error=error_obj
+        )
+
+        iterator = ResponsesAPIStreamingIterator(
+            response=mock_response,
+            model="gpt-5",
+            responses_api_provider_config=mock_config,
+            logging_obj=mock_logging_obj,
+            custom_llm_provider="openai",
+        )
+
+        with pytest.raises(litellm.APIError) as exc_info:
+            async for _ in iterator:
+                pass
+        assert exc_info.value.status_code == 429

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -17,7 +17,7 @@ import os
 import sys
 from datetime import datetime
 from typing import Any, Dict, Optional
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 

--- a/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
+++ b/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
@@ -266,3 +266,34 @@ async def test_aresponses_with_streaming_fallbacks_wraps_streaming_iterator():
         )
     assert out is wrapped
     mock_wrap.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_aresponses_fallback_on_in_stream_error_event():
+    """APIError raised by _maybe_raise_for_error_event propagates through the wrapper."""
+    import litellm
+
+    router = _make_router()
+
+    class _ErrorOnFirstChunkSource:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise litellm.APIError(
+                status_code=429,
+                message="rate limited",
+                llm_provider="openai",
+                model="gpt-5",
+            )
+
+    source = _ErrorOnFirstChunkSource()
+    wrapped = await router._aresponses_streaming_iterator(
+        response=source,
+        initial_kwargs={"model": "primary"},
+    )
+
+    with pytest.raises(litellm.APIError) as exc_info:
+        async for _ in wrapped:
+            pass
+    assert exc_info.value.status_code == 429

--- a/tests/test_litellm/responses/test_streaming_iterator_error_events.py
+++ b/tests/test_litellm/responses/test_streaming_iterator_error_events.py
@@ -1,0 +1,146 @@
+"""
+Regression: in-stream error events (type="error", type="response.failed") must
+raise litellm.APIError so callers see an exception rather than a benign chunk.
+Previously they were returned as-is, silently bypassing router cooldown logic.
+
+Also covers: ErrorEventError.param must accept dict payloads without raising a
+Pydantic ValidationError (previously typed as Optional[str]).
+"""
+
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.responses.streaming_iterator import (
+    BaseResponsesAPIStreamingIterator,
+    ResponsesAPIStreamingIterator,
+)
+from litellm.types.llms.openai import (
+    ErrorEvent,
+    ErrorEventError,
+    ResponsesAPIStreamEvents,
+)
+
+
+def _make_iterator() -> BaseResponsesAPIStreamingIterator:
+    mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    mock_config = Mock(spec=BaseResponsesAPIConfig)
+    mock_response = Mock()
+    mock_response.headers = {}
+    return BaseResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5",
+        responses_api_provider_config=mock_config,
+        logging_obj=mock_logging_obj,
+        custom_llm_provider="openai",
+    )
+
+
+def _make_error_chunk(code: str, message: str = "err") -> ErrorEvent:
+    error_obj = ErrorEventError(
+        type="rate_limit_error" if code.startswith("rate_limit") else "invalid_request_error",
+        code=code,
+        message=message,
+    )
+    return ErrorEvent(type=ResponsesAPIStreamEvents.ERROR, sequence_number=0, error=error_obj)
+
+
+def test_maybe_raise_for_error_event_raises_on_error_type():
+    iterator = _make_iterator()
+    chunk = _make_error_chunk("internal_error", "something went wrong")
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 500
+
+
+def test_maybe_raise_for_error_event_maps_rate_limit_to_429():
+    iterator = _make_iterator()
+    chunk = _make_error_chunk("rate_limit_exceeded", "Too many requests")
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 429
+
+
+def test_maybe_raise_for_error_event_maps_invalid_request_to_400():
+    iterator = _make_iterator()
+    chunk = _make_error_chunk("invalid_request_error", "bad request")
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 400
+
+
+def test_maybe_raise_for_error_event_maps_context_length_to_400():
+    iterator = _make_iterator()
+    chunk = _make_error_chunk("context_length_exceeded", "too long")
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 400
+
+
+def test_maybe_raise_for_error_event_passes_through_normal_chunk():
+    iterator = _make_iterator()
+    chunk = Mock()
+    chunk.type = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA
+    iterator._maybe_raise_for_error_event(chunk)  # must not raise
+
+
+def test_error_event_error_param_accepts_dict():
+    error_obj = ErrorEventError(
+        type="invalid_request_error",
+        code="context_length_exceeded",
+        message="too long",
+        param={"field": "messages", "index": 0},
+    )
+    assert isinstance(error_obj.param, dict)
+
+
+@pytest.mark.asyncio
+async def test_async_iterator_raises_api_error_on_error_event():
+    error_payload = {
+        "type": "error",
+        "error": {
+            "type": "rate_limit_error",
+            "code": "rate_limit_exceeded",
+            "message": "rate limited",
+        },
+    }
+    sse_bytes = f"data: {json.dumps(error_payload)}\n\n".encode()
+
+    async def mock_aiter_bytes():
+        yield sse_bytes
+
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_response.aiter_bytes = mock_aiter_bytes
+    mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+    error_obj = ErrorEventError(
+        type="rate_limit_error", code="rate_limit_exceeded", message="rate limited"
+    )
+    mock_config.transform_streaming_response.return_value = ErrorEvent(
+        type=ResponsesAPIStreamEvents.ERROR, sequence_number=0, error=error_obj
+    )
+
+    iterator = ResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5",
+        responses_api_provider_config=mock_config,
+        logging_obj=mock_logging_obj,
+        custom_llm_provider="openai",
+    )
+
+    with pytest.raises(litellm.APIError) as exc_info:
+        async for _ in iterator:
+            pass
+    assert exc_info.value.status_code == 429

--- a/tests/test_litellm/responses/test_streaming_iterator_error_events.py
+++ b/tests/test_litellm/responses/test_streaming_iterator_error_events.py
@@ -10,7 +10,7 @@ Pydantic ValidationError (previously typed as Optional[str]).
 import json
 import os
 import sys
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -22,6 +22,7 @@ from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfi
 from litellm.responses.streaming_iterator import (
     BaseResponsesAPIStreamingIterator,
     ResponsesAPIStreamingIterator,
+    SyncResponsesAPIStreamingIterator,
 )
 from litellm.types.llms.openai import (
     ErrorEvent,
@@ -142,5 +143,66 @@ async def test_async_iterator_raises_api_error_on_error_event():
 
     with pytest.raises(litellm.APIError) as exc_info:
         async for _ in iterator:
+            pass
+    assert exc_info.value.status_code == 429
+
+
+def test_maybe_raise_for_response_failed_event_with_dict_error():
+    """response.failed chunks carry a dict error on .response.error; covers dict branch."""
+    iterator = _make_iterator()
+    mock_response_obj = Mock()
+    mock_response_obj.error = {"type": "rate_limit_error", "code": "rate_limit_exceeded", "message": "throttled"}
+    chunk = Mock()
+    chunk.type = "response.failed"
+    chunk.response = mock_response_obj
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 429
+
+
+def test_maybe_raise_for_error_event_null_error_obj():
+    """error chunk with no error field: message and code default; raises 500."""
+    iterator = _make_iterator()
+    chunk = Mock()
+    chunk.type = "error"
+    chunk.error = None
+    with pytest.raises(litellm.APIError) as exc_info:
+        iterator._maybe_raise_for_error_event(chunk)
+    assert exc_info.value.status_code == 500
+    assert "Response API in-stream error" in str(exc_info.value)
+
+
+def test_sync_iterator_raises_api_error_on_error_event():
+    """SyncResponsesAPIStreamingIterator must raise APIError on error events."""
+    error_payload = {
+        "type": "error",
+        "error": {"type": "rate_limit_error", "code": "rate_limit_exceeded", "message": "throttled"},
+    }
+    sse_bytes = f"data: {json.dumps(error_payload)}\n\n".encode()
+
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_response.iter_bytes.return_value = iter([sse_bytes])
+    mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
+    mock_logging_obj.model_call_details = {"litellm_params": {}}
+    mock_config = Mock(spec=BaseResponsesAPIConfig)
+
+    error_obj = ErrorEventError(
+        type="rate_limit_error", code="rate_limit_exceeded", message="throttled"
+    )
+    mock_config.transform_streaming_response.return_value = ErrorEvent(
+        type=ResponsesAPIStreamEvents.ERROR, sequence_number=0, error=error_obj
+    )
+
+    iterator = SyncResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-5",
+        responses_api_provider_config=mock_config,
+        logging_obj=mock_logging_obj,
+        custom_llm_provider="openai",
+    )
+
+    with pytest.raises(litellm.APIError) as exc_info:
+        for _ in iterator:
             pass
     assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Relevant issues

Fixes #31786

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## CI (LiteLLM team)

- [ ] **Branch creation CI run**
       Link:

- [ ] **CI run for the last commit**
       Link:

- [ ] **Merge / cherry-pick CI run**
       Links:

## Screenshots / Proof of Fix

Tested against a local proxy running the patched source, hitting the OpenAI Responses API with a real key:

```
curl -X POST http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <key>" \
  -d '{"model": "gpt-4o-mini", "input": "Say OK only.", "stream": true}'
```

Selected output (normal streaming path, no regression):

```
data: {"type":"response.output_text.delta","delta":"OK",...}
data: {"type":"response.output_text.done","text":"OK",...}
data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":13,"output_tokens":2,"total_tokens":15},...}}
data: [DONE]
```

The in-stream error event path is verified by the regression tests in `test_base_responses_api_streaming_iterator.py`: `test_async_iterator_raises_api_error_on_error_event` and `test_sync_iterator_raises_api_error_on_error_event` construct a mock iterator that yields a rate-limit `ErrorEvent` SSE payload and assert that `litellm.APIError(status_code=429)` is raised rather than the error being returned as a benign stream chunk. These tests fail against the unpatched code and pass after the fix.

## Type

Bug Fix

## Changes

Before this fix, `ResponsesAPIStreamingIterator.__anext__` returned `ErrorEvent` and `ResponseFailedEvent` SSE chunks as ordinary stream items. No Python exception propagated, so the router's cooldown, retry, and fallback machinery never fired when a provider returned a rate-limit or context-length error mid-stream.

Two changes ship together because they are coupled: the `ErrorEventError.param` type fix is a prerequisite for the error-raise logic, since a dict-typed `param` payload previously caused `ValidationError` inside `transform_streaming_response`, silently dropping the error event before any type inspection could run.

`litellm/types/llms/openai.py`: widen `ErrorEventError.param` from `Optional[str]` to `Optional[Union[str, Dict[str, Any]]]` so providers that send `param` as a dict no longer cause `ValidationError` during chunk transformation.

`litellm/responses/streaming_iterator.py`: add `_maybe_raise_for_error_event(self, result: object) -> None` to `BaseResponsesAPIStreamingIterator`; call it in `ResponsesAPIStreamingIterator.__anext__` and `SyncResponsesAPIStreamingIterator.__next__` immediately after `_process_chunk` returns a non-None result. The method inspects the chunk type and raises `litellm.APIError` with status 429 for rate-limit codes and 500 for all other error codes. The existing `_handle_failure` idempotency guard (`_failure_handled`) prevents double-logging when the exception propagates to `__anext__`'s `except Exception` handler.

`tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py`: extend with seven regression tests covering the raise path, rate-limit 429 mapping, normal chunk passthrough, dict-typed param validation, and end-to-end async/sync iterator behavior.

`tests/router_unit_tests/test_router_aresponses_streaming_fallback.py`: add `test_aresponses_fallback_on_in_stream_error_event` verifying that `APIError` raised by a source iterator propagates through the router's `FallbackResponsesStreamWrapper` to the caller rather than being silently swallowed.