### PR TITLE
fix: enable model discovery for the custom_openai provider

### DIFF
--- a/litellm/llms/openai_like/chat/transformation.py
+++ b/litellm/llms/openai_like/chat/transformation.py
@@ -169,7 +169,7 @@ class OpenAILikeChatConfig(OpenAIGPTConfig):
 
 
 class CustomOpenAIChatConfig(OpenAILikeChatConfig):
-    def get_models(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> List[str]:
+    def get_models(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> list[str]:
         if api_base is None:
             raise ValueError("api_base must be set to discover models for the custom_openai provider")
         models = super().get_models(api_key=api_key, api_base=api_base)

--- a/litellm/llms/openai_like/chat/transformation.py
+++ b/litellm/llms/openai_like/chat/transformation.py
@@ -166,3 +166,11 @@ class OpenAILikeChatConfig(OpenAIGPTConfig):
             mapped_params.pop("max_completion_tokens", None)
 
         return mapped_params
+
+
+class CustomOpenAIChatConfig(OpenAILikeChatConfig):
+    def get_models(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> List[str]:
+        if api_base is None:
+            raise ValueError("api_base must be set to discover models for the custom_openai provider")
+        models = super().get_models(api_key=api_key, api_base=api_base)
+        return [f"custom_openai/{model}" for model in models]

--- a/litellm/llms/openai_like/chat/transformation.py
+++ b/litellm/llms/openai_like/chat/transformation.py
@@ -172,5 +172,5 @@ class CustomOpenAIChatConfig(OpenAILikeChatConfig):
     def get_models(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> list[str]:
         if api_base is None:
             raise ValueError("api_base must be set to discover models for the custom_openai provider")
-        models = super().get_models(api_key=api_key, api_base=api_base)
+        models = super().get_models(api_key=api_key or "", api_base=api_base)
         return [f"custom_openai/{model}" for model in models]

--- a/litellm/llms/openai_like/chat/transformation.py
+++ b/litellm/llms/openai_like/chat/transformation.py
@@ -169,7 +169,7 @@ class OpenAILikeChatConfig(OpenAIGPTConfig):
 
 
 class CustomOpenAIChatConfig(OpenAILikeChatConfig):
-    def get_models(self, api_key: Optional[str] = None, api_base: Optional[str] = None) -> list[str]:
+    def get_models(self, api_key: str | None = None, api_base: str | None = None) -> list[str]:
         if api_base is None:
             raise ValueError("api_base must be set to discover models for the custom_openai provider")
         models = super().get_models(api_key=api_key or "", api_base=api_base)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8358,6 +8358,8 @@ class ProviderConfigManager:
             return litellm.FireworksAIConfig()
         elif LlmProviders.OPENAI == provider:
             return litellm.OpenAIGPTConfig()
+        elif LlmProviders.CUSTOM_OPENAI == provider:
+            return litellm.OpenAIGPTConfig()
         elif LlmProviders.GEMINI == provider:
             return litellm.GeminiModelInfo()
         elif LlmProviders.VERTEX_AI == provider:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8350,20 +8350,24 @@ class ProviderConfigManager:
         return litellm.OpenAITextCompletionConfig()
 
     @staticmethod
+    def _openai_family_model_info(provider: LlmProviders) -> BaseLLMModelInfo:
+        if provider == LlmProviders.CUSTOM_OPENAI:
+            from litellm.llms.openai_like.chat.transformation import (
+                CustomOpenAIChatConfig,
+            )
+
+            return CustomOpenAIChatConfig()
+        return litellm.OpenAIGPTConfig()
+
+    @staticmethod
     def get_provider_model_info(
         model: str | None,
         provider: LlmProviders,
     ) -> BaseLLMModelInfo | None:
         if LlmProviders.FIREWORKS_AI == provider:
             return litellm.FireworksAIConfig()
-        elif LlmProviders.OPENAI == provider:
-            return litellm.OpenAIGPTConfig()
-        elif LlmProviders.CUSTOM_OPENAI == provider:
-            from litellm.llms.openai_like.chat.transformation import (
-                CustomOpenAIChatConfig,
-            )
-
-            return CustomOpenAIChatConfig()
+        elif provider in (LlmProviders.OPENAI, LlmProviders.CUSTOM_OPENAI):
+            return ProviderConfigManager._openai_family_model_info(provider)
         elif LlmProviders.GEMINI == provider:
             return litellm.GeminiModelInfo()
         elif LlmProviders.VERTEX_AI == provider:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8359,7 +8359,11 @@ class ProviderConfigManager:
         elif LlmProviders.OPENAI == provider:
             return litellm.OpenAIGPTConfig()
         elif LlmProviders.CUSTOM_OPENAI == provider:
-            return litellm.OpenAIGPTConfig()
+            from litellm.llms.openai_like.chat.transformation import (
+                CustomOpenAIChatConfig,
+            )
+
+            return CustomOpenAIChatConfig()
         elif LlmProviders.GEMINI == provider:
             return litellm.GeminiModelInfo()
         elif LlmProviders.VERTEX_AI == provider:

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1656,6 +1656,36 @@ def test_get_valid_models_openai_proxy(monkeypatch):
         assert "litellm_proxy/gpt-5.5" in valid_models
 
 
+def test_get_valid_models_custom_openai(monkeypatch):
+    from litellm.utils import get_valid_models
+    import litellm
+
+    mock_response_data = {
+        "object": "list",
+        "data": [
+            {
+                "id": "my-custom-model",
+                "object": "model",
+                "created": 1686935002,
+                "owned_by": "organization-owner",
+            },
+        ],
+    }
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = mock_response_data
+
+    with patch.object(litellm.module_level_client, "get", return_value=mock_response):
+        valid_models = get_valid_models(
+            check_provider_endpoint=True,
+            custom_llm_provider="custom_openai",
+            api_key="sk-1234",
+            api_base="https://my-openai-compatible-endpoint/v1",
+        )
+        assert "my-custom-model" in valid_models
+
+
 def test_get_valid_models_fireworks_ai(monkeypatch):
     from litellm.utils import get_valid_models
     import litellm

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1683,7 +1683,14 @@ def test_get_valid_models_custom_openai(monkeypatch):
             api_key="sk-1234",
             api_base="https://my-openai-compatible-endpoint/v1",
         )
-        assert "my-custom-model" in valid_models
+        assert "custom_openai/my-custom-model" in valid_models
+
+
+def test_custom_openai_get_models_requires_api_base():
+    from litellm.llms.openai_like.chat.transformation import CustomOpenAIChatConfig
+
+    with pytest.raises(ValueError):
+        CustomOpenAIChatConfig().get_models(api_base=None)
 
 
 def test_get_valid_models_fireworks_ai(monkeypatch):

--- a/tests/litellm_utils_tests/test_utils.py
+++ b/tests/litellm_utils_tests/test_utils.py
@@ -1656,42 +1656,6 @@ def test_get_valid_models_openai_proxy(monkeypatch):
         assert "litellm_proxy/gpt-5.5" in valid_models
 
 
-def test_get_valid_models_custom_openai(monkeypatch):
-    from litellm.utils import get_valid_models
-    import litellm
-
-    mock_response_data = {
-        "object": "list",
-        "data": [
-            {
-                "id": "my-custom-model",
-                "object": "model",
-                "created": 1686935002,
-                "owned_by": "organization-owner",
-            },
-        ],
-    }
-
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_response_data
-
-    with patch.object(litellm.module_level_client, "get", return_value=mock_response):
-        valid_models = get_valid_models(
-            check_provider_endpoint=True,
-            custom_llm_provider="custom_openai",
-            api_key="sk-1234",
-            api_base="https://my-openai-compatible-endpoint/v1",
-        )
-        assert "custom_openai/my-custom-model" in valid_models
-
-
-def test_custom_openai_get_models_requires_api_base():
-    from litellm.llms.openai_like.chat.transformation import CustomOpenAIChatConfig
-
-    with pytest.raises(ValueError):
-        CustomOpenAIChatConfig().get_models(api_base=None)
-
 
 def test_get_valid_models_fireworks_ai(monkeypatch):
     from litellm.utils import get_valid_models

--- a/tests/test_litellm/llms/openai_like/chat/test_openai_like_chat_transformation.py
+++ b/tests/test_litellm/llms/openai_like/chat/test_openai_like_chat_transformation.py
@@ -1,5 +1,14 @@
+from unittest.mock import MagicMock, patch
+
+import litellm
 import pytest
-from litellm.llms.openai_like.chat.transformation import OpenAILikeChatConfig
+from litellm.llms.openai_like.chat.transformation import (
+    CustomOpenAIChatConfig,
+    OpenAILikeChatConfig,
+)
+from litellm.llms.openai.chat.gpt_transformation import OpenAIGPTConfig
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager, get_valid_models
 
 
 def test_sanitize_usage_obj_handles_null_tokens():
@@ -47,3 +56,50 @@ def test_sanitize_usage_obj_valid_usage():
 
     # Assert
     assert sanitized_json == original_json  # The object should be unchanged
+
+
+def test_get_valid_models_custom_openai():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "object": "list",
+        "data": [
+            {
+                "id": "my-custom-model",
+                "object": "model",
+                "created": 1686935002,
+                "owned_by": "organization-owner",
+            },
+        ],
+    }
+
+    with patch.object(litellm.module_level_client, "get", return_value=mock_response) as mock_get:
+        valid_models = get_valid_models(
+            check_provider_endpoint=True,
+            custom_llm_provider="custom_openai",
+            api_key="sk-1234",
+            api_base="https://my-openai-compatible-endpoint/v1",
+        )
+
+    assert valid_models == ["custom_openai/my-custom-model"]
+    mock_get.assert_called_once_with(
+        url="https://my-openai-compatible-endpoint/v1/models",
+        headers={"Authorization": "Bearer sk-1234"},
+    )
+
+
+def test_custom_openai_get_models_requires_api_base():
+    with pytest.raises(
+        ValueError,
+        match="api_base must be set to discover models for the custom_openai provider",
+    ):
+        CustomOpenAIChatConfig().get_models(api_base=None)
+
+
+def test_openai_model_info_uses_openai_config():
+    config = ProviderConfigManager.get_provider_model_info(
+        model=None,
+        provider=LlmProviders.OPENAI,
+    )
+
+    assert type(config) is OpenAIGPTConfig

--- a/tests/test_litellm/llms/openai_like/chat/test_openai_like_chat_transformation.py
+++ b/tests/test_litellm/llms/openai_like/chat/test_openai_like_chat_transformation.py
@@ -96,6 +96,24 @@ def test_custom_openai_get_models_requires_api_base():
         CustomOpenAIChatConfig().get_models(api_base=None)
 
 
+def test_custom_openai_get_models_does_not_use_openai_api_key(monkeypatch):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {"data": [{"id": "my-custom-model"}]}
+    monkeypatch.setenv("OPENAI_API_KEY", "unrelated-openai-api-key")
+
+    with patch.object(litellm.module_level_client, "get", return_value=mock_response) as mock_get:
+        models = CustomOpenAIChatConfig().get_models(
+            api_base="https://my-openai-compatible-endpoint/v1"
+        )
+
+    assert models == ["custom_openai/my-custom-model"]
+    mock_get.assert_called_once_with(
+        url="https://my-openai-compatible-endpoint/v1/models",
+        headers={"Authorization": "Bearer "},
+    )
+
+
 def test_openai_model_info_uses_openai_config():
     config = ProviderConfigManager.get_provider_model_info(
         model=None,


### PR DESCRIPTION
## Relevant issues

Closes #20064

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai`

## Screenshots / Proof of Fix

`get_valid_models(check_provider_endpoint=True, custom_llm_provider="custom_openai", api_base=..., api_key=...)` previously returned an empty list because `ProviderConfigManager.get_provider_model_info` returned `None` for `custom_openai`, so the `/v1/models` discovery call was never made. With this change it discovers the endpoint's models and returns them prefixed as `custom_openai/<model>`. The behavior is covered by `tests/litellm_utils_tests/test_utils.py::test_get_valid_models_custom_openai` (happy path), `::test_custom_openai_get_models_requires_api_base` (missing `api_base` raises rather than falling back to OpenAI), and `tests/test_litellm/llms/openai_like/chat/test_openai_like_chat_transformation.py::test_custom_openai_get_models_does_not_use_openai_api_key` (a process-level `OPENAI_API_KEY` is not sent to a keyless custom endpoint)

## Type

🐛 Bug Fix

## Changes

`custom_openai` now resolves to a dedicated `CustomOpenAIChatConfig` (a subclass of `OpenAILikeChatConfig`, consistent with how the routing config already maps `custom_openai`). Its `get_models` requires `api_base`; when it is missing it raises instead of letting the OpenAI base config fall back to `https://api.openai.com`, so a `custom_openai` discovery call without `api_base` no longer silently returns OpenAI's model list. Discovered ids are prefixed with `custom_openai/` the same way `LiteLLMProxyChatConfig` wraps `litellm_proxy/`, so they round-trip back into `completion()` without the caller re-adding the prefix. `get_provider_model_info` folds `openai` and `custom_openai` into one branch through a small `_openai_family_model_info` helper, which keeps the function within the ruff strict-complexity budget. When no custom key is supplied, the config passes an empty value to the inherited discovery method so a process-level `OPENAI_API_KEY` is not sent to the configured custom endpoint
