### PR TITLE
fix(anthropic): keep context_management working when drop_params is enabled

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/handler.py
@@ -78,7 +78,7 @@ async def _prepare_context_managed_request(
     system: Optional[Any],
     context_management_spec: Any,
     litellm_metadata: Optional[Dict],
-    drop_params: Optional[bool],
+    additional_drop_params: Optional[list[str]],
     llm_router: Any,
     user_api_key_auth: Any = None,
 ) -> Optional[PolyfillResult]:
@@ -95,7 +95,7 @@ async def _prepare_context_managed_request(
     # silently drop intermediate turns.
     polyfill_will_run = _polyfill_will_run(
         context_management_spec=context_management_spec,
-        drop_params=drop_params,
+        additional_drop_params=additional_drop_params,
     )
 
     if polyfill_will_run:
@@ -117,7 +117,7 @@ async def _prepare_context_managed_request(
         system=working_system,
         context_management_spec=context_management_spec,
         litellm_metadata=litellm_metadata,
-        drop_params=drop_params,
+        additional_drop_params=additional_drop_params,
         llm_router=llm_router,
         user_api_key_auth=user_api_key_auth,
     )
@@ -143,18 +143,19 @@ async def _prepare_context_managed_request(
 def _polyfill_will_run(
     *,
     context_management_spec: Any,
-    drop_params: Optional[bool],
+    additional_drop_params: Optional[list[str]],
 ) -> bool:
     """Return True when ``compact_20260112`` will run via the polyfill dispatcher.
 
-    Mirrors the gating in ``_run_polyfill_if_enabled``: an empty spec or
-    effective ``drop_params`` short-circuits the polyfill. The pre-processing
-    skip only applies when the dispatcher will actually invoke
-    ``apply_compact_20260112`` (which has its own compaction-block slicing).
+    Mirrors the gating in ``_run_polyfill_if_enabled``: an empty spec or an
+    explicit ``context_management`` entry in ``additional_drop_params``
+    short-circuits the polyfill. The pre-processing skip only applies when the
+    dispatcher will actually invoke ``apply_compact_20260112`` (which has its
+    own compaction-block slicing).
     """
     edits = _normalize_spec_edits(
         context_management_spec=context_management_spec,
-        drop_params=drop_params,
+        additional_drop_params=additional_drop_params,
     )
     if edits is None:
         return False
@@ -169,7 +170,7 @@ def _polyfill_will_run(
 def _spec_has_non_compact_edits(
     *,
     context_management_spec: Any,
-    drop_params: Optional[bool],
+    additional_drop_params: Optional[list[str]],
 ) -> bool:
     """Return True when the spec includes edits other than ``compact_20260112``.
 
@@ -180,7 +181,7 @@ def _spec_has_non_compact_edits(
     """
     edits = _normalize_spec_edits(
         context_management_spec=context_management_spec,
-        drop_params=drop_params,
+        additional_drop_params=additional_drop_params,
     )
     if edits is None:
         return False
@@ -195,10 +196,22 @@ def _spec_has_non_compact_edits(
     )
 
 
+def _context_management_explicitly_dropped(additional_drop_params: Optional[list[str]]) -> bool:
+    """True when the caller opted out of context_management via ``additional_drop_params``.
+
+    ``drop_params`` deliberately does NOT gate the polyfill: ``context_management``
+    is a LiteLLM-supported param (native on Anthropic, polyfilled elsewhere), and
+    ``drop_params`` only exists to drop genuinely unsupported params.
+    """
+    if not isinstance(additional_drop_params, list):
+        return False
+    return "context_management" in additional_drop_params
+
+
 def _normalize_spec_edits(
     *,
     context_management_spec: Any,
-    drop_params: Optional[bool],
+    additional_drop_params: Optional[list[str]],
 ) -> Optional[List[Dict[str, Any]]]:
     """Return the normalized ``edits`` list, or ``None`` if the polyfill won't run.
 
@@ -208,8 +221,7 @@ def _normalize_spec_edits(
     if not context_management_spec:
         return None
 
-    effective_drop_params = drop_params if drop_params is not None else litellm.drop_params
-    if effective_drop_params:
+    if _context_management_explicitly_dropped(additional_drop_params):
         return None
 
     from litellm.llms.anthropic.experimental_pass_through.context_management.dispatcher import (
@@ -230,22 +242,23 @@ async def _run_polyfill_if_enabled(
     system: Optional[Any],
     context_management_spec: Any,
     litellm_metadata: Optional[Dict],
-    drop_params: Optional[bool],
+    additional_drop_params: Optional[list[str]],
     llm_router: Any,
     user_api_key_auth: Any = None,
 ) -> Optional[PolyfillResult]:
     """Run the async context_management polyfill if a spec is present.
 
-    Returns ``None`` when the spec is empty or drop_params is on. Raises
-    ``AnthropicContextManagementError`` so the /v1/messages endpoint can
-    emit an Anthropic-format 400. All other exceptions are best-effort
-    swallowed (matches v0 behavior).
+    Returns ``None`` when the spec is empty or ``context_management`` is
+    listed in ``additional_drop_params`` (the explicit opt-out; ``drop_params``
+    does not disable the polyfill because context_management is a supported
+    param). Raises ``AnthropicContextManagementError`` so the /v1/messages
+    endpoint can emit an Anthropic-format 400. All other exceptions are
+    best-effort swallowed (matches v0 behavior).
     """
     if not context_management_spec:
         return None
 
-    effective_drop_params = drop_params if drop_params is not None else litellm.drop_params
-    if effective_drop_params:
+    if _context_management_explicitly_dropped(additional_drop_params):
         return None
 
     try:
@@ -274,7 +287,7 @@ async def _run_polyfill_if_enabled(
         # emits an Anthropic-format error.
         if _spec_has_non_compact_edits(
             context_management_spec=context_management_spec,
-            drop_params=drop_params,
+            additional_drop_params=additional_drop_params,
         ):
             raise AnthropicContextManagementError(
                 status_code=500,
@@ -533,7 +546,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
     ) -> Union[AnthropicMessagesResponse, AsyncIterator[Any], Iterator[bytes]]:
         """Handle non-Anthropic models asynchronously using the adapter"""
         context_management = kwargs.pop("context_management", None)
-        drop_params: Optional[bool] = kwargs.get("drop_params", None)
+        additional_drop_params: Optional[list[str]] = kwargs.get("additional_drop_params", None)
         litellm_router = kwargs.pop("litellm_router", None)
         if litellm_router is None:
             try:
@@ -555,7 +568,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
             system=system,
             context_management_spec=context_management,
             litellm_metadata=proxy_litellm_metadata,
-            drop_params=drop_params,
+            additional_drop_params=additional_drop_params,
             llm_router=litellm_router,
             user_api_key_auth=user_api_key_auth,
         )
@@ -661,7 +674,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
         # ``compact_20260112`` editor can ``await`` the summarization model);
         # bridge to it via ``run_async_function``.
         context_management = kwargs.pop("context_management", None)
-        drop_params: Optional[bool] = kwargs.get("drop_params", None)
+        additional_drop_params: Optional[list[str]] = kwargs.get("additional_drop_params", None)
         # Deliberately do NOT auto-attach the proxy ``llm_router`` here:
         # ``run_async_function`` spawns a new event loop in a worker thread
         # to bridge to the async dispatcher, but the proxy router's httpx
@@ -696,7 +709,7 @@ class LiteLLMMessagesToCompletionTransformationHandler:
                 system=system,
                 context_management_spec=context_management,
                 litellm_metadata=proxy_litellm_metadata,
-                drop_params=drop_params,
+                additional_drop_params=additional_drop_params,
                 llm_router=litellm_router,
                 user_api_key_auth=user_api_key_auth,
             )

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
@@ -12,11 +12,13 @@ Coverage:
 - custom instructions  → default prompt is not used even when tools present
 """
 
+import json
 from typing import Any, Dict, List
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import litellm
 from litellm.llms.anthropic.experimental_pass_through.context_management import (
     AnthropicContextManagementError,
     apply_context_management,
@@ -2042,12 +2044,12 @@ async def test_dispatcher_trigger_below_minimum_raises_through():
 
 
 # ---------------------------------------------------------------------------
-# _run_polyfill_if_enabled: drop_params gate
+# _run_polyfill_if_enabled: additional_drop_params gate (drop_params must NOT gate)
 # ---------------------------------------------------------------------------
 
 
-async def test_run_polyfill_skipped_when_drop_params_true():
-    """When drop_params=True the polyfill must be skipped (returns None)."""
+async def test_run_polyfill_skipped_when_context_management_in_additional_drop_params():
+    """additional_drop_params=["context_management"] is the explicit opt-out."""
     from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
         _run_polyfill_if_enabled,
     )
@@ -2059,10 +2061,37 @@ async def test_run_polyfill_skipped_when_drop_params_true():
         system=None,
         context_management_spec={"edits": [{"type": "compact_20260112"}]},
         litellm_metadata={},
-        drop_params=True,
+        additional_drop_params=["context_management"],
         llm_router=None,
     )
     assert result is None
+
+
+async def test_run_polyfill_runs_when_litellm_drop_params_true(monkeypatch):
+    """drop_params must not disable the polyfill: context_management is a
+    LiteLLM-supported param (polyfilled where not native), and drop_params only
+    exists to strip genuinely unsupported params."""
+    from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+        _run_polyfill_if_enabled,
+    )
+
+    monkeypatch.setattr(litellm, "drop_params", True)
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.context_management.editors.compact._read_summary_model_setting",
+        return_value=None,
+    ):
+        result = await _run_polyfill_if_enabled(
+            model=MODEL,
+            messages=_simple_messages(),
+            tools=None,
+            system=None,
+            context_management_spec={"edits": [{"type": "compact_20260112"}]},
+            litellm_metadata={},
+            additional_drop_params=None,
+            llm_router=None,
+        )
+    assert result is not None
+    assert result.applied_edits[0]["type"] == "compact_20260112"
 
 
 async def test_run_polyfill_skipped_when_spec_empty():
