### PR TITLE
fix(proxy): admin-gate `permissions` on /user/new and /user/update (LIT-4138)

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -39,6 +39,7 @@ from litellm.proxy.management_endpoints.common_utils import (
     validate_finite_spend,
 )
 from litellm.proxy.management_endpoints.key_management_endpoints import (
+    _check_permissions_caller_permission,
     generate_key_helper_fn,
     prepare_metadata_fields,
 )
@@ -439,6 +440,11 @@ async def new_user(
                 status_code=403,
                 detail=f"Only proxy admins can create administrative users (proxy_admin, proxy_admin_viewer). Attempted to create user with role: {data.user_role}. Your role: {user_api_key_dict.user_role}",
             )
+
+        _check_permissions_caller_permission(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+        )
 
         data_json = data.json()  # type: ignore
         data_json = _update_internal_new_user_params(data_json, data)
@@ -1197,6 +1203,11 @@ async def _update_single_user_helper(
 
     if not user_request.user_id and not user_request.user_email:
         raise ValueError("Either user_id or user_email must be provided")
+
+    _check_permissions_caller_permission(
+        data=user_request,
+        user_api_key_dict=user_api_key_dict,
+    )
 
     data_json: dict = user_request.model_dump(exclude_unset=True)
     non_default_values = _update_internal_user_params(data_json=data_json, data=user_request)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -580,7 +580,7 @@ def _check_permissions_caller_permission(
         return
     raise HTTPException(
         status_code=403,
-        detail={"error": "Only proxy admins can set `permissions` on a key."},
+        detail={"error": "Only proxy admins can set `permissions`."},
     )
 
 

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -1001,6 +1001,259 @@ async def test_new_user_non_admin_cannot_create_admin(mocker):
 
 
 @pytest.mark.asyncio
+async def test_new_user_non_admin_permissions_non_empty_rejected(mocker):
+    """`new_user` rejects a non-admin when `permissions` is present in the
+    request body. `/user/new` propagates the value into the auto-created
+    key via `generate_key_helper_fn`."""
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_check(*_args, **_kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_check,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_check,
+    )
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+
+    data = NewUserRequest(
+        user_email="alice@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        permissions={"get_spend_routes": True},
+    )
+    caller = UserAPIKeyAuth(
+        user_id="org-admin", user_role=LitellmUserRoles.ORG_ADMIN
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await new_user(data=data, user_api_key_dict=caller)
+    assert str(exc_info.value.code) == "403"
+    assert "permissions" in str(exc_info.value.message)
+
+
+@pytest.mark.asyncio
+async def test_new_user_non_admin_permissions_explicit_empty_rejected(mocker):
+    """`new_user` rejects a non-admin when `permissions` is present as
+    `{}` in the request body. The value matches the model default but
+    `model_fields_set` distinguishes the two."""
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_check(*_args, **_kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_check,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_check,
+    )
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+
+    data = NewUserRequest(
+        user_email="alice@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        permissions={},
+    )
+    assert "permissions" in data.model_fields_set
+    caller = UserAPIKeyAuth(
+        user_id="org-admin", user_role=LitellmUserRoles.ORG_ADMIN
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await new_user(data=data, user_api_key_dict=caller)
+    assert str(exc_info.value.code) == "403"
+    assert "permissions" in str(exc_info.value.message)
+
+
+@pytest.mark.asyncio
+async def test_new_user_non_admin_omits_permissions_succeeds(mocker):
+    """`new_user` does not fire the permissions gate when `permissions`
+    is absent from the request body. The model-level default `{}` is not
+    in `model_fields_set`."""
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_check(*_args, **_kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_check,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_check,
+    )
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+
+    stub_response = {"user_id": "alice", "key": "sk-alice", "expires": None}
+
+    async def stub_helper(**_kwargs):
+        return stub_response
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.generate_key_helper_fn",
+        stub_helper,
+    )
+
+    data = NewUserRequest(
+        user_email="alice@example.com",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    assert "permissions" not in data.model_fields_set
+    caller = UserAPIKeyAuth(
+        user_id="org-admin", user_role=LitellmUserRoles.ORG_ADMIN
+    )
+
+    result = await new_user(data=data, user_api_key_dict=caller)
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_new_user_admin_can_set_permissions(mocker):
+    """`new_user` accepts a PROXY_ADMIN caller for any shape of
+    `permissions` in the request body."""
+    from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+
+    mock_prisma_client = mocker.MagicMock()
+
+    async def mock_count(*args, **kwargs):
+        return 5
+
+    mock_prisma_client.db.litellm_usertable.count = mock_count
+
+    async def mock_check(*_args, **_kwargs):
+        return None
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_email",
+        mock_check,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._check_duplicate_user_id",
+        mock_check,
+    )
+    mock_license_check = mocker.MagicMock()
+    mock_license_check.is_over_limit.return_value = False
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server._license_check", mock_license_check)
+
+    async def stub_helper(**_kwargs):
+        return {"user_id": "alice", "key": "sk-alice", "expires": None}
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.generate_key_helper_fn",
+        stub_helper,
+    )
+
+    admin = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+    for permissions_value in ({"get_spend_routes": True}, {}, None):
+        data = NewUserRequest(
+            user_email=f"alice-{permissions_value}@example.com",
+            user_role=LitellmUserRoles.INTERNAL_USER,
+            permissions=permissions_value,
+        )
+        result = await new_user(data=data, user_api_key_dict=admin)
+        assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_update_single_user_non_admin_permissions_rejected(mocker):
+    """`_update_single_user_helper` rejects a non-admin when `permissions`
+    is present in the request body. Covers both `/user/update` and
+    `/user/bulk_update`, which share this helper."""
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import UpdateUserRequest
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_single_user_helper,
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+
+    data = UpdateUserRequest(
+        user_id="alice",
+        permissions={"get_spend_routes": True},
+    )
+    caller = UserAPIKeyAuth(
+        user_id="org-admin", user_role=LitellmUserRoles.ORG_ADMIN
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _update_single_user_helper(
+            user_request=data, user_api_key_dict=caller
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_update_single_user_non_admin_permissions_explicit_empty_rejected(mocker):
+    """`_update_single_user_helper` rejects a non-admin when `permissions`
+    is present as `{}` in the request body."""
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import UpdateUserRequest
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_single_user_helper,
+    )
+
+    mock_prisma_client = mocker.MagicMock()
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    mocker.patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin")
+
+    data = UpdateUserRequest(user_id="alice", permissions={})
+    assert "permissions" in data.model_fields_set
+    caller = UserAPIKeyAuth(
+        user_id="org-admin", user_role=LitellmUserRoles.ORG_ADMIN
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _update_single_user_helper(
+            user_request=data, user_api_key_dict=caller
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_user_info_url_encoding_plus_character(mocker):
     """
     Test that /user/info endpoint properly handles email addresses with + characters


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4138

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type

Bug Fix

## Changes

`NewUserRequest` and `UpdateUserRequest` inherit `permissions` from `GenerateRequestBase`. `/user/new` passes the field through `_update_internal_new_user_params` and into `generate_key_helper_fn`, which persists it on the auto-created key at `key_management_endpoints.py:3654`. The route allowlist accepts an org admin caller on `/user/new` when the request body names an organization the caller holds `org_admin` membership in (`_user_is_org_admin` in `auth_checks_organization.py:135`), so a legitimate org admin can mint a key with proxy-wide capabilities such as `get_spend_routes` that go far beyond their org

This PR wires the existing `_check_permissions_caller_permission` helper into `new_user` (after the admin-role check and before `generate_key_helper_fn`) and into `_update_single_user_helper` (after the DB-connected check and before the Prisma write). The helper is the same presence-based check introduced in LIT-4092; it keys on `data.model_fields_set`, so an omitted `permissions` flows through the model default and an explicit `{}` / `null` from a non-admin trips the gate

`_update_single_user_helper` is shared by `/user/update` and `/user/bulk_update`, so both paths inherit the gate. `/user/update` today rejects `permissions` at the Prisma layer (the `LiteLLM_UserTable` schema has no `permissions` column, so the DB errors before persistence); the gate now returns a consistent 403 upstream and forecloses a future migration silently reopening the class

Six new tests in `test_internal_user_endpoints.py` cover non-admin explicit-non-empty and explicit-empty on both `new_user` and `_update_single_user_helper`, plus the omit-default and admin controls. The four attack-vector tests fail on the pre-fix HEAD and pass on this commit. Full mapped test file (79 tests) green

## Screenshots / Proof of Fix

Live proxy on `localhost:4010` against Postgres, `LITELLM_LICENSE` set so `get_spend_routes` propagation is available. Setup: admin creates user `rca-user-b`, mints them a key, creates an organization, and adds the user to it with `role=org_admin`

Attack path on the unfixed HEAD

```
$ curl -sS -X POST http://localhost:4010/user/new \
    -H "Authorization: Bearer $ORG_ADMIN_KEY" -H "Content-Type: application/json" \
    -d "{\"user_id\":\"rca-victim-b\",\"user_role\":\"internal_user\",\"organization_id\":\"$B_ORG\",\"permissions\":{\"get_spend_routes\":true}}"
```

```json
{"key":"sk-...fXNkFA","user_id":"rca-victim-b","permissions":{"get_spend_routes":true}, ...}
```

200 OK; the newly-minted key has `get_spend_routes: true` written to the DB, granting it proxy-wide `/global/spend/*` read access

Same call on this commit

```
$ curl -sS -X POST http://localhost:4010/user/new \
    -H "Authorization: Bearer $ORG_ADMIN_KEY" -H "Content-Type: application/json" \
    -d "{\"user_id\":\"rca-victim-b2\",\"user_role\":\"internal_user\",\"organization_id\":\"$B_ORG\",\"permissions\":{\"get_spend_routes\":true}}"
```

```json
{"error":{"message":"{'error': 'Only proxy admins can set `permissions`.'}","code":"403"}}
```

Explicit empty on this commit

```
$ curl -sS -X POST http://localhost:4010/user/new \
    -H "Authorization: Bearer $ORG_ADMIN_KEY" -H "Content-Type: application/json" \
    -d "{\"user_id\":\"rca-victim-b3\",\"user_role\":\"internal_user\",\"organization_id\":\"$B_ORG\",\"permissions\":{}}"
```

```json
{"error":{"message":"{'error': 'Only proxy admins can set `permissions`.'}","code":"403"}}
```

Control: org admin `/user/new` without a `permissions` field still succeeds on the fixed proxy

```
$ curl -sS -X POST http://localhost:4010/user/new \
    -H "Authorization: Bearer $ORG_ADMIN_KEY" -H "Content-Type: application/json" \
    -d "{\"user_id\":\"rca-victim-b4\",\"user_role\":\"internal_user\",\"organization_id\":\"$B_ORG\"}"
```

```
user_id: rca-victim-b4 / key ends: Uyg8mQ
```

Proxy admin (master key) can still write any `permissions` value on `/user/new`

```
$ curl -sS -X POST http://localhost:4010/user/new \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"user_id":"admin-4138-key1","user_role":"internal_user","permissions":{"get_spend_routes":true}}'
```

```
user_id: admin-4138-key1 / key ends: Z9J7bw / permissions: {'get_spend_routes': True}
```

## Out of scope, tracked separately

The `/user/update` path has a pre-existing behavior where an explicit `permissions` value returns 400 at the Prisma layer because the `LiteLLM_UserTable` schema has no `permissions` column. That is not changed here. The helper is still wired into `_update_single_user_helper` so a future schema addition (or an alternate persistence path for `permissions` at the user level) cannot silently reopen the class

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is an authorization fix in user/key management: incorrect behavior previously allowed elevated key capabilities; the change is narrow but touches security-sensitive proxy admin boundaries.
> 
> **Overview**
> Closes a privilege-escalation path where **org admins** (and other non–proxy-admins) could pass **`permissions`** on **`/user/new`** and have those values land on the auto-created API key (e.g. `get_spend_routes`).
> 
> **`/user/new`** and **`_update_single_user_helper`** (shared by **`/user/update`** and **`/user/bulk_update`**) now call the existing **`_check_permissions_caller_permission`** helper before user/key persistence. The check is **presence-based** (`model_fields_set`): omitting `permissions` is allowed; sending any explicit value (including `{}`) as a non-admin returns **403**. Proxy admins are unchanged.
> 
> The key-management error text is generalized to “set `permissions`” (not only “on a key”). **Six tests** cover reject/allow cases for create and update paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78170b438b34fe609db77c512821ef40419d256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->