### PR TITLE
feat(vertex-ai): support gemini 3.1 flash tts

### DIFF
--- a/litellm/endpoints/speech/speech_to_completion_bridge/transformation.py
+++ b/litellm/endpoints/speech/speech_to_completion_bridge/transformation.py
@@ -22,14 +22,25 @@ class SpeechToCompletionBridgeTransformationHandler:
     ) -> dict:
         passed_optional_params = {}
         for op in optional_params:
-            if op in OPENAI_CHAT_COMPLETION_PARAMS:
+            if op != "response_format" and op in OPENAI_CHAT_COMPLETION_PARAMS:
                 passed_optional_params[op] = optional_params[op]
 
         if voice is not None:
+            audio_params = None
             if isinstance(voice, str):
-                passed_optional_params["audio"] = {"voice": voice}
+                audio_params = {"voice": voice}
+            elif isinstance(voice, dict):
+                from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+                    normalize_gemini_speech_config,
+                )
+
+                speech_config = voice.get("speechConfig", voice.get("speech_config", voice))
+                if isinstance(speech_config, dict):
+                    audio_params = {"speech_config": normalize_gemini_speech_config(speech_config)}
+            if audio_params is not None:
                 if "response_format" in optional_params:
-                    passed_optional_params["audio"]["format"] = optional_params["response_format"]
+                    audio_params["format"] = "pcm16"
+                passed_optional_params["audio"] = audio_params
 
         return_kwargs = {
             "model": model,

--- a/litellm/llms/gemini/google_genai/transformation.py
+++ b/litellm/llms/gemini/google_genai/transformation.py
@@ -16,7 +16,10 @@ from litellm.llms.vertex_ai.common_utils import (
     _build_vertex_schema,
     supports_response_json_schema,
 )
-from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+    VertexLLM,
+    normalize_gemini_speech_config,
+)
 from litellm.types.router import GenericLiteLLMParams
 
 if TYPE_CHECKING:
@@ -140,7 +143,10 @@ class GoogleGenAIConfig(BaseGoogleGenAIGenerateContentConfig, VertexLLM):
             if is_supported:
                 # Always output in camelCase for Google GenAI API
                 output_key = param_camel if param != param_camel else param
-                _generate_content_config_dict[output_key] = value
+                if param_snake == "speech_config" and isinstance(value, dict):
+                    _generate_content_config_dict[output_key] = normalize_gemini_speech_config(value)
+                else:
+                    _generate_content_config_dict[output_key] = value
         return _generate_content_config_dict
 
     def validate_environment(

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -120,6 +120,35 @@ else:
     StreamingChoices = Any
 
 
+_GEMINI_SPEECH_CONFIG_KEY_MAP: dict[str, str] = {
+    "multi_speaker_voice_config": "multiSpeakerVoiceConfig",
+    "speaker_voice_configs": "speakerVoiceConfigs",
+    "voice_config": "voiceConfig",
+    "prebuilt_voice_config": "prebuiltVoiceConfig",
+    "voice_name": "voiceName",
+    "language_code": "languageCode",
+}
+
+
+def _normalize_gemini_speech_config_item(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {
+            _GEMINI_SPEECH_CONFIG_KEY_MAP.get(key, key): _normalize_gemini_speech_config_item(item)
+            for key, item in value.items()
+            if isinstance(key, str)
+        }
+    if isinstance(value, list):
+        return [_normalize_gemini_speech_config_item(item) for item in value]
+    return value
+
+
+def normalize_gemini_speech_config(value: Mapping[str, object]) -> dict[str, object]:
+    normalized_value = _normalize_gemini_speech_config_item(value)
+    if isinstance(normalized_value, dict):
+        return cast(dict[str, object], normalized_value)
+    return {}
+
+
 class VertexAIBaseConfig:
     def get_mapped_special_auth_params(self) -> dict:
         """
@@ -1034,12 +1063,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             languageCode: "en-US",
         }
         """
-        from litellm.types.llms.vertex_ai import (
-            PrebuiltVoiceConfig,
-            SpeechConfig,
-            VoiceConfig,
-        )
-
         # Validate audio format - Gemini TTS only supports pcm16
         audio_format = value.get("format")
         if audio_format is not None and audio_format != "pcm16":
@@ -1049,18 +1072,31 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 f"Please set audio format to 'pcm16'."
             )
 
-        # Map OpenAI audio parameter to Gemini speech config
-        speech_config: SpeechConfig = {}
+        for speech_config_key in ("speechConfig", "speech_config"):
+            speech_config_value = value.get(speech_config_key)
+            if isinstance(speech_config_value, Mapping):
+                speech_config = normalize_gemini_speech_config(speech_config_value)
+                language_code = value.get("language_code", value.get("languageCode"))
+                if language_code is not None and "languageCode" not in speech_config:
+                    return {**speech_config, "languageCode": language_code}
+                return speech_config
+
+        speech_config: dict[str, object] = {}
 
         if "voice" in value:
-            prebuilt_voice_config: PrebuiltVoiceConfig = {"voiceName": value["voice"]}
-            voice_config: VoiceConfig = {"prebuiltVoiceConfig": prebuilt_voice_config}
-            speech_config["voiceConfig"] = voice_config
+            speech_config = {
+                "voiceConfig": {
+                    "prebuiltVoiceConfig": {
+                        "voiceName": value["voice"],
+                    }
+                }
+            }
 
-        if "language_code" in value:
-            speech_config["languageCode"] = value["language_code"]
+        language_code = value.get("language_code", value.get("languageCode"))
+        if language_code is not None:
+            return {**speech_config, "languageCode": language_code}
 
-        return cast(dict, speech_config)
+        return speech_config
 
     @staticmethod
     def _apply_include_server_side_tool_invocations(
@@ -1234,7 +1270,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 optional_params["responseModalities"].append("AUDIO")
 
         # Set default temperature to 1.0 for Gemini 3 models if not specified
-        if VertexGeminiConfig._is_gemini_3_or_newer(model):
+        if VertexGeminiConfig._is_gemini_3_or_newer(model) and "tts" not in model.lower():
             if "temperature" not in optional_params:
                 optional_params["temperature"] = 1.0
 

--- a/litellm/llms/vertex_ai/google_genai/transformation.py
+++ b/litellm/llms/vertex_ai/google_genai/transformation.py
@@ -38,34 +38,15 @@ class VertexAIGoogleGenAIConfig(GoogleGenAIConfig):
 
         return default_headers
 
-    def _camel_to_snake(self, camel_str: str) -> str:
-        """Convert camelCase to snake_case"""
-        import re
-
-        return re.sub(r"(?<!^)(?=[A-Z])", "_", camel_str).lower()
-
     def map_generate_content_optional_params(
         self,
-        generate_content_config_dict,
+        generate_content_config_dict: dict[str, Any],
         model: str,
-    ):
-        """
-        Map Google GenAI parameters to provider-specific format.
-
-        Args:
-            generate_content_optional_params: Optional parameters for generate content
-            model: The model name
-
-        Returns:
-            Mapped parameters for the provider
-        """
-
-        _generate_content_config_dict: Dict = {}
-
-        for param, value in generate_content_config_dict.items():
-            camel_case_key = self._camel_to_snake(param)
-            _generate_content_config_dict[camel_case_key] = value
-        return _generate_content_config_dict
+    ) -> dict[str, Any]:
+        return super().map_generate_content_optional_params(
+            generate_content_config_dict=generate_content_config_dict,
+            model=model,
+        )
 
     def transform_generate_content_request(
         self,

--- a/litellm/llms/vertex_ai/text_to_speech/transformation.py
+++ b/litellm/llms/vertex_ai/text_to_speech/transformation.py
@@ -68,6 +68,15 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         "wav": "LINEAR16",
         "pcm": "LINEAR16",
     }
+    GEMINI_FORMAT_MAPPINGS = {
+        **FORMAT_MAPPINGS,
+        "alaw": "ALAW",
+        "mulaw": "MULAW",
+        "ogg_opus": "OGG_OPUS",
+        "pcm": "LINEAR16",
+        "pcm16": "LINEAR16",
+        "linear16": "LINEAR16",
+    }
 
     def __init__(self) -> None:
         BaseTextToSpeechConfig.__init__(self)
@@ -76,6 +85,7 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
     def _map_voice_to_vertex_format(
         self,
         voice: Optional[Union[str, Dict]],
+        model: Optional[str] = None,
     ) -> Tuple[Optional[str], Optional[Dict]]:
         """
         Map voice to Vertex AI format.
@@ -92,6 +102,9 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         """
         if voice is None:
             return None, None
+
+        if model is not None and self._is_gemini_tts_model(model):
+            return self._map_gemini_tts_voice_to_vertex_format(model=model, voice=voice)
 
         if isinstance(voice, dict):
             # Already in Vertex AI format
@@ -120,6 +133,129 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         }
 
         return voice_str, voice_dict