@@ -2078,10 +2107,144 @@ async def test_run_polyfill_skipped_when_spec_empty():
         system=None,
         context_management_spec=None,
         litellm_metadata={},
-        drop_params=False,
+        additional_drop_params=None,
         llm_router=None,
     )
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Adapter handler entry points: polyfill vs drop_params / additional_drop_params
+# ---------------------------------------------------------------------------
+
+_CLEAR_TOOL_USES_SPEC: Dict[str, Any] = {
+    "edits": [
+        {
+            "type": "clear_tool_uses_20250919",
+            "trigger": {"type": "tool_uses", "value": 1},
+            "keep": {"type": "tool_uses", "value": 0},
+        }
+    ]
+}
+
+_CLEARED_PLACEHOLDER = "[Cleared by context management]"
+
+
+def _tool_use_messages() -> List[Dict[str, Any]]:
+    return [
+        {"role": "user", "content": "check the weather in two cities"},
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "SF"}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "sunny in SF"}],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "id": "toolu_02", "name": "get_weather", "input": {"city": "NY"}}],
+        },
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "toolu_02", "content": "rainy in NY"}],
+        },
+        {"role": "user", "content": "now summarize both"},
+    ]
+
+
+def _openai_chat_response():
+    from litellm.types.utils import ModelResponse
+
+    return ModelResponse(
+        id="chatcmpl-test",
+        model="gpt-4o",
+        choices=[{"finish_reason": "stop", "index": 0, "message": {"role": "assistant", "content": "done"}}],
+        usage={"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+    )
+
+
+async def _call_async_adapter_handler(**handler_kwargs: Any):
+    from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+        LiteLLMMessagesToCompletionTransformationHandler,
+    )
+
+    captured: Dict[str, Any] = {}
+
+    async def _capture_acompletion(**kwargs):
+        captured.update(kwargs)
+        return _openai_chat_response()
+
+    with patch("litellm.acompletion", side_effect=_capture_acompletion):
+        response = await LiteLLMMessagesToCompletionTransformationHandler.async_anthropic_messages_handler(
+            max_tokens=128,
+            messages=_tool_use_messages(),
+            model=MODEL,
+            context_management=_CLEAR_TOOL_USES_SPEC,
+            litellm_router=MagicMock(),
+            **handler_kwargs,
+        )
+    return response, captured
+
+
+def _assert_polyfill_applied(response: Any, captured: Dict[str, Any]) -> None:
+    applied_edits = (response.get("context_management") or {}).get("applied_edits")
+    assert applied_edits, "polyfill must run and report applied_edits"
+    assert applied_edits[0]["type"] == "clear_tool_uses_20250919"
+    forwarded = json.dumps(captured["messages"], default=str)
+    assert _CLEARED_PLACEHOLDER in forwarded
+    assert "sunny in SF" not in forwarded
+    assert "rainy in NY" in forwarded
+
+
+async def test_async_handler_runs_polyfill_when_request_drop_params_true():
+    """Regression (LIT-3768): per-request drop_params=True silently skipped the
+    polyfill, so Claude Code requests (where the proxy defaults drop_params on)
+    lost context editing on non-Anthropic models."""
+    response, captured = await _call_async_adapter_handler(drop_params=True)
+    _assert_polyfill_applied(response, captured)
+
+
+async def test_async_handler_runs_polyfill_when_litellm_drop_params_true(monkeypatch):
+    """Regression (LIT-3768): proxy-wide litellm.drop_params=True silently
+    skipped the polyfill too."""
+    monkeypatch.setattr(litellm, "drop_params", True)
+    response, captured = await _call_async_adapter_handler()
+    _assert_polyfill_applied(response, captured)
+
+
+async def test_async_handler_additional_drop_params_strips_context_management():
+    """additional_drop_params=["context_management"] stays the escape hatch:
+    the polyfill must not run and the request is forwarded untouched."""
+    response, captured = await _call_async_adapter_handler(additional_drop_params=["context_management"])
+    assert response.get("context_management") is None
+    forwarded = json.dumps(captured["messages"], default=str)
+    assert _CLEARED_PLACEHOLDER not in forwarded
+    assert "sunny in SF" in forwarded
+
+
+def test_sync_handler_runs_polyfill_when_request_drop_params_true():
+    """The sync entry point reads its own kwargs; cover its gate separately."""
+    from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
+        LiteLLMMessagesToCompletionTransformationHandler,
+    )
+
+    captured: Dict[str, Any] = {}
+
+    def _capture_completion(**kwargs):
+        captured.update(kwargs)
+        return _openai_chat_response()
+
+    with patch("litellm.completion", side_effect=_capture_completion):
+        response = LiteLLMMessagesToCompletionTransformationHandler.anthropic_messages_handler(
+            max_tokens=128,
+            messages=_tool_use_messages(),
+            model=MODEL,
+            context_management=_CLEAR_TOOL_USES_SPEC,
+            litellm_router=None,
+            drop_params=True,
+        )
+    _assert_polyfill_applied(response, captured)
 
 
 async def test_prepare_context_managed_request_forwards_proxy_litellm_metadata():
