### PR TITLE
fix(anthropic): bill streaming 1h prompt-cache writes at the 1h rate

### DIFF
--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -606,25 +606,13 @@ class ChunkProcessor:
                     usage_chunk_dict["prompt_tokens_details"],
                 )
 
-                incoming_breakdown = cast(
-                    Optional[CacheCreationTokenDetails],
-                    getattr(prompt_tokens_details, "cache_creation_token_details", None),
+                cache_creation_token_details = self._capture_cache_creation_token_details(
+                    prompt_tokens_details, cache_creation_token_details
                 )
-                if incoming_breakdown is not None:
-                    cache_creation_token_details = incoming_breakdown
 
-        if (
-            cache_creation_token_details is not None
-            and prompt_tokens_details is not None
-            and cast(
-                Optional[CacheCreationTokenDetails],
-                getattr(prompt_tokens_details, "cache_creation_token_details", None),
-            )
-            is None
-        ):
-            prompt_tokens_details = prompt_tokens_details.model_copy(
-                update={"cache_creation_token_details": cache_creation_token_details}
-            )
+        prompt_tokens_details = self._attach_cache_creation_token_details(
+            prompt_tokens_details, cache_creation_token_details
+        )
 
         completion_tokens = self._reset_anthropic_cursor_completion_tokens(
             chunks=chunks,
@@ -642,6 +630,34 @@ class ChunkProcessor:
             completion_tokens_details=completion_tokens_details,
             prompt_tokens_details=prompt_tokens_details,
         )
+
+    @staticmethod
+    def _capture_cache_creation_token_details(
+        prompt_tokens_details: Optional[PromptTokensDetailsWrapper],
+        current: Optional[CacheCreationTokenDetails],
+    ) -> Optional[CacheCreationTokenDetails]:
+        incoming = cast(
+            Optional[CacheCreationTokenDetails],
+            getattr(prompt_tokens_details, "cache_creation_token_details", None),
+        )
+        if incoming is not None:
+            return incoming
+        return current
+
+    @staticmethod
+    def _attach_cache_creation_token_details(
+        prompt_tokens_details: Optional[PromptTokensDetailsWrapper],
+        cache_creation_token_details: Optional[CacheCreationTokenDetails],
+    ) -> Optional[PromptTokensDetailsWrapper]:
+        if prompt_tokens_details is None or cache_creation_token_details is None:
+            return prompt_tokens_details
+        existing = cast(
+            Optional[CacheCreationTokenDetails],
+            getattr(prompt_tokens_details, "cache_creation_token_details", None),
+        )
+        if existing is not None:
+            return prompt_tokens_details
+        return prompt_tokens_details.model_copy(update={"cache_creation_token_details": cache_creation_token_details})
 
     @staticmethod
     def _reset_anthropic_cursor_completion_tokens(

--- a/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
+++ b/litellm/litellm_core_utils/streaming_chunk_builder_utils.py
@@ -7,6 +7,7 @@ from litellm.types.llms.openai import (
     ChatCompletionAudioDelta,
 )
 from litellm.types.utils import (
+    CacheCreationTokenDetails,
     ChatCompletionAudioResponse,
     ChatCompletionMessageToolCall,
     Choices,
@@ -541,6 +542,12 @@ class ChunkProcessor:
         web_search_requests: Optional[int] = None
         completion_tokens_details: Optional[CompletionTokensDetails] = None
         prompt_tokens_details: Optional[PromptTokensDetailsWrapper] = None
+        # Anthropic emits the cache-creation TTL breakdown (5m/1h split) only on
+        # the `message_start` event; the later `message_delta` carries the flat
+        # cache-creation count but drops the nested breakdown. prompt_tokens_details
+        # is last-wins, so without preserving this separately the 1h breakdown is
+        # lost and 1h cache writes get billed at the 5m rate.
+        cache_creation_token_details: Optional[CacheCreationTokenDetails] = None
         for chunk in chunks:
             usage_chunk: Optional[Usage] = None
             if "usage" in chunk:
@@ -594,7 +601,30 @@ class ChunkProcessor:
                         "web_search_requests",
                     )
 
-                prompt_tokens_details = usage_chunk_dict["prompt_tokens_details"]
+                prompt_tokens_details = cast(
+                    Optional[PromptTokensDetailsWrapper],
+                    usage_chunk_dict["prompt_tokens_details"],
+                )
+
+                incoming_breakdown = cast(
+                    Optional[CacheCreationTokenDetails],
+                    getattr(prompt_tokens_details, "cache_creation_token_details", None),
+                )
+                if incoming_breakdown is not None:
+                    cache_creation_token_details = incoming_breakdown
+
+        if (
+            cache_creation_token_details is not None
+            and prompt_tokens_details is not None
+            and cast(
+                Optional[CacheCreationTokenDetails],
+                getattr(prompt_tokens_details, "cache_creation_token_details", None),
+            )
+            is None
+        ):
+            prompt_tokens_details = prompt_tokens_details.model_copy(
+                update={"cache_creation_token_details": cache_creation_token_details}
+            )
 
         completion_tokens = self._reset_anthropic_cursor_completion_tokens(
             chunks=chunks,

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -325,6 +325,93 @@ def test_cache_read_input_tokens_retained():
     assert usage.cache_read_input_tokens == 11775
     assert usage.prompt_tokens_details.cached_tokens == 11775
 
+
+def test_streaming_preserves_anthropic_1hr_cache_creation_breakdown():
+    """
+    Anthropic emits the cache-creation TTL breakdown (ephemeral 5m/1h split) only
+    on the `message_start` SSE event; the later `message_delta` carries the flat
+    cache-creation count but drops the nested `cache_creation` object. Because
+    prompt_tokens_details is aggregated last-wins, the breakdown used to be
+    clobbered by message_delta, leaving cost calc with no TTL split. It then fell
+    back to the 5-minute write rate and undercounted 1-hour cache writes by ~37.5%.
+
+    Reproduces the trace: input=3, cache_creation=50 (all 1h), cache_read=8728.
+    Correct cache-write cost is 50 * 6e-06 (1h) = 0.0003, not 50 * 3.75e-06 = 0.0001875.
+    """
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+    from litellm.llms.anthropic.cost_calculation import cost_per_token
+
+    config = AnthropicConfig()
+    message_start_usage = config.calculate_usage(
+        usage_object={
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 8728,
+            "output_tokens": 1,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 50,
+            },
+        },
+        reasoning_content=None,
+    )
+    message_delta_usage = config.calculate_usage(
+        usage_object={
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 8728,
+            "output_tokens": 31,
+        },
+        reasoning_content=None,
+    )
+    # Sanity: the delta event genuinely lacks the breakdown - this is the input
+    # condition that used to defeat cost calc.
+    assert (
+        getattr(message_delta_usage.prompt_tokens_details, "cache_creation_token_details", None)
+        is None
+    )
+
+    def _usage_chunk(usage, finish_reason):
+        return ModelResponseStream(
+            id="chatcmpl-1hr-cache",
+            created=1745513206,
+            model="claude-sonnet-4-6",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=finish_reason,
+                    index=0,
+                    delta=Delta(content="" if finish_reason is None else None),
+                )
+            ],
+            stream_options={"include_usage": True},
+            usage=usage,
+        )
+
+    chunks = [
+        _usage_chunk(message_start_usage, None),
+        _usage_chunk(message_delta_usage, "stop"),
+    ]
+    usage = ChunkProcessor(chunks=chunks).calculate_usage(
+        chunks=chunks, model="claude-sonnet-4-6", completion_output="hi"
+    )
+
+    breakdown = getattr(usage.prompt_tokens_details, "cache_creation_token_details", None)
+    assert breakdown is not None, "1h/5m cache-creation breakdown lost during aggregation"
+    assert breakdown.ephemeral_1h_input_tokens == 50
+    assert breakdown.ephemeral_5m_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 50
+    assert usage.cache_read_input_tokens == 8728
+
+    prompt_cost, _ = cost_per_token(model="claude-sonnet-4-6", usage=usage)
+    # text 3*3e-06 + cache_read 8728*3e-07 + cache_write 50*6e-06 (1h rate)
+    expected = 3 * 3e-06 + 8728 * 3e-07 + 50 * 6e-06
+    assert prompt_cost == pytest.approx(expected)
+    # Guard against the regression: 5m-rate fallback would shave the write cost.
+    buggy = 3 * 3e-06 + 8728 * 3e-07 + 50 * 3.75e-06
+    assert prompt_cost != pytest.approx(buggy)
+
+
 def test_cache_read_input_tokens_retained_genericstreamingchunk():
     chunk1 = GenericStreamingChunk(
         text="Test1",

--- a/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_chunk_builder_utils.py
@@ -412,6 +412,72 @@ def test_streaming_preserves_anthropic_1hr_cache_creation_breakdown():
     assert prompt_cost != pytest.approx(buggy)
 
 
+def test_streaming_keeps_cache_creation_breakdown_from_final_chunk():
+    """When the final usage chunk itself carries the cache-creation breakdown,
+    aggregation must keep that breakdown instead of re-attaching a stale one
+    captured from an earlier chunk."""
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    config = AnthropicConfig()
+    message_start_usage = config.calculate_usage(
+        usage_object={
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 7,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 1,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 7,
+                "ephemeral_1h_input_tokens": 0,
+            },
+        },
+        reasoning_content=None,
+    )
+    message_delta_usage = config.calculate_usage(
+        usage_object={
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 50,
+            "cache_read_input_tokens": 0,
+            "output_tokens": 31,
+            "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 50,
+            },
+        },
+        reasoning_content=None,
+    )
+
+    def _usage_chunk(usage, finish_reason):
+        return ModelResponseStream(
+            id="chatcmpl-final-breakdown",
+            created=1745513206,
+            model="claude-sonnet-4-6",
+            object="chat.completion.chunk",
+            choices=[
+                StreamingChoices(
+                    finish_reason=finish_reason,
+                    index=0,
+                    delta=Delta(content="" if finish_reason is None else None),
+                )
+            ],
+            stream_options={"include_usage": True},
+            usage=usage,
+        )
+
+    chunks = [
+        _usage_chunk(message_start_usage, None),
+        _usage_chunk(message_delta_usage, "stop"),
+    ]
+    usage = ChunkProcessor(chunks=chunks).calculate_usage(
+        chunks=chunks, model="claude-sonnet-4-6", completion_output="hi"
+    )
+
+    breakdown = getattr(usage.prompt_tokens_details, "cache_creation_token_details", None)
+    assert breakdown is not None
+    assert breakdown.ephemeral_1h_input_tokens == 50
+    assert breakdown.ephemeral_5m_input_tokens == 0
+    assert usage.cache_creation_input_tokens == 50
+
+
 def test_cache_read_input_tokens_retained_genericstreamingchunk():
     chunk1 = GenericStreamingChunk(
         text="Test1",


### PR DESCRIPTION
## Relevant issues

Copy of #31724 by @rich-warbo, moved to an internal `litellm_` branch so CircleCI can run on it. The commit preserves the original author's authorship; all credit to them

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

From the original PR: live streaming request through a local proxy against the real Anthropic API (claude-sonnet-4-6), writing a system block to the 1-hour ephemeral cache

Request:

    curl --location 'http://localhost:4000/v1/chat/completions' \
      --header 'Content-Type: application/json' \
      --header 'Authorization: Bearer sk-1234' \
      --data @body.json
    # body.json: stream=true, stream_options.include_usage=true, a >1024-token
    # system block with cache_control {"type":"ephemeral","ttl":"1h"}

Final streamed usage (note the preserved 1h breakdown):

    "usage": {
      "prompt_tokens": 4818,
      "completion_tokens": 47,
      "prompt_tokens_details": {
        "cached_tokens": 0,
        "text_tokens": 15,
        "cache_creation_tokens": 4803,
        "cache_creation_token_details": {
          "ephemeral_5m_input_tokens": 0,
          "ephemeral_1h_input_tokens": 4803
        }
      },
      "cache_creation_input_tokens": 4803,
      "cache_read_input_tokens": 0
    }

Computed cost (proxy detailed_debug log):

    response_cost: 0.029568

This matches the 1-hour write rate: cache creation 4803 * 6e-06 = 0.028818, plus input 15 * 3e-06 = 0.000045, plus output 47 * 1.5e-05 = 0.000705, total 0.029568. Before the fix the streaming aggregator dropped cache_creation_token_details, so the same write was billed at the 5-minute rate (4803 * 3.75e-06 = 0.01801125) for a total of 0.01876125, undercounting the cache-creation component by ~37.5%

## Type

🐛 Bug Fix

## Changes

Anthropic sends the cache-creation TTL breakdown (the ephemeral 5m/1h split, `usage.cache_creation`) only on the streaming `message_start` event; the later `message_delta` carries the flat `cache_creation_input_tokens` count but drops the nested object. `ChunkProcessor._calculate_usage_per_chunk` aggregates `prompt_tokens_details` last-wins, so `message_delta`'s details (with `cache_creation_token_details=None`) overwrote the breakdown captured from `message_start`. Cost calc then took the flat-rate branch of `calculate_cache_writing_cost` and billed 1-hour cache writes at the 5-minute rate, undercounting the cache-creation cost component by about 37.5% on streaming requests. Non-streaming was unaffected because its usage is parsed once from the full response body

This tracks `cache_creation_token_details` across chunks with the same non-null-wins semantics already used for the flat cache counts, then stitches it back onto the final `prompt_tokens_details` when the last chunk lacks it. The capture and stitch steps live in two small static helpers (`_capture_cache_creation_token_details`, `_attach_cache_creation_token_details`) so `_calculate_usage_per_chunk` stays within the strict C901 complexity budget enforced by the lint gate. A regression test feeds the real two-event Anthropic usage shapes through `calculate_usage` and asserts the 1h write rate is applied; it fails on the pre-fix code and passes after. A second test pins the other stitch branch: when the final chunk itself carries the breakdown, aggregation keeps it instead of re-attaching a stale earlier capture


---

> [!NOTE]
> **Medium Risk**
> Touches streaming usage aggregation and billing-related token metadata; scope is narrow helpers plus tests, but incorrect stitching could still misreport costs or usage on Anthropic streams.
> 
> **Overview**
> Fixes **under-billing of Anthropic streaming prompt-cache writes** when tokens use the **1-hour ephemeral TTL**. Anthropic only sends the 5m/1h `cache_creation_token_details` on `message_start`; the final `message_delta` still has flat cache counts but drops that nested breakdown. `ChunkProcessor._calculate_usage_per_chunk` was taking **last-wins** `prompt_tokens_details`, so the delta chunk wiped the TTL split and cost logic fell back to the **5-minute write rate** (~37.5% low on 1h writes).
> 
> The aggregator now **captures** `cache_creation_token_details` across chunks (first non-null wins) and **re-attaches** it to the final `prompt_tokens_details` when the last chunk lacks it, without overwriting a breakdown already present on the final chunk. Logic lives in `_capture_cache_creation_token_details` and `_attach_cache_creation_token_details`. Regression tests cover the message_start→delta case (including `cost_per_token`) and the case where the final chunk carries the authoritative breakdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8e226577d973edde7233a20716c3c5d1f75846f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>