### PR TITLE
fix(ui): show key edit for team members granted /key/update

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/BudgetWindowsEditor.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/BudgetWindowsEditor.tsx
@@ -16,9 +16,10 @@ export const BUDGET_WINDOW_OPTIONS = [
 interface BudgetWindowsEditorProps {
   value: BudgetWindowEntry[];
   onChange: (v: BudgetWindowEntry[]) => void;
+  disabled?: boolean;
 }
 
-export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProps) {
+export function BudgetWindowsEditor({ value, onChange, disabled = false }: BudgetWindowsEditorProps) {
   const addWindow = () => {
     onChange([...value, { budget_duration: "24h", max_budget: null }]);
   };
@@ -43,6 +44,7 @@ export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProp
                 value={window.budget_duration}
                 onChange={(v) => updateWindow(idx, "budget_duration", v)}
                 style={{ width: 130 }}
+                disabled={disabled}
                 options={BUDGET_WINDOW_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
               />
               <InputNumber
@@ -54,8 +56,16 @@ export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProp
                 placeholder="Max spend ($)"
                 style={{ width: 160 }}
                 prefix="$"
+                disabled={disabled}
               />
-              <Button type="text" danger size="small" onClick={() => removeWindow(idx)} style={{ padding: "0 4px" }}>
+              <Button
+                type="text"
+                danger
+                size="small"
+                disabled={disabled}
+                onClick={() => removeWindow(idx)}
+                style={{ padding: "0 4px" }}
+              >
                 ✕
               </Button>
             </div>
@@ -65,6 +75,7 @@ export function BudgetWindowsEditor({ value, onChange }: BudgetWindowsEditorProp
       })}
       <Button
         size="small"
+        disabled={disabled}
         onClick={(e) => {
           e.preventDefault();
           addWindow();

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -15,6 +15,7 @@ export interface Team {
   keys: KeyResponse[];
   keys_count?: number;
   members_with_roles: Member[];
+  team_member_permissions?: string[];
   spend: number;
   access_group_ids?: string[];
   access_group_models?: string[];

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -690,6 +690,103 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("locks sensitive fields and strips them from submit for a non-privileged editor", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithScope = {
+      ...MOCK_KEY_DATA,
+      team_id: "team-1",
+      max_budget: 100,
+      budget_duration: "30d",
+      budget_limits: [{ budget_duration: "30d", max_budget: 100 }],
+      allowed_routes: ["llm_api_routes"],
+      access_group_ids: ["ag-1"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataWithScope}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"Internal User"}
+        premiumUser={false}
+        isPrivilegedEditor={false}
+      />,
+    );
+
+    const maxBudgetLabel = await screen.findByText(/Max Budget \(USD\)/);
+    const maxBudgetInput = maxBudgetLabel.closest(".ant-form-item")!.querySelector("input")!;
+    expect(maxBudgetInput).toBeDisabled();
+
+    const allowedRoutesInput = screen.getByLabelText(/allowed routes/i);
+    expect(allowedRoutesInput).toBeDisabled();
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      for (const field of [
+        "allowed_routes",
+        "allowed_passthrough_routes",
+        "max_budget",
+        "budget_duration",
+        "budget_limits",
+        "vector_stores",
+        "mcp_servers_and_groups",
+        "mcp_tool_permissions",
+        "agents_and_groups",
+        "access_group_ids",
+        "team_id",
+        "organization_id",
+        "guardrails",
+        "disable_global_guardrails",
+        "policies",
+      ]) {
+        expect(field in callArgs).toBe(false);
+      }
+    });
+  });
+
+  it("keeps sensitive fields editable and submitted for a privileged editor", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithScope = {
+      ...MOCK_KEY_DATA,
+      team_id: "team-1",
+      max_budget: 100,
+      budget_limits: [{ budget_duration: "30d", max_budget: 100 }],
+      access_group_ids: ["ag-1"],
+    };
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataWithScope}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken={"test-token"}
+        userID={"test-user"}
+        userRole={"admin"}
+        premiumUser={false}
+        isPrivilegedEditor={true}
+      />,
+    );
+
+    const maxBudgetLabel = await screen.findByText(/Max Budget \(USD\)/);
+    const maxBudgetInput = maxBudgetLabel.closest(".ant-form-item")!.querySelector("input")!;
+    expect(maxBudgetInput).not.toBeDisabled();
+
+    const submitButton = screen.getByRole("button", { name: /save changes/i });
+    await userEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+      const callArgs = onSubmitMock.mock.calls[0][0];
+      expect(callArgs.budget_limits).toEqual([{ budget_duration: "30d", max_budget: 100 }]);
+      expect("team_id" in callArgs).toBe(true);
+      expect("access_group_ids" in callArgs).toBe(true);
+    });
+  });
+
   it("should display 'AI APIs' label for the llm_api key type option", async () => {
     const keyDataWithLlmApiRoutes = {
       ...MOCK_KEY_DATA,

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -38,7 +38,26 @@ interface KeyEditViewProps {
   userID: string | null;
   userRole: string | null;
   premiumUser?: boolean;
+  isPrivilegedEditor?: boolean;
 }
+
+const LOCKED_FIELDS_FOR_NON_PRIVILEGED_EDITOR = [
+  "allowed_routes",
+  "allowed_passthrough_routes",
+  "max_budget",
+  "budget_duration",
+  "budget_limits",
+  "vector_stores",
+  "mcp_servers_and_groups",
+  "mcp_tool_permissions",
+  "agents_and_groups",
+  "access_group_ids",
+  "team_id",
+  "organization_id",
+  "guardrails",
+  "disable_global_guardrails",
+  "policies",
+] as const;
 
 // Add this helper function
 const getAvailableModelsForKey = (keyData: KeyResponse, teams: any[] | null): string[] => {
@@ -88,7 +107,9 @@ export function KeyEditView({
   userID,
   userRole,
   premiumUser = false,
+  isPrivilegedEditor = true,
 }: KeyEditViewProps) {
+  const lockSensitive = !isPrivilegedEditor;
   const canEditGuardrails = premiumUser || (userRole != null && rolesWithWriteAccess.includes(userRole));
   const [form] = Form.useForm();
   const [promptsList, setPromptsList] = useState<string[]>([]);
@@ -290,18 +311,24 @@ export function KeyEditView({
         values.duration = null;
       }
 
-      // Reconcile multi-window budget limits from the editor state, dropping
-      // incomplete entries (no max_budget). Sending [] tells the backend to clear
-      // all stored windows, so only send it when the user removed every window;
-      // when entries remain but are still incomplete, omit the field so the saved
-      // windows are left untouched (JSON.stringify drops the undefined key).
-      const validWindows = budgetLimits.filter(
-        (w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined,
-      );
-      if (validWindows.length > 0) {
-        values.budget_limits = validWindows;
-      } else if (budgetLimits.length === 0) {
-        values.budget_limits = [];
+      if (isPrivilegedEditor) {
+        // Reconcile multi-window budget limits from the editor state, dropping
+        // incomplete entries (no max_budget). Sending [] tells the backend to clear
+        // all stored windows, so only send it when the user removed every window;
+        // when entries remain but are still incomplete, omit the field so the saved
+        // windows are left untouched (JSON.stringify drops the undefined key).
+        const validWindows = budgetLimits.filter(
+          (w) => w.budget_duration && w.max_budget !== null && w.max_budget !== undefined,
+        );
+        if (validWindows.length > 0) {
+          values.budget_limits = validWindows;
+        } else if (budgetLimits.length === 0) {
+          values.budget_limits = [];
+        }
+      } else {
+        for (const field of LOCKED_FIELDS_FOR_NON_PRIVILEGED_EDITOR) {
+          delete values[field];
+        }
       }
 
       await onSubmit(values);
@@ -312,6 +339,22 @@ export function KeyEditView({
 
   return (
     <Form form={form} onFinish={handleSubmit} initialValues={initialValues} layout="vertical">
+      {lockSensitive && (
+        <div
+          style={{
+            marginBottom: 16,
+            padding: "8px 12px",
+            background: "#f5f5f5",
+            borderRadius: 6,
+            fontSize: 13,
+            color: "#555",
+          }}
+        >
+          <InfoCircleOutlined style={{ marginRight: 6 }} />
+          Budgets, allowed routes, guardrails and policies, access scope (vector stores, MCP, agents, access groups),
+          and organization or team assignment can only be changed by a team or proxy admin
+        </div>
+      )}
       <Form.Item label="Key Alias" name="key_alias">
         <TextInput />
       </Form.Item>
@@ -387,6 +430,7 @@ export function KeyEditView({
                 placeholder="Select key type"
                 style={{ width: "100%" }}
                 optionLabelProp="label"
+                disabled={lockSensitive}
                 value={keyTypeValue}
                 onChange={(value) => {
                   switch (value) {
@@ -444,15 +488,23 @@ export function KeyEditView({
         }
         name="allowed_routes"
       >
-        <Input placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes" />
+        <Input
+          disabled={lockSensitive}
+          placeholder="Enter allowed routes (comma-separated). Special values: llm_api_routes, management_routes. Examples: llm_api_routes, /chat/completions, /keys/*. Leave empty to allow all routes"
+        />
       </Form.Item>
 
       <Form.Item label="Max Budget (USD)" name="max_budget">
-        <NumericalInput step={0.01} style={{ width: "100%" }} placeholder="Enter a numerical value" />
+        <NumericalInput
+          step={0.01}
+          style={{ width: "100%" }}
+          placeholder="Enter a numerical value"
+          disabled={lockSensitive}
+        />
       </Form.Item>
 
       <Form.Item label="Reset Budget" name="budget_duration">
-        <Select placeholder="n/a">
+        <Select placeholder="n/a" disabled={lockSensitive}>
           <Select.Option value="daily">Daily</Select.Option>
           <Select.Option value="weekly">Weekly</Select.Option>
           <Select.Option value="monthly">Monthly</Select.Option>
@@ -469,7 +521,7 @@ export function KeyEditView({
           </span>
         }
       >
-        <BudgetWindowsEditor value={budgetLimits} onChange={setBudgetLimits} />
+        <BudgetWindowsEditor value={budgetLimits} onChange={setBudgetLimits} disabled={lockSensitive} />
       </Form.Item>
 
       <Form.Item label="TPM Limit" name="tpm_limit">
@@ -503,7 +555,7 @@ export function KeyEditView({
               form.setFieldValue("guardrails", v);
             }}
             accessToken={accessToken}
-            disabled={!canEditGuardrails}
+            disabled={!canEditGuardrails || lockSensitive}
           />
         )}
       </Form.Item>
@@ -520,7 +572,7 @@ export function KeyEditView({
         name="disable_global_guardrails"
         valuePropName="checked"
       >
-        <Switch disabled={!canEditGuardrails} checkedChildren="Yes" unCheckedChildren="No" />
+        <Switch disabled={!canEditGuardrails || lockSensitive} checkedChildren="Yes" unCheckedChildren="No" />
       </Form.Item>
 
       <Form.Item
@@ -540,7 +592,7 @@ export function KeyEditView({
               form.setFieldValue("policies", v);
             }}
             accessToken={accessToken}
-            disabled={!premiumUser}
+            disabled={!premiumUser || lockSensitive}
           />
         )}
       </Form.Item>
@@ -587,7 +639,7 @@ export function KeyEditView({
         }
         name="access_group_ids"
       >
-        <AccessGroupSelector placeholder="Select access groups (optional)" />
+        <AccessGroupSelector placeholder="Select access groups (optional)" disabled={lockSensitive} />
       </Form.Item>
 
       <Form.Item label="Allowed Pass Through Routes" name="allowed_passthrough_routes">
@@ -607,7 +659,7 @@ export function KeyEditView({
                   ? `Current: ${keyData.metadata.allowed_passthrough_routes.join(", ")}`
                   : "Select or enter allowed pass through routes"
             }
-            disabled={!premiumUser}
+            disabled={!premiumUser || lockSensitive}
           />
         </Tooltip>
       </Form.Item>
@@ -618,6 +670,7 @@ export function KeyEditView({
           value={form.getFieldValue("vector_stores")}
           accessToken={accessToken || ""}
           placeholder="Select vector stores"
+          disabled={lockSensitive}
         />
       </Form.Item>
 
@@ -628,6 +681,7 @@ export function KeyEditView({
           accessToken={accessToken || ""}
           placeholder="Select MCP servers or access groups (optional)"
           allowNoMcpServers
+          disabled={lockSensitive}
         />
       </Form.Item>
 
@@ -652,6 +706,7 @@ export function KeyEditView({
               )}
               toolPermissions={form.getFieldValue("mcp_tool_permissions") || {}}
               onChange={(toolPerms) => form.setFieldsValue({ mcp_tool_permissions: toolPerms })}
+              disabled={lockSensitive}
             />
           </div>
         )}
@@ -663,6 +718,7 @@ export function KeyEditView({
           value={form.getFieldValue("agents_and_groups")}
           accessToken={accessToken || ""}
           placeholder="Select agents or access groups (optional)"
+          disabled={lockSensitive}
         />
       </Form.Item>
 
@@ -680,7 +736,7 @@ export function KeyEditView({
         <OrganizationDropdown
           organizations={organizations}
           loading={isOrganizationsLoading}
-          disabled={userRole !== "Admin"}
+          disabled={userRole !== "Admin" || lockSensitive}
           onChange={(orgId) => {
             setSelectedOrganizationId(orgId || null);
             form.setFieldValue("team_id", undefined);
@@ -696,7 +752,7 @@ export function KeyEditView({
         <Select
           placeholder="Select team"
           showSearch
-          disabled={enableProjectsUI && hasProject}
+          disabled={(enableProjectsUI && hasProject) || lockSensitive}
           style={{ width: "100%" }}
           onChange={(teamId) => {
             const selectedTeam = teams?.find((t) => t.team_id === teamId) || null;

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -482,6 +482,82 @@ describe("KeyInfoView", () => {
 
       expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
     });
+
+    it("should show the Edit Settings button for a team member with /key/update on a service account key", async () => {
+      const teamId = "test-team-id";
+      const memberUserId = "team-member-user";
+      vi.mocked(useTeams).mockReturnValue({
+        teams: [
+          {
+            team_id: teamId,
+            team_alias: "Test Team",
+            models: [],
+            max_budget: null,
+            budget_duration: null,
+            tpm_limit: null,
+            rpm_limit: null,
+            organization_id: "org-1",
+            created_at: "2025-01-01T00:00:00Z",
+            keys: [],
+            members_with_roles: [{ user_id: memberUserId, role: "user" }],
+            team_member_permissions: ["/key/info", "/key/update"],
+            spend: 0,
+          },
+        ],
+        setTeams: vi.fn(),
+      });
+      vi.mocked(useAuthorized).mockReturnValue({
+        ...baseUseAuthorizedMock,
+        userId: memberUserId,
+        userRole: "Internal User",
+      });
+
+      await renderAndOpenSettingsTab({
+        ...MOCK_KEY_DATA,
+        team_id: teamId,
+        user_id: null as unknown as string,
+      });
+
+      expect(screen.getByRole("button", { name: /edit settings/i })).toBeInTheDocument();
+    });
+
+    it("should not show the Edit Settings button for a team member without /key/update on a service account key", async () => {
+      const teamId = "test-team-id";
+      const memberUserId = "team-member-user";
+      vi.mocked(useTeams).mockReturnValue({
+        teams: [
+          {
+            team_id: teamId,
+            team_alias: "Test Team",
+            models: [],
+            max_budget: null,
+            budget_duration: null,
+            tpm_limit: null,
+            rpm_limit: null,
+            organization_id: "org-1",
+            created_at: "2025-01-01T00:00:00Z",
+            keys: [],
+            members_with_roles: [{ user_id: memberUserId, role: "user" }],
+            team_member_permissions: ["/key/info", "/key/health"],
+            spend: 0,
+          },
+        ],
+        setTeams: vi.fn(),
+      });
+      vi.mocked(useAuthorized).mockReturnValue({
+        ...baseUseAuthorizedMock,
+        userId: memberUserId,
+        userRole: "Internal User",
+      });
+
+      await renderAndOpenSettingsTab({
+        ...MOCK_KEY_DATA,
+        team_id: teamId,
+        user_id: null as unknown as string,
+      });
+
+      expect(screen.queryByRole("button", { name: /edit settings/i })).not.toBeInTheDocument();
+    });
   });
 
   it("should display guardrails when present", async () => {

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.tsx
@@ -9,7 +9,12 @@ import { Badge, Button, Card, Grid, Tab, TabGroup, TabList, TabPanel, TabPanels,
 import { Form, Modal, Tag } from "antd";
 import { KeyInfoHeader } from "./KeyInfoHeader";
 import { useEffect, useState } from "react";
-import { isProxyAdminRole, isUserTeamAdminForSingleTeam, rolesWithWriteAccess } from "../../utils/roles";
+import {
+  canTeamMemberUpdateKey,
+  isProxyAdminRole,
+  isUserTeamAdminForSingleTeam,
+  rolesWithWriteAccess,
+} from "../../utils/roles";
 import { mapDisplayToInternalNames, mapInternalToDisplayNames } from "../callback_info_helpers";
 import AutoRotationView from "../common_components/AutoRotationView";
 import DeleteResourceModal from "../common_components/DeleteResourceModal";
@@ -381,14 +386,14 @@ export default function KeyInfoView({
     return `${dateStr} at ${timeStr}`;
   };
 
+  const keyTeam = teamsData?.find((team) => team.team_id === currentKeyData.team_id);
+
   const canModifyKey =
     isProxyAdminRole(userRole || "") ||
-    (teamsData &&
-      isUserTeamAdminForSingleTeam(
-        teamsData?.filter((team) => team.team_id === currentKeyData.team_id)[0]?.members_with_roles,
-        userID || "",
-      )) ||
+    isUserTeamAdminForSingleTeam(keyTeam?.members_with_roles ?? null, userID || "") ||
     (userID === currentKeyData.user_id && userRole !== "Internal Viewer");
+
+  const canEditKeySettings = canModifyKey || canTeamMemberUpdateKey(keyTeam, userID || "");
 
   const canResetSpend =
     isProxyAdminRole(userRole || "") ||
@@ -645,7 +650,7 @@ export default function KeyInfoView({
             <Card>
               <div className="flex justify-between items-center mb-4">
                 <Title>Key Settings</Title>
-                {!isEditing && canModifyKey && <Button onClick={() => setIsEditing(true)}>Edit Settings</Button>}
+                {!isEditing && canEditKeySettings && <Button onClick={() => setIsEditing(true)}>Edit Settings</Button>}
               </div>
 
               {isEditing ? (
@@ -658,6 +663,7 @@ export default function KeyInfoView({
                   userID={userID}
                   userRole={userRole}
                   premiumUser={premiumUser}
+                  isPrivilegedEditor={canModifyKey}
                 />
               ) : (
                 <div className="space-y-4">

--- a/ui/litellm-dashboard/src/utils/roles.test.ts
+++ b/ui/litellm-dashboard/src/utils/roles.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  canTeamMemberUpdateKey,
   isAdminRole,
   isProxyAdminRole,
   isUserTeamAdminForAnyTeam,
@@ -7,7 +8,24 @@ import {
   rolesAllowedToViewWriteScopedPages,
   rolesWithWriteAccess,
 } from "./roles";
-import { Team } from "@/components/networking";
+import { Member, Team } from "@/components/networking";
+
+const makeTeam = (overrides: Partial<Team>): Team => ({
+  team_id: "team-1",
+  team_alias: "Test Team",
+  models: [],
+  max_budget: null,
+  budget_duration: null,
+  tpm_limit: null,
+  rpm_limit: null,
+  organization_id: "org-1",
+  created_at: "2024-01-01",
+  keys: [],
+  members_with_roles: [],
+  ...overrides,
+});
+
+const member = (user_id: string, role: string): Member => ({ user_id, user_email: `${user_id}@test.com`, role });
 
 describe("roles", () => {
   describe("isAdminRole", () => {
@@ -149,6 +167,53 @@ describe("roles", () => {
 
     it("should return false when teams is empty array", () => {
       expect(isUserTeamAdminForAnyTeam([], "user-1")).toBe(false);
+    });
+  });
+
+  describe("canTeamMemberUpdateKey", () => {
+    it("returns true for a non-admin member when the team grants /key/update", () => {
+      const team = makeTeam({
+        members_with_roles: [member("user-1", "user")],
+        team_member_permissions: ["/key/info", "/key/update"],
+      });
+      expect(canTeamMemberUpdateKey(team, "user-1")).toBe(true);
+    });
+
+    it("returns false for a non-admin member when /key/update is not granted", () => {
+      const team = makeTeam({
+        members_with_roles: [member("user-1", "user")],
+        team_member_permissions: ["/key/info", "/key/health"],
+      });
+      expect(canTeamMemberUpdateKey(team, "user-1")).toBe(false);
+    });
+
+    it("returns false for a non-admin member when no permissions are set", () => {
+      const team = makeTeam({
+        members_with_roles: [member("user-1", "user")],
+        team_member_permissions: undefined,
+      });
+      expect(canTeamMemberUpdateKey(team, "user-1")).toBe(false);
+    });
+
+    it("returns true for a team admin regardless of the permission list", () => {
+      const team = makeTeam({
+        members_with_roles: [member("user-1", "admin")],
+        team_member_permissions: [],
+      });
+      expect(canTeamMemberUpdateKey(team, "user-1")).toBe(true);
+    });
+
+    it("returns false when the user is not a member of the team", () => {
+      const team = makeTeam({
+        members_with_roles: [member("user-2", "admin")],
+        team_member_permissions: ["/key/update"],
+      });
+      expect(canTeamMemberUpdateKey(team, "user-1")).toBe(false);
+    });
+
+    it("returns false when the team is null or undefined", () => {
+      expect(canTeamMemberUpdateKey(null, "user-1")).toBe(false);
+      expect(canTeamMemberUpdateKey(undefined, "user-1")).toBe(false);
     });
   });
 

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -37,6 +37,22 @@ export const isUserTeamAdminForSingleTeam = (teamMemberWithRoles: Member[] | nul
   return teamMemberWithRoles.some((member) => member.user_id === userID && member.role === "admin");
 };
 
+export const KEY_UPDATE_PERMISSION = "/key/update";
+
+export const canTeamMemberUpdateKey = (team: Team | null | undefined, userID: string): boolean => {
+  if (team == null) {
+    return false;
+  }
+  const member = team.members_with_roles?.find((m) => m.user_id === userID);
+  if (member == null) {
+    return false;
+  }
+  if (member.role === "admin") {
+    return true;
+  }
+  return (team.team_member_permissions ?? []).includes(KEY_UPDATE_PERMISSION);
+};
+
 export const formatUserRole = (userRole: string): string => {
   if (!userRole) {
     return "Undefined Role";


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduction against a local proxy on `localhost:4000` with the dashboard dev server pointed at it. Setup runs as proxy admin; verification runs as a regular team member.

1. Create a team and note its `team_id`

```bash
curl -sX POST http://localhost:4000/team/new \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"team_alias": "sa-edit-demo"}'
```

2. Add a regular member (role `user`) to the team

```bash
curl -sX POST http://localhost:4000/team/member_add \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"team_id": "<TEAM_ID>", "member": {"role": "user", "user_id": "<MEMBER_USER_ID>"}}'
```

3. Grant the team's members the `/key/update` permission

```bash
curl -sX POST http://localhost:4000/team/permissions_update \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"team_id": "<TEAM_ID>", "team_member_permissions": ["/key/info", "/key/health", "/key/update"]}'
```

4. Create a service account key for the team (its `user_id` is null by design)

```bash
curl -sX POST http://localhost:4000/key/service-account/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"team_id": "<TEAM_ID>", "metadata": {"service_account_id": "sa-edit-demo"}}'
```

5. Sign in to the dashboard as the team member from step 2, open http://localhost:4000/ui/?page=api-keys, click the service account key, then open the Settings tab

Before this change the Settings tab shows no Edit button for that key. After this change the Edit Settings button appears; opening it shows the safe operational fields editable (key alias, models, rate limits, metadata, guardrails, tags, prompts, lifecycle) while a banner at the top explains that budgets, allowed routes, access scope, and organization or team assignment can only be changed by a team or proxy admin. Those sensitive fields are disabled, and even if the form value were present it is stripped from the update payload, so a permission-only member cannot broaden the key. Saving a change to a safe field succeeds.

The route case is worth calling out. The backend rejects setting a non-empty `allowed_routes` from a non-admin, but it treats an empty list as "not set" and lets it through, so a permission-only member who could edit that field would be able to clear the restriction and turn a route-restricted key into a full-access one. The form locks that field for non-privileged editors to close the gap.

I will attach before/after screenshots of the Settings tab.

## Type

🐛 Bug Fix

## Changes

The dashboard hid every key mutation control behind a single check that allowed only proxy admins, team admins, and the key owner. Service account keys have a null `user_id`, so the ownership branch never matched, and the check never looked at team member permissions. A team member holding `/key/update` was therefore unable to edit their team's service account keys from the UI even though the backend authorizes that edit.

The Settings tab now shows the Edit Settings button when the caller is a member of the key's team and that team grants `/key/update`, mirroring `can_team_member_execute_key_management_endpoint` on the server. Delete, regenerate, and reset-spend remain gated on admin or owner as before, so a permission-only member gains edit access without inheriting admin-only actions.

Exposing the edit form to a permission-only member surfaces fields the backend treats as admin-only, plus controls that would weaken safety or escalate access. The route-restriction case is one sharp edge: the server rejects a non-empty `allowed_routes` from a non-admin but treats an empty list as "not set", so clearing the field is allowed and would let a member turn a route-restricted key into a full-access one. Guardrails are another: a delegated editor changing `guardrails`, toggling `disable_global_guardrails`, or swapping `policies` could bypass policy enforcement on the key. To keep the form aligned with backend authorization and close those gaps, a non-privileged editor gets the sensitive set disabled and stripped from the submit payload: allowed routes, key type, budgets (max budget, reset period, budget windows), passthrough routes, guardrails, policies, vector stores, MCP servers and groups, agents and access groups, and organization or team assignment. Agents and access groups matter here because the backend has no team-scope check on them for team keys, so leaving them editable would be another escalation. What stays editable is the safe operational set: key alias, models (bounded to the team's models server-side), rate limits, metadata, tags, prompts, and lifecycle.

Tests cover the new `canTeamMemberUpdateKey` helper, the Edit Settings button appearing for a permitted member on a service account key and staying hidden without the grant, and the edit form disabling and stripping the full sensitive set for a non-privileged editor while leaving it intact for a privileged one.
