### PR TITLE
fix(mcp): apply outbound concurrency limit to OBO tool calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3810,17 +3810,21 @@ class MCPServerManager:
             # OBO: the exchanged token may have been revoked/rotated upstream since it was cached, so
             # an upstream 401 gets one re-mint + retry. Gated to this mode; all others keep the plain
             # single call below.
-            tool_call_coro = self._obo_call_tool_with_retry(
-                client=client,
-                call_tool_params=call_tool_params,
-                host_progress_callback=host_progress_callback,
-                mcp_server=mcp_server,
-                server_auth_header=server_auth_header,
-                extra_headers=extra_headers,
-                stdio_env=stdio_env,
-                subject_token=subject_token,
-                user_api_key_auth=user_api_key_auth,
-            )
+            async def _obo_call_tool_limited():
+                async with self._limit_outbound_concurrency(mcp_server):
+                    return await self._obo_call_tool_with_retry(
+                        client=client,
+                        call_tool_params=call_tool_params,
+                        host_progress_callback=host_progress_callback,
+                        mcp_server=mcp_server,
+                        server_auth_header=server_auth_header,
+                        extra_headers=extra_headers,
+                        stdio_env=stdio_env,
+                        subject_token=subject_token,
+                        user_api_key_auth=user_api_key_auth,
+                    )
+
+            tool_call_coro = _obo_call_tool_limited()
         else:
 
             async def _call_tool_via_client(client, params):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6070,6 +6070,83 @@ class TestOBOCallToolRetry:
         assert first.attempts == 1 and retry.attempts == 1
 
 
+class TestOBOConcurrencyLimit:
+    """OBO (token_exchange) tool calls must honor the server's max_concurrent_requests.
+
+    Regression: the token_exchange dispatch built its coroutine outside
+    _limit_outbound_concurrency, so OBO calls skipped the per-server semaphore the
+    non-OBO path enforces and a caller could exceed the admin-configured cap.
+    """
+
+    @pytest.mark.asyncio
+    async def test_obo_dispatch_respects_max_concurrent_requests(self):
+        max_concurrent = 2
+        overflow = 3
+        server = MCPServer(
+            server_id="obo-concurrency",
+            name="obo",
+            url="https://upstream.example/mcp",
+            transport=MCPTransport.sse,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+            max_concurrent_requests=max_concurrent,
+        )
+
+        release = asyncio.Event()
+        inflight = {"current": 0, "peak": 0}
+
+        class _ConcurrencyRecordingClient:
+            async def call_tool(self, params, host_progress_callback=None, raise_on_error=False):
+                inflight["current"] += 1
+                inflight["peak"] = max(inflight["peak"], inflight["current"])
+                try:
+                    await release.wait()
+                finally:
+                    inflight["current"] -= 1
+                return CallToolResult(content=[], isError=False)
+
+        manager = MCPServerManager()
+        manager._create_mcp_client = AsyncMock(return_value=_ConcurrencyRecordingClient())
+
+        async def _dispatch():
+            return await manager._call_regular_mcp_tool(
+                mcp_server=server,
+                original_tool_name="do_thing",
+                arguments={},
+                tasks=[],
+                mcp_auth_header=None,
+                mcp_server_auth_headers=None,
+                oauth2_headers={"Authorization": "Bearer subject-jwt"},
+                raw_headers=None,
+                proxy_logging_obj=None,
+            )
+
+        callers = [asyncio.create_task(_dispatch()) for _ in range(max_concurrent + overflow)]
+
+        stable = 0
+        previous = -1
+        for _ in range(1000):
+            await asyncio.sleep(0)
+            current = inflight["current"]
+            if current == previous:
+                stable += 1
+                if current > 0 and stable >= 10:
+                    break
+            else:
+                stable = 0
+                previous = current
+
+        peak_while_blocked = inflight["peak"]
+        release.set()
+        results = await asyncio.gather(*callers)
+
+        assert peak_while_blocked == max_concurrent
+        assert inflight["current"] == 0
+        assert all(result.isError is False for result in results)
+
+
 class TestOBOEndpointDiscovery:
     """An oauth2_token_exchange server with no configured token endpoint discovers it (RFC 9728 ->
     RFC 8414) like the oauth2 flow does; an explicitly configured endpoint skips discovery."""


### PR DESCRIPTION
## Relevant issues

Stacked on #31762 (`litellm_mcp_v2_obo_endpoint_discovery`), which is where the OBO token-exchange tool-call path and the per-server `_limit_outbound_concurrency` limiter were introduced. #31983 stacks on the same base, so this fix flows up to it once it syncs with #31762

## Linear ticket

