### PR TITLE
fix(bedrock-mantle): use correct SigV4 signing service name

### DIFF
--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -53,15 +53,15 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
 
     def sign_request(
         self,
-        headers: dict,
-        optional_params: dict,
-        request_data: dict,
+        headers: dict,  # mutable-ok: matches parent class signature
+        optional_params: dict,  # mutable-ok: matches parent class signature
+        request_data: dict,  # mutable-ok: matches parent class signature
         api_base: str,
         api_key: str | None = None,
         model: str | None = None,
         stream: bool | None = None,
         fake_stream: bool | None = None,
-    ) -> tuple[dict, bytes | None]:
+    ) -> tuple[dict, bytes | None]:  # mutable-ok: matches parent class signature
         """Sign request with bedrock-mantle service name instead of bedrock."""
         return self._sign_request(
             service_name="bedrock-mantle",

--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -57,11 +57,11 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
         optional_params: dict,
         request_data: dict,
         api_base: str,
-        api_key: Optional[str] = None,
-        model: Optional[str] = None,
-        stream: Optional[bool] = None,
-        fake_stream: Optional[bool] = None,
-    ) -> tuple[dict, Optional[bytes]]:
+        api_key: str | None = None,
+        model: str | None = None,
+        stream: bool | None = None,
+        fake_stream: bool | None = None,
+    ) -> tuple[dict, bytes | None]:
         """Sign request with bedrock-mantle service name instead of bedrock."""
         return self._sign_request(
             service_name="bedrock-mantle",

--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -51,6 +51,30 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
             region=region,
         )
 
