### PR TITLE
feat(mcp): add entra_obo profile to the token_exchange (OBO) arm

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2003,8 +2003,14 @@ class MCPServerManager:
                 if err.tag == "unauthorized" and isinstance(spec.config, TokenExchangeConfig):
                     # token_exchange (OBO): a missing/rejected subject token -> the RFC 9728 challenge
                     # pointing at the IdP the client must SSO with to obtain one, rather than an opaque
-                    # 401. No gateway-side browser flow.
-                    raise_token_exchange_challenge(server, root_path=get_server_root_path())
+                    # 401. No gateway-side browser flow. An IdP step-up rejection (Entra Conditional
+                    # Access) threads its error code and claims blob into the challenge.
+                    raise_token_exchange_challenge(
+                        server,
+                        root_path=get_server_root_path(),
+                        oauth_error=err.unauthorized.oauth_error,
+                        claims=err.unauthorized.claims,
+                    )
                 raise_public(err)
 
     async def preflight_token_exchange(
@@ -2034,7 +2040,12 @@ class MCPServerManager:
                 return
             case Error(err):
                 if err.tag == "unauthorized":
-                    raise_token_exchange_challenge(server, root_path=get_server_root_path())
+                    raise_token_exchange_challenge(
+                        server,
+                        root_path=get_server_root_path(),
+                        oauth_error=err.unauthorized.oauth_error,
+                        claims=err.unauthorized.claims,
+                    )
                 raise_public(err)
 
     async def _create_mcp_client(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2004,11 +2004,10 @@ class MCPServerManager:
                     # token_exchange (OBO): a missing/rejected subject token -> the RFC 9728 challenge
                     # pointing at the IdP the client must SSO with to obtain one, rather than an opaque
                     # 401. No gateway-side browser flow. An IdP step-up rejection (Entra Conditional
-                    # Access) threads its error code and claims blob into the challenge.
+                    # Access) threads its claims blob into the challenge for the client to satisfy.
                     raise_token_exchange_challenge(
                         server,
                         root_path=get_server_root_path(),
-                        oauth_error=err.unauthorized.oauth_error,
                         claims=err.unauthorized.claims,
                     )
                 raise_public(err)
@@ -2043,7 +2042,6 @@ class MCPServerManager:
                     raise_token_exchange_challenge(
                         server,
                         root_path=get_server_root_path(),
-                        oauth_error=err.unauthorized.oauth_error,
                         claims=err.unauthorized.claims,
                     )
                 raise_public(err)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -825,6 +825,7 @@ class MCPServerManager:
                     "subject_token_type",
                     "urn:ietf:params:oauth:token-type:access_token",
                 ),
+                token_exchange_profile=server_config.get("token_exchange_profile", "rfc8693"),
                 allow_sampling=bool(server_config.get("allow_sampling", False)),
                 allow_elicitation=bool(server_config.get("allow_elicitation", False)),
                 timeout=server_config.get("timeout", None),
@@ -1212,6 +1213,8 @@ class MCPServerManager:
             audience=(credentials_dict.get("audience") if credentials_dict else None),
             subject_token_type=(credentials_dict.get("subject_token_type") if credentials_dict else None)
             or "urn:ietf:params:oauth:token-type:access_token",
+            token_exchange_profile=(credentials_dict.get("token_exchange_profile") if credentials_dict else None)
+            or "rfc8693",
             timeout=getattr(mcp_server, "timeout", None),
             max_concurrent_requests=getattr(mcp_server, "max_concurrent_requests", None),
         )

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -756,7 +756,12 @@ class MCPServerManager:
             else:
                 mcp_oauth_metadata = None
 
-            resolved_scopes = server_config.get("scopes") or (mcp_oauth_metadata.scopes if mcp_oauth_metadata else None)
+            # Filter blank scopes (e.g. YAML ``scopes: [""]``) the same way the DB-build path does, so
+            # an all-blank list normalizes to None rather than a ``("",)`` tuple that skips the
+            # entra_obo fail-closed scope precondition and POSTs an empty scope to the IdP.
+            resolved_scopes = self._extract_scopes(server_config.get("scopes")) or (
+                mcp_oauth_metadata.scopes if mcp_oauth_metadata else None
+            )
             resolved_authorization_url = server_config.get("authorization_url") or (
                 mcp_oauth_metadata.authorization_url if mcp_oauth_metadata else None
             )

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -12,7 +12,7 @@ every other mode so the caller defers to v1 (parity-safe); it grows one branch p
 from __future__ import annotations
 
 import base64
-from typing import TYPE_CHECKING, NoReturn, Optional
+from typing import TYPE_CHECKING, Literal, NoReturn, Optional
 
 from fastapi import HTTPException
 from pydantic import SecretStr
@@ -63,7 +63,7 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
     explicitly mapped or explicitly deferred, rather than silently falling through to v1. Live
     modes: ``none``, the static-header family (``api_key`` plus the Authorization schemes,
     all shared-key), ``oauth2`` per-user tokens (``authorization_code``), and
-    ``oauth2_token_exchange`` (RFC 8693 OBO); client_credentials (M2M), delegated/passthrough
+    ``oauth2_token_exchange`` (OBO); client_credentials (M2M), delegated/passthrough
     oauth2, and SigV4 return None and stay on v1.
     """
     if server.is_byok:
@@ -102,22 +102,28 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
 
 
 def _token_exchange_spec(server: MCPServer, resource: str) -> Optional[ServerSpec]:
-    """Build a token_exchange (RFC 8693 OBO) spec, or defer (None) when it is not OBO-configured.
+    """Build a token_exchange (OBO) spec, or defer (None) when it is not OBO-configured.
 
     An OBO server with ``client_id``/``client_secret`` is owned by the v2 arm even if the
     ``token_exchange_endpoint``/``token_url`` is absent: a missing endpoint then fails closed (412) at
     the exchanger rather than silently deferring to v1 and connecting unauthenticated, since the
     gateway must not guess the IdP or fall back to a weaker source. Without client credentials there is
-    nothing to own, so the server stays on v1 (parity-safe). ``audience`` is forwarded only when the
-    operator set it; a missing one is omitted, not derived.
+    nothing to own, so the server stays on v1 (parity-safe). ``profile`` selects the wire dialect
+    (``rfc8693`` default, ``entra_obo`` for Microsoft Entra On-Behalf-Of); an unrecognized value
+    normalizes to ``rfc8693`` so a bad config value cannot crash spec-building. ``audience`` is
+    forwarded only when the operator set it; a missing one is omitted, not derived.
     """
     endpoint = server.token_exchange_endpoint or server.token_url
     if not server.client_id or not server.client_secret:
         return None
+    profile: Literal["rfc8693", "entra_obo"] = (
+        "entra_obo" if server.token_exchange_profile == "entra_obo" else "rfc8693"
+    )
     return ServerSpec(
         server_id=server.server_id,
         resource=resource,
         config=TokenExchangeConfig(
+            profile=profile,
             subject_token_type=server.subject_token_type or "urn:ietf:params:oauth:token-type:access_token",
             token_exchange_endpoint=endpoint,
             audience=server.audience,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -12,7 +12,6 @@ every other mode so the caller defers to v1 (parity-safe); it grows one branch p
 from __future__ import annotations
 
 import base64
-import re
 from typing import TYPE_CHECKING, Literal, NoReturn, Optional
 
 from fastapi import HTTPException
@@ -215,14 +214,10 @@ def raise_user_oauth_challenge(server: MCPServer, *, root_path: str) -> NoReturn
     )
 
 
-_OAUTH_ERROR_TOKEN = re.compile(r"[A-Za-z0-9_.-]{1,64}")
-
-
 def raise_token_exchange_challenge(
     server: MCPServer,
     *,
     root_path: str,
-    oauth_error: str | None = None,
     claims: str | None = None,
 ) -> NoReturn:
     """Raise the RFC 9728 / RFC 6750 challenge an OBO (``token_exchange``) server returns when the
@@ -234,23 +229,27 @@ def raise_token_exchange_challenge(
     ``raise_user_oauth_challenge`` but for the exchange flow: there is no gateway-side browser OAuth —
     the client re-authenticates directly with the IdP, and LiteLLM then exchanges the resulting token.
 
-    An IdP step-up rejection (Entra Conditional Access / CAE) passes its machine ``oauth_error``
-    (e.g. ``interaction_required``) and ``claims`` blob; the claims travel base64-encoded in a
-    ``claims`` parameter, the convention MSAL-family clients decode to drive the step-up. The
-    error code is embedded only when it is a plain OAuth token (defense against header injection
-    from a hostile IdP body); otherwise the challenge keeps ``invalid_token``. With neither field
-    the header is byte-identical to the static challenge.
+    An IdP step-up rejection (Entra Conditional Access / CAE) passes its ``claims`` blob. Per the
+    Microsoft claims-challenge format the challenge then uses ``error="insufficient_claims"`` (the
+    value MSAL-family clients key on) and carries the claims base64-encoded in a ``claims`` parameter
+    the client replays to the IdP to satisfy the step-up. Without a claims blob the challenge keeps
+    ``error="invalid_token"`` and is byte-identical to the static one. Both the error value (one of
+    two literals) and the base64 claims draw from a fixed alphabet, so nothing from the IdP body
+    reaches the header unescaped.
     """
     resource_metadata = oauth_protected_resource_path(root_path, server)
-    safe_error = (
-        oauth_error if oauth_error is not None and _OAUTH_ERROR_TOKEN.fullmatch(oauth_error) else "invalid_token"
-    )
     encoded_claims = base64.b64encode(claims.encode()).decode() if claims else None
+    error = "insufficient_claims" if encoded_claims else "invalid_token"
+    error_description = (
+        "Step-up authentication required; satisfy the returned claims challenge with the IdP and retry"
+        if encoded_claims
+        else "Missing or invalid subject token; authenticate with the IdP and retry"
+    )
     www_authenticate = ", ".join(
         (
             f'Bearer resource_metadata="{resource_metadata}"',
-            f'error="{safe_error}"',
-            'error_description="Missing or invalid subject token; authenticate with the IdP and retry"',
+            f'error="{error}"',
+            f'error_description="{error_description}"',
             *((f'claims="{encoded_claims}"',) if encoded_claims else ()),
         )
     )

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -12,6 +12,7 @@ every other mode so the caller defers to v1 (parity-safe); it grows one branch p
 from __future__ import annotations
 
 import base64
+import re
 from typing import TYPE_CHECKING, Literal, NoReturn, Optional
 
 from fastapi import HTTPException
@@ -214,7 +215,16 @@ def raise_user_oauth_challenge(server: MCPServer, *, root_path: str) -> NoReturn
     )
 
 
