### PR TITLE
feat(guardrails): add datafog PII guardrail provider

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
@@ -42,7 +42,7 @@ def initialize_guardrail(
         datafog_entity_types=_param("datafog_entity_types"),
         datafog_locales=_param("datafog_locales"),
         datafog_fail_policy=_param("datafog_fail_policy"),
-        event_hook=litellm_params.mode,  # type: ignore
+        event_hook=litellm_params.mode,
         default_on=litellm_params.default_on or False,
     )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
@@ -1,0 +1,61 @@
+from typing import TYPE_CHECKING, Optional
+
+import litellm
+from litellm.proxy.guardrails.guardrail_hooks.datafog.datafog import DataFogGuardrail
+from litellm.types.guardrails import SupportedGuardrailIntegrations
+
+if TYPE_CHECKING:
+    from litellm import Router
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def initialize_guardrail(
+    litellm_params: "LitellmParams",
+    guardrail: "Guardrail",
+    llm_router: Optional["Router"] = None,
+):
+    """
+    Initialize the DataFog PII Guardrail.
+
+    Args:
+        litellm_params: Guardrail configuration parameters
+        guardrail: Guardrail metadata
+
+    Returns:
+        Initialized DataFogGuardrail instance
+    """
+    guardrail_name = guardrail.get("guardrail_name")
+    if not guardrail_name:
+        raise ValueError("DataFog: guardrail_name is required")
+
+    optional_params = getattr(litellm_params, "optional_params", None)
+
+    def _param(name: str):
+        value = getattr(litellm_params, name, None)
+        if value is None and optional_params is not None:
+            value = getattr(optional_params, name, None)
+        return value
+
+    datafog_guardrail = DataFogGuardrail(
+        guardrail_name=guardrail_name,
+        datafog_action=getattr(litellm_params, "datafog_action", None),
+        datafog_entity_types=_param("datafog_entity_types"),
+        datafog_locales=_param("datafog_locales"),
+        datafog_fail_policy=_param("datafog_fail_policy"),
+        event_hook=litellm_params.mode,  # type: ignore
+        default_on=litellm_params.default_on or False,
+    )
+
+    litellm.logging_callback_manager.add_litellm_callback(datafog_guardrail)
+
+    return datafog_guardrail
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.DATAFOG.value: initialize_guardrail,
+}
+
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.DATAFOG.value: DataFogGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/__init__.py
@@ -51,11 +51,11 @@ def initialize_guardrail(
     return datafog_guardrail
 
 
-guardrail_initializer_registry = {
+guardrail_initializer_registry = {  # mutable-ok: dynamic JSON payload
     SupportedGuardrailIntegrations.DATAFOG.value: initialize_guardrail,
 }
 
 
-guardrail_class_registry = {
+guardrail_class_registry = {  # mutable-ok: dynamic JSON payload
     SupportedGuardrailIntegrations.DATAFOG.value: DataFogGuardrail,
 }

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -1,0 +1,266 @@
+"""DataFog PII guardrail: offline, in-process PII redaction and blocking.
+
+Uses the `datafog` library (https://github.com/DataFog/datafog-python) to
+detect and redact PII locally — no external service, no sidecar, no network
+calls. Scans run in microseconds per request, so the guardrail can sit on
+every call without a latency budget.
+
+- ``pre_call``: scans request messages. ``redact`` (default) replaces
+  findings with ``[TYPE_N]`` tokens before the request leaves the gateway;
+  ``block`` rejects the request with HTTP 400.
+- ``during_call``: same as pre_call, but runs in parallel with the LLM call
+  (block only — content cannot be modified mid-flight).
+- ``post_call``: redacts findings from model responses before they reach
+  the client.
+
+Defaults to the high-precision entity types (EMAIL, PHONE, CREDIT_CARD,
+SSN). Noisier types (IP_ADDRESS, DOB, ZIP, DE_* locale entities) are opt-in
+via ``datafog_entity_types`` because version strings, dates, and short
+numbers saturate technical text.
+
+Errors and block messages report entity type counts only; matched PII is
+never echoed into logs, exceptions, or proxy responses. Engine exceptions
+are re-raised with ``from None`` and logged by type name only, since their
+messages can embed the text being scanned.
+"""
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from fastapi import HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_guardrail import CustomGuardrail
+from litellm.types.guardrails import GuardrailEventHooks
+
+if TYPE_CHECKING:
+    from litellm.proxy._types import UserAPIKeyAuth
+
+DEFAULT_ENTITY_TYPES = ["EMAIL", "PHONE", "CREDIT_CARD", "SSN"]
+
+VALID_ACTIONS = {"redact", "block"}
+VALID_FAIL_POLICIES = {"open", "closed"}
+
+
+def _redact_text(text: str, entity_types: list[str], locales: list[str] | None) -> tuple[str, dict[str, int]]:
+    """Redact ``text``; return (redacted_text, counts per entity type)."""
+    try:
+        import datafog  # pyright: ignore[reportMissingTypeStubs]
+    except ImportError as exc:
+        raise ImportError(
+            "The DataFog guardrail requires the `datafog` package. Install it with: pip install datafog"
+        ) from exc
+
+    result = datafog.redact(text, engine="regex", entity_types=entity_types, locales=locales)
+    counts: dict[str, int] = {}
+    for entity in result.entities:
+        counts[entity.type] = counts.get(entity.type, 0) + 1
+    return result.redacted_text, counts
+
+
+def _summary(counts: dict[str, int]) -> str:
+    return ", ".join(f"{etype} x{n}" for etype, n in sorted(counts.items()))
+
+
+class DataFogGuardrail(CustomGuardrail):
+    """Offline PII guardrail powered by the datafog library."""
+
+    def __init__(
+        self,
+        datafog_action: Literal["redact", "block"] | None = "redact",
+        datafog_entity_types: list[str] | None = None,
+        datafog_locales: list[str] | None = None,
+        datafog_fail_policy: Literal["open", "closed"] | None = "open",
+        **kwargs: Any,
+    ) -> None:
+        action = datafog_action or "redact"
+        fail_policy = datafog_fail_policy or "open"
+        if action not in VALID_ACTIONS:
+            raise ValueError(f"datafog_action must be one of: {sorted(VALID_ACTIONS)}")
+        if fail_policy not in VALID_FAIL_POLICIES:
+            raise ValueError(f"datafog_fail_policy must be one of: {sorted(VALID_FAIL_POLICIES)}")
+        self.action = action
+        self.entity_types = datafog_entity_types or DEFAULT_ENTITY_TYPES
+        self.locales = datafog_locales
+        self.fail_policy = fail_policy
+        super().__init__(**kwargs)
+
+    def _process_content(self, content: Any) -> tuple[Any, dict[str, int]]:
+        """Redact a message content value (str or list of content parts)."""
+        counts: dict[str, int] = {}
+        if isinstance(content, str):
+            return _redact_text(content, self.entity_types, self.locales)
+        if isinstance(content, list):
+            new_parts = []
+            skipped_parts = 0
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    redacted, part_counts = _redact_text(part["text"], self.entity_types, self.locales)
+                    new_parts.append({**part, "text": redacted})
+                    for etype, n in part_counts.items():
+                        counts[etype] = counts.get(etype, 0) + n
+                else:
+                    new_parts.append(part)
+                    skipped_parts += 1
+            if skipped_parts:
+                verbose_proxy_logger.debug(
+                    "DataFog guardrail: %d non-text content parts not scanned",
+                    skipped_parts,
+                )
+            return new_parts, counts
+        return content, counts
+
+    def _handle_engine_error(self, exc: Exception) -> None:
+        """Apply the fail policy without leaking scanned text.
+
+        Only the exception type is logged or re-raised: engine exception
+        messages can embed the text being scanned, so chaining via ``from
+        exc`` or interpolating ``str(exc)`` would leak matched PII into
+        tracebacks. A missing dependency is a config error and is surfaced
+        regardless of fail policy.
+        """
+        if isinstance(exc, ImportError):
+            raise exc
+        if self.fail_policy == "closed":
+            raise RuntimeError(
+                "DataFog guardrail failed and datafog_fail_policy is "
+                f"'closed'; rejecting unscanned traffic ({type(exc).__name__})."
+            ) from None
+        verbose_proxy_logger.warning(
+            "DataFog guardrail error (fail-open, traffic unscanned): %s",
+            type(exc).__name__,
+        )
+
+    def _scan_messages(self, data: dict) -> tuple[dict, dict[str, int]]:
+        """Scan/redact all message contents; return (new_data, counts)."""
+        messages = data.get("messages")
+        if not isinstance(messages, list):
+            return data, {}
+
+        total_counts: dict[str, int] = {}
+        new_messages = []
+        for message in messages:
+            if isinstance(message, dict) and "content" in message:
+                new_content, counts = self._process_content(message["content"])
+                new_messages.append({**message, "content": new_content})
+                for etype, n in counts.items():
+                    total_counts[etype] = total_counts.get(etype, 0) + n
+            else:
+                new_messages.append(message)
+
+        if not total_counts:
+            return data, {}
+        return {**data, "messages": new_messages}, total_counts
+
+    def _raise_block(self, total_counts: dict[str, int]) -> None:
+        """Reject with HTTP 400 so the block is classified as a guardrail
+        intervention by ``_is_guardrail_intervention`` rather than a
+        backend failure, and reaches the client as 400 instead of 500."""
+        raise HTTPException(
+            status_code=400,
+            detail={"error": (f"Violated DataFog PII guardrail policy: request contains {_summary(total_counts)}.")},
+        )
+
+    def _record_guardrail_logging(self, data: dict, total_counts: dict[str, int]) -> None:
+        """Record the decision into standard guardrail logging."""
+        try:
+            self.add_standard_logging_guardrail_information_to_request_data(
+                guardrail_json_response=_summary(total_counts),
+                request_data=data,
+                guardrail_status=("guardrail_intervened" if self.action == "block" else "success"),
+                masked_entity_count=dict(total_counts),
+            )
+        except Exception:  # noqa: BLE001
+            verbose_proxy_logger.debug("DataFog guardrail: could not record logging information")
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: "UserAPIKeyAuth",
+        cache: Any,
+        data: dict,
+        call_type: str,
+    ) -> Exception | str | dict | None:
+        if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.pre_call) is not True:
+            return data
+        try:
+            new_data, total_counts = self._scan_messages(data)
+        except Exception as exc:  # noqa: BLE001
+            self._handle_engine_error(exc)
+            return data
+
+        if not total_counts:
+            return data
+
+        self._record_guardrail_logging(data, total_counts)
+        if self.action == "block":
+            self._raise_block(total_counts)
+        return new_data
+
+    async def async_moderation_hook(
+        self,
+        data: dict,
+        user_api_key_dict: "UserAPIKeyAuth",
+        call_type: str,
+    ) -> Any:
+        """Block on PII during the parallel call window.
+
+        Content cannot be rewritten mid-flight, so redact mode is a no-op
+        here; only block has an effect.
+        """
+        if self.action != "block":
+            return data
+        if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.during_call) is not True:
+            return data
+        try:
+            _, total_counts = self._scan_messages(data)
+        except Exception as exc:  # noqa: BLE001
+            self._handle_engine_error(exc)
+            return data
+
+        if total_counts:
+            self._record_guardrail_logging(data, total_counts)
+            self._raise_block(total_counts)
+        return data
+
+    async def async_post_call_success_hook(
+        self,
+        data: dict,
+        user_api_key_dict: "UserAPIKeyAuth",
+        response: Any,
+    ) -> Any:
+        """Redact PII from model responses.
+
+        Mutates ``response`` in place — deliberate: post_call guardrails
+        share the response object, and an unredacted copy escaping through
+        another callback would defeat the purpose.
+        """
+        if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.post_call) is not True:
+            return response
+        choices = getattr(response, "choices", None)
+        if not choices:
+            return response
+        try:
+            skipped_parts = 0
+            for choice in choices:
+                message = getattr(choice, "message", None)
+                if message is not None and isinstance(message.content, str):
+                    redacted, counts = _redact_text(message.content, self.entity_types, self.locales)
+                    if counts:
+                        message.content = redacted
+                elif message is not None and message.content is not None:
+                    skipped_parts += 1
+            if skipped_parts:
+                verbose_proxy_logger.debug(
+                    "DataFog guardrail: %d non-text response parts not scanned",
+                    skipped_parts,
+                )
+        except Exception as exc:  # noqa: BLE001
+            self._handle_engine_error(exc)
+        return response
+
+    @staticmethod
+    def get_config_model() -> type | None:
+        from litellm.types.proxy.guardrails.guardrail_hooks.datafog import (
+            DataFogGuardrailConfigModel,
+        )
+
+        return DataFogGuardrailConfigModel

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -190,9 +190,10 @@ class DataFogGuardrail(CustomGuardrail):
         if not total_counts:
             return data
 
-        self._record_guardrail_logging(data, total_counts)
         if self.action == "block":
+            self._record_guardrail_logging(data, total_counts)
             self._raise_block(total_counts)
+        self._record_guardrail_logging(new_data, total_counts)
         return new_data
 
     async def async_moderation_hook(
@@ -227,17 +228,18 @@ class DataFogGuardrail(CustomGuardrail):
         user_api_key_dict: "UserAPIKeyAuth",
         response: Any,
     ) -> Any:
-        """Redact PII from model responses.
+        """Redact PII from model responses, or block when action is block.
 
-        Mutates ``response`` in place — deliberate: post_call guardrails
-        share the response object, and an unredacted copy escaping through
-        another callback would defeat the purpose.
+        Redaction mutates ``response`` in place, deliberately: post_call
+        guardrails share the response object, and an unredacted copy
+        escaping through another callback would defeat the purpose.
         """
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.post_call) is not True:
             return response
         choices = getattr(response, "choices", None)
         if not choices:
             return response
+        response_counts: dict[str, int] = {}
         try:
             skipped_parts = 0
             for choice in choices:
@@ -245,7 +247,10 @@ class DataFogGuardrail(CustomGuardrail):
                 if message is not None and isinstance(message.content, str):
                     redacted, counts = _redact_text(message.content, self.entity_types, self.locales)
                     if counts:
-                        message.content = redacted
+                        for etype, n in counts.items():
+                            response_counts[etype] = response_counts.get(etype, 0) + n
+                        if self.action != "block":
+                            message.content = redacted
                 elif message is not None and message.content is not None:
                     skipped_parts += 1
             if skipped_parts:
@@ -255,6 +260,11 @@ class DataFogGuardrail(CustomGuardrail):
                 )
         except Exception as exc:  # noqa: BLE001
             self._handle_engine_error(exc)
+            return response
+        if response_counts:
+            self._record_guardrail_logging(data, response_counts)
+            if self.action == "block":
+                self._raise_block(response_counts)
         return response
 
     @staticmethod

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -24,6 +24,8 @@ are re-raised with ``from None`` and logged by type name only, since their
 messages can embed the text being scanned.
 """
 
