### PR TITLE
fix(proxy): support azure text moderation config params

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/__init__.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING, Union
 
-from litellm.types.guardrails import SupportedGuardrailIntegrations
+from litellm.types.guardrails import (
+    AZURE_TEXT_MODERATION_PARAM_KEYS,
+    SupportedGuardrailIntegrations,
+)
 
 from .prompt_shield import AzureContentSafetyPromptShieldGuardrail
 from .text_moderation import AzureContentSafetyTextModerationGuardrail
@@ -38,10 +41,16 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
             },
         )
     elif azure_guardrail == "text_moderations":
+        litellm_params_dict = litellm_params.model_dump(exclude_none=True)
+        optional_params = litellm_params_dict.pop("optional_params", None)
+        if optional_params is not None:
+            litellm_params_dict.update(
+                {key: optional_params[key] for key in AZURE_TEXT_MODERATION_PARAM_KEYS if key in optional_params}
+            )
         azure_content_safety_guardrail = AzureContentSafetyTextModerationGuardrail(
             guardrail_name=guardrail_name,
             **{
-                **litellm_params.model_dump(exclude_none=True),
+                **litellm_params_dict,
                 "api_key": litellm_params.api_key,
                 "api_base": litellm_params.api_base,
                 "default_on": litellm_params.default_on,

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -148,10 +148,17 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
 
     def check_severity_threshold(self, response: "AzureTextModerationGuardrailResponse") -> Literal[True]:
         """
+        - Reject blocklist matches
         - Check if threshold set by category
         - Check if general severity threshold set
         - If both none, use default_severity_threshold
         """
+
+        if response["blocklistsMatch"]:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "Azure Content Safety Guardrail: Blocklist match detected"},
+            )
 
         if self.severity_threshold_by_category:
             for category in response["categoriesAnalysis"]:

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -135,6 +135,16 @@ class SupportedGuardrailIntegrations(Enum):
     STRAIKER = "straiker"
 
 
+AZURE_TEXT_MODERATION_PARAM_KEYS = (
+    "categories",
+    "severity_threshold",
+    "severity_threshold_by_category",
+    "blocklistNames",
+    "haltOnBlocklistHit",
+    "outputType",
+)
+
+
 class Role(Enum):
     SYSTEM = "system"
     ASSISTANT = "assistant"