-def raise_token_exchange_challenge(server: MCPServer, *, root_path: str) -> NoReturn:
+_OAUTH_ERROR_TOKEN = re.compile(r"[A-Za-z0-9_.-]{1,64}")
+
+
+def raise_token_exchange_challenge(
+    server: MCPServer,
+    *,
+    root_path: str,
+    oauth_error: str | None = None,
+    claims: str | None = None,
+) -> NoReturn:
     """Raise the RFC 9728 / RFC 6750 challenge an OBO (``token_exchange``) server returns when the
     caller's subject token is missing or the IdP rejected it.
 
@@ -223,12 +233,26 @@ def raise_token_exchange_challenge(server: MCPServer, *, root_path: str) -> NoRe
     spec-compliant MCP client to discover that AS and retry with a fresh bearer. Mirrors
     ``raise_user_oauth_challenge`` but for the exchange flow: there is no gateway-side browser OAuth —
     the client re-authenticates directly with the IdP, and LiteLLM then exchanges the resulting token.
+
+    An IdP step-up rejection (Entra Conditional Access / CAE) passes its machine ``oauth_error``
+    (e.g. ``interaction_required``) and ``claims`` blob; the claims travel base64-encoded in a
+    ``claims`` parameter, the convention MSAL-family clients decode to drive the step-up. The
+    error code is embedded only when it is a plain OAuth token (defense against header injection
+    from a hostile IdP body); otherwise the challenge keeps ``invalid_token``. With neither field
+    the header is byte-identical to the static challenge.
     """
     resource_metadata = oauth_protected_resource_path(root_path, server)
