### PR TITLE
fix(ui): include cache token columns in usage export

### DIFF
--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.test.ts
@@ -358,6 +358,23 @@ describe("EntityUsageExport utils", () => {
       expect(result[0]).toHaveProperty("Total Tokens");
       expect(result[0]).toHaveProperty("Prompt Tokens");
       expect(result[0]).toHaveProperty("Completion Tokens");
+      expect(result[0]).toHaveProperty("Cache Read Input Tokens");
+      expect(result[0]).toHaveProperty("Cache Creation Input Tokens");
+    });
+
+    it("should export exact cache token values per entity per day", () => {
+      const result = generateDailyData(mockSpendData, "Team", mockTeamAliasMap);
+
+      const day1Team1 = result.find((r) => r.Date === "2025-01-01" && r["Team ID"] === "team-1");
+      const day1Team2 = result.find((r) => r.Date === "2025-01-01" && r["Team ID"] === "team-2");
+      const day2Team1 = result.find((r) => r.Date === "2025-01-02" && r["Team ID"] === "team-1");
+
+      expect(day1Team1?.["Cache Read Input Tokens"]).toBe(50);
+      expect(day1Team1?.["Cache Creation Input Tokens"]).toBe(30);
+      expect(day1Team2?.["Cache Read Input Tokens"]).toBe(100);
+      expect(day1Team2?.["Cache Creation Input Tokens"]).toBe(60);
+      expect(day2Team1?.["Cache Read Input Tokens"]).toBe(75);
+      expect(day2Team1?.["Cache Creation Input Tokens"]).toBe(45);
     });
 
     it("should sort data by date ascending", () => {
@@ -469,6 +486,8 @@ describe("EntityUsageExport utils", () => {
 
       expect(result[0]["Prompt Tokens"]).toBe(0);
       expect(result[0]["Completion Tokens"]).toBe(0);
+      expect(result[0]["Cache Read Input Tokens"]).toBe(0);
+      expect(result[0]["Cache Creation Input Tokens"]).toBe(0);
     });
   });
 
