### PR TITLE
fix(proxy): admin-gate `permissions` on /key/update and /key/regenerate (LIT-4092)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -563,18 +563,18 @@ def _check_allowed_routes_caller_permission(
 
 
 def _check_permissions_caller_permission(
-    permissions: Optional[dict],
+    data: GenerateRequestBase,
     user_api_key_dict: UserAPIKeyAuth,
 ) -> None:
     """
-    Only proxy admins may set the `permissions` dict on a key.
+    Require PROXY_ADMIN when `permissions` is present in the request body.
 
-    The field grants ambient capabilities (e.g. `get_spend_routes` exposes
-    `/global/spend/*`), so it must follow the same admin gate as
-    `allowed_routes`. Without this gate a non-admin can self-grant capabilities
-    they do not hold, including read access to global spend.
+    Presence is detected via `data.model_fields_set` so a caller that
+    omits the field (default flows through) is distinct from one that
+    sends any explicit value.
     """
-    if not permissions:
+    permissions_in_request = "permissions" in data.model_fields_set
+    if not permissions_in_request and not data.permissions:
         return
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
         return
@@ -840,7 +840,7 @@ async def _common_key_generation_helper(
         team_table=team_table,
     )
     _check_permissions_caller_permission(
-        permissions=data.permissions,
+        data=data,
         user_api_key_dict=user_api_key_dict,
     )
 
@@ -2233,6 +2233,10 @@ async def _validate_update_key_data(
         user_api_key_dict=user_api_key_dict,
     )
     _check_passthrough_routes_caller_permission(
+        data=data,
+        user_api_key_dict=user_api_key_dict,
+    )
+    _check_permissions_caller_permission(
         data=data,
         user_api_key_dict=user_api_key_dict,
     )
@@ -4549,6 +4553,10 @@ async def regenerate_key_fn(
                 user_api_key_dict=user_api_key_dict,
             )
             _check_passthrough_routes_caller_permission(
+                data=data,
+                user_api_key_dict=user_api_key_dict,
+            )
+            _check_permissions_caller_permission(
                 data=data,
                 user_api_key_dict=user_api_key_dict,
             )

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -13644,3 +13644,270 @@ async def test_permissions_admin_can_set_any(monkeypatch):
             team_table=None,
         )
     assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_permissions_explicit_empty_rejected_for_non_admin_on_generate(monkeypatch):
