### PR TITLE
fix(bedrock): map guardrailConfig to InvokeModel guardrail headers

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast, get_args
 
 import httpx
+from pydantic import TypeAdapter, ValidationError
 
 import litellm
 from litellm._logging import verbose_logger
@@ -24,6 +25,7 @@ from litellm.llms.custom_httpx.http_handler import (
     HTTPHandler,
     _get_httpx_client,
 )
+from litellm.types.llms.bedrock import GuardrailConfigBlock
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import ModelResponse, Usage
 from litellm.utils import CustomStreamWrapper
@@ -36,6 +38,30 @@ else:
     LiteLLMLoggingObj = Any
 
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
+
+_GUARDRAIL_CONFIG_VALIDATOR: "TypeAdapter[GuardrailConfigBlock]" = TypeAdapter(GuardrailConfigBlock)
+
+
+def _bedrock_invoke_guardrail_headers(raw_guardrail_config: object) -> "dict[str, str]":
+    try:
+        guardrail_config = _GUARDRAIL_CONFIG_VALIDATOR.validate_python(raw_guardrail_config)
+    except ValidationError as e:
+        raise BedrockError(
+            status_code=400,
+            message=(
+                "Invalid guardrailConfig={}. Expected format: {{'guardrailIdentifier': str, "
+                "'guardrailVersion': str, 'trace': 'enabled'|'disabled'|'enabled_full'}}. Error: {}".format(
+                    raw_guardrail_config, e
+                )
+            ),
+        )
+    trace = guardrail_config.get("trace")
+    candidate_headers = {
+        "X-Amzn-Bedrock-GuardrailIdentifier": guardrail_config.get("guardrailIdentifier"),
+        "X-Amzn-Bedrock-GuardrailVersion": guardrail_config.get("guardrailVersion"),
+        "X-Amzn-Bedrock-Trace": trace.upper() if trace is not None else None,
+    }
+    return {name: value for name, value in candidate_headers.items() if value is not None}
 
 
 class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
@@ -390,7 +416,16 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
     ) -> dict:
-        return headers
+        raw_guardrail_config = optional_params.pop("guardrailConfig", None)
+        if raw_guardrail_config is None:
+            return headers
+        existing_header_names = frozenset(name.lower() for name in headers)
+        guardrail_headers = {
+            name: value
+            for name, value in _bedrock_invoke_guardrail_headers(raw_guardrail_config).items()
+            if name.lower() not in existing_header_names
+        }
+        return {**headers, **guardrail_headers}
 
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -41,6 +41,10 @@ from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
 
 _GUARDRAIL_CONFIG_VALIDATOR: "TypeAdapter[GuardrailConfigBlock]" = TypeAdapter(GuardrailConfigBlock)
 
+_GUARDRAIL_CONFIG_EXPECTED_FORMAT = (
+    "{'guardrailIdentifier': str, 'guardrailVersion': str, 'trace': 'enabled'|'disabled'|'enabled_full'}"
+)
+
 
 def _bedrock_invoke_guardrail_headers(raw_guardrail_config: object) -> "dict[str, str]":
     try:
