### PR TITLE
fix(logging): resolve model_map_value for proxy custom pricing

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5268,6 +5268,9 @@ def get_standard_logging_object_payload(
 
         ## Get model cost information ##
         base_model = _get_base_model_from_metadata(model_call_details=kwargs)
+        # The router overrides completion_response.model to the model-group alias before
+        # this payload is built, so cost-map lookup via that alias always misses.
+        # Fall back to the actual deployment model set by the router in metadata.
         if base_model is None:
             base_model = metadata.get("deployment")
         custom_pricing = use_custom_pricing_for_model(litellm_params=litellm_params)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4722,7 +4722,7 @@ class StandardLoggingPayloadSetup:
         api_base: Optional[str] = None,
     ) -> StandardLoggingModelInformation:
         model_cost_name = _select_model_name_for_cost_calc(
-            model=base_model,
+            model=base_model if custom_pricing else None,
             completion_response=init_response_obj,  # type: ignore
             base_model=base_model,
             custom_pricing=custom_pricing,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -4722,7 +4722,7 @@ class StandardLoggingPayloadSetup:
         api_base: Optional[str] = None,
     ) -> StandardLoggingModelInformation:
         model_cost_name = _select_model_name_for_cost_calc(
-            model=None,
+            model=base_model,
             completion_response=init_response_obj,  # type: ignore
             base_model=base_model,
             custom_pricing=custom_pricing,
@@ -5268,6 +5268,8 @@ def get_standard_logging_object_payload(
 
         ## Get model cost information ##
         base_model = _get_base_model_from_metadata(model_call_details=kwargs)
+        if base_model is None:
+            base_model = metadata.get("deployment")
         custom_pricing = use_custom_pricing_for_model(litellm_params=litellm_params)
         raw_response_cost = kwargs.get("response_cost")
         response_cost: float = raw_response_cost or 0.0
@@ -5389,7 +5391,7 @@ def get_standard_logging_object_payload(
 
 def emit_standard_logging_payload(payload: StandardLoggingPayload):
     if os.getenv("LITELLM_PRINT_STANDARD_LOGGING_PAYLOAD"):
-        print(json.dumps(payload, indent=4))  # noqa: T201
+        print(json.dumps(payload, indent=4), flush=True)  # noqa: T201
 
 
 def get_standard_logging_metadata(

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -322,13 +322,11 @@ def test_get_model_cost_information():
         custom_llm_provider="openai",
         init_response_obj={},
     )
-    litellm_info_gpt_3_5_turbo_model_map_value = litellm.get_model_info(
-        model="gpt-5-mini", custom_llm_provider="openai"
-    )
     print("result", result)
-    assert result["model_map_key"] == "gpt-5-mini"
+    # provider prefix is now inferred from base_model and prepended
+    assert result["model_map_key"] in ("gpt-5-mini", "openai/gpt-5-mini")
     assert result["model_map_value"] is not None
-    assert result["model_map_value"] == litellm_info_gpt_3_5_turbo_model_map_value
+    assert result["model_map_value"]["litellm_provider"] == "openai"
     # assert all fields in StandardLoggingModelInformation are present
     assert all(
         field in result for field in StandardLoggingModelInformation.__annotations__

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -346,6 +346,63 @@ def test_get_model_cost_information_custom_pricing_uses_base_model():
     assert result["model_map_key"] != "invoke_test_claude"
 
 
+def test_standard_logging_payload_uses_deployment_when_no_base_model():
+    """metadata["deployment"] is used for cost-map lookup when base_model is not set."""
+    from datetime import datetime
+
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging,
+        get_standard_logging_object_payload,
+    )
+
+    logging_obj = Logging(
+        model="invoke_test_claude",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=datetime.now(),
+        litellm_call_id="test-deploy-fallback",
+        function_id="test-fn",
+    )
+
+    kwargs = {
+        "model": "invoke_test_claude",
+        "messages": [{"role": "user", "content": "hi"}],
+        "custom_llm_provider": "bedrock",
+        "litellm_params": {
+            "metadata": {
+                "deployment": "bedrock/invoke/global.anthropic.claude-opus-4-6-v1",
+            },
+        },
+    }
+    mock_response = {
+        "id": "chatcmpl-deploy-test",
+        "object": "chat.completion",
+        "model": "invoke_test_claude",
+        "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hello"},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+    payload = get_standard_logging_object_payload(
+        kwargs=kwargs,
+        init_response_obj=mock_response,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        logging_obj=logging_obj,
+        status="success",
+    )
+
+    assert payload is not None
+    assert payload["model_map_information"]["model_map_value"] is not None
+    assert payload["model_map_information"]["model_map_key"] != "invoke_test_claude"
+
+
 def test_get_hidden_params():
     """Test get_hidden_params with different inputs"""
     # Test with None

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -335,6 +335,17 @@ def test_get_model_cost_information():
     )
 
 
+def test_get_model_cost_information_custom_pricing_uses_base_model():
+    result = StandardLoggingPayloadSetup.get_model_cost_information(
+        base_model="bedrock/invoke/global.anthropic.claude-opus-4-6-v1",
+        custom_pricing=True,
+        custom_llm_provider="bedrock",
+        init_response_obj={"model": "invoke_test_claude"},
+    )
+    assert result["model_map_value"] is not None
+    assert result["model_map_key"] != "invoke_test_claude"
+
+
 def test_get_hidden_params():
     """Test get_hidden_params with different inputs"""
     # Test with None

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -322,11 +322,13 @@ def test_get_model_cost_information():
         custom_llm_provider="openai",
         init_response_obj={},
     )
+    litellm_info_gpt_3_5_turbo_model_map_value = litellm.get_model_info(
+        model="gpt-5-mini", custom_llm_provider="openai"
+    )
     print("result", result)
-    # provider prefix is now inferred from base_model and prepended
-    assert result["model_map_key"] in ("gpt-5-mini", "openai/gpt-5-mini")
+    assert result["model_map_key"] == "gpt-5-mini"
     assert result["model_map_value"] is not None
-    assert result["model_map_value"]["litellm_provider"] == "openai"
+    assert result["model_map_value"] == litellm_info_gpt_3_5_turbo_model_map_value
     # assert all fields in StandardLoggingModelInformation are present
     assert all(
         field in result for field in StandardLoggingModelInformation.__annotations__


### PR DESCRIPTION
Fixes LIT-3719
## Summary
- Fix `model_map_value` being null in `StandardLoggingPayload` when proxy model-group aliases override `response.model` and custom pricing is enabled
- Fall back to `metadata["deployment"]` for cost-map lookup when `base_model` is unset
- Flush stdout when printing standard logging payloads to avoid delayed output under piped logging
<img width="737" height="418" alt="image" src="https://github.com/user-attachments/assets/a3ac06f4-9d23-4c18-b5a0-d38b944eb583" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only how standard logging resolves cost-map metadata for proxy/router aliases; request handling and billing math elsewhere are untouched, with targeted tests.
> 
> **Overview**
> Fixes **null `model_map_value`** in standard logging when the proxy/router rewrites `response.model` to a model-group alias while **custom pricing** is on.
> 
> **`get_model_cost_information`** now passes **`base_model`** into cost-name selection when custom pricing is enabled, so lookup does not rely only on the alias in the response object. When building the standard logging payload, if **`base_model`** is missing it **falls back to `metadata["deployment"]`** (the real deployment id the router records).
> 
> Debug printing of standard logging payloads now **flushes stdout** so piped logging shows output promptly. New tests cover custom-pricing base-model selection and the deployment fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fabf6fa15d37cc828298af69efbbfbccfed2099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->