### PR TITLE
fix(proxy): let STORE_MODEL_IN_DB=True env override stale DB false

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5525,6 +5525,8 @@ class ProxyConfig:
                 store_model_in_db = value.lower() == "true"
             else:
                 store_model_in_db = bool(value)
+            if get_secret_bool("STORE_MODEL_IN_DB", False) is True:
+                store_model_in_db = True
             general_settings["store_model_in_db"] = store_model_in_db
 
         ## MAXIMUM SPEND LOGS RETENTION PERIOD ##

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1527,6 +1527,47 @@ async def test_ProxyConfig__update_general_settings_none_input_noop():
         await pc._update_general_settings(db_general_settings=12345)  # type: ignore[arg-type]
 
 
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_general_settings_env_true_overrides_db_false(
+    monkeypatch,
+):
+    """STORE_MODEL_IN_DB=True env var must win over a stale DB `false`.
+
+    Regression test for the case where a periodic config refresh pulled
+    ``store_model_in_db: false`` from the DB's general_settings and silently
+    disabled the feature even though the operator set STORE_MODEL_IN_DB=True.
+    """
+    monkeypatch.setenv("STORE_MODEL_IN_DB", "True")
+    monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+    pc = ProxyConfig()
+    await pc._update_general_settings({"store_model_in_db": False})
+
+    from litellm.proxy import proxy_server as ps
+
+    assert ps.store_model_in_db is True
+    assert ps.general_settings.get("store_model_in_db") is True
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_general_settings_db_false_applied_without_env(
+    monkeypatch,
+):
+    """Without the env override, a DB `false` still takes effect as before."""
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    monkeypatch.setattr("litellm.proxy.proxy_server.general_settings", {})
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", True)
+
+    pc = ProxyConfig()
+    await pc._update_general_settings({"store_model_in_db": False})
+
+    from litellm.proxy import proxy_server as ps
+
+    assert ps.store_model_in_db is False
+    assert ps.general_settings.get("store_model_in_db") is False
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig._update_config_fields
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

Fixes #31968

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced end to end against a live proxy backed by Postgres, with `STORE_MODEL_IN_DB=True` exported for the whole run. The model served is a local Ollama model, so the final completion is a real provider call with no mocks.

### 1. Setup

```bash
docker run -d --name litellm-pg -e POSTGRES_PASSWORD=pg -e POSTGRES_DB=litellm -p 5432:5432 postgres:16

export DATABASE_URL="postgresql://postgres:pg@localhost:5432/litellm"
export STORE_MODEL_IN_DB=True
export LITELLM_MASTER_KEY="sk-1234"

python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug --use_v2_migration_resolver 2>&1 | tee litellm.log
```

### 2. Baseline: with nothing stale in the DB, adding a model works

```bash
curl -sS -X POST http://localhost:4000/model/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name":"mistral-probe","litellm_params":{"model":"ollama/mistral","api_base":"http://localhost:11434"}}'
```

```
HTTP 200
{"model_id":"5315bac2-b99e-4ac2-bb28-f9e23fe0c3c4","model_name":"mistral-probe-initial", ...}
```

### 3. Seed the exact state from the issue

A stale `store_model_in_db: false` in the `LiteLLM_Config` row, which is what a prior UI toggle leaves behind.

```bash
docker exec -i litellm-pg psql -U postgres -d litellm -c \
  "INSERT INTO \"LiteLLM_Config\" (param_name, param_value) VALUES ('general_settings', '{\"store_model_in_db\": false}') ON CONFLICT (param_name) DO UPDATE SET param_value = EXCLUDED.param_value;"
```

The 30s `add_deployment` job calls `_update_general_settings` and pulls that row. Waited ~40s for one refresh to land, then hit `/model/new` again.

### 4. Before the fix (on `litellm_internal_staging`)

The refresh overwrote the env var with the stale DB `false`, so the request failed even though `STORE_MODEL_IN_DB=True` was set the whole time.

```
HTTP 500
{"error":{"message":"{'error': \"Set `'STORE_MODEL_IN_DB='True'` in your env to enable this feature.\"}","type":"auth_error","param":"None","code":"500"}}
```

### 5. After the fix

Same stale DB `false` still present and pulled by the refresh. The request now succeeds because the explicit env var wins.

```
HTTP 200
{"model_id":"d4ab93bb-b86f-4b11-a569-4d9423583fcc","model_name":"mistral-probe-after", ...}
```

### 6. The registered model actually serves traffic

```bash
curl -sS -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"mistral-probe-after","messages":[{"role":"user","content":"reply with the single word: works"}]}'
```

```
HTTP 200
{"id":"chatcmpl-be7adbb0-cdac-4958-b84c-33dbb0fccaf6","model":"mistral-probe-after","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":" Okay!","role":"assistant"}}],"usage":{"completion_tokens":3,"prompt_tokens":17,"total_tokens":20}}
```

## Type

🐛 Bug Fix

## Changes

`ProxyConfig._update_general_settings` runs on every periodic config refresh (the 30s `add_deployment` job) and applied whatever `store_model_in_db` was persisted in the DB's `general_settings`, including a stale `false`. That value overwrote the operator's `STORE_MODEL_IN_DB=True` env var at runtime, so `/model/new` began failing a minute or two after startup even though the env var was set for the whole life of the process.

The fix adds a single guard in `_update_general_settings`: after reading `store_model_in_db` from the DB, if `get_secret_bool("STORE_MODEL_IN_DB")` is `True` it forces the value back to `True`, so an explicit env var wins over a DB persisted `false`. This mirrors the override-to-True logic already applied at startup in the "ADD NEW MODELS" block of `proxy_server.py`, so the runtime refresh path and the startup path now agree. When the env var is unset a DB `false` still takes effect exactly as before, so the DB stays the source of truth for the UI toggle.

Two regression tests were added to `tests/test_litellm/proxy/proxy_server/test_proxy_config.py`. One pins that `STORE_MODEL_IN_DB=True` survives a DB `false` coming through `_update_general_settings`; the other pins that with the env var unset a DB `false` is still honored.























<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to proxy config merge logic with regression tests; no auth or data-path changes beyond honoring an existing env flag during refresh.
> 
> **Overview**
> Fixes a bug where **periodic DB config refresh** could turn off model-in-DB storage even when **`STORE_MODEL_IN_DB=True`** was set in the environment.
> 
> `ProxyConfig._update_general_settings` (used by the ~30s deployment refresh) now **re-applies the env override** after reading `store_model_in_db` from persisted `general_settings`, matching startup behavior in the “ADD NEW MODELS” path. A stale **`store_model_in_db: false`** in the DB no longer wins over an explicit env **`True`**.
> 
> When **`STORE_MODEL_IN_DB` is unset**, a DB **`false`** still applies unchanged. Regression tests cover both the override and the prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 629d593d9dfc61baff50d8c2420cd6a11dd94612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->