### PR TITLE
fix(gpt-5): honor gpt-5.5 default reasoning_effort for temperature

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -34,6 +34,17 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         return super()._supports_reasoning_effort_level(model, level)
 
     @classmethod
+    def _get_default_reasoning_effort(cls, model: str) -> str:
+        """Mirror ``_supports_reasoning_effort_level``'s prefix handling so the
+        gpt5_series/ route and bare deployment names resolve to the azure/ entry.
+        """
+        if model.startswith(cls.GPT5_SERIES_ROUTE):
+            model = "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
+        elif not model.startswith("azure/"):
+            model = "azure/" + model
+        return super()._get_default_reasoning_effort(model)
+
+    @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
         """Check if the Azure model string refers to a gpt-5 variant.
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -145,6 +145,17 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             key=f"supports_{level}_reasoning_effort",
         )
 
+    @classmethod
+    def _get_default_reasoning_effort(cls, model: str) -> str:
+        """Return the model's default reasoning_effort from the model map.
+
+        Falls back to "none" for models without the field, preserving the historical
+        gpt-5.x assumption that an omitted reasoning_effort behaves like "none".
+        """
+        from litellm.utils import _get_default_reasoning_effort
+
+        return _get_default_reasoning_effort(model=model, custom_llm_provider=None)
+
     def get_supported_openai_params(self, model: str) -> list:
         if self.is_model_gpt_5_search_model(model):
             return [
@@ -211,6 +222,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         # must be treated as effort="none" to avoid incorrect tool-drop or sampling errors.
         raw_reasoning_effort = non_default_params.get("reasoning_effort") or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(raw_reasoning_effort)
+        resolved_effort = (
+            effective_effort if effective_effort is not None else self._get_default_reasoning_effort(model)
+        )
 
         # Normalize dict reasoning_effort to string for Chat Completions API.
         # Example: {"effort": "high", "summary": "detailed"} -> "high"
@@ -260,7 +274,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         if supports_none:
             sampling_params = ["logprobs", "top_logprobs", "top_p"]
             has_sampling = any(p in non_default_params for p in sampling_params)
-            if has_sampling and effective_effort not in (None, "none"):
+            if has_sampling and resolved_effort != "none":
                 if litellm.drop_params or drop_params:
                     for p in sampling_params:
                         non_default_params.pop(p, None)
@@ -278,7 +292,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             temperature_value: Optional[float] = non_default_params.pop("temperature")
             if temperature_value is not None:
                 # models supporting reasoning_effort="none" also support flexible temperature
-                if supports_none and (effective_effort == "none" or effective_effort is None):
+                if supports_none and resolved_effort == "none":
                     optional_params["temperature"] = temperature_value
                 elif temperature_value == 1:
                     optional_params["temperature"] = temperature_value
@@ -289,7 +303,10 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                         message=(
                             "gpt-5 models (including gpt-5-codex) don't support temperature={}. "
                             "Only temperature=1 is supported. "
-                            "For gpt-5.1, temperature is supported when reasoning_effort='none' (or not specified, as it defaults to 'none'). "
+                            "For gpt-5.1/5.2/5.4, temperature is supported when reasoning_effort='none', "
+                            "which is also their default when reasoning_effort is unspecified. "
+                            "gpt-5.5 defaults to reasoning_effort='medium'; set reasoning_effort='none' "
+                            "explicitly to use a non-default temperature. "
                             "To drop unsupported params set `litellm.drop_params = True`"
                         ).format(temperature_value),
                         status_code=400,

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -152,9 +152,9 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         Falls back to "none" for models without the field, preserving the historical
         gpt-5.x assumption that an omitted reasoning_effort behaves like "none".
         """
-        from litellm.utils import _get_default_reasoning_effort
+        from litellm.utils import _lookup_default_reasoning_effort
 
-        return _get_default_reasoning_effort(model=model, custom_llm_provider=None)
+        return _lookup_default_reasoning_effort(model)
 
     def get_supported_openai_params(self, model: str) -> list:
         if self.is_model_gpt_5_search_model(model):

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -279,12 +279,17 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                     for p in sampling_params:
                         non_default_params.pop(p, None)
                 else:
