### PR TITLE
fix(proxy): harden secret name validation for external secret manager integrations

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -111,6 +111,7 @@ from litellm.repositories.verification_token_repository import (
     VerificationTokenRepository,
 )
 from litellm.router import Router
+from litellm.secret_managers.base_secret_manager import raise_if_unsafe_secret_name
 from litellm.secret_managers.main import get_secret
 from litellm.types.proxy.management_endpoints.key_management_endpoints import (
     BulkUpdateKeyRequest,
@@ -6267,8 +6268,13 @@ def _validate_key_alias_format(key_alias: Optional[str]) -> None:
     """
     Validate the format of the key_alias.
 
-    Gated behind ``litellm.enable_key_alias_format_validation`` (default **False**).
-    When disabled, no validation is performed so existing workflows are not broken.
+    A baseline validation always runs, regardless of
+    ``litellm.enable_key_alias_format_validation``.
+
+    The remaining charset/length rules are gated behind
+    ``litellm.enable_key_alias_format_validation`` (default **False**). When disabled,
+    only the baseline validation above is performed, so existing workflows are not
+    broken.
 
     Rules (when enabled):
     - None is OK (no alias).
@@ -6276,10 +6282,20 @@ def _validate_key_alias_format(key_alias: Optional[str]) -> None:
     - start/end with alphanumeric
     - only allow a-zA-Z0-9_-/.@
     """
-    if not litellm.enable_key_alias_format_validation:
+    if key_alias is None:
         return
 
-    if key_alias is None:
+    try:
+        raise_if_unsafe_secret_name(key_alias)
+    except ValueError:
+        raise ProxyException(
+            message="Invalid key_alias",
+            type=ProxyErrorTypes.bad_request_error,
+            param="key_alias",
+            code=400,
+        )
+
+    if not litellm.enable_key_alias_format_validation:
         return
 
     if not _KEY_ALIAS_PATTERN.match(key_alias):

--- a/litellm/secret_managers/base_secret_manager.py
+++ b/litellm/secret_managers/base_secret_manager.py
@@ -1,9 +1,24 @@
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional, Union
 
 import httpx
 
 from litellm import verbose_logger
+
+_UNSAFE_SECRET_NAME_PATTERN = re.compile(r"(^|/)\.\.(/|$)|[\x00-\x1f\x7f-\x9f  ]")
+
+
+def raise_if_unsafe_secret_name(secret_name: str) -> None:
+    """
+    Validate a secret name before it is used by a secret manager integration.
+
+    Rejects ".." only as a path segment (bounded by "/" or the start/end of the
+    string, e.g. "../x", "x/..", or exactly ".."), not as a plain substring, so
+    names like "release-1.0..2" are not rejected.
+    """
+    if _UNSAFE_SECRET_NAME_PATTERN.search(secret_name):
+        raise ValueError(f"Invalid secret_name {secret_name!r}")
 
 
 class BaseSecretManager(ABC):

--- a/litellm/secret_managers/cyberark_secret_manager.py
+++ b/litellm/secret_managers/cyberark_secret_manager.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Union
 from urllib.parse import quote
 
 import httpx
+import yaml
 
 import litellm
 from litellm._logging import verbose_logger
@@ -15,7 +16,7 @@ from litellm.llms.custom_httpx.http_handler import (
 )
 from litellm.proxy._types import KeyManagementSystem
 
-from .base_secret_manager import BaseSecretManager
+from .base_secret_manager import BaseSecretManager, raise_if_unsafe_secret_name
 from .main import str_to_bool
 
 
@@ -125,8 +126,11 @@ class CyberArkSecretManager(BaseSecretManager):
         """
         # In production, we'd check if the variable exists first
         # For now, we'll attempt to create it and ignore if it already exists
+        raise_if_unsafe_secret_name(secret_name)
         policy_url = f"{self.conjur_addr}/policies/{self.conjur_account}/policy/root"
-        policy_yaml = f"- !variable {secret_name}\n"
+        # Use a real YAML serializer to build the scalar safely.
+        quoted_name = yaml.safe_dump(secret_name, default_style='"').strip()
+        policy_yaml = f"- !variable {quoted_name}\n"
 
         try:
             client = _get_httpx_client(params={"ssl_verify": self.ssl_verify})

--- a/litellm/secret_managers/hashicorp_secret_manager.py
+++ b/litellm/secret_managers/hashicorp_secret_manager.py
@@ -14,7 +14,7 @@ from litellm.llms.custom_httpx.http_handler import (
 )
 from litellm.proxy._types import KeyManagementSystem
 
-from .base_secret_manager import BaseSecretManager
+from .base_secret_manager import BaseSecretManager, raise_if_unsafe_secret_name
 
 
 class HashicorpSecretManager(BaseSecretManager):
@@ -220,6 +220,7 @@ class HashicorpSecretManager(BaseSecretManager):
         - With custom mount: http://127.0.0.1:8200/v1/kv/data/mykey
         - With path prefix: http://127.0.0.1:8200/v1/secret/data/myapp/mykey
         """
+        raise_if_unsafe_secret_name(secret_name)
         resolved_namespace = self._sanitize_path_component(namespace if namespace is not None else self.vault_namespace)
         resolved_mount = self._sanitize_path_component(mount_name if mount_name is not None else self.vault_mount_name)
         if resolved_mount is None:

--- a/tests/litellm_utils_tests/test_cyberark.py
+++ b/tests/litellm_utils_tests/test_cyberark.py
@@ -5,6 +5,7 @@ Integration test for CyberArk Conjur Secret Manager.
 import os
 import sys
 import pytest
+import yaml
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -40,6 +41,82 @@ def create_mock_response(status_code: int, text: str = ""):
         mock_response.raise_for_status.side_effect = error
 
     return mock_response
+
+
+@pytest.mark.asyncio
+async def test_cyberark_write_secret_rejects_yaml_injection():
+    """
+    Regression test: async_write_secret must reject a secret_name that is not
+    safe to embed in the Conjur policy body, before any HTTP call is made.
+    """
+    with patch("litellm.proxy.proxy_server.premium_user", True):
+        malicious_secret_name = "foo\n- !grant\n  role: !!admin\n  member: attacker"
+
+        mock_sync_client = MagicMock()
+        mock_async_client = AsyncMock()
+
+        with (
+            patch(
+                "litellm.secret_managers.cyberark_secret_manager._get_httpx_client",
+                return_value=mock_sync_client,
+            ),
+            patch(
+                "litellm.secret_managers.cyberark_secret_manager.get_async_httpx_client",
+                return_value=mock_async_client,
+            ),
+        ):
+            cyberark_manager = CyberArkSecretManager()
+
+            response = await cyberark_manager.async_write_secret(
+                secret_name=malicious_secret_name,
+                secret_value="sk-1234",
+            )
+
+            assert response["status"] == "error"
+            assert "Invalid secret_name" in response["message"]
+            # The malicious policy YAML must never reach the wire.
+            mock_sync_client.client.post.assert_not_called()
+            mock_async_client.post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "secret_name",
+    [
+        "foo: bar",
+        "foo # bar",
+        "plain-alias",
+        "team/user@example.com",
+    ],
+)
+def test_cyberark_ensure_variable_exists_escapes_yaml_metacharacters(secret_name):
+    """
+    Regression test: _ensure_variable_exists must escape secret_name (not just
+    denylist-check it) so the policy body always parses back to exactly one
+    '!variable' scalar node holding the untouched secret_name.
+    """
+    with patch("litellm.proxy.proxy_server.premium_user", True):
+        captured = {}
+
+        def _capture_post(url, headers=None, content=None):
+            captured["content"] = content
+            return create_mock_response(status_code=201, text="")
+
+        mock_sync_client = MagicMock()
+        mock_sync_client.client.post.side_effect = _capture_post
+
+        with patch(
+            "litellm.secret_managers.cyberark_secret_manager._get_httpx_client",
+            return_value=mock_sync_client,
+        ):
+            cyberark_manager = CyberArkSecretManager()
+            cyberark_manager._ensure_variable_exists(secret_name)
+
+        policy_yaml = captured["content"]
+        parsed = yaml.compose(policy_yaml)
+        assert len(parsed.value) == 1
+        node = parsed.value[0]
+        assert node.tag == "!variable"
+        assert node.value == secret_name
 
 
 @pytest.mark.asyncio