+    def sign_request(
+        self,
+        headers: dict,
+        optional_params: dict,
+        request_data: dict,
+        api_base: str,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        stream: Optional[bool] = None,
+        fake_stream: Optional[bool] = None,
+    ) -> tuple[dict, Optional[bytes]]:
+        """Sign request with bedrock-mantle service name instead of bedrock."""
+        return self._sign_request(
+            service_name="bedrock-mantle",
+            headers=headers,
+            optional_params=optional_params,
+            request_data=request_data,
+            api_base=api_base,
+            api_key=api_key,
+            model=model,
+            stream=stream,
+            fake_stream=fake_stream,
+        )
+
     def validate_environment(
         self,
         headers: dict,

--- a/litellm/llms/bedrock_mantle/common_utils.py
+++ b/litellm/llms/bedrock_mantle/common_utils.py
@@ -3,7 +3,7 @@
 Mantle authenticates with a Bearer token when one is available
 (litellm_params.api_key, BEDROCK_MANTLE_API_KEY, or the standard
 AWS_BEARER_TOKEN_BEDROCK); otherwise it falls back to AWS SigV4 (service
-"bedrock") over the standard credential chain (IAM role / access key / profile /
+"bedrock-mantle") over the standard credential chain (IAM role / access key / profile /
 web identity). The Chat Completions and Responses backends share this behaviour
 through BedrockMantleAuthMixin so the two paths can never drift apart.
 
@@ -83,7 +83,7 @@ class BedrockMantleAuthMixin:
             headers = {k: v for k, v in headers.items() if k.lower() != "authorization"}
         try:
             return self._aws_signer._sign_request(
-                service_name="bedrock",
+                service_name="bedrock-mantle",
                 headers=headers,
                 optional_params=optional_params,
                 request_data=request_data,

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -1211,7 +1211,7 @@ class TestBedrockMantleResponsesSigV4:
         )
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "X-Amz-Date" in headers
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert signed_body == b'{"input": "hi"}'
@@ -1250,7 +1250,7 @@ class TestBedrockMantleResponsesSigV4:
         assert call["aws_role_name"] == "arn:aws:iam::000000000000:role/test-role"
         assert call["aws_session_name"] == "litellm-test"
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_signed_body_matches_final_data_after_normalize(self, monkeypatch):
         """Core regression: the signed bytes must equal the bytes actually sent.
@@ -1300,7 +1300,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base="https://bedrock-mantle.eu-west-1.api.aws/openai/v1/responses",
             api_key=None,
         )
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_url_region_and_sigv4_region_agree_from_litellm_params(self, monkeypatch):
         """Adversarial-review regression: a caller-supplied aws_region_name (no region
@@ -1334,7 +1334,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/ap-southeast-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/ap-southeast-2/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_injected_default_region_base_does_not_override_aws_region_name(
         self, monkeypatch
@@ -1372,7 +1372,7 @@ class TestBedrockMantleResponsesSigV4:
             api_base=url,
             api_key=None,
         )
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert "us-east-1" not in headers["Authorization"]
 
     def test_custom_proxy_host_is_preserved(self, monkeypatch):

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_transformation.py
@@ -329,7 +329,7 @@ class TestBedrockMantleChatAuth:
 
         assert headers["Authorization"].startswith("AWS4-HMAC-SHA256")
         assert "Credential=AKIAEXAMPLE/" in headers["Authorization"]
-        assert "/us-east-2/bedrock/aws4_request" in headers["Authorization"]
+        assert "/us-east-2/bedrock-mantle/aws4_request" in headers["Authorization"]
         assert headers["X-Amz-Security-Token"] == "session-token-test"
         assert json.loads(signed_body) == {
             "model": "openai.gpt-oss-120b",
@@ -364,7 +364,7 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
 
     def test_sigv4_scope_matches_api_base_when_aws_region_name_disagrees(
         self, monkeypatch
@@ -399,8 +399,8 @@ class TestBedrockMantleChatAuth:
             api_key=None,
         )
 
-        assert "/eu-west-1/bedrock/aws4_request" in headers["Authorization"]
-        assert "/us-west-2/bedrock/aws4_request" not in headers["Authorization"]
+        assert "/eu-west-1/bedrock-mantle/aws4_request" in headers["Authorization"]
+        assert "/us-west-2/bedrock-mantle/aws4_request" not in headers["Authorization"]
 
     def test_no_bearer_and_no_credentials_raises_value_error(self, monkeypatch):
         from unittest.mock import MagicMock
@@ -486,7 +486,7 @@ class TestBedrockMantleChatAuth:
         assert len(requests) == 1
         authorization = requests[0]["headers"]["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256")
-        assert "/us-east-2/bedrock/aws4_request" in authorization
+        assert "/us-east-2/bedrock-mantle/aws4_request" in authorization
         assert requests[0]["url"].startswith("https://bedrock-mantle.us-east-2.api.aws")
 
 


### PR DESCRIPTION
## Summary

The `bedrock-mantle` endpoint requires SigV4 signing with `service_name="bedrock-mantle"`, not `"bedrock"`. Using the wrong service name causes IAM permission errors because AWS evaluates the request against the `bedrock` service namespace instead of `bedrock-mantle`.

## Changes (2 files)

- **`litellm/llms/bedrock_mantle/common_utils.py`**: Changed `service_name="bedrock"` → `service_name="bedrock-mantle"` in the standalone Mantle provider's `sign_request`
- **`litellm/llms/bedrock/chat/mantle/transformation.py`**: Added `sign_request` override to `AmazonMantleConfig` that uses `service_name="bedrock-mantle"`, preventing the base class from signing with the wrong service name

`base_invoke_transformation.py` is unchanged — it serves regular Bedrock requests that correctly use `service_name="bedrock"`.

## Evidence

- AWS managed policy `AmazonBedrockMantleInferenceAccess` uses `bedrock-mantle:*` actions
- CloudTrail shows event source as `bedrock-mantle.amazonaws.com`
- `AmazonBedrockMantleFullAccess` managed policy uses `bedrock-mantle:*`

## Testing

- Verified `bedrock_mantle/common_utils.py` signs with `service_name="bedrock-mantle"`
- Verified `AmazonMantleConfig` overrides `sign_request` with correct service name
- Verified `base_invoke_transformation.py` unchanged (regular Bedrock still uses `"bedrock"`)

Fixes #31475
Fixes #31113
Fixes #31196