### PR TITLE
feat(cli): route lite login through /ui/login with SSO when configured

### DIFF
--- a/litellm/proxy/client/README.md
+++ b/litellm/proxy/client/README.md
@@ -315,8 +315,10 @@ sequenceDiagram
     
     CLI->>Proxy: POST /sso/cli/start
     Proxy->>CLI: Return login_id, poll_secret, user_code
-    CLI->>Browser: Open /sso/key/generate?source=litellm-cli&key=login_id
+    CLI->>Browser: Open /ui/login?source=litellm-cli&key=login_id
     
+    Browser->>Proxy: GET /.well-known/litellm-ui-config
+    Proxy->>Browser: sso_configured
     Browser->>Proxy: GET /sso/key/generate?source=litellm-cli&key=login_id
     Proxy->>Proxy: Set cli_state = litellm-session-token:login_id
     Proxy->>SSO: Redirect with state=litellm-session-token:login_id
@@ -345,13 +347,14 @@ The CLI provides three authentication commands:
 ### Authentication Flow Steps
 
 1. **Start Session**: CLI creates a short-lived login session with `/sso/cli/start`
-2. **Open Browser**: CLI opens browser to `/sso/key/generate` with CLI source and login ID parameters
-3. **SSO Redirect**: Proxy sets the formatted state (`litellm-session-token:{login_id}`) as OAuth state parameter and redirects to SSO provider
-4. **User Authentication**: User completes SSO authentication in browser
-5. **Callback Processing**: SSO provider redirects back to proxy with state parameter
-6. **User Code Verification**: Browser confirms the verification code shown in the CLI
-7. **Polling**: CLI polls `/sso/cli/poll/{login_id}` with the polling secret header until the JWT is ready. When `CLI_SSO_CLAIM_MAP` is configured on the proxy, the poll response may include `attribution_metadata` (allowlisted scalar OIDC claims for client attribution).
-8. **Token Storage**: CLI saves the authentication token to `~/.litellm/token.json`
+2. **Open Browser**: CLI opens browser to `/ui/login` with CLI source and login ID parameters
+3. **SSO Hand-off**: The login page reads `sso_configured` from `/.well-known/litellm-ui-config`; when SSO is set up it forwards the CLI source and login ID to `/sso/key/generate` to start the OAuth flow
+4. **SSO Redirect**: Proxy sets the formatted state (`litellm-session-token:{login_id}`) as OAuth state parameter and redirects to SSO provider
+5. **User Authentication**: User completes SSO authentication in browser
+6. **Callback Processing**: SSO provider redirects back to proxy with state parameter
+7. **User Code Verification**: Browser confirms the verification code shown in the CLI
+8. **Polling**: CLI polls `/sso/cli/poll/{login_id}` with the polling secret header until the JWT is ready. When `CLI_SSO_CLAIM_MAP` is configured on the proxy, the poll response may include `attribution_metadata` (allowlisted scalar OIDC claims for client attribution).
+9. **Token Storage**: CLI saves the authentication token to `~/.litellm/token.json`
 
 ### Benefits of This Approach
 

--- a/litellm/proxy/client/cli/commands/auth.py
+++ b/litellm/proxy/client/cli/commands/auth.py
@@ -532,15 +532,15 @@ def login(ctx: click.Context):
         poll_secret = cli_sso_flow["poll_secret"]
         user_code = cli_sso_flow["user_code"]
 
-        sso_url = f"{base_url}/sso/key/generate?" + urlencode({"source": LITELLM_CLI_SOURCE_IDENTIFIER, "key": key_id})
+        login_url = f"{base_url}/ui/login?" + urlencode({"source": LITELLM_CLI_SOURCE_IDENTIFIER, "key": key_id})
 
-        click.echo(f"Opening browser to: {sso_url}")
-        click.echo("Please complete the SSO authentication in your browser...")
+        click.echo(f"Opening browser to: {login_url}")
+        click.echo("Please complete authentication in your browser...")
         click.echo(f"Verification code: {user_code}")
         click.echo(f"Session ID: {key_id}")
 
         # Open browser
