### PR TITLE
fix(ui): preserve redirect_to when redirecting unauthenticated Model Hub users to login

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
@@ -92,7 +92,9 @@ describe("ModelHubTable", () => {
 
       await waitFor(() => {
         if (shouldRedirect) {
-          expect(mockRouterReplace).toHaveBeenCalledWith("http://localhost:4000/ui/login");
+          expect(mockRouterReplace).toHaveBeenCalledWith(
+            `http://localhost:4000/ui/login?redirect_to=${encodeURIComponent(window.location.href)}`,
+          );
         } else {
           expect(mockRouterReplace).not.toHaveBeenCalled();
         }

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -33,6 +33,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import { checkTokenValidity } from "@/utils/jwtUtils";
 import { getCookie } from "@/utils/cookieUtils";
+import { buildLoginUrlWithReturn } from "@/utils/returnUrlUtils";
 
 interface ModelHubTableProps {
   accessToken: string | null;
@@ -108,7 +109,7 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
 
       // If token is invalid, redirect to login
       if (!isTokenValid) {
-        router.replace(`${getProxyBaseUrl()}/ui/login`);
+        router.replace(buildLoginUrlWithReturn(`${getProxyBaseUrl()}/ui/login`));
         return;
       }
     }


### PR DESCRIPTION
## Summary

Fixes #31953.

When Admin Settings > UI Settings > "Require authentication for public AI Hub" is enabled, an unauthenticated user hitting `/ui/model_hub_table` is correctly redirected to `/ui/login`, but the redirect doesn't carry a `redirect_to` query param. After logging in, the user lands on the default dashboard homepage instead of back on the public Model Hub, which is confusing when admins share that link with non-admin users.

- `ModelHubTable.tsx`'s auth-check `useEffect` now builds the login redirect with the existing `buildLoginUrlWithReturn` helper (already used by every other login redirect in the dashboard) instead of a bare `${getProxyBaseUrl()}/ui/login` string.
- The login page's `redirect_to` handling (`consumeReturnUrl`/`getReturnUrl` in `returnUrlUtils.ts`) already supported this — it just wasn't being populated for this route.

## Test plan

- [x] Updated `ModelHubTable.test.tsx` assertion to expect the `redirect_to` param on the login redirect; verified it fails against the old code and passes with the fix (`npm run test`, 8/8 tests passing).
- [x] `npm run build` succeeds with no type errors.
- [x] Manually reproduced live: ran the proxy locally against Postgres, enabled "Require authentication for public AI Hub", logged out, hit `/ui/model_hub_table/` as an unauthenticated user, confirmed the redirect now includes `?redirect_to=...`, and confirmed logging back in lands directly on the Model Hub page instead of the dashboard homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)