### PR TITLE
feat: resolve DataRobot gateway model capabilities via get_provider_info

### DIFF
--- a/litellm/llms/datarobot/chat/transformation.py
+++ b/litellm/llms/datarobot/chat/transformation.py
@@ -4,8 +4,11 @@ Support for OpenAI's `/v1/chat/completions` endpoint.
 Calls done in OpenAI/openai.py as DataRobot is openai-compatible.
 """
 
-from typing import Optional, Tuple
+import re
+from typing import Optional, Tuple, cast
 from litellm.secret_managers.main import get_secret_str
+from litellm.types.utils import ProviderSpecificModelInfo
+from litellm.utils import _get_model_info_helper
 from urllib.parse import urlparse, urlunparse
 from ...openai_like.chat.transformation import OpenAILikeChatConfig
 
@@ -85,3 +88,25 @@ class DataRobotConfig(OpenAILikeChatConfig):
             str: The complete URL for the API call.
         """
         return str(api_base)  # type: ignore
+
+    def get_provider_info(self, model: str) -> Optional[ProviderSpecificModelInfo]:
+        """Resolve capabilities from the provider the gateway routes to.
+
+        DataRobot has no entries in the model map; it is OpenAI-compatible and
+        addresses models as ``<inner_provider>/<model>`` (``vertex_ai/...``,
+        ``azure/...``). ``model`` arrives with the ``datarobot/`` prefix already
+        stripped by ``get_llm_provider``, so we hand off to the inner provider's
+        model info. Azure gateway names are DataRobot deployment names whose
+        version dots are spelled as dashes, so they are adapted to litellm's keys
+        (``gpt-5-1`` -> ``gpt-5.1``).
+        """
+        if "/" not in model:
+            return None
+        if model.startswith("azure/"):
+            model = re.sub(r"(gpt-\d)-(\d)(?=-|$)", r"\1.\2", model)
+        try:
+            # Read-path helper: carries all supports_* flags, and avoids the public
+            # get_model_info, which can trigger side effects (e.g. OAuth) per provider.
+            return cast(ProviderSpecificModelInfo, _get_model_info_helper(model))
+        except Exception:  # noqa: BLE001 (unmapped model -> bare Exception)
+            return None

--- a/litellm/llms/datarobot/chat/transformation.py
+++ b/litellm/llms/datarobot/chat/transformation.py
@@ -103,7 +103,9 @@ class DataRobotConfig(OpenAILikeChatConfig):
         if "/" not in model:
             return None
         if model.startswith("azure/"):
-            model = re.sub(r"(gpt-\d)-(\d)(?=-|$)", r"\1.\2", model)
+            # dashed version -> dotted (gpt-5-1 -> gpt-5.1); minor capped at 2 digits
+            # so a 4-digit date suffix (gpt-4-2024-08-06) is not misread as a version.
+            model = re.sub(r"(gpt-\d+)-(\d{1,2})(?=-|$)", r"\1.\2", model)
         try:
             # Read-path helper: carries all supports_* flags, and avoids the public
             # get_model_info, which can trigger side effects (e.g. OAuth) per provider.

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8236,6 +8236,7 @@ class ProviderConfigManager:
             LlmProviders.XAI: litellm.XAIModelInfo,
             LlmProviders.LEMONADE: litellm.LemonadeChatConfig,
             LlmProviders.CLARIFAI: litellm.ClarifaiConfig,
+            LlmProviders.DATAROBOT: litellm.DataRobotConfig,
         }
         if provider in simple_configs:
             return simple_configs[provider]()

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8225,39 +8225,35 @@ class ProviderConfigManager:
         model: Optional[str],
         provider: LlmProviders,
     ) -> Optional[BaseLLMModelInfo]:
