### PR TITLE
fix(anthropic-adapter): split reasoning+content stream chunks into se…

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -101,7 +101,7 @@ class _CombinedChunkSplitter:
         return has_reasoning and has_content
 
     @staticmethod
-    def _split_finish(chunk: Any) -> List[Any]:
+    def _split_finish(chunk: Any) -> list[Any]:
         """Split a content + ``finish_reason`` chunk into content then finish."""
         if not _CombinedChunkSplitter._is_combined(chunk):
             return [chunk]
@@ -123,7 +123,7 @@ class _CombinedChunkSplitter:
         return [content_chunk, finish_chunk]
 
     @staticmethod
-    def _split(chunk: Any) -> List[Any]:
+    def _split(chunk: Any) -> list[Any]:
         """Split a chunk that packs multiple blocks into ordered sub-chunks.
 
         Reasoning is peeled off first (Anthropic requires the thinking block before

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -32,16 +32,24 @@ if TYPE_CHECKING:
 
 class _CombinedChunkSplitter:
     """
-    Splits a streaming chunk that carries BOTH response content and a
-    ``finish_reason`` into two chunks: a content-only chunk followed by a
-    finish-only chunk.
+    Splits a streaming chunk that packs multiple Anthropic content blocks into
+    one so each emitted piece maps to exactly one block. Two independent splits
+    compose here:
 
-    ``AnthropicStreamWrapper`` (via ``translate_streaming_openai_response_to_anthropic``)
-    assumes content and ``finish_reason`` never arrive in the same chunk — true for
-    real provider streams, but false for fake-streamed providers (e.g. Vertex AI
-    Gemma ``:predict``) where ``MockResponseIterator`` collapses the entire response
-    into a single chunk. Without this split the assumption causes all content to be
-    silently dropped (only the ``message_delta`` stop event is emitted).
+    - reasoning + response content: vLLM/SGLang reasoning models emit a boundary
+      chunk that carries the last ``reasoning_content`` token together with the
+      first answer ``content`` (or ``tool_calls``) token. These belong to two
+      different Anthropic blocks — a thinking block then a text/tool_use block.
+      Left combined, ``AnthropicStreamWrapper`` opens a ``text`` block but emits a
+      ``thinking_delta`` into it (Anthropic clients such as Claude Code reject this
+      with "Content block is not a thinking block") and the answer text is dropped.
+
+    - response content + ``finish_reason``: fake-streamed providers (e.g. Vertex AI
+      Gemma ``:predict``) collapse the entire response into a single chunk via
+      ``MockResponseIterator``. ``translate_streaming_openai_response_to_anthropic``
+      assumes content and ``finish_reason`` never share a chunk — true for real
+      provider streams — so without this split all content is silently dropped
+      (only the ``message_delta`` stop event is emitted).
 
     Supports both sync and async iteration, since ``AnthropicStreamWrapper`` exposes
     both ``__next__`` and ``__anext__``. An instance is single-mode: callers must
@@ -76,8 +84,25 @@ class _CombinedChunkSplitter:
         )
 
     @staticmethod
-    def _split(chunk: Any) -> List[Any]:
-        """Return ``[chunk]``, or ``[content_chunk, finish_chunk]`` if combined."""
+    def _has_reasoning_and_content(chunk: Any) -> bool:
+        """True if ``chunk`` carries reasoning AND answer content in one delta.
+
+        These map to two different Anthropic blocks (thinking, then text/tool_use)
+        and must be split so a ``thinking_delta`` is never emitted into a text block.
+        """
+        choices = getattr(chunk, "choices", None)
+        if not choices:
+            return False
+        delta = getattr(choices[0], "delta", None)
+        if delta is None:
+            return False
+        has_reasoning = bool(getattr(delta, "reasoning_content", None) or getattr(delta, "thinking_blocks", None))
+        has_content = bool(getattr(delta, "content", None) or getattr(delta, "tool_calls", None))
+        return has_reasoning and has_content
+
+    @staticmethod
+    def _split_finish(chunk: Any) -> List[Any]:
+        """Split a content + ``finish_reason`` chunk into content then finish."""
         if not _CombinedChunkSplitter._is_combined(chunk):
             return [chunk]
 
@@ -96,6 +121,37 @@ class _CombinedChunkSplitter:
         if hasattr(finish_delta, "thinking_blocks"):
             finish_delta.thinking_blocks = None
         return [content_chunk, finish_chunk]
