### PR TITLE
fix: anthropic_messages_handler only treated litellm_params.mock_respons

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -368,9 +368,12 @@ def _get_mock_response_content(
     if isinstance(mock_response, str):
         return mock_response
     if isinstance(mock_response, litellm.ModelResponse):
+        if not mock_response.choices:
+            return ""
         first_choice = mock_response.choices[0]
         if isinstance(first_choice, litellm.Choices):
-            return first_choice.message.content
+            return first_choice.message.content or ""
+        return ""
     return None
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -362,6 +362,18 @@ async def anthropic_messages(
     return response
 
 
+def _get_mock_response_content(
+    mock_response: Optional[Union[str, litellm.ModelResponse, Exception, Any]],
+) -> Optional[str]:
+    if isinstance(mock_response, str):
+        return mock_response
+    if isinstance(mock_response, litellm.ModelResponse):
+        first_choice = mock_response.choices[0]
+        if isinstance(first_choice, litellm.Choices):
+            return first_choice.message.content
+    return None
+
+
 def validate_anthropic_api_metadata(metadata: Optional[Dict] = None) -> Optional[Dict]:
     """
     Validate Anthropic API metadata - This is done to ensure only allowed `metadata` fields are passed to Anthropic API
@@ -466,12 +478,13 @@ def anthropic_messages_handler(
         if kwargs.get("_websearch_interception_converted_stream", False):
             litellm_logging_obj.model_call_details["websearch_interception_converted_stream"] = True
 
-    if litellm_params.mock_response and isinstance(litellm_params.mock_response, str):
+    mock_response_content = _get_mock_response_content(litellm_params.mock_response)
+    if mock_response_content is not None:
         return mock_response(
             model=model,
             messages=messages,
             max_tokens=max_tokens,
-            mock_response=litellm_params.mock_response,
+            mock_response=mock_response_content,
         )
 
     anthropic_messages_provider_config: Optional[BaseAnthropicMessagesConfig] = None

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from litellm.anthropic_interface import messages
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
-from litellm.types.utils import Delta, ModelResponse, StreamingChoices
+from litellm.types.utils import Choices, Delta, Message, ModelResponse, StreamingChoices
 
 
 def test_anthropic_experimental_pass_through_messages_handler():
@@ -646,6 +646,34 @@ def test_handler_skips_strip_when_presanitized():
         )
     assert spy.call_count == 0  # skipped the redundant scan
     assert result is not None
+
+
+def test_handler_short_circuits_on_model_response_mock_response():
+    """Regression test for #31976. BedrockGuardrail with
+    disable_exception_on_block=True sets a ModelResponse (not a str) as
+    litellm_params.mock_response to block a request without raising. The
+    handler must honor it instead of silently calling the real model."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    blocked_response = ModelResponse(
+        choices=[Choices(message=Message(content="Blocked by guardrail"))],
+        model="bedrock-guardrail",
+    )
+
+    with patch.object(
+        handler.base_llm_http_handler,
+        "anthropic_messages_handler",
+    ) as mock_base_handler:
+        result = handler.anthropic_messages_handler(
+            max_tokens=10,
+            messages=[{"role": "user", "content": "some blocked content"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            custom_llm_provider="anthropic",
+            mock_response=blocked_response,
+        )
+
+    mock_base_handler.assert_not_called()
+    assert result["content"][0]["text"] == "Blocked by guardrail"
 
 
 def test_presanitized_flag_not_leaked_to_provider_params():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -676,6 +676,55 @@ def test_handler_short_circuits_on_model_response_mock_response():
     assert result["content"][0]["text"] == "Blocked by guardrail"
 
 
+def test_handler_short_circuits_on_model_response_with_empty_choices():
+    """A ModelResponse mock with no choices must still short-circuit instead
+    of crashing on an unguarded choices[0] access."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    blocked_response = ModelResponse(choices=[], model="bedrock-guardrail")
+
+    with patch.object(
+        handler.base_llm_http_handler,
+        "anthropic_messages_handler",
+    ) as mock_base_handler:
+        result = handler.anthropic_messages_handler(
+            max_tokens=10,
+            messages=[{"role": "user", "content": "some blocked content"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            custom_llm_provider="anthropic",
+            mock_response=blocked_response,
+        )
+
+    mock_base_handler.assert_not_called()
+    assert result["content"][0]["text"] == ""
+
+
+def test_handler_short_circuits_on_model_response_with_none_content():
+    """A ModelResponse mock whose message content is None must still
+    short-circuit rather than silently falling through to the real model."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    blocked_response = ModelResponse(
+        choices=[Choices(message=Message(content=None))],
+        model="bedrock-guardrail",
+    )
+
+    with patch.object(
+        handler.base_llm_http_handler,
+        "anthropic_messages_handler",
+    ) as mock_base_handler:
+        result = handler.anthropic_messages_handler(
+            max_tokens=10,
+            messages=[{"role": "user", "content": "some blocked content"}],
+            model="anthropic/claude-3-5-sonnet-20241022",
+            custom_llm_provider="anthropic",
+            mock_response=blocked_response,
+        )
+
+    mock_base_handler.assert_not_called()
+    assert result["content"][0]["text"] == ""
+
+
 def test_presanitized_flag_not_leaked_to_provider_params():
     """The private sentinel must be popped, never forwarded as a request param."""
     from litellm.llms.anthropic.experimental_pass_through.messages import handler


### PR DESCRIPTION
Fixes #31976

## Summary
anthropic_messages_handler only treated litellm_params.mock_response as a mock when it was a str, so the ModelResponse that BedrockGuardrail sets when disable_exception_on_block=True blocks a request was silently ignored and the real model got called. Added _get_mock_response_content() to extract the block text from either a str or a ModelResponse and use it to short-circuit the call, with a regression test that reproduces the bypass on old code and passes with the fix.

## Changes
- `litellm/llms/anthropic/experimental_pass_through/messages/handler.py`
- `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py`

## How this was tested
Ran `make test-unit` locally.
