### PR TITLE
feat(proxy): add GET /version endpoint

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -655,6 +655,7 @@ class LiteLLMRoutes(enum.Enum):
             "/public/mcp_hub",
             "/public/skill_hub",
             "/public/litellm_model_cost_map",
+            "/version",
         ]
     )
 

--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -29,6 +29,7 @@ from litellm.types.proxy.public_endpoints.public_endpoints import (
     ProviderCreateInfo,
     PublicModelHubInfo,
     SupportedEndpointsResponse,
+    VersionResponse,
 )
 from litellm.types.utils import LlmProviders
 
@@ -285,6 +286,13 @@ async def public_skill_hub():
         return ListPluginsResponse(plugins=items, count=len(items))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/version", tags=["version"], response_model=VersionResponse)
+async def version_info() -> VersionResponse:
+    from litellm.proxy.proxy_server import version
+
+    return VersionResponse(version=version)
 
 
 @router.get(

--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -29,6 +29,7 @@ from litellm.types.proxy.public_endpoints.public_endpoints import (
     ProviderCreateInfo,
     PublicModelHubInfo,
     SupportedEndpointsResponse,
+    VersionResponse,
 )
 from litellm.types.utils import LlmProviders
 
@@ -285,6 +286,13 @@ async def public_skill_hub():
         return ListPluginsResponse(plugins=items, count=len(items))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/version", tags=["public", "version"], response_model=VersionResponse)
+async def version_info() -> VersionResponse:
+    from litellm._version import version
+
+    return VersionResponse(version=version)
 
 
 @router.get(

--- a/litellm/types/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/types/proxy/public_endpoints/public_endpoints.py
@@ -68,3 +68,7 @@ class SupportedEndpoint(BaseModel):
 
 class SupportedEndpointsResponse(BaseModel):
     endpoints: List[SupportedEndpoint]
+
+
+class VersionResponse(BaseModel):
+    version: str

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -86,6 +86,7 @@ def test_public_ai_hub_routes_remain_public():
         "/public/agent_hub",
         "/public/mcp_hub",
         "/public/skill_hub",
+        "/version",
     ):
         assert route in LiteLLMRoutes.public_routes.value
         assert _route_requires_auth_despite_public(route, {}) is False

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -91,6 +91,40 @@ def test_get_litellm_model_cost_map_returns_cost_map():
     )
 
 
+def test_version_endpoint():
+    import litellm._version as _ver
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, dict)
+    assert "version" in body
+    assert isinstance(body["version"], str)
+    assert body["version"] == _ver.version
+
+
+@pytest.mark.parametrize("fake_version", ["unknown", "0.0.0"])
+def test_version_endpoint_fallback_strings_still_return_200(fake_version: str):
+    import litellm.proxy.proxy_server as _ps
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with patch.object(_ps, "version", fake_version):
+        response = client.get("/version")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == fake_version
+    assert isinstance(body["version"], str)
+
+
 def test_public_ai_hub_info_is_public_by_default(monkeypatch):
     app = FastAPI()
     app.include_router(router)

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -91,6 +91,40 @@ def test_get_litellm_model_cost_map_returns_cost_map():
     )
 
 
+def test_version_endpoint():
+    import litellm._version as _ver
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    response = client.get("/version")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, dict)
+    assert "version" in body
+    assert isinstance(body["version"], str)
+    assert body["version"] == _ver.version
+
+
+@pytest.mark.parametrize("fake_version", ["unknown", "0.0.0"])
+def test_version_endpoint_fallback_strings_still_return_200(fake_version: str):
+    import litellm._version as _ver
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    with patch.object(_ver, "version", fake_version):
+        response = client.get("/version")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == fake_version
+    assert isinstance(body["version"], str)
+
+
 def test_public_ai_hub_info_is_public_by_default(monkeypatch):
     app = FastAPI()
     app.include_router(router)


### PR DESCRIPTION
## Relevant issues
Closes #24109

## Linear ticket
N/A

## Pre-Submission checklist

Please complete all items before asking a LiteLLM maintainer to review your PR

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on make test-unit
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Adds an unauthenticated `GET /version` endpoint that returns the running LiteLLM version, so operators with instances across regions/versions can cheaply probe a single instance without authenticating or fetching the full `/openapi.json`.

Verify against a local proxy:

```
curl -s http://localhost:4000/version
{"version":"1.89.0"}
```

The value is the same runtime version already exposed in `/openapi.json` (`info.version`) and `/health/readiness`. No API key is required, mirroring `/health/liveness`.

Unit test `tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py::test_version_endpoint_returns_runtime_version` asserts a 200 response with `version == litellm._version.version`, and `tests/test_litellm/proxy/auth/test_user_api_key_auth.py::test_public_ai_hub_routes_remain_public` now guards that `/version` stays in `public_routes` with no forced auth.

## Type
New Feature

## Changes

- Adds a `VersionResponse` model and a `GET /version` route in the public endpoints router, returning the runtime LiteLLM version. The route reuses the existing `version` global that the FastAPI app already reads for `info.version`.
- Adds `/version` to `LiteLLMRoutes.public_routes` so the endpoint is reachable without an API key, following the same pattern as `/health/liveness` and `/public/model_hub/info`.
- Adds focused tests: the endpoint returns the runtime version with no auth header, and the public-routes membership regression test covers `/version`.
