### PR TITLE
fix: send anthropic-workspace-id header for Bedrock Mantle

### DIFF
--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -70,7 +70,7 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
         )
         project_id = litellm_params.get("aws_bedrock_project_id")
         if project_id:
-            headers["anthropic-workspace"] = project_id
+            headers["anthropic-workspace-id"] = project_id
         return headers
 
     def transform_request(

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -67,7 +67,7 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         )
         project_id = litellm_params.get("aws_bedrock_project_id")
         if project_id:
-            headers["anthropic-workspace"] = project_id
+            headers["anthropic-workspace-id"] = project_id
         return headers, api_base
 
     def transform_anthropic_messages_request(

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -215,7 +215,7 @@ def test_mantle_validate_environment_sets_workspace_header():
         optional_params={},
         litellm_params={"aws_bedrock_project_id": "proj_abc123def456"},
     )
-    assert headers["anthropic-workspace"] == "proj_abc123def456"
+    assert headers["anthropic-workspace-id"] == "proj_abc123def456"
 
 
 def test_mantle_validate_environment_without_project_id():
@@ -227,7 +227,7 @@ def test_mantle_validate_environment_without_project_id():
         optional_params={},
         litellm_params={"aws_bedrock_project_id": None},
     )
-    assert "anthropic-workspace" not in headers
+    assert "anthropic-workspace-id" not in headers
 
 
 def test_mantle_messages_validate_environment_sets_workspace_header():
@@ -240,7 +240,7 @@ def test_mantle_messages_validate_environment_sets_workspace_header():
         litellm_params={"aws_bedrock_project_id": "proj_abc123def456"},
         api_base="https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages",
     )
-    assert headers["anthropic-workspace"] == "proj_abc123def456"
+    assert headers["anthropic-workspace-id"] == "proj_abc123def456"
     assert api_base == "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages"
 
 
@@ -253,7 +253,7 @@ def test_mantle_messages_validate_environment_without_project_id():
         optional_params={},
         litellm_params={},
     )
-    assert "anthropic-workspace" not in headers
+    assert "anthropic-workspace-id" not in headers
 
 
 def test_mantle_completion_sends_workspace_header_and_clean_body():
@@ -279,7 +279,7 @@ def test_mantle_completion_sends_workspace_header_and_clean_body():
     assert response.choices[0].message.content == "ok"
     assert len(requests) == 1
     assert requests[0]["path"] == "/anthropic/v1/messages"
-    assert requests[0]["headers"]["anthropic-workspace"] == "proj_abc123def456"
+    assert requests[0]["headers"]["anthropic-workspace-id"] == "proj_abc123def456"
     assert "aws_bedrock_project_id" not in requests[0]["body"]
 
 
@@ -313,7 +313,7 @@ async def test_mantle_anthropic_messages_sends_workspace_header_and_clean_body()
     assert response["content"][0]["text"] == "ok"
     assert len(requests) == 1
     assert requests[0]["path"] == "/anthropic/v1/messages"
-    assert requests[0]["headers"]["anthropic-workspace"] == "proj_abc123def456"
+    assert requests[0]["headers"]["anthropic-workspace-id"] == "proj_abc123def456"
     assert "aws_bedrock_project_id" not in requests[0]["body"]
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Mantle ignores the project id LiteLLM sends today
- Requests silently run at account-level data retention
- Models needing an explicit retention mode fail confusingly

How it solves it:

- Send the project id as `anthropic-workspace-id`, the header Mantle reads
- Fixes both Mantle surfaces, chat and messages
- Updates the tests that pinned the old header name

## User Flow

Before: a developer sets `aws_bedrock_project_id` on a Bedrock Mantle model, and the project is silently ignored, so the request keeps running under account-level data retention

1. They add a deployment with `model: bedrock/mantle/anthropic.claude-opus-5` and `aws_bedrock_project_id` set to a project id that does not exist
2. They send POST https://litellm-domain/v1/chat/completions with that model
3. It comes back 200 with a normal completion, even though that project does not exist, so the project id never reached Mantle
4. They send POST https://litellm-domain/v1/messages with the same model and get the same 200
5. On a model whose only allowed retention mode is `provider_data_share`, the same setup returns 400 `data retention mode 'default' is not available for this model`, because the project's mode never applied

After: the project id reaches Mantle, so it is resolved and enforced per request

1. Same deployment, same non-existent project id
2. They send POST https://litellm-domain/v1/chat/completions with that model
3. It now comes back 404 `Project 'arn:aws:bedrock-mantle:us-east-1:<account>:project/proj_bogus000000 does not exist.`, so the project id is reaching Mantle
4. They send POST https://litellm-domain/v1/messages and get the same 404
5. They put their real project id back and both routes return 200, now running under that project's data retention mode

## Relevant issues

Fixes #31947

## Linear ticket

Resolves LIT-5914

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

N/A

## Screenshots / Proof of Fix

Run against the live Bedrock Mantle endpoint with real AWS credentials and real model calls, no mocks. Both legs boot a real proxy from the commit named in the heading and go through the same routes the bug report used. The AWS account id is redacted as `<account>` throughout.

Shared setup, the same proxy config on both sides. Each case gets its own deployment and cooldowns are off, so one case cannot affect another:

```yaml
model_list:
  - model_name: chat-bogus-project
    litellm_params:
      model: bedrock/mantle/anthropic.claude-opus-5
      aws_region_name: us-east-1
      aws_bedrock_project_id: proj_bogus000000
  - model_name: chat-real-project
    litellm_params:
      model: bedrock/mantle/anthropic.claude-opus-5
      aws_region_name: us-east-1
      aws_bedrock_project_id: default
  - model_name: messages-bogus-project
    litellm_params:
      model: bedrock/mantle/anthropic.claude-opus-5
      aws_region_name: us-east-1
      aws_bedrock_project_id: proj_bogus000000
  - model_name: messages-real-project
    litellm_params:
      model: bedrock/mantle/anthropic.claude-opus-5
      aws_region_name: us-east-1
      aws_bedrock_project_id: default

router_settings:
  disable_cooldowns: true
```

