### PR TITLE
fix: respect config general_settings.store_model_in_db in background poller

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1919,6 +1919,9 @@ disable_spend_logs = False
 jwt_handler = JWTHandler()
 prompt_injection_detection_obj: Optional[_OPTIONAL_PromptInjectionDetection] = None
 store_model_in_db: bool = False
+# Set when config.yaml's general_settings.store_model_in_db is True at startup, so a stale
+# `store_model_in_db=False` row in the DB can't silently disable the feature (litellm#31968).
+_store_model_in_db_enabled_via_config: bool = False
 open_telemetry_logger: Optional[OpenTelemetry] = None
 ### INITIALIZE GLOBAL LOGGING OBJECT ###
 proxy_logging_obj: ProxyLogging = ProxyLogging(user_api_key_cache=user_api_key_cache, premium_user=premium_user)
@@ -3995,6 +3998,7 @@ class ProxyConfig:
             prompt_injection_detection_obj, \
             redis_usage_cache, \
             store_model_in_db, \
+            _store_model_in_db_enabled_via_config, \
             premium_user, \
             open_telemetry_logger, \
             health_check_details, \
@@ -4400,6 +4404,7 @@ class ProxyConfig:
             if store_model_in_db is None:
                 store_model_in_db = False
             general_settings["store_model_in_db"] = store_model_in_db
+            _store_model_in_db_enabled_via_config = store_model_in_db is True
             ### CUSTOM API KEY AUTH ###
             ## pass filepath
             custom_auth = general_settings.get("custom_auth", None)
@@ -5515,7 +5520,15 @@ class ProxyConfig:
                 general_settings["store_prompts_in_spend_logs"] = bool(value)
 
         ## STORE MODEL IN DB ##
-        if "store_model_in_db" in _general_settings:
+        # A STORE_MODEL_IN_DB env var or config.yaml general_settings.store_model_in_db=True
+        # applied at startup is the operator's deliberate choice and must not be silently
+        # flipped back to False by a stale DB row on the next polling cycle (litellm#31968).
+        env_store_model_in_db = get_secret_bool("STORE_MODEL_IN_DB", None)
+        if (
+            "store_model_in_db" in _general_settings
+            and env_store_model_in_db is None
+            and not _store_model_in_db_enabled_via_config
+        ):
             value = _general_settings["store_model_in_db"]
             if value is None:
                 pass  # Don't change store_model_in_db to None; keep current value

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6220,6 +6220,68 @@ async def test_update_general_settings_store_model_in_db_none_keeps_current():
 
 
 @pytest.mark.asyncio
+async def test_update_general_settings_store_model_in_db_env_var_overrides_stale_db_false(
+    monkeypatch,
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/31968
+
+    When STORE_MODEL_IN_DB is explicitly set via env var, a stale
+    store_model_in_db=False value persisted in the DB's general_settings
+    must not silently disable the feature the next time the background
+    poller (add_deployment -> _update_general_settings) runs.
+    """
+    monkeypatch.setenv("STORE_MODEL_IN_DB", "True")
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with (
+        patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+    ):
+        await proxy_config._update_general_settings(
+            db_general_settings={"store_model_in_db": False}
+        )
+
+        import litellm.proxy.proxy_server as ps
+
+        assert ps.store_model_in_db is True
+
+
+@pytest.mark.asyncio
+async def test_update_general_settings_store_model_in_db_yaml_config_overrides_stale_db_false(
+    monkeypatch,
+):
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/31968
+
+    When store_model_in_db=True comes from config.yaml's general_settings (no
+    STORE_MODEL_IN_DB env var set), a stale store_model_in_db=False value
+    persisted in the DB's general_settings must not silently disable the
+    feature the next time the background poller
+    (add_deployment -> _update_general_settings) runs.
+    """
+    monkeypatch.delenv("STORE_MODEL_IN_DB", raising=False)
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with (
+        patch("litellm.proxy.proxy_server.store_model_in_db", True),
+        patch("litellm.proxy.proxy_server.general_settings", {"store_model_in_db": True}),
+        patch("litellm.proxy.proxy_server._store_model_in_db_enabled_via_config", True),
+    ):
+        await proxy_config._update_general_settings(
+            db_general_settings={"store_model_in_db": False}
+        )
+
+        import litellm.proxy.proxy_server as ps
+
+        assert ps.store_model_in_db is True
+
+
+@pytest.mark.asyncio
 async def test_store_model_in_db_db_override_when_config_false():
     """
     Verify the early DB check in initialize_scheduled_background_jobs


### PR DESCRIPTION
Fixes #31968

## Summary
The 30s background poller (add_deployment -> _update_general_settings) already protected an explicit STORE_MODEL_IN_DB env var from being flipped back to False by a stale DB row, but not the equivalent config.yaml general_settings.store_model_in_db=true value, so a stale DB row could still silently re-disable model storage and break /model/new. Added a _store_model_in_db_enabled_via_config flag (set in load_config from the resolved YAML value) and used it alongside the env-var check to skip the stale DB override in either case.

## Changes
- `litellm/proxy/proxy_server.py`
- `tests/test_litellm/proxy/test_proxy_server.py`

## How this was tested
Ran `make test-unit` locally.