+                    effort_desc = (
+                        resolved_effort
+                        if effective_effort is not None
+                        else f"{resolved_effort} (model default, reasoning_effort unspecified)"
+                    )
                     raise litellm.utils.UnsupportedParamsError(
                         message=(
                             "gpt-5.1/5.2/5.4 only support logprobs, top_p, top_logprobs when "
                             "reasoning_effort='none'. Current reasoning_effort='{}'. "
                             "To drop unsupported params set `litellm.drop_params = True`"
-                        ).format(effective_effort),
+                        ).format(effort_desc),
                         status_code=400,
                     )
 

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -98,7 +98,14 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                 reasoning = params.get("reasoning") or {}
                 effort = reasoning.get("effort") if isinstance(reasoning, dict) else None
                 supports_none = self._supports_reasoning_effort_none(model=model)
-                if supports_none and (effort == "none" or effort is None):
+                from litellm.utils import _get_default_reasoning_effort
+
+                resolved_effort = (
+                    effort
+                    if effort is not None
+                    else _get_default_reasoning_effort(model=model, custom_llm_provider=None)
+                )
+                if supports_none and resolved_effort == "none":
                     pass  # flexible temperature allowed
                 elif drop_params or litellm.drop_params:
                     params.pop("temperature", None)

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -90,6 +90,8 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         is accepted unless reasoning_effort='none' on models that support it).
         Apply the same validation used by the chat completions path.
         """
+        from litellm.utils import _lookup_default_reasoning_effort
+
         params = dict(response_api_optional_params)
 
         if self._is_gpt_5_model(model=model):
@@ -98,13 +100,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                 reasoning = params.get("reasoning") or {}
                 effort = reasoning.get("effort") if isinstance(reasoning, dict) else None
                 supports_none = self._supports_reasoning_effort_none(model=model)
-                from litellm.utils import _get_default_reasoning_effort
-
-                resolved_effort = (
-                    effort
-                    if effort is not None
-                    else _get_default_reasoning_effort(model=model, custom_llm_provider=None)
-                )
+                resolved_effort = effort if effort is not None else _lookup_default_reasoning_effort(model)
                 if supports_none and resolved_effort == "none":
                     pass  # flexible temperature allowed
                 elif drop_params or litellm.drop_params:
@@ -114,8 +110,10 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                         message=(
                             "gpt-5 models don't support temperature={}. "
                             "Only temperature=1 is supported. "
-                            "For models like gpt-5.1/5.4, temperature is supported "
-                            "when reasoning.effort='none' (or not specified). "
+                            "For gpt-5.1/5.2/5.4, temperature is supported when reasoning.effort='none', "
+                            "which is also their default when effort is unspecified. "
+                            "gpt-5.5 defaults to reasoning.effort='medium'; set reasoning.effort='none' "
+                            "explicitly to use a non-default temperature. "
                             "To drop unsupported params set `litellm.drop_params = True`"
                         ).format(temperature),
                         status_code=400,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -5915,7 +5915,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "azure/gpt-5.5-2026-04-23": {
         "cache_read_input_token_cost": 5e-07,
@@ -5957,7 +5958,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "default_reasoning_effort": "medium"
     },
     "azure/gpt-5.5-pro": {
         "cache_read_input_token_cost": 3e-06,
@@ -22018,7 +22020,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "gpt-5.5-2026-04-23": {
         "cache_read_input_token_cost": 5e-07,
@@ -22067,7 +22070,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "gpt-5.5-pro": {
         "cache_read_input_token_cost": 3e-06,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -149,6 +149,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_low_reasoning_effort: Optional[bool]
     supports_xhigh_reasoning_effort: Optional[bool]
     supports_max_reasoning_effort: Optional[bool]
+    default_reasoning_effort: Optional[Literal["none", "minimal", "low", "medium", "high", "xhigh"]]
     supports_output_config: Optional[bool]
     supports_image_size: Optional[bool]
     bedrock_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2417,6 +2417,37 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: Optional[st
         return False
 
 
+def _get_default_reasoning_effort(model: str, custom_llm_provider: Optional[str] = None) -> str:
+    """Return the model's documented default reasoning_effort from the model map.
+
+    Reads ``default_reasoning_effort``, falling back to the bare model-name entry,
+    and finally to ``"none"`` for models that do not declare a default.  ``"none"``
+    is the historical assumption of the gpt-5.x path (correct for gpt-5.1/5.2/5.4);
+    gpt-5.5 declares ``"medium"`` because that is its real API default.
+    """
+    try:
+        model, custom_llm_provider, _, _ = litellm.get_llm_provider(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+        model_info = _get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider)
+        value = model_info.get("default_reasoning_effort")
+        if isinstance(value, str):
+            return value
+        bare_model_key = _get_model_cost_key(model)
+        if bare_model_key is not None:
+            bare_entry = litellm.model_cost.get(bare_model_key) or {}
+            bare_value = bare_entry.get("default_reasoning_effort")
+            if isinstance(bare_value, str):
+                return bare_value
+        return "none"
+    except Exception as e:
+        verbose_logger.debug(
+            f"Model not found or error reading default_reasoning_effort. "
+            f"model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
+        )
+        return "none"
+
+
 def supports_audio_input(model: str, custom_llm_provider: Optional[str] = None) -> bool:
     """Check if a given model supports audio input in a chat completion call"""
     return _supports_factory(model=model, custom_llm_provider=custom_llm_provider, key="supports_audio_input")
@@ -5471,6 +5502,7 @@ def _get_model_info_helper(
                 supports_low_reasoning_effort=_model_info.get("supports_low_reasoning_effort", None),
                 supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
                 supports_max_reasoning_effort=_model_info.get("supports_max_reasoning_effort", None),
+                default_reasoning_effort=_model_info.get("default_reasoning_effort", None),
                 bedrock_output_config_effort_ceiling=_model_info.get("bedrock_output_config_effort_ceiling", None),
                 bedrock_converse_supports_strict_tools=_model_info.get("bedrock_converse_supports_strict_tools", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2417,35 +2417,22 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: Optional[st
         return False
 
 
-def _get_default_reasoning_effort(model: str, custom_llm_provider: Optional[str] = None) -> str:
+def _lookup_default_reasoning_effort(model: str) -> str:
     """Return the model's documented default reasoning_effort from the model map.
 
