### PR TITLE
chore(ui): add no-console lint ratchet and strip console from prod builds

### DIFF
--- a/ui/litellm-dashboard/eslint-budgets.json
+++ b/ui/litellm-dashboard/eslint-budgets.json
@@ -1,6 +1,6 @@
 {
   "@typescript-eslint/no-explicit-any": { "max": 2040, "target": 1500 },
-  "no-console": { "max": 486, "target": 0 },
+  "no-console": { "max": 484, "target": 0 },
   "complexity": { "max": 140, "target": 80 },
   "max-depth": { "max": 70, "target": 30 }
 }

--- a/ui/litellm-dashboard/eslint-budgets.json
+++ b/ui/litellm-dashboard/eslint-budgets.json
@@ -1,5 +1,6 @@
 {
   "@typescript-eslint/no-explicit-any": { "max": 2040, "target": 1500 },
+  "no-console": { "max": 486, "target": 0 },
   "complexity": { "max": 140, "target": 80 },
   "max-depth": { "max": 70, "target": 30 }
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -2,5 +2,5 @@
   "@typescript-eslint/no-explicit-any": 1991,
   "complexity": 128,
   "max-depth": 59,
-  "no-console": 486
+  "no-console": 484
 }

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,6 @@
 {
   "@typescript-eslint/no-explicit-any": 1991,
   "complexity": 128,
-  "max-depth": 59
+  "max-depth": 59,
+  "no-console": 486
 }

--- a/ui/litellm-dashboard/eslint.config.mjs
+++ b/ui/litellm-dashboard/eslint.config.mjs
@@ -17,6 +17,7 @@ const eslintConfig = [
     rules: {
       "unused-imports/no-unused-imports": "error",
       "@typescript-eslint/no-explicit-any": "warn",
+      "no-console": ["warn", { allow: ["warn", "error"] }],
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-unused-expressions": "off",
       "@typescript-eslint/ban-ts-comment": "off",

--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -7,6 +7,9 @@ const __dirname = path.dirname(__filename);
 
 const nextConfig = {
   output: "export",
+  compiler: {
+    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
+  },
   // Required with output: "export" — default image optimizer runs only in server mode.
   // See https://nextjs.org/docs/messages/export-image-api
   images: {

--- a/ui/litellm-dashboard/next.config.mjs
+++ b/ui/litellm-dashboard/next.config.mjs
@@ -8,7 +8,7 @@ const __dirname = path.dirname(__filename);
 const nextConfig = {
   output: "export",
   compiler: {
-    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error"] } : false,
+    removeConsole: process.env.NODE_ENV === "production" ? { exclude: ["error", "warn"] } : false,
   },
   // Required with output: "export" — default image optimizer runs only in server mode.
   // See https://nextjs.org/docs/messages/export-image-api


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The prod-build strip is what the end user actually gets, so the proof is a real production build of the dashboard with the strip on versus off, counting `console.*` in the emitted bundle

```
cd ui/litellm-dashboard
NODE_ENV=production npm run build
grep -rho 'console\.log('   out/_next | wc -l
grep -rho 'console\.warn('  out/_next | wc -l
grep -rho 'console\.error(' out/_next | wc -l
```

| bundle `console.*` | strip on (this PR) | strip off |
| --- | --- | --- |
| `console.log` | 14 | 675 |
| `console.warn` | 85 | 85 |
| `console.error` | 906 | 906 |

App-code `console.log` drops from 675 to 14; the residual 14 come from `node_modules`, which the SWC transform intentionally never touches. `console.warn` and `console.error` are both preserved exactly (85 to 85, 906 to 906) because both are in the `exclude` list, so the prod strip and the lint `allow` list agree on which methods survive. A dev build (`npm run dev`) leaves everything in place since the transform is gated on `NODE_ENV=production`

The lint ratchet is enforced by the existing budget gate; `make pre-commit` and the CI `Check lint budgets` step both pass with `no-console: 484 | max: 484 | target: 0`, so any newly added `console.log` pushes the count past the max and fails CI

```
no-console: 484 | max: 484 | target: 0 | 0 of headroom
eslint-metrics.json is up to date.
```

## Type

🚄 Infrastructure

## Changes

This sets up a gradual ratchet to remove raw `console.*` calls from the dashboard, mirroring the existing `no-explicit-any` budget rather than inventing new machinery

The `no-console` eslint rule is added at `warn` severity with `allow: ["warn", "error"]`, so the 484 `console.log`/`debug`/`info` calls get tracked while the legitimate `console.error`/`console.warn` error reporting in catch blocks is left alone for now. The current count is grandfathered through `eslint-budgets.json` (`max: 484`, `target: 0`) and `eslint-metrics.json`, the same budget-plus-metrics path `no-explicit-any` already uses. No `eslint-suppressions.json` entry is needed because that baseline only holds error-level rules; a `warn` rule never fails the per-file lint, so the budget count and its drift check are what arm the ratchet. Follow-up PRs grind the max down toward zero, converting the remaining `console.error`/`console.warn` sites to `NotificationManager` or a small logger util rather than silently dropping observability

Independently of the slow source cleanup, `next.config.mjs` now strips console output from production builds through SWC `removeConsole` with `exclude: ["error", "warn"]`, gated on `NODE_ENV=production` so dev keeps full console output and the vitest suite (which reads `vitest.config.ts`, never `next.config.mjs`) is unaffected. The `exclude` list mirrors the lint `allow` list so the two agree on which methods survive; `console.warn` and `console.error` are preserved in prod, only `log`/`debug`/`info` are stripped. That gives an immediate production-hygiene net today regardless of how long the source ratchet takes
