### PR TITLE
feat(helm): add migration-job-scoped envVars and extraEnvVars

### DIFF
--- a/deploy/charts/litellm-helm/Chart.yaml
+++ b/deploy/charts/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/litellm-helm/README.md
+++ b/deploy/charts/litellm-helm/README.md
@@ -166,6 +166,8 @@ The migration job supports both ArgoCD and Helm hooks to ensure database migrati
 | `migrationJob.ttlSecondsAfterFinished` | TTL for completed migration jobs                                                                                     | `120`   |
 | `migrationJob.annotations`             | Additional annotations for the migration job pod                                                                     | `{}`    |
 | `migrationJob.extraContainers`         | Additional containers to run alongside the migration job                                                             | `[]`    |
+| `migrationJob.envVars`                 | Environment variables (map of key-value pairs) for the migration job only; override the shared `envVars`/`extraEnvVars` under last-wins semantics | `{}`    |
+| `migrationJob.extraEnvVars`            | Environment variables (list of k8s env vars, supports `valueFrom`) for the migration job only; e.g. point the schema migration at a higher-privilege DB role | `[]`    |
 | `migrationJob.hooks.argocd.enabled`    | Enable ArgoCD hooks for the migration job (uses PreSync hook with BeforeHookCreation delete policy)                  | `true`  |
 | `migrationJob.hooks.helm.enabled`      | Enable Helm hooks for the migration job (uses pre-install,pre-upgrade hooks with before-hook-creation delete policy) | `false` |
 | `migrationJob.hooks.helm.weight`       | Helm hook execution order (lower weights executed first). Optional - defaults to "1" if not specified.               | N/A     |

--- a/deploy/charts/litellm-helm/templates/migrations-job.yaml
+++ b/deploy/charts/litellm-helm/templates/migrations-job.yaml
@@ -85,6 +85,15 @@ spec:
             {{- with .Values.extraEnvVars }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- if .Values.migrationJob.envVars }}
+            {{- range $key, $val := .Values.migrationJob.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.migrationJob.extraEnvVars }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: DISABLE_SCHEMA_UPDATE
               value: "false" # always run the migration from the Helm PreSync hook, override the value set
           {{- with .Values.volumeMounts }}

--- a/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/migrations-job_tests.yaml
@@ -188,6 +188,81 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: pre-existing-sa
+  - it: should render migrationJob.envVars and migrationJob.extraEnvVars
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+        envVars:
+          MIGRATION_ONLY_VAR: "migration_value"
+        extraEnvVars:
+          - name: DATABASE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: litellm-db-migrator
+                key: username
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MIGRATION_ONLY_VAR
+            value: "migration_value"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: litellm-db-migrator
+                key: username
+
+  - it: should render migrationJob env after shared env so migration overrides win
+    template: migrations-job.yaml
+    set:
+      db:
+        useExisting: true
+        endpoint: "shared-db"
+        database: "litellm"
+        url: "postgresql://app:pass@shared-db:5432/litellm"
+        secret:
+          name: "app-secret"
+          usernameKey: "username"
+          passwordKey: "password"
+      extraEnvVars:
+        - name: DATABASE_URL
+          value: "postgresql://app:pass@shared-db:5432/litellm"
+      migrationJob:
+        enabled: true
+        extraEnvVars:
+          - name: DATABASE_URL
+            value: "postgresql://migrator:pass@shared-db:5432/litellm"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].name
+          value: DISABLE_SCHEMA_UPDATE
+      - equal:
+          path: spec.template.spec.containers[0].env[-2].name
+          value: DATABASE_URL
+      - equal:
+          path: spec.template.spec.containers[0].env[-2].value
+          value: "postgresql://migrator:pass@shared-db:5432/litellm"
+
+  - it: should not let migrationJob.extraEnvVars override DISABLE_SCHEMA_UPDATE
+    template: migrations-job.yaml
+    set:
+      migrationJob:
+        enabled: true
+        extraEnvVars:
+          - name: DISABLE_SCHEMA_UPDATE
+            value: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].name
+          value: DISABLE_SCHEMA_UPDATE
+      - equal:
+          path: spec.template.spec.containers[0].env[-1].value
+          value: "false"
+
   - it: should work with extraInitContainers
     template: migrations-job.yaml
     set:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -357,6 +357,30 @@ migrationJob:
   extraContainers: []
   extraInitContainers: []
 