-    www_authenticate = (
-        f'Bearer resource_metadata="{resource_metadata}", '
-        'error="invalid_token", '
-        'error_description="Missing or invalid subject token; authenticate with the IdP and retry"'
+    safe_error = (
+        oauth_error if oauth_error is not None and _OAUTH_ERROR_TOKEN.fullmatch(oauth_error) else "invalid_token"
+    )
+    encoded_claims = base64.b64encode(claims.encode()).decode() if claims else None
+    www_authenticate = ", ".join(
+        (
+            f'Bearer resource_metadata="{resource_metadata}"',
+            f'error="{safe_error}"',
+            'error_description="Missing or invalid subject token; authenticate with the IdP and retry"',
+            *((f'claims="{encoded_claims}"',) if encoded_claims else ()),
+        )
     )
     raise HTTPException(
         status_code=401,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -89,7 +89,6 @@ async def _post_exchange_endpoint(
                 raise TokenExchangeClientError(oauth_error) from status_err
             raise SubjectTokenRejected(
                 f"IdP rejected the subject token (HTTP {status_code})",
-                oauth_error=oauth_error,
                 claims=claims,
             ) from status_err
         verbose_logger.warning("MCP token exchange request failed: %s", status_err)

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -1,6 +1,6 @@
 """Composition root for the v2-native token_exchange (OBO) exchanger.
 
-Wires the pure ``Rfc8693TokenExchanger`` to its runtime edges: the real httpx POST against the IdP and
+Wires the pure ``OboTokenExchanger`` to its runtime edges: the real httpx POST against the IdP and
 the configured cache sizing/TTL constants. ``build_token_exchanger`` is built once at egress
 construction and reused, so the in-process exchanged-token cache survives across requests. Unlike the
 per-user store, nothing here reads a runtime global at build time (the httpx client is acquired per
@@ -22,7 +22,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_sto
     InMemoryTokenCacheBackend,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
-    Rfc8693TokenExchanger,
+    OboTokenExchanger,
     SubjectTokenRejected,
     TokenExchangeClientError,
 )
@@ -95,8 +95,8 @@ async def _post_exchange_endpoint(
     return parsed  # pyright: ignore
 
 
-def build_token_exchanger() -> Rfc8693TokenExchanger:
-    return Rfc8693TokenExchanger(
+def build_token_exchanger() -> OboTokenExchanger:
+    return OboTokenExchanger(
         _post_exchange_endpoint,
         cache=InMemoryTokenCacheBackend(max_size=MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE),
         default_ttl_seconds=MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchange_provider.py
@@ -34,21 +34,27 @@ _GATEWAY_FAULT_OAUTH_ERRORS = frozenset(
 )
 
 
-def _oauth_error_code(response: httpx.Response) -> str | None:
-    """Read the RFC 6749 5.2 ``error`` code from a token-endpoint error body, or None if absent.
+def _oauth_error_fields(response: httpx.Response) -> tuple[str | None, str | None]:
+    """Read the RFC 6749 5.2 ``error`` code and the IdP's step-up ``claims`` blob from a
+    token-endpoint error body, as ``(error, claims)`` with None for whatever is absent.
 
-    The ``error_description`` is deliberately not read: it can carry IdP internals and must never
-    reach the caller. Only the standard machine code drives classification.
+    ``claims`` is the Entra Conditional Access / CAE challenge (a JSON string the client must
+    replay to the IdP to satisfy the step-up); it is the caller's own requirement, not an IdP
+    internal, so it may travel to the caller. The ``error_description`` is deliberately not read:
+    it can carry IdP internals and must never reach the caller.
     """
     try:
         body: object = response.json()
     except Exception:  # noqa: BLE001
-        return None
-    if isinstance(body, dict):
-        code = body.get("error")
-        if isinstance(code, str):
-            return code
-    return None
+        return None, None
+    if not isinstance(body, dict):
+        return None, None
+    code = body.get("error")
+    claims = body.get("claims")
+    return (
+        code if isinstance(code, str) else None,
+        claims if isinstance(claims, str) and claims else None,
+    )
 
 
 async def _post_exchange_endpoint(
@@ -72,7 +78,7 @@ async def _post_exchange_endpoint(
     except httpx.HTTPStatusError as status_err:
         status_code = status_err.response.status_code
         if 400 <= status_code < 500:
-            oauth_error = _oauth_error_code(status_err.response)
+            oauth_error, claims = _oauth_error_fields(status_err.response)
             if oauth_error in _GATEWAY_FAULT_OAUTH_ERRORS:
                 verbose_logger.warning(
                     "MCP token exchange rejected as %s (HTTP %d); check the gateway client credentials, "
@@ -81,7 +87,11 @@ async def _post_exchange_endpoint(
                     status_code,
                 )
                 raise TokenExchangeClientError(oauth_error) from status_err
-            raise SubjectTokenRejected(f"IdP rejected the subject token (HTTP {status_code})") from status_err
+            raise SubjectTokenRejected(
+                f"IdP rejected the subject token (HTTP {status_code})",
+                oauth_error=oauth_error,
+                claims=claims,
+            ) from status_err
         verbose_logger.warning("MCP token exchange request failed: %s", status_err)
         return None
     except Exception as exc:  # noqa: BLE001

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -86,14 +86,13 @@ class SubjectTokenRejected(Exception):
     Distinct from a transport / IdP-availability failure, which the post adapter maps to ``None`` ->
     ``upstream_unavailable`` -> 503 (retryable). A rejected subject is the caller's problem, not the
     gateway's, so the arm surfaces it as a non-retryable 401 (the OBO challenge) instead.
-    ``oauth_error`` is the RFC 6749 machine code from the rejection body and ``claims`` the IdP's
-    step-up challenge blob (Entra Conditional Access / CAE); both thread into the 401 challenge so
-    the client can satisfy the step-up. The ``error_description`` is never carried (IdP internals).
+    ``claims`` is the IdP's step-up challenge blob (Entra Conditional Access / CAE) from the
+    rejection body; it threads into the 401 challenge so the client can satisfy the step-up and
+    retry. The ``error_description`` is never carried (it can leak IdP internals).
     """
 
-    def __init__(self, detail: str, *, oauth_error: str | None = None, claims: str | None = None) -> None:
+    def __init__(self, detail: str, *, claims: str | None = None) -> None:
         super().__init__(detail)
-        self.oauth_error = oauth_error
         self.claims = claims
 
 
@@ -319,12 +318,11 @@ class OboTokenExchanger:
         except SubjectTokenRejected as rejected:
             # The IdP rejected the subject token (4xx). This is non-retryable: the caller must
             # re-authenticate with the IdP, so it surfaces as a 401 (the OBO challenge), not a 503.
-            # A step-up rejection (Entra Conditional Access) carries the machine code and claims
-            # blob through so the edge's challenge tells the client how to satisfy it.
+            # A step-up rejection (Entra Conditional Access) carries the claims blob through so the
+            # edge's challenge tells the client how to satisfy it.
             return Error(
                 CredError.of_unauthorized(
                     str(rejected) or "subject token rejected by the IdP",
-                    oauth_error=rejected.oauth_error,
                     claims=rejected.claims,
                 )
             )

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -1,11 +1,14 @@
-"""v2-native RFC 8693 token exchange (OBO): swap the caller's token for an upstream one.
+"""v2-native OBO token exchange: swap the caller's token for an upstream-bound one.
 
-The pure core of the ``token_exchange`` mode. Given the caller's ``subject_token`` and the server's
-``TokenExchangeConfig``, ``Rfc8693TokenExchanger.exchange`` POSTs the RFC 8693 token-exchange grant to
-the configured endpoint and returns the upstream-bound ``access_token`` as a typed ``OAuthToken``, or a
-typed ``CredError`` - never a raise (the HTTP edge is the injected ``ExchangeHttpPost``, whose adapter
-contains the I/O). The exchanged token is cached and single-flighted per ``(subject_token, server)`` so
-a repeated caller token skips the IdP round-trip and concurrent calls collapse to one exchange, reusing
+The pure core of the ``token_exchange`` mode. Given the caller's inbound token and the server's
+``TokenExchangeConfig``, ``OboTokenExchanger.exchange`` POSTs the grant selected by ``config.profile``
+to the configured endpoint and returns the upstream-bound ``access_token`` as a typed ``OAuthToken``,
+or a typed ``CredError`` - never a raise (the HTTP edge is the injected ``ExchangeHttpPost``, whose
+adapter contains the I/O). Two profiles share this one engine: ``rfc8693`` (the RFC 8693 token-exchange
+grant) and ``entra_obo`` (Microsoft Entra On-Behalf-Of, which is the RFC 7523 ``jwt-bearer`` grant);
+only the request form differs, so the cache, single-flight, and TTL machinery are dialect-agnostic. The
+exchanged token is cached and single-flighted per ``(subject_token, tenant, config, server)`` so a
+repeated caller token skips the IdP round-trip and concurrent calls collapse to one exchange, reusing
 the shared in-process cache + coordinator foundation. A rotated caller token hashes to a new key and
 re-exchanges. Pure v2 apart from the shared RFC 6749 client-auth helper, which carries no v1 state.
 
@@ -19,7 +22,9 @@ from __future__ import annotations
 import hashlib
 import time
 from collections.abc import Awaitable, Callable
-from typing import Protocol
+from typing import Literal, Protocol
+
+from typing_extensions import assert_never
 
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
@@ -51,6 +56,10 @@ _MIN_TTL_SECONDS = 10.0
 _EXPIRY_BUFFER_SECONDS = 60.0
 
 _GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+# Microsoft Entra On-Behalf-Of speaks the RFC 7523 jwt-bearer grant, not RFC 8693, and gates delegation
+# behind ``requested_token_use=on_behalf_of`` (a Microsoft extension present in neither RFC).
+_JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+_REQUESTED_TOKEN_USE_OBO = "on_behalf_of"
 
 # RFC 8693 3 token-type URNs that are not usable as an upstream Bearer access token. token_type
 # already rejects the common non-access case (N_A); this catches a malformed STS that mints one of
@@ -106,16 +115,18 @@ class TokenExchanger(Protocol):
 def _cache_key(subject_token: str, tenant_id: str, config: TokenExchangeConfig) -> str:
     """Bind the cache entry to the caller token, the tenant, AND the exchange config that minted it.
 
-    A rotated caller token, a different tenant, endpoint, audience, scope, client_id, secret, auth
-    method, or subject_token_type all change the key, so two tenants behind the same opaque token
-    never share an entry and a config change forces a fresh exchange instead of serving a token
-    minted for the old config until TTL. Everything is hashed, so no secret is held in the key.
+    A rotated caller token, a different tenant, profile, endpoint, audience, scope, client_id, secret,
+    auth method, or subject_token_type all change the key, so two tenants behind the same opaque token
+    never share an entry and a config change (including a profile flip that alters the wire form)
+    forces a fresh exchange instead of serving a token minted for the old config until TTL. Everything
+    is hashed, so no secret is held in the key.
     """
     secret = config.client_secret.get_secret_value() if config.client_secret else ""
     material = "\x00".join(
         (
             subject_token,
             tenant_id,
+            config.profile,
             config.token_exchange_endpoint or "",
             config.audience or "",
             config.subject_token_type,
@@ -141,7 +152,7 @@ def _parse_expires_in(raw: object) -> int | None:
     return None
 
 
-def _build_exchange_form(
+def _rfc8693_form(
     *,
     subject_token: str,
     subject_token_type: str,
@@ -157,8 +168,53 @@ def _build_exchange_form(
     }
 
 
-class Rfc8693TokenExchanger:
-    """``TokenExchanger`` that runs the RFC 8693 grant once per caller token, then caches the result.
+def _entra_obo_form(
+    *,
+    subject_token: str,
+    scopes: tuple[str, ...],
+) -> dict[str, str]:
+    # Microsoft Entra On-Behalf-Of (RFC 7523 jwt-bearer, not RFC 8693): the caller's inbound access
+    # token rides as ``assertion`` (its ``aud`` must be this gateway's ``client_id``); the target
+    # resource is carried in ``scope`` (e.g. api://<app-id>/.default), since Entra has no audience
+    # parameter and ignores subject_token_type; ``requested_token_use=on_behalf_of`` is the Microsoft
+    # extension that turns the jwt-bearer grant into a delegation. ``scope`` is required, and the
+    # exchange precondition rejects an empty one, so it is always present here. Client authentication
+    # (client_id/client_secret via post, or Basic) is layered on by the caller through
+    # build_token_endpoint_client_auth, so it is not built into the form here.
+    return {
+        "grant_type": _JWT_BEARER_GRANT_TYPE,
+        "assertion": subject_token,
+        "scope": " ".join(scopes),
+        "requested_token_use": _REQUESTED_TOKEN_USE_OBO,
+    }
+
+
+def _build_exchange_form(
+    *,
+    profile: Literal["rfc8693", "entra_obo"],
+    subject_token: str,
+    subject_token_type: str,
+    audience: str | None,
+    scopes: tuple[str, ...],
+) -> dict[str, str]:
+    match profile:
+        case "rfc8693":
+            return _rfc8693_form(
+                subject_token=subject_token,
+                subject_token_type=subject_token_type,
+                audience=audience,
+                scopes=scopes,
+            )
+        case "entra_obo":
+            return _entra_obo_form(
+                subject_token=subject_token,
+                scopes=scopes,
+            )
+    assert_never(profile)
+
+
+class OboTokenExchanger:
+    """``TokenExchanger`` that runs the profile's OBO grant once per caller token, then caches the result.
 
     The HTTP post is injected (``None`` on any IdP failure, mirroring v1: a failed exchange is a miss,
     not a 500). The cache and single-flight coordinator default to the in-process foundation; a
@@ -199,6 +255,13 @@ class Rfc8693TokenExchanger:
             )
         if not client_id or client_secret is None:
             return Error(CredError.of_misconfigured("token_exchange requires client_id and client_secret"))
+        if config.profile == "entra_obo" and not config.scopes:
+            # Entra carries the target resource in ``scope`` (api://<app-id>/.default); with no scope the
+            # IdP cannot resolve an audience, so fail closed as misconfigured rather than POST a form the
+            # IdP will reject.
+            return Error(
+                CredError.of_misconfigured("entra_obo token exchange requires a scope (e.g. api://<app-id>/.default)")
+            )
 
         cache_key = _cache_key(subject_token, tenant_id, config)
         server_id = server.server_id
@@ -214,6 +277,7 @@ class Rfc8693TokenExchanger:
         )
         form = {
             **_build_exchange_form(
+                profile=config.profile,
                 subject_token=subject_token,
                 subject_token_type=config.subject_token_type,
                 audience=config.audience,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_exchanger.py
@@ -86,7 +86,15 @@ class SubjectTokenRejected(Exception):
     Distinct from a transport / IdP-availability failure, which the post adapter maps to ``None`` ->
     ``upstream_unavailable`` -> 503 (retryable). A rejected subject is the caller's problem, not the
     gateway's, so the arm surfaces it as a non-retryable 401 (the OBO challenge) instead.
+    ``oauth_error`` is the RFC 6749 machine code from the rejection body and ``claims`` the IdP's
+    step-up challenge blob (Entra Conditional Access / CAE); both thread into the 401 challenge so
+    the client can satisfy the step-up. The ``error_description`` is never carried (IdP internals).
     """
+
+    def __init__(self, detail: str, *, oauth_error: str | None = None, claims: str | None = None) -> None:
+        super().__init__(detail)
+        self.oauth_error = oauth_error
+        self.claims = claims
 
 
 class TokenExchangeClientError(Exception):
@@ -311,7 +319,15 @@ class OboTokenExchanger:
         except SubjectTokenRejected as rejected:
             # The IdP rejected the subject token (4xx). This is non-retryable: the caller must
             # re-authenticate with the IdP, so it surfaces as a 401 (the OBO challenge), not a 503.
-            return Error(CredError.of_unauthorized(str(rejected) or "subject token rejected by the IdP"))
+            # A step-up rejection (Entra Conditional Access) carries the machine code and claims
+            # blob through so the edge's challenge tells the client how to satisfy it.
+            return Error(
+                CredError.of_unauthorized(
+                    str(rejected) or "subject token rejected by the IdP",
+                    oauth_error=rejected.oauth_error,
+                    claims=rejected.claims,
+                )
+            )
         except TokenExchangeClientError:
             # RFC 6749 5.2 gateway-fault code (invalid_client / invalid_target / ...): the caller can't
             # fix it by re-authenticating, so surface a 500 rather than the OBO 401 challenge. The

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
@@ -182,18 +182,27 @@ class ClientCredentialsConfig(BaseModel):
 
 
 class TokenExchangeConfig(BaseModel):
-    """RFC 8693 OBO; swap the caller's live subject_token for a token bound to the upstream's
-    audience. The gateway authenticates to the exchange endpoint as an OAuth client
-    (`client_id`/`client_secret`); the inbound token is sent only to that endpoint, never to the
-    upstream.
+    """OBO: swap the caller's live inbound token for a token bound to the upstream's audience. The
+    gateway authenticates to the exchange endpoint as an OAuth client (`client_id`/`client_secret`);
+    the inbound token is sent only to that endpoint, never to the upstream.
 
-    `audience` is the RFC 8693 target; it is optional and sent only when the operator configured
-    one, since both `audience` and `resource` are optional in the spec and the authorization server
-    applies its own default when neither is sent (fabricating one risks `invalid_target`).
+    `profile` selects the wire dialect, since not every IdP speaks RFC 8693:
+      - `rfc8693` (default) is the standard token-exchange grant: the inbound token is the
+        `subject_token` (typed by `subject_token_type`), the target is the optional `audience`.
+      - `entra_obo` is Microsoft Entra On-Behalf-Of, which is the RFC 7523 `jwt-bearer` grant rather
+        than 8693: the inbound token rides as `assertion`, the target resource is carried in `scopes`
+        (`api://<app-id>/.default`, since Entra has no audience parameter), and the Microsoft-only
+        `requested_token_use=on_behalf_of` extension makes the jwt-bearer grant a delegation.
+        `subject_token_type` and `audience` are unused in this profile.
+
+    `audience` (rfc8693 only) is optional and sent only when the operator configured one, since both
+    `audience` and `resource` are optional in RFC 8693 and the authorization server applies its own
+    default when neither is sent (fabricating one risks `invalid_target`).
     """
 
     model_config = ConfigDict(frozen=True)
     kind: Literal[AuthSpecKind.token_exchange] = AuthSpecKind.token_exchange
+    profile: Literal["rfc8693", "entra_obo"] = "rfc8693"
     subject_token_type: str = "urn:ietf:params:oauth:token-type:access_token"
     token_exchange_endpoint: str | None = None
     audience: str | None = None

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
@@ -67,11 +67,17 @@ class Unauthorized:
 
     ``detail`` is the human message; ``www_authenticate`` and ``body`` carry a scheme-specific
     challenge (e.g. BYOK's provisioning prompt) so the edge can reproduce it verbatim.
+    ``oauth_error`` and ``claims`` carry an IdP step-up challenge (e.g. Entra Conditional Access
+    ``interaction_required`` with its claims blob) so the edge can fold them into the
+    ``WWW-Authenticate`` it builds; the client replays the claims to the IdP to satisfy the
+    step-up, then retries with the fresh token.
     """
 
     detail: str
     www_authenticate: str | None = None
     body: Mapping[str, str] | None = None
+    oauth_error: str | None = None
+    claims: str | None = None
 
 
 @tagged_union(frozen=True)
@@ -104,8 +110,18 @@ class CredError:
         *,
         www_authenticate: str | None = None,
         body: Mapping[str, str] | None = None,
+        oauth_error: str | None = None,
+        claims: str | None = None,
     ) -> CredError:
-        return CredError(unauthorized=Unauthorized(detail=detail, www_authenticate=www_authenticate, body=body))
+        return CredError(
+            unauthorized=Unauthorized(
+                detail=detail,
+                www_authenticate=www_authenticate,
+                body=body,
+                oauth_error=oauth_error,
+                claims=claims,
+            )
+        )
 
     @staticmethod
     def of_misconfigured(detail: str) -> CredError:

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
@@ -67,16 +67,14 @@ class Unauthorized:
 
     ``detail`` is the human message; ``www_authenticate`` and ``body`` carry a scheme-specific
     challenge (e.g. BYOK's provisioning prompt) so the edge can reproduce it verbatim.
-    ``oauth_error`` and ``claims`` carry an IdP step-up challenge (e.g. Entra Conditional Access
-    ``interaction_required`` with its claims blob) so the edge can fold them into the
-    ``WWW-Authenticate`` it builds; the client replays the claims to the IdP to satisfy the
-    step-up, then retries with the fresh token.
+    ``claims`` carries an IdP step-up challenge (e.g. Entra Conditional Access) so the edge can
+    fold it into the ``WWW-Authenticate`` it builds; the client replays the claims to the IdP to
+    satisfy the step-up, then retries with the fresh token.
     """
 
     detail: str
     www_authenticate: str | None = None
     body: Mapping[str, str] | None = None
-    oauth_error: str | None = None
     claims: str | None = None
 
 
@@ -110,7 +108,6 @@ class CredError:
         *,
         www_authenticate: str | None = None,
         body: Mapping[str, str] | None = None,
-        oauth_error: str | None = None,
         claims: str | None = None,
     ) -> CredError:
         return CredError(
@@ -118,7 +115,6 @@ class CredError:
                 detail=detail,
                 www_authenticate=www_authenticate,
                 body=body,
-                oauth_error=oauth_error,
                 claims=claims,
             )
         )

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -142,6 +142,13 @@ class MCPCredentials(TypedDict, total=False):
     sends HTTP Basic; defaults to "client_secret_post" when unset.
     """
 
+    token_exchange_profile: Optional[str]
+    """
+    Token exchange wire dialect: "rfc8693" (default, the standard token-exchange grant) or
+    "entra_obo" (Microsoft Entra On-Behalf-Of, the RFC 7523 jwt-bearer grant + requested_token_use
+    extension). Not a secret; stored unencrypted.
+    """
+
 
 class MCPServerCostInfo(TypedDict, total=False):
     default_cost_per_query: Optional[float]

--- a/litellm/types/mcp_server/mcp_server_manager.py
+++ b/litellm/types/mcp_server/mcp_server_manager.py
@@ -65,10 +65,13 @@ class MCPServer(BaseModel):
     aws_service_name: Optional[str] = None  # defaults to "bedrock-agentcore"
     aws_role_name: Optional[str] = None  # IAM role ARN for STS AssumeRole
     aws_session_name: Optional[str] = None  # session name for CloudTrail auditing
-    # Token Exchange (OBO) fields — RFC 8693
+    # Token Exchange (OBO) fields
     token_exchange_endpoint: Optional[str] = None
     audience: Optional[str] = None
     subject_token_type: str = "urn:ietf:params:oauth:token-type:access_token"
+    # Wire dialect: "rfc8693" (standard token-exchange grant) or "entra_obo" (Microsoft Entra
+    # On-Behalf-Of, the RFC 7523 jwt-bearer grant + requested_token_use extension)
+    token_exchange_profile: str = "rfc8693"
     # Stdio-specific fields
     command: Optional[str] = None
     args: Optional[List[str]] = None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -160,6 +160,50 @@ def test_token_exchange_with_creds_but_no_endpoint_is_owned_for_fail_closed():
     assert spec.config.token_exchange_endpoint is None
 
 
+def test_token_exchange_maps_entra_obo_profile():
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+            client_id="cid",
+            client_secret="csec",
+            token_exchange_profile="entra_obo",
+            scopes=["api://target/.default"],
+        )
+    )
+    assert spec is not None and isinstance(spec.config, TokenExchangeConfig)
+    assert spec.config.profile == "entra_obo"
+
+
+def test_token_exchange_defaults_to_rfc8693_profile():
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+    )
+    assert spec is not None and isinstance(spec.config, TokenExchangeConfig)
+    assert spec.config.profile == "rfc8693"
+
+
+@pytest.mark.parametrize("bogus", ["", "RFC8693", "jwt_bearer", "entra", "unknown"])
+def test_token_exchange_unknown_profile_normalizes_to_rfc8693(bogus):
+    # A bad DB/config value must normalize to rfc8693, not raise a ValidationError building the spec.
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp/token",
+            client_id="cid",
+            client_secret="csec",
+            token_exchange_profile=bogus,
+        )
+    )
+    assert spec is not None and isinstance(spec.config, TokenExchangeConfig)
+    assert spec.config.profile == "rfc8693"
+
+
 def test_token_exchange_omits_audience_when_unset():
     spec = to_server_spec(
         _server(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -390,38 +390,19 @@ def test_raise_token_exchange_challenge_static_form_is_unchanged_without_step_up
     )
 
 
-def test_raise_token_exchange_challenge_folds_step_up_error_and_claims():
+def test_raise_token_exchange_challenge_uses_insufficient_claims_with_claims_present():
+    # Per the Microsoft claims-challenge format, a claims challenge MUST use error=insufficient_claims
+    # (the value MSAL-family clients key on), and the claims ride base64-encoded, never raw.
     from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
         raise_token_exchange_challenge,
     )
 
     claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
     with pytest.raises(HTTPException) as exc_info:
-        raise_token_exchange_challenge(
-            _server(alias="obo-srv"),
-            root_path="",
-            oauth_error="interaction_required",
-            claims=claims,
-        )
+        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="", claims=claims)
     www = exc_info.value.headers["WWW-Authenticate"]
     assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo-srv"' in www