@@ -48,11 +52,15 @@ def _bedrock_invoke_guardrail_headers(raw_guardrail_config: object) -> "dict[str
     except ValidationError as e:
         raise BedrockError(
             status_code=400,
-            message=(
-                "Invalid guardrailConfig={}. Expected format: {{'guardrailIdentifier': str, "
-                "'guardrailVersion': str, 'trace': 'enabled'|'disabled'|'enabled_full'}}. Error: {}".format(
-                    raw_guardrail_config, e
-                )
+            message="Invalid guardrailConfig={}. Expected format: {}. Error: {}".format(
+                raw_guardrail_config, _GUARDRAIL_CONFIG_EXPECTED_FORMAT, e
+            ),
+        )
+    if "guardrailIdentifier" not in guardrail_config:
+        raise BedrockError(
+            status_code=400,
+            message="guardrailConfig={} is missing 'guardrailIdentifier'. Expected format: {}".format(
+                raw_guardrail_config, _GUARDRAIL_CONFIG_EXPECTED_FORMAT
             ),
         )
     trace = guardrail_config.get("trace")

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -325,7 +325,7 @@ class ToolConfigBlock(TypedDict, total=False):
 class GuardrailConfigBlock(TypedDict, total=False):
     guardrailIdentifier: str
     guardrailVersion: str
-    trace: Literal["enabled", "disabled"]
+    trace: Literal["enabled", "disabled", "enabled_full"]
 
 
 class InferenceConfig(TypedDict, total=False):

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -14,6 +14,7 @@ from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transfor
 from litellm.llms.bedrock.chat.invoke_transformations.base_invoke_transformation import (
     AmazonInvokeConfig,
 )
+from litellm.llms.bedrock.common_utils import BedrockError
 
 
 @pytest.mark.parametrize(
@@ -39,3 +40,143 @@ def test_transform_request_drops_stream_chunk_size(config, model):
     )
 
     assert "stream_chunk_size" not in json.dumps(request_body)
+
+
+def test_validate_environment_maps_guardrail_config_to_invoke_headers():
+    """The InvokeModel API takes the guardrail identifier/version/trace as
+    X-Amzn-Bedrock-* request headers, unlike Converse which takes them in the
+    body. https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html"""
+    optional_params = {
+        "guardrailConfig": {
+            "guardrailIdentifier": "ff6ujrregl1q",
+            "guardrailVersion": "DRAFT",
+            "trace": "enabled",
+        },
+        "max_tokens": 10,
+    }
+
+    headers = AmazonInvokeConfig().validate_environment(
+        headers={},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+    )
+
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "ff6ujrregl1q"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "DRAFT"
+    assert headers["X-Amzn-Bedrock-Trace"] == "ENABLED"
+    assert "guardrailConfig" not in optional_params
+
+
+def test_validate_environment_without_guardrail_config_leaves_headers_untouched():
+    headers = AmazonInvokeConfig().validate_environment(
+        headers={"foo": "bar"},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"max_tokens": 10},
+        litellm_params={},
+    )
+
+    assert headers == {"foo": "bar"}
+
+
+def test_validate_environment_skips_absent_guardrail_fields():
+    headers = AmazonInvokeConfig().validate_environment(
+        headers={},
+        model="amazon.titan-text-express-v1",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={"guardrailConfig": {"guardrailIdentifier": "gr-id", "guardrailVersion": "1"}},
+        litellm_params={},
+    )
+
+    assert headers == {
+        "X-Amzn-Bedrock-GuardrailIdentifier": "gr-id",
+        "X-Amzn-Bedrock-GuardrailVersion": "1",
+    }
+
+
+def test_validate_environment_does_not_clobber_explicit_guardrail_headers():
+    """Users worked around the missing guardrailConfig support by passing the
+    AWS headers directly; an explicit header must keep winning over
+    guardrailConfig regardless of casing."""
+    headers = AmazonInvokeConfig().validate_environment(
+        headers={"x-amzn-bedrock-guardrailidentifier": "explicit-id"},
+        model="anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params={
+            "guardrailConfig": {"guardrailIdentifier": "config-id", "guardrailVersion": "2"},
+        },
+        litellm_params={},
+    )
+
+    assert headers["x-amzn-bedrock-guardrailidentifier"] == "explicit-id"
+    assert "X-Amzn-Bedrock-GuardrailIdentifier" not in headers
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "2"
+
+
+@pytest.mark.parametrize(
+    "bad_guardrail_config",
+    [
+        {"guardrailIdentifier": "gr-id", "trace": "verbose"},
+        {"guardrailIdentifier": ["gr-id"]},
+        "gr-id",
+    ],
+)
+def test_validate_environment_rejects_malformed_guardrail_config(bad_guardrail_config):
+    with pytest.raises(BedrockError) as excinfo:
+        AmazonInvokeConfig().validate_environment(
+            headers={},
+            model="anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"guardrailConfig": bad_guardrail_config},
+            litellm_params={},
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "guardrailConfig" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic.claude-3-sonnet-20240229-v1:0",
+        "amazon.titan-text-express-v1",
+        "mistral.mistral-7b-instruct-v0:2",
+        "meta.llama3-8b-instruct-v1:0",
+    ],
+)
+def test_guardrail_config_flows_to_headers_not_request_body(model):
+    """Mirrors the handler flow (validate_environment then transform_request):
+    guardrailConfig must end up in the signed headers and never leak into the
+    request body, where Bedrock rejects it as an extra input."""
+    config = AmazonInvokeConfig()
+    optional_params = {
+        "guardrailConfig": {
+            "guardrailIdentifier": "ff6ujrregl1q",
+            "guardrailVersion": "DRAFT",
+            "trace": "disabled",
+        },
+        "max_tokens": 10,
+    }
+    messages = [{"role": "user", "content": "hi"}]
+
+    headers = config.validate_environment(
+        headers={},
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+    )
+    request_body = config.transform_request(
+        model=model,
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={},
+        headers=headers,
+    )
+
+    assert "guardrailConfig" not in json.dumps(request_body)
+    assert headers["X-Amzn-Bedrock-GuardrailIdentifier"] == "ff6ujrregl1q"
+    assert headers["X-Amzn-Bedrock-GuardrailVersion"] == "DRAFT"
+    assert headers["X-Amzn-Bedrock-Trace"] == "DISABLED"

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py
@@ -121,6 +121,8 @@ def test_validate_environment_does_not_clobber_explicit_guardrail_headers():
         {"guardrailIdentifier": "gr-id", "trace": "verbose"},
         {"guardrailIdentifier": ["gr-id"]},
         "gr-id",
+        {},
+        {"trace": "enabled"},
     ],
 )
 def test_validate_environment_rejects_malformed_guardrail_config(bad_guardrail_config):


### PR DESCRIPTION
## Relevant issues

