### PR TITLE
fix(router): stop per-request extra_body params leaking

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1621,6 +1621,12 @@ class Router:
             # Check for silent model experiment
             # Make a local copy of litellm_params to avoid mutating the Router's state
             litellm_params = deployment["litellm_params"].copy()
+            # Deep-copy nested mutable params (e.g. extra_body) so per-request
+            # param processing cannot mutate the Router's stored deployment config.
+            if isinstance(litellm_params.get("extra_body"), dict):
+                litellm_params["extra_body"] = copy.deepcopy(
+                    litellm_params["extra_body"]
+                )
             silent_model = litellm_params.pop("silent_model", None)
 
             if silent_model is not None:
@@ -2646,6 +2652,12 @@ class Router:
             # Check for silent model experiment
             # Make a local copy of litellm_params to avoid mutating the Router's state
             litellm_params = deployment["litellm_params"].copy()
+            # Deep-copy nested mutable params (e.g. extra_body) so per-request
+            # param processing cannot mutate the Router's stored deployment config.
+            if isinstance(litellm_params.get("extra_body"), dict):
+                litellm_params["extra_body"] = copy.deepcopy(
+                    litellm_params["extra_body"]
+                )
             silent_model = litellm_params.pop("silent_model", None)
 
             if silent_model is not None:
@@ -4336,6 +4348,11 @@ class Router:
             self._add_deployment_model_to_endpoint_for_llm_passthrough_route(
                 kwargs=kwargs, model=model, model_name=model_name
             )
+
+            # Deep-copy nested mutable params (e.g. extra_body) so per-request
+            # param processing cannot mutate the Router's stored deployment config.
+            if isinstance(data.get("extra_body"), dict):
+                data["extra_body"] = copy.deepcopy(data["extra_body"])
 
             # Get custom_llm_provider from deployment params
             try:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4334,7 +4334,15 @@ def add_provider_specific_params_to_optional_params(
     if custom_llm_provider in ["openai", "azure", "text-completion-openai"] + litellm.openai_compatible_providers:
         # for openai, azure we should pass the extra/passed params within `extra_body` https://github.com/openai/openai-python/blob/ac33853ba10d13ac149b1fa3ca6dba7d613065c9/src/openai/resources/models.py#L46
         if _should_drop_param(k="extra_body", additional_drop_params=additional_drop_params) is False:
-            extra_body = dict(passed_params.pop("extra_body", None) or {})
+            # Deep-copy so neither top-level key insertion below nor any
+            # downstream in-place mutation of nested dicts (e.g.
+            # chat_template_kwargs) can write through to the caller's /
+            # Router's stored deployment extra_body object.
+            _passed_extra_body = passed_params.pop("extra_body", None) or {}
+            try:
+                extra_body = copy.deepcopy(_passed_extra_body)
+            except Exception:
+                extra_body = dict(_passed_extra_body)
             for k in passed_params.keys():
                 if k not in openai_params and passed_params[k] is not None:
                     extra_body[k] = passed_params[k]


### PR DESCRIPTION
stop per-request extra_body params leaking into stored deployment config

The router's per-request handling can mutate a deployment's stored extra_body, so provider-specific params from one request persist into the global model config and are applied to every subsequent request (and shown in the UI's LiteLLM Params). On load-balanced deployments this bleeds one caller's params across all users of the model group.

Root cause is shared-reference aliasing plus in-place mutation:

- deployment["litellm_params"].copy() is a shallow copy, so the nested extra_body dict is shared with the Router's stored deployment.
- add_provider_specific_params_to_optional_params then writes into that same object (extra_body[k] = passed_params[k]) while sweeping non-OpenAI params in, persisting them upstream.

The recent `dict(passed_params.pop("extra_body"))` change blocks top-level key insertion but is a shallow copy, so nested dicts (e.g. chat_template_kwargs) remain aliased, and the router-side copy sites are still shallow.

Fixes:

- utils.py: deep-copy the popped extra_body before the sweep so neither top-level insertion nor nested in-place mutation writes through.
- router.py: deep-copy extra_body when copying deployment litellm_params in the sync/async chat paths and the generic helper backing /v1/messages and /responses, isolating the stored object before request processing.

Reproducible via the Anthropic Messages endpoint: a single POST carrying `chat_template_kwargs: {"__leak_probe__": "x"}` and `output_config` leaves both grafted into the deployment's stored extra_body, observable through GET /model/info.

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x ] I have added meaningful tests
- [ x ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ x ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ x ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes
