### PR TITLE
fix(presidio): keep numbered PII tokens stable across messages in one request

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -429,6 +429,20 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                 masked_entity_count[entity_type] = masked_entity_count.get(entity_type, 0) + 1
         return redacted_text["text"]
 
+    @staticmethod
+    def _is_numbered_token_of_type(token: str, prefix: str) -> bool:
+        """True if ``token`` is a ``<{ENTITY}_{n}>`` token for exactly ``prefix``.
+
+        ``prefix`` is ``<{entity_type}_``. A plain ``startswith(prefix)`` check
+        would falsely match a token whose entity type merely begins with this
+        one (e.g. prefix ``<PHONE_`` matching ``<PHONE_NUMBER_1>``), so the
+        suffix between the prefix and the closing ``>`` must be all digits.
+        """
+        if not token.startswith(prefix) or not token.endswith(">"):
+            return False
+        number = token[len(prefix) : -1]
+        return number.isdigit()
+
     def _finalize_presidio_anonymize_numbered_tokens(
         self,
         text: str,
@@ -463,7 +477,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             # corrupting unmasking (issue #31959).
             prefix = f"<{entity_type}_"
             for existing_token, existing_value in pii_tokens.items():
-                if existing_value == original_value and existing_token.startswith(prefix):
+                if existing_value == original_value and self._is_numbered_token_of_type(existing_token, prefix):
                     return existing_token
             new_token = f"{prefix}{len(pii_tokens) + 1}>"
             pii_tokens[new_token] = original_value

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -454,12 +454,28 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             request_data["metadata"]["pii_tokens"] = {}
         pii_tokens = request_data["metadata"]["pii_tokens"]
 
-        # Assign sequence numbers in forward (left-to-right) order so
-        # that <PERSON_1> is the first entity in the text, etc.
+        def _token_for_value(entity_type: str, original_value: str) -> str:
+            # The pii_tokens dict is shared across every message of the
+            # request, so the same entity value must always resolve to the
+            # same token and the sequence counter must continue across
+            # messages — otherwise two messages both produce <PERSON_1> for
+            # different people and the last write silently wins,
+            # corrupting unmasking (issue #31959).
+            prefix = f"<{entity_type}_"
+            for existing_token, existing_value in pii_tokens.items():
+                if existing_value == original_value and existing_token.startswith(prefix):
+                    return existing_token
+            new_token = f"{prefix}{len(pii_tokens) + 1}>"
+            pii_tokens[new_token] = original_value
+            return new_token
+
+        # Assign tokens in forward (left-to-right) order so that new
+        # entities are numbered by order of appearance, e.g. <PERSON_1>
+        # is the first entity in the text.
         sorted_forward = sorted(analyze_results, key=lambda x: x["start"])
-        seq_map = {}
-        for idx, ar in enumerate(sorted_forward, start=1):
-            seq_map[(ar["start"], ar["end"])] = idx
+        token_map = {}
+        for ar in sorted_forward:
+            token_map[(ar["start"], ar["end"])] = _token_for_value(ar["entity_type"], text[ar["start"] : ar["end"]])
 
         # Apply replacements in reverse order by start position so
         # that replacing later spans first does not shift earlier
@@ -468,13 +484,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             start = ar["start"]
             end = ar["end"]
             entity_type = ar["entity_type"]
-            replacement = f"<{entity_type}>"
-            seq = seq_map[(start, end)]
-            if replacement.endswith(">"):
-                replacement = f"{replacement[:-1]}_{seq}>"
-            else:
-                replacement = f"{replacement}_{seq}"
-            pii_tokens[replacement] = text[start:end]
+            replacement = token_map[(start, end)]
             new_text = new_text[:start] + replacement + new_text[end:]
             masked_entity_count[entity_type] = masked_entity_count.get(entity_type, 0) + 1
         return new_text

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2782,6 +2782,72 @@ async def test_numbered_tokens_stable_across_messages_in_one_request():
         assert _OPTIONAL_PresidioPIIMasking._unmask_pii_text(masked, pii_tokens) == original
 
 
+def test_is_numbered_token_of_type_rejects_prefix_collision():
+    """Regression for #31978 review: an entity type that is a prefix of another
+    type's token must NOT match. Only ``<{ENTITY}_{digits}>`` counts."""
+    is_token = _OPTIONAL_PresidioPIIMasking._is_numbered_token_of_type
+
+    # exact numbered token of this type
+    assert is_token("<PHONE_1>", "<PHONE_") is True
+    assert is_token("<PHONE_42>", "<PHONE_") is True
+
+    # a longer entity type whose token merely starts with this prefix
+    assert is_token("<PHONE_NUMBER_1>", "<PHONE_") is False
+    # non-numeric suffix / malformed tokens
+    assert is_token("<PHONE_A>", "<PHONE_") is False
+    assert is_token("<PHONE_1", "<PHONE_") is False
+    assert is_token("<PERSON_1>", "<PHONE_") is False
+
+
+@pytest.mark.asyncio
+async def test_numbered_tokens_do_not_collide_across_prefixed_entity_types():
+    """Regression for #31978 review.
+
+    When one entity type name is a prefix of another (e.g. PHONE vs
+    PHONE_NUMBER) the same value must NOT reuse the longer type's token:
+    each type keeps its own numbered token and unmasking is exact.
+    """
+    text = "Call 555-0100 or fax 555-0100 - same digits, different entity types"
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://test-analyzer/",
+        presidio_anonymizer_api_base="http://test-anonymizer/",
+        mock_testing=False,
+        output_parse_pii=True,
+    )
+
+    # Same literal value classified once as PHONE_NUMBER and once as PHONE.
+    first = text.find("555-0100")
+    second = text.find("555-0100", first + 1)
+    analyze_results = [
+        {"start": first, "end": first + 8, "entity_type": "PHONE_NUMBER", "score": 0.9},
+        {"start": second, "end": second + 8, "entity_type": "PHONE", "score": 0.9},
+    ]
+
+    mock_iterator = _make_mock_session_iterator(
+        json_response={"text": "ignored", "items": []},
+    )
+
+    request_data = {"metadata": {}}
+    with patch.object(guardrail, "_get_session_iterator", mock_iterator):
+        masked = await guardrail.anonymize_text(
+            text=text,
+            analyze_results=analyze_results,
+            output_parse_pii=True,
+            masked_entity_count={},
+            request_data=request_data,
+        )
+
+    pii_tokens = request_data["metadata"]["pii_tokens"]
+    # Each entity type gets its own token - no cross-type reuse.
+    assert pii_tokens == {
+        "<PHONE_NUMBER_1>": "555-0100",
+        "<PHONE_2>": "555-0100",
+    }
+    assert "<PHONE_NUMBER_1>" in masked and "<PHONE_2>" in masked
+    assert _OPTIONAL_PresidioPIIMasking._unmask_pii_text(masked, pii_tokens) == text
+
+
 def test_unmask_sse_bytes_chunk_replaces_text_delta():
     import json
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py
@@ -2697,6 +2697,91 @@ async def test_anonymize_text_uses_correct_positions_with_parse_pii():
     assert pii_tokens.get("<PHONE_NUMBER_3>") == "555-867-5309"
 
 