+
+    @staticmethod
+    def _is_gemini_tts_model(model: str) -> bool:
+        model_lower = model.lower()
+        return "gemini" in model_lower and "tts" in model_lower
+
+    @staticmethod
+    def _get_str_value(source: dict, *keys: str) -> Optional[str]:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, str):
+                return value
+        return None
+
+    @staticmethod
+    def _get_dict_value(source: dict, *keys: str) -> Optional[dict]:
+        for key in keys:
+            value = source.get(key)
+            if isinstance(value, dict):
+                return value
+        return None
+
+    def _extract_gemini_tts_speaker_configs(self, voice: dict) -> list:
+        speech_config = self._get_dict_value(voice, "speechConfig", "speech_config") or voice
+        multi_speaker_config = self._get_dict_value(
+            speech_config,
+            "multiSpeakerVoiceConfig",
+            "multi_speaker_voice_config",
+        )
+        if multi_speaker_config is None:
+            return []
+        raw_speaker_configs = multi_speaker_config.get(
+            "speakerVoiceConfigs",
+            multi_speaker_config.get("speaker_voice_configs", []),
+        )
+        if not isinstance(raw_speaker_configs, list):
+            return []
+        speaker_configs = []
+        for raw_config in raw_speaker_configs:
+            if not isinstance(raw_config, dict):
+                continue
+            speaker_alias = self._get_str_value(
+                raw_config,
+                "speakerAlias",
+                "speaker_alias",
+                "speaker",
+            )
+            speaker_id = self._get_str_value(raw_config, "speakerId", "speaker_id")
+            if speaker_id is None:
+                voice_config = self._get_dict_value(raw_config, "voiceConfig", "voice_config")
+                if voice_config is not None:
+                    prebuilt_voice_config = self._get_dict_value(
+                        voice_config,
+                        "prebuiltVoiceConfig",
+                        "prebuilt_voice_config",
+                    )
+                    if prebuilt_voice_config is not None:
+                        speaker_id = self._get_str_value(
+                            prebuilt_voice_config,
+                            "voiceName",
+                            "voice_name",
+                        )
+            if speaker_alias is not None and speaker_id is not None:
+                speaker_configs.append(
+                    {
+                        "speakerAlias": speaker_alias,
+                        "speakerId": speaker_id,
+                    }
+                )
+        return speaker_configs
+
+    def _extract_gemini_tts_voice_name(self, voice: dict) -> Optional[str]:
+        voice_name = self._get_str_value(voice, "name", "voiceName", "voice_name")
+        if voice_name is not None:
+            return voice_name
+        speech_config = self._get_dict_value(voice, "speechConfig", "speech_config") or voice
+        voice_config = self._get_dict_value(speech_config, "voiceConfig", "voice_config")
+        if voice_config is None:
+            return None
+        prebuilt_voice_config = self._get_dict_value(
+            voice_config,
+            "prebuiltVoiceConfig",
+            "prebuilt_voice_config",
+        )
+        if prebuilt_voice_config is None:
+            return None
+        return self._get_str_value(prebuilt_voice_config, "voiceName", "voice_name")
+
+    def _map_gemini_tts_voice_to_vertex_format(
+        self,
+        model: str,
+        voice: Union[str, dict],
+    ) -> Tuple[Optional[str], dict]:
+        if isinstance(voice, str):
+            return voice, {
+                "languageCode": self.DEFAULT_LANGUAGE_CODE,
+                "modelName": model,
+                "name": voice,
+            }
+
+        language_code = self._get_str_value(voice, "languageCode", "language_code") or self.DEFAULT_LANGUAGE_CODE
+        model_name = self._get_str_value(voice, "modelName", "model_name") or model
+        speaker_configs = self._extract_gemini_tts_speaker_configs(voice)
+        if speaker_configs:
+            return None, {
+                "languageCode": language_code,
+                "modelName": model_name,
+                "multiSpeakerVoiceConfig": {
+                    "speakerVoiceConfigs": speaker_configs,
+                },
+            }
+        voice_name = self._extract_gemini_tts_voice_name(voice)
+        if voice_name is not None:
+            return None, {
+                "languageCode": language_code,
+                "modelName": model_name,
+                "name": voice_name,
+            }
+        return None, {
+            **voice,
+            "languageCode": language_code,
+            "modelName": model_name,
+        }
 
     def dispatch_text_to_speech(
         self,
@@ -227,15 +363,19 @@ class VertexAITextToSpeechConfig(BaseTextToSpeechConfig, VertexBase):
         ##########################################################
         # Map voice using helper
         ##########################################################
-        mapped_voice_str, voice_dict = self._map_voice_to_vertex_format(voice)
+        mapped_voice_str, voice_dict = self._map_voice_to_vertex_format(
+            voice=voice,
+            model=model,
+        )
         if voice_dict is not None:
             mapped_params["vertex_voice_dict"] = voice_dict
 
         # Map response format
         if "response_format" in optional_params:
             format_name = optional_params["response_format"]
-            if format_name in self.FORMAT_MAPPINGS:
-                mapped_params["audioEncoding"] = self.FORMAT_MAPPINGS[format_name]
+            format_mappings = self.GEMINI_FORMAT_MAPPINGS if self._is_gemini_tts_model(model) else self.FORMAT_MAPPINGS
+            if format_name in format_mappings:
+                mapped_params["audioEncoding"] = format_mappings[format_name]
             else:
                 # Try to use it directly as Google Cloud format
                 mapped_params["audioEncoding"] = format_name

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -7716,6 +7716,7 @@ def speech(
     kwargs.pop("tags", [])
 
     optional_params = {}
+    original_voice = voice
     if response_format is not None:
         optional_params["response_format"] = response_format
     if speed is not None:
@@ -7950,7 +7951,7 @@ def speech(
         generic_optional_params = GenericLiteLLMParams(**kwargs)
 
         # Handle Gemini models separately (they use speech_to_completion_bridge)
-        if "gemini" in model:
+        if "gemini" in model and response_format is None:
             from .endpoints.speech.speech_to_completion_bridge.handler import (
                 speech_to_completion_bridge_handler,
             )
@@ -7958,7 +7959,7 @@ def speech(
             return speech_to_completion_bridge_handler.speech(
                 model=model,
                 input=input,
-                voice=voice,
+                voice=original_voice,
                 optional_params=optional_params,
                 litellm_params=litellm_params_dict,
                 headers=headers or {},

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18267,6 +18267,31 @@
         "tpm": 4000000,
         "rpm": 10
     },
+    "gemini/gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
+    },
     "gemini/gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -35633,6 +35658,31 @@
         },
         "web_search_billing_unit": "per_query"
     },
+    "vertex_ai/gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
+    },
     "vertex_ai/gemini-3.1-flash-lite": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