@@ -988,6 +998,22 @@ class LitellmParams(
             return float(v)
         except (TypeError, ValueError) as e:
             raise ValueError(f"timeout must be numeric, got {v!r}") from e
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_azure_text_moderation_params(cls, data):
+        if not isinstance(data, dict):
+            return data
+        if data.get("guardrail") != SupportedGuardrailIntegrations.AZURE_TEXT_MODERATIONS.value:
+            return data
+
+        optional_params = dict(data.get("optional_params") or {})
+        for key in AZURE_TEXT_MODERATION_PARAM_KEYS:
+            if key in data:
+                optional_params[key] = data.pop(key)
+        if optional_params:
+            data["optional_params"] = optional_params
+        return data
 
     def __init__(self, **kwargs):
         default_on = kwargs.pop("default_on", None)

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py
@@ -198,6 +198,55 @@ async def test_azure_text_moderation_violation_in_chunk():
 
 
 @pytest.mark.asyncio
+async def test_azure_text_moderation_blocklist_match_is_rejected():
+    azure_text_moderation_guardrail = AzureContentSafetyTextModerationGuardrail(
+        guardrail_name="azure_text_moderation",
+        api_key="azure_text_moderation_api_key",
+        api_base="azure_text_moderation_api_base",
+        blocklistNames=["blocked-terms"],
+        haltOnBlocklistHit=True,
+    )
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "blocklistsMatch": [
+            {
+                "blocklistName": "blocked-terms",
+                "blocklistItemId": "item-1",
+                "blocklistItemText": "blocked phrase",
+            }
+        ],
+        "categoriesAnalysis": [],
+    }
+
+    with patch.object(
+        azure_text_moderation_guardrail.async_handler,
+        "post",
+        return_value=mock_response,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await azure_text_moderation_guardrail.async_pre_call_hook(
+                user_api_key_dict=UserAPIKeyAuth(
+                    api_key="azure_text_moderation_api_key"
+                ),
+                cache=None,
+                data={
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "contains a blocked phrase",
+                        }
+                    ]
+                },
+                call_type="completion",
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == {
+        "error": "Azure Content Safety Guardrail: Blocklist match detected"
+    }
+
+
+@pytest.mark.asyncio
 async def test_azure_text_moderation_guardrail_post_call_success_hook():
 
     azure_text_moderation_guardrail = AzureContentSafetyTextModerationGuardrail(

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation_config.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation_config.py
@@ -1,0 +1,29 @@
+from litellm.proxy.guardrails.guardrail_hooks.azure import initialize_guardrail
+from litellm.proxy.guardrails.guardrail_hooks.azure.text_moderation import (
+    AzureContentSafetyTextModerationGuardrail,
+)
+from litellm.types.guardrails import LitellmParams
+
+
+def test_azure_text_moderation_initialize_forwards_provider_params():
+    litellm_params = LitellmParams(
+        guardrail="azure/text_moderations",
+        mode=["pre_call", "post_call"],
+        api_key="azure_text_moderation_api_key",
+        api_base="azure_text_moderation_api_base",
+        severity_threshold=2,
+        categories=["Hate", "Sexual"],
+        haltOnBlocklistHit=True,
+        outputType="EightSeverityLevels",
+    )
+
+    guardrail = initialize_guardrail(
+        litellm_params=litellm_params,
+        guardrail={"guardrail_name": "azure_text_moderation"},
+    )
+
+    assert isinstance(guardrail, AzureContentSafetyTextModerationGuardrail)
+    assert guardrail.severity_threshold == 2
+    assert guardrail.optional_params_request_body["categories"] == ["Hate", "Sexual"]
+    assert guardrail.optional_params_request_body["haltOnBlocklistHit"] is True
+    assert guardrail.optional_params_request_body["outputType"] == "EightSeverityLevels"

--- a/tests/test_litellm/types/test_guardrails_case_normalization.py
+++ b/tests/test_litellm/types/test_guardrails_case_normalization.py
@@ -92,6 +92,27 @@ class TestLitellmParamsCaseNormalization:
             assert params.on_disallowed_action in ["block", "rewrite"]
             assert params.on_disallowed_action.islower()
 
+    def test_azure_text_moderation_provider_params_validate(self):
+        """Azure text moderation accepts Azure-specific top-level config fields."""
+        params = LitellmParams(
+            guardrail="azure/text_moderations",
+            mode=["pre_call", "post_call"],
+            api_key="test-key",
+            api_base="https://example.com",
+            severity_threshold=2,
+            categories=["Hate", "Sexual", "SelfHarm", "Violence"],
+        )
+
+        assert params.categories is None
+        assert params.severity_threshold is None
+        assert params.optional_params.categories == [
+            "Hate",
+            "Sexual",
+            "SelfHarm",
+            "Violence",
+        ]
+        assert params.optional_params.severity_threshold == 2
+
 
 class TestSensitiveDataRoutingValidation:
     """on_sensitive_data='route' requires a target model to be set"""


### PR DESCRIPTION
## Relevant issues

Fixes #32061

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The bug happens during proxy guardrail config validation.

The issue config uses Azure text moderation fields at the top level:

- `severity_threshold: 2`
- `categories: ["Hate", "Sexual", "SelfHarm", "Violence"]`

Before this fix, `LitellmParams` interpreted those fields as generic content-filter fields and raised Pydantic validation errors.

After this fix, the same config validates and preserves the Azure values in `optional_params`.

Proof command run locally:

`uv run python -c "from litellm.types.guardrails import LitellmParams; p=LitellmParams(guardrail='azure/text_moderations', mode=['pre_call','post_call'], api_key='x', api_base='https://example.com', severity_threshold=2, categories=['Hate','Sexual','SelfHarm','Violence'], default_on=False); print(p.optional_params.categories, p.optional_params.severity_threshold)"`

Output:

`['Hate', 'Sexual', 'SelfHarm', 'Violence'] 2`

## Type

Bug fix

## Changes

- Normalize Azure text moderation provider-specific config fields into `optional_params` before generic guardrail validation.
- Forward Azure text moderation optional params into the Azure text moderation guardrail initializer.
- Reject non-empty Azure `blocklistsMatch` responses before evaluating category severity thresholds.
- Add regression coverage for validation, initializer forwarding, and blocklist enforcement.

## Tests

`uv run --no-sync pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation.py tests/test_litellm/proxy/guardrails/guardrail_hooks/azure/test_azure_text_moderation_config.py tests/test_litellm/types/test_guardrails_case_normalization.py::TestLitellmParamsCaseNormalization::test_azure_text_moderation_provider_params_validate -q`

Result:

`13 passed, 1 warning`