### PR TITLE
feat(proxy): strip additional_drop_params on pass-through endpoints

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -868,6 +868,14 @@ async def pass_through_request(
             logging_obj=logging_obj,
         )
 
+        _additional_drop_params: List[str] = getattr(litellm, "additional_drop_params", None) or []
+        if _additional_drop_params and isinstance(_parsed_body, dict):
+            from litellm.litellm_core_utils.dot_notation_indexing import delete_nested_value
+
+            for path in _additional_drop_params:
+                _parsed_body = delete_nested_value(_parsed_body, path)
+            passthrough_logging_payload["request_body"] = _parsed_body
+
         # Store custom_llm_provider in kwargs and logging object if provided
         if custom_llm_provider:
             logging_obj.model_call_details["custom_llm_provider"] = custom_llm_provider

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -3619,3 +3619,92 @@ async def test_non_guardrail_exception_still_logs_with_traceback():
     assert (
         logger.warning.call_count == 0
     ), "a genuine failure must not be downgraded to WARNING"
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_strips_additional_drop_params():
+    """Regression: additional_drop_params configured globally must be stripped from
+    the forwarded body on all pass-through routes (Gemini, Cohere, Vertex AI, etc.)."""
+    import litellm
+
+    litellm.additional_drop_params = ["thinking"]
+    try:
+        with patch(
+            "litellm.proxy.proxy_server.proxy_logging_obj"
+        ) as mock_proxy_logging:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.HttpPassThroughEndpointHelpers.non_streaming_http_request_handler"
+            ) as mock_http_handler:
+                with patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.ProxyBaseLLMRequestProcessing"
+                ) as mock_processing:
+                    with patch(
+                        "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler"
+                    ) as mock_success_handler:
+                        with patch(
+                            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_response_body"
+                        ) as mock_get_response_body:
+                            mock_proxy_logging.pre_call_hook = AsyncMock(
+                                return_value={
+                                    "model": "gemini-1.5-flash",
+                                    "thinking": {"type": "enabled"},
+                                    "messages": [{"role": "user", "content": "hi"}],
+                                }
+                            )
+                            mock_proxy_logging.post_call_failure_hook = AsyncMock()
+                            mock_proxy_logging.post_call_response_headers_hook = (
+                                AsyncMock(return_value=None)
+                            )
+
+                            mock_response = MagicMock()
+                            mock_response.status_code = 200
+                            mock_response.headers = {}
+                            mock_response.aread = AsyncMock(
+                                return_value=b'{"success": true}'
+                            )
+                            mock_response.text = '{"success": true}'
+                            mock_response.raise_for_status = MagicMock()
+                            mock_http_handler.return_value = mock_response
+
+                            mock_get_response_body.return_value = {"success": True}
+                            mock_processing.get_custom_headers.return_value = {}
+                            mock_success_handler.return_value = None
+
+                            mock_request = MagicMock(spec=Request)
+                            mock_request.method = "POST"
+                            mock_request.url = "http://test-proxy.com/gemini/v1beta/models/gemini-1.5-flash:generateContent"
+                            mock_request.body = AsyncMock(
+                                return_value=b'{"model": "gemini-1.5-flash", "thinking": {"type": "enabled"}, "messages": [{"role": "user", "content": "hi"}]}'
+                            )
+                            mock_request.headers = Headers({})
+                            mock_request.query_params = QueryParams({})
+
+                            mock_user_api_key_dict = MagicMock()
+                            mock_user_api_key_dict.api_key = "test-api-key"
+                            mock_user_api_key_dict.key_alias = None
+                            mock_user_api_key_dict.user_email = None
+                            mock_user_api_key_dict.user_id = None
+                            mock_user_api_key_dict.team_id = None
+                            mock_user_api_key_dict.org_id = None
+                            mock_user_api_key_dict.team_alias = None
+                            mock_user_api_key_dict.end_user_id = None
+                            mock_user_api_key_dict.request_route = (
+                                "/gemini/v1beta/models/gemini-1.5-flash:generateContent"
+                            )
+
+                            await pass_through_request(
+                                request=mock_request,
+                                target="https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent",
+                                custom_headers={},
+                                user_api_key_dict=mock_user_api_key_dict,
+                            )
+
+                            mock_http_handler.assert_called_once()
+                            forwarded_body = mock_http_handler.call_args.kwargs[
+                                "_parsed_body"
+                            ]
+                            assert "thinking" not in forwarded_body
+                            assert "model" in forwarded_body
+                            assert "messages" in forwarded_body
+    finally:
+        litellm.additional_drop_params = None


### PR DESCRIPTION
## Relevant issues

Closes #31744

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Proof of Fix

Start the proxy with `additional_drop_params: ["thinking"]` in `litellm_settings`, then send a request with `thinking` in the body to the Gemini pass-through route:

```bash
curl "http://localhost:4000/gemini/v1beta/models/gemini-2.0-flash:generateContent?key=$GEMINI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}],"thinking":{"type":"enabled","budget_tokens":100}}'
```

The proxy log confirms the incoming request contained `thinking`:

```
'proxy_server_request': {'body': {'contents': [...], 'thinking': {'type': 'enabled', 'budget_tokens': 100}}}
```

And that `thinking` was stripped before forwarding to Google:

```
'passthrough_logging_payload': {'request_body': {'contents': [{'role': 'user', 'parts': [{'text': 'hi'}]}]}}
```

Google returned a 429 (quota) rather than a 400 (bad request), confirming it received a valid body with no unknown fields.


## Type

🆕 New Feature

## Changes

In `pass_through_request`, after `_init_kwargs_for_pass_through_endpoint` strips litellm-internal params, read `litellm.additional_drop_params` and apply `delete_nested_value` for each configured path before the body is forwarded downstream. This covers all pass-through routes (Gemini, Cohere, Vertex AI, etc.) and keeps the logging payload in sync with the stripped body. Regression test added in `tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-driven request-body shaping on pass-through only; mirrors existing additional_drop_params behavior and is covered by a regression test. Raw signed-byte passthrough paths are unchanged.
> 
> **Overview**
> Proxy pass-through routes (Gemini, Cohere, Vertex, etc.) now honor globally configured **`litellm.additional_drop_params`**, which previously only affected unified LiteLLM calls.
> 
> In **`pass_through_request`**, after internal LiteLLM fields are removed, each configured path is stripped from the parsed JSON body via **`delete_nested_value`** (supports nested/dot paths). The body sent upstream and **`passthrough_logging_payload["request_body`** are both updated so logs match what providers receive—e.g. dropping **`thinking`** so Gemini does not get unknown fields.
> 
> A regression test asserts **`thinking`** is absent from the forwarded body when **`litellm.additional_drop_params = ["thinking"]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243c5bd7e871f445f99395288ffbf2f291174ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->