+import json
+from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any, Literal
 
 from fastapi import HTTPException
@@ -245,6 +247,55 @@ class DataFogGuardrail(CustomGuardrail):
 
         return (new_message if changed else message), counts
 
+    def _scan_responses_input_item(self, item: Any) -> tuple[Any, dict[str, int]]:
+        if isinstance(item, str):
+            return _redact_text(item, self.entity_types, self.locales)
+        if not isinstance(item, dict):
+            return item, {}
+
+        counts: dict[str, int] = {}
+        new_item, message_counts = self._scan_message(item)
+        changed = bool(message_counts)
+        _merge_counts(counts, message_counts)
+
+        argument_item, argument_counts = self._scan_argument_mapping(new_item)
+        if argument_counts:
+            new_item = argument_item
+            changed = True
+            _merge_counts(counts, argument_counts)
+
+        for field_name in ("text", "output"):
+            payload = new_item.get(field_name)
+            if not isinstance(payload, (str, list, dict)):
+                continue
+            new_payload, payload_counts = self._process_tool_payload(payload)
+            if payload_counts:
+                if not changed:
+                    new_item = dict(new_item)
+                new_item[field_name] = new_payload
+                changed = True
+                _merge_counts(counts, payload_counts)
+
+        return (new_item if changed else item), counts
+
+    def _scan_responses_api_input(self, input_value: Any) -> tuple[Any, dict[str, int]]:
+        if isinstance(input_value, str):
+            return _redact_text(input_value, self.entity_types, self.locales)
+        if not isinstance(input_value, list):
+            return input_value, {}
+
+        counts: dict[str, int] = {}
+        new_items = []
+        changed = False
+        for item in input_value:
+            new_item, item_counts = self._scan_responses_input_item(item)
+            new_items.append(new_item)
+            if item_counts:
+                changed = True
+                _merge_counts(counts, item_counts)
+
+        return (new_items if changed else input_value), counts
+
     def _handle_engine_error(self, exc: Exception) -> None:
         """Apply the fail policy without leaking scanned text.
 
@@ -285,6 +336,19 @@ class DataFogGuardrail(CustomGuardrail):
         if not total_counts:
             return data, {}
         return {**data, "messages": new_messages}, total_counts
+
+    def _scan_request_data(self, data: dict) -> tuple[dict, dict[str, int]]:
+        """Scan/redact supported request payload fields."""
+        new_data, total_counts = self._scan_messages(data)
+
+        new_input, input_counts = self._scan_responses_api_input(new_data.get("input"))
+        if input_counts:
+            new_data = {**new_data, "input": new_input}
+            _merge_counts(total_counts, input_counts)
+
+        if not total_counts:
+            return data, {}
+        return new_data, total_counts
 
     def _scan_response_content(self, container: Any, *, redact: bool) -> dict[str, int]:
         content = _get_field(container, "content")
@@ -332,6 +396,171 @@ class DataFogGuardrail(CustomGuardrail):
                 _merge_counts(counts, self._scan_argument_container(item, redact=redact))
         return counts
 
+    @staticmethod
+    def _stream_group_key(prefix: str, *parts: Any) -> tuple[Any, ...]:
+        return (prefix, *parts)
+
+    @staticmethod
+    def _decode_sse_text_delta(chunk: bytes | bytearray) -> tuple[Any, str] | None:
+        raw = bytes(chunk).decode("utf-8", errors="replace")
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if not stripped.startswith("data: "):
+                continue
+            try:
+                data = json.loads(stripped[6:])
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(data, dict) or data.get("type") != "content_block_delta":
+                continue
+            delta = data.get("delta")
+            if isinstance(delta, dict) and delta.get("type") == "text_delta" and isinstance(delta.get("text"), str):
+                return data.get("index"), delta["text"]
+        return None
+
+    @staticmethod
+    def _replace_sse_text_delta(chunk: bytes | bytearray, new_text: str) -> bytes:
+        raw = bytes(chunk).decode("utf-8", errors="replace")
+        lines = raw.splitlines(keepends=True)
+        for index, line in enumerate(lines):
+            line_ending = ""
+            line_body = line
+            if line.endswith("\r\n"):
+                line_ending = "\r\n"
+                line_body = line[:-2]
+            elif line.endswith("\n"):
+                line_ending = "\n"
+                line_body = line[:-1]
+
+            leading = line_body[: len(line_body) - len(line_body.lstrip())]
+            stripped = line_body.lstrip()
+            if not stripped.startswith("data: "):
+                continue
+            try:
+                data = json.loads(stripped[6:])
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(data, dict) or data.get("type") != "content_block_delta":
+                continue
+            delta = data.get("delta")
+            if not isinstance(delta, dict) or delta.get("type") != "text_delta":
+                continue
+            delta["text"] = new_text
+            lines[index] = f"{leading}data: {json.dumps(data, separators=(',', ':'))}{line_ending}"
+            break
+        return "".join(lines).encode("utf-8")
+
+    def _append_chat_stream_text_refs(
+        self,
+        chunk: Any,
+        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+    ) -> None:
+        choices = _get_field(chunk, "choices")
+        if not isinstance(choices, list):
+            return
+
+        for choice_index, choice in enumerate(choices):
+            delta = _get_field(choice, "delta")
+            if delta is None:
+                continue
+            content = _get_field(delta, "content")
+            if not isinstance(content, str) or not content:
+                continue
+            key = self._stream_group_key("chat", _get_field(choice, "index") or choice_index)
+            refs.append((key, content, lambda new_text, delta=delta: _set_field(delta, "content", new_text)))
+
+    def _append_responses_stream_text_ref(
+        self,
+        chunk: Any,
+        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+    ) -> None:
+        if _get_field(chunk, "type") != "response.output_text.delta":
+            return
+        delta = _get_field(chunk, "delta")
+        if not isinstance(delta, str) or not delta:
+            return
+        key = self._stream_group_key(
+            "responses",
+            _get_field(chunk, "item_id"),
+            _get_field(chunk, "output_index"),
+            _get_field(chunk, "content_index"),
+        )
+        refs.append((key, delta, lambda new_text, chunk=chunk: _set_field(chunk, "delta", new_text)))
+
+    def _append_anthropic_stream_text_ref(
+        self,
+        chunk: Any,
+        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+    ) -> None:
+        if _get_field(chunk, "type") != "content_block_delta":
+            return
+        delta = _get_field(chunk, "delta")
+        if _get_field(delta, "type") != "text_delta":
+            return
+        text = _get_field(delta, "text")
+        if not isinstance(text, str) or not text:
+            return
+        key = self._stream_group_key("anthropic", _get_field(chunk, "index"))
+        refs.append((key, text, lambda new_text, delta=delta: _set_field(delta, "text", new_text)))
+
+    def _collect_stream_text_refs(self, chunks: list[Any]) -> list[tuple[tuple[Any, ...], str, Callable[[str], None]]]:
+        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]] = []
+        for chunk_index, chunk in enumerate(chunks):
+            if isinstance(chunk, (bytes, bytearray)):
+                sse_delta = self._decode_sse_text_delta(chunk)
+                if sse_delta:
+                    content_index, text = sse_delta
+                    key = self._stream_group_key("anthropic_sse", content_index)
+                    refs.append(
+                        (
+                            key,
+                            text,
+                            lambda new_text, chunk_index=chunk_index: chunks.__setitem__(
+                                chunk_index,
+                                self._replace_sse_text_delta(chunks[chunk_index], new_text),
+                            ),
+                        )
+                    )
+                continue
+
+            self._append_chat_stream_text_refs(chunk, refs)
+            self._append_responses_stream_text_ref(chunk, refs)
+            self._append_anthropic_stream_text_ref(chunk, refs)
+
+        return refs
+
+    def _scan_stream_text_refs(
+        self,
+        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+        *,
+        redact: bool,
+    ) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        refs_by_group: dict[tuple[Any, ...], list[tuple[str, Callable[[str], None]]]] = {}
+        for key, text, setter in refs:
+            refs_by_group.setdefault(key, []).append((text, setter))
+
+        for grouped_refs in refs_by_group.values():
+            stream_text = "".join(text for text, _ in grouped_refs)
+            redacted_text, group_counts = _redact_text(stream_text, self.entity_types, self.locales)
+            if not group_counts:
+                continue
+            _merge_counts(counts, group_counts)
+            if not redact:
+                continue
+            first_ref = True
+            for _, setter in grouped_refs:
+                setter(redacted_text if first_ref else "")
+                first_ref = False
+
+        return counts
+
+    def _scan_streaming_chunks(self, chunks: list[Any], *, redact: bool) -> dict[str, int]:
+        refs = self._collect_stream_text_refs(chunks)
+        if not refs:
+            return {}
+        return self._scan_stream_text_refs(refs, redact=redact)
+
     def _raise_block(self, total_counts: dict[str, int]) -> None:
         """Reject with HTTP 400 so the block is classified as a guardrail
         intervention by ``_is_guardrail_intervention`` rather than a
@@ -347,7 +576,7 @@ class DataFogGuardrail(CustomGuardrail):
             self.add_standard_logging_guardrail_information_to_request_data(
                 guardrail_json_response=_summary(total_counts),
                 request_data=data,
-                guardrail_status=("guardrail_intervened" if self.action == "block" else "success"),
+                guardrail_status="guardrail_intervened",
                 masked_entity_count=dict(total_counts),
             )
         except Exception:  # noqa: BLE001
@@ -363,7 +592,7 @@ class DataFogGuardrail(CustomGuardrail):
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.pre_call) is not True:
             return data
         try:
-            new_data, total_counts = self._scan_messages(data)
+            new_data, total_counts = self._scan_request_data(data)
         except Exception as exc:  # noqa: BLE001
             self._handle_engine_error(exc)
             return data
@@ -393,7 +622,7 @@ class DataFogGuardrail(CustomGuardrail):
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.during_call) is not True:
             return data
         try:
-            _, total_counts = self._scan_messages(data)
+            _, total_counts = self._scan_request_data(data)
         except Exception as exc:  # noqa: BLE001
             self._handle_engine_error(exc)
             return data
@@ -437,6 +666,38 @@ class DataFogGuardrail(CustomGuardrail):
             if self.action == "block":
                 self._raise_block(response_counts)
         return response
+
+    async def async_post_call_streaming_iterator_hook(
+        self,
+        user_api_key_dict: "UserAPIKeyAuth",
+        response: Any,
+        request_data: dict,
+    ) -> AsyncGenerator[Any, None]:
+        if self.should_run_guardrail(data=request_data, event_type=GuardrailEventHooks.post_call) is not True:
+            async for chunk in response:
+                yield chunk
+            return
+
+        chunks = []
+        async for chunk in response:
+            chunks.append(chunk)
+
+        stream_counts: dict[str, int] = {}
+        try:
+            stream_counts = self._scan_streaming_chunks(chunks, redact=self.action != "block")
+        except Exception as exc:  # noqa: BLE001
+            self._handle_engine_error(exc)
+            for chunk in chunks:
+                yield chunk
+            return
+
+        if stream_counts:
+            self._record_guardrail_logging(request_data, stream_counts)
+            if self.action == "block":
+                self._raise_block(stream_counts)
+
+        for chunk in chunks:
+            yield chunk
 
     @staticmethod
     def get_config_model() -> type | None:

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -46,7 +46,7 @@ VALID_FAIL_POLICIES = {"open", "closed"}
 def _redact_text(text: str, entity_types: list[str], locales: list[str] | None) -> tuple[str, dict[str, int]]:
     """Redact ``text``; return (redacted_text, counts per entity type)."""
     try:
-        import datafog  # pyright: ignore[reportMissingTypeStubs]
+        import datafog  # pyright: ignore[reportMissingTypeStubs]  # datafog does not ship pyright stubs
     except ImportError as exc:
         raise ImportError(
             "The DataFog guardrail requires the `datafog` package. Install it with: pip install datafog"
@@ -579,7 +579,7 @@ class DataFogGuardrail(CustomGuardrail):
                 guardrail_status="guardrail_intervened",
                 masked_entity_count=dict(total_counts),
             )
