### PR TITLE
fix(router): enable silent_model traffic mirroring in generic execution

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1630,6 +1630,7 @@ DEFAULT_COMPETITOR_DISCOVERY_MODEL = "gpt-4o-mini"
 # Providers that support advisor_20260301 natively (no LiteLLM orchestration needed).
 # Add vertex_ai here once verified.
 ADVISOR_NATIVE_PROVIDERS: frozenset = frozenset({"anthropic"})
+SILENT_MODEL_MIRROR_ALLOWED_CALL_TYPES: frozenset = frozenset({"aresponses", "anthropic_messages"})
 # Hard cap on advisor iterations per request to prevent runaway loops.
 ADVISOR_MAX_USES: int = 5
 # Description injected into the synthetic advisor tool definition sent to non-native providers.

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -60,6 +60,7 @@ from litellm.constants import (
     DEFAULT_HEALTH_CHECK_INTERVAL,
     DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER,
     DEFAULT_MAX_LRU_CACHE_SIZE,
+    SILENT_MODEL_MIRROR_ALLOWED_CALL_TYPES,
 )
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.asyncify import run_async_function
@@ -2715,7 +2716,7 @@ class Router:
             await self._ageneric_api_call_with_fallbacks(
                 original_function=original_function, model=silent_model, **silent_kwargs
             )
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001  # a background mirror failure must never break the primary request
             verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {str(e)}")
 
     async def _silent_experiment_acompletion(self, silent_model: str, messages: List[Any], **kwargs):
@@ -4486,7 +4487,10 @@ class Router:
 
             data = deployment["litellm_params"].copy()
             silent_model = data.pop("silent_model", None)
