### PR TITLE
fix(bedrock): stream mantle /v1/messages as native Anthropic SSE

### DIFF
--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -2,11 +2,16 @@
 Transformation for Bedrock Mantle (Claude Mythos Preview) - /messages endpoint
 
 Inherits all Messages API request/response transformations from
-AmazonAnthropicClaudeMessagesConfig. Overrides only the URL and model-prefix
-stripping that are specific to the bedrock-mantle endpoint.
+AmazonAnthropicClaudeMessagesConfig. Overrides the URL, the model-prefix
+stripping, and the streaming behavior that are specific to the bedrock-mantle
+endpoint: mantle speaks the native Anthropic Messages protocol, so `stream`
+must stay in the request body and responses arrive as native SSE rather than
+the AWS binary event-stream that Bedrock Invoke emits.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple
+
+import httpx
 
 from litellm.llms.bedrock.common_utils import build_mantle_messages_url
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
@@ -93,4 +98,34 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         # body (Bedrock Invoke puts model in the URL). The mantle endpoint
         # (Messages API) requires "model" in the request body.
         request["model"] = model_id
+
+        if anthropic_messages_optional_request_params.get("stream") is True:
+            request["stream"] = True
+
         return request
+
+    def get_async_streaming_response_iterator(
+        self,
+        model: str,
+        httpx_response: httpx.Response,
+        request_body: dict,
+        litellm_logging_obj: LiteLLMLoggingObj,
+    ) -> AsyncIterator:
+        """
+        Mantle streams native Anthropic SSE; the parent's iterator decodes the
+        AWS binary event-stream and raises botocore ChecksumMismatch on SSE
+        text. Pass the SSE through like the native Anthropic route does.
+        """
+        from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+            BaseAnthropicMessagesStreamingIterator,
+        )
+
+        handler = BaseAnthropicMessagesStreamingIterator(
+            litellm_logging_obj=litellm_logging_obj,
+            request_body=request_body,
+        )
+        return handler.get_async_streaming_response_iterator(
+            httpx_response=httpx_response,
+            request_body=request_body,
+            litellm_logging_obj=litellm_logging_obj,
+        )

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -17,6 +17,7 @@ from litellm.llms.bedrock.chat.mantle.transformation import AmazonMantleConfig
 from litellm.llms.bedrock.messages.mantle_transformation import (
     AmazonMantleMessagesConfig,
 )
+from litellm.types.router import GenericLiteLLMParams
 
 
 def _anthropic_response(url: str) -> httpx.Response:
@@ -347,3 +348,106 @@ async def test_mantle_anthropic_messages_routes_to_vpc_api_base():
     assert len(urls) == 1
     assert urls[0] == f"{_VPC_ENDPOINT}/anthropic/v1/messages"
     assert "api.aws" not in urls[0]
+
+
+_NATIVE_SSE_BODY = (
+    b"event: message_start\n"
+    b'data: {"type":"message_start","message":{"id":"msg_test","type":"message",'
+    b'"role":"assistant","model":"anthropic.claude-mythos-preview","content":[],'
+    b'"stop_reason":null,"usage":{"input_tokens":5,"output_tokens":1}}}\n\n'
+    b"event: content_block_start\n"
+    b'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'
+    b"event: content_block_delta\n"
+    b'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}\n\n'
+    b"event: content_block_stop\n"
+    b'data: {"type":"content_block_stop","index":0}\n\n'
+    b"event: message_delta\n"
+    b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+    b'"usage":{"input_tokens":5,"output_tokens":3}}\n\n'
+    b"event: message_stop\n"
+    b'data: {"type":"message_stop"}\n\n'
+)
+
+
+class _NativeSSEStream(httpx.AsyncByteStream):
+    def __init__(self, body: bytes, chunk_size: int = 64):
+        self._chunks = tuple(body[i : i + chunk_size] for i in range(0, len(body), chunk_size))
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def aclose(self) -> None:
+        return None
+
+
+def _native_sse_response(url: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        headers={"content-type": "text/event-stream"},
+        stream=_NativeSSEStream(_NATIVE_SSE_BODY),
+        request=httpx.Request("POST", url),
+    )
+
+
+def test_mantle_messages_transform_keeps_stream_in_body():
+    config = AmazonMantleMessagesConfig()
+    request = config.transform_anthropic_messages_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 10, "stream": True},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert request["stream"] is True
+    assert request["model"] == "anthropic.claude-mythos-preview"
+
+
+def test_mantle_messages_transform_omits_stream_for_non_streaming():
+    config = AmazonMantleMessagesConfig()
+    request = config.transform_anthropic_messages_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 10},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert "stream" not in request
+
+
+@pytest.mark.asyncio
+async def test_mantle_anthropic_messages_streaming_relays_native_sse():
+    import litellm
+
+    requests = []
+
+    async def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=str(url), headers=headers or {}, data=data))
+        return _native_sse_response(str(url))
+
+    collected = b""
+    try:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new=mock_post,
+        ):
+            response = await litellm.anthropic_messages(
+                model="bedrock/mantle/anthropic.claude-mythos-preview",
+                messages=[{"role": "user", "content": "hello"}],
+                max_tokens=10,
+                stream=True,
+                aws_bedrock_project_id="proj_abc123def456",
+                aws_access_key_id="fake-key",
+                aws_secret_access_key="fake-secret",
+                aws_region_name="us-east-1",
+            )
+            async for chunk in response:
+                collected += chunk if isinstance(chunk, bytes) else str(chunk).encode()
+    finally:
+        await litellm.close_litellm_async_clients()
+
+    assert len(requests) == 1
+    assert requests[0]["body"]["stream"] is True
+    assert b"event: message_start" in collected
+    assert b'"text":"hello"' in collected
+    assert b"event: message_stop" in collected