+
+    @staticmethod
+    def _split(chunk: Any) -> List[Any]:
+        """Split a chunk that packs multiple blocks into ordered sub-chunks.
+
+        Reasoning is peeled off first (Anthropic requires the thinking block before
+        the text/tool_use block); the remaining content chunk then flows through the
+        content + ``finish_reason`` split.
+        """
+        if not _CombinedChunkSplitter._has_reasoning_and_content(chunk):
+            return _CombinedChunkSplitter._split_finish(chunk)
+
+        # Reasoning chunk: keep reasoning, drop content/tool_calls and finish_reason
+        # (the finish belongs with the trailing content).
+        reasoning_chunk = copy.deepcopy(chunk)
+        reasoning_chunk.choices[0].finish_reason = None
+        reasoning_delta = reasoning_chunk.choices[0].delta
+        reasoning_delta.content = None
+        if hasattr(reasoning_delta, "tool_calls"):
+            reasoning_delta.tool_calls = None
+
+        # Content chunk: drop reasoning, keep content/tool_calls (and finish_reason,
+        # which the finish split below separates out when present).
+        content_chunk = copy.deepcopy(chunk)
+        content_delta = content_chunk.choices[0].delta
+        if hasattr(content_delta, "reasoning_content"):
+            content_delta.reasoning_content = None
+        if hasattr(content_delta, "thinking_blocks"):
+            content_delta.thinking_blocks = None
+
+        return [reasoning_chunk, *_CombinedChunkSplitter._split_finish(content_chunk)]
 
     def __iter__(self) -> "Iterator[Any]":
         return self

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
@@ -183,9 +183,14 @@ def test_is_combined_false_when_delta_missing():
     assert _CombinedChunkSplitter._is_combined(chunk) is False
 
 
-def test_split_clears_reasoning_and_thinking_on_finish_chunk():
-    """When the combined delta carries reasoning/thinking, only the content
-    chunk keeps them — the finish chunk is cleared."""
+def test_split_separates_reasoning_content_and_finish():
+    """A delta carrying reasoning + content + finish_reason splits three ways:
+    a reasoning-only chunk, then a content-only chunk, then a finish-only chunk.
+
+    Reasoning must come first (Anthropic requires the thinking block before the
+    text block), and reasoning must never share a chunk with content — otherwise
+    the wrapper opens a text block and emits a thinking_delta into it, which
+    Anthropic clients reject with "Content block is not a thinking block"."""
     delta = SimpleNamespace(
         content="hi",
         tool_calls=None,
@@ -196,9 +201,134 @@ def test_split_clears_reasoning_and_thinking_on_finish_chunk():
         choices=[SimpleNamespace(finish_reason="stop", delta=delta)]
     )
 
-    content_chunk, finish_chunk = _CombinedChunkSplitter._split(chunk)
+    reasoning_chunk, content_chunk, finish_chunk = _CombinedChunkSplitter._split(chunk)
 
-    assert content_chunk.choices[0].delta.reasoning_content == "some reasoning"
-    assert content_chunk.choices[0].delta.thinking_blocks == [{"type": "thinking"}]
+    assert reasoning_chunk.choices[0].delta.reasoning_content == "some reasoning"
+    assert reasoning_chunk.choices[0].delta.thinking_blocks == [{"type": "thinking"}]
+    assert reasoning_chunk.choices[0].delta.content is None
+    assert reasoning_chunk.choices[0].finish_reason is None
+
+    assert content_chunk.choices[0].delta.content == "hi"
+    assert content_chunk.choices[0].delta.reasoning_content is None
+    assert content_chunk.choices[0].delta.thinking_blocks is None
+    assert content_chunk.choices[0].finish_reason is None
+
+    assert finish_chunk.choices[0].finish_reason == "stop"
+    assert finish_chunk.choices[0].delta.content is None
     assert finish_chunk.choices[0].delta.reasoning_content is None