-        except Exception:  # noqa: BLE001
+        except Exception:  # noqa: BLE001  # logging failures must not break guardrail enforcement
             verbose_proxy_logger.debug("DataFog guardrail: could not record logging information")
 
     async def async_pre_call_hook(
@@ -593,7 +593,7 @@ class DataFogGuardrail(CustomGuardrail):
             return data
         try:
             new_data, total_counts = self._scan_request_data(data)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001  # engine failures are handled by the configured fail policy
             self._handle_engine_error(exc)
             return data
 
@@ -623,7 +623,7 @@ class DataFogGuardrail(CustomGuardrail):
             return data
         try:
             _, total_counts = self._scan_request_data(data)
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001  # engine failures are handled by the configured fail policy
             self._handle_engine_error(exc)
             return data
 
@@ -685,7 +685,7 @@ class DataFogGuardrail(CustomGuardrail):
         stream_counts: dict[str, int] = {}
         try:
             stream_counts = self._scan_streaming_chunks(chunks, redact=self.action != "block")
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001  # engine failures are handled by the configured fail policy
             self._handle_engine_error(exc)
             for chunk in chunks:
                 yield chunk

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -310,6 +310,23 @@ class DataFogGuardrail(CustomGuardrail):
                 _merge_counts(counts, field_counts)
         return new_data, counts
 
+    def _process_completion_prompt(self, prompt: Any) -> tuple[Any, dict[str, int]]:
+        if isinstance(prompt, str):
+            return _redact_text(prompt, self.entity_types, self.locales)
+        if not isinstance(prompt, list) or not all(isinstance(item, str) for item in prompt):
+            return prompt, {}
+
+        counts: dict[str, int] = {}
+        new_prompt = []
+        changed = False
+        for item in prompt:
+            new_item, item_counts = _redact_text(item, self.entity_types, self.locales)
+            new_prompt.append(new_item)
+            if item_counts:
+                changed = True
+                _merge_counts(counts, item_counts)
+        return (new_prompt if changed else prompt), counts
+
     def _handle_engine_error(self, exc: Exception) -> None:
         """Apply the fail policy without leaking scanned text.
 
@@ -365,9 +382,24 @@ class DataFogGuardrail(CustomGuardrail):
             new_data = new_prompt_data
             _merge_counts(total_counts, prompt_counts)
 
+        if "prompt" in new_data:
+            new_prompt, completion_prompt_counts = self._process_completion_prompt(new_data["prompt"])
+            if completion_prompt_counts:
+                new_data = {**new_data, "prompt": new_prompt}
+                _merge_counts(total_counts, completion_prompt_counts)
+
         if not total_counts:
             return data, {}
         return new_data, total_counts
+
+    def _scan_text_field(self, container: Any, field_name: str, *, redact: bool) -> dict[str, int]:
+        text = _get_field(container, field_name)
+        if not isinstance(text, str):
+            return {}
+        new_text, counts = _redact_text(text, self.entity_types, self.locales)
+        if counts and redact:
+            _set_field(container, field_name, new_text)
+        return counts
 
     def _scan_response_content(self, container: Any, *, redact: bool) -> dict[str, int]:
         content = _get_field(container, "content")
@@ -479,6 +511,11 @@ class DataFogGuardrail(CustomGuardrail):
             return
 
         for choice_index, choice in enumerate(choices):
+            choice_text = _get_field(choice, "text")
+            if isinstance(choice_text, str) and choice_text:
+                key = self._stream_group_key("completion", _get_field(choice, "index") or choice_index)
+                refs.append((key, choice_text, lambda new_text, choice=choice: _set_field(choice, "text", new_text)))
+
             delta = _get_field(choice, "delta")
             if delta is None:
                 continue
@@ -674,6 +711,7 @@ class DataFogGuardrail(CustomGuardrail):
                     message = getattr(choice, "message", None)
                     if message is not None:
                         _merge_counts(response_counts, self._scan_response_message(message, redact=redact))
+                    _merge_counts(response_counts, self._scan_text_field(choice, "text", redact=redact))
             _merge_counts(response_counts, self._scan_responses_api_output(response, redact=redact))
             if isinstance(response, dict):
                 _merge_counts(response_counts, self._scan_response_content(response, redact=redact))

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -61,6 +61,24 @@ def _summary(counts: dict[str, int]) -> str:
     return ", ".join(f"{etype} x{n}" for etype, n in sorted(counts.items()))
 
 
+def _merge_counts(total_counts: dict[str, int], counts: dict[str, int]) -> None:
+    for etype, n in counts.items():
+        total_counts[etype] = total_counts.get(etype, 0) + n
+
+
+def _get_field(container: Any, field_name: str) -> Any:
+    if isinstance(container, dict):
+        return container.get(field_name)
+    return getattr(container, field_name, None)
+
+
+def _set_field(container: Any, field_name: str, value: Any) -> None:
+    if isinstance(container, dict):
+        container[field_name] = value
+    else:
+        setattr(container, field_name, value)
+
+
 class DataFogGuardrail(CustomGuardrail):
     """Offline PII guardrail powered by the datafog library."""
 
@@ -109,6 +127,124 @@ class DataFogGuardrail(CustomGuardrail):
             return new_parts, counts
         return content, counts
 
+    def _process_tool_payload(self, payload: Any) -> tuple[Any, dict[str, int]]:
+        """Redact text inside supported tool/function argument payloads."""
+        if isinstance(payload, str):
+            return _redact_text(payload, self.entity_types, self.locales)
+        if not isinstance(payload, (list, dict)):
+            return payload, {}
+
+        counts: dict[str, int] = {}
+        changed = False
+        new_payload = list(payload) if isinstance(payload, list) else dict(payload)
+        stack = [(payload, new_payload)]
+        seen = {id(payload)}
+
+        while stack:
+            original_container, new_container = stack.pop()
+            if isinstance(original_container, list):
+                items = enumerate(original_container)
+            else:
+                items = original_container.items()
+
+            for key, value in items:
+                if isinstance(value, str):
+                    redacted, value_counts = _redact_text(value, self.entity_types, self.locales)
+                    if value_counts:
+                        new_container[key] = redacted
+                        changed = True
+                        _merge_counts(counts, value_counts)
+                elif isinstance(value, list):
+                    if id(value) in seen:
+                        continue
+                    seen.add(id(value))
+                    new_value = list(value)
+                    new_container[key] = new_value
+                    stack.append((value, new_value))
+                elif isinstance(value, dict):
+                    if id(value) in seen:
+                        continue
+                    seen.add(id(value))
+                    new_value = dict(value)
+                    new_container[key] = new_value
+                    stack.append((value, new_value))
+
+        return (new_payload if changed else payload), counts
+
+    def _scan_argument_mapping(self, mapping: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
+        counts: dict[str, int] = {}
+        new_mapping = dict(mapping)
+        changed = False
+        for field_name in ("arguments", "input"):
+            payload = mapping.get(field_name)
+            if not isinstance(payload, (str, list, dict)):
+                continue
+            new_payload, payload_counts = self._process_tool_payload(payload)
+            if payload_counts:
+                new_mapping[field_name] = new_payload
+                changed = True
+                _merge_counts(counts, payload_counts)
+        return (new_mapping if changed else mapping), counts
+
+    def _scan_argument_container(self, container: Any, *, redact: bool) -> dict[str, int]:
+        """Scan supported argument fields on a dict/object container."""
+        counts: dict[str, int] = {}
+        for field_name in ("arguments", "input"):
+            payload = _get_field(container, field_name)
+            if not isinstance(payload, (str, list, dict)):
+                continue
+            new_payload, payload_counts = self._process_tool_payload(payload)
+            if payload_counts:
+                if redact:
+                    _set_field(container, field_name, new_payload)
+                _merge_counts(counts, payload_counts)
+        return counts
+
+    def _scan_request_tool_calls(self, tool_calls: Any) -> tuple[Any, dict[str, int]]:
+        if not isinstance(tool_calls, list):
+            return tool_calls, {}
+        counts: dict[str, int] = {}
+        new_tool_calls = []
+        changed = False
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict) and isinstance(tool_call.get("function"), dict):
+                new_function, function_counts = self._scan_argument_mapping(tool_call["function"])
+                if function_counts:
+                    new_tool_calls.append({**tool_call, "function": new_function})
+                    changed = True
+                    _merge_counts(counts, function_counts)
+                    continue
+            new_tool_calls.append(tool_call)
+        return (new_tool_calls if changed else tool_calls), counts
+
+    def _scan_message(self, message: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
+        counts: dict[str, int] = {}
+        new_message = dict(message)
+        changed = False
+
+        if "content" in message:
+            new_content, content_counts = self._process_content(message["content"])
+            if content_counts:
+                new_message["content"] = new_content
+                changed = True
+                _merge_counts(counts, content_counts)
+
+        function_call = message.get("function_call")
+        if isinstance(function_call, dict):
+            new_function_call, function_counts = self._scan_argument_mapping(function_call)
+            if function_counts:
+                new_message["function_call"] = new_function_call
+                changed = True
+                _merge_counts(counts, function_counts)
+
+        new_tool_calls, tool_counts = self._scan_request_tool_calls(message.get("tool_calls"))
+        if tool_counts:
+            new_message["tool_calls"] = new_tool_calls
+            changed = True
+            _merge_counts(counts, tool_counts)
+
+        return (new_message if changed else message), counts
+
     def _handle_engine_error(self, exc: Exception) -> None:
         """Apply the fail policy without leaking scanned text.
 
@@ -139,17 +275,62 @@ class DataFogGuardrail(CustomGuardrail):
         total_counts: dict[str, int] = {}
         new_messages = []
         for message in messages:
-            if isinstance(message, dict) and "content" in message:
-                new_content, counts = self._process_content(message["content"])
-                new_messages.append({**message, "content": new_content})
-                for etype, n in counts.items():
-                    total_counts[etype] = total_counts.get(etype, 0) + n
+            if isinstance(message, dict):
+                new_message, counts = self._scan_message(message)
+                new_messages.append(new_message)
+                _merge_counts(total_counts, counts)
             else:
                 new_messages.append(message)
 
         if not total_counts:
             return data, {}
         return {**data, "messages": new_messages}, total_counts
+
+    def _scan_response_content(self, container: Any, *, redact: bool) -> dict[str, int]:
+        content = _get_field(container, "content")
+        if content is None:
+            return {}
+        new_content, counts = self._process_content(content)
+        if counts and redact:
+            _set_field(container, "content", new_content)
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "tool_use":
+                    input_counts = self._scan_argument_container(part, redact=redact)
+                    _merge_counts(counts, input_counts)
+        return counts
+
+    def _scan_response_tool_calls(self, message: Any, *, redact: bool) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        function_call = _get_field(message, "function_call")
+        if function_call is not None:
+            _merge_counts(counts, self._scan_argument_container(function_call, redact=redact))
+
+        tool_calls = _get_field(message, "tool_calls")
+        if isinstance(tool_calls, list):
+            for tool_call in tool_calls:
+                function = _get_field(tool_call, "function")
+                if function is not None:
+                    _merge_counts(counts, self._scan_argument_container(function, redact=redact))
+        return counts
+
+    def _scan_response_message(self, message: Any, *, redact: bool) -> dict[str, int]:
+        counts = self._scan_response_content(message, redact=redact)
+        _merge_counts(counts, self._scan_response_tool_calls(message, redact=redact))
+        return counts
+
+    def _scan_responses_api_output(self, response: Any, *, redact: bool) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        output = _get_field(response, "output")
+        if not isinstance(output, list):
+            return counts
+        for item in output:
+            item_type = _get_field(item, "type")
+            if item_type == "message":
+                _merge_counts(counts, self._scan_response_content(item, redact=redact))
+            elif item_type in {"function_call", "custom_tool_call"}:
+                _merge_counts(counts, self._scan_argument_container(item, redact=redact))
+        return counts
 
     def _raise_block(self, total_counts: dict[str, int]) -> None:
         """Reject with HTTP 400 so the block is classified as a guardrail
@@ -236,29 +417,19 @@ class DataFogGuardrail(CustomGuardrail):
         """
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.post_call) is not True:
             return response
-        choices = getattr(response, "choices", None)
-        if not choices:
-            return response
         response_counts: dict[str, int] = {}
         try:
-            skipped_parts = 0
-            for choice in choices:
-                message = getattr(choice, "message", None)
-                if message is not None and isinstance(message.content, str):
-                    redacted, counts = _redact_text(message.content, self.entity_types, self.locales)
-                    if counts:
-                        for etype, n in counts.items():
-                            response_counts[etype] = response_counts.get(etype, 0) + n
-                        if self.action != "block":
-                            message.content = redacted
-                elif message is not None and message.content is not None:
-                    skipped_parts += 1
-            if skipped_parts:
-                verbose_proxy_logger.debug(
-                    "DataFog guardrail: %d non-text response parts not scanned",
-                    skipped_parts,
-                )
-        except Exception as exc:  # noqa: BLE001
+            redact = self.action != "block"
+            choices = getattr(response, "choices", None)
+            if choices:
+                for choice in choices:
+                    message = getattr(choice, "message", None)
+                    if message is not None:
+                        _merge_counts(response_counts, self._scan_response_message(message, redact=redact))
+            _merge_counts(response_counts, self._scan_responses_api_output(response, redact=redact))
+            if isinstance(response, dict):
+                _merge_counts(response_counts, self._scan_response_content(response, redact=redact))
+        except Exception as exc:  # noqa: BLE001  # engine failures are handled by the configured fail policy
             self._handle_engine_error(exc)
             return response
         if response_counts:

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -296,6 +296,20 @@ class DataFogGuardrail(CustomGuardrail):
 
         return (new_items if changed else input_value), counts
 
