### PR TITLE
fix(proxy): admin-gate `permissions` on _process_single_key_update (LIT-4137)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2060,6 +2060,11 @@ async def _process_single_key_update(
     # Validate max_budget
     _validate_max_budget(update_key_request.max_budget)
 
+    _check_permissions_caller_permission(
+        data=update_key_request,
+        user_api_key_dict=user_api_key_dict,
+    )
+
     # Get and validate existing key
     if existing_key_row is None:
         existing_key_row = await _get_and_validate_existing_key(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -11265,6 +11265,67 @@ async def test_process_single_key_update_cache_invalidation_with_token_hash():
 
 
 @pytest.mark.asyncio
+async def test_process_single_key_update_non_admin_permissions_rejected():
+    """`_process_single_key_update` rejects a non-admin when `permissions`
+    is present in the constructed `UpdateKeyRequest`. Guards the bulk path
+    against a future widening of the `BulkUpdateKeyRequestItem` or
+    `KeyUpdateFields` allowlists reopening the class."""
+    update_key_request = UpdateKeyRequest(
+        key="abc123",
+        permissions={"get_spend_routes": True},
+    )
+    assert "permissions" in update_key_request.model_fields_set
+
+    non_admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-non-admin",
+        user_id="user-1",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _process_single_key_update(
+            update_key_request=update_key_request,
+            user_api_key_dict=non_admin,
+            litellm_changed_by=None,
+            prisma_client=AsyncMock(),
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            llm_router=MagicMock(),
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_process_single_key_update_non_admin_permissions_explicit_empty_rejected():
+    """`_process_single_key_update` rejects a non-admin when `permissions`
+    is present as `{}` in the constructed `UpdateKeyRequest`. Presence
+    check on `model_fields_set` catches the explicit-empty case the same
+    as any other value."""
+    update_key_request = UpdateKeyRequest(key="abc123", permissions={})
+    assert "permissions" in update_key_request.model_fields_set
+
+    non_admin = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        api_key="sk-non-admin",
+        user_id="user-1",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _process_single_key_update(
+            update_key_request=update_key_request,
+            user_api_key_dict=non_admin,
+            litellm_changed_by=None,
+            prisma_client=AsyncMock(),
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            llm_router=MagicMock(),
+        )
+    assert exc_info.value.status_code == 403
+    assert "permissions" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
 async def test_execute_virtual_key_regeneration_cache_invalidation_with_token_hash():
     """
     _execute_virtual_key_regeneration must pass the token hash as-is (not


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4137

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type

Bug Fix

## Changes

The bulk-update entrypoints `/key/bulk_update` and `/team/key/bulk_update` route through `_process_single_key_update`, not through `_validate_update_key_data`, so the `_check_permissions_caller_permission` gate LIT-4092 wired into the single-key path never fires on bulk

The bulk paths are currently safe by two independent structural barriers: `BulkUpdateKeyRequestItem` (per-item request model for `/key/bulk_update`) doesn't declare `permissions`, so Pydantic silently drops the field before it can reach persistence. `KeyUpdateFields` (broadcast payload for `/team/key/bulk_update`) uses `model_config = ConfigDict(extra="forbid")`, so Pydantic 422s at parse time. Neither structural barrier is pinned by a test that would fail if the barrier were ever loosened

This wires `_check_permissions_caller_permission(data=update_key_request, user_api_key_dict=user_api_key_dict)` into `_process_single_key_update` right after `_validate_max_budget` and before `prepare_key_update_data`. Zero behavior change today for callers routing through the current bulk request models. Defense-in-depth for the class: a future widening of either allowlist to include `permissions` cannot reopen the vulnerability

Two regression tests in `tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`

- `test_process_single_key_update_non_admin_permissions_rejected` — non-admin `UpdateKeyRequest` with `permissions={"get_spend_routes": True}` returns 403
- `test_process_single_key_update_non_admin_permissions_explicit_empty_rejected` — same for `permissions={}` via `model_fields_set`

Both mutation-killed against removing the gate. Full mapped test file (341 tests) green

## Screenshots / Proof of Fix

Live proxy on `localhost:4010` against Postgres. Admin mints two keys, then exercises the current bulk-update surface

Existing bulk behavior on non-permissions field (unchanged control)

```
$ curl -sS -X POST http://localhost:4010/key/bulk_update \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"keys\":[{\"key\":\"$K1\",\"max_budget\":42},{\"key\":\"$K2\",\"max_budget\":99}]}"
total_requested: 2
successful_updates: 2
failed_updates: 0
```

`/key/bulk_update` with `permissions` in the request body. `BulkUpdateKeyRequestItem` silently drops the unknown field, the update proceeds without persisting `permissions`

```
$ curl -sS -X POST http://localhost:4010/key/bulk_update \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"keys\":[{\"key\":\"$K1\",\"permissions\":{\"get_spend_routes\":true}}]}"
$ curl -sS "http://localhost:4010/key/info?key=$K1" -H "Authorization: Bearer sk-1234"
permissions: {}
```

`/team/key/bulk_update` with `permissions` in `update_fields`. `KeyUpdateFields` is `extra="forbid"`, so Pydantic 422s at parse time

```
$ curl -sS -X POST http://localhost:4010/team/key/bulk_update \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"team_id\":\"litellm-dashboard\",\"key_ids\":[\"$K1\"],\"update_fields\":{\"permissions\":{\"get_spend_routes\":true}}}"
{"detail":[{"type":"extra_forbidden","loc":["body","update_fields","permissions"],"msg":"Extra inputs are not permitted", ...}]}
```

Non-admin cannot reach `/key/bulk_update` at all (existing admin-only gate at handler layer)

```
$ curl -sS -X POST http://localhost:4010/key/bulk_update \
    -H "Authorization: Bearer $NA_KEY" -H "Content-Type: application/json" \
    -d '{"keys":[{"key":"sk-anything","max_budget":42}]}'
{"detail":{"error":"Only proxy admins can perform bulk key updates"}}
```

The new gate is a defense-in-depth layer on the inner perimeter. Every write path through `_process_single_key_update` that would ever carry `permissions` from a non-admin now hits the 403 before the DB write

## Related

Closes the third item in the LIT-4092 / LIT-4139 / LIT-4137 family. LIT-4092 gated `permissions` on the single-key write paths; LIT-4139 did the same for `allowed_routes`; this PR extends the `permissions` gate to the bulk write path helper so all four write paths (`/key/generate`, `/key/update`, `/key/regenerate`, and both bulk endpoints via the helper) share the same admin-only rule

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small authorization hardening on key management with no intended behavior change for current bulk APIs; tests cover the new gate.
> 
> **Overview**
> Adds **defense-in-depth** so bulk key updates cannot set `permissions` unless the caller is a proxy admin.
> 
> `_check_permissions_caller_permission` (already used on single-key validation) is now invoked at the start of `_process_single_key_update`, which backs `/key/bulk_update` and `/team/key/bulk_update`. Any `UpdateKeyRequest` that explicitly includes `permissions`—including `{}` via `model_fields_set`—returns **403** for non-admins before DB work.
> 
> Current bulk request models still strip or forbid `permissions`, so day-to-day behavior is unchanged; the gate protects the shared helper if those allowlists widen later. Two async unit tests lock in the 403 behavior on `_process_single_key_update`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ac7b8a0ac11846c972a214ab14fd2a0911da96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->