@@ -42444,6 +42494,31 @@
         "supported_endpoints": [
             "/v1/audio/speech"
         ]
+    },
+    "gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
     },
     "gemini-flash-latest": {
         "cache_read_input_token_cost": 3e-08,

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9060,10 +9060,21 @@ async def audio_speech(
         if callback_headers:
             custom_headers.update(callback_headers)
 
-        # Determine media type based on model type
         media_type = "audio/mpeg"  # Default for OpenAI TTS
-        request_model = data.get("model", "")
-        if request_model:
+        response_format = data.get("response_format")
+        if isinstance(response_format, str):
+            response_format_media_types = {
+                "mp3": "audio/mpeg",
+                "opus": "audio/ogg",
+                "ogg_opus": "audio/ogg",
+                "wav": "audio/wav",
+                "pcm": "audio/wav",
+                "pcm16": "audio/wav",
+                "linear16": "audio/wav",
+            }
+            media_type = response_format_media_types.get(response_format.lower(), media_type)
+        else:
+            request_model = data.get("model", "")
             request_model_lower = request_model.lower()
             if "gemini" in request_model_lower and (
                 "tts" in request_model_lower or "preview-tts" in request_model_lower
@@ -9084,7 +9095,22 @@ async def audio_speech(
         )
         verbose_proxy_logger.error("litellm.proxy.proxy_server.audio_speech(): Exception occured - {}".format(str(e)))
         verbose_proxy_logger.debug(traceback.format_exc())
-        raise e
+        if isinstance(e, ProxyException):
+            raise e
+        if isinstance(e, HTTPException):
+            raise ProxyException(
+                message=getattr(e, "message", str(e)),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+            )
+        error_msg = f"{str(e)}"
+        raise ProxyException(
+            message=getattr(e, "message", error_msg),
+            type=getattr(e, "type", "None"),
+            param=getattr(e, "param", "None"),
+            code=getattr(e, "status_code", 500),
+        )
 
 
 @router.post(

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -226,8 +226,18 @@ class VoiceConfig(TypedDict):
     prebuiltVoiceConfig: PrebuiltVoiceConfig
 
 
+class SpeakerVoiceConfig(TypedDict):
+    speaker: str
+    voiceConfig: VoiceConfig
+
+
+class MultiSpeakerVoiceConfig(TypedDict):
+    speakerVoiceConfigs: List[SpeakerVoiceConfig]
+
+
 class SpeechConfig(TypedDict, total=False):
     voiceConfig: VoiceConfig
+    multiSpeakerVoiceConfig: MultiSpeakerVoiceConfig
     languageCode: str
 
 

--- a/litellm/types/llms/vertex_ai_text_to_speech.py
+++ b/litellm/types/llms/vertex_ai_text_to_speech.py
@@ -4,7 +4,7 @@ Type definitions for Vertex AI Text-to-Speech API
 Reference: https://cloud.google.com/text-to-speech/docs/reference/rest/v1/text/synthesize
 """
 
-from typing import Optional
+from typing import List, Optional
 
 from typing_extensions import TypedDict
 
@@ -18,6 +18,16 @@ class VertexTextToSpeechInput(TypedDict, total=False):
 
     text: Optional[str]
     ssml: Optional[str]
+    prompt: Optional[str]
+
+
+class VertexTextToSpeechSpeakerVoiceConfig(TypedDict):
+    speakerAlias: str
+    speakerId: str
+
+
+class VertexTextToSpeechMultiSpeakerVoiceConfig(TypedDict):
+    speakerVoiceConfigs: List[VertexTextToSpeechSpeakerVoiceConfig]
 
 
 class VertexTextToSpeechVoice(TypedDict, total=False):
@@ -31,6 +41,8 @@ class VertexTextToSpeechVoice(TypedDict, total=False):
 
     languageCode: str
     name: str
+    modelName: str
+    multiSpeakerVoiceConfig: VertexTextToSpeechMultiSpeakerVoiceConfig
 
 
 class VertexTextToSpeechAudioConfig(TypedDict, total=False):
@@ -44,6 +56,7 @@ class VertexTextToSpeechAudioConfig(TypedDict, total=False):
 
     audioEncoding: str
     speakingRate: str
+    sampleRateHertz: int
 
 
 class VertexTextToSpeechRequest(TypedDict, total=False):

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18428,6 +18428,31 @@
         "tpm": 4000000,
         "rpm": 10
     },
+    "gemini/gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
+    },
     "gemini/gemini-2.5-pro": {
         "cache_read_input_token_cost": 1.25e-07,
         "cache_read_input_token_cost_above_200k_tokens": 2.5e-07,
@@ -35838,6 +35863,31 @@
         },
         "web_search_billing_unit": "per_query"
     },
+    "vertex_ai/gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
+    },
     "vertex_ai/gemini-3.1-flash-lite": {
         "cache_read_input_token_cost": 2.5e-08,
         "cache_read_input_token_cost_flex": 1.25e-08,
@@ -42679,6 +42729,31 @@
         "supported_endpoints": [
             "/v1/audio/speech"
         ]
+    },
+    "gemini-3.1-flash-tts-preview": {
+        "health_check_voice": "Kore",
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "audio_speech",
+        "output_cost_per_audio_token": 2e-05,
+        "output_cost_per_token": 2e-05,
+        "source": "https://cloud.google.com/text-to-speech/pricing",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "audio"
+        ],
+        "supports_audio_input": false,
+        "supports_audio_output": true,
+        "supports_function_calling": false,
+        "supports_prompt_caching": false
     },
     "gemini-flash-latest": {
         "cache_read_input_token_cost": 3e-08,

--- a/tests/litellm/llms/vertex_ai/text_to_speech/test_transformation.py
+++ b/tests/litellm/llms/vertex_ai/text_to_speech/test_transformation.py
@@ -1,14 +1,10 @@
-import json
 import os
 import sys
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import httpx
-import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.llms.vertex_ai.text_to_speech.transformation import (
@@ -46,9 +42,7 @@ class TestVertexAITextToSpeechConfig:
 
     @patch.object(VertexAITextToSpeechConfig, "_ensure_access_token")
     @patch.object(VertexAITextToSpeechConfig, "_get_token_and_url")
-    def test_transform_text_to_speech_request_body(
-        self, mock_get_token, mock_ensure_token
-    ):
+    def test_transform_text_to_speech_request_body(self, mock_get_token, mock_ensure_token):
         """Test that transform_text_to_speech_request generates correct request body"""
         # Mock authentication
         mock_ensure_token.return_value = ("mock-token", "test-project")
@@ -109,9 +103,7 @@ class TestVertexAITextToSpeechConfig:
         config = VertexAITextToSpeechConfig()
 
         # Test with a Chirp3 HD voice
-        voice_str, voice_dict = config._map_voice_to_vertex_format(
-            "en-US-Chirp3-HD-Charon"
-        )
+        voice_str, voice_dict = config._map_voice_to_vertex_format("en-US-Chirp3-HD-Charon")
 
         assert voice_str == "en-US-Chirp3-HD-Charon"
         assert voice_dict is not None
@@ -131,6 +123,125 @@ class TestVertexAITextToSpeechConfig:
         assert voice_str is None
         assert voice_dict == voice_input
 
+    def test_gemini_tts_multi_speaker_voice_mapping(self):
+        config = VertexAITextToSpeechConfig()
+
+        voice = {
+            "multi_speaker_voice_config": {
+                "speaker_voice_configs": [
+                    {
+                        "speaker": "Ryan",
+                        "voice_config": {
+                            "prebuilt_voice_config": {
+                                "voice_name": "Umbriel",
+                            },
+                        },
+                    },
+                    {
+                        "speaker": "Katie",
+                        "voice_config": {
+                            "prebuilt_voice_config": {
+                                "voice_name": "Leda",
+                            },
+                        },
+                    },
+                ],
+            },
+        }
+
+        expected_voice = {
+            "languageCode": "en-US",
+            "modelName": "gemini-3.1-flash-tts-preview",
+            "multiSpeakerVoiceConfig": {
+                "speakerVoiceConfigs": [
+                    {
+                        "speakerAlias": "Ryan",
+                        "speakerId": "Umbriel",
+                    },
+                    {
+                        "speakerAlias": "Katie",
+                        "speakerId": "Leda",
+                    },
+                ],
+            },
+        }
+
+        voice_str, optional_params = config.map_openai_params(
+            model="gemini-3.1-flash-tts-preview",
+            optional_params={"response_format": "mp3"},
+            voice=voice,
+        )
+        assert voice_str is None
+        assert optional_params["audioEncoding"] == "MP3"
+        assert optional_params["vertex_voice_dict"] == expected_voice
+
+        voice_str, optional_params = config.map_openai_params(
+            model="gemini-3.1-flash-tts-preview",
+            optional_params={"response_format": "pcm16"},
+            voice=voice,
+        )
+        assert voice_str is None
+        assert optional_params["audioEncoding"] == "LINEAR16"
+        assert optional_params["vertex_voice_dict"] == expected_voice
+
+    @patch.object(VertexAITextToSpeechConfig, "_ensure_access_token")
+    @patch.object(VertexAITextToSpeechConfig, "_get_token_and_url")
+    def test_gemini_tts_mp3_request_body(self, mock_get_token, mock_ensure_token):
+        mock_ensure_token.return_value = ("mock-token", "test-project")
+        mock_get_token.return_value = ("mock-token", "mock-url")
+        config = VertexAITextToSpeechConfig()
+
+        result = config.transform_text_to_speech_request(
+            model="gemini-3.1-flash-tts-preview",
+            input="Ryan: Hi.\nKatie: Hello.",
+            voice=None,
+            optional_params={
+                "audioEncoding": "MP3",
+                "vertex_voice_dict": {
+                    "languageCode": "en-US",
+                    "modelName": "gemini-3.1-flash-tts-preview",
+                    "multiSpeakerVoiceConfig": {
+                        "speakerVoiceConfigs": [
+                            {
+                                "speakerAlias": "Ryan",
+                                "speakerId": "Umbriel",
+                            },
+                            {
+                                "speakerAlias": "Katie",
+                                "speakerId": "Leda",
+                            },
+                        ],
+                    },
+                },
+            },
+            litellm_params={
+                "vertex_credentials": None,
+                "vertex_project": "test-project",
+                "vertex_location": "global",
+            },
+            headers={},
+        )
+
+        request_body = result["dict_body"]
+        assert request_body["input"] == {"text": "Ryan: Hi.\nKatie: Hello."}
+        assert request_body["voice"] == {
+            "languageCode": "en-US",
+            "modelName": "gemini-3.1-flash-tts-preview",
+            "multiSpeakerVoiceConfig": {
+                "speakerVoiceConfigs": [
+                    {
+                        "speakerAlias": "Ryan",
+                        "speakerId": "Umbriel",
+                    },
+                    {
+                        "speakerAlias": "Katie",
+                        "speakerId": "Leda",
+                    },
+                ],
+            },
+        }
+        assert request_body["audioConfig"]["audioEncoding"] == "MP3"
+
 
 @patch("litellm.llms.custom_httpx.llm_http_handler.HTTPHandler.post")
 @patch.object(VertexAITextToSpeechConfig, "_ensure_access_token")
@@ -145,9 +256,7 @@ def test_litellm_speech_vertex_ai_chirp(mock_get_token, mock_ensure_token, mock_
 
     # Mock HTTP response
     mock_response = Mock(spec=httpx.Response)
-    mock_response.content = (
-        b'{"audioContent": "SGVsbG8gV29ybGQ="}'  # base64 encoded "Hello World"
-    )
+    mock_response.content = b'{"audioContent": "SGVsbG8gV29ybGQ="}'  # base64 encoded "Hello World"
     mock_response.status_code = 200
     mock_response.headers = {"content-type": "application/json"}
     mock_response.json.return_value = {"audioContent": "SGVsbG8gV29ybGQ="}
@@ -166,13 +275,11 @@ def test_litellm_speech_vertex_ai_chirp(mock_get_token, mock_ensure_token, mock_
     call_kwargs = mock_post.call_args.kwargs
 
     # Verify the URL is the Google Cloud TTS API
-    assert (
-        call_kwargs["url"] == "https://texttospeech.googleapis.com/v1/text:synthesize"
-    )
+    assert call_kwargs["url"] == "https://texttospeech.googleapis.com/v1/text:synthesize"
 
     # Verify request body structure
-    assert "data" in call_kwargs
-    request_body = json.loads(call_kwargs["data"])
+    assert "json" in call_kwargs
+    request_body = call_kwargs["json"]
 
     # Verify input
     assert "input" in request_body
@@ -190,3 +297,68 @@ def test_litellm_speech_vertex_ai_chirp(mock_get_token, mock_ensure_token, mock_
     assert "headers" in call_kwargs
     assert "Authorization" in call_kwargs["headers"]
     assert call_kwargs["headers"]["Authorization"] == "Bearer mock-token"
+
+
+@patch("litellm.llms.custom_httpx.llm_http_handler.HTTPHandler.post")
+@patch.object(VertexAITextToSpeechConfig, "_ensure_access_token")
+@patch.object(VertexAITextToSpeechConfig, "_get_token_and_url")
+def test_litellm_speech_vertex_ai_gemini_tts_mp3_uses_cloud_tts(mock_get_token, mock_ensure_token, mock_post):
+    mock_ensure_token.return_value = ("mock-token", "test-project")
+    mock_get_token.return_value = ("mock-token", "mock-url")
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = {"audioContent": "SGVsbG8gV29ybGQ="}
+    mock_post.return_value = mock_response
+
+    litellm.speech(
+        model="vertex_ai/gemini-3.1-flash-tts-preview",
+        input="Ryan: Hi.\nKatie: Hello.",
+        voice={
+            "multi_speaker_voice_config": {
+                "speaker_voice_configs": [
+                    {
+                        "speaker": "Ryan",
+                        "voice_config": {
+                            "prebuilt_voice_config": {
+                                "voice_name": "Umbriel",
+                            },
+                        },
+                    },
+                    {
+                        "speaker": "Katie",
+                        "voice_config": {
+                            "prebuilt_voice_config": {
+                                "voice_name": "Leda",
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+        response_format="mp3",
+        vertex_project="test-project",
+        vertex_location="global",
+    )
+
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args.kwargs
+    assert call_kwargs["url"] == "https://texttospeech.googleapis.com/v1/text:synthesize"
+    request_body = call_kwargs["json"]
+    assert request_body["audioConfig"]["audioEncoding"] == "MP3"
+    assert request_body["voice"] == {
+        "languageCode": "en-US",
+        "modelName": "gemini-3.1-flash-tts-preview",
+        "multiSpeakerVoiceConfig": {
+            "speakerVoiceConfigs": [
+                {
+                    "speakerAlias": "Ryan",
+                    "speakerId": "Umbriel",
+                },
+                {
+                    "speakerAlias": "Katie",
+                    "speakerId": "Leda",
+                },
+            ],
+        },
+    }

--- a/tests/test_litellm/google_genai/test_google_genai_transformation.py
+++ b/tests/test_litellm/google_genai/test_google_genai_transformation.py
@@ -2,16 +2,16 @@
 """
 Test to verify the Google GenAI transformation logic for generateContent parameters
 """
+
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 import pytest
 
 from litellm.llms.gemini.google_genai.transformation import GoogleGenAIConfig
+from litellm.llms.vertex_ai.google_genai.transformation import VertexAIGoogleGenAIConfig
 from litellm.responses.litellm_completion_transformation.transformation import (
     LiteLLMCompletionResponsesConfig,
 )
@@ -36,10 +36,7 @@ def test_map_generate_content_optional_params_response_json_schema_camelcase():
 
     # responseJsonSchema should be in the result (camelCase format for Google GenAI API)
     assert "responseJsonSchema" in result
-    assert (
-        result["responseJsonSchema"]
-        == generate_content_config_dict["responseJsonSchema"]
-    )
+    assert result["responseJsonSchema"] == generate_content_config_dict["responseJsonSchema"]
     assert "temperature" in result
     assert result["temperature"] == 1.0
 
@@ -63,10 +60,7 @@ def test_map_generate_content_optional_params_response_schema_snakecase():
 
     # response_schema should be converted to responseJsonSchema (camelCase)
     assert "responseJsonSchema" in result
-    assert (
-        result["responseJsonSchema"]
-        == generate_content_config_dict["response_json_schema"]
-    )
+    assert result["responseJsonSchema"] == generate_content_config_dict["response_json_schema"]
     assert "temperature" in result
 
 
@@ -160,6 +154,68 @@ def test_map_generate_content_optional_params_response_mime_type():
     # responseMimeType should be passed through (it's already camelCase)
     assert "responseMimeType" in result or "response_mime_type" in result
     assert "responseJsonSchema" in result
+
+
+@pytest.mark.parametrize("config_class", [GoogleGenAIConfig, VertexAIGoogleGenAIConfig])
+def test_map_generate_content_optional_params_speech_config(config_class):
+    config = config_class()
+
+    result = config.map_generate_content_optional_params(
+        generate_content_config_dict={
+            "response_modalities": ["AUDIO"],
+            "speech_config": {
+                "multi_speaker_voice_config": {
+                    "speaker_voice_configs": [
+                        {
+                            "speaker": "Ryan",
+                            "voice_config": {
+                                "prebuilt_voice_config": {
+                                    "voice_name": "Umbriel",
+                                },
+                            },
+                        },
+                        {
+                            "speaker": "Katie",
+                            "voice_config": {
+                                "prebuilt_voice_config": {
+                                    "voice_name": "Leda",
+                                },
+                            },
+                        },
+                    ],
+                },
+                "language_code": "en-US",
+            },
+        },
+        model="gemini-3.1-flash-tts-preview",
+    )
+
+    assert result["responseModalities"] == ["AUDIO"]
+    assert "response_modalities" not in result
+    assert "speech_config" not in result
+    assert result["speechConfig"] == {
+        "multiSpeakerVoiceConfig": {
+            "speakerVoiceConfigs": [
+                {
+                    "speaker": "Ryan",
+                    "voiceConfig": {
+                        "prebuiltVoiceConfig": {
+                            "voiceName": "Umbriel",
+                        },
+                    },
+                },
+                {
+                    "speaker": "Katie",
+                    "voiceConfig": {
+                        "prebuiltVoiceConfig": {
+                            "voiceName": "Leda",
+                        },
+                    },
+                },
+            ],
+        },
+        "languageCode": "en-US",
+    }
 
 
 def test_responses_api_reasoning_dict_format():
@@ -259,9 +315,7 @@ def test_transform_generate_content_request_with_system_instruction():
 
     # Verify that systemInstruction is in the request
     assert "systemInstruction" in result, "systemInstruction should be in request body"
-    assert (
-        result["systemInstruction"] == system_instruction
-    ), "systemInstruction should match input"
+    assert result["systemInstruction"] == system_instruction, "systemInstruction should match input"
     assert result["model"] == "gemini-3-flash-preview"
     assert result["contents"] == contents
 
@@ -284,9 +338,7 @@ def test_transform_generate_content_request_without_system_instruction():
     )
 
     # Verify that systemInstruction is NOT in the request when not provided
-    assert (
-        "systemInstruction" not in result
-    ), "systemInstruction should not be in request when None"
+    assert "systemInstruction" not in result, "systemInstruction should not be in request when None"
     assert result["model"] == "gemini-3-flash-preview"
     assert result["contents"] == contents
 
@@ -295,9 +347,7 @@ def test_transform_generate_content_request_system_instruction_with_tools():
     """Test that systemInstruction works correctly alongside tools"""
     config = GoogleGenAIConfig()
 
-    system_instruction = {
-        "parts": [{"text": "You are a helpful assistant that uses tools"}]
-    }
+    system_instruction = {"parts": [{"text": "You are a helpful assistant that uses tools"}]}
 
     contents = [{"role": "user", "parts": [{"text": "What's the weather?"}]}]
 
@@ -379,9 +429,7 @@ def test_transform_generate_content_request_normalizes_response_schema_2_5():
     assert "responseJsonSchema" in gen_config
     normalized = gen_config["responseJsonSchema"]
     assert "$defs" in normalized
-    assert normalized["properties"]["highlights"]["items"] == {
-        "$ref": "#/$defs/Highlight"
-    }
+    assert normalized["properties"]["highlights"]["items"] == {"$ref": "#/$defs/Highlight"}
 
 
 def test_transform_generate_content_request_flattens_response_schema_1_5():
@@ -586,12 +634,8 @@ def test_validate_environment_with_dict_api_key():
 
     # The dict should be merged into headers, not set as a value
     assert "x-goog-api-key" in result, "x-goog-api-key should be in headers"
-    assert (
-        result["x-goog-api-key"] == "sk-test-key-123"
-    ), "API key should be the string value, not a dict"
-    assert isinstance(
-        result["x-goog-api-key"], str
-    ), "Header value should be a string, not a dict"
+    assert result["x-goog-api-key"] == "sk-test-key-123", "API key should be the string value, not a dict"
+    assert isinstance(result["x-goog-api-key"], str), "Header value should be a string, not a dict"
     assert "Content-Type" in result, "Content-Type should be in headers"
     assert result["Content-Type"] == "application/json"
 
@@ -637,9 +681,7 @@ def test_validate_environment_with_extra_headers():
 
     # Both the auth dict and extra headers should be merged
     assert "x-goog-api-key" in result, "x-goog-api-key should be in headers"
-    assert (
-        result["x-goog-api-key"] == "sk-test-key-789"
-    ), "API key should be correctly set"
+    assert result["x-goog-api-key"] == "sk-test-key-789", "API key should be correctly set"
     assert isinstance(result["x-goog-api-key"], str), "Header value should be a string"
     assert "X-Custom-Header" in result, "Extra headers should be merged"
     assert result["X-Custom-Header"] == "custom-value"

--- a/tests/test_litellm/llms/gemini/test_gemini_tts.py
+++ b/tests/test_litellm/llms/gemini/test_gemini_tts.py
@@ -7,13 +7,65 @@ import sys
 import pytest
 from unittest.mock import patch, MagicMock
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 import litellm
+from litellm.endpoints.speech.speech_to_completion_bridge.transformation import (
+    SpeechToCompletionBridgeTransformationHandler,
+)
 from litellm.llms.gemini.chat.transformation import GoogleAIStudioGeminiConfig
 from litellm.utils import get_supported_openai_params
+
+
+GEMINI_3_1_FLASH_TTS_MODEL = "gemini-3.1-flash-tts-preview"
+
+MULTI_SPEAKER_SPEECH_CONFIG = {
+    "multi_speaker_voice_config": {
+        "speaker_voice_configs": [
+            {
+                "speaker": "Ryan",
+                "voice_config": {
+                    "prebuilt_voice_config": {
+                        "voice_name": "Umbriel",
+                    },
+                },
+            },
+            {
+                "speaker": "Katie",
+                "voice_config": {
+                    "prebuilt_voice_config": {
+                        "voice_name": "Leda",
+                    },
+                },
+            },
+        ],
+    },
+    "language_code": "en-US",
+}
+
+NORMALIZED_MULTI_SPEAKER_SPEECH_CONFIG = {
+    "multiSpeakerVoiceConfig": {
+        "speakerVoiceConfigs": [
+            {
+                "speaker": "Ryan",
+                "voiceConfig": {
+                    "prebuiltVoiceConfig": {
+                        "voiceName": "Umbriel",
+                    },
+                },
+            },
+            {
+                "speaker": "Katie",
+                "voiceConfig": {
+                    "prebuiltVoiceConfig": {
+                        "voiceName": "Leda",
+                    },
+                },
+            },
+        ],
+    },
+    "languageCode": "en-US",
+}
 
 
 class TestGeminiTTSTransformation:
@@ -24,17 +76,16 @@ class TestGeminiTTSTransformation:
         config = GoogleAIStudioGeminiConfig()
 
         # Test TTS models (both preview and non-preview versions)
-        assert (
-            config.is_model_gemini_audio_model("gemini-2.5-flash-preview-tts") == True
-        )
-        assert config.is_model_gemini_audio_model("gemini-2.5-pro-preview-tts") == True
-        assert config.is_model_gemini_audio_model("gemini-2.5-flash-tts") == True
-        assert config.is_model_gemini_audio_model("gemini-2.5-pro-tts") == True
+        assert config.is_model_gemini_audio_model("gemini-2.5-flash-preview-tts")
+        assert config.is_model_gemini_audio_model("gemini-2.5-pro-preview-tts")
+        assert config.is_model_gemini_audio_model("gemini-2.5-flash-tts")
+        assert config.is_model_gemini_audio_model("gemini-2.5-pro-tts")
+        assert config.is_model_gemini_audio_model(GEMINI_3_1_FLASH_TTS_MODEL)
 
         # Test non-TTS models
-        assert config.is_model_gemini_audio_model("gemini-2.5-flash") == False
-        assert config.is_model_gemini_audio_model("gemini-2.5-pro") == False
-        assert config.is_model_gemini_audio_model("gpt-4o-audio-preview") == False
+        assert not config.is_model_gemini_audio_model("gemini-2.5-flash")
+        assert not config.is_model_gemini_audio_model("gemini-2.5-pro")
+        assert not config.is_model_gemini_audio_model("gpt-4o-audio-preview")
 
     def test_gemini_tts_supported_params(self):
         """Test that audio parameter is included for TTS models"""
@@ -71,10 +122,7 @@ class TestGeminiTTSTransformation:
         assert "speechConfig" in result
         assert "voiceConfig" in result["speechConfig"]
         assert "prebuiltVoiceConfig" in result["speechConfig"]["voiceConfig"]
-        assert (
-            result["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"]
-            == "Kore"
-        )
+        assert result["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
 
         # Check response modalities
         assert "responseModalities" in result
@@ -83,9 +131,7 @@ class TestGeminiTTSTransformation:
     def test_gemini_tts_audio_parameter_mapping_with_language_code(self):
         config = GoogleAIStudioGeminiConfig()
 
-        non_default_params = {
-            "audio": {"voice": "Kore", "format": "pcm16", "language_code": "en-US"}
-        }
+        non_default_params = {"audio": {"voice": "Kore", "format": "pcm16", "language_code": "en-US"}}
         optional_params = {}
 
         result = config.map_openai_params(
@@ -97,17 +143,12 @@ class TestGeminiTTSTransformation:
 
         assert "speechConfig" in result
         assert result["speechConfig"]["languageCode"] == "en-US"
-        assert (
-            result["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"]
-            == "Kore"
-        )
+        assert result["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
 
     def test_map_audio_params_language_code(self):
         config = GoogleAIStudioGeminiConfig()
 
-        result = config._map_audio_params(
-            {"voice": "Kore", "format": "pcm16", "language_code": "de-DE"}
-        )
+        result = config._map_audio_params({"voice": "Kore", "format": "pcm16", "language_code": "de-DE"})
 
         assert result["languageCode"] == "de-DE"
         assert result["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
@@ -119,6 +160,29 @@ class TestGeminiTTSTransformation:
 
         assert "languageCode" not in result
         assert result["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+
+    def test_gemini_tts_multi_speaker_audio_parameter_mapping(self):
+        """Test multi-speaker audio parameter mapping for Gemini 3.1 TTS models"""
+        config = GoogleAIStudioGeminiConfig()
+
+        non_default_params = {
+            "audio": {
+                "speech_config": MULTI_SPEAKER_SPEECH_CONFIG,
+                "format": "pcm16",
+            }
+        }
+        optional_params = {}
+
+        result = config.map_openai_params(
+            non_default_params=non_default_params,
+            optional_params=optional_params,
+            model=GEMINI_3_1_FLASH_TTS_MODEL,
+            drop_params=False,
+        )
+
+        assert result["speechConfig"] == NORMALIZED_MULTI_SPEAKER_SPEECH_CONFIG
+        assert result["responseModalities"] == ["AUDIO"]
+        assert "temperature" not in result
 
     def test_gemini_tts_audio_parameter_with_existing_modalities(self):
         """Test audio parameter mapping when modalities already exist"""
@@ -203,9 +267,7 @@ class TestGeminiTTSTransformation:
         }
         optional_params = {}
 
-        with pytest.raises(
-            ValueError, match="Unsupported audio format for Gemini TTS models"
-        ):
+        with pytest.raises(ValueError, match="Unsupported audio format for Gemini TTS models"):
             config.map_openai_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
@@ -244,6 +306,28 @@ def test_gemini_tts_completion_mock():
         assert response.choices[0].message.content is not None
 
 
+def test_gemini_tts_speech_bridge_accepts_multi_speaker_voice_dict():
+    handler = SpeechToCompletionBridgeTransformationHandler()
+
+    result = handler.transform_request(
+        model=f"vertex_ai/{GEMINI_3_1_FLASH_TTS_MODEL}",
+        input="Ryan: How are you doing today Katie?\nKatie: Not too bad.",
+        voice=MULTI_SPEAKER_SPEECH_CONFIG,
+        optional_params={"response_format": "mp3"},
+        litellm_params={},
+        headers={},
+        litellm_logging_obj=MagicMock(),
+        custom_llm_provider="vertex_ai",
+    )
+
+    assert result["modalities"] == ["audio"]
+    assert result["audio"] == {
+        "speech_config": NORMALIZED_MULTI_SPEAKER_SPEECH_CONFIG,
+        "format": "pcm16",
+    }
+    assert "response_format" not in result
+
+
 class TestGeminiTTSSpeechConfigInRequestBody:
     """Test that speechConfig is properly included in the final request body.
 
@@ -260,11 +344,11 @@ class TestGeminiTTSSpeechConfigInRequestBody:
             ("gemini-2.5-flash-preview-tts", "vertex_ai"),
             ("gemini-2.5-flash-preview-tts", "gemini"),
             ("gemini-2.5-pro-tts", "vertex_ai"),
+            (GEMINI_3_1_FLASH_TTS_MODEL, "vertex_ai"),
+            (GEMINI_3_1_FLASH_TTS_MODEL, "gemini"),
         ],
     )
-    def test_speechconfig_in_generation_config_transform_request_body(
-        self, model, custom_llm_provider
-    ):
+    def test_speechconfig_in_generation_config_transform_request_body(self, model, custom_llm_provider):
         """Test that speechConfig is included in generationConfig after _transform_request_body()"""
         from litellm.llms.vertex_ai.gemini.transformation import (
             _transform_request_body,
@@ -272,9 +356,7 @@ class TestGeminiTTSSpeechConfigInRequestBody:
 
         # Simulate optional_params after map_openai_params() has run
         optional_params = {
-            "speechConfig": {
-                "voiceConfig": {"prebuiltVoiceConfig": {"voiceName": "Kore"}}
-            },
+            "speechConfig": {"voiceConfig": {"prebuiltVoiceConfig": {"voiceName": "Kore"}}},
             "responseModalities": ["AUDIO"],
         }
 
@@ -297,12 +379,7 @@ class TestGeminiTTSSpeechConfigInRequestBody:
             f"speechConfig was filtered out of generationConfig for model={model}, provider={custom_llm_provider}. "
             "Ensure speechConfig is in the GenerationConfig TypedDict."
         )
-        assert (
-            generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"][
-                "voiceName"
-            ]
-            == "Kore"
-        )
+        assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
 
     @pytest.mark.parametrize(
         "model,custom_llm_provider",
@@ -310,6 +387,8 @@ class TestGeminiTTSSpeechConfigInRequestBody:
             ("gemini-2.5-flash-tts", "vertex_ai"),
             ("gemini-2.5-flash-tts", "gemini"),
             ("gemini-2.5-flash-preview-tts", "vertex_ai"),
+            (GEMINI_3_1_FLASH_TTS_MODEL, "vertex_ai"),
+            (GEMINI_3_1_FLASH_TTS_MODEL, "gemini"),
         ],
     )
     def test_speechconfig_end_to_end_mapping(self, model, custom_llm_provider):