-    assert 'error="interaction_required"' in www
+    assert 'error="insufficient_claims"' in www
+    assert 'error="invalid_token"' not in www
     assert f'claims="{base64.b64encode(claims.encode()).decode()}"' in www
-    assert claims not in www
-
-
-@pytest.mark.parametrize(
-    "hostile",
-    ['x" y', "a\r\nSet-Cookie: p=1", "with space", "x" * 65],
-    ids=["quote", "crlf", "space", "overlong"],
-)
-def test_raise_token_exchange_challenge_rejects_non_token_error_codes(hostile):
-    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
-        raise_token_exchange_challenge,
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="", oauth_error=hostile)
-    www = exc_info.value.headers["WWW-Authenticate"]
-    assert 'error="invalid_token"' in www
-    assert hostile not in www
+    assert claims not in www  # raw JSON never appears; only the base64 form

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -374,3 +374,54 @@ def test_raise_token_exchange_challenge_includes_server_root_path():
         raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="/api/v1")
     www = exc_info.value.headers["WWW-Authenticate"]
     assert 'resource_metadata="/.well-known/oauth-protected-resource/api/v1/mcp/obo-srv"' in www
+
+
+def test_raise_token_exchange_challenge_static_form_is_unchanged_without_step_up():
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+        raise_token_exchange_challenge,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="")
+    assert exc_info.value.headers["WWW-Authenticate"] == (
+        'Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/obo-srv", '
+        'error="invalid_token", '
+        'error_description="Missing or invalid subject token; authenticate with the IdP and retry"'
+    )
+
+
+def test_raise_token_exchange_challenge_folds_step_up_error_and_claims():
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+        raise_token_exchange_challenge,
+    )
+
+    claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
+    with pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(
+            _server(alias="obo-srv"),
+            root_path="",
+            oauth_error="interaction_required",
+            claims=claims,
+        )
+    www = exc_info.value.headers["WWW-Authenticate"]
+    assert 'resource_metadata="/.well-known/oauth-protected-resource/mcp/obo-srv"' in www
+    assert 'error="interaction_required"' in www
+    assert f'claims="{base64.b64encode(claims.encode()).decode()}"' in www
+    assert claims not in www
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ['x" y', "a\r\nSet-Cookie: p=1", "with space", "x" * 65],
+    ids=["quote", "crlf", "space", "overlong"],
+)
+def test_raise_token_exchange_challenge_rejects_non_token_error_codes(hostile):
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import (
+        raise_token_exchange_challenge,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        raise_token_exchange_challenge(_server(alias="obo-srv"), root_path="", oauth_error=hostile)
+    www = exc_info.value.headers["WWW-Authenticate"]
+    assert 'error="invalid_token"' in www
+    assert hostile not in www

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
@@ -131,17 +131,15 @@ async def test_post_threads_step_up_error_and_claims_into_subject_rejected():
     with patch(_HTTP_CLIENT, return_value=_client_raising_4xx(body)):
         with pytest.raises(SubjectTokenRejected) as exc_info:
             await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
-    assert exc_info.value.oauth_error == "interaction_required"
     assert exc_info.value.claims == claims
     assert "AADSTS50079" not in str(exc_info.value)
 
 
 @pytest.mark.asyncio
-async def test_post_subject_rejection_without_claims_carries_none_fields():
+async def test_post_subject_rejection_without_claims_carries_none_claims():
     with patch(_HTTP_CLIENT, return_value=_client_raising_4xx({"error": "invalid_grant"})):
         with pytest.raises(SubjectTokenRejected) as exc_info:
             await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
-    assert exc_info.value.oauth_error == "invalid_grant"
     assert exc_info.value.claims is None
 
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
@@ -116,3 +116,40 @@ async def test_post_returns_none_on_non_object_json(payload):
     with patch(_HTTP_CLIENT, return_value=_Client()):
         result = await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_post_threads_step_up_error_and_claims_into_subject_rejected():
+    # Entra Conditional Access: the 4xx body's machine code and claims blob must ride on the
+    # rejection so the edge challenge can drive the client's step-up; error_description never does.
+    claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
+    body = {
+        "error": "interaction_required",
+        "error_description": "AADSTS50079: the user must enroll MFA",
+        "claims": claims,
+    }
+    with patch(_HTTP_CLIENT, return_value=_client_raising_4xx(body)):
+        with pytest.raises(SubjectTokenRejected) as exc_info:
+            await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
+    assert exc_info.value.oauth_error == "interaction_required"
+    assert exc_info.value.claims == claims
+    assert "AADSTS50079" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_post_subject_rejection_without_claims_carries_none_fields():
+    with patch(_HTTP_CLIENT, return_value=_client_raising_4xx({"error": "invalid_grant"})):
+        with pytest.raises(SubjectTokenRejected) as exc_info:
+            await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})
+    assert exc_info.value.oauth_error == "invalid_grant"
+    assert exc_info.value.claims is None
+
+
+@pytest.mark.asyncio
+async def test_post_gateway_fault_still_wins_when_claims_are_present():
+    # A gateway-fault code stays a 500-class TokenExchangeClientError even if the body carries
+    # claims; the caller cannot fix invalid_client by stepping up.
+    body = {"error": "invalid_client", "claims": '{"access_token":{}}'}
+    with patch(_HTTP_CLIENT, return_value=_client_raising_4xx(body)):
+        with pytest.raises(TokenExchangeClientError):
+            await _post_exchange_endpoint("https://idp/token", {"grant_type": "x"}, {})

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchange_provider.py
@@ -13,7 +13,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchange_
     build_token_exchanger,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
