### PR TITLE
(Security) - Prevent potential Anthropic key exposure through advisor tool client-side credential overrides

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -186,12 +186,15 @@ def _resolve_advisor_credentials(advisor_tool: dict) -> tuple[Optional[str], Opt
     ``api_key``: without one, ``AnthropicModelInfo.get_auth_header()`` falls
     back to the proxy's own Anthropic credentials, which would then be sent to
     the caller-chosen ``api_base``. A caller-supplied ``api_base`` is also
-    required to be https and SSRF-validated so it can't target a
-    private/internal/cloud-metadata address, mirroring
-    ``proxy.auth.auth_utils.check_complete_credentials``. https is required
-    because ``validate_url`` only rewrites the connection to a DNS-pinned IP
-    for http; for https with TLS verification on, it returns the URL
-    unchanged and relies on certificate validation to block DNS rebinding.
+    required to be https with TLS verification on, and SSRF-validated so it
+    can't target a private/internal/cloud-metadata address, mirroring
+    ``proxy.auth.auth_utils.check_complete_credentials``. https with TLS
+    verification is required because ``validate_url`` only rewrites the
+    connection to a DNS-pinned IP for http, or for https with
+    ``litellm.ssl_verify`` disabled; otherwise it returns the URL unchanged
+    and relies on certificate validation to block DNS rebinding, so this
+    closes the same gap without threading the pinned URL through the whole
+    ``anthropic_messages()`` call chain.
     """
     if not _allow_client_side_advisor_credentials():
         return None, None
@@ -208,6 +211,12 @@ def _resolve_advisor_credentials(advisor_tool: dict) -> tuple[Optional[str], Opt
         )
     if not api_base.startswith("https://"):
         raise ValueError(f"advisor tool definition sets 'api_base'={api_base!r}, which must use the https scheme.")
+    if getattr(litellm, "ssl_verify", True) is False:
+        raise ValueError(
+            "advisor tool definition sets 'api_base' but the proxy has TLS verification "
+            "disabled (litellm.ssl_verify=False), so a caller-supplied api_base can't be "
+            "safely validated against DNS rebinding."
+        )
     if getattr(litellm, "user_url_validation", True):
         validate_url(api_base)
     return api_key, api_base

--- a/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py
@@ -17,7 +17,9 @@ How it works:
 import uuid
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
+import litellm
 import litellm.constants as _c
+from litellm.litellm_core_utils.url_utils import validate_url
 from litellm.llms.anthropic.common_utils import strip_advisor_blocks_from_messages
 from litellm.types.llms.anthropic_messages.anthropic_response import (
     AnthropicMessagesResponse,
@@ -76,16 +78,7 @@ class AdvisorOrchestrationHandler(MessagesInterceptor):
             raise ValueError("advisor tool definition must include a 'model' field specifying the advisor model")
         _raw_max_uses = advisor_tool.get("max_uses")
         max_uses: int = ADVISOR_MAX_USES if _raw_max_uses is None else int(_raw_max_uses)
-        # Optional routing overrides for the advisor sub-call (e.g. proxy routing).
-        # If not set in the tool definition, litellm resolves from env vars.
-        # The advisor tool is caller-controlled; only honor a client-supplied
-        # api_base/api_key when the proxy has enabled clientside credentials,
-        # otherwise let litellm resolve from server config.
-        advisor_api_key: Optional[str] = None
-        advisor_api_base: Optional[str] = None
-        if _allow_client_side_advisor_credentials():
-            advisor_api_key = advisor_tool.get("api_key")
-            advisor_api_base = advisor_tool.get("api_base")
+        advisor_api_key, advisor_api_base = _resolve_advisor_credentials(advisor_tool)
 
         # Build the synthetic tool definition the provider will receive.
         synthetic_advisor_tool = _make_synthetic_advisor_tool()
@@ -184,6 +177,40 @@ def _allow_client_side_advisor_credentials() -> bool:
     except (ImportError, ModuleNotFoundError):
         return True
     return general_settings.get("allow_client_side_credentials") is True
+
+
+def _resolve_advisor_credentials(advisor_tool: dict) -> tuple[Optional[str], Optional[str]]:
+    """Resolve the (api_key, api_base) override for the advisor sub-call.
+
+    A caller-supplied ``api_base`` is only honored alongside a caller-supplied
+    ``api_key``: without one, ``AnthropicModelInfo.get_auth_header()`` falls
+    back to the proxy's own Anthropic credentials, which would then be sent to
+    the caller-chosen ``api_base``. A caller-supplied ``api_base`` is also
+    required to be https and SSRF-validated so it can't target a
+    private/internal/cloud-metadata address, mirroring
+    ``proxy.auth.auth_utils.check_complete_credentials``. https is required
+    because ``validate_url`` only rewrites the connection to a DNS-pinned IP
+    for http; for https with TLS verification on, it returns the URL
+    unchanged and relies on certificate validation to block DNS rebinding.
+    """
+    if not _allow_client_side_advisor_credentials():
+        return None, None
+    api_key: Optional[str] = advisor_tool.get("api_key")
+    api_base: Optional[str] = advisor_tool.get("api_base")
+    if api_base is None:
+        return api_key, None
+    if not api_key:
+        raise ValueError(
+            "advisor tool definition sets 'api_base' without 'api_key'. A "
+            "caller-supplied api_base is only honored alongside a "
+            "caller-supplied api_key, so the proxy's own credentials are "
+            "never sent to a caller-chosen destination."
+        )
+    if not api_base.startswith("https://"):
+        raise ValueError(f"advisor tool definition sets 'api_base'={api_base!r}, which must use the https scheme.")
+    if getattr(litellm, "user_url_validation", True):
+        validate_url(api_base)
+    return api_key, api_base
 
 
 def _make_synthetic_advisor_tool() -> Dict:

--- a/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
+++ b/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
@@ -558,9 +558,14 @@ async def _run_advisor_and_capture_subcall_kwargs():
             return advisor_advice_resp
         return final_resp
 
-    with patch(
-        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
-        side_effect=mock_call,
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._call_messages_handler",
+            side_effect=mock_call,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor.validate_url",
+        ),
     ):
         h = AdvisorOrchestrationHandler()
         await h.handle(
@@ -730,3 +735,168 @@ async def test_advisor_uses_tool_credentials_when_clientside_enabled():
         captured = await _run_advisor_and_capture_subcall_kwargs()
     assert captured["api_key"] == "sk-other"
     assert captured["api_base"] == "https://other.example"
+
+
+# ---------------------------------------------------------------------------
+# 14. _resolve_advisor_credentials: api_base is only honored alongside a
+#     caller-supplied api_key, and is SSRF-validated before use.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_advisor_credentials_returns_none_when_gate_closed():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=False,
+    ):
+        result = _resolve_advisor_credentials(ADVISOR_TOOL_WITH_CREDS)
+    assert result == (None, None)
+
+
+def test_resolve_advisor_credentials_allows_api_key_without_api_base():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {**ADVISOR_TOOL, "api_key": "sk-other"}
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+            return_value=True,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor.validate_url",
+            side_effect=AssertionError("validate_url must not run without an api_base"),
+        ),
+    ):
+        result = _resolve_advisor_credentials(tool)
+    assert result == ("sk-other", None)
+
+
+def test_resolve_advisor_credentials_rejects_api_base_without_api_key():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {**ADVISOR_TOOL, "api_base": "https://other.example"}
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=True,
+    ):
+        with pytest.raises(ValueError, match="api_base"):
+            _resolve_advisor_credentials(tool)
+
+
+def test_resolve_advisor_credentials_validates_api_base_before_use():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+            return_value=True,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor.validate_url"
+        ) as mock_validate,
+    ):
+        result = _resolve_advisor_credentials(ADVISOR_TOOL_WITH_CREDS)
+    mock_validate.assert_called_once_with("https://other.example")
+    assert result == ("sk-other", "https://other.example")
+
+
+def test_resolve_advisor_credentials_propagates_ssrf_error():
+    from litellm.litellm_core_utils.url_utils import SSRFError
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+            return_value=True,
+        ),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor.validate_url",
+            side_effect=SSRFError("URL targets a blocked address"),
+        ),
+    ):
+        with pytest.raises(SSRFError):
+            _resolve_advisor_credentials(ADVISOR_TOOL_WITH_CREDS)
+
+
+def test_resolve_advisor_credentials_skips_validation_when_url_validation_disabled():
+    import litellm
+
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+            return_value=True,
+        ),
+        patch.object(litellm, "user_url_validation", False),
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor.validate_url",
+            side_effect=AssertionError("validate_url must not run when user_url_validation is disabled"),
+        ),
+    ):
+        result = _resolve_advisor_credentials(ADVISOR_TOOL_WITH_CREDS)
+    assert result == ("sk-other", "https://other.example")
+
+
+def test_resolve_advisor_credentials_blocks_real_cloud_metadata_address():
+    """End-to-end (no mocked validate_url): a caller can't redirect the
+    advisor sub-call to the cloud-metadata address even with an api_key."""
+    from litellm.litellm_core_utils.url_utils import SSRFError
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {
+        **ADVISOR_TOOL,
+        "api_key": "sk-other",
+        "api_base": "https://169.254.169.254/latest/meta-data/",
+    }
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=True,
+    ):
+        with pytest.raises(SSRFError):
+            _resolve_advisor_credentials(tool)
+
+
+def test_resolve_advisor_credentials_rejects_non_https_api_base():
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {**ADVISOR_TOOL, "api_key": "sk-other", "api_base": "http://8.8.8.8"}
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=True,
+    ):
+        with pytest.raises(ValueError, match="https"):
+            _resolve_advisor_credentials(tool)
+
+
+def test_resolve_advisor_credentials_allows_real_public_ip_address():
+    """End-to-end (no mocked validate_url): a globally-routable literal IP
+    api_base is honored when paired with an api_key."""
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {**ADVISOR_TOOL, "api_key": "sk-other", "api_base": "https://8.8.8.8"}
+    with patch(
+        "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+        return_value=True,
+    ):
+        result = _resolve_advisor_credentials(tool)
+    assert result == ("sk-other", "https://8.8.8.8")

--- a/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
+++ b/tests/test_litellm/llms/anthropic/messages/test_advisor_orchestration.py
@@ -886,6 +886,25 @@ def test_resolve_advisor_credentials_rejects_non_https_api_base():
             _resolve_advisor_credentials(tool)
 
 
+def test_resolve_advisor_credentials_rejects_api_base_when_ssl_verify_disabled():
+    import litellm
+
+    from litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor import (
+        _resolve_advisor_credentials,
+    )
+
+    tool = {**ADVISOR_TOOL, "api_key": "sk-other", "api_base": "https://8.8.8.8"}
+    with (
+        patch(
+            "litellm.llms.anthropic.experimental_pass_through.messages.interceptors.advisor._allow_client_side_advisor_credentials",
+            return_value=True,
+        ),
+        patch.object(litellm, "ssl_verify", False),
+    ):
+        with pytest.raises(ValueError, match="ssl_verify"):
+            _resolve_advisor_credentials(tool)
+
+
 def test_resolve_advisor_credentials_allows_real_public_ip_address():
     """End-to-end (no mocked validate_url): a globally-routable literal IP
     api_base is honored when paired with an api_key."""


### PR DESCRIPTION
## Security impact

This closes a critical credential-leak and SSRF path in advisor orchestration, reachable when `allow_client_side_credentials` is enabled. The advisor tool extracted a caller-supplied `api_base` without requiring a caller `api_key` and without SSRF-validating the destination. Because the Anthropic auth path falls back to the proxy's own credentials when no key is supplied, a caller could point the advisor sub-call at an attacker-controlled or internal URL and have the server's real Anthropic key, plus the full conversation content, sent there, while the caller-facing response looked normal. The fix honors a caller `api_base` only alongside a non-empty caller `api_key`, requires `https` with TLS verification, and validates the destination against the SSRF guard.

Severity: Critical, gated behind an opt-in. Only exploitable when `allow_client_side_credentials` is on; where on, it silently exfiltrates the server's Anthropic key and conversation data

## Relevant issues

## Linear ticket

Resolves LIT-4198

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a live proxy with `general_settings.allow_client_side_credentials: true`, using a local listener standing in for an attacker-controlled endpoint. Before the fix, an advisor tool definition that set a custom `api_base` without also supplying an `api_key` caused the proxy's own Anthropic credentials, plus the conversation content, to be sent to that endpoint, while the caller-facing response looked completely normal.

After the fix, the same request is rejected before any outbound call is made, with no data reaching the listener. Also verified live: an internal/cloud-metadata-style destination is blocked by the SSRF guard even when the caller supplies their own credential, a non-`https` destination is rejected outright regardless of credentials, and the legitimate flow (caller's own credential paired with an admin-allowlisted destination) continues to work unchanged, with the caller's own credential (not the server's) reaching the destination.

Full request/response detail from this verification is available on request rather than published here, since it doubles as a working reproduction of the underlying issue.

The https-scheme requirement is additionally covered by an unmocked unit test that performs real DNS resolution against a real public address and confirms it is honored.

## Type

🐛 Bug Fix

## Changes

`AdvisorOrchestrationHandler` (`litellm/llms/anthropic/experimental_pass_through/messages/interceptors/advisor.py`) extracted a caller-supplied `api_base`/`api_key` from the advisor tool definition once `general_settings.allow_client_side_credentials` was enabled, without requiring the caller to also supply their own `api_key` and without validating `api_base` against SSRF. Because `AnthropicModelInfo.get_auth_header()` falls back to the proxy's own Anthropic credentials when no key is given, a caller who could set a client-side `api_base` could redirect the advisor sub-call, and the server's real credentials plus the conversation history, to an attacker-controlled or internal address.

`_resolve_advisor_credentials()` now only honors a caller-supplied `api_base` alongside a non-empty caller-supplied `api_key`, requires the `https` scheme with `litellm.ssl_verify` on, and validates `api_base` via `validate_url()` before use (respecting the existing `litellm.user_url_validation` toggle), mirroring the intent already documented on `check_complete_credentials` in `proxy/auth/auth_utils.py`. The `https`/`ssl_verify` requirement matters because `validate_url` only rewrites the connection to a DNS-pinned address for `http`, or for `https` with TLS verification disabled; otherwise it returns the URL unchanged and relies on certificate validation to block DNS rebinding, so this closes that gap without threading a pinned address and Host-header override through the whole `anthropic_messages()` call chain. `check_complete_credentials` itself has the same discarded-rewrite pattern for its own SSRF check, but it currently has zero call sites in the codebase; filed as LIT-4203 so it isn't silently re-wired in without also closing that gap. This PR only changes behavior when `allow_client_side_credentials` is enabled; the default-closed gate is unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix in proxy advisor routing when clientside credentials are enabled; incorrect validation could block legitimate routing or leave SSRF/credential exfil paths open.
> 
> **Overview**
> **Closes a credential-leak and SSRF path** when `allow_client_side_credentials` is on and the advisor tool supplies a custom `api_base`.
> 
> Advisor orchestration now resolves client routing through **`_resolve_advisor_credentials()`** instead of copying `api_key` / `api_base` from the tool inline. A caller **`api_base` is accepted only with a non-empty caller `api_key`**, so the proxy’s Anthropic credentials are not sent to an attacker-chosen URL. **`api_base` must be `https://`**, **`litellm.ssl_verify` must be enabled**, and **`validate_url()`** runs when `user_url_validation` is on (same SSRF posture as proxy credential checks). The existing clientside-credentials gate is unchanged when the opt-in is off.
> 
> Tests cover the new helper (pairing rules, HTTPS/TLS gates, SSRF including cloud metadata, and honoring public HTTPS IPs) and patch **`validate_url`** in integration-style advisor sub-call tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c77815d755d553d0f2fde24c35f16f582401d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

