### PR TITLE
feat(proxy): add per-model use_local_token_counter to skip provider CountTokens API

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -10205,6 +10205,10 @@ def _get_provider_token_counter(
     if deployment is None:
         return None
 
+    model_info = deployment.get("model_info") or {}
+    if model_info.get("use_local_token_counter"):
+        return None, None, None
+
     from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
 
     full_model = deployment.get("litellm_params", {}).get("model", "")

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -133,6 +133,8 @@ class ModelInfo(BaseModel):
     base_model: Optional[str] = None  # specify if the base model is azure/gpt-3.5-turbo etc for accurate cost tracking
     tier: Optional[Literal["free", "paid"]] = None
 
+    use_local_token_counter: Optional[bool] = None
+
     """
     Team Model Specific Fields
     """

--- a/tests/proxy_unit_tests/test_proxy_token_counter.py
+++ b/tests/proxy_unit_tests/test_proxy_token_counter.py
@@ -1364,3 +1364,86 @@ async def test_anthropic_endpoint_429_rate_limit_error_format():
     finally:
         anthropic_endpoints._read_request_body = original_read_request_body
         proxy_server.token_counter = original_token_counter
+
+
+@pytest.mark.asyncio
+async def test_get_provider_token_counter_respects_use_local_token_counter():
+    """
+    Regression: a deployment whose model_info sets use_local_token_counter=True must NOT
+    resolve a provider (remote) token counter, so callers fall back to the local tokenizer.
+    Without the flag, the Bedrock provider counter is still returned.
+    """
+    from litellm.proxy.proxy_server import _get_provider_token_counter
+
+    bedrock_params = {"model": "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"}
+    resolved_model = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+    with_flag = {
+        "litellm_params": bedrock_params,
+        "model_info": {"use_local_token_counter": True},
+    }
+    without_flag = {
+        "litellm_params": bedrock_params,
+        "model_info": {},
+    }
+
+    assert _get_provider_token_counter(with_flag, resolved_model) == (None, None, None)
+
+    counter, _model, provider = _get_provider_token_counter(without_flag, resolved_model)
+    assert isinstance(counter, BedrockTokenCounter)
+    assert provider == "bedrock"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_local", [True, False])
+async def test_token_counter_use_local_flag_bypasses_bedrock_api(use_local):
+    """
+    Regression for the per-model model_info.use_local_token_counter flag.
+
+    call_endpoint=True normally routes Bedrock models to the remote CountTokens API. With
+    use_local_token_counter=True the proxy must skip the remote API entirely and count locally,
+    never instantiating/calling the Bedrock handler. Without it, the remote API is still used.
+    """
+    import litellm.proxy.proxy_server as proxy_server
+
+    model_info = {"use_local_token_counter": True} if use_local else {}
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "claude-bedrock",
+                "litellm_params": {
+                    "model": "bedrock/anthropic.claude-3-sonnet-20240229-v1:0"
+                },
+                "model_info": model_info,
+            }
+        ]
+    )
+    setattr(proxy_server, "llm_router", llm_router)
+
+    with patch(
+        "litellm.llms.bedrock.count_tokens.bedrock_token_counter.BedrockCountTokensHandler"
+    ) as MockHandler:
+        mock_handler_instance = MockHandler.return_value
+        mock_handler_instance.handle_count_tokens_request = AsyncMock(
+            return_value={"input_tokens": 999}
+        )
+
+        response = await token_counter(
+            request=TokenCountRequest(
+                model="claude-bedrock",
+                messages=[
+                    {"role": "user", "content": "Hello Claude, how are you today?"}
+                ],
+            ),
+            call_endpoint=True,
+        )
+
+    if use_local:
+        mock_handler_instance.handle_count_tokens_request.assert_not_called()
+        assert response.tokenizer_type != "bedrock_api"
+        assert response.total_tokens > 0
+        assert response.total_tokens != 999
+    else:
+        mock_handler_instance.handle_count_tokens_request.assert_called_once()
+        assert response.tokenizer_type == "bedrock_api"
+        assert response.total_tokens == 999

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -33010,6 +33010,8 @@ export interface components {
             updated_at?: string | null;
             /** Updated By */
             updated_by?: string | null;
+            /** Use Local Token Counter */
+            use_local_token_counter?: boolean | null;
         } & {
             [key: string]: unknown;
         };


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Configure two Bedrock deployments, one with the new flag and one without, then hit the token counter with `call_endpoint=true` and compare `tokenizer_type`.

`dev_config.yaml`:

```yaml
model_list:
  - model_name: claude-remote-count
    litellm_params:
      model: bedrock/anthropic.claude-3-5-haiku-20241022-v1:0
      aws_region_name: us-west-2
  - model_name: claude-local-count
    litellm_params:
      model: bedrock/anthropic.claude-3-5-haiku-20241022-v1:0
      aws_region_name: us-west-2
    model_info:
      use_local_token_counter: true
```

Run the proxy, then:

```bash
# no flag -> hits Bedrock's remote CountTokens API
curl -sS -X POST 'http://localhost:4000/utils/token_counter?call_endpoint=true' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"claude-remote-count","messages":[{"role":"user","content":"Hello Claude, how are you today?"}]}'

# flag set -> stays local, no AWS call
curl -sS -X POST 'http://localhost:4000/utils/token_counter?call_endpoint=true' \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"claude-local-count","messages":[{"role":"user","content":"Hello Claude, how are you today?"}]}'
```

Expected: the first response reports `"tokenizer_type":"bedrock_api"` (remote count), the second reports a local tokenizer type (e.g. the anthropic/tiktoken tokenizer) and never calls Bedrock.

## Type

🆕 New Feature

## Changes

Previously there was no way to keep token counting local for a specific deployment. Anthropic-format `/v1/messages/count_tokens` and `/utils/token_counter?call_endpoint=true` always dispatch to the provider's remote CountTokens API (for Bedrock, Anthropic, Vertex, etc.), and the only existing switch, `litellm.disable_token_counter`, disables counting entirely instead of falling back to the local tokenizer.

This adds a per-model `model_info.use_local_token_counter` flag. When set, `_get_provider_token_counter` resolves no provider counter for that deployment, so both endpoints fall through to the local tokenizer (tiktoken/HF/anthropic-local depending on the model) and no remote CountTokens request is made. It lives next to the existing `model_info.custom_tokenizer` field, which is the other token-counting knob on `model_info`.

Tests in `tests/proxy_unit_tests/test_proxy_token_counter.py` cover the gate directly (`_get_provider_token_counter` returns no counter when the flag is set, and still returns `BedrockTokenCounter` when it is not) and end-to-end through the `token_counter` endpoint (flag on -> Bedrock handler never called and `tokenizer_type` is local; flag off -> remote API used). Removing the gate makes the flag-on cases fail.