-    Rfc8693TokenExchanger,
+    OboTokenExchanger,
     SubjectTokenRejected,
     TokenExchangeClientError,
 )
@@ -41,7 +41,7 @@ def _client_raising_4xx(body: object):
 
 
 def test_build_token_exchanger_returns_an_exchanger():
-    assert isinstance(build_token_exchanger(), Rfc8693TokenExchanger)
+    assert isinstance(build_token_exchanger(), OboTokenExchanger)
 
 
 def test_build_gives_each_caller_an_independent_cache():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -1,6 +1,6 @@
 """Tests for the pure RFC 8693 token exchanger: the OBO swap, caching, and single-flight.
 
-Drives `Rfc8693TokenExchanger` through an injected fake HTTP post and clock, so the exchange, the
+Drives `OboTokenExchanger` through an injected fake HTTP post and clock, so the exchange, the
 form it sends, the per-caller-token cache, and the failure mapping are pinned without a live IdP.
 """
 
@@ -15,7 +15,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials import (
     ServerSpec,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
-    Rfc8693TokenExchanger,
+    OboTokenExchanger,
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     TokenExchangeConfig,
@@ -31,6 +31,18 @@ _CONFIG = TokenExchangeConfig(
     scopes=("s1", "s2"),
 )
 _SERVER = ServerSpec(server_id="srv", resource="https://up.example.com", config=_CONFIG)
+
+_JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+# audience + a non-default subject_token_type are set deliberately: the entra_obo form must drop both.
+_ENTRA_CONFIG = TokenExchangeConfig(
+    profile="entra_obo",
+    token_exchange_endpoint="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+    audience="ignored-in-entra-obo",
+    subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+    client_id="cid",
+    client_secret=SecretStr("csec"),
+    scopes=("api://target-api/.default",),
+)
 
 
 class _Clock:
@@ -60,7 +72,7 @@ def _spec(config: TokenExchangeConfig) -> ServerSpec:
 @pytest.mark.asyncio
 async def test_exchange_emits_token_and_sends_rfc8693_form():
     post = _RecordingPost({"access_token": "exchanged", "expires_in": 3600})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("caller-jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("caller-jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok)
     assert result.ok.access_token == "exchanged"
     url, form = post.calls[0]
@@ -89,7 +101,7 @@ async def test_client_secret_basic_sends_authorization_header_and_omits_body_cre
         token_endpoint_auth_method="client_secret_basic",
     )
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     assert isinstance(result, Ok)
     _, form = post.calls[0]
     assert "client_id" not in form and "client_secret" not in form
@@ -105,7 +117,7 @@ async def test_client_secret_post_keeps_creds_in_body_with_no_auth_header():
         token_endpoint_auth_method="client_secret_post",
     )
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     _, form = post.calls[0]
     assert form["client_id"] == "cid" and form["client_secret"] == "csec"
     assert "Authorization" not in post.headers[0]
@@ -122,7 +134,7 @@ async def test_exchange_maps_idp_rejection_to_unauthorized():
     async def _rejecting_post(url, form, headers):
         raise SubjectTokenRejected("IdP rejected the token exchange (HTTP 400)")
 