### PR DESCRIPTION
## Relevant issues

Fixes #31845

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The mantle Claude preview is enrollment gated, so this account cannot reach a real mantle Claude model (the bearer token authenticates against `bedrock-mantle.eu-west-2.api.aws` but every Claude model returns `not_found_error`). Since mantle speaks the native Anthropic Messages protocol on the wire, the proof runs the real proxy against a thin local stand-in on `:9099` that relays `/anthropic/v1/messages` verbatim to the real Anthropic API, so the bytes hitting the proxy are genuine native Anthropic SSE from a real provider call

Proxy config:

```yaml
model_list:
  - model_name: mantle-claude
    litellm_params:
      model: bedrock/mantle/claude-haiku-4-5-20251001
      aws_bedrock_runtime_endpoint: http://127.0.0.1:9099
      aws_region_name: us-east-1
      aws_bedrock_project_id: proj_local_test
```

Before the fix (identical request, identical upstream), the proxy returns the exact failure from the issue, including the same checksum `0x3a22636c`:

```
$ curl -sS -N -X POST http://127.0.0.1:4000/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" \
    -d '{"model":"mantle-claude","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Say hi in exactly 3 words"}]}'

{"error":{"message":"Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\n\nTraceback (most recent call last):\n ...
  File \".../litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py\", line 812, in bedrock_sse_wrapper\n ...
  File \".../litellm/llms/bedrock/chat/invoke_handler.py\", line 1631, in aiter_bytes\n    for event in event_stream_buffer:\n ...
botocore.eventstream.ChecksumMismatch: Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\n","type":"None","param":"None","code":"500"}}
---HTTP_STATUS=500---
```

After the fix, the same curl streams token by token:

```
$ curl -sS -N -X POST http://127.0.0.1:4000/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" \
    -d '{"model":"mantle-claude","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Say hi in exactly 3 words"}]}'

event: message_start
data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_014P5CxshJjfQP39CZodYzHQ",...}}

event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi there"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" friend"}}

event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn",...},"usage":{"input_tokens":15,...,"output_tokens":6}}

event: message_stop
data: {"type":"message_stop"}

---HTTP_STATUS=200---
```

The stand-in also logs what the proxy sends upstream, confirming the second half of the fix (before: body had no `stream` key, so the upstream returned one JSON document even for streaming requests; after: `stream=True` reaches the wire):

```
[forwarder] incoming keys=['anthropic_version', 'max_tokens', 'messages', 'model', 'stream'] stream=True
```

Non-streaming through the same model still works unchanged:

```
$ curl -sS -X POST http://127.0.0.1:4000/v1/messages \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" \
    -d '{"model":"mantle-claude","max_tokens":32,"stream":false,"messages":[{"role":"user","content":"Say hi in exactly 3 words"}]}'

{"model":"mantle-claude","id":"msg_013MvZdW2vy5FaJ8NbMCmWAH","type":"message","role":"assistant","content":[{"type":"text","text":"Hi there friend"}],"stop_reason":"end_turn",...}
---HTTP_STATUS=200---
```

## Type

🐛 Bug Fix

## Changes

Streaming a bedrock-mantle Claude model through `/v1/messages` crashes with `botocore.eventstream.ChecksumMismatch`. The reported "expected 0x3a22636c" decodes to ASCII `:"cl`, which is the tell: response text is being parsed as an AWS binary event-stream prelude

Root cause is two inherited Bedrock Invoke behaviors in `AmazonMantleMessagesConfig`. The parent's request transform pops `stream` from the body because Invoke signals streaming via the URL, but mantle is the native Anthropic Messages API and only streams when `"stream": true` is in the body, so mantle always returned a single JSON document. The parent's `get_async_streaming_response_iterator` then fed that text into the botocore binary event-stream decoder, which fails the prelude CRC check

The fix keeps `"stream": true` in the mantle request body when the caller requested streaming, and overrides `get_async_streaming_response_iterator` to pass the native SSE through `BaseAnthropicMessagesStreamingIterator`, the same handler the `anthropic` and bedrock `claude_platform` routes use, so logging and spend tracking behave identically to those routes. Non-streaming behavior is untouched; the override is only reached under `if stream:` in `llm_http_handler.py`

Tests: two transform-level tests pin the `stream` body contract (kept for streaming, absent otherwise) and an end-to-end test drives `litellm.anthropic_messages(stream=True)` with a mocked upstream returning native Anthropic SSE, asserting the request body carries `stream: true` and the SSE frames pass through intact. Both regression tests fail on the unpatched code (`KeyError: 'stream'` and the ChecksumMismatch path) and pass with the fix