-            if silent_model is not None:
+            if (
+                silent_model is not None
+                and getattr(original_generic_function, "__name__", None) in SILENT_MODEL_MIRROR_ALLOWED_CALL_TYPES
+            ):
                 asyncio.create_task(
                     self._silent_experiment_ageneric(
                         silent_model=silent_model,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1851,6 +1851,7 @@ class Router:
         silent_kwargs.pop("litellm_logging_obj", None)
         silent_kwargs.pop("standard_logging_object", None)
         # DON'T pop proxy_server_request — it's needed for spend log metadata
+        silent_kwargs["metadata"].pop("tags", None)
 
         return silent_kwargs
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2704,6 +2704,19 @@ class Router:
 
         return SyncFallbackStreamWrapper(stream_with_fallbacks())
 
+    async def _silent_experiment_ageneric(self, silent_model: str, original_function: Callable, **kwargs: Any) -> None:
+        try:
+            if kwargs.get("metadata", {}).get("is_silent_experiment", False):
+                return
+            verbose_router_logger.info(f"Starting silent experiment for model {silent_model}")
+            silent_kwargs = self._get_silent_experiment_kwargs(**kwargs)
+            silent_kwargs["metadata"]["model_group"] = silent_model
+            await self._ageneric_api_call_with_fallbacks(
+                original_function=original_function, model=silent_model, **silent_kwargs
+            )
+        except Exception as e:
+            verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {str(e)}")
+
     async def _silent_experiment_acompletion(self, silent_model: str, messages: List[Any], **kwargs):
         """
         Run a silent experiment in the background.
@@ -4471,6 +4484,15 @@ class Router:
             self._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs, function_name=function_name)
 
             data = deployment["litellm_params"].copy()
+            silent_model = data.pop("silent_model", None)
+            if silent_model is not None:
+                asyncio.create_task(
+                    self._silent_experiment_ageneric(
+                        silent_model=silent_model,
+                        original_function=original_generic_function,
+                        **kwargs,
+                    )
+                )
             model_name = data["model"]
             self.total_calls[model_name] += 1
 
@@ -4499,6 +4521,7 @@ class Router:
             if custom_llm_provider is not None:
                 response_kwargs["custom_llm_provider"] = custom_llm_provider
 
+            response_kwargs.pop("silent_model", None)
             response = original_generic_function(**response_kwargs)
 
             rpm_semaphore = self._get_client(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2710,6 +2710,16 @@ class Router:
         try:
             if kwargs.get("metadata", {}).get("is_silent_experiment", False):
                 return
+
+            from litellm.responses.mcp.litellm_proxy_mcp_handler import (
+                LiteLLM_Proxy_MCP_Handler,
+            )
+
+            if LiteLLM_Proxy_MCP_Handler._should_auto_execute_tools(
+                mcp_tools_with_litellm_proxy=kwargs.get("tools") or []
+            ):
+                return
+
             verbose_router_logger.info(f"Starting silent experiment for model {silent_model}")
             silent_kwargs = self._get_silent_experiment_kwargs(**kwargs)
             silent_kwargs["metadata"]["model_group"] = silent_model

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2714,7 +2714,7 @@ class Router:
             await self._ageneric_api_call_with_fallbacks(
                 original_function=original_function, model=silent_model, **silent_kwargs
             )
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {str(e)}")
 
     async def _silent_experiment_acompletion(self, silent_model: str, messages: List[Any], **kwargs):

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -209,11 +209,7 @@ async def test_router_silent_experiment_acompletion():
 
         # Find the silent call
         silent_call = next(
-            (
-                c
-                for c in call_args_list
-                if c[1].get("metadata", {}).get("is_silent_experiment") is True
-            ),
+            (c for c in call_args_list if c[1].get("metadata", {}).get("is_silent_experiment") is True),
             None,
         )
         assert silent_call is not None
@@ -221,11 +217,7 @@ async def test_router_silent_experiment_acompletion():
 
         # Find the primary call
         primary_call = next(
-            (
-                c
-                for c in call_args_list
-                if not c[1].get("metadata", {}).get("is_silent_experiment")
-            ),
+            (c for c in call_args_list if not c[1].get("metadata", {}).get("is_silent_experiment")),
             None,
         )
         assert primary_call is not None
@@ -294,11 +286,7 @@ def test_router_silent_experiment_completion():
 
         # Find the silent call
         silent_call = next(
-            (
-                c
-                for c in call_args_list
-                if c[1].get("metadata", {}).get("is_silent_experiment") is True
-            ),
+            (c for c in call_args_list if c[1].get("metadata", {}).get("is_silent_experiment") is True),
             None,
         )
         assert silent_call is not None
@@ -333,6 +321,7 @@ async def test_router_silent_experiment_aresponses():
 
     mock_response = MagicMock()
     mock_aresponses = AsyncMock(return_value=mock_response)
+    mock_aresponses.__name__ = "aresponses"
 
     with patch.object(litellm, "aresponses", mock_aresponses):
         router = Router(model_list=model_list)
@@ -363,6 +352,45 @@ async def test_router_silent_experiment_aresponses():
         )
         assert primary_call is not None
         assert primary_call.kwargs["model"] == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_router_silent_experiment_skips_mutating_call_types():
+    """
+    Regression test: silent_model mirroring must not replay mutating
+    operations (fine-tuning jobs, skill deletion, file operations,
+    passthrough) against the silent deployment's account. Only the explicit
+    allowlist of safe inference call types (aresponses, anthropic_messages)
+    is eligible for mirroring.
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "api_key": "fake-key",
+                "silent_model": "silent-model",
+            },
+        },
+        {
+            "model_name": "silent-model",
+            "litellm_params": {
+                "model": "openai/gpt-4o",
+                "api_key": "fake-key",
+            },
+        },
+    ]
+
+    mock_response = MagicMock()
+    mock_adelete_skill = AsyncMock(return_value=mock_response)
+
+    with patch.object(litellm, "adelete_skill", mock_adelete_skill):
+        router = Router(model_list=model_list)
+        await router.adelete_skill(model="primary-model", skill_id="skill-123")
+
+        await asyncio.sleep(0.1)
+
+        assert mock_adelete_skill.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -281,3 +281,61 @@ def test_router_silent_experiment_completion():
         assert silent_call[1]["model"] == "openai/gpt-4"
         # Verify model_group is set to the silent model name for correct metric attribution
         assert silent_call[1]["metadata"]["model_group"] == "silent-model"
