### PR TITLE
feat(ui): add All Proxy Models option to key creation model selector

### DIFF
--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -921,7 +921,7 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                 label={
                   <span>
                     Models{" "}
-                    <Tooltip title="Select which models this key can access. Choose 'All Team Models' to grant access to all models available to the team. Leave empty to allow access to all models.">
+                    <Tooltip title="Select which models this key can access. 'All Proxy Models' grants access to every model on the proxy. 'All Team Models' inherits the team's allowlist and requires the key to be assigned to a team. Leave empty to allow access to all models.">
                       <InfoCircleOutlined style={{ marginLeft: "4px" }} />
                     </Tooltip>
                   </span>
@@ -941,7 +941,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                   style={{ width: "100%" }}
                   disabled={keyType === "management" || keyType === "read_only"}
                   onChange={(values) => {
-                    if (values.includes("all-team-models")) {
+                    if (values.includes("all-proxy-models")) {
+                      form.setFieldsValue({ models: ["all-proxy-models"] });
+                    } else if (values.includes("all-team-models")) {
                       form.setFieldsValue({ models: ["all-team-models"] });
                     }
                   }}

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -946,6 +946,9 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
                     }
                   }}
                 >
+                  <Option key="all-proxy-models" value="all-proxy-models">
+                    All Proxy Models
+                  </Option>
                   {!selectedProjectId && (
                     <Option key="all-team-models" value="all-team-models">
                       All Team Models


### PR DESCRIPTION
## Summary
Fixes  #30737
Adding the \"All Proxy Models\" option in the key creation model selector.
Keys with `all-proxy-models` grant access to every model on the proxy regardless of team membership. This is distinct from `all-team-models`, which inherits the parent team's allowlist and requires a team to be assigned to the key. Users who want per-user budgets without team membership (a valid setup) need `all-proxy-models` since `all-team-models` does not expand correctly for teamless keys.

The onChange handler now enforces exclusive selection for both sentinel values (selecting either clears other models from the field). The tooltip is updated to describe both options.

## Test plan

1. Start proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. Go to http://localhost:4000/ui, open key creation
3. Confirm \"All Proxy Models\" appears as the first option in the Models dropdown
4. Select \"All Proxy Models\" then try adding a specific model; confirm only \"All Proxy Models\" remains
5. Create a key with \"All Proxy Models\" selected
6. Call `/v1/models` with the new key; confirm it returns actual models, not the sentinel string