@@ -2120,7 +2283,7 @@ async def test_prepare_context_managed_request_forwards_proxy_litellm_metadata()
                 "user_api_key_user_id": "user-xyz",
                 "litellm_call_id": "call-1",
             },
-            drop_params=False,
+            additional_drop_params=None,
             llm_router=_RouterStub(),
         )
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py
@@ -2223,8 +2223,7 @@ async def test_async_handler_additional_drop_params_strips_context_management():
     assert "sunny in SF" in forwarded
 
 
-def test_sync_handler_runs_polyfill_when_request_drop_params_true():
-    """The sync entry point reads its own kwargs; cover its gate separately."""
+def _call_sync_adapter_handler(**handler_kwargs: Any):
     from litellm.llms.anthropic.experimental_pass_through.adapters.handler import (
         LiteLLMMessagesToCompletionTransformationHandler,
     )
@@ -2242,9 +2241,33 @@ def test_sync_handler_runs_polyfill_when_request_drop_params_true():
             model=MODEL,
             context_management=_CLEAR_TOOL_USES_SPEC,
             litellm_router=None,
-            drop_params=True,
+            **handler_kwargs,
         )
+    return response, captured
+
+
+def test_sync_handler_runs_polyfill_when_request_drop_params_true():
+    """The sync entry point reads its own kwargs; cover its gate separately."""
+    response, captured = _call_sync_adapter_handler(drop_params=True)
     _assert_polyfill_applied(response, captured)
