### PR TITLE
fix(proxy): /v1/models does not resolve entity Access Groups (access_group_ids)

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5983,7 +5983,7 @@ async def _get_entity_access_group_models(
     prisma_client: Optional["PrismaClient"],
     user_api_key_cache: Optional["UserApiKeyCache"],
     proxy_logging_obj: Optional["ProxyLogging"],
-) -> List[str]:
+) -> list[str]:
     """
     Resolve entity Access Groups (`access_group_ids` on the key and on its
     team) into model names for model discovery (/v1/models,
@@ -5996,7 +5996,7 @@ async def _get_entity_access_group_models(
         get_team_object,
     )
 
-    group_ids: List[str] = list(user_api_key_dict.access_group_ids or [])
+    group_ids: list[str] = list(user_api_key_dict.access_group_ids or [])
 
     effective_team_id = team_id or user_api_key_dict.team_id
     if effective_team_id and prisma_client is not None and user_api_key_cache is not None:
@@ -6025,7 +6025,7 @@ async def _get_entity_access_group_models(
     )
 
 
-def _strip_authorization_sentinels(models: List[str]) -> List[str]:
+def _strip_authorization_sentinels(models: list[str]) -> list[str]:
     """
     Remove authorization sentinel values (no-default-models,
     all-team-models, all-proxy-models) from a model list.

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5977,6 +5977,73 @@ def construct_database_url_from_env_vars() -> Optional[str]:
     return None
 
 
+async def _get_entity_access_group_models(
+    user_api_key_dict: "UserAPIKeyAuth",
+    team_id: Optional[str],
+    prisma_client: Optional["PrismaClient"],
+    user_api_key_cache: Optional["UserApiKeyCache"],
+    proxy_logging_obj: Optional["ProxyLogging"],
+) -> List[str]:
+    """
+    Resolve entity Access Groups (`access_group_ids` on the key and on its
+    team) into model names for model discovery (/v1/models,
+    /model/info).
+
+    Returns an empty list when the caller has no entity access groups.
+    """
+    from litellm.proxy.auth.auth_checks import (
+        _get_models_from_access_groups,
+        get_team_object,
+    )
+
+    group_ids: List[str] = list(user_api_key_dict.access_group_ids or [])
+
+    effective_team_id = team_id or user_api_key_dict.team_id
+    if (
+        effective_team_id
+        and prisma_client is not None
+        and user_api_key_cache is not None
+    ):
+        try:
+            team_object = await get_team_object(
+                team_id=effective_team_id,
+                prisma_client=prisma_client,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+            group_ids.extend(team_object.access_group_ids or [])
+        except HTTPException:
+            # Team was deleted between auth and listing; any key-level
+            # access groups still apply.
+            pass
+
+    group_ids = list(dict.fromkeys(group_ids))
+    if not group_ids:
+        return []
+
+    return await _get_models_from_access_groups(
+        access_group_ids=group_ids,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
+def _strip_authorization_sentinels(models: List[str]) -> List[str]:
+    """
+    Remove authorization sentinel values (no-default-models,
+    all-team-models, all-proxy-models) from a model list.
+    """
+    from litellm.proxy._types import SpecialModelNames
+
+    sentinels = {
+        SpecialModelNames.no_default_models.value,
+        SpecialModelNames.all_team_models.value,
+        SpecialModelNames.all_proxy_models.value,
+    }
+    return [m for m in models if m not in sentinels]
+
+
 async def get_available_models_for_user(
     user_api_key_dict: "UserAPIKeyAuth",
     llm_router: Optional["Router"],
@@ -6070,6 +6137,17 @@ async def get_available_models_for_user(
         only_model_access_groups=only_model_access_groups,
         team_id=effective_team_id,
     )
+
+    if not only_model_access_groups:
+        entity_group_models = await _get_entity_access_group_models(
+            user_api_key_dict=user_api_key_dict,
+            team_id=team_id,
+            prisma_client=prisma_client,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        all_models.extend(m for m in entity_group_models if m not in all_models)
+        all_models = _strip_authorization_sentinels(all_models)
 
     return all_models
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -5999,11 +5999,7 @@ async def _get_entity_access_group_models(
     group_ids: List[str] = list(user_api_key_dict.access_group_ids or [])
 
     effective_team_id = team_id or user_api_key_dict.team_id
-    if (
-        effective_team_id
-        and prisma_client is not None
-        and user_api_key_cache is not None
-    ):
+    if effective_team_id and prisma_client is not None and user_api_key_cache is not None:
         try:
             team_object = await get_team_object(
                 team_id=effective_team_id,


### PR DESCRIPTION
## Relevant issues

#31966 

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review


## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

🐛 Bug Fix

## Changes

When a teams or keys model access is granted only via entity Access Groups (`access_group_ids`), enforcement and discovery disagree. Enforcement is correct: `can_team_access_model` / `can_key_call_model` fall back to
`_get_models_from_access_groups` and allow the group's models. 
Discovery is not: `get_available_models_for_user()` never reads `access_group_ids`, so `GET /v1/models` returns only the literal sentinel `"no-default-models"`. Clients that build model pickers from `/v1/models` show zero models for keys that can call models.

Two additions to `litellm/proxy/utils.py`:

- `_get_entity_access_group_models()`: collects `access_group_ids` from the  key and its team (cached `get_team_object`) and resolves them through the  same enforcement helper, `auth_checks._get_models_from_access_groups`, so discovery and enforcement use one resolver.
- `_strip_authorization_sentinels()`: removes `no-default-models` /  `all-team-models` / `all-proxy-models` from return.