### PR TITLE
fix(cost): honor served OpenAI response service tier

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -851,16 +851,32 @@ def _map_traffic_type_to_service_tier(traffic_type: Optional[str]) -> Optional[s
 
 def _normalize_service_tier(service_tier: object) -> str | None:
     """
-    Reduce a service_tier value to a concrete billable tier string or None.
+    Reduce a service_tier value to a tier string used by cost calculation.
 
     "auto" is a routing preference and any non-string value is not a billable
     tier, so both defer to standard pricing (or to the tier the provider reports
     on the response usage) instead of crashing the downstream cost-key lookup,
-    which calls service_tier.lower()
+    which calls service_tier.lower().
+
+    Keep string values like "default" and "standard" so a provider-reported
+    served tier can override a request-level "priority" preference. The cost-key
+    resolver maps non-premium strings to standard pricing.
     """
     if not isinstance(service_tier, str) or service_tier.lower() == ServiceTier.AUTO.value:
         return None
     return service_tier
+
+
+def _get_normalized_service_tier_from_object(service_tier_object: Any) -> str | None:
+    if service_tier_object is None:
+        return None
+    if isinstance(service_tier_object, BaseModel):
+        service_tier = getattr(service_tier_object, "service_tier", None)
+    elif isinstance(service_tier_object, dict):
+        service_tier = service_tier_object.get("service_tier")
+    else:
+        service_tier = getattr(service_tier_object, "service_tier", None)
+    return _normalize_service_tier(service_tier)
 
 
 def _get_usage_object(
@@ -1178,29 +1194,16 @@ def completion_cost(
         cost_per_token_usage_object: Optional[Usage] = _get_usage_object(completion_response=completion_response)
         rerank_billed_units: Optional[RerankBilledUnits] = None
 
-        # Extract service_tier from optional_params if not provided directly
-        if service_tier is None and optional_params is not None:
-            service_tier = optional_params.get("service_tier")
-
-        service_tier = _normalize_service_tier(service_tier)
-
-        # Extract service_tier from completion_response if not provided
-        if service_tier is None and completion_response is not None:
-            if isinstance(completion_response, BaseModel):
-                service_tier = getattr(completion_response, "service_tier", None)
-            elif isinstance(completion_response, dict):
-                service_tier = completion_response.get("service_tier")
-
-        service_tier = _normalize_service_tier(service_tier)
-
-        # Extract service_tier from usage object if not provided
-        if service_tier is None and cost_per_token_usage_object is not None:
-            if isinstance(cost_per_token_usage_object, BaseModel):
-                service_tier = getattr(cost_per_token_usage_object, "service_tier", None)
-            elif isinstance(cost_per_token_usage_object, dict):
-                service_tier = cost_per_token_usage_object.get("service_tier")
-
-        service_tier = _normalize_service_tier(service_tier)
+        # Prefer the provider-reported served tier over the request preference.
+        # OpenAI Responses can accept service_tier="priority" but return
+        # service_tier="default" when priority processing was not used; billing
+        # must follow the served tier when present.
+        response_service_tier = _get_normalized_service_tier_from_object(completion_response)
+        usage_service_tier = _get_normalized_service_tier_from_object(cost_per_token_usage_object)
+        request_service_tier = _normalize_service_tier(service_tier)
+        if request_service_tier is None and optional_params is not None:
+            request_service_tier = _normalize_service_tier(optional_params.get("service_tier"))
+        service_tier = response_service_tier or usage_service_tier or request_service_tier
 
         selected_model = _select_model_name_for_cost_calc(
             model=model,

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -18,7 +18,7 @@ from litellm.cost_calculator import (
     handle_realtime_stream_cost_calculation,
     response_cost_calculator,
 )
-from litellm.types.llms.openai import OpenAIRealtimeStreamList
+from litellm.types.llms.openai import OpenAIRealtimeStreamList, ResponsesAPIResponse
 from litellm.types.utils import ModelResponse, PromptTokensDetailsWrapper, Usage
 from litellm.utils import TranscriptionResponse
 
@@ -2086,14 +2086,27 @@ def test_completion_cost_extracts_service_tier_from_usage():
 
 
 def test_completion_cost_service_tier_priority():
-    """Test that service_tier extraction follows priority: optional_params > completion_response > usage."""
+    """Test that service_tier extraction follows priority: completion_response > usage > optional_params."""
     from litellm import completion_cost
 
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
-    # Test with gpt-5-nano which has flex pricing
-    model = "gpt-5-nano"
+    model = "test-openai-service-tier-priority-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+                "input_cost_per_token_priority": 0.01,
+                "output_cost_per_token_priority": 0.02,
+                "input_cost_per_token_flex": 0.0005,
+                "output_cost_per_token_flex": 0.001,
+                "litellm_provider": "openai",
+                "max_tokens": 8192,
+            }
+        }
+    )
 
     # Create usage object with service_tier="flex"
     usage = Usage(prompt_tokens=1000, completion_tokens=500, total_tokens=1500)
@@ -2106,19 +2119,12 @@ def test_completion_cost_service_tier_priority():
     )
     setattr(response, "service_tier", "priority")
 