+
+
+def test_sync_handler_runs_polyfill_when_litellm_drop_params_true(monkeypatch):
+    """Proxy-wide litellm.drop_params=True must not skip the polyfill on the
+    sync entry point either."""
+    monkeypatch.setattr(litellm, "drop_params", True)
+    response, captured = _call_sync_adapter_handler()
+    _assert_polyfill_applied(response, captured)
+
+
+def test_sync_handler_additional_drop_params_strips_context_management():
+    """The additional_drop_params=["context_management"] escape hatch is honored
+    on the sync entry point too: no polyfill, request forwarded untouched."""
+    response, captured = _call_sync_adapter_handler(additional_drop_params=["context_management"])
+    assert response.get("context_management") is None
+    forwarded = json.dumps(captured["messages"], default=str)
+    assert _CLEARED_PLACEHOLDER not in forwarded
+    assert "sunny in SF" in forwarded
 
 
 async def test_prepare_context_managed_request_forwards_proxy_litellm_metadata():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3768

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy started from this repo with proxy-wide `litellm_settings.drop_params: true`, hitting the real Gemini API, exercising `/v1/messages` with a `clear_tool_uses_20250919` context_management spec. A Gemini model is used because it takes the chat-completions adapter path this PR fixes; OpenAI models route `/v1/messages` through the Responses API bridge instead. The request carries two tool_use/tool_result rounds where the first tool_result is ~17KB of filler, a low `input_tokens` trigger (200) and `keep: 0`, so the editor must clear the bulky first tool_result while preserving the latest one. The before run is the merge base `litellm_internal_staging` (2633e8f8a8), the after run is this PR's fix commit (c135e44d74); same worktree, venv, config and port