@@ -614,6 +633,61 @@ describe("EntityUsageExport utils", () => {
       expect(result[0]).toHaveProperty("Total Tokens");
       expect(result[0]).toHaveProperty("Prompt Tokens");
       expect(result[0]).toHaveProperty("Completion Tokens");
+      expect(result[0]).toHaveProperty("Cache Read Input Tokens");
+      expect(result[0]).toHaveProperty("Cache Creation Input Tokens");
+    });
+
+    it("should export and aggregate cache token values per key", () => {
+      const makeDay = (cacheRead: number, cacheCreation: number) => ({
+        date: "2025-01-01",
+        breakdown: {
+          entities: {
+            "team-1": {
+              metrics: {
+                spend: 5.0,
+                api_requests: 50,
+                successful_requests: 50,
+                failed_requests: 0,
+                total_tokens: 500,
+                prompt_tokens: 300,
+                completion_tokens: 200,
+                cache_read_input_tokens: cacheRead,
+                cache_creation_input_tokens: cacheCreation,
+              },
+              api_key_breakdown: {
+                key1: {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 50,
+                    successful_requests: 50,
+                    failed_requests: 0,
+                    total_tokens: 500,
+                    prompt_tokens: 300,
+                    completion_tokens: 200,
+                    cache_read_input_tokens: cacheRead,
+                    cache_creation_input_tokens: cacheCreation,
+                  },
+                  metadata: {
+                    team_id: "team-1",
+                    key_alias: "alias-1",
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const spendDataWithCache: EntitySpendData = {
+        results: [makeDay(40, 25), makeDay(10, 5)],
+        metadata: mockSpendDataWithKeys.metadata,
+      };
+
+      const result = generateDailyWithKeysData(spendDataWithCache, "Team");
+
+      expect(result).toHaveLength(1);
+      expect(result[0]["Cache Read Input Tokens"]).toBe(50);
+      expect(result[0]["Cache Creation Input Tokens"]).toBe(30);
     });
 
     it("should sort data by date ascending", () => {
@@ -935,6 +1009,8 @@ describe("EntityUsageExport utils", () => {
 
       expect(key1Entry?.["Prompt Tokens"]).toBe(0);
       expect(key1Entry?.["Completion Tokens"]).toBe(0);
+      expect(key1Entry?.["Cache Read Input Tokens"]).toBe(0);
+      expect(key1Entry?.["Cache Creation Input Tokens"]).toBe(0);
     });
 
     it("should handle empty api_key_breakdown", () => {
@@ -1096,6 +1172,117 @@ describe("EntityUsageExport utils", () => {
       expect(result[0]).toHaveProperty("Successful");
       expect(result[0]).toHaveProperty("Failed");
       expect(result[0]).toHaveProperty("Total Tokens");
+      expect(result[0]).toHaveProperty("Prompt Tokens");
+      expect(result[0]).toHaveProperty("Completion Tokens");
+      expect(result[0]).toHaveProperty("Cache Read Input Tokens");
+      expect(result[0]).toHaveProperty("Cache Creation Input Tokens");
+    });
+
+    it("should export prompt, completion, and cache token values summed across keys for the same model", () => {
+      const data: EntitySpendData = {
+        results: [
+          {
+            date: "2025-03-01",
+            breakdown: {
+              entities: {
+                "team-1": {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 25,
+                    successful_requests: 25,
+                    failed_requests: 0,
+                    total_tokens: 1050,
+                    prompt_tokens: 750,
+                    completion_tokens: 300,
+                    cache_read_input_tokens: 450,
+                    cache_creation_input_tokens: 200,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 2.0,
+                        api_requests: 10,
+                        successful_requests: 10,
+                        failed_requests: 0,
+                        total_tokens: 700,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                    key2: {
+                      metrics: {
+                        spend: 3.0,
+                        api_requests: 15,
+                        successful_requests: 15,
+                        failed_requests: 0,
+                        total_tokens: 350,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+              },
+              models: {
+                "claude-sonnet-4-5": {
+                  metrics: {
+                    spend: 5.0,
+                    api_requests: 25,
+                    successful_requests: 25,
+                    failed_requests: 0,
+                    total_tokens: 1050,
+                  },
+                  api_key_breakdown: {
+                    key1: {
+                      metrics: {
+                        spend: 2.0,
+                        api_requests: 10,
+                        successful_requests: 10,
+                        failed_requests: 0,
+                        total_tokens: 700,
+                        prompt_tokens: 500,
+                        completion_tokens: 200,
+                        cache_read_input_tokens: 300,
+                        cache_creation_input_tokens: 120,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                    key2: {
+                      metrics: {
+                        spend: 3.0,
+                        api_requests: 15,
+                        successful_requests: 15,
+                        failed_requests: 0,
+                        total_tokens: 350,
+                        prompt_tokens: 250,
+                        completion_tokens: 100,
+                        cache_read_input_tokens: 150,
+                        cache_creation_input_tokens: 80,
+                      },
+                      metadata: { team_id: "team-1" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        metadata: {
+          total_spend: 5.0,
+          total_api_requests: 25,
+          total_successful_requests: 25,
+          total_failed_requests: 0,
+          total_tokens: 1050,
+        },
+      };
+
+      const result = generateDailyWithModelsData(data, "Team");
+
+      expect(result).toHaveLength(1);
+      expect(result[0].Model).toBe("claude-sonnet-4-5");
+      expect(result[0]["Total Tokens"]).toBe(1050);
+      expect(result[0]["Prompt Tokens"]).toBe(750);
+      expect(result[0]["Completion Tokens"]).toBe(300);
+      expect(result[0]["Cache Read Input Tokens"]).toBe(450);
+      expect(result[0]["Cache Creation Input Tokens"]).toBe(200);
     });
 
     it("should sort data by date ascending", () => {

--- a/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
+++ b/ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts
@@ -126,6 +126,8 @@ export const generateDailyData = (
         "Total Tokens": data.metrics.total_tokens,
         "Prompt Tokens": data.metrics.prompt_tokens || 0,
         "Completion Tokens": data.metrics.completion_tokens || 0,
+        "Cache Read Input Tokens": data.metrics.cache_read_input_tokens || 0,
+        "Cache Creation Input Tokens": data.metrics.cache_creation_input_tokens || 0,
       });
     });
   });
@@ -154,6 +156,8 @@ export const generateDailyWithKeysData = (
         total_tokens: number;
         prompt_tokens: number;
         completion_tokens: number;
+        cache_read_input_tokens: number;
+        cache_creation_input_tokens: number;
       };
     };
   } = {};
@@ -186,6 +190,8 @@ export const generateDailyWithKeysData = (
               total_tokens: keyData.metrics?.total_tokens || 0,
               prompt_tokens: keyData.metrics?.prompt_tokens || 0,
               completion_tokens: keyData.metrics?.completion_tokens || 0,
+              cache_read_input_tokens: keyData.metrics?.cache_read_input_tokens || 0,
+              cache_creation_input_tokens: keyData.metrics?.cache_creation_input_tokens || 0,
             },
           };
         } else {
@@ -197,6 +203,9 @@ export const generateDailyWithKeysData = (
           aggregatedData[uniqueKey].metrics.total_tokens += keyData.metrics?.total_tokens || 0;
           aggregatedData[uniqueKey].metrics.prompt_tokens += keyData.metrics?.prompt_tokens || 0;
           aggregatedData[uniqueKey].metrics.completion_tokens += keyData.metrics?.completion_tokens || 0;
+          aggregatedData[uniqueKey].metrics.cache_read_input_tokens += keyData.metrics?.cache_read_input_tokens || 0;
+          aggregatedData[uniqueKey].metrics.cache_creation_input_tokens +=
+            keyData.metrics?.cache_creation_input_tokens || 0;
         }
       });
     });
@@ -216,6 +225,8 @@ export const generateDailyWithKeysData = (
     "Total Tokens": item.metrics.total_tokens,
     "Prompt Tokens": item.metrics.prompt_tokens,
     "Completion Tokens": item.metrics.completion_tokens,
+    "Cache Read Input Tokens": item.metrics.cache_read_input_tokens,
+    "Cache Creation Input Tokens": item.metrics.cache_creation_input_tokens,
   }));
 
   return dailyKeyBreakdown.sort((a, b) => new Date(a.Date).getTime() - new Date(b.Date).getTime());
@@ -251,6 +262,10 @@ export const generateDailyWithModelsData = (
               successful: 0,
               failed: 0,
               tokens: 0,
+              promptTokens: 0,
+              completionTokens: 0,
+              cacheReadInputTokens: 0,
+              cacheCreationInputTokens: 0,
             };
           }
           dailyEntityModels[entity][model].spend += keyMetrics.spend || 0;
@@ -258,6 +273,10 @@ export const generateDailyWithModelsData = (
           dailyEntityModels[entity][model].successful += keyMetrics.successful_requests || 0;
           dailyEntityModels[entity][model].failed += keyMetrics.failed_requests || 0;
           dailyEntityModels[entity][model].tokens += keyMetrics.total_tokens || 0;
+          dailyEntityModels[entity][model].promptTokens += keyMetrics.prompt_tokens || 0;
+          dailyEntityModels[entity][model].completionTokens += keyMetrics.completion_tokens || 0;
+          dailyEntityModels[entity][model].cacheReadInputTokens += keyMetrics.cache_read_input_tokens || 0;
+          dailyEntityModels[entity][model].cacheCreationInputTokens += keyMetrics.cache_creation_input_tokens || 0;
         });
       });
     });
@@ -276,6 +295,10 @@ export const generateDailyWithModelsData = (
           Successful: metrics.successful,
           Failed: metrics.failed,
           "Total Tokens": metrics.tokens,
+          "Prompt Tokens": metrics.promptTokens,
+          "Completion Tokens": metrics.completionTokens,
+          "Cache Read Input Tokens": metrics.cacheReadInputTokens,
+          "Cache Creation Input Tokens": metrics.cacheCreationInputTokens,
         });
       });
     });


### PR DESCRIPTION
## Relevant issues

Reported by a customer via support

## Linear ticket

Resolves LIT-4011

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Everything below ran against a real proxy and the real Anthropic API; no mocks anywhere. Setup: a fresh git worktree of this repo, a brand new venv (`uv venv .venv-qa` then `uv pip install -e ".[proxy]" prisma`), a dedicated Postgres database created only for this run (`CREATE DATABASE litellm_qa_export_32015`), and the proxy started on a randomly picked free port. Two chat completions were sent to `anthropic/claude-haiku-4-5` with an ephemeral `cache_control` system block so the first call creates a cache entry and the second call reads it. After the daily spend flush landed, the actual export builders from the checked-out source (`generateExportData` in `ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts`, serialized with `Papa.unparse`, which is exactly what `handleExportCSV` downloads) were run over the live `/user/daily/activity` response, first at the base commit and then at this PR's commit, using the identical command

Pick a random free port and start the proxy; `.env` provides `ANTHROPIC_API_KEY` and the `DATABASE_URL` of the dedicated QA database (values never printed)

```console
$ python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1',0)); print(s.getsockname()[1])"
64023

$ cat qa_config.yaml
model_list:
  - model_name: anthropic-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-qa-1234

$ set -a; source .env; set +a; .venv-qa/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 64023 > qa_proxy.log 2>&1 &
$ curl -s http://localhost:64023/health/liveliness
"I'm alive!"
```

Generate real cached traffic: the system block is ~9.5k tokens, well above the haiku cacheable minimum. First call creates the cache, second call reads it

```console
$ python3 -c "import json; text=' '.join(f'Policy clause {i}: all reimbursement requests filed under schedule {i} must include itemized receipts, a cost center code, and written approval from the designated budget owner before payment processing may begin.' for i in range(220)); json.dump({'model': 'anthropic-haiku-4-5', 'max_tokens': 40, 'system': [{'type': 'text', 'text': text, 'cache_control': {'type': 'ephemeral'}}], 'messages': [{'role': 'user', 'content': 'In one short sentence, what do these clauses govern?'}]}, open('qa_payload.json', 'w'))"

$ curl -s http://localhost:64023/v1/chat/completions -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" -d @qa_payload.json | jq .usage
{
  "completion_tokens": 28,
  "prompt_tokens": 9479,
  "total_tokens": 9507,
  "completion_tokens_details": {
    "reasoning_tokens": 0,
    "text_tokens": 28
  },
  "prompt_tokens_details": {
    "cached_tokens": 0,
    "text_tokens": 18,
    "cache_creation_tokens": 9461,
    "cache_creation_token_details": {
      "ephemeral_5m_input_tokens": 9461,
      "ephemeral_1h_input_tokens": 0
    }
  },
  "cache_creation_input_tokens": 9461,
  "cache_read_input_tokens": 0,
  "inference_geo": "not_available",
  "service_tier": "standard"
}

$ curl -s http://localhost:64023/v1/chat/completions -H "Authorization: Bearer sk-qa-1234" -H "Content-Type: application/json" -d @qa_payload.json | jq .usage
{
  "completion_tokens": 26,
  "prompt_tokens": 9479,
  "total_tokens": 9505,
  "completion_tokens_details": {
    "reasoning_tokens": 0,
    "text_tokens": 26
  },
  "prompt_tokens_details": {
    "cached_tokens": 9461,
    "text_tokens": 18,
    "cache_creation_tokens": 0,
    "cache_creation_token_details": {
      "ephemeral_5m_input_tokens": 0,
      "ephemeral_1h_input_tokens": 0
    }
  },
  "cache_creation_input_tokens": 0,
  "cache_read_input_tokens": 9461,
  "inference_geo": "not_available",
  "service_tier": "standard"
}
```

The backend daily activity API carries both cache token fields for the bucket (requests land in UTC date buckets, hence 2026-07-03), so the data the export modal receives is complete; only the row builders drop it

```console
$ curl -s "http://localhost:64023/user/daily/activity?start_date=2026-07-01&end_date=2026-07-04" -H "Authorization: Bearer sk-qa-1234" | jq '.results[] | select(.metrics.api_requests > 0) | {date: .date, spend: .metrics.spend, prompt_tokens: .metrics.prompt_tokens, completion_tokens: .metrics.completion_tokens, cache_read_input_tokens: .metrics.cache_read_input_tokens, cache_creation_input_tokens: .metrics.cache_creation_input_tokens}'
{
  "date": "2026-07-03",
  "spend": 0.01307835,
  "prompt_tokens": 18958,
  "completion_tokens": 54,
  "cache_read_input_tokens": 9461,
  "cache_creation_input_tokens": 9461
}
```

The runner script imports the production builders from the checked-out source and prints the exact CSV the modal would download (the Usage page teams tab passes entity label "Team")

```console
$ cat ui/litellm-dashboard/qa_export.ts
import Papa from "papaparse";
import { generateExportData } from "./src/components/EntityUsageExport/utils";

const port = process.env.QA_PORT;
const url = `http://localhost:${port}/user/daily/activity?start_date=2026-07-01&end_date=2026-07-04`;

const main = async () => {
  const res = await fetch(url, { headers: { Authorization: "Bearer sk-qa-1234" } });
  const spendData = await res.json();
  spendData.results = spendData.results.filter((day: any) => day.metrics.api_requests > 0);

  const dailyRows = generateExportData(spendData, "daily", "Team", {});
  console.log("===== CSV: scope 'daily' (what handleExportCSV downloads) =====");
  console.log(Papa.unparse(dailyRows));

  const modelRows = generateExportData(spendData, "daily_with_models", "Team", {});
  console.log("===== CSV: scope 'daily_with_models' =====");
  console.log(Papa.unparse(modelRows));
};

main();
```

Before, at the base commit: the daily CSV stops at "Completion Tokens" and the models CSV has no token detail at all, so the cache tokens are silently dropped

```console
$ git checkout --detach origin/litellm_internal_staging
HEAD is now at 27069bd74f feat(ui): shadcn migration foundation: Tailwind v4, shadcn init, antd cascade fix (#31995)
$ cd ui/litellm-dashboard && npm ci && QA_PORT=64023 npx tsx qa_export.ts
===== CSV: scope 'daily' (what handleExportCSV downloads) =====
Date,Team,Team ID,Spend ($),Requests,Successful Requests,Failed Requests,Total Tokens,Prompt Tokens,Completion Tokens
2026-07-03,default_user_id,default_user_id,0.0131,2,2,0,19012,18958,54
===== CSV: scope 'daily_with_models' =====
Date,Team,Team ID,Model,Spend ($),Requests,Successful,Failed,Total Tokens
2026-07-03,default_user_id,default_user_id,anthropic/claude-haiku-4-5,0.0131,2,2,0,19012
```

Reconciling that export against published claude-haiku-4-5 prices (input 1e-06, output 5e-06 per token) fails; the exported columns cannot explain the exported spend

```console
$ python3 -c "
prompt, completion = 18958, 54
naive = prompt * 1e-06 + completion * 5e-06
print(f'naive spend = prompt*1e-06 + completion*5e-06 = {naive:.6f}')
print('CSV Spend   = 0.0131')
print(f'delta       = {naive - 0.0131:+.6f}  (cannot be explained from the exported columns)')"
naive spend = prompt*1e-06 + completion*5e-06 = 0.019228
CSV Spend   = 0.0131
delta       = +0.006128  (cannot be explained from the exported columns)
```

After, at this PR's commit, rerunning the identical command: both cache columns appear in both scopes with the real token counts, and the models scope also gains prompt and completion tokens

```console
$ git checkout --detach origin/litellm_fix_usage_export_cache_columns
HEAD is now at fbca54416a fix(ui): include cache token columns in usage export
$ cd ui/litellm-dashboard && QA_PORT=64023 npx tsx qa_export.ts
===== CSV: scope 'daily' (what handleExportCSV downloads) =====
Date,Team,Team ID,Spend ($),Requests,Successful Requests,Failed Requests,Total Tokens,Prompt Tokens,Completion Tokens,Cache Read Input Tokens,Cache Creation Input Tokens
2026-07-03,default_user_id,default_user_id,0.0131,2,2,0,19012,18958,54,9461,9461
===== CSV: scope 'daily_with_models' =====
Date,Team,Team ID,Model,Spend ($),Requests,Successful,Failed,Total Tokens,Prompt Tokens,Completion Tokens,Cache Read Input Tokens,Cache Creation Input Tokens
2026-07-03,default_user_id,default_user_id,anthropic/claude-haiku-4-5,0.0131,2,2,0,19012,18958,54,9461,9461
```

With the cache columns present the row reconciles exactly, to eight decimals, against the same price sheet (cache creation 1.25e-06, cache read 1e-07 per token)

```console
$ python3 -c "
prompt, completion, cache_read, cache_creation = 18958, 54, 9461, 9461
regular_input = prompt - cache_read - cache_creation
spend = regular_input * 1e-06 + cache_creation * 1.25e-06 + cache_read * 1e-07 + completion * 5e-06
print(f'regular input tokens = {regular_input}')
print(f'reconstructed spend  = {spend:.8f}')
print('API bucket spend     = 0.01307835')
print(f'CSV Spend column     = 0.0131 (display rounded to 4 decimals; {spend:.4f} == 0.0131: {round(spend, 4) == 0.0131})')"
regular input tokens = 36
reconstructed spend  = 0.01307835
API bucket spend     = 0.01307835
CSV Spend column     = 0.0131 (display rounded to 4 decimals; 0.0131 == 0.0131: True)
```

## Type

🐛 Bug Fix

## Changes

The Export Data modal on the Usage page drops cache token metrics from both CSV and JSON exports. The daily activity API and the frontend aggregation both carry `cache_read_input_tokens` and `cache_creation_input_tokens`, but the three row builders in `ui/litellm-dashboard/src/components/EntityUsageExport/utils.ts` omitted them from the exported rows. This made exported spend impossible to reconcile against model prices: a real export row showed Spend $0.011054 with Prompt Tokens 16306 (which includes cache tokens) and Completion Tokens 8, yet 16306 x $1/M plus 8 x $5/M works out to $0.016346. With the previously hidden fields (24 regular input tokens, 8141 cache creation tokens at $1.25/M, 8141 cache read tokens at $0.10/M) the row reconciles exactly to $0.01105435

This PR adds "Cache Read Input Tokens" and "Cache Creation Input Tokens" columns to all three export scopes. `generateDailyData` sources them from the entity metrics, and `generateDailyWithKeysData` accumulates them in its per-key aggregation before emitting the columns. `generateDailyWithModelsData` previously only emitted "Total Tokens"; its per-model aggregation now also accumulates prompt, completion, and both cache token fields and emits them as columns, so per-model rows become reconcilable like the other scopes. The JSON export shares these row builders, so it picks up the same columns automatically

Regression tests assert the exact numeric cache values per entity per day, per key (including aggregation across duplicate day entries for the same key), and per model (including summation across two keys that hit the same model), plus zero defaults when the backend omits the fields

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only export formatting with additive columns and unit tests; no API or billing logic changes.
> 
> **Overview**
> Fixes Usage page CSV/JSON exports that already received `cache_read_input_tokens` and `cache_creation_input_tokens` from daily activity but dropped them in the row builders.
> 
> **`generateDailyData`** now emits **Cache Read Input Tokens** and **Cache Creation Input Tokens** from entity metrics (defaulting to 0 when absent). **`generateDailyWithKeysData`** tracks those fields in per-date/entity/key aggregation and includes them on each row. **`generateDailyWithModelsData`** now sums prompt, completion, and both cache token types from each model’s per-key breakdown and exports them as columns (previously model rows only had total tokens), so spend can be reconciled against cache-aware pricing.
> 
> JSON export uses the same builders, so it picks up the new columns automatically. Tests cover exact values, key-level aggregation across duplicate days, model-level summation across keys, and zero defaults when metrics are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbca54416a8a9f37b0892ec055297e76ef3a9743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->