--- a/tests/litellm_utils_tests/test_hashicorp.py
+++ b/tests/litellm_utils_tests/test_hashicorp.py
@@ -409,6 +409,33 @@ def test_hashicorp_custom_mount_and_prefix(hashicorp_secret_manager):
         hashicorp_secret_manager.vault_namespace = original_namespace
 
 
+@pytest.mark.parametrize(
+    "malicious_secret_name",
+    [
+        "../../../other-app/creds",
+        "litellm/../../secret",
+        "foo\nbar",
+        "foo bar",
+        "foo bar",
+        "foo\x85bar",
+    ],
+)
+def test_hashicorp_get_url_rejects_path_traversal(monkeypatch, malicious_secret_name):
+    """
+    Regression test: get_url must reject an invalid secret_name instead of
+    building a URL from it.
+
+    Uses monkeypatch + a directly-constructed manager (not the shared
+    hashicorp_secret_manager fixture) so this runs in CI without real Vault
+    credentials configured; get_url performs no I/O.
+    """
+    monkeypatch.setenv("HCP_VAULT_TOKEN", "test-token-for-get-url-only")
+    manager = HashicorpSecretManager()
+
+    with pytest.raises(ValueError):
+        manager.get_url(malicious_secret_name)
+
+
 mock_old_vault_response = {
     "request_id": "80fafb6a-e96a-4c5b-29fa-ff505ac72201",
     "lease_id": "",

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -8969,7 +8969,7 @@ class TestValidateKeyAliasFormat:
         litellm.enable_key_alias_format_validation = False
 
     def test_validation_skipped_when_flag_disabled(self):
-        """When enable_key_alias_format_validation is False (default), no validation occurs."""
+        """When enable_key_alias_format_validation is False (default), no charset/length validation occurs."""
         from litellm.proxy.management_endpoints.key_management_endpoints import (
             _validate_key_alias_format,
         )
@@ -8979,6 +8979,33 @@ class TestValidateKeyAliasFormat:
         _validate_key_alias_format("")
         _validate_key_alias_format("!invalid!")
         _validate_key_alias_format("a" * 256)
+
+    @pytest.mark.parametrize(
+        "unsafe_alias",
+        [
+            "../../../other-app/creds",
+            "litellm/../../secret",
+            "foo\n- !grant\n  role: !!admin\n  member: attacker",
+            "foo\rbar",
+            "foo\x00bar",
+        ],
+    )
+    def test_validate_key_alias_format_rejects_traversal_and_control_chars_even_when_flag_disabled(
+        self, unsafe_alias
+    ):
+        """
+        Regression test: this check must reject an invalid key_alias unconditionally,
+        even when enable_key_alias_format_validation (the separate, opt-in charset
+        rule) is disabled.
+        """
+        from litellm.proxy.management_endpoints.key_management_endpoints import (
+            _validate_key_alias_format,
+        )
+
+        with pytest.raises(ProxyException) as exc:
+            _validate_key_alias_format(unsafe_alias)
+        assert str(exc.value.code) == "400"
+        assert "Invalid key_alias" in str(exc.value.message)
 
     def test_validate_key_alias_format_valid(self):
         from litellm.proxy.management_endpoints.key_management_endpoints import (

--- a/tests/test_litellm/secret_managers/test_base_secret_manager.py
+++ b/tests/test_litellm/secret_managers/test_base_secret_manager.py
@@ -1,0 +1,59 @@
+"""
+Test raise_if_unsafe_secret_name, the shared guard applied before secret_name
+reaches a secret manager backend.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
+
+from litellm.secret_managers.base_secret_manager import raise_if_unsafe_secret_name
+
+
+@pytest.mark.parametrize(
+    "secret_name",
+    [
+        "..",
+        "../../../other-app/creds",
+        "litellm/../../secret",
+        "foo/../bar",
+        "foo/..",
+        "../foo",
+        "foo\nbar",
+        "foo\rbar",
+        "foo\x00bar",
+        "foo\x7fbar",
+        "foo\x85bar",
+        "foo bar",
+        "foo bar",
+    ],
+)
+def test_raise_if_unsafe_secret_name_rejects_traversal_and_line_breaks(secret_name):
+    with pytest.raises(ValueError):
+        raise_if_unsafe_secret_name(secret_name)
+
+
+@pytest.mark.parametrize(
+    "secret_name",
+    [
+        "plain-alias",
+        "my-key-123",
+        "prod/my-service-key",
+        "team/user@example.com",
+        "foo: bar",
+        "foo # bar",
+        "foo?evil=1",
+        "foo#bar",
+        "a" * 500,
+        "release-1.0..2",
+        "my..key",
+        "..foo",
+        "foo..",
+        "v2.0..1-beta",
+    ],
+)
+def test_raise_if_unsafe_secret_name_allows_legitimate_aliases(secret_name):
+    raise_if_unsafe_secret_name(secret_name)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4201

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Final end-to-end verification against a live proxy (real Postgres, master key auth) on the current code, hitting `/key/generate` directly:

```
Rejected (HTTP 400, "Invalid key_alias"):
  ".."
  "../etc/creds"
  "litellm/../../secret"
  "foo/.."
  "foo\n- !grant\n  role: !!admin\n  member: attacker"
  "foo\rbar"
  "foo\x00bar"
  "foo bar"

Allowed (HTTP 200):
  "prod/my-service-key"
  "team/user@example.com"
  "release-1.0..2"
  "plain-alias"
```

Also re-verified directly against a live HashiCorp Vault dev server and a live CyberArk Conjur OSS server on the current code (not mocks):
- Vault: normal write/read round-trips correctly; `get_url` still rejects real traversal payloads; hierarchical and email-style aliases build the expected literal path, unchanged from before this PR.
- Conjur: confirmed the new quoted policy YAML is backward compatible with data written under the old unquoted format — created a variable and value using the pre-fix raw YAML, then confirmed the new code reads, recognizes, and rotates that pre-existing variable correctly.

Regression tests are mutation-tested (fail on the pre-fix code, pass on the fix) and cover:
- `HashicorpSecretManager.get_url` input validation (`tests/litellm_utils_tests/test_hashicorp.py`)
- `CyberArkSecretManager.async_write_secret` / `_ensure_variable_exists` input validation and safe serialization (`tests/litellm_utils_tests/test_cyberark.py`)
- `raise_if_unsafe_secret_name` directly (`tests/test_litellm/secret_managers/test_base_secret_manager.py`)
- `_validate_key_alias_format` unconditional validation, independent of the opt-in charset flag (`tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py`)

## Type

🐛 Bug Fix

## Changes

`key_alias` can become the secret name used by external secret manager integrations (HashiCorp Vault, CyberArk Conjur) when `store_virtual_keys` is enabled. This PR adds baseline validation of that value before it is used, both at the integration layer and at the `/key/generate`, `/key/update`, and `/key/regenerate` API boundary.

Specifically:
- Adds `raise_if_unsafe_secret_name` (`litellm/secret_managers/base_secret_manager.py`), a shared validation check. It rejects `..` only as a path segment (bounded by `/` or the start/end of the string), not as a plain substring, so version-like names such as `release-1.0..2` are not rejected.
- Applies it in `HashicorpSecretManager.get_url`, the single choke point for all Vault read/write/delete/rotate calls.
- Applies it in `CyberArkSecretManager._ensure_variable_exists`, and switches the policy body construction from raw string interpolation to a proper YAML serializer.
- Applies it in `_validate_key_alias_format` unconditionally, independent of the existing `litellm.enable_key_alias_format_validation` opt-in flag (which only ever gated a separate, cosmetic charset/length rule).

AWS Secrets Manager and Google Secret Manager were reviewed and don't need changes: AWS passes the secret name through a structured, serialized body field, and Google Secret Manager has no write path reachable from `key_alias`. Azure has no write-capable secret manager integration in this codebase.

## Known Limitations

`key_alias` values containing a `..` path segment (`../etc`, `foo/..`, or exactly `..`) or a control/line-break character are now rejected outright at `/key/generate`, `/key/update`, and `/key/regenerate`, regardless of whether a secret manager is configured. Previously only the background secret-manager sync could fail on such a value; now the whole request fails with a 400.
