### PR TITLE
Litellm prometheus api provider labels

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2004,6 +2004,25 @@ class PrometheusLogger(CustomLogger):
 
         return False
 
+    @staticmethod
+    def _extract_api_provider_from_request_data(request_data: dict) -> Optional[str]:
+        """
+        Best-effort provider for the client-side failure path.
+
+        A request can fail before a deployment is resolved, so the provider is
+        not always known. Prefer the resolved ``custom_llm_provider`` on
+        ``litellm_params``, then any provider recovered onto a partial
+        ``standard_logging_object`` (e.g. a stream that broke mid-flight);
+        return ``None`` when it cannot be determined so the label emits empty
+        rather than a guess.
+        """
+        litellm_params = request_data.get("litellm_params") or {}
+        provider = litellm_params.get("custom_llm_provider")
+        if provider:
+            return provider
+        standard_logging_object = request_data.get("standard_logging_object") or {}
+        return standard_logging_object.get("custom_llm_provider") or None
+
     async def async_post_call_failure_hook(
         self,
         request_data: dict,
@@ -2039,6 +2058,7 @@ class PrometheusLogger(CustomLogger):
             _metadata = request_data.get("metadata", {}) or {}
             model_id = _metadata.get("model_info", {}).get("id") or request_data.get("model_info", {}).get("id")
             rate_limit_category, rate_limit_type = self._extract_rate_limit_labels(original_exception)
+            api_provider = self._extract_api_provider_from_request_data(request_data)
             enum_values = UserAPIKeyLabelValues(
                 end_user=user_api_key_dict.end_user_id,
                 user=user_api_key_dict.user_id,
@@ -2060,6 +2080,7 @@ class PrometheusLogger(CustomLogger):
                 client_ip=_metadata.get("requester_ip_address"),
                 user_agent=_metadata.get("user_agent"),
                 model_id=model_id,
+                api_provider=api_provider,
                 stream=(str(request_data.get("stream")) if litellm.prometheus_emit_stream_label else None),
             )
             _label_ctx = PrometheusLabelFactoryContext(enum_values)

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -2012,16 +2012,27 @@ class PrometheusLogger(CustomLogger):
         A request can fail before a deployment is resolved, so the provider is
         not always known. Prefer the resolved ``custom_llm_provider`` on
         ``litellm_params``, then any provider recovered onto a partial
-        ``standard_logging_object`` (e.g. a stream that broke mid-flight);
-        return ``None`` when it cannot be determined so the label emits empty
-        rather than a guess.
+        ``standard_logging_object`` (e.g. a stream that broke mid-flight), and
+        finally infer it from the requested model name (e.g. ``gpt-4o-mini`` ->
+        ``openai``) since the proxy's failure ``request_data`` usually carries
+        only the client-supplied model. Return ``None`` when it cannot be
+        determined so the label emits empty rather than a guess.
         """
         litellm_params = request_data.get("litellm_params") or {}
         provider = litellm_params.get("custom_llm_provider")
         if provider:
             return provider
         standard_logging_object = request_data.get("standard_logging_object") or {}
-        return standard_logging_object.get("custom_llm_provider") or None
+        provider = standard_logging_object.get("custom_llm_provider")
+        if provider:
+            return provider
+        model = litellm_params.get("model") or request_data.get("model")
+        if not model:
+            return None
+        try:
+            return litellm.get_llm_provider(model=model)[1] or None
+        except Exception:
+            return None
 
     async def async_post_call_failure_hook(
         self,

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -283,6 +283,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.END_USER.value,
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_llm_api_time_to_first_token_metric = [
@@ -295,6 +296,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.END_USER.value,
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_request_total_latency_metric = [
@@ -307,6 +309,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_request_queue_time_seconds = [
@@ -319,6 +322,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     # Guardrail metrics - these use custom labels (guardrail_name, status, error_type, hook_type)
@@ -341,6 +345,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_proxy_failed_requests_metric = [
@@ -362,6 +367,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_deployment_latency_per_output_token = [
@@ -458,6 +464,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_EMAIL.value,
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_total_tokens_metric = [
@@ -471,6 +478,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_EMAIL.value,
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_output_tokens_metric = [
@@ -484,6 +492,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_EMAIL.value,
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     # Token-type detail metrics — reuse the same label set as
@@ -682,6 +691,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.END_USER.value,
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.API_PROVIDER.value,
     ]
 
     litellm_cache_hits_metric = _cache_metric_labels

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -173,8 +173,9 @@ def test_extract_api_provider_from_request_data_failure_path():
     """
     On the client-side failure path the provider is not always known. Prefer the
     resolved custom_llm_provider on litellm_params, fall back to a partial
-    standard_logging_object (e.g. a stream that broke mid-flight), and return
-    None when neither is present so the label emits empty rather than a guess.
+    standard_logging_object (e.g. a stream that broke mid-flight), then infer it
+    from the requested model name, and return None only when nothing maps so the
+    label emits empty rather than a guess.
     """
     from litellm.integrations.prometheus import PrometheusLogger
 
@@ -195,8 +196,14 @@ def test_extract_api_provider_from_request_data_failure_path():
         )
         == "openai"
     )
+    # Fallback: infer provider from the requested model name when the proxy's
+    # failure request_data carries only the client-supplied model. This is the
+    # common client-side failure case (e.g. an invalid param rejected with 400).
+    assert extract({"model": "gpt-4o-mini"}) == "openai"
+    assert extract({"litellm_params": {"model": "anthropic/claude-haiku-4-5"}}) == "anthropic"
     assert extract({}) is None
-    assert extract({"litellm_params": {"custom_llm_provider": ""}}) is None
+    # Unmappable model name -> None, not a guess
+    assert extract({"model": "some-unknown-model-xyz"}) is None
 
 
 def test_user_email_label_exists():

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -85,6 +85,120 @@ def test_api_provider_in_spend_and_requests_metrics():
         print(f"✅ {metric_name} contains api_provider label")
 
 
+def test_api_provider_in_token_latency_and_request_metrics():
+    """
+    Regression test for LIT-4178.
+
+    These metrics are all emitted from the same call site (async_log_success_event
+    / async_post_call_failure_hook) as litellm_spend_metric and
+    litellm_requests_metric, which already carry api_provider. They were the odd
+    ones out with no way to break down tokens, latency, request counts or cache
+    hits by upstream provider, even though the provider is available on the
+    payload as custom_llm_provider.
+    """
+    api_provider_label = UserAPIKeyLabelNames.API_PROVIDER.value
+
+    metrics_with_api_provider = [
+        "litellm_llm_api_latency_metric",
+        "litellm_llm_api_time_to_first_token_metric",
+        "litellm_request_total_latency_metric",
+        "litellm_request_queue_time_seconds",
+        "litellm_proxy_total_requests_metric",
+        "litellm_proxy_failed_requests_metric",
+        "litellm_input_tokens_metric",
+        "litellm_total_tokens_metric",
+        "litellm_output_tokens_metric",
+        "litellm_cache_hits_metric",
+        "litellm_cache_misses_metric",
+    ]
+
+    for metric_name in metrics_with_api_provider:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert (
+            api_provider_label in labels
+        ), f"Metric {metric_name} should contain api_provider label"
+
+
+def test_api_provider_value_flows_through_label_factory():
+    """
+    The label being in the allow-list is necessary but not sufficient: the
+    factory must also carry the value from the enum through to the emitted
+    label. This would fail if the label were dropped from the metric's list or
+    if the value plumbing regressed, which the allow-list assertion above cannot
+    catch on its own.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.integrations.prometheus import (
+        PrometheusLogger,
+        UserAPIKeyLabelValues,
+        prometheus_label_factory,
+    )
+
+    prometheus_logger = MagicMock()
+    prometheus_logger._cached_metric_labels = {}
+    prometheus_logger.label_filters = {}
+    prometheus_logger.get_labels_for_metric = (
+        PrometheusLogger.get_labels_for_metric.__get__(prometheus_logger)
+    )
+
+    enum_values = UserAPIKeyLabelValues(
+        api_provider="anthropic",
+        litellm_model_name="claude-sonnet-4",
+        requested_model="claude",
+        status_code="200",
+    )
+
+    for metric_name in [
+        "litellm_input_tokens_metric",
+        "litellm_total_tokens_metric",
+        "litellm_output_tokens_metric",
+        "litellm_llm_api_latency_metric",
+        "litellm_request_total_latency_metric",
+        "litellm_proxy_total_requests_metric",
+        "litellm_cache_hits_metric",
+    ]:
+        labels = prometheus_label_factory(
+            supported_enum_labels=prometheus_logger.get_labels_for_metric(
+                metric_name=metric_name
+            ),
+            enum_values=enum_values,
+        )
+        assert (
+            labels.get("api_provider") == "anthropic"
+        ), f"{metric_name} should emit api_provider=anthropic, got {labels.get('api_provider')!r}"
+
+
+def test_extract_api_provider_from_request_data_failure_path():
+    """
+    On the client-side failure path the provider is not always known. Prefer the
+    resolved custom_llm_provider on litellm_params, fall back to a partial
+    standard_logging_object (e.g. a stream that broke mid-flight), and return
+    None when neither is present so the label emits empty rather than a guess.
+    """
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    extract = PrometheusLogger._extract_api_provider_from_request_data
+
+    assert extract({"litellm_params": {"custom_llm_provider": "bedrock"}}) == "bedrock"
+    assert (
+        extract({"standard_logging_object": {"custom_llm_provider": "vertex_ai"}})
+        == "vertex_ai"
+    )
+    # litellm_params wins over standard_logging_object when both are present
+    assert (
+        extract(
+            {
+                "litellm_params": {"custom_llm_provider": "openai"},
+                "standard_logging_object": {"custom_llm_provider": "azure"},
+            }
+        )
+        == "openai"
+    )
+    assert extract({}) is None
+    assert extract({"litellm_params": {"custom_llm_provider": ""}}) is None
+
+
 def test_user_email_label_exists():
     """Test that the USER_EMAIL label is properly defined"""
     assert UserAPIKeyLabelNames.USER_EMAIL.value == "user_email"


### PR DESCRIPTION
## Relevant issues

[LIT-4178](https://linear.app/litellm-ai/issue/LIT-4178/add-api-provider-tag-to-missing-prometheus-metrics)

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before
<img width="897" height="515" alt="Screenshot 2026-07-03 at 12 41 06 PM" src="https://github.com/user-attachments/assets/6734597c-64c0-4f4c-9959-d8004246d56f" />
<img width="907" height="339" alt="Screenshot 2026-07-03 at 12 40 57 PM" src="https://github.com/user-attachments/assets/dfd471e2-7e2e-4266-a2fe-9a6c334f7439" />

After
<img width="877" height="511" alt="Screenshot 2026-07-03 at 12 33 52 PM" src="https://github.com/user-attachments/assets/6dd3f907-b252-41cb-9efb-8b14bf4a92dc" />
<img width="835" height="342" alt="Screenshot 2026-07-03 at 12 34 27 PM" src="https://github.com/user-attachments/assets/db95c221-957f-488f-9f91-2c5afd63f19d" />


<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

LiteLLM exposes Prometheus metrics. Some metrics already had a tag telling you which upstream provider handled the request (OpenAI, Anthropic, Bedrock, etc.), but a bunch of the important ones didn't. That meant we couldn't split token usage, latency, request counts, or cache hits by provider on our dashboards. 

What I changed

Added the api_provider tag to the metrics that were missing it — the token metrics (input/output/total), the latency metrics (API latency, time-to-first-token, total request latency, queue time), the request counters (total and failed), and the cache hit/miss metrics. This is the core of the request.
The value was already available for successful requests, so once the tag was added, those metrics just started showing the real provider (e.g. api_provider="openai"). No extra wiring needed there.
Fixed a gap on the failure path. When a request fails, the code that records the "failed requests" metric didn't have the provider handy, so the tag showed up empty ("None") even when the provider was obvious. I made it figure out the provider from the model name (for example, gpt-4o-mini clearly means OpenAI) as a fallback. If the model name genuinely can't be matched to a provider, it stays empty instead of guessing.
Added tests that check the tag is present on every one of those metrics, that the value actually flows through to the output, and that the failure-path provider lookup works and falls back safely.