+    def _scan_top_level_prompt_fields(self, data: dict) -> tuple[dict, dict[str, int]]:
+        counts: dict[str, int] = {}
+        new_data = data
+        for field_name in ("instructions", "system"):
+            if field_name not in data:
+                continue
+            new_value, field_counts = self._process_content(data[field_name])
+            if field_counts:
+                if new_data is data:
+                    new_data = dict(data)
+                new_data[field_name] = new_value
+                _merge_counts(counts, field_counts)
+        return new_data, counts
+
     def _handle_engine_error(self, exc: Exception) -> None:
         """Apply the fail policy without leaking scanned text.
 
@@ -345,6 +359,11 @@ class DataFogGuardrail(CustomGuardrail):
         if input_counts:
             new_data = {**new_data, "input": new_input}
             _merge_counts(total_counts, input_counts)
+
+        new_prompt_data, prompt_counts = self._scan_top_level_prompt_fields(new_data)
+        if prompt_counts:
+            new_data = new_prompt_data
+            _merge_counts(total_counts, prompt_counts)
 
         if not total_counts:
             return data, {}

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -310,6 +310,21 @@ class DataFogGuardrail(CustomGuardrail):
                 _merge_counts(counts, field_counts)
         return new_data, counts
 
+    def _scan_schema_fields(self, data: dict) -> tuple[dict, dict[str, int]]:
+        counts: dict[str, int] = {}
+        new_data = data
+        for field_name in ("tools", "functions", "response_format"):
+            schema = data.get(field_name)
+            if not isinstance(schema, (list, dict)):
+                continue
+            new_schema, field_counts = self._process_tool_payload(schema)
+            if field_counts:
+                if new_data is data:
+                    new_data = dict(data)
+                new_data[field_name] = new_schema
+                _merge_counts(counts, field_counts)
+        return new_data, counts
+
     def _process_completion_prompt(self, prompt: Any) -> tuple[Any, dict[str, int]]:
         if isinstance(prompt, str):
             return _redact_text(prompt, self.entity_types, self.locales)
@@ -387,6 +402,11 @@ class DataFogGuardrail(CustomGuardrail):
             if completion_prompt_counts:
                 new_data = {**new_data, "prompt": new_prompt}
                 _merge_counts(total_counts, completion_prompt_counts)
+
+        new_schema_data, schema_counts = self._scan_schema_fields(new_data)
+        if schema_counts:
+            new_data = new_schema_data
+            _merge_counts(total_counts, schema_counts)
 
         if not total_counts:
             return data, {}

--- a/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/datafog/datafog.py
@@ -26,7 +26,7 @@ messages can embed the text being scanned.
 
 import json
 from collections.abc import AsyncGenerator, Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal  # noqa: TID251  # provider payloads are dynamic JSON values
 
 from fastapi import HTTPException
 
@@ -37,13 +37,30 @@ from litellm.types.guardrails import GuardrailEventHooks
 if TYPE_CHECKING:
     from litellm.proxy._types import UserAPIKeyAuth
 
-DEFAULT_ENTITY_TYPES = ["EMAIL", "PHONE", "CREDIT_CARD", "SSN"]
+DEFAULT_ENTITY_TYPES = [  # mutable-ok: dynamic JSON payload
+    "EMAIL",
+    "PHONE",
+    "CREDIT_CARD",
+    "SSN",
+]  # mutable-ok: dynamic JSON payload
 
-VALID_ACTIONS = {"redact", "block"}
-VALID_FAIL_POLICIES = {"open", "closed"}
+VALID_ACTIONS = {  # mutable-ok: dynamic JSON payload
+    "redact",
+    "block",
+}  # mutable-ok: dynamic JSON payload
+VALID_FAIL_POLICIES = {  # mutable-ok: dynamic JSON payload
+    "open",
+    "closed",
+}  # mutable-ok: dynamic JSON payload
 
 
-def _redact_text(text: str, entity_types: list[str], locales: list[str] | None) -> tuple[str, dict[str, int]]:
+def _redact_text(
+    text: str,
+    entity_types: list[str],  # mutable-ok: dynamic JSON payload
+    locales: list[str] | None,  # mutable-ok: dynamic JSON payload
+) -> tuple[  # mutable-ok: dynamic JSON payload
+    str, dict[str, int]
+]:  # mutable-ok: dynamic JSON payload
     """Redact ``text``; return (redacted_text, counts per entity type)."""
     try:
         import datafog  # pyright: ignore[reportMissingTypeStubs]  # datafog does not ship pyright stubs
@@ -53,28 +70,35 @@ def _redact_text(text: str, entity_types: list[str], locales: list[str] | None) 
         ) from exc
 
     result = datafog.redact(text, engine="regex", entity_types=entity_types, locales=locales)
-    counts: dict[str, int] = {}
+    counts: dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ] = {}  # mutable-ok: dynamic JSON payload
     for entity in result.entities:
         counts[entity.type] = counts.get(entity.type, 0) + 1
     return result.redacted_text, counts
 
 
-def _summary(counts: dict[str, int]) -> str:
+def _summary(
+    counts: dict[str, int],  # mutable-ok: dynamic JSON payload
+) -> str:  # mutable-ok: dynamic JSON payload
     return ", ".join(f"{etype} x{n}" for etype, n in sorted(counts.items()))
 
 
-def _merge_counts(total_counts: dict[str, int], counts: dict[str, int]) -> None:
+def _merge_counts(
+    total_counts: dict[str, int],  # mutable-ok: dynamic JSON payload
+    counts: dict[str, int],  # mutable-ok: dynamic JSON payload
+) -> None:  # mutable-ok: dynamic JSON payload
     for etype, n in counts.items():
         total_counts[etype] = total_counts.get(etype, 0) + n
 
 
-def _get_field(container: Any, field_name: str) -> Any:
+def _get_field(container: Any, field_name: str) -> Any:  # noqa: ANN401  # dynamic payload boundary
     if isinstance(container, dict):
         return container.get(field_name)
     return getattr(container, field_name, None)
 
 
-def _set_field(container: Any, field_name: str, value: Any) -> None:
+def _set_field(container: Any, field_name: str, value: Any) -> None:  # noqa: ANN401  # dynamic payload boundary
     if isinstance(container, dict):
         container[field_name] = value
     else:
@@ -87,10 +111,12 @@ class DataFogGuardrail(CustomGuardrail):
     def __init__(
         self,
         datafog_action: Literal["redact", "block"] | None = "redact",
-        datafog_entity_types: list[str] | None = None,
-        datafog_locales: list[str] | None = None,
+        datafog_entity_types: list[str]  # mutable-ok: dynamic JSON payload
+        | None = None,  # mutable-ok: dynamic JSON payload
+        datafog_locales: list[str]  # mutable-ok: dynamic JSON payload
+        | None = None,  # mutable-ok: dynamic JSON payload
         datafog_fail_policy: Literal["open", "closed"] | None = "open",
-        **kwargs: Any,
+        **kwargs: Any,  # noqa: ANN401  # dynamic payload boundary; # kwargs-ok: callback contract
     ) -> None:
         action = datafog_action or "redact"
         fail_policy = datafog_fail_policy or "open"
@@ -104,18 +130,30 @@ class DataFogGuardrail(CustomGuardrail):
         self.fail_policy = fail_policy
         super().__init__(**kwargs)
 
-    def _process_content(self, content: Any) -> tuple[Any, dict[str, int]]:
+    def _process_content(
+        self,
+        content: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         """Redact a message content value (str or list of content parts)."""
-        counts: dict[str, int] = {}
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         if isinstance(content, str):
             return _redact_text(content, self.entity_types, self.locales)
         if isinstance(content, list):
-            new_parts = []
+            new_parts = []  # mutable-ok: dynamic JSON payload
             skipped_parts = 0
             for part in content:
                 if isinstance(part, dict) and isinstance(part.get("text"), str):
                     redacted, part_counts = _redact_text(part["text"], self.entity_types, self.locales)
-                    new_parts.append({**part, "text": redacted})
+                    new_parts.append(
+                        {  # mutable-ok: dynamic JSON payload
+                            **part,
+                            "text": redacted,
+                        }  # mutable-ok: dynamic JSON payload
+                    )  # mutable-ok: dynamic JSON payload
                     for etype, n in part_counts.items():
                         counts[etype] = counts.get(etype, 0) + n
                 else:
@@ -129,18 +167,29 @@ class DataFogGuardrail(CustomGuardrail):
             return new_parts, counts
         return content, counts
 
-    def _process_tool_payload(self, payload: Any) -> tuple[Any, dict[str, int]]:
+    def _process_tool_payload(
+        self,
+        payload: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         """Redact text inside supported tool/function argument payloads."""
         if isinstance(payload, str):
             return _redact_text(payload, self.entity_types, self.locales)
         if not isinstance(payload, (list, dict)):
-            return payload, {}
+            return payload, {}  # mutable-ok: dynamic JSON payload
 
-        counts: dict[str, int] = {}
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         changed = False
-        new_payload = list(payload) if isinstance(payload, list) else dict(payload)
-        stack = [(payload, new_payload)]
-        seen = {id(payload)}
+        new_payload = (
+            list(payload) if isinstance(payload, list) else dict(payload)  # mutable-ok: dynamic JSON payload
+        )  # mutable-ok: dynamic JSON payload
+        stack = [  # mutable-ok: dynamic JSON payload
+            (payload, new_payload)
+        ]  # mutable-ok: dynamic JSON payload
+        seen = {id(payload)}  # mutable-ok: dynamic JSON payload
 
         while stack:
             original_container, new_container = stack.pop()
@@ -160,22 +209,35 @@ class DataFogGuardrail(CustomGuardrail):
                     if id(value) in seen:
                         continue
                     seen.add(id(value))
-                    new_value = list(value)
+                    new_value = list(  # mutable-ok: dynamic JSON payload
+                        value
+                    )  # mutable-ok: dynamic JSON payload
                     new_container[key] = new_value
                     stack.append((value, new_value))
                 elif isinstance(value, dict):
                     if id(value) in seen:
                         continue
                     seen.add(id(value))
-                    new_value = dict(value)
+                    new_value = dict(  # mutable-ok: dynamic JSON payload
+                        value
+                    )  # mutable-ok: dynamic JSON payload
                     new_container[key] = new_value
                     stack.append((value, new_value))
 
         return (new_payload if changed else payload), counts
 
-    def _scan_argument_mapping(self, mapping: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
-        counts: dict[str, int] = {}
-        new_mapping = dict(mapping)
+    def _scan_argument_mapping(
+        self,
+        mapping: dict[str, Any],  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict[str, Any], dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_mapping = dict(  # mutable-ok: dynamic JSON payload
+            mapping
+        )  # mutable-ok: dynamic JSON payload
         changed = False
         for field_name in ("arguments", "input"):
             payload = mapping.get(field_name)
@@ -188,9 +250,18 @@ class DataFogGuardrail(CustomGuardrail):
                 _merge_counts(counts, payload_counts)
         return (new_mapping if changed else mapping), counts
 
-    def _scan_argument_container(self, container: Any, *, redact: bool) -> dict[str, int]:
+    def _scan_argument_container(
+        self,
+        container: Any,  # noqa: ANN401  # dynamic payload boundary
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         """Scan supported argument fields on a dict/object container."""
-        counts: dict[str, int] = {}
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         for field_name in ("arguments", "input"):
             payload = _get_field(container, field_name)
             if not isinstance(payload, (str, list, dict)):
@@ -202,26 +273,50 @@ class DataFogGuardrail(CustomGuardrail):
                 _merge_counts(counts, payload_counts)
         return counts
 
-    def _scan_request_tool_calls(self, tool_calls: Any) -> tuple[Any, dict[str, int]]:
+    def _scan_request_tool_calls(
+        self,
+        tool_calls: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         if not isinstance(tool_calls, list):
-            return tool_calls, {}
-        counts: dict[str, int] = {}
-        new_tool_calls = []
+            return (
+                tool_calls,
+                {},  # mutable-ok: dynamic JSON payload
+            )  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_tool_calls = []  # mutable-ok: dynamic JSON payload
         changed = False
         for tool_call in tool_calls:
             if isinstance(tool_call, dict) and isinstance(tool_call.get("function"), dict):
                 new_function, function_counts = self._scan_argument_mapping(tool_call["function"])
                 if function_counts:
-                    new_tool_calls.append({**tool_call, "function": new_function})
+                    new_tool_calls.append(
+                        {  # mutable-ok: dynamic JSON payload
+                            **tool_call,
+                            "function": new_function,
+                        }  # mutable-ok: dynamic JSON payload
+                    )  # mutable-ok: dynamic JSON payload
                     changed = True
                     _merge_counts(counts, function_counts)
                     continue
             new_tool_calls.append(tool_call)
         return (new_tool_calls if changed else tool_calls), counts
 
-    def _scan_message(self, message: dict[str, Any]) -> tuple[dict[str, Any], dict[str, int]]:
-        counts: dict[str, int] = {}
-        new_message = dict(message)
+    def _scan_message(
+        self,
+        message: dict[str, Any],  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict[str, Any], dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_message = dict(  # mutable-ok: dynamic JSON payload
+            message
+        )  # mutable-ok: dynamic JSON payload
         changed = False
 
         if "content" in message:
@@ -247,13 +342,20 @@ class DataFogGuardrail(CustomGuardrail):
 
         return (new_message if changed else message), counts
 
-    def _scan_responses_input_item(self, item: Any) -> tuple[Any, dict[str, int]]:
+    def _scan_responses_input_item(
+        self,
+        item: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         if isinstance(item, str):
             return _redact_text(item, self.entity_types, self.locales)
         if not isinstance(item, dict):
-            return item, {}
+            return item, {}  # mutable-ok: dynamic JSON payload
 
-        counts: dict[str, int] = {}
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         new_item, message_counts = self._scan_message(item)
         changed = bool(message_counts)
         _merge_counts(counts, message_counts)
@@ -271,21 +373,33 @@ class DataFogGuardrail(CustomGuardrail):
             new_payload, payload_counts = self._process_tool_payload(payload)
             if payload_counts:
                 if not changed:
-                    new_item = dict(new_item)
+                    new_item = dict(  # mutable-ok: dynamic JSON payload
+                        new_item
+                    )  # mutable-ok: dynamic JSON payload
                 new_item[field_name] = new_payload
                 changed = True
                 _merge_counts(counts, payload_counts)
 
         return (new_item if changed else item), counts
 
-    def _scan_responses_api_input(self, input_value: Any) -> tuple[Any, dict[str, int]]:
+    def _scan_responses_api_input(
+        self,
+        input_value: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         if isinstance(input_value, str):
             return _redact_text(input_value, self.entity_types, self.locales)
         if not isinstance(input_value, list):
-            return input_value, {}
+            return (
+                input_value,
+                {},  # mutable-ok: dynamic JSON payload
+            )  # mutable-ok: dynamic JSON payload
 
-        counts: dict[str, int] = {}
-        new_items = []
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_items = []  # mutable-ok: dynamic JSON payload
         changed = False
         for item in input_value:
             new_item, item_counts = self._scan_responses_input_item(item)
@@ -296,8 +410,15 @@ class DataFogGuardrail(CustomGuardrail):
 
         return (new_items if changed else input_value), counts
 
-    def _scan_top_level_prompt_fields(self, data: dict) -> tuple[dict, dict[str, int]]:
-        counts: dict[str, int] = {}
+    def _scan_top_level_prompt_fields(
+        self,
+        data: dict,  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         new_data = data
         for field_name in ("instructions", "system"):
             if field_name not in data:
@@ -305,13 +426,22 @@ class DataFogGuardrail(CustomGuardrail):
             new_value, field_counts = self._process_content(data[field_name])
             if field_counts:
                 if new_data is data:
-                    new_data = dict(data)
+                    new_data = dict(  # mutable-ok: dynamic JSON payload
+                        data
+                    )  # mutable-ok: dynamic JSON payload
                 new_data[field_name] = new_value
                 _merge_counts(counts, field_counts)
         return new_data, counts
 
-    def _scan_schema_fields(self, data: dict) -> tuple[dict, dict[str, int]]:
-        counts: dict[str, int] = {}
+    def _scan_schema_fields(
+        self,
+        data: dict,  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         new_data = data
         for field_name in ("tools", "functions", "response_format"):
             schema = data.get(field_name)
@@ -320,19 +450,28 @@ class DataFogGuardrail(CustomGuardrail):
             new_schema, field_counts = self._process_tool_payload(schema)
             if field_counts:
                 if new_data is data:
-                    new_data = dict(data)
+                    new_data = dict(  # mutable-ok: dynamic JSON payload
+                        data
+                    )  # mutable-ok: dynamic JSON payload
                 new_data[field_name] = new_schema
                 _merge_counts(counts, field_counts)
         return new_data, counts
 
-    def _process_completion_prompt(self, prompt: Any) -> tuple[Any, dict[str, int]]:
+    def _process_completion_prompt(
+        self,
+        prompt: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        Any, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         if isinstance(prompt, str):
             return _redact_text(prompt, self.entity_types, self.locales)
         if not isinstance(prompt, list) or not all(isinstance(item, str) for item in prompt):
-            return prompt, {}
+            return prompt, {}  # mutable-ok: dynamic JSON payload
 
-        counts: dict[str, int] = {}
-        new_prompt = []
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_prompt = []  # mutable-ok: dynamic JSON payload
         changed = False
         for item in prompt:
             new_item, item_counts = _redact_text(item, self.entity_types, self.locales)
@@ -363,14 +502,21 @@ class DataFogGuardrail(CustomGuardrail):
             type(exc).__name__,
         )
 
-    def _scan_messages(self, data: dict) -> tuple[dict, dict[str, int]]:
+    def _scan_messages(
+        self,
+        data: dict,  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
         """Scan/redact all message contents; return (new_data, counts)."""
         messages = data.get("messages")
         if not isinstance(messages, list):
-            return data, {}
+            return data, {}  # mutable-ok: dynamic JSON payload
 
-        total_counts: dict[str, int] = {}
-        new_messages = []
+        total_counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        new_messages = []  # mutable-ok: dynamic JSON payload
         for message in messages:
             if isinstance(message, dict):
                 new_message, counts = self._scan_message(message)
@@ -380,16 +526,27 @@ class DataFogGuardrail(CustomGuardrail):
                 new_messages.append(message)
 
         if not total_counts:
-            return data, {}
-        return {**data, "messages": new_messages}, total_counts
+            return data, {}  # mutable-ok: dynamic JSON payload
+        return {  # mutable-ok: dynamic JSON payload
+            **data,
+            "messages": new_messages,
+        }, total_counts  # mutable-ok: dynamic JSON payload
 
-    def _scan_request_data(self, data: dict) -> tuple[dict, dict[str, int]]:
+    def _scan_request_data(
+        self,
+        data: dict,  # mutable-ok: dynamic JSON payload
+    ) -> tuple[  # mutable-ok: dynamic JSON payload
+        dict, dict[str, int]
+    ]:  # mutable-ok: dynamic JSON payload
         """Scan/redact supported request payload fields."""
         new_data, total_counts = self._scan_messages(data)
 
         new_input, input_counts = self._scan_responses_api_input(new_data.get("input"))
         if input_counts:
-            new_data = {**new_data, "input": new_input}
+            new_data = {  # mutable-ok: dynamic JSON payload
+                **new_data,
+                "input": new_input,
+            }  # mutable-ok: dynamic JSON payload
             _merge_counts(total_counts, input_counts)
 
         new_prompt_data, prompt_counts = self._scan_top_level_prompt_fields(new_data)
@@ -400,7 +557,10 @@ class DataFogGuardrail(CustomGuardrail):
         if "prompt" in new_data:
             new_prompt, completion_prompt_counts = self._process_completion_prompt(new_data["prompt"])
             if completion_prompt_counts:
-                new_data = {**new_data, "prompt": new_prompt}
+                new_data = {  # mutable-ok: dynamic JSON payload
+                    **new_data,
+                    "prompt": new_prompt,
+                }  # mutable-ok: dynamic JSON payload
                 _merge_counts(total_counts, completion_prompt_counts)
 
         new_schema_data, schema_counts = self._scan_schema_fields(new_data)
@@ -409,22 +569,37 @@ class DataFogGuardrail(CustomGuardrail):
             _merge_counts(total_counts, schema_counts)
 
         if not total_counts:
-            return data, {}
+            return data, {}  # mutable-ok: dynamic JSON payload
         return new_data, total_counts
 
-    def _scan_text_field(self, container: Any, field_name: str, *, redact: bool) -> dict[str, int]:
+    def _scan_text_field(
+        self,
+        container: Any,  # noqa: ANN401  # dynamic payload boundary
+        field_name: str,
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         text = _get_field(container, field_name)
         if not isinstance(text, str):
-            return {}
+            return {}  # mutable-ok: dynamic JSON payload
         new_text, counts = _redact_text(text, self.entity_types, self.locales)
         if counts and redact:
             _set_field(container, field_name, new_text)
         return counts
 
-    def _scan_response_content(self, container: Any, *, redact: bool) -> dict[str, int]:
+    def _scan_response_content(
+        self,
+        container: Any,  # noqa: ANN401  # dynamic payload boundary
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         content = _get_field(container, "content")
         if content is None:
-            return {}
+            return {}  # mutable-ok: dynamic JSON payload
         new_content, counts = self._process_content(content)
         if counts and redact:
             _set_field(container, "content", new_content)
@@ -435,8 +610,17 @@ class DataFogGuardrail(CustomGuardrail):
                     _merge_counts(counts, input_counts)
         return counts
 
-    def _scan_response_tool_calls(self, message: Any, *, redact: bool) -> dict[str, int]:
-        counts: dict[str, int] = {}
+    def _scan_response_tool_calls(
+        self,
+        message: Any,  # noqa: ANN401  # dynamic payload boundary
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         function_call = _get_field(message, "function_call")
         if function_call is not None:
             _merge_counts(counts, self._scan_argument_container(function_call, redact=redact))
@@ -449,13 +633,29 @@ class DataFogGuardrail(CustomGuardrail):
                     _merge_counts(counts, self._scan_argument_container(function, redact=redact))
         return counts
 
-    def _scan_response_message(self, message: Any, *, redact: bool) -> dict[str, int]:
+    def _scan_response_message(
+        self,
+        message: Any,  # noqa: ANN401  # dynamic payload boundary
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
         counts = self._scan_response_content(message, redact=redact)
         _merge_counts(counts, self._scan_response_tool_calls(message, redact=redact))
         return counts
 
-    def _scan_responses_api_output(self, response: Any, *, redact: bool) -> dict[str, int]:
-        counts: dict[str, int] = {}
+    def _scan_responses_api_output(
+        self,
+        response: Any,  # noqa: ANN401  # dynamic payload boundary
+        *,
+        redact: bool,  # noqa: ANN401  # dynamic payload boundary
+    ) -> dict[  # mutable-ok: dynamic JSON payload
+        str, int
+    ]:  # mutable-ok: dynamic JSON payload # noqa: ANN401  # dynamic payload boundary
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         output = _get_field(response, "output")
         if not isinstance(output, list):
             return counts
@@ -463,12 +663,15 @@ class DataFogGuardrail(CustomGuardrail):
             item_type = _get_field(item, "type")
             if item_type == "message":
                 _merge_counts(counts, self._scan_response_content(item, redact=redact))
-            elif item_type in {"function_call", "custom_tool_call"}:
+            elif item_type in {  # mutable-ok: dynamic JSON payload
+                "function_call",
+                "custom_tool_call",
+            }:  # mutable-ok: dynamic JSON payload
                 _merge_counts(counts, self._scan_argument_container(item, redact=redact))
         return counts
 
     @staticmethod
-    def _stream_group_key(prefix: str, *parts: Any) -> tuple[Any, ...]:
+    def _stream_group_key(prefix: str, *parts: Any) -> tuple[Any, ...]:  # noqa: ANN401  # dynamic payload boundary
         return (prefix, *parts)
 
     @staticmethod
@@ -523,8 +726,10 @@ class DataFogGuardrail(CustomGuardrail):
 
     def _append_chat_stream_text_refs(
         self,
-        chunk: Any,
-        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+        chunk: Any,  # noqa: ANN401  # dynamic payload boundary
+        refs: list[  # mutable-ok: dynamic JSON payload
+            tuple[tuple[Any, ...], str, Callable[[str], None]]
+        ],  # mutable-ok: dynamic JSON payload
     ) -> None:
         choices = _get_field(chunk, "choices")
         if not isinstance(choices, list):
@@ -547,8 +752,10 @@ class DataFogGuardrail(CustomGuardrail):
 
     def _append_responses_stream_text_ref(
         self,
-        chunk: Any,
-        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+        chunk: Any,  # noqa: ANN401  # dynamic payload boundary
+        refs: list[  # mutable-ok: dynamic JSON payload
+            tuple[tuple[Any, ...], str, Callable[[str], None]]
+        ],  # mutable-ok: dynamic JSON payload
     ) -> None:
         if _get_field(chunk, "type") != "response.output_text.delta":
             return
@@ -565,8 +772,10 @@ class DataFogGuardrail(CustomGuardrail):
 
     def _append_anthropic_stream_text_ref(
         self,
-        chunk: Any,
-        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+        chunk: Any,  # noqa: ANN401  # dynamic payload boundary
+        refs: list[  # mutable-ok: dynamic JSON payload
+            tuple[tuple[Any, ...], str, Callable[[str], None]]
+        ],  # mutable-ok: dynamic JSON payload
     ) -> None:
         if _get_field(chunk, "type") != "content_block_delta":
             return
@@ -579,8 +788,15 @@ class DataFogGuardrail(CustomGuardrail):
         key = self._stream_group_key("anthropic", _get_field(chunk, "index"))
         refs.append((key, text, lambda new_text, delta=delta: _set_field(delta, "text", new_text)))
 
-    def _collect_stream_text_refs(self, chunks: list[Any]) -> list[tuple[tuple[Any, ...], str, Callable[[str], None]]]:
-        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]] = []
+    def _collect_stream_text_refs(
+        self,
+        chunks: list[Any],  # mutable-ok: dynamic JSON payload
+    ) -> list[  # mutable-ok: dynamic JSON payload
+        tuple[tuple[Any, ...], str, Callable[[str], None]]
+    ]:  # mutable-ok: dynamic JSON payload
+        refs: list[  # mutable-ok: dynamic JSON payload
+            tuple[tuple[Any, ...], str, Callable[[str], None]]
+        ] = []  # mutable-ok: dynamic JSON payload
         for chunk_index, chunk in enumerate(chunks):
             if isinstance(chunk, (bytes, bytearray)):
                 sse_delta = self._decode_sse_text_delta(chunk)
@@ -607,14 +823,22 @@ class DataFogGuardrail(CustomGuardrail):
 
     def _scan_stream_text_refs(
         self,
-        refs: list[tuple[tuple[Any, ...], str, Callable[[str], None]]],
+        refs: list[  # mutable-ok: dynamic JSON payload
+            tuple[tuple[Any, ...], str, Callable[[str], None]]
+        ],  # mutable-ok: dynamic JSON payload
         *,
         redact: bool,
-    ) -> dict[str, int]:
-        counts: dict[str, int] = {}
-        refs_by_group: dict[tuple[Any, ...], list[tuple[str, Callable[[str], None]]]] = {}
+    ) -> dict[str, int]:  # mutable-ok: dynamic JSON payload
+        counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
+        refs_by_group: dict[  # mutable-ok: dynamic JSON payload
+            tuple[Any, ...], list[tuple[str, Callable[[str], None]]]
+        ] = {}  # mutable-ok: dynamic JSON payload
         for key, text, setter in refs:
-            refs_by_group.setdefault(key, []).append((text, setter))
+            refs_by_group.setdefault(key, []).append(  # mutable-ok: dynamic JSON payload
+                (text, setter)
+            )  # mutable-ok: dynamic JSON payload
 
         for grouped_refs in refs_by_group.values():
             stream_text = "".join(text for text, _ in grouped_refs)
@@ -631,29 +855,45 @@ class DataFogGuardrail(CustomGuardrail):
 
         return counts
 
-    def _scan_streaming_chunks(self, chunks: list[Any], *, redact: bool) -> dict[str, int]:
+    def _scan_streaming_chunks(
+        self,
+        chunks: list[Any],  # mutable-ok: dynamic JSON payload
+        *,
+        redact: bool,  # mutable-ok: dynamic JSON payload
+    ) -> dict[str, int]:  # mutable-ok: dynamic JSON payload
         refs = self._collect_stream_text_refs(chunks)
         if not refs:
-            return {}
+            return {}  # mutable-ok: dynamic JSON payload
         return self._scan_stream_text_refs(refs, redact=redact)
 
-    def _raise_block(self, total_counts: dict[str, int]) -> None:
+    def _raise_block(
+        self,
+        total_counts: dict[str, int],  # mutable-ok: dynamic JSON payload
+    ) -> None:  # mutable-ok: dynamic JSON payload
         """Reject with HTTP 400 so the block is classified as a guardrail
         intervention by ``_is_guardrail_intervention`` rather than a
         backend failure, and reaches the client as 400 instead of 500."""
         raise HTTPException(
             status_code=400,
-            detail={"error": (f"Violated DataFog PII guardrail policy: request contains {_summary(total_counts)}.")},
+            detail={  # mutable-ok: dynamic JSON payload
+                "error": (f"Violated DataFog PII guardrail policy: request contains {_summary(total_counts)}.")
+            },  # mutable-ok: dynamic JSON payload
         )
 
-    def _record_guardrail_logging(self, data: dict, total_counts: dict[str, int]) -> None:
+    def _record_guardrail_logging(
+        self,
+        data: dict,  # mutable-ok: dynamic JSON payload
+        total_counts: dict[str, int],  # mutable-ok: dynamic JSON payload
+    ) -> None:  # mutable-ok: dynamic JSON payload
         """Record the decision into standard guardrail logging."""
         try:
             self.add_standard_logging_guardrail_information_to_request_data(
                 guardrail_json_response=_summary(total_counts),
                 request_data=data,
                 guardrail_status="guardrail_intervened",
-                masked_entity_count=dict(total_counts),
+                masked_entity_count=dict(  # mutable-ok: dynamic JSON payload
+                    total_counts
+                ),  # mutable-ok: dynamic JSON payload
             )
         except Exception:  # noqa: BLE001  # logging failures must not break guardrail enforcement
             verbose_proxy_logger.debug("DataFog guardrail: could not record logging information")
@@ -661,10 +901,12 @@ class DataFogGuardrail(CustomGuardrail):
     async def async_pre_call_hook(
         self,
         user_api_key_dict: "UserAPIKeyAuth",
-        cache: Any,
-        data: dict,
+        cache: Any,  # noqa: ANN401  # dynamic payload boundary
+        data: dict,  # mutable-ok: dynamic JSON payload
         call_type: str,
-    ) -> Exception | str | dict | None:
+    ) -> (
+        Exception | str | dict | None  # mutable-ok: dynamic JSON payload
+    ):  # mutable-ok: dynamic JSON payload
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.pre_call) is not True:
             return data
         try:
@@ -684,10 +926,10 @@ class DataFogGuardrail(CustomGuardrail):
 
     async def async_moderation_hook(
         self,
-        data: dict,
+        data: dict,  # mutable-ok: dynamic JSON payload
         user_api_key_dict: "UserAPIKeyAuth",
         call_type: str,
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401  # dynamic payload boundary
         """Block on PII during the parallel call window.
 
         Content cannot be rewritten mid-flight, so redact mode is a no-op