@@ -356,17 +435,55 @@ class TestGeminiTTSSpeechConfigInRequestBody:
             f"speechConfig was filtered out during _transform_request_body() for model={model}, provider={custom_llm_provider}. "
             "This breaks Gemini TTS - speechConfig must be in GenerationConfig TypedDict."
         )
-        assert (
-            generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"][
-                "voiceName"
-            ]
-            == "Puck"
-        )
+        assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Puck"
 
         # Also verify responseModalities is present
         assert "responseModalities" in generation_config
         assert "AUDIO" in generation_config["responseModalities"]
 
+    @pytest.mark.parametrize(
+        "custom_llm_provider",
+        [
+            "vertex_ai",
+            "gemini",
+        ],
+    )
+    def test_multi_speaker_speechconfig_end_to_end_mapping(self, custom_llm_provider):
+        """Test full pipeline for Gemini 3.1 multi-speaker TTS speechConfig"""
+        from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+            VertexGeminiConfig,
+        )
+        from litellm.llms.vertex_ai.gemini.transformation import (
+            _transform_request_body,
+        )
+
+        config = VertexGeminiConfig()
+
+        mapped_params = config.map_openai_params(
+            non_default_params={
+                "audio": {
+                    "speech_config": MULTI_SPEAKER_SPEECH_CONFIG,
+                    "format": "pcm16",
+                }
+            },
+            optional_params={},
+            model=GEMINI_3_1_FLASH_TTS_MODEL,
+            drop_params=False,
+        )
+
+        request_body = _transform_request_body(
+            messages=[{"role": "user", "content": "Ryan: Hi.\nKatie: Hello."}],
+            model=GEMINI_3_1_FLASH_TTS_MODEL,
+            optional_params=mapped_params,
+            custom_llm_provider=custom_llm_provider,
+            litellm_params={},
+            cached_content=None,
+        )
+
+        generation_config = request_body["generationConfig"]
+        assert generation_config["speechConfig"] == NORMALIZED_MULTI_SPEAKER_SPEECH_CONFIG
+        assert generation_config["responseModalities"] == ["AUDIO"]
+        assert "temperature" not in generation_config
 
     @pytest.mark.parametrize(
         "model,custom_llm_provider",
@@ -386,9 +503,7 @@ class TestGeminiTTSSpeechConfigInRequestBody:
 
         config = VertexGeminiConfig()
 
-        non_default_params = {
-            "audio": {"voice": "Puck", "format": "pcm16", "language_code": "pt-BR"}
-        }
+        non_default_params = {"audio": {"voice": "Puck", "format": "pcm16", "language_code": "pt-BR"}}
         optional_params = {}
 
         mapped_params = config.map_openai_params(
@@ -411,12 +526,7 @@ class TestGeminiTTSSpeechConfigInRequestBody:
 
         generation_config = request_body["generationConfig"]
         assert generation_config["speechConfig"]["languageCode"] == "pt-BR"
-        assert (
-            generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"][
-                "voiceName"
-            ]
-            == "Puck"
-        )
+        assert generation_config["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Puck"
         assert "AUDIO" in generation_config["responseModalities"]
 
 

--- a/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
+++ b/tests/test_litellm/proxy/proxy_server/test_routes_audio.py
@@ -80,6 +80,38 @@ def patched_speech_error(monkeypatch):
 
 
 @pytest.fixture
+def patched_speech_provider_error(monkeypatch):
+    monkeypatch.setattr(proxy_server, "llm_router", MagicMock())
+    monkeypatch.setattr(
+        proxy_server,
+        "proxy_logging_obj",
+        MagicMock(
+            pre_call_hook=AsyncMock(side_effect=lambda **kw: kw["data"]),
+            post_call_failure_hook=AsyncMock(),
+            post_call_response_headers_hook=AsyncMock(return_value={}),
+            update_request_status=AsyncMock(),
+        ),
+    )
+
+    async def _add_data(data, **kwargs):
+        return data
+
+    monkeypatch.setattr(proxy_server, "add_litellm_data_to_request", _add_data)
+
+    class _ProviderBadRequestError(Exception):
+        status_code = 400
+        message = "Unsupported audio encoding."
+        type = "invalid_request_error"
+        param = None
+
+    async def _raise(*args, **kwargs):
+        raise _ProviderBadRequestError("Unsupported audio encoding.")
+
+    monkeypatch.setattr(proxy_server, "route_request", _raise)
+    yield
+
+
+@pytest.fixture
 def patched_transcription(monkeypatch):
     router = MagicMock()
     router.model_names = ["whisper-1"]
@@ -99,9 +131,7 @@ def patched_transcription(monkeypatch):
         return data
 
     monkeypatch.setattr(proxy_server, "add_litellm_data_to_request", _add_data)
-    monkeypatch.setattr(
-        proxy_server, "check_file_size_under_limit", lambda **kwargs: True
-    )
+    monkeypatch.setattr(proxy_server, "check_file_size_under_limit", lambda **kwargs: True)
 
     async def _form_data(request):
         from starlette.datastructures import FormData, UploadFile
@@ -153,6 +183,20 @@ def test_audio_speech_happy_path(client, auth_as, patched_speech, path):
 
 
 @pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
+def test_audio_speech_pcm16_uses_wav_media_type(client, auth_as, patched_speech, path):
+    payload = {
+        "model": "gemini-3.1-flash-tts-preview",
+        "input": "Hi",
+        "voice": "Umbriel",
+        "response_format": "pcm16",
+    }
+    with auth_as():
+        response = client.post(path, json=payload)
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "") == "audio/wav"
+
+
+@pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
 def test_audio_speech_error(client, auth_as, patched_speech_error, path):
     """Pins ``POST /v1/audio/speech`` and ``POST /audio/speech`` (error)."""
     payload = {"model": "tts-1", "input": "Hi", "voice": "alloy"}
@@ -160,6 +204,20 @@ def test_audio_speech_error(client, auth_as, patched_speech_error, path):
         response = client.post(path, json=payload)
     assert response.status_code == 500
     assert len(response.content) > 0
+
+
+@pytest.mark.parametrize("path", ["/v1/audio/speech", "/audio/speech"])
+def test_audio_speech_provider_error_preserves_status_and_message(
+    client,
+    auth_as,
+    patched_speech_provider_error,
+    path,
+):
+    payload = {"model": "tts-1", "input": "Hi", "voice": "alloy"}
+    with auth_as():
+        response = client.post(path, json=payload)
+    assert response.status_code == 400
+    assert response.json()["error"]["message"] == "Unsupported audio encoding."
 
 
 @pytest.mark.parametrize("path", ["/v1/audio/transcriptions", "/audio/transcriptions"])

--- a/tests/test_litellm/test_gemini_3_1_flash_tts_metadata.py
+++ b/tests/test_litellm/test_gemini_3_1_flash_tts_metadata.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import pytest
+
+
+EXPECTED_MODELS = {
+    "gemini-3.1-flash-tts-preview": "gemini",
+    "gemini/gemini-3.1-flash-tts-preview": "gemini",
+    "vertex_ai/gemini-3.1-flash-tts-preview": "vertex_ai-language-models",
+}
+
+
+def _load_model_cost_map(path: Path) -> dict:
+    with open(path, encoding="utf-8") as model_cost_file:
+        return json.load(model_cost_file)
+
+
+@pytest.mark.parametrize("model,provider", EXPECTED_MODELS.items())
+def test_gemini_3_1_flash_tts_model_metadata(model, provider):
+    model_cost = _load_model_cost_map(Path(__file__).parents[2] / "model_prices_and_context_window.json")
+
+    info = model_cost.get(model)
+    assert info is not None, f"{model} not found in model cost map"
+
+    assert info["litellm_provider"] == provider
+    assert info["mode"] == "audio_speech"
+    assert info["input_cost_per_token"] == 1e-06
+    assert info["output_cost_per_token"] == 2e-05
+    assert info["output_cost_per_audio_token"] == 2e-05
+    assert info["max_input_tokens"] == 8192
+    assert info["max_output_tokens"] == 16384
+    assert info["max_tokens"] == 16384
+    assert info["supported_endpoints"] == ["/v1/audio/speech"]
+    assert info["supported_modalities"] == ["text"]
+    assert info["supported_output_modalities"] == ["audio"]
+    assert info["supports_audio_input"] is False
+    assert info["supports_audio_output"] is True
+    assert info["supports_function_calling"] is False
+    assert info["supports_prompt_caching"] is False
+    assert info["health_check_voice"] == "Kore"
+
+
+def test_gemini_3_1_flash_tts_backup_matches_main():
+    repo_root = Path(__file__).parents[2]
+    main_cost = _load_model_cost_map(repo_root / "model_prices_and_context_window.json")
+    backup_cost = _load_model_cost_map(repo_root / "litellm" / "model_prices_and_context_window_backup.json")
+
+    for model in EXPECTED_MODELS:
+        assert backup_cost.get(model) == main_cost.get(model), (
+            f"{model} differs between main and backup model cost maps"
+        )

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -771,6 +771,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "ocr_cost_per_page": {"type": "number"},
                 "ocr_cost_per_credit": {"type": "number"},
                 "code_interpreter_cost_per_session": {"type": "number"},
+                "health_check_voice": {"type": "string"},
                 "inference_geo": {"type": "string"},
                 "litellm_provider": {"type": "string"},
                 "max_input_tokens": {"type": "number"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini 3.1 Flash TTS lacks complete speech support
- The speech bridge drops structured multi-speaker voice settings
- PCM aliases need the provider's supported audio encoding

How it solves it:

- Adds model metadata and Cloud Text-to-Speech routing
- Preserves normalized speaker settings through the speech bridge
- Maps PCM aliases to LINEAR16 and preserves output MIME

## User Flow

Before: an application cannot reliably request Gemini multi-speaker speech

1. The developer sends POST http://localhost:4000/v1/audio/speech with `model: vertex_ai/gemini-3.1-flash-tts-preview`, a two-speaker dialogue, and voice settings assigning Ryan to Umbriel and Katie to Leda
2. The request fails or loses the requested speaker settings

After: the speech request preserves the requested voices and output format

1. The developer sends POST http://localhost:4000/v1/audio/speech with the same model, dialogue, and speaker settings
2. The response contains generated audio with the configured voices and matching Content-Type

Cloud Text-to-Speech supports explicit MP3 requests. The generateContent speech bridge accepts PCM or WAV formats and retains the normalized multi-speaker configuration

## Relevant issues

## Affected release

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The focused tests covering this change pass locally
- [x] My PR passes all required CI/CD checks at the current tip
- [ ] My PR scope is as isolated as possible
- [x] The current tip has a Greptile Confidence Score of at least 4/5

## Changes

Gemini 3.1 Flash TTS supports structured single-speaker and multi-speaker voice settings. Cloud TTS requests retain the selected model and encoding; the generateContent bridge normalizes voice dictionaries and returns supported PCM/WAV formats. Existing Vertex Gemini 2.5 TTS models are registered with generative-speech metadata, and detection handles provider-stripped names. Chirp and Lyria keep their existing routing. Model identifiers and rates were verified against [Google TTS documentation](https://docs.cloud.google.com/text-to-speech/docs/gemini-tts) and [pricing](https://cloud.google.com/text-to-speech/pricing)

## Current validation

Rebased onto main at `3ad9a7f336e91da3e1225053da5b044b257e3d57`. Current tip: `fb1faa7dd841cc10f62287fa769a92753f9c0d19`

135 focused TTS, voice, bridge, and metadata tests passed using the local catalog

Python lint and type checks are verified locally and through CI. Lint budgets and coverage thresholds are unchanged. Required CI passes at this tip, with 90.20% patch coverage. Greptile reports 5/5; Veria and Bugbot completed with no outstanding findings

## Screenshots / Proof of Fix

Fresh Before/After live QA is pending because Google credentials are not configured in this environment. Previous proof from older commits has been removed

## Type

New Feature
Bug Fix

## Health checks

Set `model_info.health_check_voice: Kore` in the deployment configuration when enabling speech health checks. The catalog omits this key because the trusted cost-map guard on main does not classify it yet

## Caveats (if any)

### Medium

- Fresh live provider QA requires working Google credentials

### Low

- Cloud TTS LINEAR16 output includes a WAV header
- The generateContent speech bridge does not support MP3

## Final Attestation

- [x] Regression tests exercise the changed behavior and identified edge cases
