### PR TITLE
fix(headroom guardrail): log real token/compression stats instead of "allow"

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -282,7 +282,7 @@ class HeadroomGuardrail(CustomGuardrail):
         self,
         messages: list[dict[str, object]],
         model: str | None,
-    ) -> tuple[list[dict[str, object]], bool]:
+    ) -> tuple[list[dict[str, object]], bool, dict[str, object]]:
         payload: dict[str, object] = {"messages": messages}
         if model:
             payload["model"] = model
@@ -298,19 +298,19 @@ class HeadroomGuardrail(CustomGuardrail):
                 messages,
                 "Headroom compression service returned an error",
                 {"status_code": e.response.status_code, "body": e.response.text},
-            ), False
+            ), False, {}
         except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError, litellm.Timeout) as e:
             return self._handle_compress_failure(
                 messages,
                 "Headroom compression service unreachable",
                 {"detail": str(e)},
-            ), False
+            ), False, {}
         if raw_response is None:
             return self._handle_compress_failure(
                 messages,
                 "Headroom compression service returned no response",
                 {},
-            ), False
+            ), False, {}
         response: HttpxResponse = raw_response
 
         if response.status_code != 200:
@@ -318,7 +318,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 messages,
                 "Headroom compression service returned an error",
                 {"status_code": response.status_code, "body": response.text},
-            ), False
+            ), False, {}
 
         try:
             body: object = response.json()
@@ -327,13 +327,13 @@ class HeadroomGuardrail(CustomGuardrail):
                 messages,
                 "Headroom compression service returned non-JSON response",
                 {"body": response.text[:500]},
-            ), False
+            ), False, {}
         if not _is_str_object_dict(body):
             return self._handle_compress_failure(
                 messages,
                 "Headroom compression service returned unexpected response shape",
                 {"body": response.text[:500]},
-            ), False
+            ), False, {}
 
         compressed_messages = body.get("messages")
         if not _is_object_list(compressed_messages):
@@ -341,7 +341,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 messages,
                 "Headroom compression service response missing 'messages'",
                 {"body": response.text},
-            ), False
+            ), False, {}
 
         filtered = [item for item in compressed_messages if _is_str_object_dict(item)]
         if not filtered:
@@ -349,7 +349,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 messages,
                 "Headroom compression service returned empty message list",
                 {"body": response.text},
-            ), False
+            ), False, {}
 
         verbose_proxy_logger.debug(
             "Headroom: compressed %s tokens -> %s tokens (ratio %.2f)",
@@ -357,7 +357,21 @@ class HeadroomGuardrail(CustomGuardrail):
             body.get("tokens_after", "?"),
             body.get("compression_ratio", 0),
         )
-        return filtered, True
+
+        # Token/compression stats only - deliberately excludes 'messages' so
+        # raw request/response content never lands in spend logs.
+        stats = {
+            key: body[key]
+            for key in (
+                "tokens_before",
+                "tokens_after",
+                "tokens_saved",
+                "compression_ratio",
+                "transforms_applied",
+            )
+            if key in body
+        }
+        return filtered, True, stats
 
     async def _call_retrieve(self, hash_value: str, query: str | None = None) -> str:
         params: dict[str, str] = {}
@@ -421,13 +435,25 @@ class HeadroomGuardrail(CustomGuardrail):
             return inputs
 
         model = self.headroom_model or request_data.get("model")
-        compressed, compression_succeeded = await self._call_compress(
+        start_time = time.time()
+        compressed, compression_succeeded, stats = await self._call_compress(
             messages=messages,
             model=model if isinstance(model, str) else None,
         )
+        end_time = time.time()
 
         if not compression_succeeded:
             return {**inputs, "structured_messages": compressed}  # pyright: ignore[reportReturnType]
+
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=stats,
+            request_data=request_data,
+            guardrail_status="success",
+            guardrail_provider="headroom",
+            start_time=start_time,
+            end_time=end_time,
+            duration=end_time - start_time,
+        )
 
         hashes = extract_hashes_from_messages(compressed)
         if not hashes:


### PR DESCRIPTION
## Summary
- The headroom guardrail already fetches `tokens_before`/`tokens_after`/`compression_ratio`/`transforms_applied` from Headroom's `/v1/compress` response, but only logged them via a debug-level `verbose_proxy_logger.debug(...)` call - never persisted anywhere.
- As a result, `spend_logs.guardrail_information.guardrail_response` always showed the generic `"allow"`, with no way to tell whether compression actually ran or by how much.
- `_call_compress` now returns the token/compression stats alongside the compressed messages, and `apply_guardrail` logs them via `add_standard_logging_guardrail_information_to_request_data` (the same mechanism other guardrails like `block_code_execution` and `cisco_ai_defense` use for rich logging).
- Raw message content is intentionally excluded from what's logged - only token counts, compression ratio, and applied transform names, so no request/response text lands in spend logs.

Before:
```json
"guardrail_response": "allow"
```

After:
```json
"guardrail_response": {
  "tokens_before": 1833,
  "tokens_after": 1429,
  "tokens_saved": 404,
  "compression_ratio": 0.78,
  "transforms_applied": ["router:mixed:0.44"]
}
```

## Test plan
- [x] Verified locally against a running headroom-ai 0.28.0 proxy + litellm proxy with the headroom guardrail configured
- [x] Ran real `/v1/chat/completions` requests through litellm with small/medium/large conversation payloads (plain, JSON tool output, log dumps, diffs, code) and confirmed `guardrail_information` in `LiteLLM_SpendLogs` now shows real token stats instead of `"allow"` for compressed requests
- [x] Confirmed small/uncompressed requests still log correctly (`tokens_saved: 0`, `compression_ratio: 1.0`)