### PR TITLE
fix(ci): stop ui_unit_tests vitest onTaskUpdate RPC timeout flake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2629,7 +2629,7 @@ jobs:
             cd ui/litellm-dashboard
 
             CI=true npm run test -- --run \
-              --pool forks --poolOptions.forks.maxForks=8
+              --pool forks --poolOptions.forks.maxForks=6
 
   e2e_ui_testing:
     docker:

--- a/ui/litellm-dashboard/vitest.config.ts
+++ b/ui/litellm-dashboard/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     globals: true,
     css: true, // lets you import CSS/modules without extra mocks
     testTimeout: 30000,
+    teardownTimeout: 60000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a CI-reliability change with no runtime behavior, so a live-proxy curl doesn't apply. The evidence is the failing job itself: the `ui_unit_tests` run reported every test passing yet still exited 1

```
Test Files  396 passed (396)
     Tests  4046 passed (4046)
    Errors  1 error

⎯⎯ Unhandled Error ⎯⎯
Error: [vitest-worker]: Timeout calling "onTaskUpdate"
```

Confirming the fix means watching `ui_unit_tests` stay green across several runs on this branch, since the failure is load-dependent rather than deterministic

## Type

🐛 Bug Fix

## Changes

The `ui_unit_tests` job runs vitest with `--poolOptions.forks.maxForks=8` on a `resource_class: xlarge` container, which has 8 vCPUs. One worker fork per vCPU leaves no core for the main vitest process that services worker RPCs. Under full CPU saturation the coordinator misses the `onTaskUpdate` ack, vitest raises `Timeout calling "onTaskUpdate"` as an unhandled error, and the job exits 1 even though every test passed. Because whether the ack lands before the timeout depends on scheduling luck, the job fails intermittently rather than every time

This lowers `maxForks` to 6 so the coordinator, jsdom, and the OS keep two cores, and raises `teardownTimeout` to 60s in `ui/litellm-dashboard/vitest.config.ts` for extra slack on heavy runs. Together they remove the CPU starvation that caused the missed ack and widen the window if a run still spikes