### PR TITLE
fix(proxy): use budget reset window for projected spend alerts

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2713,6 +2713,8 @@ async def update_cache(
                 _is_projected_spend_over_limit(
                     current_spend=new_spend,
                     soft_budget_limit=existing_spend_obj.soft_budget,
+                    budget_duration=existing_spend_obj.budget_duration,
+                    budget_reset_at=existing_spend_obj.budget_reset_at,
                 )
                 is True
             )
@@ -2720,6 +2722,8 @@ async def update_cache(
             projected_spend, projected_exceeded_date = _get_projected_spend_over_limit(
                 current_spend=new_spend,
                 soft_budget_limit=existing_spend_obj.soft_budget,
+                budget_duration=existing_spend_obj.budget_duration,
+                budget_reset_at=existing_spend_obj.budget_reset_at,
             )  # type: ignore
             soft_limit = existing_spend_obj.soft_budget
             call_info = CallInfo(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5598,7 +5598,11 @@ def _get_projected_spend_over_limit(
     if soft_budget_limit is None:
         return None
 
-    today = date.today()
+    today = (
+        datetime.now(budget_reset_at.tzinfo).date()
+        if budget_reset_at is not None and budget_reset_at.tzinfo is not None
+        else date.today()
+    )
     window_end, elapsed_days = _get_budget_window(today, budget_duration, budget_reset_at)
     remaining_days = max((window_end - today).days, 0)
     daily_spend = current_spend / elapsed_days

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5560,7 +5560,7 @@ def _get_budget_window(
     today: date,
     budget_duration: Optional[str],
     budget_reset_at: Optional[datetime],
-) -> Tuple[date, int]:
+) -> tuple[date, int]:
     if budget_duration is None or budget_reset_at is None:
         return _get_month_end_date(today), max(today.day - 1, 1)
     try:
@@ -5594,7 +5594,7 @@ def _get_projected_spend_over_limit(
     soft_budget_limit: Optional[float],
     budget_duration: Optional[str] = None,
     budget_reset_at: Optional[datetime] = None,
-) -> Optional[Tuple[float, date]]:
+) -> Optional[tuple[float, date]]:
     if soft_budget_limit is None:
         return None
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -103,6 +103,7 @@ from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 from litellm.integrations.SlackAlerting.utils import _add_langfuse_trace_id_to_alert
+from litellm.litellm_core_utils.duration_parser import duration_in_seconds
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
@@ -5555,63 +5556,61 @@ def _get_month_end_date(today: date) -> date:
     return date(today.year, today.month + 1, 1) - timedelta(days=1)
 
 
-def _is_projected_spend_over_limit(current_spend: float, soft_budget_limit: Optional[float]):
-    if soft_budget_limit is None:
-        # If there's no limit, we can't exceed it.
-        return False
-
-    today = date.today()
-
-    # Finding the first day of the next month, then subtracting one day to get the end of the current month.
-    end_month = _get_month_end_date(today)
-
-    remaining_days = (end_month - today).days
-
-    # Check for the start of the month to avoid division by zero
-    if today.day == 1:
-        daily_spend_estimate = current_spend
-    else:
-        daily_spend_estimate = current_spend / (today.day - 1)
-
-    # Total projected spend for the month
-    projected_spend = current_spend + (daily_spend_estimate * remaining_days)
-
-    if projected_spend > soft_budget_limit:
-        print_verbose("Projected spend exceeds soft budget limit!")
-        return True
-    return False
+def _get_budget_window(
+    today: date,
+    budget_duration: Optional[str],
+    budget_reset_at: Optional[datetime],
+) -> Tuple[date, int]:
+    if budget_duration is None or budget_reset_at is None:
+        return _get_month_end_date(today), max(today.day - 1, 1)
+    try:
+        window_days = max(duration_in_seconds(duration=budget_duration) // 86400, 1)
+    except ValueError:
+        return _get_month_end_date(today), max(today.day - 1, 1)
+    window_end = budget_reset_at.date()
+    window_start = window_end - timedelta(days=window_days)
+    return window_end, max((today - window_start).days, 1)
 
 
-def _get_projected_spend_over_limit(current_spend: float, soft_budget_limit: Optional[float]) -> Optional[tuple]:
+def _is_projected_spend_over_limit(
+    current_spend: float,
+    soft_budget_limit: Optional[float],
+    budget_duration: Optional[str] = None,
+    budget_reset_at: Optional[datetime] = None,
+) -> bool:
+    return (
+        _get_projected_spend_over_limit(
+            current_spend=current_spend,
+            soft_budget_limit=soft_budget_limit,
+            budget_duration=budget_duration,
+            budget_reset_at=budget_reset_at,
+        )
+        is not None
+    )
+
+
+def _get_projected_spend_over_limit(
+    current_spend: float,
+    soft_budget_limit: Optional[float],
+    budget_duration: Optional[str] = None,
+    budget_reset_at: Optional[datetime] = None,
+) -> Optional[Tuple[float, date]]:
     if soft_budget_limit is None:
         return None
 
     today = date.today()
-    end_month = _get_month_end_date(today)
-    remaining_days = (end_month - today).days
-
-    # assuming the current spend till today (not including today)
-    if today.day == 1:
-        daily_spend = current_spend
-    else:
-        daily_spend = current_spend / (today.day - 1)
+    window_end, elapsed_days = _get_budget_window(today, budget_duration, budget_reset_at)
+    remaining_days = max((window_end - today).days, 0)
+    daily_spend = current_spend / elapsed_days
     projected_spend = current_spend + (daily_spend * remaining_days)
 
-    if projected_spend > soft_budget_limit:
-        if daily_spend <= 0:
-            limit_exceed_date = today
-        else:
-            remaining_budget = soft_budget_limit - current_spend
-            if remaining_budget <= 0:
-                limit_exceed_date = today
-            else:
-                approx_days = remaining_budget / daily_spend
-                limit_exceed_date = today + timedelta(days=approx_days)
+    if projected_spend <= soft_budget_limit:
+        return None
 
-        # return the projected spend and the date it will exceeded
-        return projected_spend, limit_exceed_date
-
-    return None
+    remaining_budget = soft_budget_limit - current_spend
+    if daily_spend <= 0 or remaining_budget <= 0:
+        return projected_spend, today
+    return projected_spend, min(today + timedelta(days=remaining_budget / daily_spend), window_end)
 
 
 def _is_valid_team_configs(team_id=None, team_config=None, request_data=None):

--- a/tests/test_litellm/proxy/utils/helpers/test_month_end_projection.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_month_end_projection.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -292,3 +292,38 @@ def test_get_projected_spend_over_limit_without_duration_keeps_month_end_behavio
     assert result is not None
     projected, _ = result
     assert projected == pytest.approx(8.0 + (8.0 / 14) * 16)
+
+
+def test_get_projected_spend_over_limit_uses_reset_timezone_not_host_timezone(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 16))
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2024, 1, 15, 23, 30, tzinfo=tz)
+
+    monkeypatch.setattr("litellm.proxy.utils.datetime", _FrozenDatetime)
+    result = _get_projected_spend_over_limit(
+        current_spend=8.0,
+        soft_budget_limit=10.0,
+        budget_duration="1d",
+        budget_reset_at=datetime(2024, 1, 16, 0, 0, 0, tzinfo=timezone.utc),
+    )
+    assert result is not None
+    projected, exceed_date = result
+    assert projected == 16.0
+    assert exceed_date <= date(2024, 1, 16)
+
+
+def test_get_projected_spend_over_limit_exceed_date_never_past_reset(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    for spend, soft in [(8.0, 9.99), (8.0, 13.9), (8.0, 13.99)]:
+        result = _get_projected_spend_over_limit(
+            current_spend=spend,
+            soft_budget_limit=soft,
+            budget_duration="7d",
+            budget_reset_at=datetime(2024, 1, 18, 0, 0, 0),
+        )
+        assert result is not None
+        _, exceed_date = result
+        assert exceed_date <= date(2024, 1, 18)

--- a/tests/test_litellm/proxy/utils/helpers/test_month_end_projection.py
+++ b/tests/test_litellm/proxy/utils/helpers/test_month_end_projection.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 import pytest
 
@@ -230,3 +230,65 @@ def test_get_projected_spend_over_limit_raises_when_today_missing(monkeypatch):
     monkeypatch.setattr("litellm.proxy.utils.date", _Broken)
     with pytest.raises(RuntimeError):
         _get_projected_spend_over_limit(current_spend=1.0, soft_budget_limit=1.0)
+
+
+def test_get_projected_spend_over_limit_daily_budget_projects_to_reset_not_month_end(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    result = _get_projected_spend_over_limit(
+        current_spend=8.0,
+        soft_budget_limit=10.0,
+        budget_duration="1d",
+        budget_reset_at=datetime(2024, 1, 16, 0, 0, 0),
+    )
+    assert result is not None
+    projected, exceed_date = result
+    assert projected == 16.0
+    assert exceed_date <= date(2024, 1, 16)
+
+
+def test_get_projected_spend_over_limit_weekly_budget_uses_window_daily_rate(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    result = _get_projected_spend_over_limit(
+        current_spend=8.0,
+        soft_budget_limit=10.0,
+        budget_duration="7d",
+        budget_reset_at=datetime(2024, 1, 18, 0, 0, 0),
+    )
+    assert result is not None
+    projected, exceed_date = result
+    assert projected == 14.0
+    assert exceed_date == date(2024, 1, 16)
+
+
+def test_get_projected_spend_over_limit_daily_budget_under_limit_no_false_alert(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    assert (
+        _get_projected_spend_over_limit(
+            current_spend=4.0,
+            soft_budget_limit=10.0,
+            budget_duration="1d",
+            budget_reset_at=datetime(2024, 1, 16, 0, 0, 0),
+        )
+        is None
+    )
+
+
+def test_is_projected_spend_over_limit_daily_budget_under_limit(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    assert (
+        _is_projected_spend_over_limit(
+            current_spend=4.0,
+            soft_budget_limit=10.0,
+            budget_duration="1d",
+            budget_reset_at=datetime(2024, 1, 16, 0, 0, 0),
+        )
+        is False
+    )
+
+
+def test_get_projected_spend_over_limit_without_duration_keeps_month_end_behavior(monkeypatch):
+    _freeze_today(monkeypatch, date(2024, 1, 15))
+    result = _get_projected_spend_over_limit(current_spend=8.0, soft_budget_limit=10.0)
+    assert result is not None
+    projected, _ = result
+    assert projected == pytest.approx(8.0 + (8.0 / 14) * 16)


### PR DESCRIPTION
## Relevant issues

Fixes #31934


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

<img width="786" height="341" alt="image-1782971049760" src="https://github.com/user-attachments/assets/ca7a3780-6bd2-4b5c-859d-04c8e70f1c6d" />


## Type

🐛 Bug Fix

## Changes

`_get_projected_spend_over_limit` and `_is_projected_spend_over_limit` in `litellm/proxy/utils.py` always projected spend to the end of the calendar month and estimated the daily rate as `current_spend / (day_of_month - 1)`. For keys whose budgets reset daily or weekly this produces inflated projections and exceed dates that land beyond the reset boundary

This PR adds a `_get_budget_window` helper that derives the projection window from the key's `budget_duration` and `budget_reset_at` (both already available on `UserAPIKeyAuth` at the call site in `_update_key_cache`): the window ends at the next reset and the daily rate divides by days elapsed within the window. When a key has no budget duration the previous month-end behavior is preserved exactly. `_is_projected_spend_over_limit` now delegates to `_get_projected_spend_over_limit` instead of duplicating the same math, and the exceed date is clamped so it can never land after the reset

Regression tests cover the daily and weekly windows, the no-false-alert case, and the month-end fallback; they fail on main and pass with this change