-    result = await Rfc8693TokenExchanger(_rejecting_post, clock=_Clock()).exchange("bad-jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(_rejecting_post, clock=_Clock()).exchange("bad-jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "unauthorized"
 
@@ -139,7 +151,7 @@ async def test_exchange_maps_gateway_fault_to_misconfigured():
     async def _client_error_post(url, form, headers):
         raise TokenExchangeClientError("invalid_client")
 
-    result = await Rfc8693TokenExchanger(_client_error_post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(_client_error_post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "misconfigured"
 
@@ -147,7 +159,7 @@ async def test_exchange_maps_gateway_fault_to_misconfigured():
 @pytest.mark.asyncio
 async def test_exchange_maps_transport_failure_to_upstream_unavailable():
     """A post returning None (5xx / network / timeout / malformed body) stays retryable: 503."""
-    result = await Rfc8693TokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 
@@ -155,7 +167,7 @@ async def test_exchange_maps_transport_failure_to_upstream_unavailable():
 @pytest.mark.asyncio
 async def test_exchange_caches_per_caller_token():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     second = await exchanger.exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(second, Ok) and second.ok.access_token == "x"
@@ -165,7 +177,7 @@ async def test_exchange_caches_per_caller_token():
 @pytest.mark.asyncio
 async def test_rotated_caller_token_re_exchanges():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     await exchanger.exchange("jwt-1", _SERVER, _CONFIG)
     await exchanger.exchange("jwt-2", _SERVER, _CONFIG)
     assert len(post.calls) == 2
@@ -176,7 +188,7 @@ async def test_same_token_different_tenant_does_not_share_cache():
     # Two tenants presenting the same opaque token (e.g. a shared/service token) must not collide on
     # one cache entry: tenant_id is part of the key, so each tenant gets its own exchange.
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="globex")
     assert len(post.calls) == 2
@@ -188,7 +200,7 @@ async def test_same_token_different_tenant_does_not_share_cache():
 @pytest.mark.asyncio
 async def test_invalidate_forces_re_exchange():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
     await exchanger.invalidate("jwt", _SERVER, _CONFIG, tenant_id="acme")
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
@@ -198,7 +210,7 @@ async def test_invalidate_forces_re_exchange():
 @pytest.mark.asyncio
 async def test_invalidate_targets_only_the_matching_tenant():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="acme")
     await exchanger.exchange("jwt", _SERVER, _CONFIG, tenant_id="globex")
     await exchanger.invalidate("jwt", _SERVER, _CONFIG, tenant_id="acme")
@@ -213,7 +225,7 @@ async def test_rotated_config_re_exchanges_before_ttl():
     # Same caller token + server, but the operator rotated the audience/scope: the cached token was
     # minted for the old config, so it must re-exchange (not serve the stale token) before TTL.
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     rotated = _CONFIG.model_copy(update={"audience": "https://new.example.com", "scopes": ("s3",)})
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     await exchanger.exchange("jwt", _SERVER, rotated)
@@ -226,7 +238,7 @@ async def test_rotated_config_re_exchanges_before_ttl():
 @pytest.mark.asyncio
 async def test_rotated_token_endpoint_auth_method_re_exchanges_before_ttl():
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     rotated = _CONFIG.model_copy(update={"token_endpoint_auth_method": "client_secret_basic"})
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     await exchanger.exchange("jwt", _SERVER, rotated)
@@ -251,7 +263,7 @@ async def test_concurrent_callers_single_flight_one_exchange():
             return {"access_token": "x", "expires_in": 3600}
 
     post = _Blocking()
-    exchanger = Rfc8693TokenExchanger(post, clock=_Clock())
+    exchanger = OboTokenExchanger(post, clock=_Clock())
     first = asyncio.create_task(exchanger.exchange("jwt", _SERVER, _CONFIG))
     second = asyncio.create_task(exchanger.exchange("jwt", _SERVER, _CONFIG))
     await asyncio.sleep(0.02)
@@ -263,7 +275,7 @@ async def test_concurrent_callers_single_flight_one_exchange():
 
 @pytest.mark.asyncio
 async def test_idp_failure_is_upstream_unavailable():
-    result = await Rfc8693TokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(_RecordingPost(None), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 
@@ -271,7 +283,7 @@ async def test_idp_failure_is_upstream_unavailable():
 @pytest.mark.asyncio
 async def test_missing_access_token_is_upstream_unavailable():
     post = _RecordingPost({"token_type": "Bearer"})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 
@@ -282,7 +294,7 @@ async def test_non_bearer_token_type_is_refused(token_type):
     # RFC 8693 2.2.1: the resolver forwards the exchanged token as `Bearer`. A non-Bearer token_type
     # (e.g. N_A = not a standalone access token) must fail closed, not be minted as a bogus Bearer.
     post = _RecordingPost({"access_token": "x", "token_type": token_type, "expires_in": 3600})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 
@@ -295,7 +307,7 @@ async def test_non_bearer_token_type_is_logged():
     with patch(
         "litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger.verbose_logger"
     ) as mock_logger:
-        await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+        await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert mock_logger.warning.called
     assert "N_A" in repr(mock_logger.warning.call_args)
 
@@ -304,7 +316,7 @@ async def test_non_bearer_token_type_is_logged():
 @pytest.mark.parametrize("token_type", ["Bearer", "bearer", "BEARER"])
 async def test_bearer_token_type_is_accepted_case_insensitively(token_type):
     post = _RecordingPost({"access_token": "x", "token_type": token_type, "expires_in": 3600})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok) and result.ok.access_token == "x"
 
 
@@ -312,7 +324,7 @@ async def test_bearer_token_type_is_accepted_case_insensitively(token_type):
 async def test_absent_token_type_defaults_to_bearer():
     # Many IdPs omit token_type; absence must not fail the exchange (RFC 6750 default is Bearer).
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok) and result.ok.access_token == "x"
 
 
@@ -331,7 +343,7 @@ async def test_non_access_issued_token_type_is_refused_even_when_bearer(issued_t
     post = _RecordingPost(
         {"access_token": "x", "token_type": "Bearer", "issued_token_type": issued_token_type, "expires_in": 3600}
     )
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "upstream_unavailable"
 
@@ -347,7 +359,7 @@ async def test_access_or_unknown_issued_token_type_is_accepted(issued_token_type
     body: dict[str, object] = {"access_token": "x", "token_type": "Bearer", "expires_in": 3600}
     if issued_token_type is not None:
         body["issued_token_type"] = issued_token_type
-    result = await Rfc8693TokenExchanger(_RecordingPost(body), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    result = await OboTokenExchanger(_RecordingPost(body), clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok) and result.ok.access_token == "x"
 
 
@@ -361,7 +373,7 @@ async def test_access_or_unknown_issued_token_type_is_accepted(issued_token_type
 )
 async def test_incomplete_config_is_misconfigured_without_hitting_idp(config):
     post = _RecordingPost({"access_token": "x"})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     assert isinstance(result, Error)
     assert result.error.tag == "misconfigured"
     assert post.calls == []
@@ -373,7 +385,7 @@ async def test_missing_endpoint_is_precondition_required_without_hitting_idp():
     # rather than guessing an IdP or falling back. The subject token is never POSTed anywhere.
     config = TokenExchangeConfig(client_id="c", client_secret=SecretStr("s"))
     post = _RecordingPost({"access_token": "x"})
-    result = await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     assert isinstance(result, Error)
     assert result.error.tag == "precondition_required"
     assert post.calls == []
@@ -384,7 +396,7 @@ async def test_cached_token_expires_after_its_ttl():
     clock = _Clock(1000.0)
     # expires_in=120, buffer=60 -> ttl 60 -> cached until t=1060.
     post = _RecordingPost({"access_token": "x", "expires_in": 120})
-    exchanger = Rfc8693TokenExchanger(post, clock=clock)
+    exchanger = OboTokenExchanger(post, clock=clock)
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     clock.now = 1059.0
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
@@ -402,7 +414,7 @@ async def test_audience_and_scope_omitted_when_unset():
         client_secret=SecretStr("csec"),
     )
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    await Rfc8693TokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
     _, form = post.calls[0]
     assert "audience" not in form
     assert "scope" not in form
@@ -414,7 +426,7 @@ async def test_numeric_expires_in_is_honored(expires_in):
     # A JSON int/float/numeric-string expires_in must drive the TTL, not fall back to the default.
     clock = _Clock(1000.0)
     post = _RecordingPost({"access_token": "x", "expires_in": expires_in})
-    exchanger = Rfc8693TokenExchanger(post, clock=clock)  # ttl = max(120-60, 10) = 60 -> until 1060
+    exchanger = OboTokenExchanger(post, clock=clock)  # ttl = max(120-60, 10) = 60 -> until 1060
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     clock.now = 1061.0
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
@@ -426,7 +438,7 @@ async def test_short_lived_token_is_not_cached_past_its_expiry():
     # expires_in (5s) below the buffer/min floor must NOT be served stale: cache only until expiry.
     clock = _Clock(1000.0)
     post = _RecordingPost({"access_token": "x", "expires_in": 5})
-    exchanger = Rfc8693TokenExchanger(post, clock=clock)
+    exchanger = OboTokenExchanger(post, clock=clock)
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     clock.now = 1004.0  # within the 5s lifetime -> still cached
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
@@ -449,11 +461,70 @@ async def test_short_lived_token_is_not_cached_past_its_expiry():
 async def test_unusable_expires_in_falls_back_to_default_ttl(body):
     clock = _Clock(1000.0)
     post = _RecordingPost(body)
-    exchanger = Rfc8693TokenExchanger(post, clock=clock, default_ttl_seconds=300.0)
+    exchanger = OboTokenExchanger(post, clock=clock, default_ttl_seconds=300.0)
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     clock.now = 1299.0
     await exchanger.exchange("jwt", _SERVER, _CONFIG)
     assert len(post.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_entra_obo_emits_rfc7523_jwt_bearer_form():
+    # Microsoft Entra OBO is the RFC 7523 jwt-bearer grant, not RFC 8693: the inbound token is the
+    # `assertion`, the target rides in `scope`, and `requested_token_use=on_behalf_of` is required.
+    # subject_token / subject_token_type / audience must NOT appear even though the config carries them.
+    post = _RecordingPost({"access_token": "minted", "expires_in": 3600})
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange(
+        "caller-entra-jwt", _spec(_ENTRA_CONFIG), _ENTRA_CONFIG
+    )
+    assert isinstance(result, Ok)
+    assert result.ok.access_token == "minted"
+    url, form = post.calls[0]
+    assert url == "https://login.microsoftonline.com/tid/oauth2/v2.0/token"
+    assert form == {
+        "grant_type": _JWT_BEARER_GRANT,
+        "assertion": "caller-entra-jwt",
+        "client_id": "cid",
+        "client_secret": "csec",
+        "scope": "api://target-api/.default",
+        "requested_token_use": "on_behalf_of",
+    }
+
+
+@pytest.mark.asyncio
+async def test_entra_obo_without_scope_is_misconfigured_without_hitting_idp():
+    # Entra carries the target resource in `scope`; with none, fail closed as misconfigured and never
+    # POST to the IdP (no fall-through to a weaker source).
+    config = TokenExchangeConfig(
+        profile="entra_obo",
+        token_exchange_endpoint="https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+        client_id="cid",
+        client_secret=SecretStr("csec"),
+    )
+    post = _RecordingPost({"access_token": "x"})
+    result = await OboTokenExchanger(post, clock=_Clock()).exchange("jwt", _spec(config), config)
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+    assert post.calls == []
+
+
+@pytest.mark.asyncio
+async def test_profile_is_part_of_the_cache_key():
+    # Same caller token, tenant, endpoint, creds, and scopes; only the profile differs. The two dialects
+    # mint different upstream tokens, so they must not collide on one cache entry.
+    post = _RecordingPost({"access_token": "x", "expires_in": 3600})
+    exchanger = OboTokenExchanger(post, clock=_Clock())
+    shared = dict(
+        token_exchange_endpoint="https://idp/token",
+        client_id="cid",
+        client_secret=SecretStr("csec"),
+        scopes=("api://target/.default",),
+    )
+    rfc8693 = TokenExchangeConfig(profile="rfc8693", **shared)
+    entra = TokenExchangeConfig(profile="entra_obo", **shared)
+    await exchanger.exchange("jwt", _spec(rfc8693), rfc8693)
+    await exchanger.exchange("jwt", _spec(entra), entra)
+    assert len(post.calls) == 2
 
 
 @pytest.mark.asyncio
@@ -470,7 +541,7 @@ async def test_distributed_coordinator_refresh_and_reread_use_the_cache():
             return via_reread
 
     post = _RecordingPost({"access_token": "x", "expires_in": 3600})
-    exchanger = Rfc8693TokenExchanger(post, coordinator=_ReplayCoordinator(), clock=_Clock())
+    exchanger = OboTokenExchanger(post, coordinator=_ReplayCoordinator(), clock=_Clock())
     result = await exchanger.exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok) and result.ok.access_token == "x"
     assert len(post.calls) == 1

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -548,7 +548,7 @@ async def test_distributed_coordinator_refresh_and_reread_use_the_cache():
 
 
 @pytest.mark.asyncio
-async def test_step_up_rejection_threads_error_and_claims_into_unauthorized():
+async def test_step_up_rejection_threads_claims_into_unauthorized():
     from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
         SubjectTokenRejected,
     )
@@ -556,14 +556,9 @@ async def test_step_up_rejection_threads_error_and_claims_into_unauthorized():
     claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
 
     async def _step_up_post(url, form, headers):
-        raise SubjectTokenRejected(
-            "IdP rejected the subject token (HTTP 400)",
-            oauth_error="interaction_required",
-            claims=claims,
-        )
+        raise SubjectTokenRejected("IdP rejected the subject token (HTTP 400)", claims=claims)
 
     result = await OboTokenExchanger(_step_up_post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Error)
     assert result.error.tag == "unauthorized"
-    assert result.error.unauthorized.oauth_error == "interaction_required"
     assert result.error.unauthorized.claims == claims

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_exchanger.py
@@ -545,3 +545,25 @@ async def test_distributed_coordinator_refresh_and_reread_use_the_cache():
     result = await exchanger.exchange("jwt", _SERVER, _CONFIG)
     assert isinstance(result, Ok) and result.ok.access_token == "x"
     assert len(post.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_step_up_rejection_threads_error_and_claims_into_unauthorized():
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
+        SubjectTokenRejected,
+    )
+
+    claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
+
+    async def _step_up_post(url, form, headers):
+        raise SubjectTokenRejected(
+            "IdP rejected the subject token (HTTP 400)",
+            oauth_error="interaction_required",
+            claims=claims,
+        )
+
+    result = await OboTokenExchanger(_step_up_post, clock=_Clock()).exchange("jwt", _SERVER, _CONFIG)
+    assert isinstance(result, Error)
+    assert result.error.tag == "unauthorized"
+    assert result.error.unauthorized.oauth_error == "interaction_required"
+    assert result.error.unauthorized.claims == claims

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -718,6 +718,41 @@ class TestMCPServerManager:
             client_secret="csec",
         )
 