-        webbrowser.open(sso_url)
+        webbrowser.open(login_url)
 
         # Poll for authentication completion
         click.echo("Waiting for authentication...")

--- a/tests/test_litellm/proxy/client/cli/test_auth_commands.py
+++ b/tests/test_litellm/proxy/client/cli/test_auth_commands.py
@@ -321,7 +321,8 @@ class TestLoginCommand:
             # Verify browser was opened with correct URL
             mock_browser.assert_called_once()
             call_args = mock_browser.call_args[0][0]
-            assert "https://test.example.com/sso/key/generate" in call_args
+            assert "https://test.example.com/ui/login" in call_args
+            assert "source=litellm-cli" in call_args
             assert "cli-test-uuid-123" in call_args
             assert "Verification code: ABCD-EFGH" in result.output
             mock_post.assert_called_once()
@@ -650,7 +651,7 @@ class TestCLIKeyRegenerationFlow:
             # Verify browser was opened
             mock_browser.assert_called_once()
             call_args = mock_browser.call_args[0][0]
-            assert "https://test.example.com/sso/key/generate" in call_args
+            assert "https://test.example.com/ui/login" in call_args
 
             # Verify two polling requests were made
             assert mock_get.call_count == 2
@@ -715,7 +716,7 @@ class TestCLIKeyRegenerationFlow:
             # Verify browser was opened
             mock_browser.assert_called_once()
             call_args = mock_browser.call_args[0][0]
-            assert "https://test.example.com/sso/key/generate" in call_args
+            assert "https://test.example.com/ui/login" in call_args
             assert "source=litellm-cli" in call_args
             assert "key=cli-session-uuid-solo" in call_args
 

--- a/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.test.tsx
@@ -370,4 +370,98 @@ describe("LoginPage", () => {
       expect(mockReplace).not.toHaveBeenCalledWith("/ui/?login=success");
     });
   });
