### PR TITLE
fix(proxy): persist router settings as JSON objects

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -121,6 +121,22 @@ from litellm.utils import (
     load_credentials_from_list,
 )
 
+
+def _normalize_config_param_value(value: Any) -> Any:
+    """
+    LiteLLM_Config.param_value is a Json column. Older /config/update writes
+    stored whole sections as JSON strings inside that Json column; normalize
+    those rows back to objects when reading while preserving non-object strings.
+    """
+    if isinstance(value, str):
+        try:
+            parsed_value = json.loads(value)
+        except (json.JSONDecodeError, TypeError):
+            return value
+        return parsed_value if isinstance(parsed_value, dict) else value
+    return value
+
+
 if TYPE_CHECKING:
     from aiohttp import ClientSession
     from opentelemetry.trace import Span as _Span
@@ -5311,6 +5327,11 @@ class ProxyConfig:
             db_router_settings = await ConfigRepository(prisma_client).table.find_first(
                 where={"param_name": "router_settings"}
             )
+            db_router_settings_value = (
+                _normalize_config_param_value(db_router_settings.param_value)
+                if db_router_settings is not None
+                else None
+            )
 
             config_router_settings = config_data.get("router_settings", {})
 
@@ -5319,15 +5340,15 @@ class ProxyConfig:
                 config_router_settings is not None
                 and isinstance(config_router_settings, dict)
                 and db_router_settings is not None
-                and isinstance(db_router_settings.param_value, dict)
+                and isinstance(db_router_settings_value, dict)
             ):
                 from litellm.utils import _update_dictionary
 
-                combined_router_settings = _update_dictionary(config_router_settings, db_router_settings.param_value)
+                combined_router_settings = _update_dictionary(config_router_settings, db_router_settings_value)
             elif config_router_settings is not None and isinstance(config_router_settings, dict):
                 combined_router_settings = config_router_settings
-            elif db_router_settings is not None and isinstance(db_router_settings.param_value, dict):
-                combined_router_settings = db_router_settings.param_value
+            elif db_router_settings is not None and isinstance(db_router_settings_value, dict):
+                combined_router_settings = db_router_settings_value
 
             if combined_router_settings:
                 llm_router.update_settings(**combined_router_settings)
@@ -5643,7 +5664,7 @@ class ProxyConfig:
                 continue
 
             param_name = getattr(response, "param_name", None)
-            param_value = getattr(response, "param_value", None)
+            param_value = _normalize_config_param_value(getattr(response, "param_value", None))
             verbose_proxy_logger.debug(f"param_name={param_name}, param_value={param_value}")
 
             if param_name is not None and param_value is not None:
