### PR TITLE
docs: fix parameter name mismatches in proxy endpoint docstrings

### DIFF
--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1859,8 +1859,8 @@ async def get_users(
             - internal_user_viewer
         user_ids: Optional[str]
             Get list of users by user_ids. Comma separated list of user_ids.
-        sso_ids: Optional[str]
-            Get list of users by sso_ids. Comma separated list of sso_ids.
+        sso_user_ids: Optional[str]
+            Get list of users by sso_user_ids. Comma separated list of sso_user_ids.
         user_email: Optional[str]
             Filter users by partial email match
         team: Optional[str]

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3902,7 +3902,9 @@ async def delete_verification_tokens(
 
     Args:
         tokens: List of tokens to delete
-        user_id: Optional user_id to filter by
+        user_api_key_cache: In-memory key cache to invalidate deleted tokens from
+        user_api_key_dict: User authentication information
+        litellm_changed_by: Optional username of the admin performing the change, for audit logs
 
     Returns:
         Tuple[Optional[Dict], List[LiteLLM_VerificationToken]]:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4473,14 +4473,14 @@ async def ui_view_teams(
     [PROXY-ADMIN ONLY] Filter teams based on partial match of team_id or team_alias with pagination.
 
     Args:
-        user_id (Optional[str]): Partial user ID to search for
-        user_email (Optional[str]): Partial email to search for
+        team_id (Optional[str]): Partial team ID to search for
+        team_alias (Optional[str]): Partial team alias to search for
         page (int): Page number for pagination (starts at 1)
         page_size (int): Number of items per page (max 100)
         user_api_key_dict (UserAPIKeyAuth): User authentication information
 
     Returns:
-        List[LiteLLM_SpendLogs]: Paginated list of matching user records
+        List[LiteLLM_TeamTable]: Paginated list of matching team records
     """
     from litellm.proxy.proxy_server import prisma_client
 


### PR DESCRIPTION
## Title

docs: fix parameter name mismatches in proxy endpoint docstrings

## Relevant issues

N/A - trivial documentation fixes found while reading the source.

## Type

📖 Documentation

## Changes

Fixes three proxy endpoint docstrings where the documented parameter names do not match the actual function signatures:

| File | Function | Docstring said | Signature has |
|------|----------|---------------|---------------|
| `proxy/management_endpoints/team_endpoints.py` | `ui_view_teams` | `user_id`, `user_email` (copied from a user-search endpoint), returns "user records" | `team_id`, `team_alias`, returns teams |
| `proxy/management_endpoints/internal_user_endpoints.py` | `get_users` | `sso_ids` | `sso_user_ids` |
| `proxy/management_endpoints/key_management_endpoints.py` | `delete_verification_tokens` | stale `user_id` | `user_api_key_cache`, `user_api_key_dict`, `litellm_changed_by` |

Doc-only change; no behavior modified. These docstrings feed the endpoint docs, so this also fixes user-facing API documentation.