### PR TITLE
chore(lint): remove dead E501 config, fix stale blame-ignore SHAs, note 120 width in CLAUDE.md

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,7 +13,7 @@
 7edf3a9cb55548b143df1692f4ed7c4681d7fcf7
 
 # style: reformat litellm/ with ruff format (#31317)
-430b5b8f1b12dc261a49fda99ac5d1b22381a428
+17bfd415aeb5a57fb646b5cc67da1c730aa7c50b
 
 # style: unify ruff format width on 120 (#31518)
-3dfbeabe626d203ac9de86024519d9a96c484ce4
+48b5a5a0cc5a694a11219416ee0b6eb6e620e74e

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ If you ever make public-facing PR descriptions, comments, issues, commit message
 
 Don't hesitate to use values in .env to get needed API keys and other secrets, as long as you never add them to conversation history, commit them, or include them in GitHub issues / PRs
 
-Python line length is 120, not 88. `line-length = 120` in ruff.toml is the single source of truth, shared by `ruff format` and the import sorter. Don't wrap code to 88 or "fix" long lines under 120
+Python line length is 120, not 88
 
 Run tests before you commit. Also, run `make pre-commit` right before each commit, which generates types (as needed) and formats/lints your code. Any errors found must be fixed. It only runs when there are staged frontend and/or backend changes and calculates violations, generates types, etc. based on the worktree, so stage what you need or stash/delete unwanted files in litellm/ or ui/ (where backend and frontend lint run, respectively) before running it. If it fails because dashboard api types are stale, it already regenerated them for you. You just need to stage the schema.d.ts, re-run `make pre-commit` to confirm it passes, and commit
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,8 @@ If you ever make public-facing PR descriptions, comments, issues, commit message
 
 Don't hesitate to use values in .env to get needed API keys and other secrets, as long as you never add them to conversation history, commit them, or include them in GitHub issues / PRs
 
+Python line length is 120, not 88. `line-length = 120` in ruff.toml is the single source of truth, shared by `ruff format` and the import sorter. Don't wrap code to 88 or "fix" long lines under 120
+
 Run tests before you commit. Also, run `make pre-commit` right before each commit, which generates types (as needed) and formats/lints your code. Any errors found must be fixed. It only runs when there are staged frontend and/or backend changes and calculates violations, generates types, etc. based on the worktree, so stage what you need or stash/delete unwanted files in litellm/ or ui/ (where backend and frontend lint run, respectively) before running it. If it fails because dashboard api types are stale, it already regenerated them for you. You just need to stage the schema.d.ts, re-run `make pre-commit` to confirm it passes, and commit
 
 When you fix violations gated by `ruff-strict-budget.json`, `type-discipline-budget.json`, or `basedpyright-code-budget.json`, run `make lint-budget-update` and commit the lowered limits so the ceilings ratchet down instead of leaving stale headroom. It measures the working tree, so it must contain exactly the fixes you're committing

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ install-hooks:
 
 # Formatting
 # Wrap width is ruff.toml's single source of truth (line-length = 120), shared by the
-# formatter, E501, and the import sorter so there's no 88-vs-120 split to reconcile.
+# formatter and the import sorter so there's no 88-vs-120 split to reconcile.
 format: install-dev
 	cd litellm && $(UV_RUN) ruff format --exclude '/enterprise/' . && cd ..
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
-lint.ignore = ["F405", "E402", "E501", "F403"]
-lint.extend-select = ["E501", "T20", "PGH004", "RUF008", "RUF009", "RUF100"]
+lint.ignore = ["F405", "E402", "F403"]
+lint.extend-select = ["T20", "PGH004", "RUF008", "RUF009", "RUF100"]
 # RUF100 (unused-noqa) only knows the rules enabled in THIS config, so it would strip
 # `# noqa` directives that protect rules enforced elsewhere. List those codes as external
 # so RUF100 leaves their directives alone: the strict gate (ruff-strict.toml) and upstream


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Config-only change, so the proof is that each removed piece was demonstrably dead and lint still passes after

E501 was inert before this PR. A 130-char line passes `ruff check` under the old config while a rule that is genuinely enabled (T201) fires, showing the config loads fine and E501 specifically is suppressed by `lint.ignore`:

```
$ printf 'print("hi")\nx = "%s"\n' "$(python3 -c "print('a'*130)")" | uv run ruff check --no-cache --config ../ruff.toml --stdin-filename litellm/fake_probe.py -
T201 `print` found
 --> litellm/fake_probe.py:1:1
Found 1 error.
```

After the removal, the full lint run is still clean:

```
$ cd litellm && uv run --no-sync ruff check .
All checks passed!
```

For the blame-ignore fix, the listed SHAs were the PR-head commits of #31317 and #31518, which never landed on this branch because both PRs were squash merged; the commits actually in history are the squash SHAs this PR swaps in (verifiable in the GitHub UI: the old SHAs 430b5b8f and 3dfbeabe are not reachable from litellm_internal_staging, while 17bfd415 and 48b5a5a0 are the commits on the branch)

## Type

🧹 Refactoring

## Changes

Three small pieces of lint-config housekeeping surfaced while auditing the line-length setup

ruff.toml had E501 in both `lint.ignore` and `lint.extend-select`. Ignore wins, so no maximum line length has actually been linted since E501 was added to the ignore list back in Oct 2024; the formatter's wrap width (`line-length = 120`) is the only real control. This PR removes E501 from both lists so the config stops implying an enforcement that does not exist, and updates the Makefile comment that mentioned E501 accordingly. No `# noqa: E501` directives exist in linted paths, so nothing is orphaned

.git-blame-ignore-revs listed the pre-squash PR-head SHAs for the two ruff reformat commits (#31317 and #31518). Since both PRs were squash merged, those SHAs are not ancestors of the branch and git blame (and the GitHub blame UI) ignored nothing for the two largest formatting commits in the repo. They are replaced with the squash-merge SHAs that are actually in history. The prettier entry for #29622 was checked and already points at the real squash commit

CLAUDE.md now states that the Python line length is 120 (ruff.toml being the single source of truth for the formatter and import sorter), not 88, so agents and contributors stop wrapping new code to the old Black width

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdMxF1xtARDvs4tnEq5yHx)_