+@pytest.mark.asyncio
+async def test_numbered_tokens_stable_across_messages_in_one_request():
+    """
+    Regression test for issue #31959.
+
+    With output_parse_pii=True and multiple messages in one request, each
+    unique entity value must map to one stable token across all messages,
+    and the shared pii_tokens map must stay one-to-one. Previously the
+    sequence counter restarted at 1 per message, so different values in
+    different messages collided onto the same token (last write wins) and
+    unmasking restored the wrong original value.
+    """
+    messages = [
+        "My wife is Marry Le. My name is John Smith, email john.smith@example.com",
+        "Hi, I am John Smith and my wife is Marry Le, reach me at john.smith@example.com",
+        "My son is David Smith. Please update the intro to include him",
+    ]
+
+    def _analyze_results_for(text):
+        results = []
+        for value, entity_type in [
+            ("Marry Le", "PERSON"),
+            ("John Smith", "PERSON"),
+            ("David Smith", "PERSON"),
+            ("john.smith@example.com", "EMAIL_ADDRESS"),
+        ]:
+            start = text.find(value)
+            if start != -1:
+                results.append(
+                    {
+                        "start": start,
+                        "end": start + len(value),
+                        "entity_type": entity_type,
+                        "score": 0.85,
+                    }
+                )
+        return results
+
+    guardrail = _OPTIONAL_PresidioPIIMasking(
+        presidio_analyzer_api_base="http://test-analyzer/",
+        presidio_anonymizer_api_base="http://test-anonymizer/",
+        mock_testing=False,
+        output_parse_pii=True,
+    )
+
+    # Anonymizer response body is not used on the numbered-tokens path,
+    # but the POST must succeed.
+    mock_iterator = _make_mock_session_iterator(
+        json_response={"text": "ignored", "items": []},
+    )
+
+    request_data = {"metadata": {}}
+    masked_messages = []
+    with patch.object(guardrail, "_get_session_iterator", mock_iterator):
+        for text in messages:
+            masked_messages.append(
+                await guardrail.anonymize_text(
+                    text=text,
+                    analyze_results=_analyze_results_for(text),
+                    output_parse_pii=True,
+                    masked_entity_count={},
+                    request_data=request_data,
+                )
+            )
+
+    pii_tokens = request_data["metadata"]["pii_tokens"]
+
+    # One token per unique value — no collisions, no duplicates
+    assert pii_tokens == {
+        "<PERSON_1>": "Marry Le",
+        "<PERSON_2>": "John Smith",
+        "<EMAIL_ADDRESS_3>": "john.smith@example.com",
+        "<PERSON_4>": "David Smith",
+    }
+
+    # Same value keeps the same token in every message
+    assert masked_messages[0] == "My wife is <PERSON_1>. My name is <PERSON_2>, email <EMAIL_ADDRESS_3>"
+    assert masked_messages[1] == "Hi, I am <PERSON_2> and my wife is <PERSON_1>, reach me at <EMAIL_ADDRESS_3>"
+    assert masked_messages[2] == "My son is <PERSON_4>. Please update the intro to include him"
+
+    # Unmasking every masked message restores the original text exactly
+    for masked, original in zip(masked_messages, messages):
+        assert _OPTIONAL_PresidioPIIMasking._unmask_pii_text(masked, pii_tokens) == original
+
+
 def test_unmask_sse_bytes_chunk_replaces_text_delta():
     import json
 