@@ -13943,15 +13964,15 @@ async def update_config(
             row = await ConfigRepository(prisma_client).table.find_first(where={"param_name": param_name})
             if row is None or row.param_value is None:
                 return {}
-            return dict(row.param_value)
+            value = _normalize_config_param_value(row.param_value)
+            return dict(value) if isinstance(value, dict) else {}
 
         async def _upsert_section(param_name: str, value: dict) -> None:
-            serialized = json.dumps(value)
             await ConfigRepository(prisma_client).table.upsert(
                 where={"param_name": param_name},
                 data={
-                    "create": {"param_name": param_name, "param_value": serialized},
-                    "update": {"param_value": serialized},
+                    "create": {"param_name": param_name, "param_value": value},
+                    "update": {"param_value": value},
                 },
             )
             # invalidate the DualCache entry so the next reader (this process

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -2937,7 +2937,10 @@ async def test_update_config_success_callback_normalization():
         return None
 
     async def fake_upsert(where=None, data=None):
-        upserted[where["param_name"]] = json.loads(data["update"]["param_value"])
+        value = data["update"]["param_value"]
+        upserted[where["param_name"]] = (
+            json.loads(value) if isinstance(value, str) else value
+        )
 
     class MockPrisma:
         def __init__(self):
@@ -2973,6 +2976,110 @@ async def test_update_config_success_callback_normalization():
     assert "sQs" not in callbacks
     # Existing callback should still be present
     assert "langfuse" in callbacks
+
+
+def test_normalize_config_param_value_preserves_non_object_values():
+    """Only legacy JSON object strings should be coerced back to dicts."""
+    from litellm.proxy.proxy_server import _normalize_config_param_value
+
+    assert _normalize_config_param_value({"setting": "value"}) == {"setting": "value"}
+    assert _normalize_config_param_value('{"setting": "value"}') == {
+        "setting": "value"
+    }
+    assert _normalize_config_param_value('["not", "an", "object"]') == (
+        '["not", "an", "object"]'
+    )
+    assert _normalize_config_param_value("not-json") == "not-json"
+
+
+@pytest.mark.asyncio
+async def test_add_router_settings_from_db_config_normalizes_legacy_json_string():
+    """DB-backed router_settings may exist as a legacy JSON string."""
+    import litellm.proxy.proxy_server as proxy_server
+
+    proxy_config = proxy_server.ProxyConfig()
+    mock_router = MagicMock()
+    mock_router.update_settings = MagicMock()
+
+    mock_db_config = MagicMock()
+    mock_db_config.param_value = json.dumps(
+        {"model_group_alias": {"alias-model:auto": "target-model"}}
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_config.find_first = AsyncMock(
+        return_value=mock_db_config
+    )
+
+    await proxy_config._add_router_settings_from_db_config(
+        config_data={"router_settings": {"timeout": 30}},
+        llm_router=mock_router,
+        prisma_client=mock_prisma_client,
+    )
+
+    mock_router.update_settings.assert_called_once_with(
+        timeout=30, model_group_alias={"alias-model:auto": "target-model"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_config_router_settings_merges_legacy_json_string(monkeypatch):
+    """A legacy JSON-string row should be read as a dict and written as an object."""
+    import litellm.proxy.proxy_server as proxy_server
+    from litellm.proxy._types import ConfigYAML, LitellmUserRoles, UserAPIKeyAuth
+
+    class FakeRow:
+        def __init__(self, name, value):
+            self.param_name = name
+            self.param_value = value
+
+    upserted = {}
+
+    async def fake_find_first(where=None):
+        if where and where.get("param_name") == "router_settings":
+            return FakeRow(
+                "router_settings",
+                json.dumps({"timeout": 10}),
+            )
+        return None
+
+    async def fake_upsert(where=None, data=None):
+        upserted[where["param_name"]] = data["update"]["param_value"]
+
+    class MockPrisma:
+        def __init__(self):
+            self.db = MagicMock()
+            self.db.litellm_config = MagicMock()
+            self.db.litellm_config.find_first = AsyncMock(side_effect=fake_find_first)
+            self.db.litellm_config.upsert = AsyncMock(side_effect=fake_upsert)
+
+    class MockProxyConfig:
+        async def add_deployment(self, prisma_client=None, proxy_logging_obj=None):
+            return None
+
+    monkeypatch.setattr(proxy_server, "prisma_client", MockPrisma())
+    monkeypatch.setattr(proxy_server, "proxy_config", MockProxyConfig())
+    monkeypatch.setattr(proxy_server, "proxy_logging_obj", MagicMock())
+    monkeypatch.setattr(
+        proxy_server, "invalidate_config_param", AsyncMock(return_value=None)
+    )
+
+    admin_user = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-test"
+    )
+    await proxy_server.update_config(
+        ConfigYAML(
+            router_settings={
+                "model_group_alias": {"alias-model:auto": "target-model"},
+            }
+        ),
+        user_api_key_dict=admin_user,
+    )
+
+    assert upserted["router_settings"] == {
+        "timeout": 10.0,
+        "model_group_alias": {"alias-model:auto": "target-model"},
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -3821,6 +3821,44 @@ async def test_add_router_settings_from_db_config_merge_logic():
 
 
 @pytest.mark.asyncio
+async def test_add_router_settings_from_db_config_accepts_legacy_json_string():
+    """
+    Regression: older /config/update stored router_settings.param_value as a
+    JSON string inside the Json column. Reload must coerce that legacy row back
+    to a dict so model_group_alias reaches the live Router.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+    mock_router = MagicMock()
+    mock_router.update_settings = MagicMock()
+
+    mock_db_config = MagicMock()
+    mock_db_config.param_value = json.dumps(
+        {
+            "model_group_alias": {"alias-model:auto": "target-model"}
+        }
+    )
+
+    mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_config.find_first = AsyncMock(
+        return_value=mock_db_config
+    )
+
+    await proxy_config._add_router_settings_from_db_config(
+        config_data={},
+        llm_router=mock_router,
+        prisma_client=mock_prisma_client,
+    )
+
+    mock_router.update_settings.assert_called_once_with(
+        model_group_alias={"alias-model:auto": "target-model"}
+    )
+
+
+@pytest.mark.asyncio
 async def test_add_router_settings_from_db_config_edge_cases():
     """
     Test edge cases for _add_router_settings_from_db_config method.
@@ -7621,8 +7659,7 @@ class _FakeLitellmConfig:
 
     async def _upsert(self, where=None, data=None):
         name = where["param_name"]
-        raw = data["update"]["param_value"]
-        value = json.loads(raw) if isinstance(raw, str) else raw
+        value = data["update"]["param_value"]
         self.rows[name] = value
         self.upsert_calls.append((name, value))
 
@@ -7821,6 +7858,28 @@ def test_update_config_litellm_settings_request_wins_for_non_callback_keys(
         stored = prisma.db.litellm_config.rows["litellm_settings"]
         assert stored["drop_params"] is False
         assert stored["set_verbose"] is True
+    finally:
+        restore()
+
+
+def test_update_config_router_settings_stores_json_object(_update_config_setup):
+    """router_settings is stored in a Json column, so /config/update must persist
+    an object rather than a JSON string. Otherwise DB reload skips settings like
+    model_group_alias that require dict values."""
+    client, prisma, restore = _update_config_setup()
+    try:
+        resp = client.post(
+            "/config/update",
+            json={
+                "router_settings": {
+                    "model_group_alias": {"alias-model:auto": "target-model"}
+                }
+            },
+        )
+        assert resp.status_code == 200
+        stored = prisma.db.litellm_config.rows["router_settings"]
+        assert isinstance(stored, dict)
+        assert stored["model_group_alias"] == {"alias-model:auto": "target-model"}
     finally:
         restore()
 


### PR DESCRIPTION
## Relevant issues

Fixes #31836

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before/after screenshots are from local proof commands run against `litellm_oss_staging` and this PR branch with anonymized inputs. This backend regression has no dashboard UI flow, so the screenshots show command output from the relevant LiteLLM code path.

Before:

![router alias before](https://gist.githubusercontent.com/silencedoctor/86820c5264b0589e937e12fc971c363d/raw/router-before-real.png)

After:

![router alias after](https://gist.githubusercontent.com/silencedoctor/86820c5264b0589e937e12fc971c363d/raw/router-after-real.png)

Local proxy startup verification:

```text
GET http://127.0.0.1:4417/health/liveliness -> 200 "I'm alive!"
GET http://127.0.0.1:4417/health/readiness -> 200 {"status":"healthy","db":"Not connected"}
```

Validation:

```text
poetry run python -m pytest tests/test_litellm/proxy/test_proxy_server.py -k "router_settings or update_config" -vv
# 16 passed

poetry run python -m pytest tests/proxy_unit_tests/test_proxy_server.py -k "normalize_config_param_value or add_router_settings_from_db_config_normalizes_legacy_json_string or update_config_router_settings_merges_legacy_json_string or test_update_config_success_callback_normalization" -vv
# 4 passed

poetry run ruff check litellm/proxy/proxy_server.py
# passed

git diff --check
# passed
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Store `/config/update` section rows as JSON objects in `LiteLLM_Config.param_value` instead of JSON strings.
- Normalize legacy JSON object strings when reading DB-backed config, so existing rows created by older versions still apply.
- Add regression coverage for `router_settings.model_group_alias` reload and `/config/update` persistence shape.
- Keep the existing proxy unit test fake compatible with direct JSON-object writes.