-    assert finish_chunk.choices[0].delta.thinking_blocks is None
+
+
+def _open_block_type_by_index(events):
+    """Map content-block index -> the type it was opened with."""
+    return {
+        event["index"]: event["content_block"]["type"]
+        for event in events
+        if event.get("type") == "content_block_start"
+    }
+
+
+def _assert_no_delta_block_mismatch(events):
+    """Every thinking/signature delta must land in a thinking block and every
+    text delta in a text block. A mismatch is exactly what makes Anthropic
+    clients (e.g. Claude Code) raise "Content block is not a thinking block"."""
+    open_types = _open_block_type_by_index(events)
+    for event in events:
+        if event.get("type") != "content_block_delta":
+            continue
+        delta_type = event["delta"]["type"]
+        block_type = open_types.get(event["index"])
+        if delta_type in ("thinking_delta", "signature_delta"):
+            assert block_type == "thinking", (
+                f"{delta_type} emitted into a {block_type!r} block: {event}"
+            )
+        elif delta_type == "text_delta":
+            assert block_type == "text", (
+                f"text_delta emitted into a {block_type!r} block: {event}"
+            )
+
+
+def _reasoning_then_answer_chunks():
+    """Mimic a vLLM reasoning model whose boundary chunk carries the last
+    reasoning token together with the first answer token (verified live with
+    hosted_vllm/qwen)."""
+    return [
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0, delta=Delta(reasoning_content="Let me think."), finish_reason=None
+                )
+            ]
+        ),
+        ModelResponseStream(
+            choices=[
+                StreamingChoices(
+                    index=0,
+                    delta=Delta(reasoning_content="\n", content="Hi there!"),
+                    finish_reason=None,
+                )
+            ]
+        ),
+        ModelResponseStream(
+            choices=[StreamingChoices(index=0, delta=Delta(), finish_reason="stop")]
+        ),
+    ]
+
+
+def _text_deltas(events):
+    return [
+        event["delta"]["text"]
+        for event in events
+        if event.get("type") == "content_block_delta"
+        and event["delta"].get("type") == "text_delta"
+    ]
+
+
+def _thinking_deltas(events):
+    return [
+        event["delta"]["thinking"]
+        for event in events
+        if event.get("type") == "content_block_delta"
+        and event["delta"].get("type") == "thinking_delta"
+    ]
+
+
+def test_boundary_reasoning_content_chunk_sync():
+    """Sync: a boundary chunk with reasoning+content must not emit a
+    thinking_delta into a text block, and must not drop the answer text."""
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_reasoning_then_answer_chunks()), model="qwen"
+    )
+    events = [event for event in wrapper if isinstance(event, dict)]
+
+    _assert_no_delta_block_mismatch(events)
+    assert "".join(_thinking_deltas(events)) == "Let me think.\n"
+    assert "".join(_text_deltas(events)) == "Hi there!"
+
+
+def test_boundary_reasoning_content_chunk_async():
+    """Async: same guarantees as the sync path."""
+
+    class _AsyncStream:
+        def __init__(self, chunks):
+            self._it = iter(chunks)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._it)
+            except StopIteration:
+                raise StopAsyncIteration
+
+    async def _run():
+        wrapper = AnthropicStreamWrapper(
+            completion_stream=_AsyncStream(_reasoning_then_answer_chunks()), model="qwen"
+        )
+        return [event async for event in wrapper if isinstance(event, dict)]
+
+    events = asyncio.run(_run())
+
+    _assert_no_delta_block_mismatch(events)
+    assert "".join(_thinking_deltas(events)) == "Let me think.\n"
+    assert "".join(_text_deltas(events)) == "Hi there!"

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py
@@ -30,9 +30,7 @@ from litellm.types.utils import (
 )
 
 
-def _build_fake_stream(
-    content: str, finish_reason: str = "stop"
-) -> MockResponseIterator:
+def _build_fake_stream(content: str, finish_reason: str = "stop") -> MockResponseIterator:
     """Mimic a Vertex Gemma `:predict` fake stream: one collapsed chunk."""
     model_response = ModelResponse()
     model_response.choices = [
@@ -132,9 +130,7 @@ def test_delayed_usage_chunk_preserves_cache_tokens():
     wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="gpt-4o")
     events = list(wrapper)
 
-    message_delta = next(
-        event for event in events if event.get("type") == "message_delta"
-    )
+    message_delta = next(event for event in events if event.get("type") == "message_delta")
 
     assert message_delta["usage"]["input_tokens"] == 70
     assert message_delta["usage"]["output_tokens"] == 5
@@ -144,13 +140,7 @@ def test_delayed_usage_chunk_preserves_cache_tokens():
 
 def test_splitter_passes_through_non_combined_chunks():
     """A chunk with content but no finish_reason is not split."""
-    chunk = ModelResponseStream(
-        choices=[
-            StreamingChoices(
-                index=0, delta=Delta(content="partial"), finish_reason=None
-            )
-        ]
-    )
+    chunk = ModelResponseStream(choices=[StreamingChoices(index=0, delta=Delta(content="partial"), finish_reason=None)])
     chunks = list(_CombinedChunkSplitter(iter([chunk])))
     assert len(chunks) == 1
     assert chunks[0].choices[0].delta.content == "partial"