Reported by a customer: passing `guardrailConfig` to a Bedrock invoke-route model did nothing, so their Bedrock guardrails never ran. They are currently working around it by passing the `X-Amzn-Bedrock-*` headers explicitly on every request

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The Converse API takes the guardrail identifier, version and trace in the request body, and LiteLLM supports that. The InvokeModel API takes them as request headers (`X-Amzn-Bedrock-GuardrailIdentifier`, `X-Amzn-Bedrock-GuardrailVersion`, `X-Amzn-Bedrock-Trace`, see the [InvokeModel API reference](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_InvokeModel.html)), and the invoke transformer had no code to set them

Ran the proxy with `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug` after adding an invoke-route model to the config:

```yaml
  - model_name: bedrock-invoke-guardrail-haiku
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-east-1
```

Then sent the exact request an end user would send:

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock-invoke-guardrail-haiku",
    "messages": [{"role": "user", "content": "Say hi in 3 words"}],
    "max_tokens": 20,
    "guardrailConfig": {
      "guardrailIdentifier": "ff6ujrregl1q",
      "guardrailVersion": "DRAFT",
      "trace": "enabled"
    }
  }'
```

On `litellm_internal_staging` (before this fix), `--detailed_debug` shows the request LiteLLM sends to Bedrock has no guardrail headers and leaks `guardrailConfig` into the body, which the Anthropic invoke spec rejects as an extra input:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke \
-H 'Content-Type: application/json' -H 'X-Amz-Date: 20260702T184715Z' -H 'Authorization: AW****2f' \
-d '{'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Say hi in 3 words'}]}], 'max_tokens': 20, 'guardrailConfig': {'guardrailIdentifier': 'ff6ujrregl1q', 'guardrailVersion': 'DRAFT', 'trace': 'enabled'}, 'anthropic_version': 'bedrock-2023-05-31'}'
```

On this branch, the same curl produces a request with the three guardrail headers set (and SigV4-signed, since `x-amzn-*` headers are included in signing) and a clean body:

```
POST Request Sent from LiteLLM:
curl -X POST \
https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-haiku-4-5-20251001-v1:0/invoke \
-H 'Content-Type: application/json' -H 'X-Amzn-Bedrock-GuardrailIdentifier: ff6ujrregl1q' -H 'X-Amzn-Bedrock-GuardrailVersion: DRAFT' -H 'X-Amzn-Bedrock-Trace: ENABLED' -H 'X-Amz-Date: 20260702T184410Z' -H 'Authorization: AW****69' \
-d '{'messages': [{'role': 'user', 'content': [{'type': 'text', 'text': 'Say hi in 3 words'}]}], 'max_tokens': 20, 'anthropic_version': 'bedrock-2023-05-31'}'
```

The sandbox this ran in has no valid AWS credentials, so AWS answered both runs with `InvalidClientTokenId` after the request reached `bedrock-runtime.us-east-1.amazonaws.com`; the excerpts above are the real signed requests LiteLLM put on the wire. To close the loop against a live guardrail, run the same curl with valid AWS creds and the id of a guardrail that has a denied topic, send a prompt on that topic, and confirm the response is the guardrail's blocked message (and that `trace: enabled` returns the guardrail trace) while the same prompt without `guardrailConfig` answers normally

## Type

🐛 Bug Fix

## Changes

`AmazonInvokeConfig.validate_environment` now pops `guardrailConfig` from the optional params, validates it against `GuardrailConfigBlock` with a pydantic `TypeAdapter` (a malformed value raises a 400 `BedrockError` client-side instead of an opaque AWS error), and merges the `X-Amzn-Bedrock-GuardrailIdentifier`, `X-Amzn-Bedrock-GuardrailVersion` and `X-Amzn-Bedrock-Trace` (uppercased, per the invoke spec) headers into the request before SigV4 signing. Headers the caller already set win over `guardrailConfig`, case-insensitively, so anyone who worked around this bug by passing the AWS headers directly sees no behavior change

Per Greptile's review, a `guardrailConfig` without `guardrailIdentifier` (e.g. an empty dict) is also rejected with a 400 instead of silently producing no headers, since a request proceeding with guardrails silently not applied is the exact failure mode this fix removes

Every invoke provider config (Anthropic, Nova, Titan, Llama, Mistral, Cohere, AI21, DeepSeek, Qwen, Moonshot) inherits this `validate_environment`, so the fix covers all invoke-route models, both `/invoke` and `/invoke-with-response-stream`. Popping the key in `validate_environment`, which the handler calls before `transform_request`, also stops `guardrailConfig` from leaking into request bodies

`GuardrailConfigBlock.trace` gains the `enabled_full` value that both Converse and InvokeModel accept

Regression tests in `tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_base_invoke_transformation.py` cover the header mapping, the pop out of `optional_params`, explicit-header precedence, malformed or identifier-less config rejection, and a handler-flow test asserting `guardrailConfig` ends in headers and never in the request body across the Anthropic, Titan, Mistral and Llama invoke transforms