-        if LlmProviders.FIREWORKS_AI == provider:
-            return litellm.FireworksAIConfig()
-        elif LlmProviders.OPENAI == provider:
-            return litellm.OpenAIGPTConfig()
-        elif LlmProviders.GEMINI == provider:
-            return litellm.GeminiModelInfo()
+        # Providers whose model info is a zero-arg config with no local import.
+        simple_configs = {
+            LlmProviders.FIREWORKS_AI: litellm.FireworksAIConfig,
+            LlmProviders.OPENAI: litellm.OpenAIGPTConfig,
+            LlmProviders.GEMINI: litellm.GeminiModelInfo,
+            LlmProviders.LITELLM_PROXY: litellm.LiteLLMProxyChatConfig,
+            LlmProviders.TOPAZ: litellm.TopazModelInfo,
+            LlmProviders.ANTHROPIC: litellm.AnthropicModelInfo,
+            LlmProviders.XAI: litellm.XAIModelInfo,
+            LlmProviders.LEMONADE: litellm.LemonadeChatConfig,
+            LlmProviders.CLARIFAI: litellm.ClarifaiConfig,
+        }
+        if provider in simple_configs:
+            return simple_configs[provider]()
         elif LlmProviders.VERTEX_AI == provider:
             from litellm.llms.vertex_ai.common_utils import VertexAIModelInfo
 
             return VertexAIModelInfo()
-        elif LlmProviders.LITELLM_PROXY == provider:
-            return litellm.LiteLLMProxyChatConfig()
-        elif LlmProviders.TOPAZ == provider:
-            return litellm.TopazModelInfo()
-        elif LlmProviders.ANTHROPIC == provider:
-            return litellm.AnthropicModelInfo()
-        elif LlmProviders.XAI == provider:
-            return litellm.XAIModelInfo()
-        elif LlmProviders.OLLAMA == provider or LlmProviders.OLLAMA_CHAT == provider:
+        elif provider in (LlmProviders.OLLAMA, LlmProviders.OLLAMA_CHAT):
             # Dynamic model listing for Ollama server
             from litellm.llms.ollama.common_utils import OllamaModelInfo
 
             return OllamaModelInfo()
-        elif LlmProviders.VLLM == provider or LlmProviders.HOSTED_VLLM == provider:
+        elif provider in (LlmProviders.VLLM, LlmProviders.HOSTED_VLLM):
             from litellm.llms.vllm.common_utils import (
                 VLLMModelInfo,  # experimental approach, to reduce bloat on __init__.py
             )
 
             return VLLMModelInfo()
-        elif LlmProviders.LEMONADE == provider:
-            return litellm.LemonadeChatConfig()
-        elif LlmProviders.CLARIFAI == provider:
-            return litellm.ClarifaiConfig()
         elif LlmProviders.BEDROCK == provider:
             from litellm.llms.bedrock.common_utils import BedrockModelInfo
 

--- a/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
+++ b/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
@@ -152,6 +152,37 @@ class TestDataRobotConfig:
 
         assert captured["model"] == "azure/gpt-4o"  # untouched
 
