### PR TITLE
fix(proxy): preserve reasoning fields on streaming cache hits

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -203,12 +203,7 @@ async def convert_to_streaming_response_async(
                     t["index"] = index
                 pydantic_tool_calls.append(ChatCompletionDeltaToolCall(**t))
             choice["message"]["tool_calls"] = pydantic_tool_calls
-        delta = Delta(
-            content=choice["message"].get("content", None),
-            role=choice["message"]["role"],
-            function_call=choice["message"].get("function_call", None),
-            tool_calls=choice["message"].get("tool_calls", None),
-        )
+        delta = Delta(**choice["message"])
         finish_reason = choice.get("finish_reason", None)
 
         if finish_reason is None:

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -204,12 +204,7 @@ async def convert_to_streaming_response_async(
                     t["index"] = index
                 pydantic_tool_calls.append(ChatCompletionDeltaToolCall(**t))
             choice["message"]["tool_calls"] = pydantic_tool_calls
-        delta = Delta(
-            content=choice["message"].get("content", None),
-            role=choice["message"]["role"],
-            function_call=choice["message"].get("function_call", None),
-            tool_calls=choice["message"].get("tool_calls", None),
-        )
+        delta = Delta(**choice["message"])
         finish_reason = choice.get("finish_reason", None)
 
         if finish_reason is None:

--- a/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
+++ b/tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
@@ -2005,6 +2005,60 @@ class TestConvertToStreamingResponseAsync:
         assert chunks[-1].choices[0].finish_reason == "stop"
         assert chunks[-1].usage.prompt_tokens == 3
 
+    def test_preserves_reasoning_fields(self):
+        import asyncio
+
+        from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+            convert_to_streaming_response_async,
+        )
+
+        thinking_blocks = [
+            {
+                "type": "thinking",
+                "thinking": "cached reasoning",
+                "signature": "sig-cache",
+            }
+        ]
+        response_object = {
+            "id": "msg_async_reasoning_cache",
+            "model": "claude-3",
+            "created": 1700000000,
+            "choices": [
+                {
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "message": {
+                        "content": "Final answer",
+                        "role": "assistant",
+                        "reasoning_content": "cached reasoning",
+                        "thinking_blocks": thinking_blocks,
+                    },
+                }
+            ],
+        }
+
+        async def run():
+            return [
+                chunk
+                async for chunk in convert_to_streaming_response_async(
+                    response_object=response_object
+                )
+            ]
+
+        chunks = asyncio.run(run())
+
+        assert (
+            "".join(c.choices[0].delta.content or "" for c in chunks) == "Final answer"
+        )
+        assert chunks[0].choices[0].delta.reasoning_content == "cached reasoning"
+        assert chunks[0].choices[0].delta.thinking_blocks == thinking_blocks
+        assert not any(
+            hasattr(c.choices[0].delta, "reasoning_content") for c in chunks[1:]
+        )
+        assert not any(
+            hasattr(c.choices[0].delta, "thinking_blocks") for c in chunks[1:]
+        )
+
 
 class TestHandleInvalidParallelToolCalls:
     def test_none_input(self):


### PR DESCRIPTION
## Relevant issues

Fixes #32068

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run  
       Link:

- [ ] CI run for the last commit  
       Link:

- [ ] Merge / cherry-pick CI run  
       Links:

## Screenshots / Proof of Fix

Streaming cache hits were replayed through `convert_to_streaming_response_async`, which rebuilt `Delta` with only `content`, `role`, `function_call`, and `tool_calls`. Cached `reasoning_content` and `thinking_blocks` were present in the stored response but dropped during replay

The regression test failed before the fix with:

```text
AttributeError: 'Delta' object has no attribute 'reasoning_content'
```

After this change, async streaming replay preserves cached reasoning fields on the first replay chunk while later content-slice chunks still avoid duplicating metadata

Live proxy proof runbook for a reviewer with Redis and a reasoning-capable model configured:

```sh
curl -N -i http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "REASONING_MODEL",
    "stream": true,
    "messages": [
      {"role": "user", "content": "Think briefly, then answer with the word done."}
    ]
  }'
```

Run the same request twice. Expected behavior: the first request is a cache miss and includes streamed `delta.reasoning_content`; the second request is a cache hit and still includes streamed `delta.reasoning_content`

I could not run this live proxy proof locally because this checkout does not have a Redis-backed proxy and real reasoning provider key configured

## Type

Bug Fix
Test

## Changes

Follow-up to #31022 in the same reasoning-streaming area

This changes async cached streaming replay to construct `Delta` from the full cached message dict, matching the sync cached replay path. That preserves `reasoning_content`, `thinking_blocks`, and any future `Delta` fields instead of hard-coding a small subset

Regression coverage verifies that cached async streaming replay preserves reasoning metadata on the first replay chunk and does not duplicate it on later content-slice chunks

Validation run:

```text
uv run --no-sync pytest tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py::TestConvertToStreamingResponseAsync::test_preserves_reasoning_fields -q
uv run --no-sync pytest tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py -q
uv run --no-sync black --check tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
uv run --no-sync ruff check litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
uv run --no-sync ruff check --ignore T201,F401 tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
uv run --no-sync python -m py_compile litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py tests/llm_translation/test_llm_response_utils/test_convert_dict_to_chat_completion.py
git --no-pager diff --check
```

Results:

```text
74 passed
All checks passed for the changed production file and the new test path
```