### PR DESCRIPTION
## Relevant issues

Fixes #31959

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

**Root cause.** With `output_parse_pii: true`, each message of a `/chat/completions` request is anonymized as its own `check_pii` task, but all tasks share one request-scoped `metadata["pii_tokens"]` map. `_finalize_presidio_anonymize_numbered_tokens` numbered entities per message (`enumerate(..., start=1)`), so the counter restarted at 1 for every message. Two messages could both emit `<PERSON_1>` for different people; the later write overwrote the earlier one (nondeterministically, since messages run concurrently via `asyncio.gather`), and unmasking then restored the wrong person's name.

**Before** (messages from the issue repro — `<PERSON_1>` means a different person in every message, and the shared map collapses to the last writer):

```
msg1: My wife is <PERSON_1>. My name is <PERSON_2>, email <EMAIL_ADDRESS_3>
msg2: Hi, I am <PERSON_1> and my wife is <PERSON_2>, reach me at <EMAIL_ADDRESS_3>
msg3: My son is <PERSON_1>.

pii_tokens: {"<PERSON_1>": "David Smith", "<PERSON_2>": "Marry Le", "<EMAIL_ADDRESS_3>": "john.smith@example.com"}
```

**After** (each unique value keeps one token across all messages; the map stays one-to-one and unmasking round-trips every message exactly):

```
msg1: My wife is <PERSON_1>. My name is <PERSON_2>, email <EMAIL_ADDRESS_3>
msg2: Hi, I am <PERSON_2> and my wife is <PERSON_1>, reach me at <EMAIL_ADDRESS_3>
msg3: My son is <PERSON_4>. Please update the intro to include him

pii_tokens: {"<PERSON_1>": "Marry Le", "<PERSON_2>": "John Smith", "<EMAIL_ADDRESS_3>": "john.smith@example.com", "<PERSON_4>": "David Smith"}
```

**Fix.** Tokens are now assigned from the shared map: a value that already has a token for its entity type reuses it; new values continue the request-wide sequence (`len(pii_tokens) + 1`). Numbering within a message is still left-to-right, and the single-message behavior is unchanged (existing regression test `test_anonymize_text_uses_correct_positions_with_parse_pii` for #24160 still passes untouched).

**Tests.**

```
$ pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py -q
76 passed

$ pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py::test_numbered_tokens_stable_across_messages_in_one_request -q
1 passed
```

The new test drives `anonymize_text` for the issue's three messages against one shared request and asserts stable tokens, a one-to-one map, and exact unmask round-trip. It fails on `main` with the collided map shown above.

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/guardrails/guardrail_hooks/presidio.py`: `_finalize_presidio_anonymize_numbered_tokens` now reuses the existing token for an already-seen (entity type, value) pair and continues the request-wide sequence for new values, instead of restarting numbering per message.
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_presidio.py`: regression test for multi-message token stability and unmask round-trip (#31959).