+    """`_common_key_generation_helper` rejects a non-admin when
+    `permissions` is present in the request body, even as `{}`. Omit-default
+    stays allowed; that carve-out lives in
+    `test_permissions_empty_default_allowed_for_non_admin`."""
+    monkeypatch.setattr(
+        "litellm.proxy.management_endpoints.key_management_endpoints.litellm.default_key_generate_params",
+        None,
+        raising=False,
+    )
+    caller = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="user-1",
+        max_budget=100.0,
+    )
+    request = GenerateKeyRequest(permissions={})
+    assert "permissions" in request.model_fields_set
+    with pytest.raises(HTTPException) as exc_info:
+        await _common_key_generation_helper(
+            data=request,
+            user_api_key_dict=caller,
+            litellm_changed_by=None,
+            team_table=None,
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+def _make_personal_key_row_for_alice():
+    return MagicMock(
+        token="hashed_alice_personal_key",
+        user_id="alice",
+        team_id=None,
+        created_by="alice",
+        max_budget=None,
+        organization_id=None,
+        project_id=None,
+    )
+
+
+def _make_alice_internal_user():
+    return UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-alice",
+        user_id="alice",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_key_non_admin_permissions_non_empty_rejected(monkeypatch):
+    """`_validate_update_key_data` rejects a non-admin when `permissions`
+    is present in the request body (personal-key fast-path caller)."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    data = UpdateKeyRequest(
+        key="sk-alice-personal",
+        permissions={"get_spend_routes": True},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await _validate_update_key_data(
+            data=data,
+            existing_key_row=_make_personal_key_row_for_alice(),
+            user_api_key_dict=_make_alice_internal_user(),
+            llm_router=None,
+            premium_user=True,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+    assert "permissions" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_key_non_admin_permissions_explicit_empty_rejected(monkeypatch):
+    """`_validate_update_key_data` rejects a non-admin when `permissions`
+    is present as `{}` in the request body. The value matches the model
+    default but `model_fields_set` distinguishes the two."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    data = UpdateKeyRequest(
+        key="sk-alice-personal",
+        permissions={},
+    )
+    assert "permissions" in data.model_fields_set
+
+    with pytest.raises(HTTPException) as exc:
+        await _validate_update_key_data(
+            data=data,
+            existing_key_row=_make_personal_key_row_for_alice(),
+            user_api_key_dict=_make_alice_internal_user(),
+            llm_router=None,
+            premium_user=True,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+    assert "permissions" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_key_non_admin_permissions_explicit_null_rejected(monkeypatch):
+    """`_validate_update_key_data` rejects a non-admin when `permissions`
+    is present as `null` in the request body."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    data = UpdateKeyRequest(
+        key="sk-alice-personal",
+        permissions=None,
+    )
+    assert "permissions" in data.model_fields_set
+
+    with pytest.raises(HTTPException) as exc:
+        await _validate_update_key_data(
+            data=data,
+            existing_key_row=_make_personal_key_row_for_alice(),
+            user_api_key_dict=_make_alice_internal_user(),
+            llm_router=None,
+            premium_user=True,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=MagicMock(),
+        )
+    assert exc.value.status_code == 403
+    assert "permissions" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_key_non_admin_omits_permissions_succeeds(monkeypatch):
+    """`_validate_update_key_data` accepts a non-admin owner when
+    `permissions` is absent from the request body (personal-key fast path
+    on an unrelated field)."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    data = UpdateKeyRequest(key="sk-alice-personal", tpm_limit=42)
+    assert "permissions" not in data.model_fields_set
+
+    await _validate_update_key_data(
+        data=data,
+        existing_key_row=_make_personal_key_row_for_alice(),
+        user_api_key_dict=_make_alice_internal_user(),
+        llm_router=None,
+        premium_user=True,
+        prisma_client=mock_prisma_client,
+        user_api_key_cache=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_key_admin_can_set_permissions(monkeypatch):
+    """`_validate_update_key_data` accepts a PROXY_ADMIN caller for every
+    shape of `permissions` in the request body."""
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.jsonify_object = lambda data: data
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+        api_key="sk-admin",
+        user_id="admin-1",
+    )
+    for permissions_value in ({"get_spend_routes": True}, {}, None):
+        data = UpdateKeyRequest(
+            key="sk-alice-personal",
+            permissions=permissions_value,
+        )
+        await _validate_update_key_data(
+            data=data,
+            existing_key_row=_make_personal_key_row_for_alice(),
+            user_api_key_dict=admin,
+            llm_router=None,
+            premium_user=True,
+            prisma_client=mock_prisma_client,
+            user_api_key_cache=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_regenerate_key_non_admin_permissions_rejected(monkeypatch):
+    """`regenerate_key_fn` rejects a non-admin when `permissions` is
+    present in the request body, before any DB work."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        regenerate_key_fn,
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+    data = RegenerateKeyRequest(
+        key="sk-alice-personal",
+        permissions={"get_spend_routes": True},
+    )
+
+    with pytest.raises(ProxyException) as exc:
+        await regenerate_key_fn(
+            key=None,
+            data=data,
+            user_api_key_dict=_make_alice_internal_user(),
+            litellm_changed_by=None,
+        )
+    assert int(exc.value.code) == 403
+    assert "permissions" in str(exc.value.message)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_key_non_admin_permissions_explicit_empty_rejected(monkeypatch):
+    """`regenerate_key_fn` rejects a non-admin when `permissions` is
+    present as `{}` in the request body."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        regenerate_key_fn,
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+    data = RegenerateKeyRequest(key="sk-alice-personal", permissions={})
+    assert "permissions" in data.model_fields_set
+
+    with pytest.raises(ProxyException) as exc:
+        await regenerate_key_fn(
+            key=None,
+            data=data,
+            user_api_key_dict=_make_alice_internal_user(),
+            litellm_changed_by=None,
+        )
+    assert int(exc.value.code) == 403
+    assert "permissions" in str(exc.value.message)
+
+
+@pytest.mark.asyncio
+async def test_regenerate_key_non_admin_permissions_rejected_before_enterprise_gate(monkeypatch):
+    """`regenerate_key_fn` runs `_check_permissions_caller_permission`
+    before the `premium_user` check, so a non-premium proxy still returns
+    the permissions rejection (403) rather than the enterprise-license
+    error (500) when a non-admin sends `permissions`."""
+    from litellm.proxy._types import RegenerateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        regenerate_key_fn,
+    )
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", False)
+
+    data = RegenerateKeyRequest(
+        key="sk-alice-personal",
+        permissions={"get_spend_routes": True},
+    )
+
+    with pytest.raises(ProxyException) as exc:
+        await regenerate_key_fn(
+            key=None,
+            data=data,
+            user_api_key_dict=_make_alice_internal_user(),
+            litellm_changed_by=None,
+        )
+    assert int(exc.value.code) == 403
+    assert "permissions" in str(exc.value.message)
+    assert "Enterprise" not in str(exc.value.message)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4092

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type

Bug Fix

## Changes

`_check_permissions_caller_permission` was only wired into `_common_key_generation_helper`. It is now also invoked from `_validate_update_key_data` and `regenerate_key_fn` so the three write paths share the same admin-only rule for the `permissions` field on the key model

The helper is refactored to accept the full request model and key its check on `"permissions" in data.model_fields_set` rather than the value's truthiness. The model default (`permissions = {}` on `GenerateRequestBase`) is not in `model_fields_set` when the field is omitted, so the omit case continues to pass for non-admin callers on all three endpoints. Any explicit value in the request body, including `{}` or `null`, is treated the same as any other write and requires PROXY_ADMIN

In `regenerate_key_fn` the gate runs before the `premium_user` license check. Ordering is pinned by `test_regenerate_key_non_admin_permissions_rejected_before_enterprise_gate`, which fails on a mutant that swaps the two gates (the test observes a 500 enterprise error instead of the 403 permissions rejection)

Nine tests in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py` cover the matrix: non-admin explicit-non-empty, explicit-empty, explicit-null (rejected 403), non-admin omit-field (allowed), and PROXY_ADMIN across every shape (allowed). Seven of the nine fail on the pre-fix HEAD; all nine pass on this commit. Full mapped test file (339 tests) green

## Screenshots / Proof of Fix

Live proxy on `localhost:4010` against Postgres, `LITELLM_LICENSE` set to make `/key/regenerate` reachable. A non-admin key `$USER_KEY` owned by an `internal_user` role sends `permissions` in the request body

`/key/update` explicit non-empty

```
$ curl -sS -X POST http://localhost:4010/key/update \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\",\"permissions\":{\"get_spend_routes\":true}}"
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

`/key/update` explicit empty

```
$ curl -sS -X POST http://localhost:4010/key/update \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\",\"permissions\":{}}"
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

`/key/regenerate` explicit non-empty

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\",\"permissions\":{\"get_spend_routes\":true}}"
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

`/key/regenerate` explicit empty

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\",\"permissions\":{}}"
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

Ordering: same proxy launched with `LITELLM_LICENSE` unset (`premium_user=False`). Non-admin with `permissions` in the request body gets the 403 rather than the 500 enterprise error, confirming the gate runs before the license check

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\",\"permissions\":{\"get_spend_routes\":true}}"
{"error":{"message":"{'error': 'Only proxy admins can set `permissions` on a key.'}","code":"403"}}
```

Same non-premium proxy, same caller, no `permissions` in the body: reaches the license check as expected

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $USER_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$OWN_KEY\"}"
{"error":{"message":"Regenerating Virtual Keys is an Enterprise feature...","code":"500"}}
```

Controls unchanged: PROXY_ADMIN can still set `permissions` to any value on all three endpoints; a non-admin caller who omits `permissions` on `/key/update` still uses the personal-key fast path for unrelated fields; a non-admin caller who omits `permissions` on `/key/generate` still creates a key with the model default

## Out of scope, tracked separately

- LIT-4137: bulk-update handlers go through `_process_single_key_update` which does not invoke the helper. `/key/bulk_update` is admin-only. `/team/key/bulk_update` broadcasts via `KeyUpdateFields`, an `extra="forbid"` allowlist that omits `permissions`, so the field is currently unreachable through that route; adding it to the allowlist without also invoking the helper would regress
- LIT-4138: `NewUserRequest` and `UpdateUserRequest` inherit the `permissions` field. `/user/new` with `auto_create_key=True` (default) can carry the field into `generate_key_helper_fn`; the current helper is invoked from `_common_key_generation_helper` but not from `generate_key_helper_fn` directly, so the `/user/new` path is not covered
- LIT-4139: `_check_allowed_routes_caller_permission` uses the truthiness pattern this PR replaced for `permissions`. The same `model_fields_set` treatment applies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Authorization on virtual-key `permissions` is security-sensitive; the change tightens gates on update/regenerate paths where the bug allowed self-granted capabilities.
> 
> **Overview**
> Closes a privilege-escalation gap where non-admins could set key **`permissions`** (e.g. `get_spend_routes`) via **`/key/update`** and **`/key/regenerate`** because **`_check_permissions_caller_permission`** only ran on key generation.
> 
> The helper now takes the full request model and treats **`permissions`** as “in the body” when it appears in **`model_fields_set`**, so explicit **`{}`**, **`null`**, or non-empty dicts all require **PROXY_ADMIN**; omitting the field still allows normal non-admin flows. The same check is wired into **`_validate_update_key_data`** and **`regenerate_key_fn`** (before the enterprise license gate on regenerate). Tests cover generate/update/regenerate for omit vs explicit values and admin vs non-admin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a6301437452abb3504005e5543eee7daa8a390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->