### PR TITLE
fix(responses): make response-id encoding idempotent to prevent MCP g…

### DIFF
--- a/litellm/responses/utils.py
+++ b/litellm/responses/utils.py
@@ -204,6 +204,9 @@ class ResponsesAPIRequestUtils:
         if response_id is None:
             return responses_api_response
 
+        if ResponsesAPIRequestUtils._is_litellm_encoded_response_id(response_id):
+            return responses_api_response
+
         updated_id = ResponsesAPIRequestUtils._build_responses_api_response_id(
             model_id=model_id,
             custom_llm_provider=custom_llm_provider,
@@ -469,6 +472,14 @@ class ResponsesAPIRequestUtils:
                 model_id=None,
                 response_id=response_id,
             )
+
+    @staticmethod
+    def _is_litellm_encoded_response_id(response_id: str) -> bool:
+        decoded_response_id = ResponsesAPIRequestUtils._decode_responses_api_response_id(response_id)
+        return (
+            decoded_response_id.get("model_id") is not None
+            or decoded_response_id.get("custom_llm_provider") is not None
+        )
 
     @staticmethod
     def get_model_id_from_response_id(response_id: Optional[str]) -> Optional[str]:

--- a/tests/test_litellm/responses/test_responses_utils.py
+++ b/tests/test_litellm/responses/test_responses_utils.py
@@ -142,6 +142,26 @@ class TestResponsesAPIRequestUtils:
         assert decoded.get("model_id") == "gpt-4o"
         assert decoded.get("custom_llm_provider") == "openai"
 
+
+    def test_update_responses_api_response_id_with_model_id_is_idempotent_for_litellm_ids(self):
+        raw = "resp_" + "a" * 48
+        litellm_metadata = {"model_info": {"id": "model-123"}}
+
+        once = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+            {"id": raw},
+            custom_llm_provider="openai",
+            litellm_metadata=litellm_metadata,
+        )
+        twice = ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id(
+            {"id": once["id"]},
+            custom_llm_provider="openai",
+            litellm_metadata=litellm_metadata,
+        )
+
+        assert twice == once
+        assert ResponsesAPIRequestUtils.decode_previous_response_id_to_original_previous_response_id(twice["id"]) == raw
+        assert ResponsesAPIRequestUtils._decode_responses_api_response_id(once["id"]).get("response_id") == raw
+
     def test_build_decode_container_id_omits_none_model_id(self):
         """model_id=None must not round-trip as the truthy string 'None'."""
         encoded = ResponsesAPIRequestUtils._build_container_id(


### PR DESCRIPTION
…ateway double-encoding previous_response_id

## Relevant issues

[Fixes #32031
](https://github.com/BerriAI/litellm/issues/32031)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: registered a hosted MCP server in `config.yaml` and started the proxy locally.

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

mcp_servers:
  deepwiki:
    url: "https://mcp.deepwiki.com/mcp"
```

```
python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug
```

Turn 1 (no `previous_response_id`) and turn 2 (`previous_response_id` from turn 1), both dispatched through the MCP gateway (`server_url: "litellm_proxy/mcp/deepwiki"`):

```bash
curl -s http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o-mini",
    "input": "Use the ask_question tool to ask the deepwiki MCP server: what is BerriAI/litellm used for? Answer in one sentence.",
    "tools": [{"type": "mcp", "server_label": "deepwiki", "server_url": "litellm_proxy/mcp/deepwiki", "require_approval": "never"}]
  }'
```

```bash
curl -s http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o-mini",
    "previous_response_id": "<id from turn 1>",
    "input": "Now summarize your previous answer in exactly 5 words.",
    "tools": [{"type": "mcp", "server_label": "deepwiki", "server_url": "litellm_proxy/mcp/deepwiki", "require_approval": "never"}]
  }'
```

### Before this fix

Turn 1 returned a doubly-encoded id, 809 characters long. Turn 2 with that id as `previous_response_id` returned `400`:

```json
{"error":{"message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Invalid 'previous_response_id': string too long. Expected a string with maximum length 64, but got a string with length 241 instead.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"previous_response_id\",\n    \"code\": \"string_above_max_length\"\n  }\n}. Received Model Group=gpt-4o-mini\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

### After this fix

Turn 1 returned a single-encoded id, 477 characters long. Turn 2 with that id as `previous_response_id` returned `200` with a real completion:

```json
{
  "id": "resp_hqkoeXu0Y1_6NueqHZYxZZ_m-swauWcJaFi...",
  "status": "completed",
  "output": [
    {
      "type": "message",
      "content": [{"text": "Unified interface for multiple LLMs."}]
    }
  ]
}
```




## Type

🐛 Bug Fix

## Changes

`aresponses` is decorated with `@client`, which encodes the response id via `ResponsesAPIRequestUtils._update_responses_api_response_id_with_model_id` on the way out. When a request carries a hosted MCP tool, `aresponses` dispatches through `_responses_try_dispatch_mcp_gateway` -> `aresponses_api_with_mcp`, which internally calls `aresponses` again. The inner call encodes the id once and the outer call encodes it a second time, so the client receives a doubly-wrapped `resp_...` id. On the next turn only one layer is decoded, so a still-encoded ~205-char `previous_response_id` reaches the provider and is rejected with `Invalid 'previous_response_id': string too long. Expected a string with maximum length 64`. On the streaming MCP path that error is swallowed and the client gets a silent empty completion (`mcp_list_tools.completed` then `[DONE]` with no output).

This makes the encode step idempotent. `_update_responses_api_response_id_with_model_id` now returns the response unchanged when the id is already a LiteLLM-encoded id, so nested `aresponses` calls no longer add a second layer and the existing single-layer decode on the next turn recovers the raw provider id.

Pseudation of the change in `litellm/responses/utils.py`:

```python
def _update_responses_api_response_id_with_model_id(responses_api_response, custom_llm_provider, litellm_metadata=None):
    ...
    if response_id is None:
        return responses_api_response
    if _is_litellm_encoded_response_id(response_id):   # new: skip re-wrapping an already-encoded id
        return responses_api_response
    updated_id = _build_responses_api_response_id(...)
    ...
```

`_is_litellm_encoded_response_id` decodes the id and treats it as already-encoded when `model_id` or `custom_llm_provider` come back non-None (a raw provider id decodes to both being None).