-    # Test that optional_params takes priority over response and usage
-    cost_from_params = completion_cost(
+    # Test that response takes priority over request params and usage.
+    cost_from_response = completion_cost(
         completion_response=response,
         model=model,
         custom_llm_provider="openai",
         optional_params={"service_tier": "flex"},
-    )
-
-    # Test that response takes priority over usage when optional_params is not provided
-    completion_cost(
-        completion_response=response,
-        model=model,
-        custom_llm_provider="openai",
     )
 
     # Test that usage is used when neither optional_params nor response have service_tier
@@ -2135,14 +2141,83 @@ def test_completion_cost_service_tier_priority():
         custom_llm_provider="openai",
     )
 
-    # All should use flex pricing (from different sources)
-    assert cost_from_params > 0, "Cost from params should be greater than 0"
+    assert cost_from_response > 0, "Cost from response should be greater than 0"
     assert cost_from_usage > 0, "Cost from usage should be greater than 0"
+    assert cost_from_response > cost_from_usage, "Response priority tier should override request/usage flex tier"
 
-    # Costs should be similar (all using flex)
-    assert (
-        abs(cost_from_params - cost_from_usage) < 1e-6
-    ), "Costs from params and usage should be similar (both flex)"
+
+def test_completion_cost_openai_responses_uses_response_service_tier_default_over_request_priority():
+    """
+    OpenAI Responses reports the tier actually used on the response. If a
+    priority request is served as default, cost tracking must use standard
+    pricing instead of the request-level priority preference.
+    """
+    from litellm import completion_cost
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    model = "test-openai-responses-default-tier-cost-model"
+    litellm.register_model(
+        model_cost={
+            model: {
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+                "input_cost_per_token_priority": 0.002,
+                "output_cost_per_token_priority": 0.004,
+                "litellm_provider": "openai",
+                "max_tokens": 8192,
+                "mode": "responses",
+            }
+        }
+    )
+
+    usage = {"input_tokens": 1000, "output_tokens": 500, "total_tokens": 1500}
+    response = ResponsesAPIResponse(
+        id="resp_default_tier",
+        created_at=0,
+        model=model,
+        object="response",
+        output=[],
+        usage=usage,
+        service_tier="default",
+    )
+
+    response_cost = completion_cost(
+        completion_response=response,
+        model=model,
+        custom_llm_provider="openai",
+        optional_params={"service_tier": "priority"},
+        service_tier="priority",
+    )
+    standard_cost = completion_cost(
+        completion_response=ResponsesAPIResponse(
+            id="resp_no_tier",
+            created_at=0,
+            model=model,
+            object="response",
+            output=[],
+            usage=usage,
+        ),
+        model=model,
+        custom_llm_provider="openai",
+    )
+    priority_cost = completion_cost(
+        completion_response=ResponsesAPIResponse(
+            id="resp_priority_tier",
+            created_at=0,
+            model=model,
+            object="response",
+            output=[],
+            usage=usage,
+            service_tier="priority",
+        ),
+        model=model,
+        custom_llm_provider="openai",
+    )
+
+    assert response_cost == pytest.approx(standard_cost)
+    assert priority_cost == pytest.approx(2 * standard_cost)
 
 
 def test_completion_cost_service_tier_for_bedrock():


### PR DESCRIPTION
## Relevant issues

Fixes #31837

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before/after screenshots are from local proof commands run against `litellm_oss_staging` and this PR branch with anonymized inputs. This backend cost regression has no dashboard UI flow, so the screenshots show command output from the relevant LiteLLM code path.

Before:

![service tier before](https://gist.githubusercontent.com/silencedoctor/86820c5264b0589e937e12fc971c363d/raw/service-tier-before-real.png)

After:

![service tier after](https://gist.githubusercontent.com/silencedoctor/86820c5264b0589e937e12fc971c363d/raw/service-tier-after-real.png)

Local proxy startup verification:

```text
GET http://127.0.0.1:4417/health/liveliness -> 200 "I'm alive!"
GET http://127.0.0.1:4417/health/readiness -> 200 {"status":"healthy","db":"Not connected"}
```

Validation:

```text
poetry run python -m pytest tests/test_litellm/test_cost_calculator.py -k "service_tier" -vv
# 9 passed

poetry run ruff check litellm/cost_calculator.py
# passed

git diff --check
# passed
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- Prefer provider-reported served `service_tier` from the response/usage over the request preference during cost calculation.
- Preserve non-premium string tiers like `default`/`standard` so they can override a request-level `priority`; the existing cost key resolver maps them to standard pricing.
- Add OpenAI Responses regression coverage for `request=priority` + `response=default`.


