### PR TITLE
fix(release): make Create Release reliable for stable maintenance cuts

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -148,6 +148,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 release_id: response.data.id,
+                tag_name: tag,
                 body: updatedBody,
                 draft: false,
               });
@@ -157,6 +158,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   release_id: response.data.id,
+                  tag_name: tag,
                   make_latest: makeLatest,
                 });
               }

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -122,10 +122,20 @@ jobs:
                 makeLatest = (!latestVersion || isAtLeast(newVersion, latestVersion)) ? "true" : "false";
               }
 
+              try {
+                await github.rest.git.createRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `refs/tags/${tag}`,
+                  sha: commitHash,
+                });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+              }
+
               const response = await github.rest.repos.createRelease({
                 draft: true,
                 generate_release_notes: true,
-                target_commitish: commitHash,
                 name: tag,
                 owner: context.repo.owner,
                 prerelease: isPrerelease,
@@ -140,8 +150,16 @@ jobs:
                 release_id: response.data.id,
                 body: updatedBody,
                 draft: false,
-                make_latest: makeLatest,
               });
+
+              if (!isPrerelease) {
+                await github.rest.repos.updateRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: response.data.id,
+                  make_latest: makeLatest,
+                });
+              }
 
             } catch (error) {
               core.setFailed(error.message);

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -131,6 +131,14 @@ jobs:
                 });
               } catch (error) {
                 if (error.status !== 422) throw error;
+                const existing = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: `tags/${tag}`,
+                });
+                if (existing.data.object.sha !== commitHash) {
+                  throw new Error(`Tag ${tag} already exists at ${existing.data.object.sha}, expected ${commitHash}`);
+                }
               }
 
               const response = await github.rest.repos.createRelease({


### PR DESCRIPTION
## Relevant issues

The Create Release workflow (`.github/workflows/create-release.yml`) succeeded for dev/rc tags but failed for every stable maintenance tag with "Resource not accessible by integration", so stable and patch releases had to be cut by hand

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests (N/A; this is a workflow-only change with no unit-test harness. Verification is covered under Proof of Fix)
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only touches the two release workflows
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

A live-proxy curl does not apply here since this is a GitHub Actions workflow. The root cause was pinned from a real dispatch run with debug logging: `getLatestRelease` returned 200, then `POST /git/refs` for `refs/tags/v1.90.1` returned 403 "Resource not accessible by integration". No ruleset or classic tag-protection blocks that tag creation (all were checked), so the Actions `GITHUB_TOKEN`, which is a GitHub App installation token, simply cannot create tags in this repo; a maintainer's git push creates the same tag without issue because a user token is not an app integration

Primary fix. Route the release job's `github-script` through `secrets.GH_TOKEN`, the PAT already used elsewhere to push branches and open PRs, and pass it to the release-branch reusable workflow so branch refs are created by the same actor and cannot hit the same wall at a stable commit. The reusable workflow falls back to `github.token` when the secret is absent

Supporting changes that make the flow correct once the token can act. The tag is created up front with `git.createRef` and `target_commitish` is dropped, so the release attaches to an existing tag rather than asking the release API to mint one from a commit, a path that 404s for some commits (cli/cli#9773). A 422 from `createRef` is tolerated only when the existing tag already points at the intended commit, so clean re-runs stay idempotent while a tag that exists at a different commit fails loudly instead of publishing against the wrong SHA. Publishing and `make_latest` are split into two calls, and `make_latest` runs only for non-prereleases, because `make_latest` is ignored during the draft-to-published transition (cli/cli#8201) and a backport would otherwise seize the repo "latest" badge from a newer line. `tag_name` is sent on every update so a draft edit against an already-existing tag cannot reset the binding to the `untagged-<hash>` placeholder

Verification note. The full flow cannot be dispatch-tested end to end without minting a permanent immutable tag, so the confirming run is the next real stable cut. The token-permission finding itself is directly evidenced by the debug log above, and the API sequence was validated by hand during the manual v1.89.5 cut

## Type

🐛 Bug Fix

## Changes

Run the `release` job's script under `secrets.GH_TOKEN` and pass it to the `create-release-branch` reusable workflow, which now accepts the secret and falls back to `github.token`. Create the tag ref before the release, drop `target_commitish`, verify the SHA on a pre-existing tag before reusing it, split publish from `make_latest`, gate `make_latest` to non-prereleases, and pin `tag_name` on both updates