+    def test_get_provider_info_normalizes_multi_digit_minor(self, handler):
+        captured = {}
+
+        def fake_helper(model, *args, **kwargs):
+            captured["model"] = model
+            return {"supports_function_calling": True}
+
+        with patch(
+            "litellm.llms.datarobot.chat.transformation._get_model_info_helper",
+            side_effect=fake_helper,
+        ):
+            handler.get_provider_info("azure/gpt-5-12")
+
+        assert captured["model"] == "azure/gpt-5.12"  # two-digit minor
+
+    def test_get_provider_info_dated_name_not_read_as_version(self, handler):
+        """A 4-digit date suffix must not be dotted into a version."""
+        captured = {}
+
+        def fake_helper(model, *args, **kwargs):
+            captured["model"] = model
+            return {"supports_function_calling": True}
+
+        with patch(
+            "litellm.llms.datarobot.chat.transformation._get_model_info_helper",
+            side_effect=fake_helper,
+        ):
+            handler.get_provider_info("azure/gpt-4-2024-08-06")
+
+        assert captured["model"] == "azure/gpt-4-2024-08-06"  # untouched
+
     def test_get_provider_info_unknown_model_returns_none(self, handler):
         with patch(
             "litellm.llms.datarobot.chat.transformation._get_model_info_helper",

--- a/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
+++ b/tests/test_litellm/llms/datarobot/chat/test_datarobot_chat_transformation.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+import litellm
 from litellm.llms.datarobot.chat.transformation import DataRobotConfig
 
 
@@ -105,3 +106,63 @@ class TestDataRobotConfig:
         os.environ["DATAROBOT_API_TOKEN"] = "env_key"
         assert handler._resolve_api_key(None) == "env_key"
         del os.environ["DATAROBOT_API_TOKEN"]
+
+    def test_get_provider_info_resolves_inner_provider(self, handler):
+        """Capabilities come from the provider the gateway routes to."""
+        info = handler.get_provider_info("azure/gpt-4o")
+        assert info is not None
+        assert info["supports_function_calling"] is True
+
+    def test_get_provider_info_resolves_vertex_ai(self, handler):
+        """Non-azure inner providers (e.g. vertex_ai) resolve too."""
+        info = handler.get_provider_info("vertex_ai/gemini-2.5-pro")
+        assert info is not None
+        assert info["supports_function_calling"] is True
+
+    def test_get_provider_info_normalizes_azure_deployment_name(self, handler):
+        captured = {}
+
+        def fake_helper(model, *args, **kwargs):
+            captured["model"] = model
+            return {"supports_function_calling": True}
+
+        with patch(
+            "litellm.llms.datarobot.chat.transformation._get_model_info_helper",
+            side_effect=fake_helper,
+        ):
+            info = handler.get_provider_info("azure/gpt-5-1-2025-11-13")
+
+        # dashed version dotted, date kept
+        assert captured["model"] == "azure/gpt-5.1-2025-11-13"
+        assert info["supports_function_calling"] is True
+
+    def test_get_provider_info_passes_unversioned_name_unchanged(self, handler):
+        """The azure regex must not mangle a name with no dashed version."""
+        captured = {}
+
+        def fake_helper(model, *args, **kwargs):
+            captured["model"] = model
+            return {"supports_function_calling": True}
+
+        with patch(
+            "litellm.llms.datarobot.chat.transformation._get_model_info_helper",
+            side_effect=fake_helper,
+        ):
+            handler.get_provider_info("azure/gpt-4o")
+
+        assert captured["model"] == "azure/gpt-4o"  # untouched
+
+    def test_get_provider_info_unknown_model_returns_none(self, handler):
+        with patch(
+            "litellm.llms.datarobot.chat.transformation._get_model_info_helper",
+            side_effect=Exception("not mapped"),
+        ):
+            assert handler.get_provider_info("vertex_ai/unknown-xyz") is None
+
+    def test_get_provider_info_no_inner_provider_returns_none(self, handler):
+        assert handler.get_provider_info("datarobot-deployed-llm") is None
+
+
+def test_supports_function_calling_for_datarobot_routed_model():
+    """End-to-end: the `datarobot/` prefix resolves via the provider model-info."""
+    assert litellm.supports_function_calling("datarobot/azure/gpt-4o") is True


### PR DESCRIPTION
## Relevant issues

_N/A_

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests (`make test-unit`)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review (`@greptileai`) and received a Confidence Score of at least 4/5

## Type

🆕 New Feature

## Changes

`litellm.supports_function_calling` returned `False` for every `datarobot/`-prefixed model — DataRobot is an OpenAI-compatible gateway with no entries in the model-cost map — so frameworks that gate native tool-calling on the flag (e.g. CrewAI) silently downgraded tool-capable models to prompt-based tool use.

Adds `DataRobotConfig.get_provider_info`, which delegates to the inner provider's model info (DataRobot addresses models as `<inner_provider>/<model>`, e.g. `azure/…`, `vertex_ai/…`) and normalizes the Azure gateway deployment-name quirk (`gpt-5-1` → `gpt-5.1`). Registers `DataRobotConfig` in `ProviderConfigManager.get_provider_model_info`.

The first commit (`refactor:`) collapses the trivial zero-arg provider branches in `get_provider_model_info` into a dict — that function was already at the C901 complexity ceiling (15), so a plain `elif` would trip the strict-rule lint gate. It is behavior-preserving: every provider resolves to the same config class.

## Proof of Fix

Same litellm version, before vs. after the patch:

| model | supports_function_calling |
|---|---|
| `datarobot/azure/gpt-4o` | False → **True** |
| `datarobot/azure/gpt-5-1` | False → **True** (azure `gpt-5-1` → `gpt-5.1`) |
| `datarobot/vertex_ai/gemini-2.5-pro` | False → **True** |
| `datarobot/bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0` | False → **True** |

Non-DataRobot models (`azure/gpt-4o`, `gpt-4o`) are unchanged → no regression.
