### PR TITLE
feat(bedrock): add eu-west-1 pricing for qwen.qwen3-next-80b-a3b

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8954,6 +8954,19 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "bedrock/eu-west-1/qwen.qwen3-next-80b-a3b": {
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.41e-06,
+        "supports_function_calling": true,
+        "supports_native_structured_output": true,
+        "supports_system_messages": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/eu-west-2/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 3.45e-06,
         "litellm_provider": "bedrock",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8954,6 +8954,19 @@
         "supports_tool_choice": true,
         "source": "https://aws.amazon.com/bedrock/pricing/"
     },
+    "bedrock/eu-west-1/qwen.qwen3-next-80b-a3b": {
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "bedrock",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.41e-06,
+        "supports_function_calling": true,
+        "supports_native_structured_output": true,
+        "supports_system_messages": true,
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/eu-west-2/meta.llama3-70b-instruct-v1:0": {
         "input_cost_per_token": 3.45e-06,
         "litellm_provider": "bedrock",


### PR DESCRIPTION
## Relevant issues

Fixes #31692

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests - N/A; this is a data-only addition to the model cost map, no code paths change, matching how other regional bedrock entries are added
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review - will request after opening

## Screenshots / Proof of Fix

`bedrock/eu-west-1/qwen.qwen3-next-80b-a3b` had no entry, so cost tracking fell back to the bare `qwen.qwen3-next-80b-a3b` entry, which carries US pricing of $0.15 / $1.20 per 1M tokens. The eu-west-1 price on the Bedrock pricing page is $0.18 / $1.41 per 1M tokens, verified against https://aws.amazon.com/bedrock/pricing/, so eu-west-1 usage was under-counted

For a request of 1M input + 1M output tokens in eu-west-1:

```
before (fell back to US pricing 1.5e-07 / 1.2e-06): $1.3500
after  (eu-west-1 pricing        1.8e-07 / 1.41e-06): $1.5900
```

That is a ~15% under-count corrected

The issue suggested `"litellm_provider": "bedrock_converse"`, but every one of the 151 existing `bedrock/<region>/` entries uses `"bedrock"`, so this entry follows that convention for consistency

## Type

🐛 Bug Fix

## Changes

Added `bedrock/eu-west-1/qwen.qwen3-next-80b-a3b` to both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json` so `ci_cd/check_files_match.py` stays green. Context window and capability flags mirror the base `qwen.qwen3-next-80b-a3b` entry; only the region-specific prices differ
