### PR TITLE
fix(proxy): admin-gate `allowed_routes` presence on /key/update and /key/regenerate (LIT-4139)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -530,26 +530,33 @@ def _check_allowed_routes_caller_permission(
     allowed_routes: Optional[list],
     user_api_key_dict: UserAPIKeyAuth,
     *,
+    allowed_routes_was_provided: bool = False,
     allow_safe_presets: bool = False,
 ) -> None:
     """
-    Only proxy admins may set `allowed_routes` on a key.
+    Require PROXY_ADMIN when `allowed_routes` is present in the request body,
+    unless the caller went through the `key_type` preset flow.
 
-    `allowed_routes` overrides the standard role-based route gate in
-    RouteChecks.non_proxy_admin_allowed_routes_check, so the field is
-    restricted to admins. Non-admins must instead use `key_type` to pick a
-    preset bucket — that path goes through `handle_key_type` and re-enters
-    this function with `allow_safe_presets=True`, which lets the derived
-    `llm_api_routes` / `info_routes` values through. Raw-body call sites
-    leave `allow_safe_presets=False` so non-admins can't write those values
-    directly.
+    Raw-body call sites pass
+    `allowed_routes_was_provided="allowed_routes" in data.model_fields_set` so a
+    caller that omits the field (model default flows through) is distinct from
+    one that sends any explicit value.
+
+    Post-`handle_key_type` call sites pass `allow_safe_presets=True` with the
+    values derived by `handle_key_type`; those values are not from the request
+    body, so `allowed_routes_was_provided` stays False and the safe-preset
+    carve-out below accepts any list of tokens in
+    `_NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS`.
     """
-    # Empty list is the default on GenerateKeyRequest — treat as "not set".
-    if not allowed_routes:
+    if not allowed_routes_was_provided and not allowed_routes:
         return
     if user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN.value:
         return