`proj_bogus000000` is a project id that does not exist, so it shows whether the project id reaches Mantle at all. `default` is a real project in the account. The bogus cases are the discriminator: a project id that never leaves LiteLLM under a name Mantle reads cannot produce a "does not exist" error.

### Before (710f6b2dcd10e0ab3b496d11596b76a92db100d1)

At this commit both transformations send `anthropic-workspace`.

#### chat completions, non-existent project id

```
curl -X POST http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY" \
  -d '{"model":"chat-bogus-project","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":8}'
```

```json
{"id":"chatcmpl-66ef5177-6f28-402f-8cf5-e36e4b00d4c8","created":1787358213,"model":"chat-bogus-project","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant"}}],"usage":{"completion_tokens":4,"prompt_tokens":15,"total_tokens":19}}
HTTP_STATUS:200
```

200 and a normal completion, even though that project does not exist. The project id never reached Mantle.

#### chat completions, real project id

```
curl -X POST http://127.0.0.1:$PORT/v1/chat/completions \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY" \
  -d '{"model":"chat-real-project","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":8}'
```

```json
... "usage":{"completion_tokens":8,"prompt_tokens":15,"total_tokens":23}}
HTTP_STATUS:200
```

200. The capture harness kept only the last 900 bytes of this one response, so the head of the JSON is cut; the status line and token usage are as shown.

#### anthropic messages, non-existent project id

```
curl -X POST http://127.0.0.1:$PORT/v1/messages \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY" \
  -d '{"model":"messages-bogus-project","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":8}'
```

```json
{"model":"messages-bogus-project","id":"msg_bdrk_ixl6sw5c3z43csfgsds25k53wwpcj45dzbljjs2gsw436wyrj2za","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":15,"output_tokens":4}}
HTTP_STATUS:200
```

200 again, despite the project not existing.

#### anthropic messages, real project id

```
curl -X POST http://127.0.0.1:$PORT/v1/messages \
  -H 'Content-Type: application/json' -H "Authorization: Bearer $KEY" \
  -d '{"model":"messages-real-project","messages":[{"role":"user","content":"Reply with the single word ok"}],"max_tokens":8}'
```

```json
{"model":"messages-real-project","id":"msg_bdrk_okawu3zxuecgcj36jfe7clhr2xhzotqew4axrhkhajcz53kttewq","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":15,"output_tokens":4}}
HTTP_STATUS:200
```

### After (13a0d457ae5feb1e986b043eecb714d479a48481)

At this commit both transformations send `anthropic-workspace-id`. Same config, same four commands.

#### chat completions, non-existent project id

```json
{"error":{"message":"litellm.NotFoundError: BedrockException - {\"type\":\"error\",\"request_id\":\"req_z4hqvo2nzcgwdy5jqegmyqsg7h6u6qi3cqz4gvl6kyhy3w5kms4a\",\"error\":{\"type\":\"not_found_error\",\"message\":\"Project 'arn:aws:bedrock-mantle:us-east-1:<account>:project/proj_bogus000000 does not exist.\"}}. Received Model Group=chat-bogus-project\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
HTTP_STATUS:404
```

Mantle now resolves the project id to a project ARN and rejects it. That is what makes the project's retention mode apply.

#### chat completions, real project id

```json
{"id":"chatcmpl-8be4376f-e21a-45b8-a817-8892d773fb75","created":1787358185,"model":"chat-real-project","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant"}}],"usage":{"completion_tokens":4,"prompt_tokens":15,"total_tokens":19}}
HTTP_STATUS:200
```

#### anthropic messages, non-existent project id

```json
{"error":{"message":"{\"type\":\"error\",\"request_id\":\"req_h7xxeyer3stsu6vqv2vse6mc47pushcet3yu4xppkxfevqzysgdq\",\"error\":{\"type\":\"not_found_error\",\"message\":\"Project 'arn:aws:bedrock-mantle:us-east-1:<account>:project/proj_bogus000000 does not exist.\"}}. Received Model Group=messages-bogus-project\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"404"}}
HTTP_STATUS:404
```

#### anthropic messages, real project id

```json
{"model":"messages-real-project","id":"msg_bdrk_edo2tccj5pyrcz2hfzmnqc6a76cdstlkz47yhxuqexrezlgxbzyq","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":15,"output_tokens":4}}
HTTP_STATUS:200
```

Unit tests at the tip: `uv run pytest tests/test_litellm/llms/bedrock/test_mantle.py -q` gives 21 passed.

For the reported symptom itself, `anthropic.claude-fable-5` lists `allowed_modes: ["provider_data_share"]`, and calling it with no project in effect returns 400 `data retention mode 'default' is not available for this model`, matching #31947.

## Type

🐛 Bug Fix

## Caveats (if any)

- AWS's Workspaces doc still shows the old `anthropic-workspace` spelling. The live endpoint ignores that spelling and validates the `-id` one, as the 404s above show, so the doc reads as stale
- The proof above shows the project id reaching Mantle and being resolved, not the `provider_data_share` success path end to end. The test account has one project (`default`, mode `inherit`) and project creation is denied there, so no project with that mode was available to call Fable 5 against
- Data retention mode is a property of the project object itself, so selecting the project is how the mode gets selected; there is no separate retention header to get wrong

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