@@ -158,11 +148,7 @@ def test_splitter_passes_through_non_combined_chunks():
 
 def test_splitter_splits_combined_chunk_into_content_then_finish():
     """A chunk with both content and finish_reason becomes two chunks."""
-    chunk = ModelResponseStream(
-        choices=[
-            StreamingChoices(index=0, delta=Delta(content="done"), finish_reason="stop")
-        ]
-    )
+    chunk = ModelResponseStream(choices=[StreamingChoices(index=0, delta=Delta(content="done"), finish_reason="stop")])
     content_chunk, finish_chunk = list(_CombinedChunkSplitter(iter([chunk])))
 
     assert content_chunk.choices[0].delta.content == "done"
@@ -197,9 +183,7 @@ def test_split_separates_reasoning_content_and_finish():
         reasoning_content="some reasoning",
         thinking_blocks=[{"type": "thinking"}],
     )
-    chunk = SimpleNamespace(
-        choices=[SimpleNamespace(finish_reason="stop", delta=delta)]
-    )
+    chunk = SimpleNamespace(choices=[SimpleNamespace(finish_reason="stop", delta=delta)])
 
     reasoning_chunk, content_chunk, finish_chunk = _CombinedChunkSplitter._split(chunk)
 
@@ -221,9 +205,7 @@ def test_split_separates_reasoning_content_and_finish():
 def _open_block_type_by_index(events):
     """Map content-block index -> the type it was opened with."""
     return {
-        event["index"]: event["content_block"]["type"]
-        for event in events
-        if event.get("type") == "content_block_start"
+        event["index"]: event["content_block"]["type"] for event in events if event.get("type") == "content_block_start"
     }
 
 
@@ -238,13 +220,9 @@ def _assert_no_delta_block_mismatch(events):
         delta_type = event["delta"]["type"]
         block_type = open_types.get(event["index"])
         if delta_type in ("thinking_delta", "signature_delta"):
-            assert block_type == "thinking", (
-                f"{delta_type} emitted into a {block_type!r} block: {event}"
-            )
+            assert block_type == "thinking", f"{delta_type} emitted into a {block_type!r} block: {event}"
         elif delta_type == "text_delta":
-            assert block_type == "text", (
-                f"text_delta emitted into a {block_type!r} block: {event}"
-            )
+            assert block_type == "text", f"text_delta emitted into a {block_type!r} block: {event}"
 
 
 def _reasoning_then_answer_chunks():