-    if allow_safe_presets and all(r in _NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS for r in allowed_routes):
+    if (
+        allow_safe_presets
+        and allowed_routes
+        and all(r in _NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS for r in allowed_routes)
+    ):
         return
     raise HTTPException(
         status_code=403,
@@ -1566,6 +1573,7 @@ async def generate_key_fn(
         _check_allowed_routes_caller_permission(
             allowed_routes=data.allowed_routes,
             user_api_key_dict=user_api_key_dict,
+            allowed_routes_was_provided="allowed_routes" in data.model_fields_set,
         )
         _check_passthrough_routes_caller_permission(
             data=data,
@@ -1736,6 +1744,7 @@ async def generate_service_account_key_fn(
     _check_allowed_routes_caller_permission(
         allowed_routes=data.allowed_routes,
         user_api_key_dict=user_api_key_dict,
+        allowed_routes_was_provided="allowed_routes" in data.model_fields_set,
     )
     _check_passthrough_routes_caller_permission(
         data=data,
@@ -2231,6 +2240,7 @@ async def _validate_update_key_data(
     _check_allowed_routes_caller_permission(
         allowed_routes=data.allowed_routes,
         user_api_key_dict=user_api_key_dict,
+        allowed_routes_was_provided="allowed_routes" in data.model_fields_set,
     )
     _check_passthrough_routes_caller_permission(
         data=data,
@@ -4551,6 +4561,7 @@ async def regenerate_key_fn(
             _check_allowed_routes_caller_permission(
                 allowed_routes=data.allowed_routes,
                 user_api_key_dict=user_api_key_dict,
+                allowed_routes_was_provided="allowed_routes" in data.model_fields_set,
             )
             _check_passthrough_routes_caller_permission(
                 data=data,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11141,6 +11141,249 @@ class TestAllowedRoutesCallerPermission:
         assert str(exc_info.value.code) == "403"
         assert "allowed_routes" in str(exc_info.value.message)
 
+    @pytest.mark.asyncio
+    async def test_non_admin_update_key_explicit_empty_allowed_routes_rejected(self):
+        """`update_key_fn` rejects a non-admin when `allowed_routes` is
+        present as `[]` in the request body. The value matches the model
+        default but `model_fields_set` distinguishes the two."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            update_key_fn,
+        )
+
+        data = UpdateKeyRequest(key="sk-test", allowed_routes=[])
+        assert "allowed_routes" in data.model_fields_set
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_update", None),
+            patch("litellm.proxy.proxy_server.llm_router", None),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._get_and_validate_existing_key",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await update_key_fn(
+                    request=MagicMock(),
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_routes" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_update_key_explicit_null_allowed_routes_rejected(self):
+        """`update_key_fn` rejects a non-admin when `allowed_routes` is
+        present as `null` in the request body."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            update_key_fn,
+        )
+
+        data = UpdateKeyRequest(key="sk-test", allowed_routes=None)
+        assert "allowed_routes" in data.model_fields_set
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_update", None),
+            patch("litellm.proxy.proxy_server.llm_router", None),
+            patch("litellm.proxy.proxy_server.premium_user", True),
+            patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._get_and_validate_existing_key",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await update_key_fn(
+                    request=MagicMock(),
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_routes" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_regenerate_key_explicit_empty_allowed_routes_rejected(self):
+        """`regenerate_key_fn` rejects a non-admin when `allowed_routes` is
+        present as `[]` in the request body."""
+        from litellm.proxy._types import RegenerateKeyRequest
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            regenerate_key_fn,
+        )
+
+        data = RegenerateKeyRequest(key="sk-test", allowed_routes=[])
+        assert "allowed_routes" in data.model_fields_set
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+
+        with patch("litellm.proxy.proxy_server.premium_user", True):
+            with pytest.raises(ProxyException) as exc_info:
+                await regenerate_key_fn(
+                    key=None,
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_routes" in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_regenerate_key_allowed_routes_rejected_before_enterprise_gate(self):
+        """`regenerate_key_fn` runs `_check_allowed_routes_caller_permission`
+        before the `premium_user` check, so a non-premium proxy still returns
+        the allowed_routes rejection (403) rather than the enterprise-license
+        error (500) when a non-admin sends `allowed_routes`."""
+        from litellm.proxy._types import RegenerateKeyRequest
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            regenerate_key_fn,
+        )
+
+        data = RegenerateKeyRequest(key="sk-test", allowed_routes=["/*"])
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+
+        with patch("litellm.proxy.proxy_server.premium_user", False):
+            with pytest.raises(ProxyException) as exc_info:
+                await regenerate_key_fn(
+                    key=None,
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_routes" in str(exc_info.value.message)
+        assert "Enterprise" not in str(exc_info.value.message)
+
+    @pytest.mark.asyncio
+    async def test_non_admin_generate_key_explicit_empty_allowed_routes_rejected(self):
+        """`generate_key_fn` rejects a non-admin when `allowed_routes` is
+        present as `[]` in the request body. The value matches the model
+        default but `model_fields_set` distinguishes the two, so the
+        explicit-empty case on the create path is caught."""
+        data = GenerateKeyRequest(key_alias="plain-key", allowed_routes=[])
+        assert "allowed_routes" in data.model_fields_set
+        user_api_key_dict = UserAPIKeyAuth(
+            user_id="internal-user-123",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+        )
+        mock_prisma_client = AsyncMock()
+
+        with (
+            patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_custom_key_generate", None),
+            patch(
+                "litellm.proxy.management_endpoints.key_management_endpoints._common_key_generation_helper",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await generate_key_fn(
+                    data=data,
+                    user_api_key_dict=user_api_key_dict,
+                    litellm_changed_by=None,
+                )
+        assert str(exc_info.value.code) == "403"
+        assert "allowed_routes" in str(exc_info.value.message)
+
+    def test_helper_accepts_derived_safe_preset_for_non_admin(self):
+        """`_check_allowed_routes_caller_permission` accepts a non-admin
+        when `allow_safe_presets=True` and `allowed_routes` is entirely
+        composed of `_NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS` tokens. This
+        is the shape the post-`handle_key_type` recheck at line 914 uses
+        after deriving `["llm_api_routes"]` from `key_type=llm_api`."""
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_allowed_routes_caller_permission,
+        )
+
+        _check_allowed_routes_caller_permission(
+            allowed_routes=["llm_api_routes"],
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="internal-user-123",
+                user_role=LitellmUserRoles.INTERNAL_USER,
+            ),
+            allow_safe_presets=True,
+        )
+        _check_allowed_routes_caller_permission(
+            allowed_routes=["info_routes"],
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="internal-user-123",
+                user_role=LitellmUserRoles.INTERNAL_USER,
+            ),
+            allow_safe_presets=True,
+        )
+
+    def test_helper_rejects_derived_unsafe_preset_for_non_admin(self):
+        """`_check_allowed_routes_caller_permission` rejects a non-admin
+        when `allow_safe_presets=True` but the derived value is outside
+        `_NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS` (for example
+        `["management_routes"]` from `key_type=management`)."""
+        from fastapi import HTTPException
+
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_allowed_routes_caller_permission,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            _check_allowed_routes_caller_permission(
+                allowed_routes=["management_routes"],
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_id="internal-user-123",
+                    user_role=LitellmUserRoles.INTERNAL_USER,
+                ),
+                allow_safe_presets=True,
+            )
+        assert exc_info.value.status_code == 403
+        assert "allowed_routes" in str(exc_info.value.detail)
+
+    def test_helper_rejects_when_provided_and_none_without_typeerror(self):
+        """`_check_allowed_routes_caller_permission` returns a 403 (not a
+        TypeError from iterating `None`) when a caller ever combines
+        `allowed_routes_was_provided=True` with `allowed_routes=None` and
+        `allow_safe_presets=True`. Pins the `and allowed_routes` guard on
+        the safe-preset branch."""
+        from fastapi import HTTPException
+
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _check_allowed_routes_caller_permission,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            _check_allowed_routes_caller_permission(
+                allowed_routes=None,
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_id="internal-user-123",
+                    user_role=LitellmUserRoles.INTERNAL_USER,
+                ),
+                allowed_routes_was_provided=True,
+                allow_safe_presets=True,
+            )
+        assert exc_info.value.status_code == 403
+        assert "allowed_routes" in str(exc_info.value.detail)
+
 
 def test_jinja_prompt_manager_is_sandboxed():
     """


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4139

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type

Bug Fix

## Changes

`_check_allowed_routes_caller_permission` previously used truthiness (`if not allowed_routes: return`) to distinguish "field not set" from "field explicitly set to a truthy value". The refactor adds an `allowed_routes_was_provided: bool = False` keyword param. Raw-body call sites pass `"allowed_routes" in data.model_fields_set`; the omit-default carve-out remains for `not allowed_routes_was_provided and not allowed_routes`

Four raw-body call sites updated to pass the presence flag from `model_fields_set`: `_common_key_generation_helper` (line 1571), `generate_service_account_key_fn` (line 1742), `_validate_update_key_data` (line 2237), and `regenerate_key_fn` (line 4559). Two derived-value call sites left unchanged (the post-`handle_key_type` recheck with `allow_safe_presets=True` at line 914 and its regenerate mirror at line 4580) — those pass values derived by `handle_key_type` from `data.key_type`, not from `data.model_fields_set`, and are handled by the `_NON_ADMIN_SAFE_ALLOWED_ROUTES_PRESETS` allowlist inside the helper

In `regenerate_key_fn` the gate runs before the `premium_user` license check so the rejection is consistent across premium and non-premium deployments. That ordering is pinned by `test_non_admin_regenerate_key_allowed_routes_rejected_before_enterprise_gate`

Eight new tests in `TestAllowedRoutesCallerPermission` in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`. Five cover the non-admin explicit-empty case on generate / update / regenerate, explicit-null on update, and the enterprise-gate ordering on regenerate. Three helper-level tests pin the derived-value acceptance path (`llm_api_routes` accepted, `management_routes` rejected) and the load-bearing `and allowed_routes` guard against a future caller that pairs `allowed_routes_was_provided=True` with a `None` value. Every added attack-vector or contract test is mutation-killed against a targeted change to the code it locks. Full mapped file (347 tests) green

## Screenshots / Proof of Fix

Live proxy on `localhost:4010` against Postgres, `LITELLM_LICENSE` set so `/key/regenerate` is available. Admin creates alice as an `internal_user` and sets `allowed_routes: ["/chat/completions"]` on alice's personal key

`/key/update` explicit empty

```
$ curl -sS -X POST http://localhost:4010/key/update \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":[]}"
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

`/key/update` explicit null

```
$ curl -sS -X POST http://localhost:4010/key/update \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":null}"
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

`/key/regenerate` explicit empty

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":[]}"
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

DB state after three rejected attacks

```
$ curl -sS "http://localhost:4010/key/info?key=$ALICE_OWN" -H "Authorization: Bearer sk-1234"
allowed_routes: ['/chat/completions']
```

The admin-set value survived. Controls: admin still writes `allowed_routes` freely, admin still clears with `[]`, alice still updates unrelated fields (`tpm_limit=42`) on her key, alice's `/key/generate {"key_type":"llm_api"}` still resolves to `allowed_routes: ["llm_api_routes"]` through the preset flow, alice's `/key/generate {}` still mints keys with the default `allowed_routes: []`

### Boundary conditions

Same fixed premium proxy, verified after the internal review

Explicit `null` on generate and regenerate as a non-admin. The presence check keys on `model_fields_set` so `null` is caught the same as `[]` or any other explicit value

```
$ curl -sS -X POST http://localhost:4010/key/generate \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d '{"allowed_routes":null}'
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":null}"
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

Raw-body `["llm_api_routes"]` from a non-admin on all three endpoints. Raw-body call sites leave `allow_safe_presets=False`, so a non-admin cannot hand-invoke the safe-preset carve-out; only the `key_type` preset flow reaches the derivation call site with `allow_safe_presets=True`

```
$ curl -sS -X POST http://localhost:4010/key/generate \
    -H "Authorization: Bearer $ALICE_KEY" -H "Content-Type: application/json" \
    -d '{"allowed_routes":["llm_api_routes"]}'
{"error":{"message":"{'error': 'Only proxy admins can set `allowed_routes` on a key. Use `key_type` to pick a preset route bucket instead.'}","code":"403"}}
```

`/key/update` and `/key/regenerate` return the same 403 for the same payload

Admin `[]` accepted on all three endpoints (admin fast path)

```
$ curl -sS -X POST http://localhost:4010/key/generate \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"allowed_routes":[]}'
minted key ends: PGCsEw / allowed_routes: []
```

```
$ curl -sS -X POST http://localhost:4010/key/update \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":[]}"
allowed_routes: []
```

```
$ curl -sS -X POST http://localhost:4010/key/regenerate \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"key\":\"$ALICE_OWN\",\"allowed_routes\":[]}"
new key ends: 9MIulg / allowed_routes: []
```

Note on admin `null` (pre-existing, unrelated to this fix): `UpdateKeyRequest.allowed_routes` and `RegenerateKeyRequest.allowed_routes` are typed `Optional[list] = []` but the Pydantic validator on these routes rejects an explicit `null` at request-parse time (400 on `/key/update`, 500 on `/key/regenerate` after the wrapper). `/key/generate` accepts and coerces to `[]`. Neither behavior changed here. The unit tests for the helper-level `None` case bypass Pydantic parsing (constructing the model in Python directly), so they exercise the hypothetical future where Pydantic loosens and confirm the gate still behaves

## Out of scope, tracked separately

- LIT-4137 covers the same presence-based check for the bulk endpoints (`/key/bulk_update`, `/team/key/bulk_update`), which route through `_process_single_key_update` and do not invoke this helper. `KeyUpdateFields` (`extra="forbid"`) omits `allowed_routes`, so the field is currently unreachable through the team-bulk path; single-key bulk is admin-only. Latent trap if the allowlist widens

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authorization on proxy key management endpoints; behavior change for non-admins who explicitly send `allowed_routes`, with broad test coverage to limit regressions on the `key_type` preset flow.
> 
> **Overview**
> Non-admins could bypass the **`allowed_routes`** admin gate by sending **`[]`** or **`null`** in `/key/generate`, `/key/update`, and `/key/regenerate`, because **`_check_allowed_routes_caller_permission`** treated empty/falsy values as “not set.”
> 
> The helper now takes **`allowed_routes_was_provided`**, set from **`"allowed_routes" in data.model_fields_set`** at raw-body entry points, so any explicit body value (including empty list or null) requires **PROXY_ADMIN**. Omitted fields still skip the gate when the value is the model default. The **`key_type`** preset path is unchanged: post-**`handle_key_type`** rechecks use **`allow_safe_presets=True`** without the presence flag.
> 
> **`regenerate_key_fn`** runs this check before the enterprise **`premium_user`** gate so non-admins get a consistent 403. Tests cover explicit empty/null, preset allowlist behavior, and the safe-preset **`None`** guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 067c20ac3dd99a43e0db2d11451f36beae66e7f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