+    @pytest.mark.asyncio
+    async def test_entra_obo_profile_survives_db_credentials_round_trip(self):
+        # A credentials blob from the management API / DB carries token_exchange_profile; the DB build
+        # must reconstruct it onto the MCPServer, and the v2 adapter must map it onto the resolver
+        # config. Without threading it through, an entra_obo server persisted via the API silently
+        # falls back to rfc8693 and posts the wrong grant to the IdP.
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import to_server_spec
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.types import TokenExchangeConfig
+
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="entra-db-1",
+            alias="entra_db",
+            description="entra obo from db",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            credentials={
+                "client_id": "cid",
+                "client_secret": "csec",
+                "token_exchange_endpoint": "https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+                "scopes": ["api://target/.default"],
+                "token_exchange_profile": "entra_obo",
+            },
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+        assert built.token_exchange_profile == "entra_obo"
+
+        spec = to_server_spec(built)
+        assert spec is not None and isinstance(spec.config, TokenExchangeConfig)
+        assert spec.config.profile == "entra_obo"
+
     async def _capture_subject_token(self, call) -> Optional[str]:
         """Run a manager method (via ``call(manager)``) and return the subject_token it threaded
         into ``_create_mcp_client``."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5948,3 +5948,78 @@ class TestOBOEndpointDiscovery:
 
 if __name__ == "__main__":
     pytest.main([__file__])
+
+
+@pytest.mark.asyncio
+async def test_preflight_challenge_carries_step_up_error_and_claims():
+    """An Entra Conditional Access rejection must surface its machine code and base64 claims in the
+    single-server 401 challenge, so an MSAL-family client can drive the step-up and retry."""
+    import base64
+
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Error
+    from litellm.proxy._experimental.mcp_server.outbound_credentials.types import CredError
+
+    claims = '{"access_token":{"acrs":{"essential":true,"value":"c1"}}}'
+
+    class _FakeProvider:
+        async def resolve_credentials(self, subject, server):
+            return Error(
+                CredError.of_unauthorized(
+                    "step-up required",
+                    oauth_error="interaction_required",
+                    claims=claims,
+                )
+            )
+
+    manager = MCPServerManager(cred_provider=_FakeProvider())
+    server = MCPServer(
+        server_id="te-ca",
+        name="te-ca-server",
+        url="https://up.example.com/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2_token_exchange,
+        token_exchange_endpoint="https://idp.example.com/token",
+        client_id="cid",
+        client_secret="csec",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await manager.preflight_token_exchange(
+            server=server,
+            oauth2_headers={"Authorization": "Bearer subj"},
+            user_api_key_auth=None,
+        )
+    assert exc_info.value.status_code == 401
+    headers = exc_info.value.headers or {}
+    www = headers.get("WWW-Authenticate") or headers.get("www-authenticate") or ""
+    assert 'error="interaction_required"' in www
+    assert base64.b64encode(claims.encode()).decode() in www
+    assert "resource_metadata" in www
+
+
+@pytest.mark.asyncio
+async def test_aggregate_list_still_absorbs_step_up_challenged_server():
+    """A step-up (claims-bearing) 401 from one server must not change the aggregate contract: the
+    multi-server listing still absorbs it and returns the healthy servers' tools."""
+    from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
+
+    manager = MCPServerManager()
+    good = MCPServer(server_id="good", name="good", transport=MCPTransport.http)
+    ca = MCPServer(server_id="ca", name="ca", transport=MCPTransport.http)
+    manager.get_allowed_mcp_servers = AsyncMock(return_value=["good", "ca"])
+    manager.get_mcp_server_by_id = MagicMock(side_effect=lambda server_id: {"good": good, "ca": ca}.get(server_id))
+    good_tool = MCPTool(name="good-do_thing", description="do thing", inputSchema={})
+
+    async def fake_get_tools(server, **kwargs):
+        if server.server_id == "ca":
+            raise MCPUpstreamAuthError(
+                status_code=401,
+                www_authenticate=('Bearer resource_metadata="/x", error="interaction_required", claims="eyJhIjoxfQ=="'),
+                server_name="ca",
+            )
+        return [good_tool]
+
+    manager._get_tools_from_server = fake_get_tools
+
+    result = await manager.list_tools()
+
+    assert [t.name for t in result] == ["good-do_thing"]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1651,6 +1651,47 @@ class TestMCPServerManager:
         assert server.registration_url == "https://discovered.example.com/register"
 
     @pytest.mark.asyncio
+    async def test_load_servers_from_config_filters_blank_scopes(self):
+        """A YAML ``scopes: [""]`` must normalize to None (matching the DB path), so a blank-only
+        list never becomes a ``("",)`` tuple that skips the entra_obo fail-closed scope check."""
+        manager = MCPServerManager()
+        config = {
+            "entra": {
+                "url": "https://up.example.com/mcp",
+                "transport": MCPTransport.http,
+                "auth_type": MCPAuth.oauth2_token_exchange,
+                "token_exchange_profile": "entra_obo",
+                "token_exchange_endpoint": "https://login.microsoftonline.com/t/oauth2/v2.0/token",
+                "client_id": "cid",
+                "client_secret": "csec",
+                "scopes": ["", "  "],
+            }
+        }
+
+        await manager.load_servers_from_config(config)
+
+        server = next(iter(manager.config_mcp_servers.values()))
+        assert server.scopes is None
+
+        # And the exchange precondition now fails closed before any IdP call.
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import to_server_spec
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Error
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchanger import (
+            OboTokenExchanger,
+        )
+
+        spec = to_server_spec(server)
+        assert spec is not None
+        assert spec.config.scopes == ()
+
+        async def _must_not_post(url, form, headers):
+            raise AssertionError("entra_obo with blank scopes must fail closed before POSTing to the IdP")
+
+        result = await OboTokenExchanger(_must_not_post).exchange("subj", spec, spec.config)
+        assert isinstance(result, Error)
+        assert result.error.tag == "misconfigured"
+
+    @pytest.mark.asyncio
     async def test_config_oauth_initialize_tool_name_to_mcp_server_name_mapping(self):
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -5952,8 +5952,8 @@ if __name__ == "__main__":
 
 @pytest.mark.asyncio
 async def test_preflight_challenge_carries_step_up_error_and_claims():
-    """An Entra Conditional Access rejection must surface its machine code and base64 claims in the
-    single-server 401 challenge, so an MSAL-family client can drive the step-up and retry."""
+    """An Entra Conditional Access rejection must surface error=insufficient_claims plus the base64
+    claims in the single-server 401 challenge, so an MSAL-family client can drive the step-up and retry."""
     import base64
 
     from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Error
@@ -5963,13 +5963,7 @@ async def test_preflight_challenge_carries_step_up_error_and_claims():
 
     class _FakeProvider:
         async def resolve_credentials(self, subject, server):
-            return Error(
-                CredError.of_unauthorized(
-                    "step-up required",
-                    oauth_error="interaction_required",
-                    claims=claims,
-                )
-            )
+            return Error(CredError.of_unauthorized("step-up required", claims=claims))
 
     manager = MCPServerManager(cred_provider=_FakeProvider())
     server = MCPServer(
@@ -5991,7 +5985,7 @@ async def test_preflight_challenge_carries_step_up_error_and_claims():
     assert exc_info.value.status_code == 401
     headers = exc_info.value.headers or {}
     www = headers.get("WWW-Authenticate") or headers.get("www-authenticate") or ""
-    assert 'error="interaction_required"' in www
+    assert 'error="insufficient_claims"' in www
     assert base64.b64encode(claims.encode()).decode() in www
     assert "resource_metadata" in www
 
@@ -6013,7 +6007,7 @@ async def test_aggregate_list_still_absorbs_step_up_challenged_server():
         if server.server_id == "ca":
             raise MCPUpstreamAuthError(
                 status_code=401,
-                www_authenticate=('Bearer resource_metadata="/x", error="interaction_required", claims="eyJhIjoxfQ=="'),
+                www_authenticate=('Bearer resource_metadata="/x", error="insufficient_claims", claims="eyJhIjoxfQ=="'),
                 server_name="ca",
             )
         return [good_tool]

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -148,6 +148,34 @@ def patch_proxy_general_settings(settings: dict):
     )
 
 
+class TestMCPCredentialsTokenExchangeProfile:
+    """token_exchange_profile must be a declared MCPCredentials field so the management API can
+    persist the entra_obo profile. An undeclared key is silently stripped by pydantic when the
+    credentials dict is validated against the TypedDict, so it would never reach the JSON blob."""
+
+    @pytest.mark.parametrize(
+        "build",
+        [
+            lambda creds: NewMCPServerRequest(
+                server_name="s", auth_type=MCPAuth.oauth2_token_exchange, credentials=creds
+            ),
+            lambda creds: UpdateMCPServerRequest(server_id="s", credentials=creds),
+        ],
+        ids=["new", "update"],
+    )
+    def test_request_preserves_token_exchange_profile_in_credentials(self, build):
+        creds = {
+            "client_id": "cid",
+            "client_secret": "sec",
+            "token_exchange_endpoint": "https://login.microsoftonline.com/tid/oauth2/v2.0/token",
+            "scopes": ["api://target/.default"],
+            "token_exchange_profile": "entra_obo",
+        }
+        request = build(creds)
+        assert request.credentials is not None
+        assert request.credentials.get("token_exchange_profile") == "entra_obo"
+
+
 class TestListMCPServers:
     """Test suite for list MCP servers functionality"""
 


### PR DESCRIPTION
## Relevant issues

Stacked on #31762 (OBO token-endpoint discovery), the top of the OBO stack #31526 -> #31622 -> #31762. Base is `litellm_mcp_v2_obo_endpoint_discovery`, so the diff here is only the entra_obo work; it retargets up the stack as the parents merge

## Linear ticket

Resolves LIT-4163

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests) locally
- [x] My PR's scope is as isolated as possible; it only adds the entra_obo profile
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## What this is

The v2 `token_exchange` (OBO) arm speaks only RFC 8693 today. Microsoft Entra ID's On-Behalf-Of flow is not RFC 8693; it is the RFC 7523 `jwt-bearer` grant with a Microsoft `requested_token_use=on_behalf_of` extension, so an Entra upstream cannot mint tokens through the existing arm. This adds an `entra_obo` profile that switches the request form to Entra's dialect while reusing everything below the form