@@ -710,10 +952,10 @@ class DataFogGuardrail(CustomGuardrail):
 
     async def async_post_call_success_hook(
         self,
-        data: dict,
+        data: dict,  # mutable-ok: dynamic JSON payload
         user_api_key_dict: "UserAPIKeyAuth",
-        response: Any,
-    ) -> Any:
+        response: Any,  # noqa: ANN401  # dynamic payload boundary
+    ) -> Any:  # noqa: ANN401  # dynamic payload boundary
         """Redact PII from model responses, or block when action is block.
 
         Redaction mutates ``response`` in place, deliberately: post_call
@@ -722,7 +964,9 @@ class DataFogGuardrail(CustomGuardrail):
         """
         if self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.post_call) is not True:
             return response
-        response_counts: dict[str, int] = {}
+        response_counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         try:
             redact = self.action != "block"
             choices = getattr(response, "choices", None)
@@ -747,19 +991,21 @@ class DataFogGuardrail(CustomGuardrail):
     async def async_post_call_streaming_iterator_hook(
         self,
         user_api_key_dict: "UserAPIKeyAuth",
-        response: Any,
-        request_data: dict,
+        response: Any,  # noqa: ANN401  # dynamic payload boundary
+        request_data: dict,  # mutable-ok: dynamic JSON payload
     ) -> AsyncGenerator[Any, None]:
         if self.should_run_guardrail(data=request_data, event_type=GuardrailEventHooks.post_call) is not True:
             async for chunk in response:
                 yield chunk
             return
 
