### PR TITLE
Fix user selector search by alias and ID

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1822,6 +1822,10 @@ async def get_users(
     user_ids: Optional[str] = fastapi.Query(default=None, description="Get list of users by user_ids"),
     sso_user_ids: Optional[str] = fastapi.Query(default=None, description="Get list of users by sso_user_id"),
     user_email: Optional[str] = fastapi.Query(default=None, description="Filter users by partial email match"),
+    search: Optional[str] = fastapi.Query(
+        default=None,
+        description="Search users by partial user_id, sso_user_id, user_email, or user_alias match",
+    ),
     team: Optional[str] = fastapi.Query(default=None, description="Filter users by team id"),
     page: int = fastapi.Query(default=1, ge=1, description="Page number"),
     page_size: int = fastapi.Query(default=25, ge=1, le=100, description="Number of items per page"),
@@ -1852,6 +1856,8 @@ async def get_users(
             Get list of users by sso_ids. Comma separated list of sso_ids.
         user_email: Optional[str]
             Filter users by partial email match
+        search: Optional[str]
+            Search users by partial user_id, sso_user_id, user_email, or user_alias match
         team: Optional[str]
             Filter users by team id. Will match if user has this team in their teams array.
         page: int
@@ -1910,6 +1916,36 @@ async def get_users(
             "contains": user_email,
             "mode": "insensitive",  # Case-insensitive search
         }
+
+    if search is not None and isinstance(search, str):
+        normalized_search = search.strip()
+        if normalized_search:
+            where_conditions["OR"] = [
+                {
+                    "user_id": {
+                        "contains": normalized_search,
+                        "mode": "insensitive",
+                    }
+                },
+                {
+                    "sso_user_id": {
+                        "contains": normalized_search,
+                        "mode": "insensitive",
+                    }
+                },
+                {
+                    "user_email": {
+                        "contains": normalized_search,
+                        "mode": "insensitive",
+                    }
+                },
+                {
+                    "user_alias": {
+                        "contains": normalized_search,
+                        "mode": "insensitive",
+                    }
+                },
+            ]
 
     if team is not None and isinstance(team, str):
         where_conditions["teams"] = {

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1707,6 +1707,69 @@ async def test_get_users_user_id_partial_match(mocker):
     assert captured_where_conditions["user_id"]["in"] == ["user1", "user2", "user3"]
 
 
+@pytest.mark.asyncio
+async def test_get_users_searches_alias_email_user_id_and_sso_user_id(mocker):
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_many = mocker.AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_usertable.count = mocker.AsyncMock(return_value=0)
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    admin_key = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+    await get_users(
+        role=LitellmUserRoles.INTERNAL_USER.value,
+        search="  中文别名  ",
+        page=1,
+        page_size=1,
+        user_api_key_dict=admin_key,
+        organization_ids=None,
+    )
+
+    where = mock_prisma_client.db.litellm_usertable.find_many.call_args.kwargs[
+        "where"
+    ]
+    assert where["user_role"] == LitellmUserRoles.INTERNAL_USER.value
+    assert where["OR"] == [
+        {"user_id": {"contains": "中文别名", "mode": "insensitive"}},
+        {"sso_user_id": {"contains": "中文别名", "mode": "insensitive"}},
+        {"user_email": {"contains": "中文别名", "mode": "insensitive"}},
+        {"user_alias": {"contains": "中文别名", "mode": "insensitive"}},
+    ]
+    mock_prisma_client.db.litellm_usertable.count.assert_awaited_once_with(
+        where=where
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_users_ignores_blank_search_and_keeps_legacy_email_filter(mocker):
+    mock_prisma_client = mocker.MagicMock()
+    mock_prisma_client.db.litellm_usertable.find_many = mocker.AsyncMock(
+        return_value=[]
+    )
+    mock_prisma_client.db.litellm_usertable.count = mocker.AsyncMock(return_value=0)
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    admin_key = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+    await get_users(
+        user_email="user",
+        search="   ",
+        page=1,
+        page_size=1,
+        user_api_key_dict=admin_key,
+        organization_ids=None,
+    )
+
+    where = mock_prisma_client.db.litellm_usertable.find_many.call_args.kwargs[
+        "where"
+    ]
+    assert "OR" not in where
+    assert where["user_email"] == {
+        "contains": "user",
+        "mode": "insensitive",
+    }
+
+
 def test_update_internal_user_params_reset_max_budget_with_none():
     """
     Test that _update_internal_user_params allows setting max_budget to None.

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.test.ts
@@ -74,6 +74,21 @@ describe("useInfiniteUsers", () => {
   const wrapper = ({ children }: { children: ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 
+  const userListCallArgs = (page = 1, pageSize = 50, search: string | null = null) => [
+    "test-access-token",
+    null,
+    page,
+    pageSize,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    search,
+  ];
+
   it("should return paginated user data when query is successful", async () => {
     const mockResponse = buildUserListResponse(1, 2);
     (userListCall as any).mockResolvedValue(mockResponse);
@@ -86,7 +101,7 @@ describe("useInfiniteUsers", () => {
 
     expect(result.current.data?.pages).toHaveLength(1);
     expect(result.current.data?.pages[0]).toEqual(mockResponse);
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs());
   });
 
   it("should use the default page size of 50", async () => {
@@ -99,7 +114,7 @@ describe("useInfiniteUsers", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs());
   });
 
   it("should use a custom page size when provided", async () => {
@@ -115,15 +130,15 @@ describe("useInfiniteUsers", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, customPageSize, null);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs(1, customPageSize));
   });
 
-  it("should pass searchEmail to userListCall when provided", async () => {
-    const searchEmail = "search@example.com";
+  it("should pass search to userListCall when provided", async () => {
+    const search = "中文别名";
     const mockResponse = buildUserListResponse(1, 1, 1);
     (userListCall as any).mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() => useInfiniteUsers(50, searchEmail), {
+    const { result } = renderHook(() => useInfiniteUsers(50, search), {
       wrapper,
     });
 
@@ -131,10 +146,10 @@ describe("useInfiniteUsers", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, searchEmail);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs(1, 50, search));
   });
 
-  it("should pass null for searchEmail when not provided", async () => {
+  it("should pass null for search when not provided", async () => {
     const mockResponse = buildUserListResponse(1, 1);
     (userListCall as any).mockResolvedValue(mockResponse);
 
@@ -146,7 +161,7 @@ describe("useInfiniteUsers", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs());
   });
 
   it("should fetch the next page when more pages are available", async () => {
@@ -175,7 +190,7 @@ describe("useInfiniteUsers", () => {
 
     expect(result.current.data?.pages[1]).toEqual(page2);
     expect(userListCall).toHaveBeenCalledTimes(2);
-    expect(userListCall).toHaveBeenLastCalledWith("test-access-token", null, 2, 50, null);
+    expect(userListCall).toHaveBeenLastCalledWith(...userListCallArgs(2));
   });
 
   it("should not have a next page when on the last page", async () => {
@@ -270,7 +285,7 @@ describe("useInfiniteUsers", () => {
     expect(result.current.data).toBeUndefined();
   });
 
-  it("should pass empty string searchEmail as null", async () => {
+  it("should pass empty string search as null", async () => {
     const mockResponse = buildUserListResponse(1, 1);
     (userListCall as any).mockResolvedValue(mockResponse);
 
@@ -282,6 +297,6 @@ describe("useInfiniteUsers", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(userListCall).toHaveBeenCalledWith("test-access-token", null, 1, 50, null);
+    expect(userListCall).toHaveBeenCalledWith(...userListCallArgs());
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/users/useUsers.ts
@@ -8,13 +8,13 @@ const infiniteUsersKeys = createQueryKeys("infiniteUsers");
 
 const DEFAULT_PAGE_SIZE = 50;
 
-export const useInfiniteUsers = (pageSize: number = DEFAULT_PAGE_SIZE, searchEmail?: string) => {
+export const useInfiniteUsers = (pageSize: number = DEFAULT_PAGE_SIZE, search?: string) => {
   const { accessToken, userRole } = useAuthorized();
   return useInfiniteQuery<UserListResponse>({
     queryKey: infiniteUsersKeys.list({
       filters: {
         pageSize,
-        ...(searchEmail && { searchEmail }),
+        ...(search && { search }),
       },
     }),
     queryFn: async ({ pageParam }) => {
@@ -23,7 +23,14 @@ export const useInfiniteUsers = (pageSize: number = DEFAULT_PAGE_SIZE, searchEma
         null, // userIDs
         pageParam as number, // page
         pageSize, // page_size
-        searchEmail || null, // userEmail
+        null, // userEmail
+        null, // userRole
+        null, // team
+        null, // sso_user_id
+        null, // sortBy
+        null, // sortOrder
+        null, // organizationIds
+        search || null,
       );
     },
     initialPageParam: 1,

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.test.tsx
@@ -739,7 +739,9 @@ describe("UsagePage", () => {
 
       // Admin should see the user selector select element with the placeholder attribute
       const userSelects = screen.getAllByRole("combobox");
-      const userSelect = userSelects.find((el) => el.getAttribute("placeholder") === "Select user to filter...");
+      const userSelect = userSelects.find(
+        (el) => el.getAttribute("placeholder") === "Search users by name, email, or ID...",
+      );
       expect(userSelect).toBeDefined();
     });
 
@@ -850,7 +852,9 @@ describe("UsagePage", () => {
 
       // Non-admin should not see the user selector
       const userSelects = screen.getAllByRole("combobox");
-      const userSelect = userSelects.find((el) => el.getAttribute("placeholder") === "Select user to filter...");
+      const userSelect = userSelects.find(
+        (el) => el.getAttribute("placeholder") === "Search users by name, email, or ID...",
+      );
       expect(userSelect).toBeUndefined();
     });
 

--- a/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/UsagePageView.tsx
@@ -500,7 +500,7 @@ const UsagePage: React.FC<UsagePageProps> = ({ teams, organizations }) => {
                     showSearch
                     allowClear
                     style={{ width: "100%" }}
-                    placeholder="Select user to filter..."
+                    placeholder="Search users by name, email, or ID..."
                     value={selectedUserId}
                     onChange={(value) => setSelectedUserId(value ?? null)}
                     filterOption={false}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -964,6 +964,7 @@ export const userListCall = async (
   sortBy: string | null = null,
   sortOrder: "asc" | "desc" | null = null,
   organizationIds: string[] | null = null,
+  search: string | null = null,
 ) => {
   /**
    * Get all available teams on proxy
@@ -982,6 +983,7 @@ export const userListCall = async (
         sort_by: sortBy || undefined,
         sort_order: sortOrder || undefined,
         organization_ids: organizationIds && organizationIds.length > 0 ? organizationIds.join(",") : undefined,
+        search: search || undefined,
       },
     })) as UserListResponse;
     return data;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -14552,6 +14552,8 @@ export interface paths {
          *             Get list of users by sso_ids. Comma separated list of sso_ids.
          *         user_email: Optional[str]
          *             Filter users by partial email match
+         *         search: Optional[str]
+         *             Search users by partial user_id, sso_user_id, user_email, or user_alias match
          *         team: Optional[str]
          *             Filter users by team id. Will match if user has this team in their teams array.
          *         page: int
@@ -51110,6 +51112,8 @@ export interface operations {
                 sso_user_ids?: string | null;
                 /** @description Filter users by partial email match */
                 user_email?: string | null;
+                /** @description Search users by partial user_id, sso_user_id, user_email, or user_alias match */
+                search?: string | null;
                 /** @description Filter users by team id */
                 team?: string | null;
                 /** @description Page number */


### PR DESCRIPTION
## Relevant issues

Fixes no public issue

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (local targeted checks are listed below)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Manual UI verification path:

1. Start a local proxy and open `http://localhost:4000/ui/?page=new_usage`
2. In `Filter by user`, search a user by display name or user alias
3. The dropdown should return the matching user, matching the selected label format

Local targeted verification:

- `uv run ruff check litellm/proxy/management_endpoints/internal_user_endpoints.py`
- `uv run pytest tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py::test_get_users_searches_alias_email_user_id_and_sso_user_id tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py::test_get_users_ignores_blank_search_and_keeps_legacy_email_filter`
- `npm test -- --run 'src/app/(dashboard)/hooks/users/useUsers.test.ts' 'src/components/common_components/user_single_select.test.tsx' 'src/components/UsagePage/components/UsagePageView.test.tsx'`

A live proxy screenshot is not included because this branch was prepared in a temporary upstream worktree without frontend dependencies

## Type

Bug Fix
Test

## Changes

Adds a `search` query parameter to `/user/list` that matches partial `user_id`, `sso_user_id`, `user_email`, and `user_alias`

Updates the dashboard infinite users hook and new usage user filter to send free-form input as `search` instead of `user_email`

Keeps legacy `user_email`, `user_ids`, and `sso_user_ids` filters intact for existing callers
