### PR TITLE
fix(fireworks): apply cache-read price to cached prompt tokens

### DIFF
--- a/litellm/llms/fireworks_ai/cost_calculator.py
+++ b/litellm/llms/fireworks_ai/cost_calculator.py
@@ -75,8 +75,20 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
         model_info = get_model_info(model=base_model, custom_llm_provider="fireworks_ai")
 
     ## CALCULATE INPUT COST
-
-    prompt_cost: float = usage["prompt_tokens"] * model_info["input_cost_per_token"]
+    # Fireworks returns cached prompt tokens in prompt_tokens_details.cached_tokens.
+    # Bill those at the cache-read rate when the model defines one, matching the
+    # generic cost path; otherwise fall back to charging every token at full price.
+    prompt_tokens_details = usage.get("prompt_tokens_details") or None
+    cached_tokens = getattr(prompt_tokens_details, "cached_tokens", 0) or 0
+    cache_read_cost = model_info.get("cache_read_input_token_cost")
+    if cache_read_cost is not None and cached_tokens:
+        uncached_tokens = usage["prompt_tokens"] - cached_tokens
+        prompt_cost: float = (
+            uncached_tokens * model_info["input_cost_per_token"]
+            + cached_tokens * cache_read_cost
+        )
+    else:
+        prompt_cost = usage["prompt_tokens"] * model_info["input_cost_per_token"]
 
     ## CALCULATE OUTPUT COST
     completion_cost = usage["completion_tokens"] * model_info["output_cost_per_token"]

--- a/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py
+++ b/tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py
@@ -1,0 +1,36 @@
+from unittest.mock import patch
+
+from litellm.llms.fireworks_ai.cost_calculator import cost_per_token
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+MODEL_INFO = {
+    "input_cost_per_token": 4e-07,
+    "output_cost_per_token": 1.6e-06,
+    "cache_read_input_token_cost": 8e-08,
+}
+
+
+def _usage(prompt_tokens, cached_tokens, completion_tokens=100):
+    return Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=cached_tokens),
+    )
+
+
+@patch("litellm.llms.fireworks_ai.cost_calculator.get_model_info", return_value=MODEL_INFO)
+def test_cached_prompt_tokens_use_cache_read_cost(mock_info):
+    """Cached prefix tokens should be billed at cache_read_input_token_cost."""
+    prompt_cost, _ = cost_per_token(model="qwen", usage=_usage(10000, 9000))
+    expected = 1000 * MODEL_INFO["input_cost_per_token"] + 9000 * MODEL_INFO[
+        "cache_read_input_token_cost"
+    ]
+    assert prompt_cost == expected
+
+
+@patch("litellm.llms.fireworks_ai.cost_calculator.get_model_info", return_value=MODEL_INFO)
+def test_no_cached_tokens_charges_full_price(mock_info):
+    """With no cached tokens, every prompt token is billed at the input rate."""
+    prompt_cost, _ = cost_per_token(model="qwen", usage=_usage(10000, 0))
+    assert prompt_cost == 10000 * MODEL_INFO["input_cost_per_token"]


### PR DESCRIPTION
## Summary
Fireworks' `cost_per_token` bills every prompt token at `input_cost_per_token`, ignoring cached tokens — so prompt-cache hits are charged at full price. Other providers and the generic cost path already honor `cache_read_input_token_cost`; this aligns Fireworks with them.

## Change
Read `prompt_tokens_details.cached_tokens` and bill them at `cache_read_input_token_cost` when the model defines one; otherwise unchanged (full price).

## Example (qwen: input $0.40/M, cached $0.08/M — 10k prompt, 9k cached)
- Before: $0.00400 (full price)
- After: $0.00112 (cached tokens discounted)

## Test
Adds `tests/test_litellm/llms/fireworks_ai/test_fireworks_ai_cost_calculator.py` covering the cached and no-cache cases.