+
+
+@pytest.mark.asyncio
+async def test_router_silent_experiment_aresponses():
+    """
+    Regression: silent_model in litellm_params must fire a background aresponses call
+    when the primary request goes through /v1/responses (issue #31888).
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {
+                "model": "openai/gpt-4o-mini",
+                "api_key": "fake-key",
+                "silent_model": "silent-model",
+            },
+        },
+        {
+            "model_name": "silent-model",
+            "litellm_params": {
+                "model": "openai/gpt-4o",
+                "api_key": "fake-key",
+            },
+        },
+    ]
+
+    mock_response = MagicMock()
+    mock_aresponses = AsyncMock(return_value=mock_response)
+
+    with patch.object(litellm, "aresponses", mock_aresponses):
+        router = Router(model_list=model_list)
+        await router.aresponses(
+            model="primary-model",
+            input=[{"role": "user", "content": "hi"}],
+        )
+
+        await asyncio.sleep(0.1)
+
+        assert mock_aresponses.call_count == 2
+
+        call_args_list = mock_aresponses.call_args_list
+        for call in call_args_list:
+            assert "silent_model" not in call.kwargs
+
+        silent_call = next(
+            (c for c in call_args_list if c.kwargs.get("metadata", {}).get("is_silent_experiment") is True),
+            None,
+        )
+        assert silent_call is not None
+        assert silent_call.kwargs["model"] == "openai/gpt-4o"
+        assert silent_call.kwargs["metadata"]["model_group"] == "silent-model"
+
+        primary_call = next(
+            (c for c in call_args_list if not c.kwargs.get("metadata", {}).get("is_silent_experiment")),
+            None,
+        )
+        assert primary_call is not None
+        assert primary_call.kwargs["model"] == "openai/gpt-4o-mini"

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -394,6 +394,35 @@ async def test_router_silent_experiment_skips_mutating_call_types():
 
 
 @pytest.mark.asyncio
+async def test_silent_experiment_ageneric_skips_auto_executable_mcp_tools():
+    """
+    Regression test: mirroring must not fire when the request's tools
+    include an MCP tool with require_approval == "never". aresponses
+    auto-executes such tools using the request's MCP auth headers, so
+    mirroring would independently replay that tool execution against the
+    silent deployment.
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+        },
+    ]
+    router = Router(model_list=model_list)
+    mock_aresponses = AsyncMock()
+
+    with patch.object(litellm, "aresponses", mock_aresponses):
+        await router._silent_experiment_ageneric(
+            silent_model="primary-model",
+            original_function=litellm.aresponses,
+            input=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "mcp", "server_label": "x", "require_approval": "never"}],
+        )
+
+    mock_aresponses.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_silent_experiment_ageneric_no_recurse():
     """
     _silent_experiment_ageneric must not fire a second experiment when

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -86,6 +86,30 @@ def test_get_silent_experiment_kwargs():
     assert result["metadata"]["user_api_key_auth"] is mock_auth
 
 
+def test_get_silent_experiment_kwargs_strips_tags():
+    """
+    Regression test: _update_kwargs_with_deployment merges deployment and
+    credential tags onto metadata["tags"] additively and never resets them.
+    If the primary deployment's tags survive into the silent kwargs, they
+    leak into the silent deployment's own tag merge on the second pass,
+    corrupting spend/tag attribution for the mirrored call.
+    """
+    model_list = [
+        {
+            "model_name": "gpt-3.5-turbo",
+            "litellm_params": {"model": "gpt-3.5-turbo", "api_key": "fake-key"},
+        },
+    ]
+    router = Router(model_list=model_list)
+    kwargs = {
+        "metadata": {
+            "tags": ["Credential: primary-cred", "primary-deployment-tag"],
+        },
+    }
+    result = router._get_silent_experiment_kwargs(**kwargs)
+    assert "tags" not in result["metadata"]
+
+
 def test_silent_experiment_completion_direct():
     """
     Test _silent_experiment_completion directly (for router code coverage).

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -339,3 +339,58 @@ async def test_router_silent_experiment_aresponses():
         )
         assert primary_call is not None
         assert primary_call.kwargs["model"] == "openai/gpt-4o-mini"
