### PR TITLE
build: restore maturin backend to bundle the Rust bridge in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,8 +234,25 @@ healthcheck = [
 ]
 
 [build-system]
-requires = ["uv_build==0.11.8"]
-build-backend = "uv_build"
+requires = ["maturin==1.9.4"]
+build-backend = "maturin"
+
+[tool.maturin]
+manifest-path = "litellm-rust/crates/python-bridge/Cargo.toml"
+module-name = "litellm.rust_bridge._native"
+python-source = "."
+bindings = "pyo3"
+include = ["litellm/proxy/_experimental/out/**"]
+exclude = [
+    "litellm/proxy/enterprise",
+    "litellm/proxy/enterprise/**",
+    "**/__pycache__",
+    "**/__pycache__/**",
+    "**/.pytest_cache",
+    "**/.pytest_cache/**",
+    "**/.ruff_cache",
+    "**/.ruff_cache/**",
+]
 
 [tool.uv]
 constraint-dependencies = [
@@ -257,18 +274,6 @@ litellm-enterprise = { workspace = true }
 
 [tool.uv.workspace]
 members = ["enterprise", "litellm-proxy-extras"]
-
-[tool.uv.build-backend]
-module-root = ""
-source-exclude = [
-    "litellm/proxy/enterprise",
-    "**/__pycache__",
-    "**/__pycache__/**",
-    "**/.pytest_cache",
-    "**/.pytest_cache/**",
-    "**/.ruff_cache",
-    "**/.ruff_cache/**",
-]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Local build with `maturin==1.9.4` (the pin the release pipeline uses) against Python 3.13, confirming the wheel carries both the native Rust module and the committed Admin UI bundle:

```
$ maturin build --out dist --interpreter .venv/bin/python
📦 Including files matching "litellm/proxy/_experimental/out/**"
📦 Built wheel for CPython 3.13 to dist/litellm-1.92.0-cp313-cp313-macosx_11_0_arm64.whl

$ unzip -l dist/*.whl | grep -E '_native|_experimental/out/index.html'
    22340  ...  litellm/proxy/_experimental/out/index.html
 16007296  ...  litellm/rust_bridge/_native.cpython-313-darwin.so
```

## Type

🚄 Infrastructure

## Changes

Re-applies the maturin build backend (reversing #31470, which had temporarily restored the pure-Python `uv_build` backend). maturin packages the Rust bridge (`litellm.rust_bridge._native`) into the wheel; `litellm/rust_bridge/loader.py` already falls back gracefully when the native module is absent, so pure-Python installs are unaffected

The earlier revert was needed because the release pipeline emitted a bare `cp312` `linux_x86_64` wheel that PyPI rejects. That is resolved on the pipeline side: it now branches on the build backend and, for maturin, builds proper `manylinux_2_28` wheels (x86_64 + aarch64) and validates each wheel carries the native module, so maturin wheels are PyPI-acceptable again. The `maturin==1.9.4` pin here matches the pin the manylinux build path installs

The `[tool.maturin] include = ["litellm/proxy/_experimental/out/**"]` line is sdist coverage for the Admin UI bundle. maturin's `include` overrides `.gitignore` for the sdist but not for the wheel, so it is not wheel protection; `litellm/proxy/_experimental/out/` stays committed and un-ignored, which is what puts the bundle into the wheel (maturin's python-source walk) and the sdist. No `.gitignore` changes and no bundle-cleanup are part of this PR

Coordination: this pairs with the release-pipeline change that builds the Admin UI from source and adds an offline gate on the built wheel/sdist for the bundle. That change should land first so the pipeline can build and verify a maturin UI wheel before this flips the backend to maturin