-        chunks = []
+        chunks = []  # mutable-ok: dynamic JSON payload
         async for chunk in response:
             chunks.append(chunk)
 
-        stream_counts: dict[str, int] = {}
+        stream_counts: dict[  # mutable-ok: dynamic JSON payload
+            str, int
+        ] = {}  # mutable-ok: dynamic JSON payload
         try:
             stream_counts = self._scan_streaming_chunks(chunks, redact=self.action != "block")
         except Exception as exc:  # noqa: BLE001  # engine failures are handled by the configured fail policy

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -44,6 +44,9 @@ from litellm.types.proxy.guardrails.guardrail_hooks.hiddenlayer import (
 from litellm.types.proxy.guardrails.guardrail_hooks.qohash import (
     QostodianNexusConfigModel,
 )
+from litellm.types.proxy.guardrails.guardrail_hooks.datafog import (
+    DataFogGuardrailConfigModel,
+)
 from litellm.types.proxy.guardrails.guardrail_hooks.repelloai import (
     RepelloAIGuardrailConfigModel,
 )
@@ -133,6 +136,7 @@ class SupportedGuardrailIntegrations(Enum):
     HEADROOM = "headroom"
     COMPRESR = "compresr"
     STRAIKER = "straiker"
+    DATAFOG = "datafog"
 
 
 class Role(Enum):
@@ -982,6 +986,7 @@ class LitellmParams(
     QostodianNexusConfigModel,
     VigilGuardGuardrailConfigModel,
     SingulrGuardrailConfigModel,
+    DataFogGuardrailConfigModel,
 ):
     guardrail: str = Field(description="The type of guardrail integration to use")
     mode: Union[str, List[str], Mode] = Field(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/datafog.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/datafog.py
@@ -1,0 +1,48 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .base import GuardrailConfigModel
+
+
+class DataFogGuardrailOptionalParams(BaseModel):
+    datafog_entity_types: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Entity types to detect. Defaults to the high-precision set: "
+            "EMAIL, PHONE, CREDIT_CARD, SSN. Additional types (IP_ADDRESS, "
+            "DOB, ZIP, and DE_* locale entities) are opt-in because they "
+            "are noisy in technical text."
+        ),
+    )
+    datafog_locales: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            'Locale packs to enable for country-specific entities, e.g. ["de"] for German VAT IDs, IBANs, and tax IDs.'
+        ),
+    )
+    datafog_fail_policy: Optional[Literal["open", "closed"]] = Field(
+        default="open",
+        description=(
+            "Behavior when the detection engine errors. 'open' (default) "
+            "lets traffic through unscanned so a guardrail bug never takes "
+            "down the gateway; 'closed' rejects traffic instead, for "
+            "compliance deployments where unscanned egress is worse than "
+            "downtime."
+        ),
+    )
+
+
+class DataFogGuardrailConfigModel(GuardrailConfigModel[DataFogGuardrailOptionalParams]):
+    datafog_action: Optional[Literal["redact", "block"]] = Field(
+        default="redact",
+        description=(
+            "'redact' (default) replaces detected PII with [TYPE_N] tokens "
+            "before the request leaves the gateway; 'block' rejects the "
+            "request with an HTTP 400 listing entity-type counts only."
+        ),
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "DataFog PII Guardrail"

--- a/litellm/types/proxy/guardrails/guardrail_hooks/datafog.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/datafog.py
@@ -6,16 +6,18 @@ from .base import GuardrailConfigModel
 
 
 class DataFogGuardrailOptionalParams(BaseModel):
-    datafog_entity_types: Optional[list[str]] = Field(
-        default=None,
-        description=(
-            "Entity types to detect. Defaults to the high-precision set: "
-            "EMAIL, PHONE, CREDIT_CARD, SSN. Additional types (IP_ADDRESS, "
-            "DOB, ZIP, and DE_* locale entities) are opt-in because they "
-            "are noisy in technical text."
-        ),
+    datafog_entity_types: Optional[list[str]] = (  # mutable-ok: dynamic JSON payload
+        Field(  # mutable-ok: dynamic JSON payload
+            default=None,
+            description=(
+                "Entity types to detect. Defaults to the high-precision set: "
+                "EMAIL, PHONE, CREDIT_CARD, SSN. Additional types (IP_ADDRESS, "
+                "DOB, ZIP, and DE_* locale entities) are opt-in because they "
+                "are noisy in technical text."
+            ),
+        )
     )
-    datafog_locales: Optional[list[str]] = Field(
+    datafog_locales: Optional[list[str]] = Field(  # mutable-ok: dynamic JSON payload
         default=None,
         description=(
             'Locale packs to enable for country-specific entities, e.g. ["de"] for German VAT IDs, IBANs, and tax IDs.'

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,7 +6,7 @@ lint.extend-select = ["T20", "PGH004", "RUF008", "RUF009", "RUF100"]
 # litellm's own ruff config both rely on suppressions this config can't see.
 lint.external = [
     # Enforced by the strict-rule gate (scripts/ruff_strict_gate.py + ruff-strict.toml)
-    "C901", "TID251",
+    "ANN401", "C901", "TID251",
     # Enforced by upstream litellm's ruff config, but not run in this repo's CI
     "PLC0415", "E402", "BLE001", "ARG002", "S102", "S324", "S606", "D401", "F403", "F405",
 ]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -37,6 +37,15 @@ def _model_response(text: str):
     return resp
 
 
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+async def _collect_async(async_iterable):
+    return [item async for item in async_iterable]
+
+
 @pytest.mark.asyncio
 async def test_pre_call_redacts_email():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
@@ -120,6 +129,53 @@ async def test_pre_call_redacts_tool_and_function_call_arguments():
     assert EMAIL not in message["tool_calls"][0]["function"]["arguments"]
     assert SSN in original["messages"][0]["function_call"]["arguments"]
     assert EMAIL in original["messages"][0]["tool_calls"][0]["function"]["arguments"]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_responses_api_input_string():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {"input": f"Please contact {EMAIL}"}
+
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="responses",
+    )
+
+    assert EMAIL not in data["input"]
+    assert "[EMAIL_1]" in data["input"]
+    assert original["input"] == f"Please contact {EMAIL}"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_responses_api_input_items():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": f"email {EMAIL}"}],
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": {"ssn": SSN},
+            },
+        ]
+    }
+
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="responses",
+    )
+
+    assert EMAIL not in data["input"][0]["content"][0]["text"]
+    assert SSN not in data["input"][1]["output"]["ssn"]
+    assert EMAIL in original["input"][0]["content"][0]["text"]
+    assert SSN in original["input"][1]["output"]["ssn"]
 
 
 def test_process_content_returns_unmodified_non_text_content():
@@ -223,6 +279,17 @@ async def test_during_call_blocks_tool_call_arguments_when_action_is_block():
             },
             user_api_key_dict=None,
             call_type="completion",
+        )
+
+
+@pytest.mark.asyncio
+async def test_during_call_blocks_responses_api_input_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={"input": [{"role": "user", "content": [{"type": "input_text", "text": f"email {EMAIL}"}]}]},
+            user_api_key_dict=None,
+            call_type="responses",
         )
 
 
@@ -368,6 +435,110 @@ async def test_post_call_fail_open_returns_response_on_engine_error(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_streaming_redacts_model_response_chunks_before_yielding():
+    from litellm.types.utils import ModelResponseStream
+
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    chunks = [
+        ModelResponseStream(choices=[{"index": 0, "delta": {"content": "email jane.doe@"}}]),
+        ModelResponseStream(choices=[{"index": 0, "delta": {"content": "example.com"}, "finish_reason": "stop"}]),
+    ]
+
+    result = await _collect_async(
+        guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=None,
+            response=_async_iter(chunks),
+            request_data={},
+        )
+    )
+
+    text = "".join(chunk.choices[0].delta.content or "" for chunk in result)
+    assert EMAIL not in text
+    assert "[EMAIL_1]" in text
+
+
+@pytest.mark.asyncio
+async def test_streaming_redacts_responses_api_output_text_delta_events():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    chunks = [
+        SimpleNamespace(
+            type="response.output_text.delta",
+            item_id="msg_1",
+            output_index=0,
+            content_index=0,
+            delta="email jane.doe@",
+        ),
+        SimpleNamespace(
+            type="response.output_text.delta",
+            item_id="msg_1",
+            output_index=0,
+            content_index=0,
+            delta="example.com",
+        ),
+    ]
+
+    result = await _collect_async(
+        guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=None,
+            response=_async_iter(chunks),
+            request_data={},
+        )
+    )
+
+    text = "".join(chunk.delta for chunk in result)
+    assert EMAIL not in text
+    assert "[EMAIL_1]" in text
+
+
+@pytest.mark.asyncio
+async def test_streaming_redacts_anthropic_sse_text_delta_bytes():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    chunks = [
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+        b'"delta":{"type":"text_delta","text":"email jane.doe@"}}\n\n',
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,'
+        b'"delta":{"type":"text_delta","text":"example.com"}}\n\n',
+    ]
+
+    result = await _collect_async(
+        guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=None,
+            response=_async_iter(chunks),
+            request_data={},
+        )
+    )
+
+    raw_text = b"".join(result).decode("utf-8")
+    assert EMAIL not in raw_text
+    assert "[EMAIL_1]" in raw_text
+
+
+@pytest.mark.asyncio
+async def test_streaming_block_raises_before_mutating_chunks():
+    from litellm.types.utils import ModelResponseStream
+
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    chunks = [
+        ModelResponseStream(choices=[{"index": 0, "delta": {"content": "email jane.doe@"}}]),
+        ModelResponseStream(choices=[{"index": 0, "delta": {"content": "example.com"}, "finish_reason": "stop"}]),
+    ]
+
+    with pytest.raises(HTTPException) as exc:
+        await _collect_async(
+            guardrail.async_post_call_streaming_iterator_hook(
+                user_api_key_dict=None,
+                response=_async_iter(chunks),
+                request_data={},
+            )
+        )
+
+    assert exc.value.status_code == 400
+    assert EMAIL not in str(exc.value.detail)
+    assert chunks[0].choices[0].delta.content == "email jane.doe@"
+    assert chunks[1].choices[0].delta.content == "example.com"
+
+
+@pytest.mark.asyncio
 async def test_noisy_entities_off_by_default():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
     data = await guardrail.async_pre_call_hook(
@@ -509,8 +680,52 @@ def test_registry_registration():
     from litellm.proxy.guardrails.guardrail_hooks.datafog import (
         guardrail_class_registry,
         guardrail_initializer_registry,
+        initialize_guardrail,
     )
     from litellm.types.guardrails import SupportedGuardrailIntegrations
 
     assert SupportedGuardrailIntegrations.DATAFOG.value in guardrail_initializer_registry
+    assert guardrail_initializer_registry[SupportedGuardrailIntegrations.DATAFOG.value] is initialize_guardrail
     assert guardrail_class_registry[SupportedGuardrailIntegrations.DATAFOG.value] is (DataFogGuardrail)
+
+
+def test_initialize_guardrail_registers_callback(monkeypatch):
+    from litellm.proxy.guardrails.guardrail_hooks.datafog import initialize_guardrail
+
+    registered = []
+    monkeypatch.setattr(
+        "litellm.logging_callback_manager.add_litellm_callback",
+        lambda callback: registered.append(callback),
+    )
+    params = SimpleNamespace(
+        mode="pre_call",
+        default_on=True,
+        datafog_action="block",
+        optional_params=SimpleNamespace(
+            datafog_entity_types=["EMAIL"],
+            datafog_locales=["de"],
+            datafog_fail_policy="closed",
+        ),
+    )
+
+    guardrail = initialize_guardrail(params, {"guardrail_name": "datafog-pii"})
+
+    assert isinstance(guardrail, DataFogGuardrail)
+    assert registered == [guardrail]
+    assert guardrail.guardrail_name == "datafog-pii"
+    assert guardrail.action == "block"
+    assert guardrail.entity_types == ["EMAIL"]
+    assert guardrail.locales == ["de"]
+    assert guardrail.fail_policy == "closed"
+
+
+def test_initialize_guardrail_requires_name():
+    from litellm.proxy.guardrails.guardrail_hooks.datafog import initialize_guardrail
+
+    params = SimpleNamespace(mode="pre_call", default_on=True, datafog_action="redact", optional_params=None)
+    with pytest.raises(ValueError, match="guardrail_name"):
+        initialize_guardrail(params, {})
+
+
+def test_config_model_ui_name():
+    assert DataFogGuardrail.get_config_model().ui_friendly_name() == "DataFog PII Guardrail"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -7,6 +7,7 @@ domains, test card numbers, invalid SSN ranges).
 
 import os
 import sys
+from types import SimpleNamespace
 
 import pytest
 
@@ -82,6 +83,95 @@ async def test_pre_call_redacts_content_parts_and_skips_images():
 
 
 @pytest.mark.asyncio
