### PR TITLE
fix(litellm_proxy): forward metadata to downstream proxy

### DIFF
--- a/litellm/llms/litellm_proxy/chat/transformation.py
+++ b/litellm/llms/litellm_proxy/chat/transformation.py
@@ -15,6 +15,32 @@ if TYPE_CHECKING:
 
 
 class LiteLLMProxyChatConfig(OpenAIGPTConfig):
+    @staticmethod
+    def _get_litellm_proxy_request_body(
+        model: str,
+        messages: list["AllMessageValues"],
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> dict:
+        request_body = {
+            "model": model,
+            "messages": messages,
+            **optional_params,
+        }
+        metadata = litellm_params.get("metadata")
+        requester_metadata = metadata.get("requester_metadata") if isinstance(metadata, dict) else None
+        if isinstance(requester_metadata, dict) and isinstance(requester_metadata.get("tags"), list):
+            request_body["metadata"] = {"tags": requester_metadata["tags"]}
+
+        session_id = litellm_params.get("litellm_session_id")
+        if session_id is not None:
+            extra_body = request_body.get("extra_body")
+            request_body["extra_body"] = {
+                **(extra_body if isinstance(extra_body, dict) else {}),
+                "litellm_session_id": session_id,
+            }
+        return request_body
+
     def get_supported_openai_params(self, model: str) -> List:
         params_list = super().get_supported_openai_params(model)
         params_list.extend(OPENAI_CHAT_COMPLETION_PARAMS)
@@ -119,12 +145,12 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        # don't transform the request
-        return {
-            "model": model,
-            "messages": messages,
-            **optional_params,
-        }
+        return self._get_litellm_proxy_request_body(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+        )
 
     async def async_transform_request(
         self,
@@ -134,9 +160,9 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        # don't transform the request
-        return {
-            "model": model,
-            "messages": messages,
-            **optional_params,
-        }
+        return self._get_litellm_proxy_request_body(
+            model=model,
+            messages=messages,
+            optional_params=optional_params,
+            litellm_params=litellm_params,
+        )

--- a/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
+++ b/tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py
@@ -1,9 +1,3 @@
-from typing import Optional
-from unittest.mock import patch
-
-import pytest
-
-import litellm
 from litellm.llms.litellm_proxy.chat.transformation import LiteLLMProxyChatConfig
 
 
@@ -38,5 +32,28 @@ def test_litellm_gateway_from_sdk_with_user_param():
     supported_params = LiteLLMProxyChatConfig().get_supported_openai_params(
         "openai/gpt-4o"
     )
-    print(f"supported_params: {supported_params}")
     assert "user" in supported_params
+
+
+def test_litellm_proxy_forwards_request_metadata_to_downstream_proxy():
+    config = LiteLLMProxyChatConfig()
+    messages = [{"role": "user", "content": "hello"}]
+
+    request = config.transform_request(
+        model="gpt-4o",
+        messages=messages,
+        optional_params={},
+        litellm_params={
+            "metadata": {
+                "requester_metadata": {
+                    "tags": ["project-x", "cost-center-42"],
+                    "user_api_key": "do-not-forward",
+                }
+            },
+            "litellm_session_id": "session-abc-123",
+        },
+        headers={},
+    )
+
+    assert request["metadata"] == {"tags": ["project-x", "cost-center-42"]}
+    assert request["extra_body"] == {"litellm_session_id": "session-abc-123"}


### PR DESCRIPTION
## Relevant issues

Fixes #31867

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes the focused lint and unit checks listed below
- [x] My PR scope is isolated to litellm_proxy chat request transformation
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Not included: this is a request-body transformation fix and the local environment does not have a running downstream LiteLLM proxy plus database for a full e2e curl proof

## Type

Bug Fix

Test

## Changes

Root cause: `LiteLLMProxyChatConfig.transform_request` rebuilt the downstream request from `model`, `messages`, and `optional_params` only, so `metadata.tags` and `litellm_session_id` already captured in `litellm_params` were dropped before the request reached the downstream LiteLLM proxy

This change forwards only the allowed operational metadata needed by the downstream proxy: `metadata.tags` from requester metadata and `litellm_session_id` through `extra_body`. It intentionally does not forward the full metadata envelope, since that can contain internal auth and logging fields

The sync and async chat transforms now share the same request-body helper so both paths preserve the same fields

Validation:

- `uv run ruff check litellm/llms/litellm_proxy/chat/transformation.py tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py`
- `uv run pytest tests/test_litellm/llms/litellm_proxy/chat/test_litellm_proxy_chat_transformation.py -q`
- `make pre-commit`
