### PR TITLE
feat(ui): disclaim that the Update API Key modal only rotates api_key

### DIFF
--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Form, Input, Modal, Typography } from "antd";
+import { Alert, Button, Form, Input, Modal, Typography } from "antd";
 import { useState } from "react";
 import { modelPatchUpdateCall } from "./networking";
 import NotificationsManager from "./molecules/notifications_manager";
@@ -58,6 +58,12 @@ export default function UpdateModelCredentialsModal({
       <Text className="block mb-4 text-gray-500">
         Rotate this model&apos;s API key. Only the new key is sent; the rest of the deployment is left untouched.
       </Text>
+      <Alert
+        type="warning"
+        showIcon
+        className="mb-4"
+        message="Only the API key is rotated here. Models that authenticate with an Azure AD token, AWS credentials, or a Vertex service-account JSON aren't supported yet; update those from the model's LiteLLM Params for now."
+      />
       <Form form={form} onFinish={handleSubmit} layout="vertical">
         <Form.Item label="New API Key" name="api_key" rules={[{ required: true, message: "Enter a new API key" }]}>
           <Input.Password placeholder="Enter the new API key" autoComplete="new-password" />

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
@@ -56,7 +56,8 @@ export default function UpdateModelCredentialsModal({
   return (
     <Modal title="Update API Key" open={open} onCancel={close} footer={null} width={520} destroyOnHidden={true}>
       <Text className="block mb-4 text-gray-500">
-        Update this model&apos;s API key. Only the new key is sent; the rest of the deployment configuration is left untouched.
+        Update this model&apos;s API key. Only the new key is sent; the rest of the deployment configuration is left
+        untouched.
       </Text>
       <Alert
         type="warning"

--- a/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
+++ b/ui/litellm-dashboard/src/components/update_model_credentials_modal.tsx
@@ -56,7 +56,7 @@ export default function UpdateModelCredentialsModal({
   return (
     <Modal title="Update API Key" open={open} onCancel={close} footer={null} width={520} destroyOnHidden={true}>
       <Text className="block mb-4 text-gray-500">
-        Rotate this model&apos;s API key. Only the new key is sent; the rest of the deployment is left untouched.
+        Update this model&apos;s API key. Only the new key is sent; the rest of the deployment configuration is left untouched.
       </Text>
       <Alert
         type="warning"


### PR DESCRIPTION
## Relevant issues

Follow-up to #28089

## Linear ticket

## Summary

The Update API Key modal added in #28089 always writes `litellm_params.api_key`, so it does not rotate the credential for models that authenticate a different way (Azure using `azure_ad_token`, Bedrock using AWS keys, Vertex using a service-account JSON). On those models the button is still shown, and pasting a new secret there writes a stray `api_key` that the provider ignores while the real credential is left unchanged. This adds a warning so users of those providers are not misled into thinking their secret was rotated

Broadening the modal to rotate the correct field per provider is the real fix and is left as a follow-up; this is just the honest interim disclaimer

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Static antd warning `Alert` inside the modal. To see it: open the Admin UI at `/ui/models-and-endpoints`, open any DB model, click "Update API Key", and the warning renders above the New API Key field. No test added because it is a static informational element with no logic

## Type

📖 Documentation

## Changes

Adds a warning `Alert` to `UpdateModelCredentialsModal` noting that only `api_key` is rotated and that Azure AD token / AWS / Vertex JSON providers are not covered yet
