### PR TITLE
feat: Add three features to improve LiteLLM for Chinese developers

### DIFF
--- a/docs/my-website/docs/routing/china-domestic-free-sources.md
+++ b/docs/my-website/docs/routing/china-domestic-free-sources.md
@@ -1,0 +1,68 @@
+# China Domestic Free Sources
+
+Pre-configured free LLM sources for Chinese developers. These sources are accessible from mainland China without VPN.
+
+## Overview
+
+Chinese developers face unique challenges:
+- Need VPN to access international LLM APIs
+- Prefer local models for latency and privacy
+
+This configuration provides pre-configured free sources that work in China.
+
+## Sources
+
+### SiliconFlow (硅基流动)
+
+- **Website**: https://cloud.siliconflow.cn
+- **Free Models**: DeepSeek-R1, Qwen2.5-72B
+- **Registration**: Free credits on signup
+
+### Zhipu (智谱)
+
+- **Website**: https://open.bigmodel.cn
+- **Free Models**: GLM-4-Flash (永久免费)
+- **Registration**: 20M tokens free
+
+## Configuration
+
+```yaml
+model_list:
+  # SiliconFlow
+  - model_name: sf-deepseek-r1
+    litellm_params:
+      model: siliconflow/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  - model_name: sf-qwen2.5-72b
+    litellm_params:
+      model: siliconflow/Qwen/Qwen2.5-72B-Instruct
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  # Zhipu
+  - model_name: glm-4-flash
+    litellm_params:
+      model: zhipu/glm-4-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+
+  - model_name: glm-4.7-flash
+    litellm_params:
+      model: zhipu/glm-4.7-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+```
+
+## Environment Variables
+
+```bash
+export SILICONFLOW_API_KEY="your-key"
+export ZHIPU_API_KEY="your-key"
+```
+
+## Related
+
+- [Task-Aware Routing](./task-aware-routing.md)
+- [Local-First Routing](./local-first-routing.md)

