### PR TITLE
fix(azure_sentinel): resolve audit stream from AZURE_SENTINEL_AUDIT_STREAM_NAME

### DIFF
--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -61,13 +61,15 @@ class AzureSentinelLogger(CustomBatchLogger):
             client_secret (str, optional): Azure Client Secret for OAuth2 authentication.
                 If not provided, will use AZURE_SENTINEL_CLIENT_SECRET or AZURE_CLIENT_SECRET env var.
             audit_stream_name (str, optional): Stream name from DCR for audit logs.
-                If not provided, audit logs use the standard stream name.
+                If not provided, will use AZURE_SENTINEL_AUDIT_STREAM_NAME env var or the standard stream name.
         """
         self.async_httpx_client = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
         resolved_dcr_immutable_id = dcr_immutable_id or os.getenv("AZURE_SENTINEL_DCR_IMMUTABLE_ID")
         resolved_stream_name = stream_name or os.getenv("AZURE_SENTINEL_STREAM_NAME") or "Custom-LiteLLM"
-        resolved_audit_stream_name = audit_stream_name or resolved_stream_name
+        resolved_audit_stream_name = (
+            audit_stream_name or os.getenv("AZURE_SENTINEL_AUDIT_STREAM_NAME") or resolved_stream_name
+        )
         resolved_endpoint = endpoint or os.getenv("AZURE_SENTINEL_ENDPOINT")
         resolved_tenant_id = tenant_id or os.getenv("AZURE_SENTINEL_TENANT_ID") or os.getenv("AZURE_TENANT_ID")
         resolved_client_id = client_id or os.getenv("AZURE_SENTINEL_CLIENT_ID") or os.getenv("AZURE_CLIENT_ID")

--- a/tests/test_litellm/integrations/test_azure_sentinel.py
+++ b/tests/test_litellm/integrations/test_azure_sentinel.py
@@ -263,3 +263,36 @@ async def test_azure_sentinel_flushes_standard_and_audit_logs_separately():
     ]
     assert "Custom-LiteLLM-Audit" in audit_call.kwargs["url"]
     assert json.loads(audit_call.kwargs["data"].decode("utf-8")) == [audit_log]
+
+
+@pytest.mark.asyncio
+async def test_azure_sentinel_audit_stream_name_from_env_var(monkeypatch):
+    """Audit stream resolves from AZURE_SENTINEL_AUDIT_STREAM_NAME when the string
+    callback constructs the logger with no audit_stream_name argument."""
+    monkeypatch.setenv("AZURE_SENTINEL_STREAM_NAME", "Custom-LiteLLM-Standard")
+    monkeypatch.setenv("AZURE_SENTINEL_AUDIT_STREAM_NAME", "Custom-LiteLLM-Audit")
+
+    with patch("asyncio.create_task", side_effect=_close_periodic_flush_task):
+        logger = AzureSentinelLogger(
+            dcr_immutable_id="dcr-test123456789",
+            endpoint="https://test-dce.eastus-1.ingest.monitor.azure.com",
+            tenant_id="test-tenant-id",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+        )
+
+    assert logger.audit_stream_name == "Custom-LiteLLM-Audit"
+    assert "streams/Custom-LiteLLM-Audit" in logger.audit_api_endpoint
+    assert "streams/Custom-LiteLLM-Standard" in logger.api_endpoint
+
+    with patch("asyncio.create_task", side_effect=_close_periodic_flush_task):
+        explicit_logger = AzureSentinelLogger(
+            dcr_immutable_id="dcr-test123456789",
+            endpoint="https://test-dce.eastus-1.ingest.monitor.azure.com",
+            tenant_id="test-tenant-id",
+            client_id="test-client-id",
+            client_secret="test-client-secret",
+            audit_stream_name="Custom-LiteLLM-Explicit",
+        )
+
+    assert explicit_logger.audit_stream_name == "Custom-LiteLLM-Explicit"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4174

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`AzureSentinelLogger` already supports an `audit_stream_name` so audit logs can target a separate DCR stream, but when the logger is resolved from the string callback name `azure_sentinel` it is constructed with no arguments, so `audit_stream_name` was always `None` and fell back to the standard `AZURE_SENTINEL_STREAM_NAME`. Audit events then land on the access-log DCR stream, whose schema is built from `StandardLoggingPayload`, and Azure Monitor Logs Ingestion silently drops the undeclared audit columns, so audit rows arrive with only `TimeGenerated`.

This was verified end to end against a real Azure Monitor Logs Ingestion workspace: a real Data Collection Endpoint, one Data Collection Rule with two streams (an access-log stream `Custom-LiteLLM_CL` and a dedicated audit stream `Custom-LiteLLM_Audit_CL`, each mapped to its own custom table), and a service principal granted Monitoring Metrics Publisher on the DCR. A live proxy was run with the ticket's config, a real admin action created a real audit log, and the rows were queried back from the workspace. Audit-log generation is an enterprise feature so the license check was satisfied for the run; the `AzureSentinelLogger` code under test is unmodified.

Config (the exact setup from the ticket):

```yaml
litellm_settings:
  store_audit_logs: true
  callbacks: ["azure_sentinel"]
  audit_log_callbacks: ["azure_sentinel"]
```

```bash
AZURE_SENTINEL_STREAM_NAME="Custom-LiteLLM_CL"             # access-log stream
AZURE_SENTINEL_AUDIT_STREAM_NAME="Custom-LiteLLM_Audit_CL" # dedicated audit stream
AZURE_SENTINEL_DCR_IMMUTABLE_ID / ENDPOINT / TENANT_ID / CLIENT_ID / CLIENT_SECRET=...
```

Trigger (a real admin action that produces a real audit log):

```bash
curl -sS http://localhost:4010/team/new \
  -H "Authorization: Bearer sk-..." -H "Content-Type: application/json" \
  -d '{"team_alias":"lit4174-demo"}'
```

Before the fix, with `AZURE_SENTINEL_AUDIT_STREAM_NAME` set, the audit event ingests into the access-log table `LiteLLM_CL`, which has no audit columns, so everything except `TimeGenerated` is dropped:

```
// KQL: LiteLLM_CL | project TimeGenerated, id, call_type, model, status
TimeGenerated                 Call_type   Model   Status
2026-07-03T18:53:10.6733165Z  (empty)     (empty) (empty)

// KQL: LiteLLM_Audit_CL | count  ->  unchanged; the audit event never arrived here
```

After the fix, the same action with the same environment ingests into the dedicated audit table `LiteLLM_Audit_CL` with every audit column populated:

```
// KQL: LiteLLM_Audit_CL | project TimeGenerated, action, table_name, object_id, changed_by
TimeGenerated                 action    table_name          object_id                              changed_by
2026-07-03T18:21:30.9233039Z  created   LiteLLM_TeamTable   645386d8-0029-4055-a616-f9401802f626   default_user_id
2026-07-03T18:21:30.9233039Z  created   LiteLLM_TeamTable   3b68857f-c9a5-49a6-be84-72afd54a9c7a   default_user_id
2026-07-03T18:20:30.6118873Z  created   LiteLLM_TeamTable   4c7a5511-dda5-4c44-8a71-00cd6fe7bd69   default_user_id

// KQL: LiteLLM_CL | count  ->  0; audit events did not leak into the access-log table
```

The `object_id` values are the team IDs returned by the create-team calls, confirming these rows are the events those requests produced. Live proxy log for one flush: `Azure Sentinel - about to flush 1 audit logs` then `Azure Sentinel: Response from API status_code: 204`.

<!-- SCREENSHOT: drop the LiteLLM_Audit_CL query result here (populated audit rows in the dedicated table) -->

The standard access-log endpoint is unchanged; `api_endpoint` and `audit_api_endpoint` are built independently in `__init__`, so the fix only affects the audit stream

## Type

🐛 Bug Fix

## Changes

`AzureSentinelLogger.__init__` now resolves the audit stream as `audit_stream_name or os.getenv("AZURE_SENTINEL_AUDIT_STREAM_NAME") or resolved_stream_name`, mirroring the `AZURE_SENTINEL_STREAM_NAME` fallback already used for the standard stream. Because every string-callback construction site (`_init_custom_logger_compatible_class` for both `callbacks` and `audit_log_callbacks`) builds the logger with no arguments, this single change lets audit logs target a separate DCR stream without a custom callbacks file. A regression test constructs the logger with no `audit_stream_name` and only the env var set, and asserts the resolved audit endpoint uses the env var stream while the standard endpoint keeps the access-log stream

## CI note

The `AZURE_SENTINEL_AUDIT_STREAM_NAME` env var is documented in the separate env-settings reference via BerriAI/litellm-docs#477 (merged), which the `documentation` and `code-quality` checks validate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow logging-callback configuration fix with tests; no auth or core proxy request-path changes.
> 
> **Overview**
> Fixes audit logs being ingested into the **standard** DCR stream when the proxy registers `azure_sentinel` as a string callback with no constructor args.
> 
> `AzureSentinelLogger` now resolves the audit stream as `audit_stream_name` → **`AZURE_SENTINEL_AUDIT_STREAM_NAME`** → standard stream (same pattern as `AZURE_SENTINEL_STREAM_NAME`). That updates `audit_api_endpoint` only; access-log ingestion is unchanged. Docstring reflects the new env var.
> 
> A regression test asserts env-based resolution splits audit vs standard endpoints, and that an explicit `audit_stream_name` still overrides the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460600c4acc14186f82bedfd6ce6c3dd36be39a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