+
+
+@pytest.mark.asyncio
+async def test_silent_experiment_ageneric_no_recurse():
+    """
+    _silent_experiment_ageneric must not fire a second experiment when
+    is_silent_experiment is already True in metadata (infinite-loop guard).
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+        },
+    ]
+    router = Router(model_list=model_list)
+    mock_aresponses = AsyncMock()
+
+    with patch.object(litellm, "aresponses", mock_aresponses):
+        await router._silent_experiment_ageneric(
+            silent_model="primary-model",
+            original_function=litellm.aresponses,
+            model="primary-model",
+            input=[{"role": "user", "content": "hi"}],
+            metadata={"is_silent_experiment": True},
+        )
+
+    mock_aresponses.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_silent_experiment_ageneric_error_is_caught():
+    """
+    _silent_experiment_ageneric must catch and log exceptions from the
+    downstream call without propagating them to the caller.
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "fake-key"},
+        },
+    ]
+    router = Router(model_list=model_list)
+
+    with patch.object(
+        router,
+        "_ageneric_api_call_with_fallbacks",
+        new_callable=AsyncMock,
+        side_effect=Exception("downstream failure"),
+    ):
+        await router._silent_experiment_ageneric(
+            silent_model="primary-model",
+            original_function=litellm.aresponses,
+            model="primary-model",
+            input=[{"role": "user", "content": "hi"}],
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #31888

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
Start the proxy with two models configured in model_list — gpt-4o-mini-with-mirror (has silent_model: gpt-4o-mini-mirror in litellm_params) and gpt-4o-mini-mirror:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

```bash
curl -s http://localhost:4000/v1/responses 

-H "Content-Type: application/json" 

-H "Authorization: Bearer sk-1234" 

-d '{"model":"gpt-4o-mini-with-mirror","input":[{"role":"user","content":"say hi"}]}'
```

Response:

```json
{"id":"resp_X9_ai5...","output":[{"content":[{"text":"Hi there! How can I assist you today?","type":"output_text"}],"role":"assistant","status":"completed","type":"message"}],"status":"completed"}
```

Proxy log confirming the silent experiment fired as a background task:

```
14:46:44 - LiteLLM Router:INFO - router.py:2578 - Starting silent experiment for model gpt-4o-mini-mirror
```

The primary call returned a real response from OpenAI. The log line confirms Starting silent experiment now fires for /v1/responses requests. Before this fix, silent_model in litellm_params was silently ignored on the generic execution path and this line never appeared

## Type

🐛 Bug Fix

## Changes

`_ageneric_api_call_with_fallbacks_helper` never checked `silent_model` like `_acompletion` does, so mirroring was silently dropped on `/v1/responses`, Anthropic Messages, and other non-completion routes. Adds `_silent_experiment_ageneric` to fire the mirrored call as a background task, popping `silent_model` so it doesn't leak upstream.

Three follow-up commits fix issues review caught: a tag leak in `_get_silent_experiment_kwargs` that corrupted spend attribution on the mirrored call, mirroring being reachable from mutating operations (fine-tuning, skill deletion, file ops, passthrough) via an explicit call-type allowlist, and the mirror re-executing auto-approved MCP tools with the same auth headers. Each has a regression test confirmed to fail pre-fix and pass after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Change is limited to optional background mirror traffic on the generic router path; primary request behavior is unchanged aside from stripping an invalid param.
> 
> **Overview**
> **Fixes silent `silent_model` mirroring on routes that use the router’s generic execution path** (e.g. `/v1/responses`), where `litellm_params.silent_model` was ignored while `_acompletion` already mirrored traffic.
> 
> Adds `_silent_experiment_ageneric`, which reuses `_get_silent_experiment_kwargs`, sets `metadata.model_group` on the shadow call, and invokes `_ageneric_api_call_with_fallbacks` with the same underlying API function. `_ageneric_api_call_with_fallbacks_helper` now pops `silent_model` from deployment params, schedules that work via `asyncio.create_task`, and also removes `silent_model` from the primary `response_kwargs` so it is not forwarded upstream.
> 
> Includes `test_router_silent_experiment_aresponses` to assert `router.aresponses` issues a primary plus a background call tagged with `is_silent_experiment`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc8353a4724e958ac8befe040a922261f192b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