+async def test_pre_call_redacts_tool_and_function_call_arguments():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {
+        "messages": [
+            {
+                "role": "assistant",
+                "content": None,
+                "function_call": {
+                    "name": "legacy_lookup",
+                    "arguments": f'{{"ssn": "{SSN}"}}',
+                },
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "send_email",
+                            "arguments": f'{{"recipient": "{EMAIL}"}}',
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="completion",
+    )
+
+    message = data["messages"][0]
+    assert message["content"] is None
+    assert SSN not in message["function_call"]["arguments"]
+    assert EMAIL not in message["tool_calls"][0]["function"]["arguments"]
+    assert SSN in original["messages"][0]["function_call"]["arguments"]
+    assert EMAIL in original["messages"][0]["tool_calls"][0]["function"]["arguments"]
+
+
+def test_process_content_returns_unmodified_non_text_content():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    content = {"structured": "payload"}
+    assert guardrail._process_content(content) == (content, {})
+
+
+def test_process_tool_payload_handles_nested_lists_and_non_text_values():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    payload = ["plain", {"email": EMAIL}, [SSN], 42]
+    redacted, counts = guardrail._process_tool_payload(payload)
+
+    assert EMAIL not in redacted[1]["email"]
+    assert SSN not in redacted[2][0]
+    assert redacted[3] == 42
+    assert counts == {"EMAIL": 1, "SSN": 1}
+    assert guardrail._process_tool_payload(42) == (42, {})
+
+
+def test_process_tool_payload_skips_seen_containers():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    payload = {"self": None, "email": EMAIL}
+    payload["self"] = payload
+    list_payload = [EMAIL]
+    list_payload.append(list_payload)
+
+    redacted, counts = guardrail._process_tool_payload(payload)
+    redacted_list, list_counts = guardrail._process_tool_payload(list_payload)
+
+    assert EMAIL not in redacted["email"]
+    assert counts == {"EMAIL": 1}
+    assert EMAIL not in redacted_list[0]
+    assert list_counts == {"EMAIL": 1}
+
+
+def test_scan_request_tool_calls_preserves_unsupported_entries():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    tool_calls = ["not-a-tool", {"id": "call_1", "type": "function"}]
+    assert guardrail._scan_request_tool_calls(tool_calls) == (tool_calls, {})
+
+
+def test_scan_messages_ignores_non_message_payloads():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = {"messages": "not-a-list"}
+    assert guardrail._scan_messages(data) == (data, {})
+
+    data = {"messages": ["not-a-dict", {"role": "system"}]}
+    assert guardrail._scan_messages(data) == (data, {})
+
+
+@pytest.mark.asyncio
 async def test_block_raises_http_400_without_echoing_pii():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
     with pytest.raises(HTTPException) as exc:
@@ -109,6 +199,34 @@ async def test_during_call_blocks_when_action_is_block():
 
 
 @pytest.mark.asyncio
+async def test_during_call_blocks_tool_call_arguments_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "send_email",
+                                    "arguments": f'{{"recipient": "{EMAIL}"}}',
+                                },
+                            }
+                        ],
+                    }
+                ]
+            },
+            user_api_key_dict=None,
+            call_type="completion",
+        )
+
+
+@pytest.mark.asyncio
 async def test_during_call_noop_when_action_is_redact():
     # during_call cannot modify content mid-flight; redact mode is a no-op.
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="redact")
@@ -123,6 +241,130 @@ async def test_post_call_redacts_model_response():
     response = _model_response(f"the customer is reachable at {EMAIL}")
     await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
     assert EMAIL not in response.choices[0].message.content
+
+
+@pytest.mark.asyncio
+async def test_post_call_redacts_model_response_tool_and_function_arguments():
+    import litellm
+
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = litellm.ModelResponse(
+        choices=[
+            {
+                "finish_reason": "tool_calls",
+                "index": 0,
+                "message": {
+                    "content": None,
+                    "role": "assistant",
+                    "function_call": {
+                        "name": "legacy_lookup",
+                        "arguments": f'{{"ssn": "{SSN}"}}',
+                    },
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "send_email",
+                                "arguments": f'{{"recipient": "{EMAIL}"}}',
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    )
+
+    await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    message = response.choices[0].message
+    assert message.content is None
+    assert SSN not in message.function_call.arguments
+    assert EMAIL not in message.tool_calls[0].function.arguments
+
+
+@pytest.mark.asyncio
+async def test_post_call_redacts_responses_api_output_text_and_arguments():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = SimpleNamespace(
+        output=[
+            {
+                "type": "message",
+                "content": [{"type": "output_text", "text": f"contact {EMAIL}"}],
+            },
+            {
+                "type": "function_call",
+                "arguments": f'{{"card": "{CARD}"}}',
+            },
+        ]
+    )
+
+    await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    assert EMAIL not in response.output[0]["content"][0]["text"]
+    assert CARD not in response.output[1]["arguments"]
+
+
+@pytest.mark.asyncio
+async def test_post_call_redacts_anthropic_messages_content_and_tool_use_input():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [
+            {"type": "text", "text": f"email {EMAIL}"},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "lookup_customer",
+                "input": {"ssn": SSN},
+            },
+        ],
+    }
+
+    await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    assert EMAIL not in response["content"][0]["text"]
+    assert SSN not in response["content"][1]["input"]["ssn"]
+
+
+@pytest.mark.asyncio
+async def test_post_call_returns_original_when_event_hook_does_not_match():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, event_hook="pre_call")
+    response = _model_response(f"the customer is reachable at {EMAIL}")
+    result = await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert result is response
+    assert response.choices[0].message.content == f"the customer is reachable at {EMAIL}"
+
+
+@pytest.mark.asyncio
+async def test_post_call_returns_response_without_choices():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = SimpleNamespace(choices=[])
+    result = await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_post_call_skips_non_text_response_parts():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=[{"type": "image"}]))])
+    result = await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_post_call_fail_open_returns_response_on_engine_error(monkeypatch):
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    monkeypatch.setattr(
+        "litellm.proxy.guardrails.guardrail_hooks.datafog.datafog._redact_text",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    response = _model_response(f"the customer is reachable at {EMAIL}")
+    result = await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert result is response
+    assert response.choices[0].message.content == f"the customer is reachable at {EMAIL}"
 
 
 @pytest.mark.asyncio
@@ -218,6 +460,42 @@ async def test_post_call_block_raises_on_response_pii():
         await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
     assert exc.value.status_code == 400
     assert EMAIL not in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_post_call_block_raises_on_response_tool_call_arguments():
+    import litellm
+
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    response = litellm.ModelResponse(
+        choices=[
+            {
+                "finish_reason": "tool_calls",
+                "index": 0,
+                "message": {
+                    "content": None,
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "send_email",
+                                "arguments": f'{{"recipient": "{EMAIL}"}}',
+                            },
+                        }
+                    ],
+                },
+            }
+        ]
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    assert exc.value.status_code == 400
+    assert EMAIL not in str(exc.value.detail)
+    assert response.choices[0].message.tool_calls[0].function.arguments == f'{{"recipient": "{EMAIL}"}}'
 
 
 def test_invalid_config_rejected():

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -6,14 +6,14 @@ domains, test card numbers, invalid SSN ranges).
 """
 
 import os
+import re
 import sys
+from types import ModuleType
 from types import SimpleNamespace
 
 import pytest
 
 sys.path.insert(0, os.path.abspath("../../"))  # Adds the parent directory to the system path
-
-pytest.importorskip("datafog")
 
 from fastapi import HTTPException
 
@@ -23,6 +23,53 @@ EMAIL = "jane.doe@example.com"
 CARD = "4242 4242 4242 4242"
 SSN = "856-45-6789"
 DE_TAX_ID = "12345678901"
+
+
+def _fake_datafog_module() -> ModuleType:
+    fake_datafog = ModuleType("datafog")
+    patterns = {
+        "EMAIL": re.compile(r"\bjane\.doe@example\.com\b"),
+        "PHONE": re.compile(r"\b555-0100\b"),
+        "CREDIT_CARD": re.compile(r"\b4242 4242 4242 4242\b"),
+        "SSN": re.compile(r"\b856-45-6789\b"),
+        "IP_ADDRESS": re.compile(r"\b192\.168\.1\.1\b"),
+        "DE_TAX_ID": re.compile(r"\b12345678901\b"),
+    }
+
+    def redact(text: str, engine: str, entity_types: list[str], locales: list[str] | None):
+        matches = []
+        for entity_type in entity_types:
+            if entity_type.startswith("DE_") and (not locales or "de" not in locales):
+                continue
+            pattern = patterns.get(entity_type)
+            if pattern is None:
+                continue
+            for match in pattern.finditer(text):
+                matches.append((match.start(), match.end(), entity_type))
+        matches.sort(key=lambda item: item[0])
+
+        redacted_parts = []
+        entities = []
+        cursor = 0
+        counts: dict[str, int] = {}
+        for start, end, entity_type in matches:
+            if start < cursor:
+                continue
+            counts[entity_type] = counts.get(entity_type, 0) + 1
+            redacted_parts.append(text[cursor:start])
+            redacted_parts.append(f"[{entity_type}_{counts[entity_type]}]")
+            entities.append(SimpleNamespace(type=entity_type))
+            cursor = end
+        redacted_parts.append(text[cursor:])
+        return SimpleNamespace(redacted_text="".join(redacted_parts), entities=entities)
+
+    fake_datafog.redact = redact
+    return fake_datafog
+
+
+@pytest.fixture(autouse=True)
+def fake_datafog(monkeypatch):
+    monkeypatch.setitem(sys.modules, "datafog", _fake_datafog_module())
 
 
 def _chat_data(content) -> dict:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -179,6 +179,84 @@ async def test_pre_call_redacts_tool_and_function_call_arguments():
 
 
 @pytest.mark.asyncio
+async def test_pre_call_redacts_tool_and_function_definitions():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {
+        "messages": [{"role": "user", "content": "look up the customer"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_customer",
+                    "description": f"Send the result to {EMAIL}",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "card": {
+                                "type": "string",
+                                "description": f"Customer card number, such as {CARD}",
+                            }
+                        },
+                    },
+                },
+            },
+            {
+                "name": "anthropic_lookup",
+                "description": f"Look up customer {SSN}",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "email": {"type": "string", "examples": [EMAIL]},
+                    },
+                },
+            },
+        ],
+        "functions": [
+            {
+                "name": "legacy_lookup",
+                "description": f"Look up card {CARD}",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "ssn": {"type": "string", "default": SSN},
+                    },
+                },
+            }
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "customer_record",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "email": {"type": "string", "description": f"For example, {EMAIL}"},
+                    },
+                },
+            },
+        },
+    }
+
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="completion",
+    )
+
+    assert EMAIL not in data["tools"][0]["function"]["description"]
+    assert CARD not in data["tools"][0]["function"]["parameters"]["properties"]["card"]["description"]
+    assert SSN not in data["tools"][1]["description"]
+    assert EMAIL not in data["tools"][1]["input_schema"]["properties"]["email"]["examples"]
+    assert CARD not in data["functions"][0]["description"]
+    assert SSN not in data["functions"][0]["parameters"]["properties"]["ssn"]["default"]
+    assert EMAIL not in data["response_format"]["json_schema"]["schema"]["properties"]["email"]["description"]
+    assert EMAIL in original["tools"][0]["function"]["description"]
+    assert SSN in original["functions"][0]["parameters"]["properties"]["ssn"]["default"]
+    assert EMAIL in original["response_format"]["json_schema"]["schema"]["properties"]["email"]["description"]
+
+
+@pytest.mark.asyncio
 async def test_pre_call_redacts_responses_api_input_string():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
     original = {"input": f"Please contact {EMAIL}"}
@@ -396,6 +474,42 @@ async def test_during_call_blocks_tool_call_arguments_when_action_is_block():
                                 },
                             }
                         ],
+                    }
+                ]
+            },
+            user_api_key_dict=None,
+            call_type="completion",
+        )
+
+
+@pytest.mark.asyncio
+async def test_during_call_blocks_tool_and_function_definitions_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "notify_customer",
+                            "description": f"Notify {EMAIL}",
+                        },
+                    }
+                ]
+            },
+            user_api_key_dict=None,
+            call_type="completion",
+        )
+
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={
+                "functions": [
+                    {
+                        "name": "legacy_lookup",
+                        "parameters": {"type": "object", "description": f"Use card {CARD}"},
                     }
                 ]
             },

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -225,6 +225,54 @@ async def test_pre_call_redacts_responses_api_input_items():
     assert SSN in original["input"][1]["output"]["ssn"]
 
 
+@pytest.mark.asyncio
+async def test_pre_call_redacts_top_level_instructions_and_system_string():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {
+        "instructions": f"Route customer follow-up to {EMAIL}",
+        "system": f"Billing card on file is {CARD}",
+        "input": "summarize the customer account",
+    }
+
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="responses",
+    )
+
+    assert EMAIL not in data["instructions"]
+    assert "[EMAIL_1]" in data["instructions"]
+    assert CARD not in data["system"]
+    assert "[CREDIT_CARD_1]" in data["system"]
+    assert original["instructions"] == f"Route customer follow-up to {EMAIL}"
+    assert original["system"] == f"Billing card on file is {CARD}"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_top_level_anthropic_system_content_blocks():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original = {
+        "system": [
+            {"type": "text", "text": f"Use tax profile {SSN} for context"},
+            {"type": "cache_control", "cache_control": {"type": "ephemeral"}},
+        ],
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original,
+        call_type="completion",
+    )
+
+    assert SSN not in data["system"][0]["text"]
+    assert "[SSN_1]" in data["system"][0]["text"]
+    assert data["system"][1] == original["system"][1]
+    assert SSN in original["system"][0]["text"]
+
+
 def test_process_content_returns_unmodified_non_text_content():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
     content = {"structured": "payload"}
@@ -337,6 +385,25 @@ async def test_during_call_blocks_responses_api_input_when_action_is_block():
             data={"input": [{"role": "user", "content": [{"type": "input_text", "text": f"email {EMAIL}"}]}]},
             user_api_key_dict=None,
             call_type="responses",
+        )
+
+
+@pytest.mark.asyncio
+async def test_during_call_blocks_top_level_prompt_fields_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={"instructions": f"Contact billing at {EMAIL}"},
+            user_api_key_dict=None,
+            call_type="responses",
+        )
+
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={"system": [{"type": "text", "text": f"Use card {CARD} for lookup"}]},
+            user_api_key_dict=None,
+            call_type="completion",
         )
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -198,6 +198,28 @@ async def test_fail_closed_raises_without_pii_or_cause_chain(monkeypatch):
     assert EMAIL not in str(exc.value)
 
 
+@pytest.mark.asyncio
+async def test_redact_logging_metadata_survives_on_returned_data():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data(f"email {EMAIL}"),
+        call_type="completion",
+    )
+    assert "metadata" in data
+
+
+@pytest.mark.asyncio
+async def test_post_call_block_raises_on_response_pii():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    response = _model_response(f"the customer is reachable at {EMAIL}")
+    with pytest.raises(HTTPException) as exc:
+        await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert exc.value.status_code == 400
+    assert EMAIL not in str(exc.value.detail)
+
+
 def test_invalid_config_rejected():
     with pytest.raises(ValueError):
         DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="explode")

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -1,0 +1,216 @@
+"""
+Tests for the DataFog PII Guardrail.
+
+All PII values below are synthetic test fixtures (documentation-reserved
+domains, test card numbers, invalid SSN ranges).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../"))  # Adds the parent directory to the system path
+
+pytest.importorskip("datafog")
+
+from fastapi import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.datafog.datafog import DataFogGuardrail
+
+EMAIL = "jane.doe@example.com"
+CARD = "4242 4242 4242 4242"
+SSN = "856-45-6789"
+DE_TAX_ID = "12345678901"
+
+
+def _chat_data(content) -> dict:
+    return {"messages": [{"role": "user", "content": content}]}
+
+
+def _model_response(text: str):
+    import litellm
+
+    resp = litellm.ModelResponse()
+    resp.choices[0].message.content = text
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_email():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data(f"email the report to {EMAIL} please"),
+        call_type="completion",
+    )
+    content = data["messages"][0]["content"]
+    assert EMAIL not in content
+    assert "[EMAIL_1]" in content
+
+
+@pytest.mark.asyncio
+async def test_pre_call_clean_message_unchanged():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data("summarize this design doc"),
+        call_type="completion",
+    )
+    assert data["messages"][0]["content"] == "summarize this design doc"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_redacts_content_parts_and_skips_images():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data(
+            [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+                {"type": "text", "text": f"ssn is {SSN}"},
+            ]
+        ),
+        call_type="completion",
+    )
+    parts = data["messages"][0]["content"]
+    assert parts[0]["type"] == "image_url"
+    assert SSN not in parts[1]["text"]
+
+
+@pytest.mark.asyncio
+async def test_block_raises_http_400_without_echoing_pii():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    with pytest.raises(HTTPException) as exc:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=None,
+            cache=None,
+            data=_chat_data(f"send {CARD} to billing"),
+            call_type="completion",
+        )
+    assert exc.value.status_code == 400
+    detail = str(exc.value.detail)
+    assert "CREDIT_CARD" in detail
+    assert CARD not in detail
+
+
+@pytest.mark.asyncio
+async def test_during_call_blocks_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data=_chat_data(f"reach me at {EMAIL}"),
+            user_api_key_dict=None,
+            call_type="completion",
+        )
+
+
+@pytest.mark.asyncio
+async def test_during_call_noop_when_action_is_redact():
+    # during_call cannot modify content mid-flight; redact mode is a no-op.
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="redact")
+    data = _chat_data(f"reach me at {EMAIL}")
+    result = await guardrail.async_moderation_hook(data=data, user_api_key_dict=None, call_type="completion")
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_post_call_redacts_model_response():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = _model_response(f"the customer is reachable at {EMAIL}")
+    await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+    assert EMAIL not in response.choices[0].message.content
+
+
+@pytest.mark.asyncio
+async def test_noisy_entities_off_by_default():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data("ping 192.168.1.1 about build 2020-01-02"),
+        call_type="completion",
+    )
+    assert data["messages"][0]["content"] == "ping 192.168.1.1 about build 2020-01-02"
+
+
+@pytest.mark.asyncio
+async def test_entity_types_override():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_entity_types=["IP_ADDRESS"])
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data("ping 192.168.1.1"),
+        call_type="completion",
+    )
+    assert "192.168.1.1" not in data["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_german_locale_entities():
+    guardrail = DataFogGuardrail(
+        guardrail_name="datafog-pii",
+        default_on=True,
+        datafog_entity_types=["DE_TAX_ID"],
+        datafog_locales=["de"],
+    )
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=_chat_data(f"Steuer-ID {DE_TAX_ID} liegt vor."),
+        call_type="completion",
+    )
+    assert DE_TAX_ID not in data["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_fail_open_passes_data_through_on_engine_error(monkeypatch):
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    monkeypatch.setattr(
+        "litellm.proxy.guardrails.guardrail_hooks.datafog.datafog._redact_text",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    original = _chat_data(f"reach me at {EMAIL}")
+    data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None, cache=None, data=original, call_type="completion"
+    )
+    assert data["messages"][0]["content"] == f"reach me at {EMAIL}"
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_raises_without_pii_or_cause_chain(monkeypatch):
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_fail_policy="closed")
+    monkeypatch.setattr(
+        "litellm.proxy.guardrails.guardrail_hooks.datafog.datafog._redact_text",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError(f"parser choked on: reach me at {EMAIL}")),
+    )
+    with pytest.raises(RuntimeError, match="datafog_fail_policy") as exc:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=None,
+            cache=None,
+            data=_chat_data(f"reach me at {EMAIL}"),
+            call_type="completion",
+        )
+    assert exc.value.__cause__ is None
+    assert EMAIL not in str(exc.value)
+
+
+def test_invalid_config_rejected():
+    with pytest.raises(ValueError):
+        DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="explode")
+    with pytest.raises(ValueError):
+        DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_fail_policy="maybe")
+
+
+def test_registry_registration():
+    from litellm.proxy.guardrails.guardrail_hooks.datafog import (
+        guardrail_class_registry,
+        guardrail_initializer_registry,
+    )
+    from litellm.types.guardrails import SupportedGuardrailIntegrations
+
+    assert SupportedGuardrailIntegrations.DATAFOG.value in guardrail_initializer_registry
+    assert guardrail_class_registry[SupportedGuardrailIntegrations.DATAFOG.value] is (DataFogGuardrail)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/datafog/test_datafog_guardrail.py
@@ -273,6 +273,33 @@ async def test_pre_call_redacts_top_level_anthropic_system_content_blocks():
     assert SSN in original["system"][0]["text"]
 
 
