### PR TITLE
fix(watsonx): update Granite 4 H Small context window

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37075,7 +37075,7 @@
     "watsonx/ibm/granite-4-h-small": {
         "max_tokens":131072,
         "max_input_tokens":131072,
-        "max_output_tokens": 20480,
+        "max_output_tokens": 131072,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.5e-07,
         "litellm_provider": "watsonx",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -37073,8 +37073,8 @@
         "supports_vision": false
     },
     "watsonx/ibm/granite-4-h-small": {
-        "max_tokens": 20480,
-        "max_input_tokens": 20480,
+        "max_tokens":131072,
+        "max_input_tokens":131072,
         "max_output_tokens": 20480,
         "input_cost_per_token": 6e-08,
         "output_cost_per_token": 2.5e-07,


### PR DESCRIPTION
Updates the context window values for watsonx/ibm/granite-4-h-small based on IBM's official documentation.

Changes
Updated max_tokens from 20480 to 131072
Updated max_input_tokens from 20480 to 131072
Also updated max_output_tokens  tp131072
Reference
IBM Granite 4 documentation:
https://dataplatform.cloud.ibm.com/docs/content/wsj/analyze-data/fm-models-ibm.html?context=wx#granite-4

Related to https://github.com/BerriAI/litellm/issues/24554
