### PR TITLE
fix(spend-tracking): skip cache key computation for unsupported call types

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -367,10 +367,21 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
             additional_usage_values.update({k: v})
     clean_metadata["additional_usage_values"] = additional_usage_values
 
-    if litellm.cache is not None:
+    # Only compute a cache key when the current call type is actually cacheable.
+    # A cache backend may be configured with `supported_call_types` that excludes
+    # this call type (e.g. Redis used only for routing state with
+    # `supported_call_types: []`). In that case `litellm.cache` is not None but
+    # nothing is ever cached, so calling `get_cache_key` is wasted work on the
+    # logging hot-path and pollutes the SpendLogs `cache_key` column with a
+    # meaningless hash. Mirror the three-part guard already used by
+    # `CachingHandler._is_call_type_supported_by_cache`.
+    cache_key = "Cache OFF"
+    if (
+        litellm.cache is not None
+        and litellm.cache.supported_call_types is not None
+        and call_type in litellm.cache.supported_call_types
+    ):
         cache_key = litellm.cache.get_cache_key(**kwargs)
-    else:
-        cache_key = "Cache OFF"
     if cache_hit is True:
         import time
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2257,6 +2257,7 @@ def _make_counting_cache(supported_call_types):
         (["acompletion"], "acompletion", "HASH", 1),
         # Cache backend present but a different call type is requested.
         (["completion"], "acompletion", "Cache OFF", 0),
+        (["acompletion"], None, "Cache OFF", 0),
     ],
 )
 def test_get_logging_payload_cache_key_respects_supported_call_types(

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2229,3 +2229,90 @@ def test_get_logging_payload_cache_hit_keeps_raw_litellm_call_id():
     assert json.loads(payload["metadata"])["litellm_call_id"] == trace_call_id
     assert "_cache_hit" in payload["request_id"]
     assert json.loads(payload["metadata"])["litellm_call_id"] != payload["request_id"]
+
+
+def _make_counting_cache(supported_call_types):
+    """Build a litellm Cache whose get_cache_key invocations are counted."""
+    from litellm.caching.caching import Cache
+
+    cache = Cache(type="local", supported_call_types=supported_call_types)
+    counter = {"calls": 0}
+    original_get_cache_key = cache.get_cache_key
+
+    def _counting_get_cache_key(**kwargs):
+        counter["calls"] += 1
+        return original_get_cache_key(**kwargs)
+
+    cache.get_cache_key = _counting_get_cache_key
+    return cache, counter
+
+
+@pytest.mark.parametrize(
+    "supported_call_types, call_type, expect_cache_key, expect_calls",
+    [
+        # Cache backend present but this call type is NOT cacheable
+        # (e.g. Redis configured for routing state with supported_call_types: []).
+        ([], "acompletion", "Cache OFF", 0),
+        # Cache backend present and this call type is explicitly supported.
+        (["acompletion"], "acompletion", "HASH", 1),
+        # Cache backend present but a different call type is requested.
+        (["completion"], "acompletion", "Cache OFF", 0),
+    ],
+)
+def test_get_logging_payload_cache_key_respects_supported_call_types(
+    supported_call_types, call_type, expect_cache_key, expect_calls
+):
+    """
+    Regression test for issue #31862.
+
+    `get_logging_payload` must only invoke `litellm.cache.get_cache_key` when the
+    current call type is actually cacheable. Previously it computed a cache key
+    for every request whenever any cache backend existed, wasting CPU on the
+    logging hot-path and polluting the SpendLogs `cache_key` column with a
+    meaningless SHA-256 hash. This mirrors the three-part guard already used by
+    `CachingHandler._is_call_type_supported_by_cache`.
+    """
+    cache, counter = _make_counting_cache(supported_call_types)
+    original_cache = litellm.cache
+    litellm.cache = cache
+    try:
+        kwargs = {
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "hello"}],
+            "call_type": call_type,
+            "litellm_params": {"metadata": {"user_api_key": "sk-test"}},
+        }
+        now = datetime.datetime.now(timezone.utc)
+        payload = get_logging_payload(
+            kwargs=kwargs, response_obj={}, start_time=now, end_time=now
+        )
+    finally:
+        litellm.cache = original_cache
+
+    assert counter["calls"] == expect_calls
+    if expect_cache_key == "HASH":
+        assert payload["cache_key"] != "Cache OFF"
+        assert len(payload["cache_key"]) == 64  # SHA-256 hex digest
+    else:
+        assert payload["cache_key"] == "Cache OFF"
+
+
+def test_get_logging_payload_cache_key_off_when_cache_is_none():
+    """When no cache backend is configured, cache_key must be the 'Cache OFF' sentinel."""
+    original_cache = litellm.cache
+    litellm.cache = None
+    try:
+        kwargs = {
+            "model": "openai/gpt-4o",
+            "messages": [{"role": "user", "content": "hello"}],
+            "call_type": "acompletion",
+            "litellm_params": {"metadata": {"user_api_key": "sk-test"}},
+        }
+        now = datetime.datetime.now(timezone.utc)
+        payload = get_logging_payload(
+            kwargs=kwargs, response_obj={}, start_time=now, end_time=now
+        )
+    finally:
+        litellm.cache = original_cache
+
+    assert payload["cache_key"] == "Cache OFF"


