### PR TITLE
fix(embedding): route custom_openai and deepinfra to OpenAI-compatible handler

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5999,6 +5999,8 @@ def embedding(
             or custom_llm_provider == "together_ai"
             or custom_llm_provider == "nvidia_nim"
             or custom_llm_provider == "litellm_proxy"
+            or custom_llm_provider == "custom_openai"
+            or custom_llm_provider == "deepinfra"
             or (model in litellm.open_ai_embedding_models and custom_llm_provider is None)
         ):
             api_base = (

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1962,3 +1962,35 @@ class TestCallTypesOCR:
 
         call_type = CallTypes("aocr")
         assert call_type == CallTypes.aocr
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["deepinfra", "custom_openai"])
+def test_embedding_routes_openai_compatible_providers(custom_llm_provider):
+    """OpenAI-compatible providers should reach the OpenAI embedding handler.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/31894:
+    ``embedding()`` raised ``LiteLLMUnknownProvider`` for ``deepinfra`` and
+    ``custom_openai`` because those providers were missing from the
+    OpenAI-compatible embedding branch, even though ``completion()`` already
+    routes them through the OpenAI-compatible handler. They should instead be
+    dispatched to the OpenAI embedding handler with the user-supplied
+    ``api_base``/``api_key``.
+    """
+    with patch.object(
+        litellm_main.openai_chat_completions, "embedding"
+    ) as mock_embedding:
+        mock_embedding.return_value = litellm.EmbeddingResponse()
+
+        litellm.embedding(
+            model="Qwen/Qwen3-Embedding-8B",
+            input=["hello world"],
+            custom_llm_provider=custom_llm_provider,
+            api_base="https://api.deepinfra.com/v1/openai",
+            api_key="fake-key",
+        )
+
+        mock_embedding.assert_called_once()
+        assert mock_embedding.call_args.kwargs["model"] == "Qwen/Qwen3-Embedding-8B"
+        assert mock_embedding.call_args.kwargs["api_base"] == (
+            "https://api.deepinfra.com/v1/openai"
+        )


### PR DESCRIPTION
## Relevant issues

Fixes #31894

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes lint/format for the changed lines and unit tests pass locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## What / Why

`embedding()` raised `LiteLLMUnknownProvider` ("Unmapped LLM provider for this endpoint") for `custom_openai` and `deepinfra`, even though both are OpenAI-compatible and `completion()` already routes them through the OpenAI-compatible handler (see `litellm/main.py`, the completion dispatch groups `custom_openai`/`deepinfra`/... together). The embedding dispatch's OpenAI-compatible branch only matched `openai`, `together_ai`, `nvidia_nim`, and `litellm_proxy`, so `custom_openai`/`deepinfra` fell through to the final `else` and raised.

As the reporter noted, the only workaround was to set `custom_llm_provider="openai"` with an `api_base` pointing at the provider — which is confusing and undocumented.

## The fix

Add `custom_openai` and `deepinfra` to the OpenAI-compatible embedding branch in `litellm/main.py`, so they are dispatched to the OpenAI embedding handler with the user-supplied `api_base`/`api_key`, matching how `completion()` already treats them.

```diff
         elif (
             custom_llm_provider == "openai"
             or custom_llm_provider == "together_ai"
             or custom_llm_provider == "nvidia_nim"
             or custom_llm_provider == "litellm_proxy"
+            or custom_llm_provider == "custom_openai"
+            or custom_llm_provider == "deepinfra"
             or (model in litellm.open_ai_embedding_models and custom_llm_provider is None)
         ):
```

Scope is intentionally limited to the two providers named in the issue (rather than a broad `custom_llm_provider in litellm.openai_compatible_providers`), because some OpenAI-compatible providers already have their own dedicated embedding branches (e.g. `perplexity`) and shouldn't be re-routed.

## Test

Added a mocked regression test in `tests/test_litellm/test_main.py` (no real API calls) that asserts `embedding()` routes both `deepinfra` and `custom_openai` to the OpenAI embedding handler with the supplied `api_base`, instead of raising:

```bash
uv run pytest tests/test_litellm/test_main.py::test_embedding_routes_openai_compatible_providers -v
# 2 passed
```

## Proof of Fix

**Before** (current `main`) — both providers raise:
```
litellm.embedding(model="Qwen/Qwen3-Embedding-8B", input=["hi"],
    custom_llm_provider="deepinfra", api_base="https://api.deepinfra.com/v1/openai", api_key=...)
# -> litellm.BadRequestError: Unmapped LLM provider for this endpoint.
#    You passed model=Qwen/Qwen3-Embedding-8B, custom_llm_provider=deepinfra
# (same for custom_openai)
```

**After** (this PR) — both route to the OpenAI embedding handler:
```
deepinfra:     openai_chat_completions.embedding called = True
custom_openai: openai_chat_completions.embedding called = True
```

> Note: I don't have paid DeepInfra credentials, so the end-to-end proof above uses the mocked routing assertion rather than a live billed call. The routing change is what fixes the reported `LiteLLMUnknownProvider`; the downstream OpenAI-compatible embedding handler is already exercised by the existing `openai`/`together_ai` embedding path. Happy to add a live e2e run if a maintainer can provide/confirm against a DeepInfra key.