@@ -253,11 +231,7 @@ def _reasoning_then_answer_chunks():
     hosted_vllm/qwen)."""
     return [
         ModelResponseStream(
-            choices=[
-                StreamingChoices(
-                    index=0, delta=Delta(reasoning_content="Let me think."), finish_reason=None
-                )
-            ]
+            choices=[StreamingChoices(index=0, delta=Delta(reasoning_content="Let me think."), finish_reason=None)]
         ),
         ModelResponseStream(
             choices=[
@@ -268,9 +242,7 @@ def _reasoning_then_answer_chunks():
                 )
             ]
         ),
-        ModelResponseStream(
-            choices=[StreamingChoices(index=0, delta=Delta(), finish_reason="stop")]
-        ),
+        ModelResponseStream(choices=[StreamingChoices(index=0, delta=Delta(), finish_reason="stop")]),
     ]
 
 
@@ -278,8 +250,7 @@ def _text_deltas(events):
     return [
         event["delta"]["text"]
         for event in events
-        if event.get("type") == "content_block_delta"
-        and event["delta"].get("type") == "text_delta"
+        if event.get("type") == "content_block_delta" and event["delta"].get("type") == "text_delta"
     ]
 
 
@@ -287,17 +258,14 @@ def _thinking_deltas(events):
     return [
         event["delta"]["thinking"]
         for event in events
-        if event.get("type") == "content_block_delta"
-        and event["delta"].get("type") == "thinking_delta"
+        if event.get("type") == "content_block_delta" and event["delta"].get("type") == "thinking_delta"
     ]
 
 
 def test_boundary_reasoning_content_chunk_sync():
     """Sync: a boundary chunk with reasoning+content must not emit a
     thinking_delta into a text block, and must not drop the answer text."""
-    wrapper = AnthropicStreamWrapper(
-        completion_stream=iter(_reasoning_then_answer_chunks()), model="qwen"
-    )
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(_reasoning_then_answer_chunks()), model="qwen")
     events = [event for event in wrapper if isinstance(event, dict)]
 
     _assert_no_delta_block_mismatch(events)
@@ -322,9 +290,7 @@ def test_boundary_reasoning_content_chunk_async():
                 raise StopAsyncIteration
 
     async def _run():
-        wrapper = AnthropicStreamWrapper(
-            completion_stream=_AsyncStream(_reasoning_then_answer_chunks()), model="qwen"
-        )
+        wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(_reasoning_then_answer_chunks()), model="qwen")
         return [event async for event in wrapper if isinstance(event, dict)]
 
     events = asyncio.run(_run())


### PR DESCRIPTION
# fix(anthropic-adapter): split reasoning+content stream chunks into separate blocks

  ## Relevant issues

  ## Linear ticket

  ## Pre-Submission checklist

  **Please complete all items before asking a LiteLLM maintainer to review your PR**

  - [x] I have added meaningful tests
  - [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
  - [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
  - [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

  ## Delays in PR merge?

  If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

  ## Screenshots / Proof of Fix

  Reproduced end-to-end against a live proxy backed by a real vLLM reasoning model (`hosted_vllm/qwen`), streaming through `/v1/messages` exactly as Claude Code does.

  Proxy started with:

  python litellm/proxy/proxy_cli.py --config local_config.yaml --detailed_debug

  Request (a prompt that forces a reasoning then answer transition, which is where vLLM emits a single chunk carrying both `reasoning_content` and `content`):

  curl -sN http://localhost:4000/v1/messages
    -H 'content-type: application/json'
    -H "x-api-key: $LITELLM_MASTER_KEY"
    -H 'anthropic-version: 2023-06-01' 
    -d '{"model":"qwen36-27b","max_tokens":1024,"stream":true,
         "messages":[{"role":"user","content":"Think briefly, then reply with exactly: Hi!"}]}'

  Emitted SSE block sequence (walking every event and tracking each open block's type by index):

  message_start
  content_block_start[0]=text  -> content_block_stop[0]
  content_block_start[1]=thinking -> thinking_delta ... -> content_block_stop[1]
  content_block_start[2]=text -> text_delta ("\n\nHi!") -> content_block_stop[2]
  message_delta -> message_stop

  MISMATCHES (thinking_delta landing in a non-thinking block): []
  THINKING: "...Draft Response: Hi!\n5. Final Verification: ... Result: Hi!\n"
  TEXT: "\n\nHi!"

  Every `thinking_delta` lands in a `thinking` block and every `text_delta` in a `text` block, and the answer text is preserved. Running the same request repeatedly and across several prompts consistently yields `text -> thinking -> text` with zero mismatches.

  Before the fix, the boundary chunk carrying both `reasoning_content` and `content` made the wrapper open a `content_block_start` of `type: "text"` and then emit a `thinking_delta` into it, so Anthropic clients such as Claude Code crashed with `API Error: Content block is
   not a thinking block` and the answer text was dropped.

  ## Type

  🐛 Bug Fix

  ## Changes

  Claude Code talks to the proxy over the Anthropic `/v1/messages` endpoint with streaming. For `hosted_vllm` there is no native Anthropic-messages provider config, so the response is translated from OpenAI-style chunks back into Anthropic SSE by `AnthropicStreamWrapper`
  in `litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py`.

  vLLM reasoning models (e.g. qwen) stream chain-of-thought as `reasoning_content` and the answer as `content`, and at the reasoning to answer boundary vLLM emits a single chunk that carries both fields together (verified live). That chunk desyncs two functions in the
  adapter: block-type detection returns `text` because it inspects `content` first, while delta production returns `thinking_delta` because it inspects `reasoning_content` first. The wrapper therefore opens a text block and emits a `thinking_delta` into it while silently
  dropping the answer text; spec-enforcing clients reject this with "Content block is not a thinking block"

  The fix extends `_CombinedChunkSplitter` so a chunk holding both reasoning and response content is split into an ordered reasoning-only chunk followed by the content chunk, which still flows through the existing content plus `finish_reason` split. Each emitted piece now
  maps to exactly one Anthropic block, reasoning first, so no `thinking_delta` lands in a text block and the answer text is preserved. This reuses the splitter pattern already established for the content plus `finish_reason` case rather than adding branching to the
  sync/async state machine, so the two translate functions are left unchanged

  Regression tests were added to `tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_combined_chunk.py` covering both sync and async paths: they assert that a boundary reasoning+content chunk never emits a `thinking_delta` into a
  text block and never drops the answer text, plus a unit test on the three-way split. These fail on the current base and pass with the fix. An existing test that encoded the old behavior (reasoning and content staying in one chunk) was updated to assert the correct separation