### PR TITLE
feat(provider): add Kenari as OpenAI-compatible JSON provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -132,6 +132,12 @@
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   },
+  "kenari": {
+    "base_url": "https://kenari.id/v1",
+    "api_key_env": "KENARI_API_KEY",
+    "api_base_env": "KENARI_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions"]
+  },
   "tensormesh": {
     "base_url": "https://serverless.tensormesh.ai/v1",
     "api_key_env": "TENSORMESH_INFERENCE_API_KEY",

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1252,6 +1252,23 @@
         "rerank": false
       }
     },
+    "kenari": {
+      "display_name": "Kenari (`kenari`)",
+      "url": "https://docs.litellm.ai/docs/providers/kenari",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "lambda_ai": {
       "display_name": "Lambda AI (`lambda_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/lambda_ai",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3362,6 +3362,7 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     NEOSANTARA = "neosantara"
+    KENARI = "kenari"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3699,6 +3699,7 @@ class LlmProviders(str, Enum):
     POE = "poe"
     CHUTES = "chutes"
     NEOSANTARA = "neosantara"
+    KENARI = "kenari"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"
     TENSORMESH = "tensormesh"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1367,6 +1367,23 @@
         "rerank": false
       }
     },
+    "kenari": {
+      "display_name": "Kenari (`kenari`)",
+      "url": "https://docs.litellm.ai/docs/providers/kenari",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "lambda_ai": {
       "display_name": "Lambda AI (`lambda_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/lambda_ai",

--- a/tests/test_litellm/llms/kenari/test_kenari.py
+++ b/tests/test_litellm/llms/kenari/test_kenari.py
@@ -1,0 +1,66 @@
+import os
+from unittest.mock import patch
+
+KENARI_API_BASE = "https://kenari.id/v1"
+
+
+def test_kenari_json_registry():
+    import litellm
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    assert litellm.LlmProviders.KENARI.value == "kenari"
+    assert litellm.LlmProviders("kenari") == litellm.LlmProviders.KENARI
+    assert JSONProviderRegistry.exists("kenari")
+    config = JSONProviderRegistry.get("kenari")
+    assert config is not None
+    assert config.base_url == KENARI_API_BASE
+    assert config.api_key_env == "KENARI_API_KEY"
+    assert config.api_base_env == "KENARI_API_BASE"
+    assert config.supported_endpoints == ["/v1/chat/completions"]
+
+
+def test_kenari_dynamic_config_env_vars():
+    from litellm.llms.openai_like.dynamic_config import create_config_class
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    config = create_config_class(JSONProviderRegistry.get("kenari"))()
+
+    with patch.dict(
+        os.environ,
+        {
+            "KENARI_API_KEY": "test-key",
+            "KENARI_API_BASE": "https://custom.kenari.example/v1",
+        },
+    ):
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+
+    assert api_base == "https://custom.kenari.example/v1"
+    assert api_key == "test-key"
+
+
+def test_kenari_provider_detection_by_prefix():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, _, api_base = get_llm_provider("kenari/deepseek-v4-pro")
+
+    assert model == "deepseek-v4-pro"
+    assert provider == "kenari"
+    assert api_base == KENARI_API_BASE
+
+
+def test_kenari_chat_complete_url():
+    from litellm.llms.openai_like.dynamic_config import create_config_class
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    config = create_config_class(JSONProviderRegistry.get("kenari"))()
+
+    assert (
+        config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="deepseek-v4-pro",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://kenari.id/v1/chat/completions"
+    )


### PR DESCRIPTION
## Relevant issues

N/A (new provider addition via the JSON-based provider path)

## Type

🆕 New Feature

## Changes

Adds [Kenari](https://kenari.id) as a JSON-configured OpenAI-compatible provider, following the same pattern as the `neosantara` addition (#29646).

Kenari is an LLM gateway with IDR (Indonesian Rupiah) billing, serving models from DeepSeek, GLM, Kimi, Qwen, Claude, GPT and others through one OpenAI-compatible endpoint at `https://kenari.id/v1`.

- `litellm/llms/openai_like/providers.json`: `kenari` entry (`KENARI_API_KEY`, `KENARI_API_BASE` override). No `param_mappings` needed: the API accepts `max_completion_tokens` natively.
- `litellm/types/utils.py`: `LlmProviders.KENARI` enum value.
- `provider_endpoints_support.json` + backup: chat completions entry.
- `tests/test_litellm/llms/kenari/test_kenari.py`: registry, env-var config, prefix detection, complete-URL tests (mirrors the neosantara test file).

## Testing

```
$ pytest tests/test_litellm/llms/kenari/test_kenari.py -q
4 passed
```

Verified live against the production endpoint:

```python
import litellm
r = litellm.completion(
    model="kenari/deepseek-v4-flash",
    messages=[{"role": "user", "content": "Say OK"}],
)
# content: "OK", usage reported; streaming also verified
```