N/A (found during review of the OBO stack)

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Root cause: in `_call_regular_mcp_tool` the `oauth2_token_exchange` (OBO) branch built its coroutine by calling `_obo_call_tool_with_retry` directly, outside the `_limit_outbound_concurrency(mcp_server)` context manager that the regular branch wraps its call in. OBO tool calls, and the on-401 re-mint retry (a second upstream `call_tool`), therefore never acquired the per-server `max_concurrent_requests` semaphore, so a caller with access to an OBO MCP server could run unlimited concurrent tool calls against it regardless of the admin-configured cap

Reproduced against a live proxy on `localhost:4011` backed by real Postgres, a real RFC 8693 token-exchange round-trip to a local IdP, and a real upstream MCP server (streamable-http). The upstream records how many `call_tool` invocations overlap. The MCP server is configured with `auth_type: oauth2_token_exchange` and `max_concurrent_requests: 2`; the proxy key travels in `x-litellm-api-key` so `Authorization` carries the OBO subject token. The same subject token is reused across the batch, so the exchanger single-flights to one exchange and all six calls pile onto the upstream semaphore

Command (identical before and after):

```bash
for i in $(seq 1 6); do
  curl -s http://localhost:4011/mcp-rest/tools/call \
    -H "x-litellm-api-key: sk-1234" \
    -H "Authorization: Bearer subject-jwt-caller-001" \
    -H "Content-Type: application/json" \
    -d "{\"server_id\":\"$SID\",\"name\":\"slow_echo\",\"arguments\":{\"text\":\"c$i\"}}" \
    -w "call $i -> http %{http_code} in %{time_total}s\n" &
done
wait
```

Before the fix, all six calls run at once (peak upstream concurrency 6, every call returns in ~1.6s) despite the limit of 2:

```
call 1 -> http 200 in 1.589s   call 2 -> http 200 in 1.601s
call 3 -> http 200 in 1.609s   call 4 -> http 200 in 1.613s
call 5 -> http 200 in 1.608s   call 6 -> http 200 in 1.610s

# upstream MCP inflight timeline (peak reaches 6)
ENTER inflight=1   ENTER inflight=2   ENTER inflight=3
ENTER inflight=4   ENTER inflight=5   ENTER inflight=6
EXIT  inflight=5 ... EXIT inflight=0
```

After the fix, the six calls serialize into three waves of two (peak upstream concurrency 2, completions bucket at ~1.6s / ~3.2s / ~4.7s):

```
call 1 -> http 200 in 1.612s   call 2 -> http 200 in 1.617s
call 3 -> http 200 in 3.154s   call 4 -> http 200 in 3.155s
call 5 -> http 200 in 4.694s   call 6 -> http 200 in 4.701s

# upstream MCP inflight timeline (peak stays at 2)
ENTER inflight=1   ENTER inflight=2   EXIT inflight=1   EXIT inflight=0
ENTER inflight=1   ENTER inflight=2   EXIT inflight=1   EXIT inflight=0
ENTER inflight=1   ENTER inflight=2   EXIT inflight=1   EXIT inflight=0
```

## Type

🐛 Bug Fix

## Changes

`_call_regular_mcp_tool` now wraps the OBO coroutine in `_limit_outbound_concurrency(mcp_server)`, mirroring the regular branch's `_call_tool_via_client`. One permit is held across the whole logical call: the initial `client.call_tool`, the on-401 credential invalidation and client re-mint, and the retry. The initial client build stays outside the semaphore, matching the regular path, so OBO and non-OBO tool calls now enforce `max_concurrent_requests` identically

Added `TestOBOConcurrencyLimit.test_obo_dispatch_respects_max_concurrent_requests`, which drives concurrent OBO dispatches through `_call_regular_mcp_tool` against a blocking client and asserts the observed peak equals the configured cap. It fails on the unfixed code (peak equals the number of callers) and passes with the fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted concurrency fix aligned with existing non-OBO behavior; regression test covers the OBO dispatch path with no auth or data-model changes.
> 
> **Overview**
> **OBO (`oauth2_token_exchange`) MCP tool calls now respect each server’s `max_concurrent_requests` cap**, matching the non-OBO dispatch path.
> 
> In `_call_regular_mcp_tool`, the token-exchange branch previously scheduled `_obo_call_tool_with_retry` without entering `_limit_outbound_concurrency`, so concurrent OBO calls could bypass the per-server semaphore. The fix wraps that work in `_obo_call_tool_limited()`, holding one permit for the full logical call (initial `call_tool`, optional 401 re-mint, and retry).
> 
> Adds `TestOBOConcurrencyLimit.test_obo_dispatch_respects_max_concurrent_requests` to assert peak in-flight calls equals the configured limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0534fde31945206130efef16210e2281e26ec2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->