### PR TITLE
fix(proxy): add api_base parameter to count tokens request for Anthropic

### DIFF
--- a/litellm/llms/anthropic/count_tokens/handler.py
+++ b/litellm/llms/anthropic/count_tokens/handler.py
@@ -67,7 +67,7 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
             verbose_logger.debug(f"Transformed request: {request_body}")
 
             # Get endpoint URL
-            endpoint_url = api_base or self.get_anthropic_count_tokens_endpoint()
+            endpoint_url = f"{api_base}/v1/messages/count_tokens" if api_base else self.get_anthropic_count_tokens_endpoint()
 
             verbose_logger.debug(f"Making request to: {endpoint_url}")
 

--- a/litellm/llms/anthropic/count_tokens/handler.py
+++ b/litellm/llms/anthropic/count_tokens/handler.py
@@ -67,7 +67,9 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
             verbose_logger.debug(f"Transformed request: {request_body}")
 
             # Get endpoint URL
-            endpoint_url = f"{api_base}/v1/messages/count_tokens" if api_base else self.get_anthropic_count_tokens_endpoint()
+            endpoint_url = (
+                f"{api_base}/v1/messages/count_tokens" if api_base else self.get_anthropic_count_tokens_endpoint()
+            )
 
             verbose_logger.debug(f"Making request to: {endpoint_url}")
 

--- a/litellm/llms/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/anthropic/count_tokens/token_counter.py
@@ -68,6 +68,7 @@ class AnthropicTokenCounter(BaseTokenCounter):
                 model=model_to_use,
                 messages=messages,
                 api_key=api_key,
+                api_base=litellm_params.get("api_base", None)
                 tools=tools,
                 system=system,
             )

--- a/litellm/llms/anthropic/count_tokens/token_counter.py
+++ b/litellm/llms/anthropic/count_tokens/token_counter.py
@@ -68,7 +68,7 @@ class AnthropicTokenCounter(BaseTokenCounter):
                 model=model_to_use,
                 messages=messages,
                 api_key=api_key,
-                api_base=litellm_params.get("api_base", None)
+                api_base=litellm_params.get("api_base", None),
                 tools=tools,
                 system=system,
             )


### PR DESCRIPTION
## Relevant issues

NA

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Anthropic handle_count_tokens_request allow the use of api_base parameter
<img width="750" height="408" alt="image" src="https://github.com/user-attachments/assets/9956f28e-6eb2-4d6e-b863-c8dd1db0c1c9" />
However litellm_params's api_base is not passed in if it is defined.
<img width="719" height="563" alt="image" src="https://github.com/user-attachments/assets/afe2c2e6-609e-4098-819c-28184da32d3e" />


## Type

🐛 Bug Fix

## Changes

Allow the use of custom anthropic base endpoint. Since the parameter is there but forgot to pass it in.