`qa_config.yaml`:

```yaml
model_list:
  - model_name: gemini-3.5-flash
    litellm_params:
      model: gemini/gemini-3.5-flash
      api_key: os.environ/GEMINI_API_KEY

litellm_settings:
  drop_params: true

general_settings:
  master_key: sk-qa-lit3768
```

Proxy: `python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 50769 --detailed_debug`

The exact command, identical for both runs:

```bash
FILLER=$(python3 -c "print('lorem ipsum dolor sit amet consectetur adipiscing elit ' * 300)")
curl -sS http://127.0.0.1:50769/v1/messages \
  -H "Authorization: Bearer sk-qa-lit3768" \
  -H "Content-Type: application/json" \
  -d @- <<EOF | jq .
{
  "model": "gemini-3.5-flash",
  "max_tokens": 1024,
  "context_management": {
    "edits": [
      {
        "type": "clear_tool_uses_20250919",
        "trigger": {"type": "input_tokens", "value": 200},
        "keep": {"type": "tool_uses", "value": 0}
      }
    ]
  },
  "tools": [
    {
      "name": "lookup",
      "description": "Look up a fact",
      "input_schema": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]}
    }
  ],
  "messages": [
    {"role": "user", "content": "Use the lookup tool to find facts, then answer my question."},
    {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_01", "name": "lookup", "input": {"query": "background dossier"}}]},
    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_01", "content": "$FILLER"}]},
    {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_02", "name": "lookup", "input": {"query": "capital of France"}}]},
    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "toolu_02", "content": "The capital of France is Paris."}, {"type": "text", "text": "What is the capital of France? Answer in one word."}]}
  ]
}
EOF
```

Before (base `litellm_internal_staging`):

```json
{
  "id": "OC9HarruLI6PjrEPyKSrmAI",
  "type": "message",
  "role": "assistant",
  "model": "gemini-3.5-flash",
  "stop_sequence": null,
  "usage": {
    "input_tokens": 2528,
    "output_tokens": 59
  },
  "content": [
    {
      "type": "text",
      "text": "Paris"
    }
  ],
  "stop_reason": "end_turn"
}
```

No `context_management` block in the response and `usage.input_tokens` is 2528; the proxy log confirms the polyfill never ran and the full filler tool_result was forwarded to Gemini untouched

After (this PR, identical command):

```json
{
  "id": "Vi9HaoSXGbWrsOIPsL-3yQw",
  "type": "message",
  "role": "assistant",
  "model": "gemini-3.5-flash",
  "stop_sequence": null,
  "usage": {
    "input_tokens": 132,
    "output_tokens": 85
  },
  "content": [
    {
      "type": "text",
      "text": "Paris"
    }
  ],
  "stop_reason": "end_turn",
  "context_management": {
    "applied_edits": [
      {
        "type": "clear_tool_uses_20250919",
        "cleared_tool_uses": 1,
        "cleared_input_tokens": 2396
      }
    ]
  }
}
```