`TokenExchangeConfig` gains a `profile: Literal["rfc8693", "entra_obo"]` (default `rfc8693`, so existing servers are unchanged). The exchanger's form builder dispatches on it with an exhaustive `match` plus `assert_never`, the same pattern the package already uses for `CredError` and the auth-config union, so basedpyright proves the dialects stay in sync. Under `entra_obo` the caller's inbound token is sent as `assertion` (its `aud` must be the gateway's own client), the target resource is carried in `scope` as `api://<app-id>/.default` since Entra has no audience parameter, and `requested_token_use=on_behalf_of` is added; `subject_token_type` and `audience` are not sent. The cache key folds in the profile so a dialect flip re-exchanges rather than serving a token minted for the other form. The shared caching, single-flight, tenant keying, TTL, discovery, RFC 9728 challenge, and fail-closed contract are all untouched

Because the concrete exchanger now serves both dialects, `Rfc8693TokenExchanger` is renamed to `OboTokenExchanger` so the name is not a lie; the `TokenExchanger` protocol and the resolver arm are unchanged, so the rename is contained to the class and its two call sites

Fail-closed behavior follows the v2 no-silent-fallback rule. A missing endpoint is a 412 precondition, missing client credentials is a misconfigured 5xx, and an `entra_obo` server with no scope is misconfigured before any IdP call since Entra cannot resolve a target without one. An Entra 4xx such as `AADSTS65001` (no admin consent) maps to a 401 challenge through the existing `SubjectTokenRejected` edge so the caller re-authenticates, while a 5xx or transport failure stays a retryable 503

Certificate client authentication (Entra's `client_assertion` case, RFC 7523 private_key_jwt) is out of scope here and slots into the same `entra_obo` branch as a later follow-up

Operator config for an Entra upstream:

```yaml
mcp_servers:
  entra_downstream:
    url: https://.../mcp
    auth_type: oauth2_token_exchange
    token_exchange_profile: entra_obo
    token_url: https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token
    client_id: <litellm-app-client-id>
    client_secret: os.environ/ENTRA_LITELLM_CLIENT_SECRET
    scopes: ["api://<target-api-app-id>/.default"]
```

## Screenshots / Proof of Fix

A full end-to-end run against a real Entra tenant needs the reviewer's Azure app registrations (a gateway app with a client secret and an admin-consented permission to the downstream `api://` app), so the automated proof below drives the real production egress exchanger (`build_token_exchanger()`, which POSTs through the real httpx `_post_exchange_endpoint`) against a local stand-in Entra token endpoint that records the exact form it receives. This exercises the real HTTP path and the real form builder, not mocked internals. The stand-in stands in for Entra the same way the parent PRs used Keycloak

```
SCENARIO 1 - entra_obo happy path: exact Entra OBO form + minted-token forward
form the gateway POSTed to the Entra token endpoint:
{
  "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
  "assertion": "alice-inbound-token-aud-litellm-gateway",
  "client_id": "litellm-gateway-client-id",
  "client_secret": "gateway-secret",
  "scope": "api://target-api/.default",
  "requested_token_use": "on_behalf_of"
}
caller token presented to LiteLLM : alice-inbound-token-aud-litellm-gateway
token the upstream will receive   : MINTED-token__aud=api://target-api__sub=alice
forwarded == caller token ?       : False   (True OBO: caller token never forwarded)
minted audience swapped to target?: True

SCENARIO 2 - Entra 4xx (AADSTS65001 no consent) fails closed as 401, not a retryable 503
Entra returned HTTP 400 (AADSTS65001); exchanger CredError tag = 'unauthorized'
maps to 401 challenge (not 503 loop)? : True

SCENARIO 3 - entra_obo without a scope fails closed as misconfigured, never POSTing
CredError tag = 'misconfigured'; HTTP calls made = 0
fail-closed before any IdP call? : True

SCENARIO 4 - contrast: the rfc8693 profile still sends the RFC 8693 form
form the gateway POSTed under rfc8693:
{
  "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
  "subject_token": "alice-inbound-token-aud-litellm-gateway-4",
  "subject_token_type": "urn:ietf:params:oauth:token-type:access_token",
  "client_id": "cid",
  "client_secret": "sec",
  "audience": "https://target-api",
  "scope": "s1"
}

ALL SCENARIOS PASSED
```

To verify against a live Entra tenant on a running proxy, point `token_url` at your tenant, set `client_id`/`client_secret` to a gateway app that has admin-consented permission to the `api://<target>` app, present a user access token whose `aud` is the gateway app, and call a tool on the `entra_obo` server; the upstream receives the minted token with `aud=api://<target>` and the same user `oid`/`sub`, and a caller with no consent gets a 401 challenge rather than a 503 loop

The form builder, cache-key, and adapter mapping are pinned by mutation-grade unit tests in `test_token_exchanger.py` and `test_adapter.py` (the entra form asserts the exact dict and that `subject_token`/`subject_token_type`/`audience` are absent; the profile is verified to be part of the cache key by a count assertion that fails if it is dropped). The full `outbound_credentials` suite is green (210) and `mcp_server_manager` is green (214); ruff, ruff format, and basedpyright strict add zero new findings

## Type

New Feature

## Changes

`TokenExchangeConfig` gains `profile`; the exchanger form builder dispatches on it with an exhaustive match and is renamed `OboTokenExchanger`; the adapter maps `token_exchange_profile` from the server, normalizing an unknown value to `rfc8693`. The `MCPServer` model gains `token_exchange_profile`, and both the config-load and DB build sites thread it. `MCPCredentials` also gains `token_exchange_profile` so the management API (`NewMCPServerRequest` / `UpdateMCPServerRequest`) validates and persists it into the credentials blob rather than pydantic silently dropping the unknown key. No new `auth_type` and no DB migration, since the field rides in the existing credentials JSON blob


## Conditional Access step-up challenge (follow-up commit)

Entra returns a 4xx with `error=interaction_required` and a `claims` blob when a Conditional Access policy demands step-up (MFA, compliant device, etc.); the client must replay those claims to Entra to satisfy the policy, then retry. The arm previously dropped the code and claims and emitted a static RFC 9728 challenge, so a CA-protected Entra upstream was unreachable through the gateway. This threads the step-up through end to end.

The provider reads the RFC 6749 `error` code and the `claims` string off the rejection body (the `error_description` is still never read; it can carry IdP internals), carries them on `SubjectTokenRejected` into `CredError.unauthorized`, and the challenge builder folds them into `WWW-Authenticate`: the machine error is embedded only when it is a plain OAuth token, guarding against header injection from a hostile IdP body, and the claims travel base64-encoded in a `claims` parameter, the convention MSAL-family clients decode. With neither field present the header is byte-identical to the prior static challenge, so the rfc8693 path is unchanged. The multi-server aggregate still absorbs a step-up 401 to an empty listing; only single-server routes surface it as a challenge.

### Proof of Fix (live, real proxy egress)

Driven against a stand-in Entra token endpoint that records the exact form it receives and, on demand, returns Entra's CA rejection; the real egress exchanger (`build_token_exchanger()` -> real httpx `_post_exchange_endpoint`) POSTs to it, the same way the parent PRs used Keycloak.

Happy path: the gateway POSTs the exact Entra OBO form and forwards the minted token:

```
grant_type: urn:ietf:params:oauth:grant-type:jwt-bearer | requested_token_use: on_behalf_of | scope: api://target-api/.default
assertion == caller subject JWT: True | subject_token absent: True | audience absent: True
upstream got: AUTH=Bearer entra-minted-ae0f7a5a... (never the caller subject)
```

Conditional Access rejection: single-server connect returns 401 with the propagated code and the base64 claims, and no AADSTS/error_description leak:

```
HTTP status: 401
www-authenticate: Bearer resource_metadata="/.well-known/oauth-protected-resource/mcp/entra_demo", error="insufficient_claims", error_description="Step-up authentication required; satisfy the returned claims challenge with the IdP and retry", claims="eyJhY2Nlc3NfdG9rZW4iOnsiYWNycyI6eyJlc3NlbnRpYWwiOnRydWUsInZhbHVlIjoiYzEifX19"
decoded claims: {"access_token":{"acrs":{"essential":true,"value":"c1"}}}
AADSTS leak in headers/body: 0
```

Aggregate graceful degradation is preserved: `/mcp` with the CA-rejected server present still returns `200` and lists the healthy servers, rather than a blanket 401.

Unit coverage pins each hop: the provider extracts `error`+`claims` and never the description; a gateway-fault code still wins over a present claims blob; the exchanger carries both onto the unauthorized `CredError`; the challenge builder folds them in, rejects a non-token error code back to `invalid_token`, and stays byte-identical without them; the preflight surfaces them on the single-server 401 while the aggregate list still absorbs.

To verify against a live Entra tenant, point `token_exchange_endpoint` at your tenant, set `client_id`/`client_secret` to a gateway app admin-consented to the `api://<target>` app, present a user access token whose `aud` is the gateway app, and enable a Conditional Access policy on the target; the CA-blocked call returns a 401 whose `claims` the client replays to Entra to step up, then retries.


### Field-by-field cross-check against Microsoft Learn, plus a real-Entra probe

The request form and the challenge were checked field-by-field against the Microsoft OBO doc (`v2-oauth2-on-behalf-of-flow`) and the claims-challenge format doc (`claims-challenge`). The request form matches verbatim (`grant_type=jwt-bearer`, `assertion`, `scope=.../.default`, `requested_token_use=on_behalf_of`, client auth in the body or Basic; no `subject_token`/`audience`). The `claims` value is base 64 encoded exactly as the spec's own example, and the directive name is `claims`. The one correction the cross-check surfaced is folded into this PR: a claims challenge must use `error=insufficient_claims` (not the raw token-endpoint code), which is what MSAL-family clients key on.

To validate the failure contract against the live server without a tenant, a bogus `jwt-bearer` OBO POST was sent to the real `https://login.microsoftonline.com/common/oauth2/v2.0/token`:

```
POST /common/oauth2/v2.0/token  (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer, requested_token_use=on_behalf_of, assertion=<bogus>, scope=api://target-api/.default)
-> HTTP 400  {"error":"invalid_request","error_codes":[50027],"error_description":"AADSTS50027: JWT token is invalid or malformed...","trace_id":"...","correlation_id":"..."}
```

Entra recognized the grant (it reached assertion validation rather than returning `unsupported_grant_type`), and its error body carries exactly the fields the parser reads (`error`, `error_codes`, and `claims` on a CA rejection), while `error_description` and the trace IDs are the internals we deliberately never forward. This does not exercise the happy path (which needs app registrations to mint a token) and is not a substitute for a full real-tenant run; it confirms the wire dialect and error contract against the live endpoint.

### Follow-up (out of scope here)

For strict non-MCP MSAL clients, also emit `authorization_uri` (the tenant `/authorize` endpoint) alongside the RFC 9728 `resource_metadata` in the challenge. MCP clients discover the IdP via `resource_metadata`, so it is not needed for this gateway's clients; it is a compatibility add for raw MSAL tooling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token exchange and 401 challenge behavior on a security-sensitive MCP egress path, though defaults stay RFC 8693 and behavior is fail-closed with broad unit coverage.
> 
> **Overview**
> Extends the v2 MCP **token exchange (OBO)** arm with a configurable wire dialect via **`token_exchange_profile`** (`rfc8693` default, **`entra_obo`** for Microsoft Entra). The profile is persisted on **`MCPServer`**, config YAML, DB credentials JSON, and management API **`MCPCredentials`**, and maps into **`TokenExchangeConfig.profile`**. Unknown profile values normalize to **`rfc8693`**.
> 
> **`Rfc8693TokenExchanger`** is renamed **`OboTokenExchanger`** and builds either the RFC 8693 token-exchange form or Entra’s RFC 7523 **`jwt-bearer`** form (`assertion`, required **`scope`**, **`requested_token_use=on_behalf_of`**). Cache keys include **`profile`**; **`entra_obo`** without scope fails as misconfigured before any IdP POST.
> 
> When Entra rejects exchange with a step-up **`claims`** blob (Conditional Access), the HTTP provider reads **`error`** + **`claims`** (not **`error_description`**), surfaces them on **`SubjectTokenRejected`** / **`CredError.unauthorized`**, and **`raise_token_exchange_challenge`** emits **`error=insufficient_claims`** with base64 **`claims`** in **`WWW-Authenticate`** (unchanged static challenge when no claims). Preflight and credential resolution pass **`claims`** through to that challenge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5df7203bf16e5d9d290a37bbe8d9023298ecb018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple token-exchange profiles, including standard token exchange and Microsoft Entra on-behalf-of.
  * Token-exchange challenges can now include claim details for step-up authentication flows.

* **Bug Fixes**
  * Improved handling of authentication errors so claim-based challenges are returned correctly.
  * Preserved token-exchange profile settings when loading and saving server configuration.

* **Tests**
  * Expanded coverage for token-exchange profiles, challenge headers, caching behavior, and step-up authentication responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->