-    Reads ``default_reasoning_effort``, falling back to the bare model-name entry,
-    and finally to ``"none"`` for models that do not declare a default.  ``"none"``
-    is the historical assumption of the gpt-5.x path (correct for gpt-5.1/5.2/5.4);
-    gpt-5.5 declares ``"medium"`` because that is its real API default.
+    Reads ``default_reasoning_effort`` from the model's cost-map entry, falling back
+    to the bare model-name key, and finally to ``"none"`` for models that do not
+    declare a default.  ``"none"`` is the historical assumption of the gpt-5.x path
+    (correct for gpt-5.1/5.2/5.4); gpt-5.5 declares ``"medium"`` because that is its
+    real API default.
     """
-    try:
-        model, custom_llm_provider, _, _ = litellm.get_llm_provider(
-            model=model, custom_llm_provider=custom_llm_provider
-        )
-        model_info = _get_model_info_helper(model=model, custom_llm_provider=custom_llm_provider)
-        value = model_info.get("default_reasoning_effort")
+    for key in (model, _get_model_cost_key(model)):
+        if key is None:
+            continue
+        value = (litellm.model_cost.get(key) or {}).get("default_reasoning_effort")
         if isinstance(value, str):
             return value
-        bare_model_key = _get_model_cost_key(model)
-        if bare_model_key is not None:
-            bare_entry = litellm.model_cost.get(bare_model_key) or {}
-            bare_value = bare_entry.get("default_reasoning_effort")
-            if isinstance(bare_value, str):
-                return bare_value
-        return "none"
-    except Exception as e:
-        verbose_logger.debug(
-            f"Model not found or error reading default_reasoning_effort. "
-            f"model={model}, custom_llm_provider={custom_llm_provider}. Error: {str(e)}"
-        )
-        return "none"
+    return "none"
 
 
 def supports_audio_input(model: str, custom_llm_provider: Optional[str] = None) -> bool:

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -5915,7 +5915,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "azure/gpt-5.5-2026-04-23": {
         "cache_read_input_token_cost": 5e-07,
@@ -5957,7 +5958,8 @@
         "supports_system_messages": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "supports_web_search": true
+        "supports_web_search": true,
+        "default_reasoning_effort": "medium"
     },
     "azure/gpt-5.5-pro": {
         "cache_read_input_token_cost": 3e-06,
@@ -22176,7 +22178,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "gpt-5.5-2026-04-23": {
         "cache_read_input_token_cost": 5e-07,
@@ -22225,7 +22228,8 @@
         "supports_web_search": true,
         "supports_none_reasoning_effort": true,
         "supports_xhigh_reasoning_effort": true,
-        "supports_minimal_reasoning_effort": false
+        "supports_minimal_reasoning_effort": false,
+        "default_reasoning_effort": "medium"
     },
     "gpt-5.5-pro": {
         "cache_read_input_token_cost": 3e-06,

--- a/tests/llm_responses_api_testing/test_openai_responses_api.py
+++ b/tests/llm_responses_api_testing/test_openai_responses_api.py
@@ -1813,6 +1813,7 @@ async def test_extra_body_merges_with_request_data(extra_body_mock_response_data
             model="gpt-5.5",
             input="Test",
             temperature=0.7,
+            reasoning={"effort": "none"},
             max_output_tokens=20,
             extra_body={
                 "custom_field": "custom_value",

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -1,12 +1,22 @@
 import pytest
 
 import litellm
+from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 from litellm.llms.azure.chat.gpt_5_transformation import AzureOpenAIGPT5Config
 
 
 @pytest.fixture()
 def config() -> AzureOpenAIGPT5Config:
     return AzureOpenAIGPT5Config()
+
+
+@pytest.fixture(autouse=True)
+def use_local_model_cost_map(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(
+        litellm, "model_cost", get_model_cost_map(url=litellm.model_cost_map_url)
+    )
+    litellm.add_known_models(model_cost_map=litellm.model_cost)
 
 
 def test_azure_gpt5_supports_reasoning_effort(config: AzureOpenAIGPT5Config):
@@ -299,3 +309,56 @@ def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
     supported_params = config.get_supported_openai_params(model="gpt-5.1")
     assert "logprobs" not in supported_params
     assert "top_logprobs" not in supported_params
+
+
+def test_azure_gpt5_5_temperature_dropped_when_effort_omitted(config: AzureOpenAIGPT5Config):
+    """azure/gpt-5.5 omitted effort must drop temperature (customer's exact PROD case)."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="azure/gpt-5.5",
+        drop_params=True,
+        api_version="2024-05-01-preview",
+    )
+    assert "temperature" not in params
+
+
+def test_azure_gpt5_5_temperature_error_when_effort_omitted(config: AzureOpenAIGPT5Config):
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.2},
+            optional_params={},
+            model="azure/gpt-5.5",
+            drop_params=False,
+            api_version="2024-05-01-preview",
+        )
+
+
+def test_azure_gpt5_5_dated_temperature_dropped_when_effort_omitted(config: AzureOpenAIGPT5Config):
+    """azure/gpt-5.5-2026-04-23 resolves supports_none via fallback, so it fires the same bug."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="azure/gpt-5.5-2026-04-23",
+        drop_params=True,
+        api_version="2024-05-01-preview",
+    )
+    assert "temperature" not in params
+
+
+def test_azure_gpt5_5_temperature_forwarded_with_explicit_effort_none(config: AzureOpenAIGPT5Config):
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2, "reasoning_effort": "none"},
+        optional_params={},
+        model="azure/gpt-5.5",
+        drop_params=False,
+        api_version="2024-05-01-preview",
+    )
+    assert params["temperature"] == 0.2
+
+
+def test_azure_get_default_reasoning_effort_normalizes_prefix(config: AzureOpenAIGPT5Config):
+    """gpt5_series/ and bare names resolve to the azure/ entry -> 'medium'."""
+    assert config._get_default_reasoning_effort("azure/gpt-5.5") == "medium"
+    assert config._get_default_reasoning_effort("gpt5_series/gpt-5.5") == "medium"
+    assert config._get_default_reasoning_effort("azure/gpt-5.1") == "none"

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1183,6 +1183,71 @@ def test_gpt5_1_logprobs_dropped_with_reasoning_effort(config: OpenAIConfig):
     assert params["reasoning_effort"] == "high"
 
 
+def test_gpt5_5_temperature_dropped_when_effort_omitted(config: OpenAIConfig):
+    """gpt-5.5 defaults to reasoning_effort='medium', so an omitted effort must NOT
+    forward a non-default temperature; drop_params=True drops it (was forwarded -> Azure 400)."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="gpt-5.5",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_gpt5_5_temperature_error_when_effort_omitted(config: OpenAIConfig):
+    """Without drop_params, gpt-5.5 + omitted effort + temp!=1 raises instead of a silent forward."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.2},
+            optional_params={},
+            model="gpt-5.5",
+            drop_params=False,
+        )
+
+
+def test_gpt5_5_temperature_forwarded_with_explicit_effort_none(config: OpenAIConfig):
+    """gpt-5.5 accepts flexible temperature at explicit reasoning_effort='none'."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2, "reasoning_effort": "none"},
+        optional_params={},
+        model="gpt-5.5",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.2
+    assert params["reasoning_effort"] == "none"
+
+
+def test_gpt5_5_sampling_params_dropped_when_effort_omitted(config: OpenAIConfig):
+    """Sibling defect: logprobs/top_p must be dropped for gpt-5.5 on omitted effort."""
+    params = config.map_openai_params(
+        non_default_params={"logprobs": True, "top_p": 0.9},
+        optional_params={},
+        model="gpt-5.5",
+        drop_params=True,
+    )
+    assert "logprobs" not in params
+    assert "top_p" not in params
+
+
+def test_gpt5_1_temperature_still_forwarded_when_effort_omitted(config: OpenAIConfig):
+    """Control: gpt-5.1 default is 'none', so omitted effort must still forward temperature (guards #27351)."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="gpt-5.1",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.2
+
+
+def test_get_default_reasoning_effort_gpt5_5_vs_gpt5_1(gpt5_config: OpenAIGPT5Config):
+    """The helper reads 'medium' for gpt-5.5 and defaults to 'none' for gpt-5.1."""
+    assert gpt5_config._get_default_reasoning_effort("gpt-5.5") == "medium"
+    assert gpt5_config._get_default_reasoning_effort("gpt-5.5-2026-04-23") == "medium"
+    assert gpt5_config._get_default_reasoning_effort("gpt-5.1") == "none"
+
+
 # ---------------------------------------------------------------------------
 # Responses API: GPT-5 temperature validation (#16090)
 # ---------------------------------------------------------------------------
@@ -1309,3 +1374,30 @@ def test_responses_gpt54_allow_temperature_effort_none(
         drop_params=False,
     )
     assert params["temperature"] == 0.7
+
+
+def test_responses_gpt5_5_drop_temperature_effort_omitted(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """Responses API: gpt-5.5 omitted effort must drop temperature (default 'medium')."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(temperature=0.5),
+        model="gpt-5.5",
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_responses_gpt5_5_allow_temperature_effort_none(
+    responses_config: OpenAIResponsesAPIConfig,
+):
+    """Responses API: gpt-5.5 with explicit reasoning.effort='none' allows temperature."""
+    params = responses_config.map_openai_params(
+        response_api_optional_params=ResponsesAPIOptionalRequestParams(
+            temperature=0.5,
+            reasoning={"effort": "none"},
+        ),
+        model="gpt-5.5",
+        drop_params=False,
+    )
+    assert params["temperature"] == 0.5