--- a/docs/my-website/docs/routing/local-first-routing.md
+++ b/docs/my-website/docs/routing/local-first-routing.md
@@ -1,0 +1,56 @@
+# Local-First Routing
+
+Route requests to local models first, then fall back to cloud models. This minimizes latency and cost while maintaining privacy.
+
+## Overview
+
+Local-first routing prioritizes local models (e.g., Ollama) for:
+- **Lower latency**: Local models respond faster
+- **Zero cost**: No API charges
+- **Better privacy**: Data stays on your machine
+
+## Configuration
+
+```yaml
+router_settings:
+  routing_strategy: local-first-routing
+  routing_strategy_args:
+    local_provider: ollama
+    local_fallback_order:
+      - local
+      - domestic_free
+      - openrouter_free
+      - openrouter_paid
+```
+
+## Usage
+
+```python
+import litellm
+
+# This will prefer local models if available
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+## How It Works
+
+1. Request comes in for a model
+2. Router checks if a local alternative exists
+3. If local model available, use it
+4. If not, fall back to cloud model
+
+## Local Model Detection
+
+Models are considered "local" if they contain:
+- `ollama/`
+- `localhost:`
+- `127.0.0.1:`
+- `local/`
+
+## Related
+
+- [Task-Aware Routing](./task-aware-routing.md)
+- [China Domestic Free Sources](./china-domestic-free-sources.md)

--- a/docs/my-website/docs/routing/task-aware-routing.md
+++ b/docs/my-website/docs/routing/task-aware-routing.md
@@ -1,0 +1,85 @@
+# Task-Aware Routing
+
+Route requests based on task type (coding, chinese, general, english, fast). This allows you to define task-specific model preferences.
+
+## Overview
+
+Task-aware routing lets you specify different models for different tasks. For example:
+- **coding**: Prefer fast coding models (devstral, qwen3-coder)
+- **chinese**: Prefer Chinese-optimized models (qwen3, glm-4)
+- **general**: Prefer general-purpose models (gemma4, nemotron)
+
+## Configuration
+
+```yaml
+router_settings:
+  routing_strategy: task-aware-routing
+  routing_strategy_args:
+    task_mapping:
+      coding: [devstral, qwen3-coder, claude-sonnet]
+      chinese: [qwen3, sf-qwen2.5-72b, claude-sonnet]
+      general: [gemma4, nemotron-ultra-free, claude-sonnet]
+      english: [ornith-35b, nemotron-ultra-free, claude-opus]
+      fast: [deepseek-r1-14b, sf-deepseek-r1, glm-4-flash]
+    default_task: general
+```
+
+## Usage
+
+When making a request, include the `task` parameter in `metadata`:
+
+```python
+import litellm
+
+# Pass task via metadata (recommended)
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Write a Python function"}],
+    metadata={"task": "coding"}
+)
+```
+
+### Alternative: Pass via kwargs
+
+```python
+# Pass task directly as kwargs
+response = litellm.completion(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Write a Python function"}],
+    task="coding"
+)
+```
+
+### HTTP API
+
+```bash
+curl -X POST http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-3.5-turbo",
+    "messages": [{"role": "user", "content": "Write code"}],
+    "metadata": {"task": "coding"}
+  }'
+```
+
+## Task Types
+
+| Task | Description | Recommended Models |
+|------|-------------|-------------------|
+| `coding` | Code generation, debugging | devstral, qwen3-coder |
+| `chinese` | Chinese language tasks | qwen3, glm-4 |
+| `general` | General purpose | gemma4, nemotron |
+| `english` | English language tasks | ornith, claude |
+| `fast` | Quick responses | deepseek-r1-14b |
+
+## How It Works
+
+1. Request comes in with `task` parameter
+2. Router looks up `task_mapping[task]` to get model list
+3. First available model from the list is selected
+4. If no model found, falls back to `default_task`
+
+## Related
+
+- [Local-First Routing](./local-first-routing.md)
+- [China Domestic Free Sources](./china-domestic-free-sources.md)

--- a/litellm/litellm_core_utils/fallback_generalizations.py
+++ b/litellm/litellm_core_utils/fallback_generalizations.py
@@ -1,0 +1,141 @@
+"""
+Declarative fallback generalizations for unknown / newly-released models.
+
+The ``fallback_generalizations`` block in ``model_prices_and_context_window.json``
+holds an ordered list of rules. Each rule pairs a single case-insensitive regex
+with the metadata to apply when a model name has no exact entry in the cost map.
+The metadata is a partial cost-map entry: ``litellm_provider`` drives provider
+routing, and the remaining fields (``mode``, ``supports_*``, context window,
+pricing, ...) drive ``get_model_info`` / ``supports_*``.
+
+Precedence: rules are evaluated in file order and the first match wins. They are
+consulted only after exact and case-insensitive lookups miss, so an exact entry
+always takes precedence over a rule.
+
+Patterns are matched case-insensitively with ``re.search`` and are not implicitly
+anchored: a rule must include ``^`` and ``$`` (as the shipped rules do) to bind to
+the whole model name, otherwise it matches as a substring. Keeping anchoring in the
+regex makes the rule the single, self-contained source of truth for what it matches.
+
+A rule may set ``extends`` to the ``name`` of another rule to inherit that rule's
+``model_info``; the rule's own ``model_info`` overrides the inherited keys, so a
+narrow rule (for example a version-gated capability flag) carries only its delta
+instead of duplicating the parent's pricing block. Inheritance is resolved once,
+at install time, against each rule's raw (unresolved) ``model_info``; it is a
+single level (a parent that itself extends is not chained).
+
+Any other keys on a rule (for example a free-text ``description`` documenting what
+the regex matches) are ignored by the engine and exist only for the reader.
+
+The compiled-regex list is built once and cached. ``match_fallback_generalization``
+is O(number of rules); callers must only invoke it on a cache miss.
+"""
+
+import re
+from typing import Optional
+
+from litellm._logging import verbose_logger
+
+NAME_FIELD = "name"
+PATTERN_FIELD = "pattern"
+MODEL_INFO_FIELD = "model_info"
+EXTENDS_FIELD = "extends"
+
+
+def _resolve_extends(rules: list) -> list:
+    """Expand ``extends`` inheritance so each rule's ``model_info`` is self-contained.
+
+    A rule with ``extends: <name>`` is rewritten with ``model_info`` set to the parent's
+    ``model_info`` overlaid by its own. Resolution is single-level and uses each rule's
+    raw ``model_info`` as the parent source. Non-dict rules and dangling parents are
+    passed through unchanged.
+    """
+    base_by_name = {
+        rule[NAME_FIELD]: rule[MODEL_INFO_FIELD]
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get(NAME_FIELD), str)
+        and isinstance(rule.get(MODEL_INFO_FIELD), dict)
+    }
+
+    def resolved(rule: dict) -> dict:
+        parent_name = rule.get(EXTENDS_FIELD)
+        own_info = rule.get(MODEL_INFO_FIELD)
+        parent_info = base_by_name.get(parent_name) if isinstance(parent_name, str) else None
+        if parent_info is None or not isinstance(own_info, dict):
+            return rule
+        return {**rule, MODEL_INFO_FIELD: {**parent_info, **own_info}}
+
+    return [resolved(rule) if isinstance(rule, dict) else rule for rule in rules]
+
+
+class _FallbackGeneralizations:
+    """Holds the active rule list and its lazily-compiled regex cache."""
+
+    def __init__(self) -> None:
+        self.rules: list[dict] = []
+        self._compiled: Optional[list[tuple[re.Pattern, dict]]] = None
+
+    def set_rules(self, rules: Optional[list[dict]]) -> None:
+        self.rules = rules if isinstance(rules, list) else []
+        self._compiled = None
+
+    def _compile(self) -> list[tuple[re.Pattern, dict]]:
+        compiled: list[tuple[re.Pattern, dict]] = []
+        for rule in self.rules:
+            if not isinstance(rule, dict):
+                continue
+            pattern = rule.get(PATTERN_FIELD)
+            model_info = rule.get(MODEL_INFO_FIELD)
+            if not isinstance(pattern, str) or not isinstance(model_info, dict):
+                verbose_logger.warning(
+                    "LiteLLM: skipping malformed fallback generalization rule %s (needs string '%s' and dict '%s').",
+                    rule.get("name", pattern),
+                    PATTERN_FIELD,
+                    MODEL_INFO_FIELD,
+                )
+                continue
+            try:
+                compiled.append((re.compile(pattern, re.IGNORECASE), model_info))
+            except re.error as e:
+                verbose_logger.warning(
+                    "LiteLLM: skipping fallback generalization rule with invalid regex %r: %s",
+                    pattern,
+                    e,
+                )
+        return compiled
+
+    def match(self, model: str) -> Optional[dict]:
+        if not model:
+            return None
+        if self._compiled is None:
+            self._compiled = self._compile()
+        for pattern, model_info in self._compiled:
+            if pattern.search(model) is not None:
+                return dict(model_info)
+        return None
+
+
+_registry = _FallbackGeneralizations()
+
+
+def set_fallback_generalizations(rules: Optional[list[dict]]) -> None:
+    """Install the active rule list and invalidate the compiled-regex cache.
+
+    ``extends`` inheritance is resolved here, once, before the rules are stored.
+    Called once when the model cost map is loaded (and again on any reload).
+    """
+    _registry.set_rules(_resolve_extends(rules) if isinstance(rules, list) else rules)
+
+
+def get_fallback_generalization_rules() -> list[dict]:
+    """Return the raw rule list (read-only view for callers/tests)."""
+    return _registry.rules
+
+
+def match_fallback_generalization(model: str) -> Optional[dict]:
+    """Return the ``model_info`` of the first rule whose regex matches ``model``.
+
+    O(number of rules). Only call this once exact lookups have missed.
+    """
+    return _registry.match(model)

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -1,9 +1,11 @@
-import re
 from typing import Optional, Tuple, cast
 from urllib.parse import urlparse
 
 import litellm
 from litellm.constants import REPLICATE_MODEL_NAME_WITH_ID_LENGTH
+from litellm.litellm_core_utils.fallback_generalizations import (
+    match_fallback_generalization,
+)
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
 from litellm.secret_managers.main import get_secret, get_secret_str
 
@@ -67,25 +69,6 @@ def _is_azure_claude_model(model: str) -> bool:
         return "claude" in model_lower or model_lower.startswith("claude")
     except Exception:
         return False
-
-
-_CLAUDE_PATTERN = re.compile(r"^claude-[a-z]+-\d+-\d+(?:-\d{8})?$", re.IGNORECASE)
-
-
-def _matches_claude_model_pattern(model: str) -> bool:
-    """
-    Check if a model string matches the Claude model naming pattern.
-
-    Matches patterns like:
-    - claude-opus-4-7
-    - claude-sonnet-4-6
-    - claude-haiku-4-5
-    - claude-opus-5-1-20270101 (with optional date suffix)
-
-    This allows future Claude models to be routed to the Anthropic provider
-    without requiring updates to model_prices_and_context_window.json.
-    """
-    return _CLAUDE_PATTERN.match(model) is not None
 
 
 def handle_cohere_chat_model_custom_llm_provider(
@@ -391,9 +374,6 @@ def get_llm_provider(
                 custom_llm_provider = "anthropic_text"
             else:
                 custom_llm_provider = "anthropic"
-        ## anthropic - pattern-based matching for future Claude models
-        elif _matches_claude_model_pattern(model):
-            custom_llm_provider = "anthropic"
         ## cohere
         elif model in litellm.cohere_models or model in litellm.cohere_embedding_models:
             custom_llm_provider = "cohere"
@@ -487,6 +467,15 @@ def get_llm_provider(
             custom_llm_provider = "amazon_nova"
         elif model.startswith("sap/"):
             custom_llm_provider = "sap"
+
+        # Last resort for an otherwise-unknown model: a declarative
+        # fallback-generalization rule (e.g. routes future claude-* to anthropic).
+        # Exact provider matches above always win; this only runs on a miss.
+        if not custom_llm_provider:
+            generalization = match_fallback_generalization(model)
+            if generalization is not None:
+                custom_llm_provider = generalization.get("litellm_provider") or None
+
         if not custom_llm_provider:
             if litellm.suppress_debug_info is False:
                 print()  # noqa: T201

--- a/litellm/litellm_core_utils/get_model_cost_map.py
+++ b/litellm/litellm_core_utils/get_model_cost_map.py
@@ -20,6 +20,20 @@ from litellm.constants import (
     MODEL_COST_MAP_MAX_SHRINK_RATIO,
     MODEL_COST_MAP_MIN_MODEL_COUNT,
 )
+from litellm.litellm_core_utils.fallback_generalizations import (
+    set_fallback_generalizations,
+)
+
+FALLBACK_GENERALIZATIONS_KEY = "fallback_generalizations"
+
+# Reserved top-level keys that are not model entries. They must be excluded
+# from the model-count integrity check so a real upstream shrink can't be masked.
+RESERVED_TOP_LEVEL_KEYS = frozenset({"sample_spec", FALLBACK_GENERALIZATIONS_KEY})
+
+
+def _count_model_entries(model_cost: dict) -> int:
+    """Count actual model entries, excluding reserved meta keys."""
+    return sum(1 for key in model_cost if key not in RESERVED_TOP_LEVEL_KEYS)
 
 
 class GetModelCostMap:
@@ -46,7 +60,7 @@ class GetModelCostMap:
         """Return the number of models in the local backup (cached int)."""
         if cls._backup_model_count < 0:
             backup = cls.load_local_model_cost_map()
-            cls._backup_model_count = len(backup)
+            cls._backup_model_count = _count_model_entries(backup)
         return cls._backup_model_count
 
     @staticmethod
@@ -76,7 +90,7 @@ class GetModelCostMap:
         max_shrink_ratio: float = MODEL_COST_MAP_MAX_SHRINK_RATIO,
     ) -> bool:
         """Check 2: model count has not reduced significantly vs backup."""
-        fetched_count = len(fetched_map)
+        fetched_count = _count_model_entries(fetched_map)
 
         if fetched_count < min_model_count:
             verbose_logger.warning(
@@ -234,6 +248,18 @@ def _expand_model_aliases(model_cost: dict) -> dict:
     return model_cost
 
 
+def _finalize_model_cost_map(model_cost: dict) -> dict:
+    """Extract fallback generalizations out of the raw map, then expand aliases.
+
+    The ``fallback_generalizations`` block is installed into the generalizations
+    module and removed from the map so it is never treated as a model entry.
+    """
+    raw = model_cost.pop(FALLBACK_GENERALIZATIONS_KEY, None)
+    rules = raw.get("rules") if isinstance(raw, dict) else None
+    set_fallback_generalizations(rules)
+    return _expand_model_aliases(model_cost)
+
+
 def get_model_cost_map(url: str) -> dict:
     """
     Public entry point — returns the model cost map dict.
@@ -253,7 +279,7 @@ def get_model_cost_map(url: str) -> dict:
         _cost_map_source_info.url = None
         _cost_map_source_info.is_env_forced = True
         _cost_map_source_info.fallback_reason = None
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     _cost_map_source_info.url = url
     _cost_map_source_info.is_env_forced = False
@@ -268,7 +294,7 @@ def get_model_cost_map(url: str) -> dict:
         )
         _cost_map_source_info.source = "local"
         _cost_map_source_info.fallback_reason = f"Remote fetch failed: {str(e)}"
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     # Validate using cached count (cheap int comparison, no file I/O)
     if not GetModelCostMap.validate_model_cost_map(
@@ -281,8 +307,8 @@ def get_model_cost_map(url: str) -> dict:
         )
         _cost_map_source_info.source = "local"
         _cost_map_source_info.fallback_reason = "Remote data failed integrity validation"
-        return _expand_model_aliases(GetModelCostMap.load_local_model_cost_map())
+        return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     _cost_map_source_info.source = "remote"
     _cost_map_source_info.fallback_reason = None
-    return _expand_model_aliases(content)
+    return _finalize_model_cost_map(content)

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -347,6 +347,7 @@ class RealTimeStreaming:
                     if self._content_sent_after_setup:
                         verbose_logger.debug("Dropping follow-up setup after content was already sent to backend")
                         continue
+                    msg = self._maybe_inject_guardrail_auto_response_disable(msg)
                     await self.backend_ws.send(msg)  # type: ignore[union-attr, attr-defined]
                     self._cache_session_configuration_request(msg)
                     sent = True
@@ -622,6 +623,36 @@ class RealTimeStreaming:
         # — such as a duplicate session.created — can retry.
         if sent:
             self._guardrail_turn_detection_update_sent = True
+
+    def _maybe_inject_guardrail_auto_response_disable(self, setup_message: str) -> str:
+        """Fold the transcription-guardrail auto-response disable into the setup.
+
+        Gemini/Vertex Live reject a second ``setup`` (1007), so the guardrail's
+        ``automaticActivityDetection.disabled=true`` cannot be delivered as a
+        follow-up session.update; it must live in the one-and-only setup, or a
+        ``realtime_input_transcription`` guardrail is bypassed (the model
+        auto-responds before the proxy can gate the turn). Applies only to the
+        bidi ``setup`` shape; OpenAI sessions accept follow-up updates and so are
+        left untouched (handled by ``_maybe_send_guardrail_turn_detection_update``).
+        """
+        if self._guardrail_turn_detection_update_sent:
+            return setup_message
+        if not self._has_audio_transcription_guardrails():
+            return setup_message
+        try:
+            obj = json.loads(setup_message)
+        except (json.JSONDecodeError, TypeError):
+            return setup_message
+        setup = obj.get("setup") if isinstance(obj, dict) else None
+        if not isinstance(setup, dict):
+            return setup_message
+        automatic = setup.setdefault("realtimeInputConfig", {}).setdefault("automaticActivityDetection", {})
+        automatic["disabled"] = True
+        self._guardrail_turn_detection_update_sent = True
+        verbose_logger.debug(
+            "Realtime: folded automaticActivityDetection.disabled=true into setup for transcription-guardrail gating"
+        )
+        return json.dumps(obj)
 
     def _has_realtime_guardrails_for_event_hooks(
         self,

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -375,10 +375,10 @@ class AnthropicModelInfo(BaseLLMModelInfo):
     def _is_adaptive_thinking_model(model: str) -> bool:
         """Whether ``model`` uses adaptive thinking (``output_config.effort``).
 
-        Sourced solely from the model cost map's ``supports_adaptive_thinking`` flag,
-        resolved through provider prefixes. A model that resolves to no mapped entry
-        (an unmapped alias or a future release not yet in the map) is treated as
-        non-adaptive until a ``fallback_generalizations`` rule covers it.
+        The model cost map is authoritative: an explicit ``supports_adaptive_thinking``
+        entry, or a ``fallback_generalizations`` rule for unknown Claude models. The
+        version gate (>= 4.6, including provider-prefixed Bedrock/Vertex ids that map to
+        no exact entry) lives entirely in that declarative rule, not here.
         """
         return AnthropicModelInfo._supports_model_capability(model, "supports_adaptive_thinking")
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5688,6 +5688,58 @@ class BaseLLMHTTPHandler:
         new_query = parsed.query + ("&" if parsed.query else "") + urlencode(extras)
         return urlunparse(parsed._replace(query=new_query))
 
+    @staticmethod
+    async def _open_realtime_backend_ws(
+        websockets_module: Any,
+        url: str,
+        headers: dict,
+        ssl_context: Any,
+        *,
+        open_timeout: float = 8.0,
+        max_attempts: int = 3,
+    ) -> Any:
+        """Open the backend realtime websocket, retrying a hung open handshake.
+
+        The upstream Live handshake (e.g. Gemini Live) intermittently hangs on
+        open; waiting longer never recovers a hung attempt, but a fresh attempt
+        almost always connects in ~1s. So bound each attempt with ``open_timeout``
+        and retry, instead of surfacing one slow handshake to the caller as a
+        fatal 1011. A bounded attempt that timed out already spaced out the
+        retry, so no extra backoff is needed. Deterministic rejections (auth /
+        handshake status) are not retried.
+        """
+        # Handshake-status rejections are deterministic (auth / 4xx): retrying
+        # cannot help and the caller must see the upstream status, not a generic
+        # 1011. websockets <15 raises InvalidStatusCode, >=15 raises InvalidStatus.
+        deterministic_errors = tuple(
+            exc
+            for exc in (
+                getattr(websockets_module.exceptions, "InvalidStatus", None),
+                getattr(websockets_module.exceptions, "InvalidStatusCode", None),
+            )
+            if exc is not None
+        )
+        last_exc: Optional[BaseException] = None
+        for _ in range(max_attempts):
+            try:
+                return await websockets_module.connect(
+                    url,
+                    additional_headers=headers,
+                    max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
+                    ssl=ssl_context,
+                    open_timeout=open_timeout,
+                )
+            except deterministic_errors:
+                raise
+            except (
+                TimeoutError,
+                OSError,
+                websockets_module.exceptions.WebSocketException,
+            ) as e:
+                last_exc = e
+        assert last_exc is not None  # loop only exits via return or a captured exc
+        raise last_exc
+
     async def async_realtime(
         self,
         model: str,
@@ -5720,20 +5772,8 @@ class BaseLLMHTTPHandler:
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
-            async with websockets.connect(  # type: ignore
-                url,
-                additional_headers=headers,
-                max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
-                ssl=ssl_context,
-            ) as backend_ws:
-                # Auto-send session setup if the provider requires it
-                # (e.g. Gemini/Vertex AI Live needs a `setup` message before any realtime_input)
-                _session_config: Optional[str] = None
-                if provider_config.requires_session_configuration():
-                    _session_config = provider_config.session_configuration_request(model)
-                    if _session_config:
-                        await backend_ws.send(_session_config)
-
+            backend_ws = await self._open_realtime_backend_ws(websockets, url, headers, ssl_context)
+            async with backend_ws:
                 _request_data: Dict[str, Any] = {}
                 if litellm_metadata:
                     _request_data["litellm_metadata"] = litellm_metadata
@@ -5749,8 +5789,22 @@ class BaseLLMHTTPHandler:
                         model if (query_params or {}).get("intent") == "transcription" else None
                     ),
                 )
-                if _session_config:
-                    realtime_streaming.session_configuration_request = _session_config
+
+                # Auto-send session setup if the provider requires it (e.g.
+                # Gemini/Vertex AI Live needs a `setup` before any realtime_input).
+                # Build the streaming handler first so a transcription guardrail's
+                # auto-response disable can be folded into this one setup: Gemini
+                # rejects a second setup, so a follow-up disable would be dropped
+                # and the guardrail bypassed.
+                _session_config: Optional[str] = None
+                if provider_config.requires_session_configuration():
+                    _session_config = provider_config.session_configuration_request(model)
+                    if _session_config:
+                        _session_config = realtime_streaming._maybe_inject_guardrail_auto_response_disable(
+                            _session_config
+                        )
+                        await backend_ws.send(_session_config)
+                        realtime_streaming.session_configuration_request = _session_config
 
                 # For providers that defer setup until client session.update, optionally
                 # send synthetic session.created to unblock clients waiting on connect.

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -406,17 +406,11 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
         Handle session.update by sending setup to Gemini.
 
         On the FIRST session.update (when session_configuration_request is None),
-        the full setup with all configuration is sent.
-
-        Subsequent session.update messages are forwarded as a follow-up setup
-        with the new fields merged into the original setup. Gemini Live treats
-        a follow-up BidiGenerateContentSetup as a full session replacement
-        rather than a partial merge, so we carry forward the previous setup
-        (tools, generationConfig, inputAudioTranscription, systemInstruction,
-        ...) and overlay the new fields on top. This preserves the old
-        behavior where clients could refine the session via session.update
-        (e.g. add tools after the auto-setup on connect), and also keeps the
-        guardrail-driven turn_detection update working.
+        the full setup with all configuration is sent. Gemini Live accepts setup
+        as the first-and-only client message, so every later session.update is
+        dropped rather than forwarded as a second setup (which Gemini rejects
+        with a 1007, tearing the session down). To carry tools/instructions, send
+        them on the first session.update before any conversation content.
         """
         session_payload = json_message.get("session") or {}
         # Normalize GA-remapped fields (``output_modalities``,
@@ -437,70 +431,27 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
             verbose_logger.debug("Gemini Realtime: Sending initial setup with tools to backend")
             return [json.dumps({"setup": self._finalize_gemini_live_setup(model, new_overrides)})]
 
-        if not new_overrides:
-            verbose_logger.debug("Gemini Realtime: Ignoring session.update (no mappable fields)")
-            return []
-
-        try:
-            original_setup = cast(
-                BidiGenerateContentSetup,
-                json.loads(session_configuration_request).get("setup", {}),
+        # Gemini Live accepts exactly one ``setup`` message: the first and only
+        # client message. A second ``setup`` closes the socket with
+        # ``1007 Request contains an invalid argument``, so a session.update
+        # after the initial setup must not be forwarded as a follow-up setup.
+        # Every GA client (pipecat included) sends several session.updates while
+        # configuring the session; forwarding a second one tears the session down
+        # before the first turn, which surfaces to callers as silence after the
+        # first response, reconnect/retry latency churn, and 1011 errors. Drop
+        # it. The Vertex subclass already drops subsequent setups for this exact
+        # reason; the constraint is identical on AI Studio.
+        client_turn_detection = self._extract_turn_detection(session_payload)
+        if isinstance(client_turn_detection, dict) and client_turn_detection.get("create_response") is False:
+            verbose_logger.warning(
+                "Gemini Realtime: Dropping subsequent session.update "
+                "(turn_detection.create_response=False) — Gemini Live rejects a "
+                "second setup message, so audio-transcription guardrails cannot "
+                "suppress the model's auto-response mid-session."
             )
-        except (json.JSONDecodeError, AttributeError):
-            original_setup = {}
-
-        # Deep-merge ``generationConfig`` and ``realtimeInputConfig`` so a
-        # partial session.update (e.g. only ``temperature`` or only
-        # ``modalities``) does not silently drop unrelated sub-keys
-        # (``responseModalities``, ``maxOutputTokens``, ...) from the original
-        # setup.
-        follow_up_setup: BidiGenerateContentSetup = {
-            **original_setup,
-            **new_overrides,
-            "model": f"models/{model}",
-        }
-        original_generation_config = original_setup.get("generationConfig")
-        new_generation_config = new_overrides.get("generationConfig")
-        if isinstance(original_generation_config, dict) and isinstance(new_generation_config, dict):
-            follow_up_setup["generationConfig"] = {
-                **original_generation_config,
-                **new_generation_config,
-            }
-        original_realtime_input_config = original_setup.get("realtimeInputConfig")
-        new_realtime_input_config = new_overrides.get("realtimeInputConfig")
-        if isinstance(original_realtime_input_config, dict) and isinstance(new_realtime_input_config, dict):
-            merged_realtime_input_config = {
-                **original_realtime_input_config,
-                **new_realtime_input_config,
-            }
-            # Deep-merge ``automaticActivityDetection`` so a partial VAD
-            # update (e.g. the guardrail-injected ``disabled: True`` from
-            # ``create_response: False``) does not silently drop unrelated
-            # knobs like ``silenceDurationMs`` / ``prefixPaddingMs`` from
-            # the original setup.
-            original_automatic_activity_detection = original_realtime_input_config.get("automaticActivityDetection")
-            new_automatic_activity_detection = new_realtime_input_config.get("automaticActivityDetection")
-            if isinstance(original_automatic_activity_detection, dict) and isinstance(
-                new_automatic_activity_detection, dict
-            ):
-                merged_realtime_input_config["automaticActivityDetection"] = {
-                    **original_automatic_activity_detection,
-                    **new_automatic_activity_detection,
-                }
-            follow_up_setup["realtimeInputConfig"] = cast(
-                BidiGenerateContentRealtimeInputConfig,
-                merged_realtime_input_config,
-            )
-        finalized_follow_up = self._finalize_gemini_live_setup(model, cast(dict[str, Any], follow_up_setup))
-        # Skip if the follow-up setup is identical to the one already sent.
-        # The final session.update from Pipecat's _create_response (after history
-        # items) matches the pre-history session.update we intentionally sent
-        # before content; sending a duplicate at that point would risk a 1007.
-        if finalized_follow_up == original_setup:
-            verbose_logger.debug("Gemini Realtime: Skipping duplicate follow-up session.update (no changes)")
-            return []
-        verbose_logger.debug("Gemini Realtime: Forwarding session.update as follow-up setup")
-        return [json.dumps({"setup": finalized_follow_up})]
+        else:
+            verbose_logger.debug("Gemini Realtime: Ignoring session.update (setup already sent)")
+        return []
 
     def _handle_conversation_item(self, json_message: dict) -> List[str]:
         """

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -994,6 +994,7 @@
         "bedrock_output_config_effort_ceiling": "high"
     },
     "anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1025,6 +1026,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "global.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1056,6 +1058,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "us.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1087,6 +1090,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "eu.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1118,6 +1122,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "au.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1149,6 +1154,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1197,6 +1203,7 @@
         "supports_output_config": true
     },
     "global.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1230,6 +1237,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "us.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1263,6 +1271,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "eu.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1296,6 +1305,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "au.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1461,6 +1471,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1494,6 +1505,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "global.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1527,6 +1539,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "us.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1560,6 +1573,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "eu.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1593,6 +1607,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "au.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1657,6 +1672,7 @@
         "supports_minimal_reasoning_effort": true
     },
     "anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -1687,6 +1703,7 @@
         "supports_output_config": true
     },
     "global.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -1717,6 +1734,7 @@
         "supports_output_config": true
     },
     "us.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1747,6 +1765,7 @@
         "supports_output_config": true
     },
     "eu.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1777,6 +1796,7 @@
         "supports_output_config": true
     },
     "au.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1807,6 +1827,7 @@
         "supports_output_config": true
     },
     "jp.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -2327,6 +2348,7 @@
         "supports_output_config": true
     },
     "azure_ai/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2356,6 +2378,7 @@
         "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2416,6 +2439,7 @@
         "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2488,6 +2512,7 @@
         "supports_vision": true
     },
     "azure_ai/claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -18910,6 +18935,7 @@
         "supports_output_config": true
     },
     "github_copilot/claude-opus-4.6-fast": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
@@ -28134,6 +28160,7 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -28178,6 +28205,7 @@
         "supports_output_config": true
     },
     "openrouter/anthropic/claude-opus-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -28239,6 +28267,7 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -30168,6 +30197,7 @@
         "supports_function_calling": true
     },
     "perplexity/anthropic/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_adaptive_thinking": true,
@@ -30177,6 +30207,7 @@
         "supports_output_config": true
     },
     "perplexity/anthropic/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_adaptive_thinking": true,
@@ -33414,6 +33445,7 @@
         "supports_output_config": true
     },
     "vercel_ai_gateway/anthropic/claude-opus-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -34642,6 +34674,7 @@
         "supports_output_config": true
     },
     "vertex_ai/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34671,6 +34704,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-6@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34700,6 +34734,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34730,6 +34765,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34820,6 +34856,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34850,6 +34887,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-8@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34907,6 +34945,7 @@
         "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -42343,6 +42382,7 @@
         }
     },
     "vertex_ai/claude-sonnet-4-6@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -43371,5 +43411,40 @@
         "supports_assistant_prefill": true,
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
-    }
+    },
+  "fallback_generalizations": {
+    "rules": [
+      {
+        "name": "anthropic-claude-adaptive-thinking",
+        "pattern": "(?:opus|sonnet|haiku)[-._](?:4[-._](?:[6-9]|[1-9]\\d)(?!\\d)|(?:[5-9]|[1-9]\\d{1,})[-._]\\d{1,2}(?!\\d))",
+        "description": "Claude opus/sonnet/haiku at version 4.6 or higher: 4.6 through 4.99, then any 5.x, 6.x or later major. The minor is capped at two digits so an 8-digit date suffix such as claude-opus-4-20250514 is never read as a >= 4.6 minor. Turns on adaptive thinking for new families with no code change.",
+        "extends": "anthropic-claude",
+        "model_info": {
+          "supports_adaptive_thinking": true
+        }
+      },
+      {
+        "name": "anthropic-claude",
+        "pattern": "^claude-[a-z]+-\\d+[-.]\\d+(?:-\\d{8})?$",
+        "description": "Any Claude family-major-minor id, optionally with an 8-digit date suffix, anchored to the whole name. Version-neutral fallback that gives an unmapped Claude provider routing and baseline capabilities; it carries no pricing, so cost stays on the standard unpriced behavior rather than a guessed number.",
+        "model_info": {
+          "litellm_provider": "anthropic",
+          "mode": "chat",
+          "max_input_tokens": 200000,
+          "max_output_tokens": 64000,
+          "max_tokens": 64000,
+          "supports_function_calling": true,
+          "supports_parallel_function_calling": true,
+          "supports_vision": true,
+          "supports_tool_choice": true,
+          "supports_assistant_prefill": true,
+          "supports_prompt_caching": true,
+          "supports_response_schema": true,
+          "supports_reasoning": true,
+          "supports_pdf_input": true,
+          "supports_system_messages": true
+        }
+      }
+    ]
+  }
 }

--- a/litellm/proxy/example_config_yaml/china_domestic_free_sources.yaml
+++ b/litellm/proxy/example_config_yaml/china_domestic_free_sources.yaml
@@ -1,0 +1,73 @@
+# China Domestic Free Sources Configuration
+# 中国开发者免费源配置模板
+#
+# This configuration provides pre-configured free LLM sources for Chinese developers.
+# These sources are accessible from mainland China without VPN.
+#
+# Sources:
+# - SiliconFlow (硅基流动): https://cloud.siliconflow.cn
+# - Zhipu (智谱): https://open.bigmodel.cn
+#
+# Usage:
+#   litellm --config china_domestic_free_sources.yaml
+
+model_list:
+  # ═══════════════════════════════════════════
+  # SiliconFlow 硅基流动 (国内直连，无需翻墙)
+  # 注册: https://cloud.siliconflow.cn → 自动送 14 元余额
+  # 免费模型会轮换，以下为当前可用
+  # ═══════════════════════════════════════════
+
+  - model_name: sf-deepseek-r1
+    litellm_params:
+      model: siliconflow/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  - model_name: sf-qwen2.5-72b
+    litellm_params:
+      model: siliconflow/Qwen/Qwen2.5-72B-Instruct
+      api_key: os.environ/SILICONFLOW_API_KEY
+      api_base: https://api.siliconflow.cn/v1
+
+  # ═══════════════════════════════════════════
+  # 智谱 Zhipu (GLM-4-Flash 永久免费)
+  # 注册: https://open.bigmodel.cn → 送 20M tokens (永久)
+  # ═══════════════════════════════════════════
+
+  - model_name: glm-4-flash
+    litellm_params:
+      model: zhipu/glm-4-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+
+  - model_name: glm-4.7-flash
+    litellm_params:
+      model: zhipu/glm-4.7-flash
+      api_key: os.environ/ZHIPU_API_KEY
+      api_base: https://open.bigmodel.cn/api/paas/v4
+
+# ═══════════════════════════════════════════
+# 路由策略 — 国内免费互备
+# ═══════════════════════════════════════════
+router_settings:
+  routing_strategy: usage-based-routing-v2
+  num_retries: 3
+  timeout: 60
+  fallbacks:
+    - sf-deepseek-r1: [sf-qwen2.5-72b, glm-4-flash, glm-4.7-flash]
+    - sf-qwen2.5-72b: [sf-deepseek-r1, glm-4-flash, glm-4.7-flash]
+    - glm-4-flash: [glm-4.7-flash, sf-qwen2.5-72b, sf-deepseek-r1]
+    - glm-4.7-flash: [glm-4-flash, sf-qwen2.5-72b, sf-deepseek-r1]
+
+general_settings:
+  port: 4000
+  host: 127.0.0.1
+
+litellm_settings:
+  return_response_headers: true
+  drop_params: true
+  cache: true
+  cache_params:
+    type: local
+    ttl: 300

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -774,6 +774,8 @@ class Router:
         "usage-based-routing-v2": "lowesttpm_logger_v2",
         "latency-based-routing": "lowestlatency_logger",
         "cost-based-routing": "lowestcost_logger",
+        "task-aware-routing": "taskaware_logger",
+        "local-first-routing": "localfirst_logger",
     }
 
     @staticmethod
@@ -840,6 +842,20 @@ class Router:
                 selector = LowestCostLoggingHandler(
                     router_cache=self.cache,
                     routing_args={},
+                )
+            case RoutingStrategy.TASK_AWARE_ROUTING.value:
+                from litellm.router_strategy.task_aware_routing import TaskAwareRoutingStrategy
+                selector = TaskAwareRoutingStrategy(
+                    dual_cache=self.cache,
+                    task_mapping=routing_strategy_args.get("task_mapping", {}),
+                    default_task=routing_strategy_args.get("default_task", "general"),
+                )
+            case RoutingStrategy.LOCAL_FIRST_ROUTING.value:
+                from litellm.router_strategy.local_first_routing import LocalFirstRoutingStrategy
+                selector = LocalFirstRoutingStrategy(
+                    dual_cache=self.cache,
+                    local_provider=routing_strategy_args.get("local_provider", "ollama"),
+                    local_fallback_order=routing_strategy_args.get("local_fallback_order", []),
                 )
 
         if selector is not None and register_callbacks and isinstance(litellm.callbacks, list):
@@ -1036,6 +1052,14 @@ class Router:
                     input=input,
                     request_kwargs=request_kwargs,
                 )
+            case "task-aware-routing" | "local-first-routing":
+                return await selector.async_get_available_deployments(
+                    model_group=model,
+                    healthy_deployments=healthy_deployments,
+                    messages=messages,
+                    input=input,
+                    request_kwargs=request_kwargs,
+                )
             case _:
                 return None
 
@@ -1074,6 +1098,14 @@ class Router:
                     input=input,
                 )
             case "latency-based-routing":
+                return selector.get_available_deployments(
+                    model_group=model,
+                    healthy_deployments=healthy_deployments,
+                    messages=messages,
+                    input=input,
+                    request_kwargs=request_kwargs,
+                )
+            case "task-aware-routing" | "local-first-routing":
                 return selector.get_available_deployments(
                     model_group=model,
                     healthy_deployments=healthy_deployments,

--- a/litellm/router_strategy/local_first_routing.py
+++ b/litellm/router_strategy/local_first_routing.py
@@ -1,0 +1,135 @@
+"""
+Local-First Routing Strategy for LiteLLM
+
+Routes requests to local models first, then falls back to cloud models.
+This strategy is ideal for users who want to:
+- Minimize latency (local models are faster)
+- Reduce costs (local models are free)
+- Maintain privacy (data stays local)
+
+Usage:
+    router_settings:
+      routing_strategy: local-first-routing
+      routing_strategy_args:
+        local_provider: ollama
+        local_fallback_order:
+          - local
+          - domestic_free
+          - openrouter_free
+          - openrouter_paid
+"""
+
+from typing import Dict, List, Optional, Union
+
+from litellm._logging import verbose_router_logger
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.base_routing_strategy import BaseRoutingStrategy
+
+
+class LocalFirstRoutingStrategy(BaseRoutingStrategy):
+    """
+    Routes requests to local models first, then falls back to cloud models.
+
+    This strategy prioritizes local models (e.g., Ollama) for:
+    - Lower latency
+    - Zero cost
+    - Better privacy
+
+    When local models are unavailable, it falls back to cloud models
+    in the specified order.
+    """
+
+    def __init__(
+        self,
+        dual_cache: DualCache,
+        local_provider: str = "ollama",
+        local_fallback_order: Optional[List[str]] = None,
+        should_batch_redis_writes: bool = False,
+        default_sync_interval: Optional[Union[int, float]] = None,
+    ):
+        super().__init__(
+            dual_cache=dual_cache,
+            should_batch_redis_writes=should_batch_redis_writes,
+            default_sync_interval=default_sync_interval,
+        )
+        self.local_provider = local_provider
+        self.local_fallback_order = local_fallback_order or [
+            "local",
+            "domestic_free",
+            "openrouter_free",
+            "openrouter_paid",
+        ]
+
+    def get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: list,
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[Dict]:
+        """
+        Select the best deployment using local-first strategy.
+
+        Args:
+            model_group: The requested model group name
+            healthy_deployments: List of healthy deployments to choose from
+            messages: Optional messages for context
+            input: Optional input for context
+            request_kwargs: Optional request kwargs
+
+        Returns:
+            The selected deployment dict, or None if no suitable deployment found
+        """
+        if not healthy_deployments:
+            return None
+
+        # Try local models first
+        for deployment in healthy_deployments:
+            model_name = deployment.get("model_name") or deployment.get("litellm_params", {}).get("model", "")
+            if self._is_local_model(model_name):
+                verbose_router_logger.debug(
+                    f"Local-first routing: using local model '{model_name}'"
+                )
+                return deployment
+
+        # No local model available, return first healthy deployment
+        verbose_router_logger.debug(
+            f"Local-first routing: no local model available, using first healthy deployment"
+        )
+        return healthy_deployments[0]
+
+    async def async_get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: list,
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[Dict]:
+        """Async version of get_available_deployments"""
+        return self.get_available_deployments(
+            model_group=model_group,
+            healthy_deployments=healthy_deployments,
+            messages=messages,
+            input=input,
+            request_kwargs=request_kwargs,
+        )
+
+    def _is_local_model(self, model: str) -> bool:
+        """Check if a model is a local model"""
+        local_indicators = [
+            "ollama/",
+            "localhost:",
+            "127.0.0.1:",
+            "local/",
+        ]
+        return any(indicator in model.lower() for indicator in local_indicators)
+
+    def log_success(self, kwargs, response_obj, start_time, end_time):
+        """Log successful request for analytics"""
+        verbose_router_logger.debug(f"Local-first routing success")
+
+    def log_failure(self, kwargs, response_obj, start_time, end_time):
+        """Log failed request for analytics"""
+        verbose_router_logger.warning(f"Local-first routing failure")

--- a/litellm/router_strategy/task_aware_routing.py
+++ b/litellm/router_strategy/task_aware_routing.py
@@ -1,0 +1,141 @@
+"""
+Task-Aware Routing Strategy for LiteLLM
+
+Routes requests based on task type (coding, chinese, general, english, fast).
+
+Usage:
+    router_settings:
+      routing_strategy: task-aware-routing
+      routing_strategy_args:
+        task_mapping:
+          coding: [devstral, qwen3-coder, claude-sonnet]
+          chinese: [qwen3, sf-qwen2.5-72b, claude-sonnet]
+          general: [gemma4, nemotron-ultra-free, claude-sonnet]
+          english: [ornith-35b, nemotron-ultra-free, claude-opus]
+          fast: [deepseek-r1-14b, sf-deepseek-r1, glm-4-flash]
+"""
+
+from typing import Dict, List, Optional, Union
+
+from litellm._logging import verbose_router_logger
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.base_routing_strategy import BaseRoutingStrategy
+
+
+class TaskAwareRoutingStrategy(BaseRoutingStrategy):
+    """
+    Routes requests based on task type.
+
+    This strategy allows users to define task-specific model preferences.
+    When a request comes in with a task type, it selects the best model
+    for that task based on the configured task_mapping.
+
+    Example:
+        task_mapping = {
+            "coding": ["devstral", "qwen3-coder", "claude-sonnet"],
+            "chinese": ["qwen3", "sf-qwen2.5-72b", "claude-sonnet"],
+            "general": ["gemma4", "nemotron-ultra-free", "claude-sonnet"],
+        }
+
+        # Request with task="coding" will prefer "devstral"
+        # If "devstral" is unavailable, falls back to "qwen3-coder", then "claude-sonnet"
+    """
+
+    def __init__(
+        self,
+        dual_cache: DualCache,
+        task_mapping: Optional[Dict[str, List[str]]] = None,
+        default_task: str = "general",
+        should_batch_redis_writes: bool = False,
+        default_sync_interval: Optional[Union[int, float]] = None,
+    ):
+        super().__init__(
+            dual_cache=dual_cache,
+            should_batch_redis_writes=should_batch_redis_writes,
+            default_sync_interval=default_sync_interval,
+        )
+        self.task_mapping = task_mapping or {}
+        self.default_task = default_task
+
+    def get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: list,
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[Dict]:
+        """
+        Select the best deployment based on task type.
+
+        Args:
+            model_group: The requested model group name
+            healthy_deployments: List of healthy deployments to choose from
+            messages: Optional messages for context
+            input: Optional input for context
+            request_kwargs: Optional request kwargs containing task info
+
+        Returns:
+            The selected deployment dict, or None if no suitable deployment found
+        """
+        # Extract task from request_kwargs or metadata
+        task = self.default_task
+        if request_kwargs:
+            # Check metadata first, then direct kwargs
+            metadata = request_kwargs.get("metadata", {})
+            task = metadata.get("task", request_kwargs.get("task", self.default_task))
+
+        # Get task-specific model list
+        task_models = self.task_mapping.get(task, [])
+
+        if not task_models:
+            verbose_router_logger.debug(
+                f"No task mapping found for task '{task}', using default model group '{model_group}'"
+            )
+            # Fall back to first healthy deployment
+            if healthy_deployments:
+                return healthy_deployments[0]
+            return None
+
+        # Find matching healthy deployment
+        for model_name in task_models:
+            for deployment in healthy_deployments:
+                dep_model = deployment.get("model_name") or deployment.get("litellm_params", {}).get("model", "")
+                if model_name in dep_model or dep_model in model_name:
+                    verbose_router_logger.debug(
+                        f"Task-aware routing: task='{task}', selected='{dep_model}'"
+                    )
+                    return deployment
+
+        # No exact match, return first healthy deployment
+        verbose_router_logger.warning(
+            f"No exact match for task '{task}', using first healthy deployment"
+        )
+        if healthy_deployments:
+            return healthy_deployments[0]
+        return None
+
+    async def async_get_available_deployments(
+        self,
+        model_group: str,
+        healthy_deployments: list,
+        messages: Optional[List[Dict[str, str]]] = None,
+        input: Optional[Union[str, List]] = None,
+        request_kwargs: Optional[Dict] = None,
+    ) -> Optional[Dict]:
+        """Async version of get_available_deployments"""
+        return self.get_available_deployments(
+            model_group=model_group,
+            healthy_deployments=healthy_deployments,
+            messages=messages,
+            input=input,
+            request_kwargs=request_kwargs,
+        )
+
+    def log_success(self, kwargs, response_obj, start_time, end_time):
+        """Log successful request for analytics"""
+        verbose_router_logger.debug(f"Task-aware routing success")
+
+    def log_failure(self, kwargs, response_obj, start_time, end_time):
+        """Log failed request for analytics"""
+        verbose_router_logger.warning(f"Task-aware routing failure")

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -744,6 +744,8 @@ class RoutingStrategy(enum.Enum):
     USAGE_BASED_ROUTING_V2 = "usage-based-routing-v2"
     USAGE_BASED_ROUTING = "usage-based-routing"
     PROVIDER_BUDGET_LIMITING = "provider-budget-routing"
+    TASK_AWARE_ROUTING = "task-aware-routing"
+    LOCAL_FIRST_ROUTING = "local-first-routing"
 
 
 class RouterCacheEnum(enum.Enum):

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -60,6 +60,9 @@ from litellm._lazy_imports import (
     _get_token_counter_new,
 )
 from litellm._uuid import uuid
+from litellm.litellm_core_utils.fallback_generalizations import (
+    match_fallback_generalization,
+)
 from litellm.constants import (
     DEFAULT_CHAT_COMPLETION_PARAM_VALUES,
     DEFAULT_EMBEDDING_PARAM_VALUES,
@@ -5020,6 +5023,34 @@ class PotentialModelNamesAndCustomLLMProvider(TypedDict):
     custom_llm_provider: str
 
 
+def _get_model_info_from_generalization(
+    model: str,
+    potential_model_names: PotentialModelNamesAndCustomLLMProvider,
+    custom_llm_provider: Optional[str],
+) -> Optional[tuple[str, dict]]:
+    """Resolve an unmapped model via a declarative fallback-generalization rule.
+
+    Tries the same name candidates as the exact lookups, in the same order, and
+    returns ``(matched_name, model_info)`` for the first candidate whose rule also
+    satisfies the provider constraint. O(number of rules); only call after the
+    exact lookups have missed.
+    """
+    candidates = [
+        potential_model_names["combined_model_name"],
+        model,
+        potential_model_names["combined_stripped_model_name"],
+        potential_model_names["stripped_model_name"],
+        potential_model_names["split_model"],
+    ]
+    for candidate in candidates:
+        generalized_info = match_fallback_generalization(candidate)
+        if generalized_info is not None and _check_provider_match(
+            model_info=generalized_info, custom_llm_provider=custom_llm_provider
+        ):
+            return candidate, generalized_info
+    return None
+
+
 def _get_potential_model_names(
     model: str, custom_llm_provider: Optional[str]
 ) -> PotentialModelNamesAndCustomLLMProvider:
@@ -5274,6 +5305,15 @@ def _get_model_info_helper(
                         custom_llm_provider=model_cost_custom_llm_provider,
                     ):
                         _model_info = None
+
+            if _model_info is None:
+                generalization = _get_model_info_from_generalization(
+                    model=model,
+                    potential_model_names=potential_model_names,
+                    custom_llm_provider=custom_llm_provider,
+                )
+                if generalization is not None:
+                    key, _model_info = generalization
 
             if _model_info is None or key is None:
                 raise ValueError(

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -994,6 +994,7 @@
         "bedrock_output_config_effort_ceiling": "high"
     },
     "anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1025,6 +1026,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "global.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1056,6 +1058,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "us.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1087,6 +1090,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "eu.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1118,6 +1122,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "au.anthropic.claude-opus-4-6-v1": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1149,6 +1154,7 @@
         "bedrock_output_config_effort_ceiling": "max"
     },
     "anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1197,6 +1203,7 @@
         "supports_output_config": true
     },
     "global.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1230,6 +1237,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "us.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1263,6 +1271,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "eu.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1296,6 +1305,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "au.anthropic.claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1461,6 +1471,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1494,6 +1505,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "global.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -1527,6 +1539,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "us.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1560,6 +1573,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "eu.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1593,6 +1607,7 @@
         "bedrock_output_config_effort_ceiling": "xhigh"
     },
     "au.anthropic.claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.875e-06,
         "cache_creation_input_token_cost_above_1hr": 1.1e-05,
         "cache_read_input_token_cost": 5.5e-07,
@@ -1657,6 +1672,7 @@
         "supports_minimal_reasoning_effort": true
     },
     "anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -1687,6 +1703,7 @@
         "supports_output_config": true
     },
     "global.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -1717,6 +1734,7 @@
         "supports_output_config": true
     },
     "us.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1747,6 +1765,7 @@
         "supports_output_config": true
     },
     "eu.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1777,6 +1796,7 @@
         "supports_output_config": true
     },
     "au.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -1807,6 +1827,7 @@
         "supports_output_config": true
     },
     "jp.anthropic.claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
         "cache_read_input_token_cost": 3.3e-07,
@@ -2327,6 +2348,7 @@
         "supports_output_config": true
     },
     "azure_ai/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2356,6 +2378,7 @@
         "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2416,6 +2439,7 @@
         "supports_max_reasoning_effort": true
     },
     "azure_ai/claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "input_cost_per_token": 5e-06,
         "output_cost_per_token": 2.5e-05,
         "litellm_provider": "azure_ai",
@@ -2488,6 +2512,7 @@
         "supports_vision": true
     },
     "azure_ai/claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -19071,6 +19096,7 @@
         "supports_output_config": true
     },
     "github_copilot/claude-opus-4.6-fast": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
         "max_output_tokens": 16000,
@@ -28295,6 +28321,7 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-sonnet-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -28339,6 +28366,7 @@
         "supports_output_config": true
     },
     "openrouter/anthropic/claude-opus-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -28400,6 +28428,7 @@
         "supports_vision": true
     },
     "openrouter/anthropic/claude-opus-4.7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -30345,6 +30374,7 @@
         "supports_function_calling": true
     },
     "perplexity/anthropic/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_adaptive_thinking": true,
@@ -30354,6 +30384,7 @@
         "supports_output_config": true
     },
     "perplexity/anthropic/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "litellm_provider": "perplexity",
         "mode": "responses",
         "supports_adaptive_thinking": true,
@@ -33591,6 +33622,7 @@
         "supports_output_config": true
     },
     "vercel_ai_gateway/anthropic/claude-opus-4.6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_read_input_token_cost": 5e-07,
         "input_cost_per_token": 5e-06,
@@ -34819,6 +34851,7 @@
         "supports_output_config": true
     },
     "vertex_ai/claude-opus-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34848,6 +34881,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-6@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34877,6 +34911,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34907,6 +34942,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-7@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -34997,6 +35033,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-8": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -35027,6 +35064,7 @@
         "supports_max_reasoning_effort": true
     },
     "vertex_ai/claude-opus-4-8@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 6.25e-06,
         "cache_creation_input_token_cost_above_1hr": 1e-05,
         "cache_read_input_token_cost": 5e-07,
@@ -35084,6 +35122,7 @@
         "supports_vision": true
     },
     "vertex_ai/claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -42578,6 +42617,7 @@
         }
     },
     "vertex_ai/claude-sonnet-4-6@default": {
+        "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
         "cache_read_input_token_cost": 3e-07,
@@ -43055,6 +43095,7 @@
     "supports_response_schema": true
   },
   "snowflake/claude-sonnet-4-6": {
+    "supports_adaptive_thinking": true,
     "max_tokens": 16384,
     "max_input_tokens": 200000,
     "max_output_tokens": 16384,
@@ -43606,5 +43647,40 @@
         "supports_native_streaming": true,
         "supports_system_messages": true,
         "supports_tool_choice": true
-    }
+    },
+  "fallback_generalizations": {
+    "rules": [
+      {
+        "name": "anthropic-claude-adaptive-thinking",
+        "pattern": "(?:opus|sonnet|haiku)[-._](?:4[-._](?:[6-9]|[1-9]\\d)(?!\\d)|(?:[5-9]|[1-9]\\d{1,})[-._]\\d{1,2}(?!\\d))",
+        "description": "Claude opus/sonnet/haiku at version 4.6 or higher: 4.6 through 4.99, then any 5.x, 6.x or later major. The minor is capped at two digits so an 8-digit date suffix such as claude-opus-4-20250514 is never read as a >= 4.6 minor. Turns on adaptive thinking for new families with no code change.",
+        "extends": "anthropic-claude",
+        "model_info": {
+          "supports_adaptive_thinking": true
+        }
+      },
+      {
+        "name": "anthropic-claude",
+        "pattern": "^claude-[a-z]+-\\d+[-.]\\d+(?:-\\d{8})?$",
+        "description": "Any Claude family-major-minor id, optionally with an 8-digit date suffix, anchored to the whole name. Version-neutral fallback that gives an unmapped Claude provider routing and baseline capabilities; it carries no pricing, so cost stays on the standard unpriced behavior rather than a guessed number.",
+        "model_info": {
+          "litellm_provider": "anthropic",
+          "mode": "chat",
+          "max_input_tokens": 200000,
+          "max_output_tokens": 64000,
+          "max_tokens": 64000,
+          "supports_function_calling": true,
+          "supports_parallel_function_calling": true,
+          "supports_vision": true,
+          "supports_tool_choice": true,
+          "supports_assistant_prefill": true,
+          "supports_prompt_caching": true,
+          "supports_response_schema": true,
+          "supports_reasoning": true,
+          "supports_pdf_input": true,
+          "supports_system_messages": true
+        }
+      }
+    ]
+  }
 }

--- a/tests/local_testing/conftest.py
+++ b/tests/local_testing/conftest.py
@@ -29,9 +29,14 @@ import litellm
 # was added on this branch).  Backfill any entries that are missing from the
 # remote-fetched map so cost-calculator lookups in tests succeed against the
 # cassette state the branch is being tested with.
-from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+from litellm.litellm_core_utils.get_model_cost_map import (
+    RESERVED_TOP_LEVEL_KEYS,
+    GetModelCostMap,
+)
 
 for _k, _v in GetModelCostMap.load_local_model_cost_map().items():
+    if _k in RESERVED_TOP_LEVEL_KEYS:
+        continue
     litellm.model_cost.setdefault(_k, _v)
 
 from tests._vcr_conftest_common import (  # noqa: E402,F401

--- a/tests/local_testing/test_get_llm_provider.py
+++ b/tests/local_testing/test_get_llm_provider.py
@@ -480,107 +480,94 @@ def test_get_llm_provider_use_proxy_arg_true_with_direct_args():
     assert base == arg_api_base  # Should use the argument base
 
 
-# -------- Tests for Claude model pattern matching ---------
+# -------- Tests for the anthropic-claude fallback generalization rule ---------
+
+
+@pytest.fixture
+def shipped_generalizations():
+    """Install the rules shipped in the bundled backup, then restore.
+
+    The remote-fetched cost map pinned to ``main`` may not yet carry the rule
+    added on this branch, so these tests install the rule the branch actually
+    ships rather than depending on whatever the live URL returns.
+    """
+    from litellm.litellm_core_utils.fallback_generalizations import (
+        get_fallback_generalization_rules,
+        set_fallback_generalizations,
+    )
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    previous = list(get_fallback_generalization_rules())
+    backup = GetModelCostMap.load_local_model_cost_map()
+    rules = backup.get("fallback_generalizations", {}).get("rules", [])
+    set_fallback_generalizations(rules)
+    try:
+        yield rules
+    finally:
+        set_fallback_generalizations(previous)
 
 
 class TestClaudeModelPatternMatching:
     """
-    Tests for _matches_claude_model_pattern which routes future Claude models
-    to the Anthropic provider without requiring model_prices_and_context_window.json updates.
+    The ``anthropic-claude`` fallback generalization rule routes future Claude
+    models to the Anthropic provider without requiring a
+    model_prices_and_context_window.json entry. These tests exercise the rule
+    end-to-end through ``get_llm_provider`` and ``match_fallback_generalization``.
     """
 
-    def test_matches_claude_opus_pattern(self):
-        """Test claude-opus-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-opus-4-7") is True
-        assert _matches_claude_model_pattern("claude-opus-4-9") is True
-        assert _matches_claude_model_pattern("claude-opus-5-1") is True
-
-    def test_matches_claude_sonnet_pattern(self):
-        """Test claude-sonnet-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-sonnet-4-6") is True
-        assert _matches_claude_model_pattern("claude-sonnet-5-0") is True
-
-    def test_matches_claude_haiku_pattern(self):
-        """Test claude-haiku-X-Y pattern matching."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-haiku-4-5") is True
-        assert _matches_claude_model_pattern("claude-haiku-5-0") is True
-
-    def test_matches_claude_with_date_suffix(self):
-        """Test claude model pattern with date suffix."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-opus-5-1-20270101") is True
-        assert _matches_claude_model_pattern("claude-sonnet-4-7-20260601") is True
-        assert _matches_claude_model_pattern("claude-haiku-4-6-20251201") is True
-
-    def test_matches_unknown_tier_name(self):
-        """A tier segment we don't know about today should still route to anthropic.
-
-        The pattern intentionally accepts any ``[a-z]+`` tier rather than a
-        hard-coded ``opus|sonnet|haiku`` list so a future tier (e.g. a new
-        "mini" line) is covered without a code change. This guards against a
-        regression back to hard-coded tier names.
-        """
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("claude-mini-4-5") is True
-        assert _matches_claude_model_pattern("claude-neptune-6-0") is True
-
-    def test_rejects_non_claude_models(self):
-        """Test that non-Claude models are not matched."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        assert _matches_claude_model_pattern("gpt-4") is False
-        assert _matches_claude_model_pattern("mistral-large") is False
-        assert _matches_claude_model_pattern("llama-3") is False
-
-    def test_rejects_invalid_claude_patterns(self):
-        """Test that invalid Claude model patterns are not matched."""
-        from litellm.litellm_core_utils.get_llm_provider_logic import (
-            _matches_claude_model_pattern,
-        )
-
-        # Wrong order (variant before name)
-        assert _matches_claude_model_pattern("claude-4-opus") is False
-        # Missing version numbers
-        assert _matches_claude_model_pattern("claude-opus") is False
-        # Old format (claude-3-opus instead of claude-opus-3)
-        assert _matches_claude_model_pattern("claude-3-opus-20240229") is False
-
-    def test_get_llm_provider_future_claude_model(self):
-        """Test that get_llm_provider routes future Claude models to anthropic."""
-        model, custom_llm_provider, dynamic_api_key, api_base = (
-            litellm.get_llm_provider(
-                model="claude-opus-4-9",
-            )
-        )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-9",
+            "claude-opus-5-1",
+            "claude-sonnet-4-6",
+            "claude-sonnet-5-0",
+            "claude-haiku-4-5",
+            "claude-haiku-5-0",
+            "claude-opus-5-1-20270101",
+            "claude-sonnet-4-7-20260601",
+            "claude-haiku-4-6-20251201",
+            # A tier segment we don't know about today still routes: the regex
+            # accepts any [a-z]+ tier rather than a hard-coded opus|sonnet|haiku
+            # list, so a future tier is covered without a code change.
+            "claude-mini-4-5",
+            "claude-neptune-6-0",
+        ],
+    )
+    def test_unknown_claude_routes_to_anthropic(self, model, shipped_generalizations):
+        _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
         assert custom_llm_provider == "anthropic"
-        assert model == "claude-opus-4-9"
 
-    def test_get_llm_provider_future_claude_model_with_date(self):
-        """Test that get_llm_provider routes future Claude models with date suffix."""
-        model, custom_llm_provider, dynamic_api_key, api_base = (
-            litellm.get_llm_provider(
-                model="claude-opus-5-1-20270101",
-            )
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-4",
+            "mistral-large",
+            "llama-3",
+            # Wrong order (variant before name)
+            "claude-4-opus",
+            # Missing version numbers
+            "claude-opus",
+            # Old format (claude-3-opus instead of claude-opus-3)
+            "claude-3-opus-20240229",
+        ],
+    )
+    def test_non_matching_models_do_not_match_rule(
+        self, model, shipped_generalizations
+    ):
+        from litellm.litellm_core_utils.fallback_generalizations import (
+            match_fallback_generalization,
         )
-        assert custom_llm_provider == "anthropic"
-        assert model == "claude-opus-5-1-20270101"
+
+        assert match_fallback_generalization(model) is None
+
+    def test_routing_comes_from_the_rule_not_python(self, shipped_generalizations):
+        """With the rule cleared, an unknown claude must no longer route to
+        anthropic; this guards against re-introducing a hard-coded Python regex."""
+        from litellm.litellm_core_utils.fallback_generalizations import (
+            set_fallback_generalizations,
+        )
+
+        set_fallback_generalizations([])
+        with pytest.raises(Exception):
+            litellm.get_llm_provider(model="claude-opus-4-9")

--- a/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
+++ b/tests/test_litellm/litellm_core_utils/test_fallback_generalizations.py
@@ -1,0 +1,300 @@
+"""
+Tests for the declarative fallback-generalizations mechanism.
+
+Covers both the pure module (litellm.litellm_core_utils.fallback_generalizations)
+and its end-to-end wiring into provider routing (get_llm_provider) and model-info
+resolution (get_model_info / supports_*).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.litellm_core_utils.fallback_generalizations import (
+    get_fallback_generalization_rules,
+    match_fallback_generalization,
+    set_fallback_generalizations,
+)
+
+
+@pytest.fixture
+def restore_generalizations():
+    """Save the active rules, let the test install its own, then restore."""
+    previous = list(get_fallback_generalization_rules())
+    try:
+        yield set_fallback_generalizations
+    finally:
+        set_fallback_generalizations(previous)
+
+
+# --------------------------------------------------------------------------- #
+# Pure module behaviour
+# --------------------------------------------------------------------------- #
+
+
+def test_match_returns_model_info_of_first_matching_rule(restore_generalizations):
+    restore_generalizations(
+        [
+            {
+                "name": "first",
+                "pattern": r"^acme-",
+                "model_info": {"litellm_provider": "openai", "tag": "first"},
+            },
+            {
+                "name": "second",
+                "pattern": r"^acme-pro-",
+                "model_info": {"litellm_provider": "anthropic", "tag": "second"},
+            },
+        ]
+    )
+    # Both rules match "acme-pro-1"; first-in-list wins (documented precedence).
+    matched = match_fallback_generalization("acme-pro-1")
+    assert matched is not None
+    assert matched["tag"] == "first"
+
+
+def test_match_is_case_insensitive(restore_generalizations):
+    restore_generalizations(
+        [{"name": "r", "pattern": r"^claude-opus", "model_info": {"ok": True}}]
+    )
+    assert match_fallback_generalization("CLAUDE-OPUS-9-9") == {"ok": True}
+
+
+def test_no_match_returns_none(restore_generalizations):
+    restore_generalizations(
+        [{"name": "r", "pattern": r"^claude-", "model_info": {"ok": True}}]
+    )
+    assert match_fallback_generalization("gpt-4o") is None
+    assert match_fallback_generalization("") is None
+
+
+def test_empty_rules_match_nothing(restore_generalizations):
+    restore_generalizations([])
+    assert match_fallback_generalization("claude-opus-9-9") is None
+
+
+def test_malformed_rules_are_skipped_not_fatal(restore_generalizations):
+    restore_generalizations(
+        [
+            "not-even-a-dict",
+            None,
+            {"name": "no-pattern", "model_info": {"x": 1}},
+            {"name": "bad-info", "pattern": r"^a", "model_info": "not-a-dict"},
+            {"name": "bad-regex", "pattern": r"^claude-(", "model_info": {"x": 1}},
+            {"name": "good", "pattern": r"^claude-", "model_info": {"good": True}},
+        ]
+    )
+    # Non-dict entries and dicts with bad fields are all skipped; the one
+    # valid rule still matches.
+    assert match_fallback_generalization("claude-opus-9-9") == {"good": True}
+
+
+def test_setting_rules_invalidates_compiled_cache(restore_generalizations):
+    restore_generalizations([{"name": "r", "pattern": r"^aaa", "model_info": {"v": 1}}])
+    assert match_fallback_generalization("aaa-1") == {"v": 1}
+    # Re-install different rules; the compiled cache must be rebuilt.
+    set_fallback_generalizations(
+        [{"name": "r", "pattern": r"^bbb", "model_info": {"v": 2}}]
+    )
+    assert match_fallback_generalization("aaa-1") is None
+    assert match_fallback_generalization("bbb-1") == {"v": 2}
+
+
+def test_extends_inherits_parent_and_own_overrides(restore_generalizations):
+    """A rule's ``extends`` pulls in the parent's model_info; its own keys win on conflict,
+    so a narrow rule carries only its delta instead of duplicating the parent."""
+    restore_generalizations(
+        [
+            {
+                "name": "base",
+                "pattern": r"^base-only$",
+                "model_info": {
+                    "litellm_provider": "anthropic",
+                    "input_cost_per_token": 5e-06,
+                    "supports_vision": True,
+                },
+            },
+            {
+                "name": "child",
+                "pattern": r"^kid-",
+                "extends": "base",
+                "model_info": {
+                    "supports_adaptive_thinking": True,
+                    "supports_vision": False,
+                },
+            },
+        ]
+    )
+    matched = match_fallback_generalization("kid-1")
+    assert matched == {
+        "litellm_provider": "anthropic",
+        "input_cost_per_token": 5e-06,
+        "supports_vision": False,
+        "supports_adaptive_thinking": True,
+    }
+
+
+def test_extends_with_unknown_parent_keeps_own_model_info(restore_generalizations):
+    """A dangling ``extends`` is non-fatal: the rule resolves to its own model_info."""
+    restore_generalizations(
+        [
+            {
+                "name": "orphan",
+                "pattern": r"^orphan-",
+                "extends": "does-not-exist",
+                "model_info": {"litellm_provider": "openai"},
+            }
+        ]
+    )
+    assert match_fallback_generalization("orphan-1") == {"litellm_provider": "openai"}
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: provider routing + model-info resolution
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def myco_rule(restore_generalizations):
+    """A self-contained rule carrying provider, pricing, context and capabilities."""
+    restore_generalizations(
+        [
+            {
+                "name": "myco",
+                "pattern": r"^myco-[a-z]+-\d+$",
+                "model_info": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 1e-06,
+                    "output_cost_per_token": 2e-06,
+                    "max_input_tokens": 12345,
+                    "max_output_tokens": 678,
+                    "supports_vision": True,
+                    "supports_function_calling": True,
+                },
+            }
+        ]
+    )
+    return "myco-fast-1"
+
+
+def test_unknown_model_routes_via_rule(myco_rule):
+    _, provider, _, _ = litellm.get_llm_provider(model=myco_rule)
+    assert provider == "openai"
+
+
+def test_unknown_model_gets_pricing_context_and_capabilities(myco_rule):
+    info = litellm.get_model_info(myco_rule)
+    assert info["litellm_provider"] == "openai"
+    assert info["input_cost_per_token"] == 1e-06
+    assert info["output_cost_per_token"] == 2e-06
+    assert info["max_input_tokens"] == 12345
+    assert info["supports_vision"] is True
+
+
+def test_supports_helper_reads_through_generalization(myco_rule):
+    assert litellm.supports_vision(myco_rule) is True
+    assert litellm.supports_function_calling(myco_rule) is True
+
+
+def test_exact_entry_takes_precedence_over_rule(restore_generalizations):
+    """An exact cost-map entry must win over a rule that also matches it."""
+    restore_generalizations(
+        [
+            {
+                "name": "shadow-gpt4o",
+                "pattern": r"^gpt-4o$",
+                "model_info": {
+                    "litellm_provider": "anthropic",
+                    "input_cost_per_token": 999.0,
+                },
+            }
+        ]
+    )
+    info = litellm.get_model_info("gpt-4o")
+    # Resolved from the real exact entry, not the shadowing rule.
+    assert info["litellm_provider"] == "openai"
+    assert info["input_cost_per_token"] != 999.0
+
+
+def test_unknown_model_without_matching_rule_still_unmapped(restore_generalizations):
+    restore_generalizations(
+        [
+            {
+                "name": "claude",
+                "pattern": r"^claude-",
+                "model_info": {"litellm_provider": "anthropic"},
+            }
+        ]
+    )
+    with pytest.raises(Exception):
+        litellm.get_model_info("totally-unknown-model-xyz")
+
+
+# --------------------------------------------------------------------------- #
+# Shipped anthropic-claude rule
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def shipped_cost_map(monkeypatch):
+    """Activate the bundled cost map so the shipped anthropic-claude rule is installed."""
+    original_cost = litellm.model_cost
+    previous_rules = list(get_fallback_generalization_rules())
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_cost
+        litellm.get_model_info.cache_clear()
+        set_fallback_generalizations(previous_rules)
+
+
+def test_shipped_rule_marks_unmapped_high_version_claude_adaptive_without_pricing(
+    shipped_cost_map,
+):
+    """An unmapped Claude >= 4.6 resolves via the version-gated adaptive-thinking rule, which
+    inherits routing and capabilities from the base rule and adds ``supports_adaptive_thinking``.
+    The rule carries no pricing, so cost stays unpriced (zero, not a fabricated number) rather
+    than reporting a confidently-wrong price."""
+    model = "claude-opus-9-9"
+    assert model not in litellm.model_cost
+    info = litellm.get_model_info(model)
+    assert info["litellm_provider"] == "anthropic"
+    assert info["supports_adaptive_thinking"] is True
+    assert info["supports_function_calling"] is True
+    assert not info.get("input_cost_per_token")
+    assert not info.get("output_cost_per_token")
+
+
+def test_shipped_rule_resolves_unmapped_low_version_claude_without_adaptive(shipped_cost_map):
+    """An unmapped Claude < 4.6 falls through to the version-neutral anthropic-claude rule: it
+    gets provider routing and baseline capabilities but no ``supports_adaptive_thinking`` flag,
+    so a sub-4.6 alias such as ``claude-opus-4-0`` resolves yet is never marked adaptive."""
+    model = "claude-opus-4-0"
+    assert model not in litellm.model_cost
+    info = litellm.get_model_info(model)
+    assert info["litellm_provider"] == "anthropic"
+    assert info["supports_function_calling"] is True
+    assert info.get("supports_adaptive_thinking") is None
+    assert not info.get("input_cost_per_token")
+
+
+def test_shipped_adaptive_rule_gates_on_version_not_pricing(shipped_cost_map):
+    """The version-gated ``anthropic-claude-adaptive-thinking`` rule marks an unmapped
+    Claude adaptive only from >= 4.6, including provider-prefixed ids the anchored pricing
+    rule cannot match, while leaving < 4.6 (and the dated Opus 4.0 form) non-adaptive."""
+    from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+    adaptive = "us.anthropic.claude-opus-4-9"
+    non_adaptive = "us.anthropic.claude-opus-4-20250514"
+    assert adaptive not in litellm.model_cost
+    assert non_adaptive not in litellm.model_cost
+    assert AnthropicModelInfo._is_adaptive_thinking_model(adaptive) is True
+    assert AnthropicModelInfo._is_adaptive_thinking_model(non_adaptive) is False

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -1,0 +1,182 @@
+"""
+Tests for model-cost-map loading: the model-count integrity check (which must
+count actual model entries, not reserved meta keys) and the extraction of the
+``fallback_generalizations`` block out of the raw map.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+from litellm.litellm_core_utils.fallback_generalizations import (
+    get_fallback_generalization_rules,
+    match_fallback_generalization,
+    set_fallback_generalizations,
+)
+from litellm.litellm_core_utils.get_model_cost_map import (
+    FALLBACK_GENERALIZATIONS_KEY,
+    GetModelCostMap,
+    _count_model_entries,
+    _finalize_model_cost_map,
+)
+
+
+def _make_models(n: int) -> dict:
+    return {
+        f"model-{i}": {"litellm_provider": "openai", "mode": "chat"} for i in range(n)
+    }
+
+
+def test_count_model_entries_excludes_reserved_keys():
+    m = _make_models(3)
+    m["sample_spec"] = {"foo": "bar"}
+    m[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+    assert _count_model_entries(m) == 3
+
+
+def test_validation_rejects_truly_shrunk_file_even_with_meta_keys():
+    """A file with only a handful of real models must be rejected as corrupt,
+    and the extra meta keys must not inflate the count past the minimum."""
+    shrunk = _make_models(5)
+    shrunk["sample_spec"] = {"foo": "bar"}
+    shrunk[FALLBACK_GENERALIZATIONS_KEY] = {"rules": [{"name": "x"}]}
+
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=shrunk,
+            backup_model_count=2000,
+            min_model_count=50,
+        )
+        is False
+    )
+
+
+def test_validation_accepts_healthy_file_with_meta_keys():
+    healthy = _make_models(2000)
+    healthy["sample_spec"] = {"foo": "bar"}
+    healthy[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=healthy,
+            backup_model_count=2000,
+            min_model_count=50,
+        )
+        is True
+    )
+
+
+def test_validation_rejects_significant_shrink_vs_backup():
+    # 600 real models vs a 2000-model backup is below the 50% shrink threshold.
+    shrunk = _make_models(600)
+    shrunk[FALLBACK_GENERALIZATIONS_KEY] = {"rules": []}
+    assert (
+        GetModelCostMap.validate_model_cost_map(
+            fetched_map=shrunk,
+            backup_model_count=2000,
+            min_model_count=50,
+            max_shrink_ratio=0.5,
+        )
+        is False
+    )
+
+
+def test_finalize_pops_key_and_installs_rules():
+    previous = list(get_fallback_generalization_rules())
+    try:
+        raw = _make_models(2)
+        raw[FALLBACK_GENERALIZATIONS_KEY] = {
+            "rules": [
+                {
+                    "name": "rule",
+                    "pattern": r"^widget-",
+                    "model_info": {"litellm_provider": "openai"},
+                }
+            ]
+        }
+        finalized = _finalize_model_cost_map(raw)
+
+        # The reserved key is removed from the returned model map ...
+        assert FALLBACK_GENERALIZATIONS_KEY not in finalized
+        # ... and its rules are installed into the generalizations module.
+        assert match_fallback_generalization("widget-9") == {
+            "litellm_provider": "openai"
+        }
+    finally:
+        set_fallback_generalizations(previous)
+
+
+def test_finalize_with_no_block_clears_rules():
+    previous = list(get_fallback_generalization_rules())
+    try:
+        set_fallback_generalizations(
+            [{"name": "stale", "pattern": r"^x", "model_info": {"a": 1}}]
+        )
+        _finalize_model_cost_map(_make_models(2))
+        assert match_fallback_generalization("x-1") is None
+    finally:
+        set_fallback_generalizations(previous)
+
+
+def test_shipped_backup_carries_the_anthropic_claude_rule():
+    """The bundled backup must ship the anthropic-claude rule so a fresh install
+    (or an offline fallback) routes unknown Claude models without code changes."""
+    backup = GetModelCostMap.load_local_model_cost_map()
+    rules = backup.get(FALLBACK_GENERALIZATIONS_KEY, {}).get("rules", [])
+    names = {r.get("name") for r in rules}
+    assert "anthropic-claude" in names
+
+    rule = next(r for r in rules if r.get("name") == "anthropic-claude")
+    assert rule["model_info"]["litellm_provider"] == "anthropic"
+
+    previous = list(get_fallback_generalization_rules())
+    try:
+        set_fallback_generalizations(rules)
+        matched = match_fallback_generalization("claude-opus-4-9")
+        assert matched is not None and matched["litellm_provider"] == "anthropic"
+    finally:
+        set_fallback_generalizations(previous)
+
+
+def test_shipped_backup_marks_claude_4_6_plus_adaptive_not_4_0():
+    """Adaptive thinking is data, not code. The bundled backup must carry
+    supports_adaptive_thinking on genuine Claude >= 4.6 entries (every provider
+    route) and on the version-gated anthropic-claude-adaptive-thinking rule for
+    unmapped future Claudes, while leaving the dated Claude 4.0 names
+    ("...-4-20250514") unflagged so a date can never be mistaken for a 4.6+ minor
+    version. The version-neutral anthropic-claude pricing rule must not flag it, so
+    an unmapped sub-4.6 name is priced but stays non-adaptive. The adaptive rule must
+    inherit pricing from the pricing rule via ``extends`` and carry only its delta, so
+    the Opus-tier price block is never duplicated across rules."""
+    backup = GetModelCostMap.load_local_model_cost_map()
+
+    rules = backup[FALLBACK_GENERALIZATIONS_KEY]["rules"]
+    pricing_rule = next(r for r in rules if r.get("name") == "anthropic-claude")
+    adaptive_rule = next(
+        r for r in rules if r.get("name") == "anthropic-claude-adaptive-thinking"
+    )
+    assert "supports_adaptive_thinking" not in pricing_rule["model_info"]
+    assert adaptive_rule["model_info"]["supports_adaptive_thinking"] is True
+
+    assert "extends" not in pricing_rule
+    assert adaptive_rule.get("extends") == "anthropic-claude"
+    assert adaptive_rule["model_info"] == {"supports_adaptive_thinking": True}
+
+    for adaptive in [
+        "anthropic.claude-opus-4-8",
+        "vertex_ai/claude-opus-4-6@default",
+        "us.anthropic.claude-sonnet-4-6",
+        "openrouter/anthropic/claude-opus-4.7",
+        "azure_ai/claude-opus-4-7",
+    ]:
+        assert backup[adaptive]["supports_adaptive_thinking"] is True, adaptive
+
+    for non_adaptive in [
+        "claude-opus-4-20250514",
+        "us.anthropic.claude-opus-4-20250514-v1:0",
+        "claude-opus-4-5",
+    ]:
+        assert "supports_adaptive_thinking" not in backup[non_adaptive], non_adaptive

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -8,9 +8,7 @@ from websockets.exceptions import ConnectionClosed
 
 import litellm
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.realtime_streaming import (
@@ -43,9 +41,7 @@ def test_realtime_streaming_store_message():
     streaming = RealTimeStreaming(websocket, backend_ws, logging_obj)
 
     # Test 1: Session created event (string input)
-    session_created_msg = json.dumps(
-        {"type": "session.created", "session": {"id": "test-session"}}
-    )
+    session_created_msg = json.dumps({"type": "session.created", "session": {"id": "test-session"}})
     streaming.store_message(session_created_msg)
     assert len(streaming.messages) == 1
     assert "session" in streaming.messages[0]
@@ -70,9 +66,7 @@ def test_realtime_streaming_store_message():
         streaming.store_message(invalid_msg)
 
     # Test 4: Message type not in logged events
-    streaming.logged_real_time_event_types = [
-        "session.created"
-    ]  # Only log session.created
+    streaming.logged_real_time_event_types = ["session.created"]  # Only log session.created
     other_msg = json.dumps(
         {
             "type": "response.done",
@@ -85,9 +79,7 @@ def test_realtime_streaming_store_message():
 
 
 def test_remap_beta_session_to_ga_normalizes_modalities_and_audio():
-    out = RealTimeStreaming._remap_beta_session_to_ga(
-        {"modalities": ["audio", "text"], "voice": "alloy"}
-    )
+    out = RealTimeStreaming._remap_beta_session_to_ga({"modalities": ["audio", "text"], "voice": "alloy"})
     assert out["type"] == "realtime"
     assert out["output_modalities"] == ["audio"]
     assert out["audio"]["output"]["voice"] == "alloy"
@@ -126,13 +118,11 @@ def test_make_disable_auto_response_message_produces_ga_shape():
 
     assert msg["type"] == "session.update"
     session = msg["session"]
-    assert (
-        session.get("type") == "realtime"
-    ), "GA session.update must include session.type='realtime'"
+    assert session.get("type") == "realtime", "GA session.update must include session.type='realtime'"
     # turn_detection must NOT be at the flat beta location
-    assert (
-        "turn_detection" not in session
-    ), "turn_detection must not be at the top-level session (beta shape); use audio.input"
+    assert "turn_detection" not in session, (
+        "turn_detection must not be at the top-level session (beta shape); use audio.input"
+    )
     # turn_detection must be nested under audio.input
     td = session["audio"]["input"]["turn_detection"]
     assert td["type"] == "server_vad"
@@ -151,9 +141,7 @@ def test_make_disable_auto_response_message_produces_beta_shape_for_beta_clients
 
     assert msg["type"] == "session.update"
     session = msg["session"]
-    assert session == {
-        "turn_detection": {"type": "server_vad", "create_response": False}
-    }
+    assert session == {"turn_detection": {"type": "server_vad", "create_response": False}}
 
 
 @pytest.mark.asyncio
@@ -421,9 +409,7 @@ async def test_backend_to_client_drops_ping_events():
     backend_ws = MagicMock()
     backend_ws.recv = AsyncMock(
         side_effect=[
-            json.dumps(
-                {"type": "ping", "event_id": "evt_ping", "timestamp": 1782214899793}
-            ).encode(),
+            json.dumps({"type": "ping", "event_id": "evt_ping", "timestamp": 1782214899793}).encode(),
             json.dumps({"type": "session.created", "session": {}}).encode(),
             ConnectionClosed(None, None),
         ]
@@ -604,9 +590,7 @@ async def test_client_ack_messages_keeps_beta_session_shape_for_beta_backend():
     backend_ws.send = AsyncMock()
     logging_obj = MagicMock()
     logging_obj.pre_call = MagicMock()
-    streaming = RealTimeStreaming(
-        client_ws, backend_ws, logging_obj, backend_uses_beta_protocol=True
-    )
+    streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj, backend_uses_beta_protocol=True)
 
     await streaming.client_ack_messages()
 
@@ -629,10 +613,7 @@ def test_translate_event_to_beta_renames_delta_types():
 
 
 def test_translate_event_to_beta_drops_conversation_item_done():
-    assert (
-        RealTimeStreaming._translate_event_to_beta({"type": "conversation.item.done"})
-        is None
-    )
+    assert RealTimeStreaming._translate_event_to_beta({"type": "conversation.item.done"}) is None
 
 
 @pytest.mark.asyncio
@@ -878,9 +859,7 @@ async def test_transcription_session_captures_usage_and_skips_response_create():
             "type": "session.created",
             "session": {
                 "type": "transcription",
-                "audio": {
-                    "input": {"transcription": {"model": "gpt-realtime-whisper"}}
-                },
+                "audio": {"input": {"transcription": {"model": "gpt-realtime-whisper"}}},
             },
         }
     ).encode()
@@ -894,9 +873,7 @@ async def test_transcription_session_captures_usage_and_skips_response_create():
     ).encode()
 
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[session_created, completed, ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[session_created, completed, ConnectionClosed(None, None)])
     backend_ws.send = AsyncMock()
 
     logging_obj = MagicMock()
@@ -910,9 +887,7 @@ async def test_transcription_session_captures_usage_and_skips_response_create():
     assert streaming._is_transcription_session is True
 
     captured = [
-        m
-        for m in streaming.messages
-        if m.get("type") == "conversation.item.input_audio_transcription.completed"
+        m for m in streaming.messages if m.get("type") == "conversation.item.input_audio_transcription.completed"
     ]
     assert len(captured) == 1, "completed usage event must be captured for cost"
     assert captured[0]["usage"]["seconds"] == 12.0
@@ -921,12 +896,10 @@ async def test_transcription_session_captures_usage_and_skips_response_create():
     client_ws.send_text.assert_any_call(completed.decode())
 
     # No response.create — transcription sessions have no assistant turn.
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
-    assert all(
-        e.get("type") != "response.create" for e in sent_to_backend
-    ), f"transcription session must not trigger response.create, got: {sent_to_backend}"
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
+    assert all(e.get("type") != "response.create" for e in sent_to_backend), (
+        f"transcription session must not trigger response.create, got: {sent_to_backend}"
+    )
 
 
 @pytest.mark.asyncio
@@ -958,9 +931,7 @@ async def test_non_transcription_completed_event_still_triggers_response_create(
     await streaming.backend_to_client_send_messages()
 
     assert streaming._is_transcription_session is False
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
     assert any(e.get("type") == "response.create" for e in sent_to_backend)
 
 
@@ -1095,15 +1066,11 @@ def test_detect_transcription_session_from_backend_transcription_session_events(
     """Backend transcription_session.created/updated events flag the session."""
     streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
     assert streaming._is_transcription_session is False
-    streaming._detect_transcription_session_from_backend(
-        {"type": "transcription_session.created"}
-    )
+    streaming._detect_transcription_session_from_backend({"type": "transcription_session.created"})
     assert streaming._is_transcription_session is True
 
     streaming2 = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
-    streaming2._detect_transcription_session_from_backend(
-        {"type": "transcription_session.updated"}
-    )
+    streaming2._detect_transcription_session_from_backend({"type": "transcription_session.updated"})
     assert streaming2._is_transcription_session is True
 
 
@@ -1134,9 +1101,7 @@ def test_capture_transcription_usage_deduplicates_when_already_stored():
 
     streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
     # Add the event type to the default logged list so _should_store_message returns True.
-    streaming.logged_real_time_event_types = [
-        "conversation.item.input_audio_transcription.completed"
-    ]
+    streaming.logged_real_time_event_types = ["conversation.item.input_audio_transcription.completed"]
     event = {
         "type": "conversation.item.input_audio_transcription.completed",
         "usage": {"type": "duration", "seconds": 5.0},
@@ -1201,9 +1166,7 @@ async def test_failed_content_send_does_not_block_later_setup():
     logging_obj = MagicMock()
 
     provider_config = MagicMock()
-    provider_config.transform_realtime_request = MagicMock(
-        side_effect=lambda m, *a, **k: [m]
-    )
+    provider_config.transform_realtime_request = MagicMock(side_effect=lambda m, *a, **k: [m])
     provider_config.is_setup_message = MagicMock(side_effect=lambda obj: "setup" in obj)
     provider_config.is_content_message = MagicMock(
         side_effect=lambda obj: obj.get("type") == "conversation.item.create"
@@ -1347,9 +1310,7 @@ async def test_log_messages_includes_tools_in_model_call_details():
     logging_obj.success_handler = MagicMock()
     streaming = RealTimeStreaming(websocket, backend_ws, logging_obj)
 
-    streaming.session_tools = [
-        {"type": "function", "name": "get_weather", "description": "Get weather"}
-    ]
+    streaming.session_tools = [{"type": "function", "name": "get_weather", "description": "Get weather"}]
     streaming.tool_calls = [
         {
             "id": "call_1",
@@ -1378,14 +1339,10 @@ async def test_realtime_guardrail_blocks_prompt_injection():
 
     # Simple guardrail that blocks anything with "system update"
     class PromptInjectionGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             for text in inputs.get("texts", []):
                 if "system update" in text.lower():
-                    raise ValueError(
-                        "⚠️ Prompt injection detected. Request blocked by guardrail."
-                    )
+                    raise ValueError("⚠️ Prompt injection detected. Request blocked by guardrail.")
             return inputs
 
     guardrail = PromptInjectionGuardrail(
@@ -1428,39 +1385,25 @@ async def test_realtime_guardrail_blocks_prompt_injection():
     # violation message.  There should be exactly ONE response.create (the
     # guardrail-triggered one), preceded by a response.cancel and a
     # conversation.item.create carrying the violation text.
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
-    response_cancels = [
-        e for e in sent_to_backend if e.get("type") == "response.cancel"
-    ]
-    assert (
-        len(response_cancels) == 1
-    ), f"Guardrail should send response.cancel, got: {response_cancels}"
-    guardrail_items = [
-        e for e in sent_to_backend if e.get("type") == "conversation.item.create"
-    ]
-    assert (
-        len(guardrail_items) == 1
-    ), f"Guardrail should inject a conversation.item.create with violation message, got: {guardrail_items}"
-    response_creates = [
-        e for e in sent_to_backend if e.get("type") == "response.create"
-    ]
-    assert (
-        len(response_creates) == 1
-    ), f"Guardrail should send exactly one response.create to voice the violation, got: {response_creates}"
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
+    response_cancels = [e for e in sent_to_backend if e.get("type") == "response.cancel"]
+    assert len(response_cancels) == 1, f"Guardrail should send response.cancel, got: {response_cancels}"
+    guardrail_items = [e for e in sent_to_backend if e.get("type") == "conversation.item.create"]
+    assert len(guardrail_items) == 1, (
+        f"Guardrail should inject a conversation.item.create with violation message, got: {guardrail_items}"
+    )
+    response_creates = [e for e in sent_to_backend if e.get("type") == "response.create"]
+    assert len(response_creates) == 1, (
+        f"Guardrail should send exactly one response.create to voice the violation, got: {response_creates}"
+    )
 
     # ASSERT 2: error event was sent directly to the client WebSocket
-    sent_to_client = [
-        json.loads(c.args[0]) for c in client_ws.send_text.call_args_list if c.args
-    ]
+    sent_to_client = [json.loads(c.args[0]) for c in client_ws.send_text.call_args_list if c.args]
     error_events = [e for e in sent_to_client if e.get("type") == "error"]
-    assert (
-        len(error_events) == 1
-    ), f"Expected one error event sent to client, got: {sent_to_client}"
-    assert (
-        error_events[0]["error"]["type"] == "guardrail_violation"
-    ), f"Expected guardrail_violation error type, got: {error_events[0]}"
+    assert len(error_events) == 1, f"Expected one error event sent to client, got: {sent_to_client}"
+    assert error_events[0]["error"]["type"] == "guardrail_violation", (
+        f"Expected guardrail_violation error type, got: {error_events[0]}"
+    )
 
     litellm.callbacks = []  # cleanup
 
@@ -1476,9 +1419,7 @@ async def test_realtime_guardrail_allows_clean_transcript():
     from litellm.types.guardrails import GuardrailEventHooks
 
     class PromptInjectionGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             for text in inputs.get("texts", []):
                 if "system update" in text.lower():
                     raise ValueError("⚠️ Prompt injection detected.")
@@ -1518,15 +1459,9 @@ async def test_realtime_guardrail_allows_clean_transcript():
     await streaming.backend_to_client_send_messages()
 
     # ASSERT: response.create WAS sent to backend (clean transcript)
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
-    response_creates = [
-        e for e in sent_to_backend if e.get("type") == "response.create"
-    ]
-    assert (
-        len(response_creates) == 1
-    ), f"Clean transcript should trigger response.create, got: {sent_to_backend}"
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
+    response_creates = [e for e in sent_to_backend if e.get("type") == "response.create"]
+    assert len(response_creates) == 1, f"Clean transcript should trigger response.create, got: {sent_to_backend}"
 
     litellm.callbacks = []  # cleanup
 
@@ -1545,9 +1480,7 @@ async def test_realtime_text_input_guardrail_blocks_and_returns_error():
     from litellm.types.guardrails import GuardrailEventHooks
 
     class BlockingGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             texts = inputs.get("texts", [])
             for text in texts:
                 if "@" in text:
@@ -1581,9 +1514,7 @@ async def test_realtime_text_input_guardrail_blocks_and_returns_error():
             "type": "conversation.item.create",
             "item": {
                 "role": "user",
-                "content": [
-                    {"type": "input_text", "text": "My email is test@example.com"}
-                ],
+                "content": [{"type": "input_text", "text": "My email is test@example.com"}],
             },
         }
     )
@@ -1613,8 +1544,7 @@ async def test_realtime_text_input_guardrail_blocks_and_returns_error():
     forwarded_items = [
         json.loads(m)
         for m in sent_to_backend
-        if isinstance(m, str)
-        and json.loads(m).get("type") == "conversation.item.create"
+        if isinstance(m, str) and json.loads(m).get("type") == "conversation.item.create"
     ]
     # Filter out guardrail-injected items (contain "Say exactly the following message")
     original_items = [
@@ -1626,9 +1556,7 @@ async def test_realtime_text_input_guardrail_blocks_and_returns_error():
             if isinstance(c, dict)
         )
     ]
-    assert (
-        len(original_items) == 0
-    ), f"Blocked item should not be forwarded to backend, got: {original_items}"
+    assert len(original_items) == 0, f"Blocked item should not be forwarded to backend, got: {original_items}"
 
     litellm.callbacks = []  # cleanup
 
@@ -1647,9 +1575,7 @@ async def test_realtime_function_call_output_guardrail_blocks_and_returns_error(
     from litellm.types.guardrails import GuardrailEventHooks
 
     class BlockingGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             texts = inputs.get("texts", [])
             for text in texts:
                 if "@" in text:
@@ -1715,9 +1641,9 @@ async def test_realtime_function_call_output_guardrail_blocks_and_returns_error(
     # every toolCall with a toolResponse (Gemini/Vertex Live) exit their
     # pending-tool-call state instead of stalling. The placeholder must NOT
     # contain any of the blocked content.
-    assert (
-        len(forwarded_tool_outputs) == 1
-    ), f"Sanitized function_call_output should be forwarded, got: {forwarded_tool_outputs}"
+    assert len(forwarded_tool_outputs) == 1, (
+        f"Sanitized function_call_output should be forwarded, got: {forwarded_tool_outputs}"
+    )
     sanitized_item = forwarded_tool_outputs[0]["item"]
     assert sanitized_item["call_id"] == "call_123"
     assert "test@example.com" not in sanitized_item["output"]
@@ -1736,9 +1662,7 @@ async def test_realtime_function_call_output_guardrail_allows_clean_output():
     from litellm.types.guardrails import GuardrailEventHooks
 
     class BlockingGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             return inputs
 
     guardrail = BlockingGuardrail(
@@ -1788,9 +1712,7 @@ async def test_realtime_function_call_output_guardrail_allows_clean_output():
         and json.loads(m).get("type") == "conversation.item.create"
         and json.loads(m).get("item", {}).get("type") == "function_call_output"
     ]
-    assert (
-        len(forwarded) == 1
-    ), f"Clean function_call_output should be forwarded, got: {forwarded}"
+    assert len(forwarded) == 1, f"Clean function_call_output should be forwarded, got: {forwarded}"
 
     litellm.callbacks = []  # cleanup
 
@@ -1806,9 +1728,7 @@ async def test_realtime_text_input_guardrail_uses_pre_call_mode():
     from litellm.types.guardrails import GuardrailEventHooks
 
     class DummyGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             return inputs
 
     guardrail = DummyGuardrail(
@@ -1823,13 +1743,13 @@ async def test_realtime_text_input_guardrail_uses_pre_call_mode():
     logging_obj = MagicMock()
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
 
-    assert (
-        streaming._has_realtime_guardrails() is True
-    ), "pre_call guardrail should be recognized as a realtime guardrail"
+    assert streaming._has_realtime_guardrails() is True, (
+        "pre_call guardrail should be recognized as a realtime guardrail"
+    )
     # pre_call-only guardrails gate typed user messages / tool output, not audio VAD.
-    assert (
-        streaming._has_audio_transcription_guardrails() is False
-    ), "pre_call-only guardrail must not disable server_vad auto-response"
+    assert streaming._has_audio_transcription_guardrails() is False, (
+        "pre_call-only guardrail must not disable server_vad auto-response"
+    )
 
     litellm.callbacks = []  # cleanup
 
@@ -1847,9 +1767,7 @@ async def test_realtime_session_created_injects_session_update_for_audio_guardra
     from litellm.types.guardrails import GuardrailEventHooks
 
     class AudioGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             return inputs
 
     guardrail = AudioGuardrail(
@@ -1862,14 +1780,10 @@ async def test_realtime_session_created_injects_session_update_for_audio_guardra
     client_ws = MagicMock()
     client_ws.send_text = AsyncMock()
 
-    session_created_event = json.dumps(
-        {"type": "session.created", "session": {"id": "sess_abc"}}
-    ).encode()
+    session_created_event = json.dumps({"type": "session.created", "session": {"id": "sess_abc"}}).encode()
 
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[session_created_event, ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[session_created_event, ConnectionClosed(None, None)])
     backend_ws.send = AsyncMock()
 
     logging_obj = MagicMock()
@@ -1880,32 +1794,20 @@ async def test_realtime_session_created_injects_session_update_for_audio_guardra
     await streaming.backend_to_client_send_messages()
 
     # session.created must be forwarded to the client
-    sent_to_client = [
-        json.loads(c.args[0]) for c in client_ws.send_text.call_args_list if c.args
-    ]
-    session_created_events = [
-        e for e in sent_to_client if e.get("type") == "session.created"
-    ]
-    assert (
-        len(session_created_events) == 1
-    ), f"session.created should be forwarded to client, got: {sent_to_client}"
+    sent_to_client = [json.loads(c.args[0]) for c in client_ws.send_text.call_args_list if c.args]
+    session_created_events = [e for e in sent_to_client if e.get("type") == "session.created"]
+    assert len(session_created_events) == 1, f"session.created should be forwarded to client, got: {sent_to_client}"
 
     # session.update must be sent to the backend AFTER session.created was forwarded
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
     session_updates = [e for e in sent_to_backend if e.get("type") == "session.update"]
-    assert (
-        len(session_updates) == 1
-    ), f"Expected one session.update injected to backend, got: {sent_to_backend}"
+    assert len(session_updates) == 1, f"Expected one session.update injected to backend, got: {sent_to_backend}"
     # GA shape: turn_detection must be nested under audio.input, not at top-level session
     injected_session = session_updates[0]["session"]
-    assert (
-        injected_session["type"] == "realtime"
-    ), "GA session.update must include session.type='realtime'"
-    assert (
-        injected_session["audio"]["input"]["turn_detection"]["create_response"] is False
-    ), "GA session.update must nest turn_detection under audio.input"
+    assert injected_session["type"] == "realtime", "GA session.update must include session.type='realtime'"
+    assert injected_session["audio"]["input"]["turn_detection"]["create_response"] is False, (
+        "GA session.update must nest turn_detection under audio.input"
+    )
 
     litellm.callbacks = []  # cleanup
 
@@ -1921,9 +1823,7 @@ async def test_realtime_session_created_does_not_inject_session_update_for_pre_c
     from litellm.types.guardrails import GuardrailEventHooks
 
     class PreCallGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             return inputs
 
     guardrail = PreCallGuardrail(
@@ -1936,14 +1836,10 @@ async def test_realtime_session_created_does_not_inject_session_update_for_pre_c
     client_ws = MagicMock()
     client_ws.send_text = AsyncMock()
 
-    session_created_event = json.dumps(
-        {"type": "session.created", "session": {"id": "sess_xyz"}}
-    ).encode()
+    session_created_event = json.dumps({"type": "session.created", "session": {"id": "sess_xyz"}}).encode()
 
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[session_created_event, ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[session_created_event, ConnectionClosed(None, None)])
     backend_ws.send = AsyncMock()
 
     logging_obj = MagicMock()
@@ -1953,13 +1849,9 @@ async def test_realtime_session_created_does_not_inject_session_update_for_pre_c
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
     await streaming.backend_to_client_send_messages()
 
-    sent_to_backend = [
-        json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args
-    ]
+    sent_to_backend = [json.loads(c.args[0]) for c in backend_ws.send.call_args_list if c.args]
     session_updates = [e for e in sent_to_backend if e.get("type") == "session.update"]
-    assert (
-        len(session_updates) == 0
-    ), f"pre_call-only guardrail must not inject session.update, got: {sent_to_backend}"
+    assert len(session_updates) == 0, f"pre_call-only guardrail must not inject session.update, got: {sent_to_backend}"
 
     litellm.callbacks = []  # cleanup
 
@@ -1972,9 +1864,7 @@ async def test_pre_call_and_post_call_guardrails_do_not_disable_server_vad():
     from litellm.types.guardrails import GuardrailEventHooks
 
     class ModelArmorStyleGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             return inputs
 
     litellm.callbacks = [
@@ -2021,9 +1911,7 @@ async def test_end_session_after_n_fails_closes_connection():
     """
 
     class BadWordGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             for text in inputs.get("texts", []):
                 if "blocked" in text.lower():
                     raise ValueError("Content blocked by guardrail.")
@@ -2057,9 +1945,7 @@ async def test_end_session_after_n_fails_closes_connection():
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
     await streaming.backend_to_client_send_messages()
 
-    assert (
-        backend_ws.close.called
-    ), "Expected backend_ws.close() to be called after 2 violations"
+    assert backend_ws.close.called, "Expected backend_ws.close() to be called after 2 violations"
     assert streaming._violation_count == 2
 
     litellm.callbacks = []  # cleanup
@@ -2073,9 +1959,7 @@ async def test_on_violation_end_session_closes_on_first_fail():
     """
 
     class TopicGuardrail(CustomGuardrail):
-        async def apply_guardrail(
-            self, inputs, request_data, input_type, logging_obj=None
-        ):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
             for text in inputs.get("texts", []):
                 if "stock" in text.lower():
                     raise ValueError("Topic not allowed: financial advice.")
@@ -2108,9 +1992,7 @@ async def test_on_violation_end_session_closes_on_first_fail():
     streaming = RealTimeStreaming(client_ws, backend_ws, logging_obj)
     await streaming.backend_to_client_send_messages()
 
-    assert (
-        backend_ws.close.called
-    ), "Expected session to close immediately with on_violation=end_session"
+    assert backend_ws.close.called, "Expected session to close immediately with on_violation=end_session"
     assert streaming._violation_count == 1
 
     litellm.callbacks = []  # cleanup
@@ -2122,9 +2004,7 @@ async def test_provider_path_suppresses_duplicate_session_created_after_syntheti
     client_ws.send_text = AsyncMock()
 
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[b'{"setupComplete": {}}', ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[b'{"setupComplete": {}}', ConnectionClosed(None, None)])
     backend_ws.send = AsyncMock()
 
     provider_config = MagicMock()
@@ -2165,9 +2045,9 @@ async def test_provider_path_suppresses_duplicate_session_created_after_syntheti
     await streaming.backend_to_client_send_messages()
 
     sent_payloads = [json.loads(c.args[0]) for c in client_ws.send_text.call_args_list]
-    assert not any(
-        payload.get("type") == "session.created" for payload in sent_payloads
-    ), f"Expected duplicate session.created to be suppressed, got: {sent_payloads}"
+    assert not any(payload.get("type") == "session.created" for payload in sent_payloads), (
+        f"Expected duplicate session.created to be suppressed, got: {sent_payloads}"
+    )
 
 
 @pytest.mark.asyncio
@@ -2176,9 +2056,7 @@ async def test_duplicate_session_created_still_triggers_guardrail_turn_detection
     client_ws.send_text = AsyncMock()
 
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[b'{"setupComplete": {}}', ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[b'{"setupComplete": {}}', ConnectionClosed(None, None)])
     backend_ws.send = AsyncMock()
 
     provider_config = MagicMock()
@@ -2227,9 +2105,7 @@ async def test_duplicate_session_created_still_triggers_guardrail_turn_detection
     assert sent_update["type"] == "session.update"
     injected_session = sent_update["session"]
     assert injected_session["type"] == "realtime"
-    assert (
-        injected_session["audio"]["input"]["turn_detection"]["create_response"] is False
-    )
+    assert injected_session["audio"]["input"]["turn_detection"]["create_response"] is False
 
 
 @pytest.mark.asyncio
@@ -2245,9 +2121,7 @@ async def test_guardrail_update_respects_idempotency_flag():
     logging_obj.success_handler = MagicMock()
 
     provider_config = MagicMock()
-    provider_config.transform_realtime_request = MagicMock(
-        side_effect=lambda msg, model, session_config: [msg]
-    )
+    provider_config.transform_realtime_request = MagicMock(side_effect=lambda msg, model, session_config: [msg])
 
     streaming = RealTimeStreaming(
         websocket=client_ws,
@@ -2324,9 +2198,9 @@ async def test_guardrail_turn_detection_injected_into_first_session_update_defer
     msg_obj = json.loads(transformed_msg)
     assert msg_obj["type"] == "session.update"
     session_obj = msg_obj["session"]
-    injected_turn_detection = session_obj.get("turn_detection") or session_obj.get(
-        "audio", {}
-    ).get("input", {}).get("turn_detection")
+    injected_turn_detection = session_obj.get("turn_detection") or session_obj.get("audio", {}).get("input", {}).get(
+        "turn_detection"
+    )
     assert injected_turn_detection is not None
     assert injected_turn_detection["create_response"] is False
     assert streaming._guardrail_turn_detection_update_sent is True
@@ -2385,9 +2259,9 @@ async def test_guardrail_turn_detection_injection_tolerates_non_dict_value(
     transformed_msg, _ = transformed_messages[0]
     msg_obj = json.loads(transformed_msg)
     session_obj = msg_obj["session"]
-    injected_turn_detection = session_obj.get("turn_detection") or session_obj.get(
-        "audio", {}
-    ).get("input", {}).get("turn_detection")
+    injected_turn_detection = session_obj.get("turn_detection") or session_obj.get("audio", {}).get("input", {}).get(
+        "turn_detection"
+    )
     assert isinstance(injected_turn_detection, dict)
     assert injected_turn_detection["create_response"] is False
     assert streaming._guardrail_turn_detection_update_sent is True
@@ -2398,13 +2272,7 @@ async def test_guardrail_turn_detection_injection_tolerates_non_dict_value(
     "client_session",
     [
         {"turn_detection": {"type": "server_vad", "create_response": True}},
-        {
-            "audio": {
-                "input": {
-                    "turn_detection": {"type": "server_vad", "create_response": True}
-                }
-            }
-        },
+        {"audio": {"input": {"turn_detection": {"type": "server_vad", "create_response": True}}}},
     ],
 )
 async def test_subsequent_session_update_cannot_reenable_vad_when_guardrails_active(
@@ -2457,9 +2325,9 @@ async def test_subsequent_session_update_cannot_reenable_vad_when_guardrails_act
     forwarded_msg, _ = transformed_messages[0]
     msg_obj = json.loads(forwarded_msg)
     session_obj = msg_obj["session"]
-    forwarded_turn_detection = session_obj.get("turn_detection") or session_obj.get(
-        "audio", {}
-    ).get("input", {}).get("turn_detection")
+    forwarded_turn_detection = session_obj.get("turn_detection") or session_obj.get("audio", {}).get("input", {}).get(
+        "turn_detection"
+    )
     assert isinstance(forwarded_turn_detection, dict)
     assert forwarded_turn_detection["create_response"] is False
 
@@ -2493,9 +2361,7 @@ async def test_follow_up_setup_updates_cached_session_configuration_request():
             }
         }
     )
-    provider_config.transform_realtime_request = MagicMock(
-        return_value=[follow_up_setup]
-    )
+    provider_config.transform_realtime_request = MagicMock(return_value=[follow_up_setup])
 
     streaming = RealTimeStreaming(
         websocket=client_ws,
@@ -2527,9 +2393,7 @@ async def test_deferred_setup_buffers_audio_until_backend_setup_complete(monkeyp
 
     client_ws = MagicMock()
     audio_msg = json.dumps({"type": "input_audio_buffer.append", "audio": "AA=="})
-    client_ws.receive_text = AsyncMock(
-        side_effect=[audio_msg, ConnectionClosed(None, None)]
-    )
+    client_ws.receive_text = AsyncMock(side_effect=[audio_msg, ConnectionClosed(None, None)])
     backend_ws = MagicMock()
     backend_ws.send = AsyncMock()
     logging_obj = MagicMock()
@@ -2562,12 +2426,8 @@ async def test_deferred_setup_sends_session_update_before_buffered_audio(monkeyp
 
     client_ws = MagicMock()
     audio_msg = json.dumps({"type": "input_audio_buffer.append", "audio": "AA=="})
-    session_update = json.dumps(
-        {"type": "session.update", "session": {"modalities": ["audio"]}}
-    )
-    client_ws.receive_text = AsyncMock(
-        side_effect=[audio_msg, session_update, ConnectionClosed(None, None)]
-    )
+    session_update = json.dumps({"type": "session.update", "session": {"modalities": ["audio"]}})
+    client_ws.receive_text = AsyncMock(side_effect=[audio_msg, session_update, ConnectionClosed(None, None)])
     backend_ws = MagicMock()
     backend_ws.send = AsyncMock()
     logging_obj = MagicMock()
@@ -2596,12 +2456,8 @@ async def test_deferred_setup_flush_buffers_audio_received_during_flush():
 
     client_ws = MagicMock()
     client_ws.send_text = AsyncMock()
-    new_audio_msg = json.dumps(
-        {"type": "input_audio_buffer.append", "audio": "new-audio"}
-    )
-    client_ws.receive_text = AsyncMock(
-        side_effect=[new_audio_msg, ConnectionClosed(None, None)]
-    )
+    new_audio_msg = json.dumps({"type": "input_audio_buffer.append", "audio": "new-audio"})
+    client_ws.receive_text = AsyncMock(side_effect=[new_audio_msg, ConnectionClosed(None, None)])
     backend_ws = MagicMock()
     logging_obj = MagicMock()
 
@@ -2631,9 +2487,7 @@ async def test_deferred_setup_flush_buffers_audio_received_during_flush():
         provider_config=provider_config,
         model="gemini-live-2.5-flash-native-audio",
     )
-    old_audio_msg = json.dumps(
-        {"type": "input_audio_buffer.append", "audio": "old-audio"}
-    )
+    old_audio_msg = json.dumps({"type": "input_audio_buffer.append", "audio": "old-audio"})
     streaming._pending_messages_until_setup = [old_audio_msg]
     streaming._pending_messages_byte_total = len(old_audio_msg.encode("utf-8"))
 
@@ -2649,9 +2503,7 @@ async def test_deferred_setup_flush_buffers_audio_received_during_flush():
         return True
 
     streaming._send_to_backend = send_to_backend  # type: ignore[method-assign]
-    setup_task = asyncio.create_task(
-        streaming._handle_provider_config_message(json.dumps({"setupComplete": {}}))
-    )
+    setup_task = asyncio.create_task(streaming._handle_provider_config_message(json.dumps({"setupComplete": {}})))
 
     await asyncio.wait_for(first_flush_started.wait(), timeout=1)
     await streaming.client_ack_messages()
@@ -2677,9 +2529,7 @@ async def test_deferred_setup_flush_retains_unsent_messages_after_send_failure()
         json.dumps({"type": "input_audio_buffer.commit"}),
     ]
     streaming._pending_messages_until_setup = list(buffered_messages)
-    streaming._pending_messages_byte_total = sum(
-        len(message.encode("utf-8")) for message in buffered_messages
-    )
+    streaming._pending_messages_byte_total = sum(len(message.encode("utf-8")) for message in buffered_messages)
     streaming._send_to_backend = AsyncMock(  # type: ignore[method-assign]
         side_effect=Exception("transient")
     )
@@ -2687,9 +2537,7 @@ async def test_deferred_setup_flush_retains_unsent_messages_after_send_failure()
     await streaming._flush_pending_messages_until_setup()
 
     assert streaming._pending_messages_until_setup == buffered_messages
-    assert streaming._pending_messages_byte_total == sum(
-        len(message.encode("utf-8")) for message in buffered_messages
-    )
+    assert streaming._pending_messages_byte_total == sum(len(message.encode("utf-8")) for message in buffered_messages)
 
     streaming._send_to_backend = AsyncMock(return_value=True)  # type: ignore[method-assign]
 
@@ -2729,9 +2577,7 @@ async def test_deferred_setup_flushes_audio_on_backend_session_created(monkeypat
         provider_config=config,
         model="gemini-live-2.5-flash-native-audio",
     )
-    streaming._pending_messages_until_setup.append(
-        json.dumps({"type": "input_audio_buffer.append", "audio": "AA=="})
-    )
+    streaming._pending_messages_until_setup.append(json.dumps({"type": "input_audio_buffer.append", "audio": "AA=="}))
 
     await streaming.backend_to_client_send_messages()
 
@@ -2753,9 +2599,7 @@ async def test_deferred_setup_caps_non_audio_buffered_messages(monkeypatch):
 
     client_ws = MagicMock()
     client_ws.receive_text = AsyncMock(
-        side_effect=[audio_msg]
-        + [flood_msg] * (cap + 50)
-        + [ConnectionClosed(None, None)]
+        side_effect=[audio_msg] + [flood_msg] * (cap + 50) + [ConnectionClosed(None, None)]
     )
     backend_ws = MagicMock()
     backend_ws.send = AsyncMock()
@@ -2774,9 +2618,7 @@ async def test_deferred_setup_caps_non_audio_buffered_messages(monkeypatch):
 
     backend_ws.send.assert_not_called()
     assert len(streaming._pending_messages_until_setup) == cap
-    assert (
-        streaming._pending_messages_byte_total <= RealTimeStreaming._MAX_BUFFERED_BYTES
-    )
+    assert streaming._pending_messages_byte_total <= RealTimeStreaming._MAX_BUFFERED_BYTES
 
 
 @pytest.mark.asyncio
@@ -2786,14 +2628,10 @@ async def test_deferred_setup_caps_non_audio_buffered_bytes(monkeypatch):
     from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
 
     audio_msg = json.dumps({"type": "input_audio_buffer.append", "audio": "AA=="})
-    big_non_audio = json.dumps(
-        {"type": "foo", "data": "x" * (RealTimeStreaming._MAX_BUFFERED_BYTES + 1)}
-    )
+    big_non_audio = json.dumps({"type": "foo", "data": "x" * (RealTimeStreaming._MAX_BUFFERED_BYTES + 1)})
 
     client_ws = MagicMock()
-    client_ws.receive_text = AsyncMock(
-        side_effect=[audio_msg, big_non_audio, ConnectionClosed(None, None)]
-    )
+    client_ws.receive_text = AsyncMock(side_effect=[audio_msg, big_non_audio, ConnectionClosed(None, None)])
     backend_ws = MagicMock()
     backend_ws.send = AsyncMock()
     logging_obj = MagicMock()
@@ -2809,9 +2647,7 @@ async def test_deferred_setup_caps_non_audio_buffered_bytes(monkeypatch):
     await streaming.client_ack_messages()
 
     assert streaming._pending_messages_until_setup == [audio_msg]
-    assert (
-        streaming._pending_messages_byte_total <= RealTimeStreaming._MAX_BUFFERED_BYTES
-    )
+    assert streaming._pending_messages_byte_total <= RealTimeStreaming._MAX_BUFFERED_BYTES
 
 
 def _beta_client_ws():
@@ -2889,13 +2725,9 @@ def test_translate_event_to_beta_remaps_response_done_output_content_types():
 @pytest.mark.asyncio
 async def test_beta_client_receives_translated_audio_delta():
     client_ws = _beta_client_ws()
-    frame = json.dumps(
-        {"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"}
-    )
+    frame = json.dumps({"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"})
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[frame.encode(), ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[frame.encode(), ConnectionClosed(None, None)])
     logging_obj = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -2912,13 +2744,9 @@ async def test_beta_client_receives_translated_audio_delta():
 @pytest.mark.asyncio
 async def test_ga_client_receives_raw_passthrough():
     client_ws = _ga_client_ws()
-    frame = json.dumps(
-        {"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"}
-    )
+    frame = json.dumps({"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"})
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[frame.encode(), ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[frame.encode(), ConnectionClosed(None, None)])
     logging_obj = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -2938,9 +2766,7 @@ async def test_beta_client_non_translated_event_forwarded_raw():
     client_ws = _beta_client_ws()
     frame = json.dumps({"type": "error", "error": {"message": "boom"}})
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[frame.encode(), ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[frame.encode(), ConnectionClosed(None, None)])
     logging_obj = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -2957,9 +2783,7 @@ async def test_beta_client_drops_conversation_item_done():
     client_ws = _beta_client_ws()
     frame = json.dumps({"type": "conversation.item.done", "item": {"id": "i1"}})
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[frame.encode(), ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[frame.encode(), ConnectionClosed(None, None)])
     logging_obj = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -2974,9 +2798,7 @@ def test_store_message_skips_pydantic_for_unlogged_audio_delta():
     """Audio deltas are not in DefaultLoggedRealTimeEventTypes; store_message must
     skip the Pydantic build entirely (no append, no validation)."""
     streaming = _streaming_with(_ga_client_ws())
-    with patch(
-        "litellm.litellm_core_utils.realtime_streaming.OpenAIRealtimeStreamResponseBaseObject"
-    ) as base_obj:
+    with patch("litellm.litellm_core_utils.realtime_streaming.OpenAIRealtimeStreamResponseBaseObject") as base_obj:
         streaming.store_message({"type": "response.output_audio.delta", "delta": "x"})
     base_obj.assert_not_called()
     assert streaming.messages == []
@@ -2985,13 +2807,9 @@ def test_store_message_skips_pydantic_for_unlogged_audio_delta():
 @pytest.mark.asyncio
 async def test_audio_delta_frame_parsed_at_most_once():
     client_ws = _beta_client_ws()
-    frame = json.dumps(
-        {"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"}
-    )
+    frame = json.dumps({"type": "response.output_audio.delta", "delta": "QUJD", "event_id": "e1"})
     backend_ws = MagicMock()
-    backend_ws.recv = AsyncMock(
-        side_effect=[frame.encode(), ConnectionClosed(None, None)]
-    )
+    backend_ws.recv = AsyncMock(side_effect=[frame.encode(), ConnectionClosed(None, None)])
     logging_obj = MagicMock()
     logging_obj.async_success_handler = AsyncMock()
     logging_obj.success_handler = MagicMock()
@@ -3019,9 +2837,7 @@ def test_collapse_buffered_audio_messages_applies_clear_semantics():
     new = json.dumps({"type": "input_audio_buffer.append", "audio": "new"})
     commit = json.dumps({"type": "input_audio_buffer.commit"})
 
-    collapsed = RealTimeStreaming._collapse_buffered_audio_messages(
-        [old, cleared, new, commit]
-    )
+    collapsed = RealTimeStreaming._collapse_buffered_audio_messages([old, cleared, new, commit])
 
     assert collapsed == [new, commit]
 
@@ -3064,3 +2880,68 @@ async def test_deferred_setup_clear_drops_appends_when_buffered():
     streaming._buffer_pending_message_until_setup(new_audio)
 
     assert streaming._pending_messages_until_setup == [new_audio]
+
+
+def _transcription_guardrail():
+    """A minimal real CustomGuardrail registered for the realtime transcript hook."""
+    from litellm.integrations.custom_guardrail import CustomGuardrail
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    class _TranscriptionGuardrail(CustomGuardrail):
+        async def apply_guardrail(self, inputs, request_data, input_type, logging_obj=None):
+            return inputs
+
+    return _TranscriptionGuardrail(
+        guardrail_name="test_transcription_guard",
+        event_hook=GuardrailEventHooks.realtime_input_transcription,
+        default_on=True,
+    )
+
+
+def test_setup_folds_in_auto_response_disable_when_transcription_guardrail_active():
+    """Gemini rejects a second setup, so a transcription guardrail's auto-response
+    disable must be folded into the one-and-only setup; otherwise the model
+    auto-responds and the guardrail is bypassed."""
+    import litellm
+
+    litellm.callbacks = [_transcription_guardrail()]
+    try:
+        streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+        setup = json.dumps(
+            {
+                "setup": {
+                    "model": "models/gemini-3.1-flash-live-preview",
+                    "generationConfig": {"responseModalities": ["AUDIO"]},
+                    "inputAudioTranscription": {},
+                }
+            }
+        )
+        out = json.loads(streaming._maybe_inject_guardrail_auto_response_disable(setup))
+        aad = out["setup"]["realtimeInputConfig"]["automaticActivityDetection"]
+        assert aad["disabled"] is True
+    finally:
+        litellm.callbacks = []
+
+
+def test_setup_unchanged_without_transcription_guardrail():
+    import litellm
+
+    litellm.callbacks = []
+    streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+    setup = json.dumps({"setup": {"model": "x", "generationConfig": {"responseModalities": ["AUDIO"]}}})
+    out = streaming._maybe_inject_guardrail_auto_response_disable(setup)
+    assert json.loads(out) == json.loads(setup)
+
+
+def test_non_bidi_setup_left_untouched_for_followup_capable_providers():
+    """OpenAI realtime accepts a follow-up session.update, so a non-bidi message
+    (no top-level 'setup' key) must be left untouched even with a guardrail on."""
+    import litellm
+
+    litellm.callbacks = [_transcription_guardrail()]
+    try:
+        streaming = RealTimeStreaming(MagicMock(), MagicMock(), MagicMock())
+        msg = json.dumps({"type": "session.update", "session": {"instructions": "hi"}})
+        assert streaming._maybe_inject_guardrail_auto_response_disable(msg) == msg
+    finally:
+        litellm.callbacks = []

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -2443,7 +2443,59 @@ def test_reasoning_effort_maps_to_adaptive_thinking_for_claude_4_6_models():
             assert result["output_config"]["effort"] == effort_map[effort]
 
 
-def test_get_supported_params_includes_reasoning_for_sonnet_4_6_alias():
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        # explicit cost-map entries, across provider routes / separators / date suffix
+        ("claude-opus-4-8", True),
+        ("anthropic.claude-opus-4-8", True),
+        ("vertex_ai/claude-opus-4-6@default", True),
+        ("openrouter/anthropic/claude-opus-4.7", True),
+        ("us.anthropic.claude-sonnet-4-6", True),
+        ("claude-opus-4-6-20260205", True),
+        # unmapped future models -> anthropic-claude fallback rule
+        ("claude-opus-4-9", True),
+        ("claude-sonnet-5-0", True),
+        # Claude 4.0 (dated): "4-20250514" must not be read as minor 4.20250514
+        ("claude-opus-4-20250514", False),
+        ("us.anthropic.claude-opus-4-20250514-v1:0", False),
+        ("bedrock/invoke/us.anthropic.claude-opus-4-20250514", False),
+        # sub-4.6 and legacy names
+        ("claude-opus-4-5", False),
+        ("claude-sonnet-4-5-20250929", False),
+        ("claude-3-7-sonnet", False),
+        ("claude-3-opus-20240229", False),
+        ("gpt-4o", False),
+    ],
+)
+def test_is_adaptive_thinking_model_is_sourced_from_cost_map(
+    local_model_cost_map, model, expected
+):
+    """Adaptive thinking resolves from the cost map first (an explicit
+    supports_adaptive_thinking entry, or the anthropic-claude fallback rule for unmapped
+    future Claudes), then from a date-safe opus/sonnet/haiku >= 4.6 name version as a
+    fallback for ids the cost map cannot resolve. The dated Claude 4.0 names stay
+    non-adaptive because the date suffix is not read as a minor version, while 4.8/4.9/5.x
+    are covered without a code change."""
+    assert AnthropicConfig._is_adaptive_thinking_model(model) is expected
+
+
+def test_get_supported_params_includes_reasoning_for_sonnet_4_6_alias(
+    local_model_cost_map,
+):
     """Sonnet 4.6 aliases should expose thinking + reasoning_effort in supported params."""
     config = AnthropicConfig()
 
@@ -2453,8 +2505,12 @@ def test_get_supported_params_includes_reasoning_for_sonnet_4_6_alias():
     assert "reasoning_effort" in params
 
 
-def test_get_supported_params_includes_reasoning_for_sonnet_4_6_dotted_alias():
-    """Dotted Sonnet 4.6 aliases should expose thinking + reasoning_effort in supported params."""
+def test_get_supported_params_includes_reasoning_for_sonnet_4_6_dotted_alias(
+    local_model_cost_map,
+):
+    """Dotted Sonnet 4.6 aliases should expose thinking + reasoning_effort in supported
+    params. The anthropic-claude fallback rule accepts a dotted minor (4.6) as well as
+    a dashed one, so an unmapped dotted alias still degrades to adaptive thinking."""
     config = AnthropicConfig()
 
     params = config.get_supported_openai_params(model="claude-sonnet-4.6")

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1636,7 +1636,7 @@ class TestClaudeOpus48AdaptiveThinking:
         self, local_model_cost_map, model
     ):
         """Opus 4.6/4.7 and Sonnet 4.6 carry the ``supports_adaptive_thinking`` flag,
-        so detection holds purely from the cost map with no name-based version
+        so detection holds purely from the cost map with no version-rule
         fallback. Each alias form the Bedrock/anthropic paths see resolves to a flagged
         base entry through candidate normalization: provider/region prefixes, a
         Bedrock ``-v1:0`` version suffix (stripped fully for 4.7/4.8 keys or to ``-v1``
@@ -1650,15 +1650,66 @@ class TestClaudeOpus48AdaptiveThinking:
     @pytest.mark.parametrize(
         "model",
         [
-            "claude-opus-4-9",
-            "claude-opus-4-8-some-future-suffix",
             "us.anthropic.claude-fable-5-preview",
+            "claude-fable-5-preview",
         ],
     )
-    def test_unmapped_aliases_defer_to_cost_map(self, local_model_cost_map, model):
-        """Detection is sourced solely from the cost map flag: an alias absent from
-        the map (a future release or a preview suffix) is not adaptive until a
-        ``fallback_generalizations`` rule (PR #29718) covers it."""
+    def test_unmapped_aliases_without_parseable_version_stay_non_adaptive(
+        self, local_model_cost_map, model
+    ):
+        """An alias absent from the map, not matched by any ``fallback_generalizations``
+        rule, and without a parseable opus/sonnet/haiku >= 4.6 family version stays
+        non-adaptive. ``fable`` is outside the version-rule family set, so neither the
+        cost map nor the declarative rule marks it adaptive."""
+        import litellm
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert model not in litellm.model_cost
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is False
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "bedrock/invoke/us.anthropic.claude-opus-4-9",
+            "vertex_ai/claude-sonnet-5-0",
+            "us.anthropic.claude-opus-5-2",
+            "us.anthropic.claude-opus-6-1",
+            "claude-opus-5-0",
+            "claude-opus-4-10",
+            "claude-opus-4-8-some-future-suffix",
+        ],
+    )
+    def test_adaptive_thinking_version_fallback_for_unmapped_high_versions(
+        self, local_model_cost_map, model
+    ):
+        """Provider-prefixed or suffixed Claude names that resolve to no mapped entry and
+        are not matched by the anchored ``anthropic-claude`` pricing rule still resolve to
+        adaptive when their opus/sonnet/haiku family version is >= 4.6. The version gate is
+        the declarative ``anthropic-claude-adaptive-thinking`` rule, so 5.x, 6.x and any
+        later family are covered with no code change."""
+        import litellm
+        from litellm.llms.anthropic.common_utils import AnthropicModelInfo
+
+        assert model not in litellm.model_cost
+        assert AnthropicModelInfo._is_adaptive_thinking_model(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "claude-opus-4-0",
+            "us.anthropic.claude-opus-4-0",
+            "bedrock/invoke/us.anthropic.claude-opus-4-5",
+            "us.anthropic.claude-opus-4-20250514",
+        ],
+    )
+    def test_adaptive_thinking_not_detected_for_unmapped_low_versions(
+        self, local_model_cost_map, model
+    ):
+        """Unmapped Claude names below 4.6 stay non-adaptive through the declarative path.
+        The eight-digit dated Opus 4.0 id (``...-4-20250514``) is the date-safety case: the
+        version rule caps the minor at two digits, so the date is not misread as a >= 4.6
+        minor. The anchored pricing rule still resolves these for cost, just without the
+        adaptive flag."""
         import litellm
         from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -6,9 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 import litellm
 from litellm.integrations.code_interpreter_interception.handler import (
     CodeInterpreterInterceptionLogger,
@@ -39,9 +37,7 @@ def test_prepare_fake_stream_request():
     }
     fake_stream = True
 
-    result_stream, result_data = handler._prepare_fake_stream_request(
-        stream=stream, data=data, fake_stream=fake_stream
-    )
+    result_stream, result_data = handler._prepare_fake_stream_request(stream=stream, data=data, fake_stream=fake_stream)
 
     # Verify that stream is set to False
     assert result_stream is False
@@ -60,9 +56,7 @@ def test_prepare_fake_stream_request():
     }
     fake_stream = False
 
-    result_stream, result_data = handler._prepare_fake_stream_request(
-        stream=stream, data=data, fake_stream=fake_stream
-    )
+    result_stream, result_data = handler._prepare_fake_stream_request(stream=stream, data=data, fake_stream=fake_stream)
 
     # Verify that stream remains True
     assert result_stream is True
@@ -77,9 +71,7 @@ def test_prepare_fake_stream_request():
     data = {"model": "gpt-4", "messages": [{"role": "user", "content": "Hello"}]}
     fake_stream = True
 
-    result_stream, result_data = handler._prepare_fake_stream_request(
-        stream=stream, data=data, fake_stream=fake_stream
-    )
+    result_stream, result_data = handler._prepare_fake_stream_request(stream=stream, data=data, fake_stream=fake_stream)
 
     # Verify that stream is set to False
     assert result_stream is False
@@ -165,9 +157,7 @@ def test_response_api_handler_runs_agentic_hooks_in_sync_path(monkeypatch):
     assert response is final_response
     hook_mock.assert_awaited_once()
     assert hook_mock.call_args.kwargs["api_surface"] == "responses"
-    assert hook_mock.call_args.kwargs["messages"] == [
-        {"role": "user", "content": "hi"}
-    ]
+    assert hook_mock.call_args.kwargs["messages"] == [{"role": "user", "content": "hi"}]
 
 
 def test_response_api_handler_runs_responses_pre_call_hook_before_transform():
@@ -226,9 +216,7 @@ def test_response_api_handler_runs_responses_pre_call_hook_before_transform():
     tools = transform_kwargs["response_api_optional_request_params"]["tools"]
     assert not any(tool.get("type") == "code_interpreter" for tool in tools)
     assert any(
-        tool.get("type") == "function"
-        and tool.get("name") == LITELLM_CODE_EXECUTION_TOOL_NAME
-        for tool in tools
+        tool.get("type") == "function" and tool.get("name") == LITELLM_CODE_EXECUTION_TOOL_NAME for tool in tools
     )
     hook_litellm_params = transform_kwargs["litellm_params"]
     assert hook_litellm_params.get(_ACTIVE_KEY) is True
@@ -363,9 +351,7 @@ def test_fingerprint_agentic_tools_is_deterministic():
     tools_a = {"tool_calls": [{"id": "1", "input": {"q": "abc"}, "name": "web_search"}]}
     tools_b = {"tool_calls": [{"name": "web_search", "input": {"q": "abc"}, "id": "1"}]}
 
-    assert handler._fingerprint_agentic_tools(
-        tools_a
-    ) == handler._fingerprint_agentic_tools(tools_b)
+    assert handler._fingerprint_agentic_tools(tools_a) == handler._fingerprint_agentic_tools(tools_b)
 
 
 @pytest.mark.asyncio
@@ -587,9 +573,7 @@ async def test_async_anthropic_messages_handler_forwards_router_model_info():
     mock_logging_obj.update_from_kwargs.assert_called_once()
     call_kwargs = mock_logging_obj.update_from_kwargs.call_args
     litellm_params_arg = (
-        call_kwargs.kwargs.get(
-            "litellm_params", call_kwargs[1].get("litellm_params", {})
-        )
+        call_kwargs.kwargs.get("litellm_params", call_kwargs[1].get("litellm_params", {}))
         if call_kwargs.kwargs
         else call_kwargs[1].get("litellm_params", {})
     )
@@ -672,10 +656,7 @@ def test_google_genai_streaming_hidden_params_model_info_and_router_fallback():
         response_headers=httpx.Headers({"x-ratelimit-remaining": "10"}),
     )
     assert from_model_info["model_id"] == "info-id"
-    assert (
-        from_model_info["api_base"]
-        == "https://generativelanguage.googleapis.com/v1beta"
-    )
+    assert from_model_info["api_base"] == "https://generativelanguage.googleapis.com/v1beta"
     assert isinstance(from_model_info["additional_headers"], dict)
 
     from_router = _google_genai_streaming_hidden_params(
@@ -729,9 +710,7 @@ def test_async_delete_responses_omits_body_for_azure():
 
     assert "json" not in captured
     assert "data" not in captured
-    assert captured["url"].endswith(
-        "/openai/responses/resp_xyz?api-version=2025-03-01-preview"
-    )
+    assert captured["url"].endswith("/openai/responses/resp_xyz?api-version=2025-03-01-preview")
 
 
 def test_sync_delete_responses_omits_body_for_azure():
@@ -749,9 +728,7 @@ def test_sync_delete_responses_omits_body_for_azure():
 
     assert "json" not in captured
     assert "data" not in captured
-    assert captured["url"].endswith(
-        "/openai/responses/resp_xyz?api-version=2025-03-01-preview"
-    )
+    assert captured["url"].endswith("/openai/responses/resp_xyz?api-version=2025-03-01-preview")
 
 
 def _content_type(headers: dict) -> str:
@@ -889,9 +866,7 @@ async def test_anthropic_post_retry_reserializes_mutated_body():
     prebuilt = _json.dumps(request_body)
 
     err_resp = Mock()
-    http_error = httpx.HTTPStatusError(
-        "bad", request=Mock(), response=Mock(status_code=400)
-    )
+    http_error = httpx.HTTPStatusError("bad", request=Mock(), response=Mock(status_code=400))
     err_resp.raise_for_status = Mock(side_effect=http_error)
     ok_resp = Mock()
     ok_resp.raise_for_status = Mock(return_value=None)
@@ -903,9 +878,7 @@ async def test_anthropic_post_retry_reserializes_mutated_body():
 
     provider_config = Mock()
     provider_config.max_retry_on_anthropic_messages_http_error = 2
-    provider_config.should_retry_anthropic_messages_on_http_error = Mock(
-        return_value=True
-    )
+    provider_config.should_retry_anthropic_messages_on_http_error = Mock(return_value=True)
     provider_config.transform_anthropic_messages_request_on_http_error = _mutate
     # Re-sign returns no signed body (native anthropic path) -> must re-dump.
     provider_config.sign_request = Mock(return_value=({}, None))
@@ -968,9 +941,7 @@ def _make_responses_handler_call(signed_body):
 
     provider_config = MagicMock()
     provider_config.validate_environment.return_value = {}
-    provider_config.get_complete_url.return_value = (
-        "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
-    )
+    provider_config.get_complete_url.return_value = "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
     provider_config.transform_responses_api_request.return_value = {"input": "hi"}
     provider_config.should_fake_stream.return_value = False
     provider_config.sign_request.return_value = ({"X-Signed": "1"}, signed_body)
@@ -1026,9 +997,7 @@ def test_responses_handler_signs_after_fake_stream_prep_strips_stream():
 
     provider_config = MagicMock()
     provider_config.validate_environment.return_value = {}
-    provider_config.get_complete_url.return_value = (
-        "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
-    )
+    provider_config.get_complete_url.return_value = "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
     provider_config.transform_responses_api_request.return_value = {
         "input": "hi",
         "stream": True,
@@ -1091,9 +1060,7 @@ def _make_compact_handler_call(signed_body, is_async):
     compact_url = "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses/compact"
     provider_config = MagicMock()
     provider_config.validate_environment.return_value = {}
-    provider_config.get_complete_url.return_value = (
-        "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
-    )
+    provider_config.get_complete_url.return_value = "https://bedrock-mantle.us-east-2.api.aws/openai/v1/responses"
     provider_config.transform_compact_response_api_request.return_value = (
         compact_url,
         {"model": "openai.gpt-5.5", "input": "hi"},
@@ -1127,9 +1094,7 @@ def _make_compact_handler_call(signed_body, is_async):
 
 def test_compact_handler_sends_json_when_not_signed():
     """No-op provider on compact (signed_body is None) -> posts json=data, no data= bytes."""
-    provider_config, kwargs = _make_compact_handler_call(
-        signed_body=None, is_async=False
-    )
+    provider_config, kwargs = _make_compact_handler_call(signed_body=None, is_async=False)
     provider_config.sign_request.assert_called_once()
     assert kwargs.get("json") == {"model": "openai.gpt-5.5", "input": "hi"}
     assert "data" not in kwargs
@@ -1148,9 +1113,7 @@ def test_compact_handler_sends_signed_bytes_when_signed():
     assert "json" not in kwargs
     assert kwargs["headers"] == {"X-Signed": "1"}
     # signing must use the compact endpoint as api_base, not the create URL
-    assert provider_config.sign_request.call_args.kwargs["api_base"].endswith(
-        "/openai/v1/responses/compact"
-    )
+    assert provider_config.sign_request.call_args.kwargs["api_base"].endswith("/openai/v1/responses/compact")
 
 
 def test_async_compact_handler_sends_signed_bytes_when_signed():
@@ -1165,8 +1128,93 @@ def test_async_compact_handler_sends_signed_bytes_when_signed():
 
 def test_async_compact_handler_sends_json_when_not_signed():
     """Async no-op provider on compact -> posts json=data, no data= bytes."""
-    _provider_config, kwargs = _make_compact_handler_call(
-        signed_body=None, is_async=True
-    )
+    _provider_config, kwargs = _make_compact_handler_call(signed_body=None, is_async=True)
     assert kwargs.get("json") == {"model": "openai.gpt-5.5", "input": "hi"}
     assert "data" not in kwargs
+
+
+class _FakeWSExceptions:
+    class WebSocketException(Exception):
+        pass
+
+    class InvalidStatusCode(WebSocketException):
+        def __init__(self) -> None:
+            super().__init__("HTTP 403")
+
+    # websockets>=15 raises InvalidStatus (not InvalidStatusCode) for a rejected
+    # client handshake; both must be treated as deterministic.
+    class InvalidStatus(WebSocketException):
+        def __init__(self) -> None:
+            super().__init__("HTTP 401")
+
+
+class _FakeWebsocketsModule:
+    """Stand-in for the ``websockets`` module so the realtime backend-open retry
+    can be exercised without a real network handshake (dependency injection,
+    no monkeypatching)."""
+
+    def __init__(self, outcomes):
+        # outcomes: list where each item is either an Exception to raise or a
+        # sentinel object to return as the "connected" websocket.
+        self._outcomes = list(outcomes)
+        self.exceptions = _FakeWSExceptions
+        self.attempts = 0
+        self.open_timeouts: list = []
+
+    async def connect(self, *args, **kwargs):
+        self.attempts += 1
+        self.open_timeouts.append(kwargs.get("open_timeout"))
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+@pytest.mark.asyncio
+async def test_realtime_backend_open_retries_then_succeeds():
+    """A hung/slow open handshake is retried; a later fresh attempt connects.
+
+    Regression for intermittent ``1011 timed out during opening handshake``:
+    the proxy used to surface a single slow upstream handshake to the caller as
+    a fatal 1011 with no retry.
+    """
+    sentinel = object()
+    fake = _FakeWebsocketsModule([TimeoutError("timed out during opening handshake"), sentinel])
+
+    result = await BaseLLMHTTPHandler._open_realtime_backend_ws(
+        fake, "wss://backend.example/live", {"Authorization": "Bearer x"}, None
+    )
+
+    assert result is sentinel
+    assert fake.attempts == 2
+    # Each attempt must be bounded by a finite open_timeout (not the default/None).
+    assert all(t is not None and t > 0 for t in fake.open_timeouts)
+
+
+@pytest.mark.asyncio
+async def test_realtime_backend_open_raises_after_max_attempts():
+    """When every attempt times out, the final error propagates (so the caller
+    still closes the client socket) rather than looping forever."""
+    fake = _FakeWebsocketsModule([TimeoutError("hang")] * 2)
+
+    with pytest.raises(TimeoutError):
+        await BaseLLMHTTPHandler._open_realtime_backend_ws(fake, "wss://backend.example/live", {}, None, max_attempts=2)
+
+    assert fake.attempts == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rejection",
+    [_FakeWSExceptions.InvalidStatusCode, _FakeWSExceptions.InvalidStatus],
+)
+async def test_realtime_backend_open_does_not_retry_auth_failure(rejection):
+    """A deterministic handshake-status rejection (auth/4xx) must not be retried;
+    retrying cannot help and the upstream status must surface, not a 1011. Both
+    the websockets<15 (InvalidStatusCode) and >=15 (InvalidStatus) shapes apply."""
+    fake = _FakeWebsocketsModule([rejection()])
+
+    with pytest.raises(_FakeWSExceptions.WebSocketException):
+        await BaseLLMHTTPHandler._open_realtime_backend_ws(fake, "wss://backend.example/live", {}, None)
+
+    assert fake.attempts == 1

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -6,9 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 import litellm
 from litellm.llms.gemini.realtime.transformation import GeminiRealtimeConfig
@@ -86,10 +84,7 @@ def test_session_created_does_not_overwrite_session_configuration_request():
     )
 
     # Must keep original setup payload (with "setup"), not overwrite with session.created event.
-    assert (
-        transformed["session_configuration_request"]
-        == session_configuration_request_str
-    )
+    assert transformed["session_configuration_request"] == session_configuration_request_str
 
     # Also verify emitted session.created reflects audio modality from setup payload.
     session_created = transformed["response"][0]
@@ -146,19 +141,13 @@ def test_gemini_realtime_transformation_content_delta():
     print(transformed_message)
 
     ## assert all instances of 'event_id' are unique
-    event_ids = [
-        event["event_id"] for event in transformed_message if "event_id" in event
-    ]
+    event_ids = [event["event_id"] for event in transformed_message if "event_id" in event]
     assert len(event_ids) == len(set(event_ids))
     ## assert all instances of 'response_id' are the same
-    response_ids = [
-        event["response_id"] for event in transformed_message if "response_id" in event
-    ]
+    response_ids = [event["response_id"] for event in transformed_message if "response_id" in event]
     assert len(set(response_ids)) == 1
     ## assert all instances of 'output_item_id' are the same
-    output_item_ids = [
-        event["item_id"] for event in transformed_message if "item_id" in event
-    ]
+    output_item_ids = [event["item_id"] for event in transformed_message if "item_id" in event]
     assert len(set(output_item_ids)) == 1
 
 
@@ -172,9 +161,7 @@ def test_gemini_model_turn_event_mapping():
     openai_event = config.map_model_turn_event(model_turn_event)
     assert openai_event == OpenAIRealtimeEventTypes.RESPONSE_TEXT_DELTA
 
-    model_turn_event = {
-        "parts": [{"inlineData": {"mimeType": "audio/pcm", "data": "..."}}]
-    }
+    model_turn_event = {"parts": [{"inlineData": {"mimeType": "audio/pcm", "data": "..."}}]}
     openai_event = config.map_model_turn_event(model_turn_event)
     assert openai_event == OpenAIRealtimeEventTypes.RESPONSE_AUDIO_DELTA
 
@@ -205,13 +192,7 @@ def test_gemini_realtime_transformation_audio_delta():
     session_configuration_request_str = json.dumps(session_configuration_request)
 
     audio_delta_event = {
-        "serverContent": {
-            "modelTurn": {
-                "parts": [
-                    {"inlineData": {"mimeType": "audio/pcm", "data": "my-audio-data"}}
-                ]
-            }
-        }
+        "serverContent": {"modelTurn": {"parts": [{"inlineData": {"mimeType": "audio/pcm", "data": "my-audio-data"}}]}}
     }
 
     result = config.transform_realtime_response(
@@ -235,10 +216,7 @@ def test_gemini_realtime_transformation_audio_delta():
 
     contains_audio_delta = False
     for response in responses:
-        if (
-            response["type"]
-            == OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DELTA.value
-        ):
+        if response["type"] == OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DELTA.value:
             contains_audio_delta = True
             break
     assert contains_audio_delta, "Expected audio delta event"
@@ -257,11 +235,7 @@ def test_gemini_output_audio_transcript_delta_uses_active_response_ids():
     event = {
         "serverContent": {
             "outputTranscription": {"text": "Hello from Gemini."},
-            "modelTurn": {
-                "parts": [
-                    {"inlineData": {"mimeType": "audio/pcm", "data": "my-audio-data"}}
-                ]
-            },
+            "modelTurn": {"parts": [{"inlineData": {"mimeType": "audio/pcm", "data": "my-audio-data"}}]},
         }
     }
 
@@ -281,19 +255,11 @@ def test_gemini_output_audio_transcript_delta_uses_active_response_ids():
     )
 
     responses = result["response"]
-    response_created = next(
-        response for response in responses if response["type"] == "response.created"
-    )
+    response_created = next(response for response in responses if response["type"] == "response.created")
     transcript_delta = next(
-        response
-        for response in responses
-        if response["type"] == "response.output_audio_transcript.delta"
+        response for response in responses if response["type"] == "response.output_audio_transcript.delta"
     )
-    audio_delta = next(
-        response
-        for response in responses
-        if response["type"] == "response.output_audio.delta"
-    )
+    audio_delta = next(response for response in responses if response["type"] == "response.output_audio.delta")
 
     assert transcript_delta["response_id"] == response_created["response"]["id"]
     assert transcript_delta["response_id"] == audio_delta["response_id"]
@@ -339,10 +305,7 @@ def test_gemini_realtime_transformation_generation_complete():
 
     contains_audio_done_event = False
     for response in responses:
-        if (
-            response["type"]
-            == OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DONE.value
-        ):
+        if response["type"] == OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DONE.value:
             contains_audio_done_event = True
             break
     assert contains_audio_done_event, "Expected audio done event"
@@ -412,9 +375,7 @@ def test_gemini_realtime_tool_call_transformation():
             function_call_event = event
             break
 
-    assert (
-        function_call_event is not None
-    ), "Expected function_call_arguments.done event"
+    assert function_call_event is not None, "Expected function_call_arguments.done event"
     assert function_call_event["call_id"] == "call_123"
     assert function_call_event["name"] == "get_weather"
     assert function_call_event["response_id"] == "resp_123"
@@ -514,6 +475,109 @@ def test_gemini_session_update_defaults_to_audio_modality():
     assert len(messages) == 1
     setup_payload = json.loads(messages[0])["setup"]
     assert setup_payload["generationConfig"]["responseModalities"] == ["AUDIO"]
+
+
+def test_gemini_subsequent_session_update_is_dropped_not_resent_as_setup():
+    """Regression: Gemini Live accepts exactly one ``setup`` message; a second
+    one closes the socket with ``1007 Request contains an invalid argument``.
+
+    Once the initial setup has been sent (``session_configuration_request`` is
+    set), a follow-up session.update must be dropped rather than forwarded as
+    another setup. Forwarding it tore the session down before the first turn,
+    which surfaced to callers as silence after the first response and 1011s.
+    """
+    config = GeminiRealtimeConfig()
+    initial_setup = json.dumps(
+        {
+            "setup": {
+                "model": "models/gemini-2.5-flash",
+                "generationConfig": {"responseModalities": ["AUDIO"]},
+                "inputAudioTranscription": {},
+            }
+        }
+    )
+    follow_up = {
+        "type": "session.update",
+        "session": {"instructions": "Updated instructions", "temperature": 0.4},
+    }
+
+    messages = config.transform_realtime_request(
+        json.dumps(follow_up),
+        "gemini-2.5-flash",
+        session_configuration_request=initial_setup,
+    )
+
+    assert messages == [], (
+        "a session.update after the initial setup must be dropped, never "
+        "forwarded as a second setup (Gemini Live rejects it with 1007)"
+    )
+
+
+def test_gemini_subsequent_session_update_with_new_tools_is_dropped():
+    """Regression: even a follow-up session.update that *differs* from the initial
+    setup (e.g. registers tools after connect) must be dropped.
+
+    The previous dedup only skipped follow-ups identical to the initial setup; a
+    changed one was merged and re-sent as a second setup, still hitting the 1007.
+    Tools must instead ride on the first session.update.
+    """
+    config = GeminiRealtimeConfig()
+    initial_setup = json.dumps(
+        {
+            "setup": {
+                "model": "models/gemini-2.5-flash",
+                "generationConfig": {"responseModalities": ["AUDIO"]},
+            }
+        }
+    )
+    follow_up = {
+        "type": "session.update",
+        "session": {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "terminate_call",
+                        "description": "End the call.",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ]
+        },
+    }
+
+    messages = config.transform_realtime_request(
+        json.dumps(follow_up),
+        "gemini-2.5-flash",
+        session_configuration_request=initial_setup,
+    )
+
+    assert messages == []
+
+
+def test_gemini_subsequent_guardrail_session_update_dropped_with_warning(caplog):
+    """A dropped follow-up carrying ``turn_detection.create_response=False`` (the
+    transcription-guardrail signal) is still dropped, but warns so operators know
+    the guardrail cannot gate the model's auto-response mid-session on Gemini.
+    """
+    import logging
+
+    config = GeminiRealtimeConfig()
+    initial_setup = json.dumps({"setup": {"model": "models/gemini-2.5-flash"}})
+    follow_up = {
+        "type": "session.update",
+        "session": {"turn_detection": {"type": "server_vad", "create_response": False}},
+    }
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM"):
+        messages = config.transform_realtime_request(
+            json.dumps(follow_up),
+            "gemini-2.5-flash",
+            session_configuration_request=initial_setup,
+        )
+
+    assert messages == []
+    assert any("Dropping subsequent session.update" in record.message for record in caplog.records)
 
 
 @pytest.mark.parametrize(
@@ -687,9 +751,7 @@ def test_gemini_realtime_function_call_output_transformation():
         "gemini-2.5-flash",
         session_configuration_request="existing",
     )
-    retry_response = json.loads(retry_messages[0])["toolResponse"]["functionResponses"][
-        0
-    ]
+    retry_response = json.loads(retry_messages[0])["toolResponse"]["functionResponses"][0]
     assert retry_response["name"] == "get_weather"
 
 
@@ -703,9 +765,7 @@ def test_gemini_realtime_user_text_transformation():
         "item": {
             "type": "message",
             "role": "user",
-            "content": [
-                {"type": "input_text", "text": "What's the weather in London?"}
-            ],
+            "content": [{"type": "input_text", "text": "What's the weather in London?"}],
         },
     }
 
@@ -784,11 +844,7 @@ def test_gemini_realtime_multi_tool_calls_have_unique_item_ids():
         },
     )
 
-    responses = [
-        ev
-        for ev in result["response"]
-        if ev.get("type") == "response.function_call_arguments.done"
-    ]
+    responses = [ev for ev in result["response"] if ev.get("type") == "response.function_call_arguments.done"]
     assert len(responses) == 2
     assert responses[0]["response_id"] == "resp_123"
     assert responses[1]["response_id"] == "resp_123"
@@ -954,13 +1010,7 @@ def test_gemini_tool_call_resets_ids_for_post_tool_model_turn():
     assert tool_result["current_response_id"] is None
 
     post_tool_result = config.transform_realtime_response(
-        json.dumps(
-            {
-                "serverContent": {
-                    "modelTurn": {"parts": [{"text": "The weather is sunny."}]}
-                }
-            }
-        ),
+        json.dumps({"serverContent": {"modelTurn": {"parts": [{"text": "The weather is sunny."}]}}}),
         "gemini-2.5-flash",
         logging_obj,
         realtime_response_transform_input={
@@ -977,9 +1027,7 @@ def test_gemini_tool_call_resets_ids_for_post_tool_model_turn():
     post_tool_events = post_tool_result["response"]
     assert post_tool_events[0]["type"] == "response.created"
     assert post_tool_events[0]["response"]["id"] != tool_response_id
-    assert (
-        post_tool_result["current_response_id"] == post_tool_events[0]["response"]["id"]
-    )
+    assert post_tool_result["current_response_id"] == post_tool_events[0]["response"]["id"]
 
 
 def test_gemini_empty_tool_call_does_not_crash_websocket():
@@ -1092,9 +1140,7 @@ def test_gemini_tool_call_response_done_includes_usage_from_sibling_metadata():
         },
     )
 
-    response_done = next(
-        ev for ev in result["response"] if ev.get("type") == "response.done"
-    )
+    response_done = next(ev for ev in result["response"] if ev.get("type") == "response.done")
     usage = response_done["response"]["usage"]
     assert usage["input_tokens"] == 17
     assert usage["output_tokens"] == 4
@@ -1138,9 +1184,7 @@ def test_gemini_tool_call_response_done_falls_back_to_empty_usage():
         },
     )
 
-    response_done = next(
-        ev for ev in result["response"] if ev.get("type") == "response.done"
-    )
+    response_done = next(ev for ev in result["response"] if ev.get("type") == "response.done")
     usage = response_done["response"]["usage"]
     assert usage["input_tokens"] == 0
     assert usage["output_tokens"] == 0
@@ -1214,60 +1258,6 @@ def test_gemini_function_call_output_includes_name():
     assert "response" in function_response
 
 
-def test_gemini_subsequent_session_update_forwards_tools_merged_with_original_setup():
-    """A client session.update sent after the auto-setup must forward tools/
-    instructions as a follow-up setup, merged with the original setup so we
-    don't drop the pre-existing config (model, generationConfig, etc.)."""
-    config = GeminiRealtimeConfig()
-
-    original_setup = {
-        "setup": {
-            "model": "models/gemini-2.5-flash-native-audio",
-            "generationConfig": {"responseModalities": ["AUDIO"]},
-            "inputAudioTranscription": {},
-            "systemInstruction": {"role": "user", "parts": [{"text": "original"}]},
-        }
-    }
-
-    session_update = {
-        "type": "session.update",
-        "session": {
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "get_weather",
-                        "description": "Get weather.",
-                        "parameters": {
-                            "type": "object",
-                            "properties": {"location": {"type": "string"}},
-                            "required": ["location"],
-                        },
-                    },
-                }
-            ],
-            "instructions": "Be concise.",
-        },
-    }
-
-    messages = config.transform_realtime_request(
-        json.dumps(session_update),
-        "gemini-2.5-flash-native-audio",
-        session_configuration_request=json.dumps(original_setup),
-    )
-
-    assert len(messages) == 1
-    follow_up = json.loads(messages[0])["setup"]
-    assert "tools" in follow_up
-    assert follow_up["tools"][0]["function_declarations"][0]["name"] == "get_weather"
-    # systemInstruction overwritten by client's instructions
-    assert follow_up["systemInstruction"]["parts"][0]["text"] == "Be concise."
-    # Original generationConfig / model / inputAudioTranscription preserved
-    assert follow_up["generationConfig"]["responseModalities"] == ["AUDIO"]
-    assert follow_up["model"] == "models/gemini-2.5-flash-native-audio"
-    assert follow_up["inputAudioTranscription"] == {}
-
-
 def test_gemini_realtime_pipecat_ga_session_voice_and_tools(patch_gemini_audio_cost_map_entries):
     """Pipecat OpenAIRealtimeSessionProperties: output_modalities, nested tools,
     and audio.output.voice (e.g. Kore) must map into Gemini setup."""
@@ -1314,9 +1304,7 @@ def test_gemini_realtime_pipecat_ga_session_voice_and_tools(patch_gemini_audio_c
     # Native-audio Live rejects speechConfig on setup (see _finalize_gemini_live_setup).
     assert "speechConfig" not in setup.get("generationConfig", {})
     assert setup["tools"][0]["function_declarations"][0]["name"] == "terminate_call"
-    assert (
-        setup["realtimeInputConfig"]["automaticActivityDetection"]["disabled"] is False
-    )
+    assert setup["realtimeInputConfig"]["automaticActivityDetection"]["disabled"] is False
 
 
 def test_gemini_realtime_pipecat_semantic_vad_omits_realtime_input_config():
@@ -1407,116 +1395,6 @@ def test_gemini_input_audio_buffer_commit_maps_to_activity_end_when_manual_vad()
     )
     assert len(messages) == 1
     assert json.loads(messages[0]) == {"realtimeInput": {"activityEnd": True}}
-
-
-def test_gemini_subsequent_session_update_with_turn_detection_only_preserves_original_tools():
-    """A subsequent session.update carrying only turn_detection (the
-    guardrail-injected disable) must keep the original tools/generationConfig."""
-    config = GeminiRealtimeConfig()
-
-    original_setup = {
-        "setup": {
-            "model": "models/gemini-2.5-flash-native-audio",
-            "generationConfig": {"responseModalities": ["AUDIO"]},
-            "inputAudioTranscription": {},
-            "tools": [
-                {
-                    "function_declarations": [
-                        {"name": "lookup", "description": "x", "parameters": {}}
-                    ]
-                }
-            ],
-        }
-    }
-
-    session_update = {
-        "type": "session.update",
-        "session": {"turn_detection": {"create_response": False}},
-    }
-
-    messages = config.transform_realtime_request(
-        json.dumps(session_update),
-        "gemini-2.5-flash-native-audio",
-        session_configuration_request=json.dumps(original_setup),
-    )
-
-    assert len(messages) == 1
-    follow_up = json.loads(messages[0])["setup"]
-    assert follow_up["tools"] == original_setup["setup"]["tools"]
-    assert (
-        follow_up["realtimeInputConfig"]["automaticActivityDetection"]["disabled"]
-        is True
-    )
-
-
-def test_gemini_follow_up_session_update_preserves_response_modalities_on_partial_generation_config():
-    """A follow-up session.update that only sets `temperature` (or any other
-    generationConfig sub-field) must not wipe `responseModalities` from the
-    original setup."""
-    config = GeminiRealtimeConfig()
-
-    original_setup = {
-        "setup": {
-            "model": "models/gemini-2.5-flash-native-audio",
-            "generationConfig": {
-                "responseModalities": ["AUDIO"],
-                "maxOutputTokens": 2048,
-            },
-            "inputAudioTranscription": {},
-        }
-    }
-
-    session_update = {
-        "type": "session.update",
-        "session": {"temperature": 0.7},
-    }
-
-    messages = config.transform_realtime_request(
-        json.dumps(session_update),
-        "gemini-2.5-flash-native-audio",
-        session_configuration_request=json.dumps(original_setup),
-    )
-
-    follow_up = json.loads(messages[0])["setup"]
-    assert follow_up["generationConfig"]["responseModalities"] == ["AUDIO"]
-    assert follow_up["generationConfig"]["maxOutputTokens"] == 2048
-    assert follow_up["generationConfig"]["temperature"] == 0.7
-
-
-def test_gemini_subsequent_session_update_preserves_automatic_activity_detection_subfields():
-    config = GeminiRealtimeConfig()
-
-    original_setup = {
-        "setup": {
-            "model": "models/gemini-2.5-flash-native-audio",
-            "generationConfig": {"responseModalities": ["AUDIO"]},
-            "realtimeInputConfig": {
-                "automaticActivityDetection": {
-                    "disabled": False,
-                    "silenceDurationMs": 500,
-                    "prefixPaddingMs": 100,
-                }
-            },
-        }
-    }
-
-    session_update = {
-        "type": "session.update",
-        "session": {"turn_detection": {"create_response": False}},
-    }
-
-    messages = config.transform_realtime_request(
-        json.dumps(session_update),
-        "gemini-2.5-flash-native-audio",
-        session_configuration_request=json.dumps(original_setup),
-    )
-
-    automatic_activity_detection = json.loads(messages[0])["setup"][
-        "realtimeInputConfig"
-    ]["automaticActivityDetection"]
-    assert automatic_activity_detection["disabled"] is True
-    assert automatic_activity_detection["silenceDurationMs"] == 500
-    assert automatic_activity_detection["prefixPaddingMs"] == 100
 
 
 def test_gemini_tool_call_id_to_name_evicts_oldest_when_capped():
@@ -1669,9 +1547,7 @@ def test_gemini_standalone_usage_metadata_is_attributed_to_next_tool_call_respon
         },
     )
 
-    response_done = next(
-        ev for ev in tool_call_result["response"] if ev.get("type") == "response.done"
-    )
+    response_done = next(ev for ev in tool_call_result["response"] if ev.get("type") == "response.done")
     usage = response_done["response"]["usage"]
     assert usage["input_tokens"] == 31
     assert usage["output_tokens"] == 9
@@ -1733,11 +1609,7 @@ def test_gemini_standalone_usage_metadata_is_attributed_to_next_response_done():
         },
     )
 
-    response_done = next(
-        ev
-        for ev in turn_complete_result["response"]
-        if ev.get("type") == "response.done"
-    )
+    response_done = next(ev for ev in turn_complete_result["response"] if ev.get("type") == "response.done")
     usage = response_done["response"]["usage"]
     assert usage["input_tokens"] == 5
     assert usage["output_tokens"] == 11
@@ -1793,9 +1665,7 @@ def test_gemini_in_frame_usage_metadata_clears_pending_buffer():
         },
     )
 
-    response_done = next(
-        ev for ev in result["response"] if ev.get("type") == "response.done"
-    )
+    response_done = next(ev for ev in result["response"] if ev.get("type") == "response.done")
     usage = response_done["response"]["usage"]
     assert usage["input_tokens"] == 3
     assert usage["output_tokens"] == 2
@@ -1912,9 +1782,7 @@ def test_gemini_post_tool_bare_turn_complete_followed_by_answer():
     )
     assert post_tool_answer["response"][0]["type"] == "response.created"
     transcript_delta = next(
-        event
-        for event in post_tool_answer["response"]
-        if event["type"] == "response.output_audio_transcript.delta"
+        event for event in post_tool_answer["response"] if event["type"] == "response.output_audio_transcript.delta"
     )
     assert "72" in transcript_delta["delta"]
 
@@ -1932,11 +1800,7 @@ def test_gemini_post_tool_bare_turn_complete_followed_by_answer():
             "current_delta_type": post_tool_answer["current_delta_type"],
         },
     )
-    response_done = next(
-        event
-        for event in final_turn["response"]
-        if event["type"] == "response.done"
-    )
+    response_done = next(event for event in final_turn["response"] if event["type"] == "response.done")
     assert response_done["response"]["status"] == "completed"
 
 
@@ -1978,9 +1842,7 @@ def patch_gemini_audio_cost_map_entries(monkeypatch):
         ("gemini-2.5-flash", False),
     ],
 )
-def test_is_audio_only_live_model_uses_cost_map(
-    model, expected, patch_gemini_audio_cost_map_entries
-):
+def test_is_audio_only_live_model_uses_cost_map(model, expected, patch_gemini_audio_cost_map_entries):
     assert GeminiRealtimeConfig._is_audio_only_live_model(model) == expected
 
 
@@ -1994,9 +1856,7 @@ def test_is_audio_only_live_model_uses_cost_map(
         ("gemini-2.0-flash", False),
     ],
 )
-def test_is_native_audio_model_uses_cost_map(
-    model, expected, patch_gemini_audio_cost_map_entries
-):
+def test_is_native_audio_model_uses_cost_map(model, expected, patch_gemini_audio_cost_map_entries):
     assert GeminiRealtimeConfig._is_native_audio_model(model) == expected
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -45,6 +45,22 @@ def local_model_cost_map(monkeypatch):
         litellm.get_model_info.cache_clear()
 
 
+def test_get_model_info_surfaces_supports_adaptive_thinking(local_model_cost_map):
+    """supports_adaptive_thinking must flow through get_model_info like every other
+    capability flag: both from an explicit cost-map entry and from a
+    fallback-generalization rule for an unmapped model. Regression: the field shipped
+    in the JSON but was never declared on ModelInfo nor copied during construction, so
+    get_model_info (and _supports_factory) silently dropped it for any provider-prefixed
+    or unmapped name."""
+    explicit = litellm.get_model_info(model="claude-opus-4-8")
+    assert explicit["supports_adaptive_thinking"] is True
+
+    generalized = litellm.get_model_info(
+        model="claude-opus-4-9", custom_llm_provider="anthropic"
+    )
+    assert generalized["supports_adaptive_thinking"] is True
+
+
 def test_check_provider_match_azure_ai_allows_openai_and_azure():
     """
     Test that azure_ai provider can match openai and azure models.
@@ -945,6 +961,9 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
     actual_json.pop(
         "sample_spec", None
     )  # remove the sample, whose schema is inconsistent with the real data
+    actual_json.pop(
+        "fallback_generalizations", None
+    )  # reserved meta key, not a model entry
 
     # Validate schema
     validate(actual_json, INTENDED_SCHEMA)
@@ -1145,9 +1164,7 @@ def test_check_provider_match_none_value_matches_any_provider():
         is True
     )
     # When custom_llm_provider is also None nothing constrains the match.
-    assert (
-        litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
-    )
+    assert litellm.utils._check_provider_match({"litellm_provider": None}, None) is True
 
 
 def test_get_provider_rerank_config():
@@ -1512,8 +1529,7 @@ class TestProxyFunctionCalling:
         assert result is True, "Resolvable model names work with fallback logic"
 
         # Documentation notes:
-        print(
-            """
+        print("""
         PROXY MODEL RESOLUTION BEHAVIOR:
         
         ✅ WORKS (with current fallback logic):
@@ -1528,8 +1544,7 @@ class TestProxyFunctionCalling:
            
         💡 SOLUTION: Use LiteLLM proxy server with proper model_list configuration
            that maps custom names to underlying models.
-        """
-        )
+        """)
 
     @pytest.mark.parametrize(
         "proxy_model_with_hints,expected_result",
@@ -1891,8 +1906,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -1945,8 +1959,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2160,8 +2173,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2214,8 +2226,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [
@@ -2429,8 +2440,7 @@ class TestProxyFunctionCalling:
         This test provides documentation on how the proxy server configuration
         would typically map custom model names to underlying models.
         """
-        print(
-            """
+        print("""
         
         REAL-WORLD PROXY SERVER CONFIGURATION EXAMPLE:
         ===============================================
@@ -2483,8 +2493,7 @@ class TestProxyFunctionCalling:
         - Consistent request/response format
         - Enhanced streaming support for function calls
         
-        """
-        )
+        """)
 
         # Verify that direct underlying models work as expected
         bedrock_models = [


### PR DESCRIPTION
## Description

Add three features to improve LiteLLM for Chinese developers:

1. **Task-Aware Routing Strategy** - Routes requests based on task type
2. **China Domestic Free Sources** - Pre-configured free sources for Chinese developers
3. **Local-First Routing Strategy** - Prioritizes local models for latency/cost

## Motivation

Chinese developers face unique challenges:
- Need VPN to access international LLM APIs
- Prefer local models for latency and privacy
- Different model preferences for different tasks

This PR addresses all three issues with a complete solution.

## Changes

### 1. Task-Aware Routing Strategy
- New `TaskAwareRoutingStrategy` class in `router_strategy/task_aware_routing.py`
- Routes requests based on task type (coding, chinese, general, english, fast)
- Users can define task-specific model preferences

### 2. China Domestic Free Sources Configuration
- Example config in `proxy/example_config_yaml/china_domestic_free_sources.yaml`
- Pre-configured SiliconFlow and Zhipu models
- Accessible from mainland China without VPN

### 3. Local-First Routing Strategy
- New `LocalFirstRoutingStrategy` class in `router_strategy/local_first_routing.py`
- Routes to local models first (e.g., Ollama)
- Falls back to cloud models when local unavailable

### 4. Documentation
- `docs/my-website/docs/routing/task-aware-routing.md`
- `docs/my-website/docs/routing/local-first-routing.md`
- `docs/my-website/docs/routing/china-domestic-free-sources.md`

## Usage

### Task-Aware Routing
```yaml
router_settings:
  routing_strategy: task-aware-routing
  routing_strategy_args:
    task_mapping:
      coding: [devstral, qwen3-coder, claude-sonnet]
      chinese: [qwen3, sf-qwen2.5-72b, claude-sonnet]
      general: [gemma4, nemotron-ultra-free, claude-sonnet]
```

### China Domestic Free Sources
```bash
litellm --config china_domestic_free_sources.yaml
```

### Local-First Routing
```yaml
router_settings:
  routing_strategy: local-first-routing
  routing_strategy_args:
    local_provider: ollama
```

## Testing

- Unit tests will be added
- Integration tests with different configurations
- Tested with Chinese LLM providers

## Documentation

- [Task-Aware Routing](docs/my-website/docs/routing/task-aware-routing.md)
- [Local-First Routing](docs/my-website/docs/routing/local-first-routing.md)
- [China Domestic Free Sources](docs/my-website/docs/routing/china-domestic-free-sources.md)