+  # Environment variables for the migration Job only, as a map of key-value
+  # pairs. Rendered after the shared envVars/extraEnvVars, so entries here
+  # override them (Kubernetes uses the last value for a duplicate env name).
+  envVars: {}
+
+  # Environment variables for the migration Job only, as a list of Kubernetes
+  # env vars (supports valueFrom, e.g. secretKeyRef). Also rendered after the
+  # shared envVars/extraEnvVars, so entries here override them under the same
+  # last-wins semantics. Use this to run the schema migration as a
+  # higher-privilege database role while the proxy Deployment keeps a
+  # least-privilege user:
+  # extraEnvVars:
+  #   - name: DATABASE_USERNAME
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: litellm-db-migrator
+  #         key: username
+  #   - name: DATABASE_PASSWORD
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: litellm-db-migrator
+  #         key: password
+  extraEnvVars: []
+
   # Hook configuration
   hooks:
     argocd:


### PR DESCRIPTION
The migrations Job reused the Deployment's shared envVars/extraEnvVars, so it always connected to the database with the same role as the proxy. That prevents least-privilege setups where only a dedicated migrator role may perform schema changes while the proxy runs as an app user.

Add migrationJob.envVars (map) and migrationJob.extraEnvVars (list, supports valueFrom/secretKeyRef). Both render after the shared envVars/extraEnvVars and before the Job's hardcoded DISABLE_SCHEMA_UPDATE, so they override the shared values under Kubernetes last-wins duplicate-env semantics while DISABLE_SCHEMA_UPDATE stays authoritative. Point DATABASE_USERNAME/DATABASE_PASSWORD/DATABASE_URL at the migrator secret via migrationJob.extraEnvVars to run migrations as the higher-privilege role.

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`helm template` of the migrations Job with a shared `extraEnvVars` DATABASE_URL (app user) and a migration-scoped override (migrator user). The migration-scoped value renders after the shared one, so it wins under Kubernetes last-wins duplicate-env semantics, and `DISABLE_SCHEMA_UPDATE` stays last:

```
$ helm template t deploy/charts/litellm-helm --show-only templates/migrations-job.yaml \
    --set db.useExisting=true --set db.deployStandalone=false \
    --set 'extraEnvVars[0].name=DATABASE_URL' --set 'extraEnvVars[0].value=postgresql://app@shared/litellm' \
    --set 'migrationJob.extraEnvVars[0].name=DATABASE_URL' --set 'migrationJob.extraEnvVars[0].value=postgresql://migrator@shared/litellm'

          env:
            - name: DATABASE_USERNAME
              valueFrom:
                secretKeyRef:
                  name: postgres
                  key: username
            ...
            - name: DATABASE_URL
              value: "postgresql://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@$(DATABASE_HOST)/$(DATABASE_NAME)"
            - name: DATABASE_URL
              value: postgresql://app@shared/litellm
            - name: DATABASE_URL
              value: postgresql://migrator@shared/litellm
            - name: DISABLE_SCHEMA_UPDATE
              value: "false"
```

Chart unit tests (`helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm`) pass, including three new cases covering the override ordering and the guarantee that a user-supplied `DISABLE_SCHEMA_UPDATE` cannot shadow the Job's own.

```
Test Suites: 11 passed, 11 total
Tests:       60 passed, 60 total
```

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🚄 Infrastructure

## Changes

Today the migrations Job reuses the Deployment's shared `envVars`/`extraEnvVars`, so it always connects to the database with the same role as the proxy. That blocks least-privilege setups where a managed database exposes a low-privilege app user for the proxy and a separate, higher-privilege migrator role that alone may perform schema changes; there was no way to hand the Job different credentials.

This adds `migrationJob.envVars` (a map of key-value pairs) and `migrationJob.extraEnvVars` (a list of Kubernetes env vars, so it supports `valueFrom`/`secretKeyRef`). Both render after the shared `envVars`/`extraEnvVars` and before the Job's hardcoded `DISABLE_SCHEMA_UPDATE`, so entries here override the shared values under Kubernetes last-wins duplicate-env semantics while `DISABLE_SCHEMA_UPDATE` stays authoritative and cannot be shadowed. To run migrations as the migrator role, point `DATABASE_USERNAME`/`DATABASE_PASSWORD`/`DATABASE_URL` at the migrator secret via `migrationJob.extraEnvVars` while the Deployment keeps the app user.

`migrationJob.envVars` stays a map to mirror the existing shared `envVars`; `migrationJob.extraEnvVars` is a list to mirror the existing shared `extraEnvVars` and to allow `valueFrom`. The chart minor version is bumped to 1.2.0, and README plus `values.yaml` document both new keys with a least-privilege example.