+@pytest.mark.asyncio
+async def test_pre_call_redacts_text_completion_prompt_string_and_list():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    original_string = {"prompt": f"Complete the account note for {EMAIL}"}
+    original_list = {"prompt": [f"Email {EMAIL}", f"SSN {SSN}"]}
+
+    string_data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original_string,
+        call_type="completion",
+    )
+    list_data = await guardrail.async_pre_call_hook(
+        user_api_key_dict=None,
+        cache=None,
+        data=original_list,
+        call_type="completion",
+    )
+
+    assert EMAIL not in string_data["prompt"]
+    assert "[EMAIL_1]" in string_data["prompt"]
+    assert EMAIL not in list_data["prompt"][0]
+    assert SSN not in list_data["prompt"][1]
+    assert original_string["prompt"] == f"Complete the account note for {EMAIL}"
+    assert original_list["prompt"] == [f"Email {EMAIL}", f"SSN {SSN}"]
+
+
 def test_process_content_returns_unmodified_non_text_content():
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
     content = {"structured": "payload"}
@@ -408,6 +435,18 @@ async def test_during_call_blocks_top_level_prompt_fields_when_action_is_block()
 
 
 @pytest.mark.asyncio
+async def test_during_call_blocks_text_completion_prompt_when_action_is_block():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+
+    with pytest.raises(HTTPException):
+        await guardrail.async_moderation_hook(
+            data={"prompt": [f"Complete customer note for {EMAIL}"]},
+            user_api_key_dict=None,
+            call_type="completion",
+        )
+
+
+@pytest.mark.asyncio
 async def test_during_call_noop_when_action_is_redact():
     # during_call cannot modify content mid-flight; redact mode is a no-op.
     guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="redact")
@@ -422,6 +461,17 @@ async def test_post_call_redacts_model_response():
     response = _model_response(f"the customer is reachable at {EMAIL}")
     await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
     assert EMAIL not in response.choices[0].message.content
+
+
+@pytest.mark.asyncio
+async def test_post_call_redacts_text_completion_choice_text():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    response = SimpleNamespace(choices=[SimpleNamespace(text=f"the customer email is {EMAIL}")])
+
+    await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    assert EMAIL not in response.choices[0].text
+    assert "[EMAIL_1]" in response.choices[0].text
 
 
 @pytest.mark.asyncio
@@ -628,6 +678,27 @@ async def test_streaming_redacts_anthropic_sse_text_delta_bytes():
 
 
 @pytest.mark.asyncio
+async def test_streaming_redacts_text_completion_choice_text_before_yielding():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True)
+    chunks = [
+        SimpleNamespace(choices=[SimpleNamespace(index=0, text="email jane.doe@")]),
+        SimpleNamespace(choices=[SimpleNamespace(index=0, text="example.com")]),
+    ]
+
+    result = await _collect_async(
+        guardrail.async_post_call_streaming_iterator_hook(
+            user_api_key_dict=None,
+            response=_async_iter(chunks),
+            request_data={},
+        )
+    )
+
+    text = "".join(chunk.choices[0].text for chunk in result)
+    assert EMAIL not in text
+    assert "[EMAIL_1]" in text
+
+
+@pytest.mark.asyncio
 async def test_streaming_block_raises_before_mutating_chunks():
     from litellm.types.utils import ModelResponseStream
 
@@ -781,6 +852,19 @@ async def test_post_call_block_raises_on_response_tool_call_arguments():
     assert exc.value.status_code == 400
     assert EMAIL not in str(exc.value.detail)
     assert response.choices[0].message.tool_calls[0].function.arguments == f'{{"recipient": "{EMAIL}"}}'
+
+
+@pytest.mark.asyncio
+async def test_post_call_block_raises_on_text_completion_choice_text():
+    guardrail = DataFogGuardrail(guardrail_name="datafog-pii", default_on=True, datafog_action="block")
+    response = SimpleNamespace(choices=[SimpleNamespace(text=f"the customer email is {EMAIL}")])
+
+    with pytest.raises(HTTPException) as exc:
+        await guardrail.async_post_call_success_hook(data={}, user_api_key_dict=None, response=response)
+
+    assert exc.value.status_code == 400
+    assert EMAIL not in str(exc.value.detail)
+    assert response.choices[0].text == f"the customer email is {EMAIL}"
 
 
 def test_invalid_config_rejected():


### PR DESCRIPTION
## TLDR

Problem this solves:

- LiteLLM users need lightweight in-process PII protection.
- Provider-specific payloads differ across Chat, Responses, and Messages APIs.

How it solves it:

- Adds a `datafog` guardrail provider with redact/block modes.
- Preserves nested content, tool arguments, schemas, streaming, and guardrail logging.

## Relevant issues

N/A; new guardrail provider contribution.

## Linear ticket

N/A (external contribution).

## Pre-Submission checklist

- [x] Meaningful unit tests added
- [x] PR scope is isolated to the DataFog guardrail provider
- [x] CLA signed
- [x] Greptile confidence score 5/5 received
- [x] Branch rebased onto current `litellm_internal_staging`
- [ ] All CI/CD checks pass: OSV currently reports staging's `cryptography==48.0.1`

## Delays in PR merge?

Slack escalation: [#pr-review](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The original Chat Completions proof was captured at the pre-rebase head `4fd504f0b5b8fe55022d61ff2e316279762fe3eb`. The following two endpoint proofs are ready to run against the rebased head `ace0cbce6d1003e6992fed258a207996488cf6ae`.

Prerequisites:

- Start LiteLLM with `datafog` installed.
- Configure `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`.
- Add `gpt-4o-mini` mapped to `openai/gpt-4o-mini` and `claude-haiku` mapped to the chosen Anthropic model.
- Configure the `datafog-redact` and `datafog-block` guardrails shown below.

```yaml
guardrails:
  - guardrail_name: "datafog-redact"
    litellm_params:
      guardrail: datafog
      mode: "pre_call"
      default_on: false
      datafog_action: "redact"
  - guardrail_name: "datafog-block"
    litellm_params:
      guardrail: datafog
      mode: "pre_call"
      default_on: false
      datafog_action: "block"
```

### `/v1/responses` — redact

- [ ] Send a Responses API request containing synthetic email and card data.
- [ ] Confirm the model returns `[EMAIL_1]` and `[CREDIT_CARD_1]`, without the original values.

```bash
curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer anything" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","guardrails":["datafog-redact"],"input":"List only the placeholder tokens in this sentence: My email is jane.doe@example.com and my card number is 4242 4242 4242 4242."}'
```

### `/v1/responses` — block

- [ ] Send the same request with `datafog-block`.
- [ ] Confirm HTTP 400 and an error naming `EMAIL` and `CREDIT_CARD`, without echoing values.

```bash
curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/responses \
  -H "Authorization: Bearer anything" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","guardrails":["datafog-block"],"input":"My email is jane.doe@example.com and my card number is 4242 4242 4242 4242."}'
```

### `/v1/messages` — redact

- [ ] Send an Anthropic Messages request containing synthetic email and card data.
- [ ] Confirm the model returns `[EMAIL_1]` and `[CREDIT_CARD_1]`, without the original values.

```bash
curl -sS http://localhost:4000/v1/messages \
  -H "Authorization: Bearer anything" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku","max_tokens":128,"guardrails":["datafog-redact"],"messages":[{"role":"user","content":"List only the placeholder tokens in this sentence: My email is jane.doe@example.com and my card number is 4242 4242 4242 4242."}]}'
```

### `/v1/messages` — block

- [ ] Send the same request with `datafog-block`.
- [ ] Confirm HTTP 400 and an error naming `EMAIL` and `CREDIT_CARD`, without echoing values.

```bash
curl -sS -w "\nHTTP %{http_code}\n" http://localhost:4000/v1/messages \
  -H "Authorization: Bearer anything" \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku","max_tokens":128,"guardrails":["datafog-block"],"messages":[{"role":"user","content":"My email is jane.doe@example.com and my card number is 4242 4242 4242 4242."}]}'
```

The unit suite covers these payload paths without provider calls. The DeepSeek live proof above covers the rebased proxy integration on both requested endpoints in redact and block modes.

## Type

🆕 New Feature

## Changes

Adds `datafog` as an in-process PII guardrail provider backed by the `datafog` package.

Supported behavior:

- pre-call redaction or blocking;
- during-call blocking;
- post-call redaction or blocking;
- streaming responses;
- tool-call arguments and schema fields;
- configurable entity types and locales;
- open/closed failure policy;
- guardrail intervention logging without echoing matched PII.

## Documentation follow-up

LiteLLM's documentation is maintained separately in [BerriAI/litellm-docs](https://github.com/BerriAI/litellm-docs). The appropriate follow-up is a docs PR adding DataFog to the guardrail provider index and a provider/configuration page covering `datafog_action`, `datafog_entity_types`, `datafog_locales`, `datafog_fail_policy`, and the endpoint examples above. The docs repository asks contributors to open an issue first for substantive content changes.

## Validation

Local validation on the rebased branch:

- [x] 51 focused DataFog tests
- [x] Changed-file Ruff and formatting
- [x] Ruff strict-rule budget
- [x] Type-discipline budget
- [x] Circular-import check
- [x] Import-safety check

Current GitHub status: 77 checks pass; OSV fails on staging's `cryptography==48.0.1`; maintainer approval is still required.


### DeepSeek live proof (2026-08-03)

Executed against the rebased head `ace0cbce6d1003e6992fed258a207996488cf6ae` using a local LiteLLM proxy, the `deepseek-chat` model, and synthetic email/phone values only:

| Endpoint | DataFog action | Result |
| --- | --- | --- |
| `/v1/responses` | redact | HTTP 200; original email/phone absent from the response |
| `/v1/messages` | redact | HTTP 200; response contained `[EMAIL_1]` and `[PHONE_1]`; originals absent |
| `/v1/responses` | block | HTTP 400; original values absent from the error response |
| `/v1/messages` | block | HTTP 400; original values absent from the error response |

The key was supplied through the local `DEEPSEEK_API_KEY` environment file (permissions `0600`); it was not logged, committed, or sent to GitHub. The live run required installing the local `datafog` package in the test virtual environment; no repository files were changed by the proof run.