+
+  describe("CLI login (lite login) hand-off to SSO", () => {
+    const originalLocation = window.location;
+    const validKey = "cli-abcdefghijkl0123";
+
+    const setLocationSearch = (search: string) => {
+      Object.defineProperty(window, "location", {
+        value: { ...originalLocation, search, pathname: "/ui/login" },
+        writable: true,
+      });
+    };
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+
+    const renderPage = () => {
+      const queryClient = createQueryClient();
+      return render(
+        <QueryClientProvider client={queryClient}>
+          <LoginPage />
+        </QueryClientProvider>,
+      );
+    };
+
+    it("redirects to /sso/key/generate carrying source and key when SSO is configured", async () => {
+      setLocationSearch(`?source=litellm-cli&key=${validKey}`);
+      (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null, sso_configured: true },
+        isLoading: false,
+      });
+      (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          `http://localhost:4000/sso/key/generate?source=litellm-cli&key=${validKey}`,
+        );
+      });
+    });
+
+    it("forwards user_code to the SSO redirect when present", async () => {
+      setLocationSearch(`?source=litellm-cli&key=${validKey}&user_code=ABCD-EFGH`);
+      (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null, sso_configured: true },
+        isLoading: false,
+      });
+      (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          `http://localhost:4000/sso/key/generate?source=litellm-cli&key=${validKey}&user_code=ABCD-EFGH`,
+        );
+      });
+    });
+
+    it("shows the login form and does not redirect to SSO when SSO is not configured", async () => {
+      setLocationSearch(`?source=litellm-cli&key=${validKey}`);
+      (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null, sso_configured: false },
+        isLoading: false,
+      });
+      (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("does not redirect to SSO when the CLI key is malformed", async () => {
+      setLocationSearch("?source=litellm-cli&key=not-a-valid-login-id");
+      (useUIConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+        data: { auto_redirect_to_sso: false, server_root_path: "/", proxy_base_url: null, sso_configured: true },
+        isLoading: false,
+      });
+      (getCookieFromDocument as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+      renderPage();
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -13,6 +13,9 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useWorker } from "@/hooks/useWorker";
 
+const LITELLM_CLI_SOURCE_IDENTIFIER = "litellm-cli";
+const CLI_LOGIN_ID_REGEX = /^cli-[A-Za-z0-9_-]{12,124}$/;
+
 function LoginPageContent() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -69,6 +72,24 @@ function LoginPageContent() {
     if (switchingWorker && uiConfig?.is_control_plane) {
       clearTokenCookies();
       setIsLoading(false);
+      return;
+    }
+
+    const cliSource = params.get("source");
+    const cliKey = params.get("key");
+    if (
+      cliSource === LITELLM_CLI_SOURCE_IDENTIFIER &&
+      cliKey &&
+      CLI_LOGIN_ID_REGEX.test(cliKey) &&
+      uiConfig?.sso_configured
+    ) {
+      const cliUserCode = params.get("user_code");
+      const ssoQuery = new URLSearchParams({
+        source: LITELLM_CLI_SOURCE_IDENTIFIER,
+        key: cliKey,
+        ...(cliUserCode ? { user_code: cliUserCode } : {}),
+      });
+      router.push(`${getProxyBaseUrl()}/sso/key/generate?${ssoQuery.toString()}`);
       return;
     }
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run against a local proxy that has SSO configured (any of `GENERIC_CLIENT_ID`, `GOOGLE_CLIENT_ID`, or `MICROSOFT_CLIENT_ID` set), hitting the real identity provider

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Confirm the proxy reports SSO as configured

```
curl -s http://localhost:4000/.well-known/litellm-ui-config | jq '{sso_configured, auto_redirect_to_sso}'
```

3. Start the CLI login

```
lite login --base-url http://localhost:4000
```

4. The terminal now prints `Opening browser to: http://localhost:4000/ui/login?source=litellm-cli&key=cli-...` and opens that page. Because `sso_configured` is true, the dashboard login page forwards the CLI source and login id on to `/sso/key/generate` and the browser proceeds through the identity provider. After you authenticate, the browser shows the CLI success page and the terminal prints `Login successful`

5. Confirm the JWT was stored for this proxy

```
lite whoami --base-url http://localhost:4000
cat ~/.litellm/token.json | jq '{base_url, user_id}'
```

To see the non-SSO behavior, restart the proxy with the SSO client ids unset; step 2 reports `sso_configured: false` and the `/ui/login` page shows the normal username and password form instead of redirecting

## Type

🆕 New Feature

## Changes

`lite login` previously opened the browser straight to `/sso/key/generate`, which either bounced to the OAuth provider or, when no SSO was configured, rendered a bare legacy password form. This routes the CLI through the real dashboard login page at `/ui/login` instead, carrying the same `source=litellm-cli` and `key=<login_id>` query params it already used

The dashboard login page now recognizes a CLI login. It reads `sso_configured` from `/.well-known/litellm-ui-config`, and when SSO is set up it forwards the CLI source and login id on to `/sso/key/generate` to start the existing OAuth flow, so the CLI poll loop still receives a JWT keyed by the login id. The hand-off runs before the existing session-cookie check so a stale UI token can't short-circuit a fresh CLI login, and a malformed login id is rejected client-side before any redirect. When SSO is not configured the page shows the normal username and password form, unchanged

No server-side changes are needed; the OAuth state threading and the `/sso/cli/*` start, complete, and poll endpoints are reused as-is

Tests: `LoginPage.test.tsx` covers the CLI hand-off end to end, asserting it redirects to `/sso/key/generate` carrying source and key when SSO is configured, forwards `user_code` when present, shows the form without redirecting when SSO is not configured, and refuses to redirect on a malformed login id. `test_auth_commands.py` is updated to assert `lite login` opens `/ui/login` with the CLI source