With `drop_params: true` still set, the response now carries `context_management.applied_edits` (1 tool use cleared, 2396 input tokens cleared) and `usage.input_tokens` drops from 2528 to 132; the proxy log shows the polyfill trigger check (`current_tokens: 2510 > threshold: 200`) and the bulky tool_result replaced with `[Cleared by context management]` before the request was forwarded to Gemini

## Type

🐛 Bug Fix

## Changes

Anthropic-style `context_management` on `/v1/messages` is supported across all providers: native pass-through for Anthropic and Bedrock, and an in-gateway polyfill for non-Anthropic providers (#28868). But when `drop_params: true` was in effect (proxy-wide `litellm_settings.drop_params`, `litellm.drop_params`, or per-request `drop_params`), the adapter path silently stripped `context_management` and skipped the polyfill. This hit Claude Code especially hard because the proxy defaults `drop_params` on for Claude Code user agents, so context editing/compaction never ran on non-Anthropic models

`drop_params` exists to drop genuinely unsupported params; `context_management` is a LiteLLM-supported param (polyfilled where not native), so it should keep working. The explicit escape hatch to strip it remains `additional_drop_params: ["context_management"]`, consistent with the native pass-through path (#31645)

In `litellm/llms/anthropic/experimental_pass_through/adapters/handler.py`, the polyfill gates in `_normalize_spec_edits` and `_run_polyfill_if_enabled` no longer check effective `drop_params`; they now skip only when `context_management` is listed in `additional_drop_params`. Both handler entry points (async and sync) read `additional_drop_params` from kwargs instead of `drop_params` and thread it through `_prepare_context_managed_request`, `_polyfill_will_run` and `_spec_has_non_compact_edits`. As a side effect this also makes the `additional_drop_params` escape hatch actually work on the adapter path; previously it was only honored on the native pass-through path

The native Anthropic path is unchanged and already correct: `context_management` is in the supported params lists (`litellm/llms/anthropic/chat/transformation.py`, `litellm/llms/anthropic/experimental_pass_through/messages/transformation.py`), only `speed` is `drop_params`-gated there, and `additional_drop_params` strips top-level keys in `llm_http_handler.py`

Regression tests in `tests/test_litellm/llms/anthropic/experimental_pass_through/context_management/test_compact.py` drive the adapter handler end to end with a mocked `litellm.acompletion` / `litellm.completion` and assert the `clear_tool_uses_20250919` edit is actually applied to the forwarded messages: polyfill runs with per-request `drop_params=True` and with proxy-wide `litellm.drop_params=True`, and `additional_drop_params: ["context_management"]` still strips it, each covered on both the async and sync entry points. All eight new tests fail on the pre-fix code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request preprocessing on the `/v1/messages` adapter path for all traffic with `drop_params` enabled, which is common on the proxy; behavior is intentional but affects token usage and forwarded payloads.
> 
> **Overview**
> Fixes **LIT-3768**: on the non-Anthropic `/v1/messages` adapter path, **`drop_params` no longer disables** the `context_management` polyfill. Per-request `drop_params=True`, proxy-wide `litellm.drop_params`, and Claude Code’s default `drop_params` had been skipping edits such as `clear_tool_uses_20250919` and `compact_20260112` even though `context_management` is a supported LiteLLM param.
> 
> In `handler.py`, polyfill gating now uses **`additional_drop_params`** instead of **`drop_params`**. A new **`_context_management_explicitly_dropped`** helper skips the polyfill only when `"context_management"` is in that list. **`_normalize_spec_edits`**, **`_run_polyfill_if_enabled`**, **`_polyfill_will_run`**, and **`_spec_has_non_compact_edits`** follow the same rule. Async and sync adapter entry points read **`additional_drop_params`** from kwargs and pass it through **`_prepare_context_managed_request`**.
> 
> **`additional_drop_params: ["context_management"]`** remains the explicit opt-out (including on the adapter path, where it was not honored before).
> 
> Tests in **`test_compact.py`** replace the old `drop_params=True` skip test with coverage that the polyfill runs under global/request `drop_params`, still skips when `context_management` is in `additional_drop_params`, and end-to-end handler tests assert `clear_tool_uses_20250919` mutates forwarded messages on async and sync paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fa6be96dfa83701a177883cd3811a7c5a923485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->