### PR TITLE
fix(e2e): define SpendTagsResponse/TagSpend so spend suite collects

### DIFF
--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -194,6 +194,20 @@ class SpendCalculateResponse(BaseModel):
     cost: float
 
 
+# ---------- spend tags ----------
+
+
+class TagSpend(BaseModel):
+    individual_request_tag: str | None = None
+    log_count: int | None = None
+    total_spend: float | None = None
+
+
+class SpendTagsResponse(RootModel[list[TagSpend]]):
+    """GET /spend/tags answers with a bare array of per-tag aggregates, not an
+    object wrapping them (that's /global/spend/tags). Read the rows off .root."""
+
+
 # ---------- route probing ----------
 
 

--- a/tests/e2e/spend_tracking/spend_e2e_client.py
+++ b/tests/e2e/spend_tracking/spend_e2e_client.py
@@ -151,7 +151,7 @@ class SpendClient:
         )
         match result:
             case Success(data=data):
-                return data.spend_per_tag or []
+                return data.root
             case _:
                 return []
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The e2e suite aborts during collection before a single test runs, so the whole session goes red on an import, not on any real behavior:

```
spend_tracking/spend_e2e_client.py:30: in <module>
    from models import (
E   ImportError: cannot import name 'SpendTagsResponse' from 'models' (/app/e2e/models.py)
=========================== short test summary info ============================
ERROR spend_tracking - ImportError: cannot import name 'SpendTagsResponse' fr...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

The two models this restores mirror what `/spend/tags` actually returns. With a proxy on localhost:4000, after logging some tagged spend, the endpoint answers with a bare JSON array of per-tag aggregates, which is exactly what `SpendTagsResponse` (a `RootModel[list[TagSpend]]`) now validates and what `spend_by_tags` reads off `.root`

```
curl -s -X GET "http://localhost:4000/spend/tags" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq .
```

```
[
  { "individual_request_tag": "e2e-tagspend-abc123", "log_count": 2, "total_spend": 0.00012 },
  { "individual_request_tag": "prod", "log_count": 41, "total_spend": 0.53 }
]
```

## Type

🐛 Bug Fix

✅ Test

## Changes

`tests/e2e/spend_tracking/spend_e2e_client.py` imports `SpendTagsResponse` and `TagSpend` from `models`, but neither was ever defined. Importing the client raises `ImportError`, so pytest interrupts collection for the entire e2e session and the spend tag-spend coverage had never actually run

This adds the two models to `tests/e2e/models.py`, typed to match the real endpoint. `get_spend_by_tags` returns the raw query result, a bare array of `{individual_request_tag, log_count, total_spend}` rows, so `SpendTagsResponse` is a `RootModel[list[TagSpend]]` following the existing `SpendLogs` pattern rather than an object wrapping `spend_per_tag` (that shape belongs to `/global/spend/tags`). `spend_by_tags` was reading a `spend_per_tag` field that never existed and would not have matched the array anyway; it now reads `.root`, the same way `spend_logs` consumes its `RootModel`. With this, `spend_tracking` collects cleanly and the session-wide collection error is gone