### PR DESCRIPTION
## Title
fix(spend-tracking): skip cache key computation for unsupported call types

## Fixes
Fixes #31862

## The bug
`get_logging_payload` in `litellm/proxy/spend_tracking/spend_tracking_utils.py` called `litellm.cache.get_cache_key(**kwargs)` on **every request** whenever any cache backend was configured, guarded only by a single boolean:

```python
if litellm.cache is not None:
    cache_key = litellm.cache.get_cache_key(**kwargs)
else:
    cache_key = "Cache OFF"
```

A cache backend can be configured with a `supported_call_types` list that **excludes** the current call type. A common example is Redis configured purely for routing state (cooldown tracking, model-group keys) with `supported_call_types: []`. In that case `litellm.cache` is not `None`, so `get_cache_key` runs for **100% of requests** even though nothing is ever cached.

`get_cache_key` is not a trivial lookup — it iterates the entire `kwargs` dict, concatenates API params, computes a SHA-256 hash, resolves a namespace prefix, and mutates `kwargs["litellm_params"]["preset_cache_key"]`. All of that work is wasted when the call type isn't cacheable.

**Observable impact:**
1. Unnecessary CPU on the logging hot-path (runs for every request).
2. The `cache_key` column in `LiteLLM_SpendLogs` is populated with a meaningless SHA-256 hash that *implies caching is active when it is not*, instead of the accurate `"Cache OFF"` sentinel.

## Root cause
`CachingHandler._is_call_type_supported_by_cache` (`litellm/caching/caching_handler.py`) already enforces a **three-part** guard:

```python
if (
    litellm.cache is not None
    and litellm.cache.supported_call_types is not None
    and str(original_function.__name__) in litellm.cache.supported_call_types
):
```

`get_logging_payload` was written independently and only checked the first condition. The asymmetry is the root cause.

## The fix
Mirror the same three-part guard, using the `call_type` already extracted at the top of `get_logging_payload` (line 239, `call_type = kwargs.get("call_type")`):

```python
cache_key = "Cache OFF"
if (
    litellm.cache is not None
    and litellm.cache.supported_call_types is not None
    and call_type in litellm.cache.supported_call_types
):
    cache_key = litellm.cache.get_cache_key(**kwargs)
```

`call_type` is a string at runtime (compared against `CallTypes.X.value` strings throughout `litellm_logging.py`), and `supported_call_types` is a list of the same strings, so the membership check is correct.

## Testing
Added a parametrized regression test to `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py` covering:

| Scenario | get_cache_key called | cache_key |
|---|---|---|
| Cache present, `supported_call_types=[]` | 0 | `"Cache OFF"` |
| Cache present, call type supported | 1 | SHA-256 hash |
| Cache present, different call type supported | 0 | `"Cache OFF"` |
| `litellm.cache is None` | 0 | `"Cache OFF"` |

```
tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py .... [100%]
86 passed  (82 existing + 4 new, zero regressions)
```

Also verified locally: `ruff check` clean on both changed files, `scripts/ruff_strict_gate.py` passes, and `black` introduces zero changes to the added lines.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

Behaviour is unchanged for the default configuration (the default `supported_call_types` includes `completion`/`acompletion`/`embedding`/etc.). The change only suppresses the wasted hash computation when a call type is explicitly outside the configured `supported_call_types`.