--- a/tests/test_litellm/llms/openai/test_gpt5_transformation.py
+++ b/tests/test_litellm/llms/openai/test_gpt5_transformation.py
@@ -1230,6 +1230,19 @@ def test_gpt5_5_sampling_params_dropped_when_effort_omitted(config: OpenAIConfig
     assert "top_p" not in params
 
 
+def test_gpt5_5_sampling_params_error_reports_resolved_effort(config: OpenAIConfig):
+    """Raise path must report the resolved effort ('medium'), not the omitted raw value 'None'."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError) as excinfo:
+        config.map_openai_params(
+            non_default_params={"logprobs": True, "top_p": 0.9},
+            optional_params={},
+            model="gpt-5.5",
+            drop_params=False,
+        )
+    assert "medium (model default, reasoning_effort unspecified)" in str(excinfo.value)
+    assert "reasoning_effort='None'" not in str(excinfo.value)
+
+
 def test_gpt5_1_temperature_still_forwarded_when_effort_omitted(config: OpenAIConfig):
     """Control: gpt-5.1 default is 'none', so omitted effort must still forward temperature (guards #27351)."""
     params = config.map_openai_params(

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -851,6 +851,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_none_reasoning_effort": {"type": "boolean"},
                 "supports_xhigh_reasoning_effort": {"type": "boolean"},
                 "supports_max_reasoning_effort": {"type": "boolean"},
+                "default_reasoning_effort": {"type": "string"},
                 "supports_adaptive_thinking": {"type": "boolean"},
                 "supports_sampling_params": {"type": "boolean"},
                 "supports_output_config": {"type": "boolean"},


### PR DESCRIPTION
## Relevant issues

<!-- refs #27351 (same reasoning-effort/temperature gating mechanism; its contract is preserved) -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

For gpt-5.5, LiteLLM treated an omitted `reasoning_effort` as `"none"` and forwarded a non-default `temperature`. gpt-5.5's real API default is `medium`, at which the provider returns:

```
litellm.BadRequestError: AzureException BadRequestError -
Unsupported value: 'temperature' does not support 0.2 with this model.
Only the default (1) value is supported.
```

The fix lives entirely in optional-param mapping, so the behavior change is shown deterministically at the `map_openai_params` layer (real code path + real registry, no mocks):

```console
$ LITELLM_LOCAL_MODEL_COST_MAP=True python verify_gpt55.py
```

**Before**
```
  registry gpt-5.5                    supports_none=True default_reasoning_effort=None
temperature=0.2 behavior:
  gpt-5.5 (drop=True)                    -> temperature 0.2      # forwarded -> Azure 400
  azure/gpt-5.5 (drop=True)              -> temperature 0.2
  azure/gpt-5.5-2026-04-23 (drop=True)   -> temperature 0.2
  gpt-5.5 (drop=False)                   -> temperature 0.2      # silently forwarded
  gpt-5.1 (drop=False, control)          -> temperature 0.2
```

**After**
```
  registry gpt-5.5                    supports_none=True default_reasoning_effort=medium
temperature=0.2 behavior:
  gpt-5.5 (drop=True)                    -> temperature DROPPED  # call now succeeds
  azure/gpt-5.5 (drop=True)              -> temperature DROPPED
  azure/gpt-5.5-2026-04-23 (drop=True)   -> temperature DROPPED
  gpt-5.5 (drop=False)                   -> UnsupportedParamsError  # clear LiteLLM error, not opaque 400
  gpt-5.1 (drop=False, control)          -> temperature 0.2     # unchanged, #27351 contract preserved
```

<details><summary>End-to-end against a live Azure gpt-5.5 deployment</summary>

```bash
# model_list entry: model: azure/gpt-5.5, drop_params: true, no reasoning_effort
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"hi"}],"temperature":0.2}'
# before: HTTP 400 (Unsupported value: 'temperature' ...); after: HTTP 200 (temperature dropped)
```
</details>

## Type

🐛 Bug Fix

## Changes

- **`litellm/types/utils.py`** — add `default_reasoning_effort` to `ProviderSpecificModelInfo`.
- **`litellm/utils.py`** — thread the field through `_get_model_info_helper`; add `_get_default_reasoning_effort()` (registry read + bare-model fallback, defaults to `"none"`).
- **`litellm/llms/openai/chat/gpt_5_transformation.py`** — resolve an omitted `reasoning_effort` to the model's default for gating only (never injected into the request); gate `temperature` and the `logprobs`/`top_p`/`top_logprobs` siblings on the resolved effort; clarify the error message.
- **`litellm/llms/azure/chat/gpt_5_transformation.py`** — Azure override normalizing `gpt5_series/` and bare deployment names to the `azure/` entry.
- **`litellm/llms/openai/responses/transformation.py`** — same resolved-effort gate on the Responses API path.
- **`model_prices_and_context_window.json` + `litellm/model_prices_and_context_window_backup.json`** — `default_reasoning_effort: "medium"` on `gpt-5.5`, `gpt-5.5-2026-04-23`, `azure/gpt-5.5`, `azure/gpt-5.5-2026-04-23`. Models without the field resolve to `none`, so gpt-5.1/5.2/5.4 are unchanged.
- **Tests** — regression coverage in `test_gpt5_transformation.py` (chat + Responses) and `test_azure_gpt5_transformation.py`.

## Notes for reviewers

- **Provider-agnostic by design.** gpt-5.5 defaults to `reasoning_effort=medium`, and at any non-`none` effort the reasoning stack rejects a non-default `temperature` — the same restriction the codebase already applies to gpt-5 / gpt-5.1 on both the OpenAI and Azure paths. So the field is set for both `gpt-5.5` and `azure/gpt-5.5`. This is a model property, not Azure-specific: see the [OpenAI GPT-5.5 model docs](https://developers.openai.com/api/docs/models/gpt-5.5) (medium default; sampling params unsupported with reasoning) and the parallel report [langchain-ai/langchain#35423](https://github.com/langchain-ai/langchain/issues/35423) (temperature dropped for the gpt-5.2 default effort on the OpenAI Responses API).
- **One existing Responses test updated.** `test_extra_body_merges_with_request_data` used `gpt-5.5` + `temperature=0.7` as an incidental vehicle and asserted the temperature was forwarded — behavior this fix intentionally changes. It now passes `reasoning={"effort": "none"}`, the supported way to send a non-default temperature to gpt-5.5, keeping the test's original intent intact.
