### PR TITLE
fix(proxy): enable response cache on db router rebuild

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5066,6 +5066,7 @@ class ProxyConfig:
                         ),
                         search_tools=search_tools,
                         ignore_invalid_deployments=True,
+                        cache_responses=litellm.cache is not None,
                     )
                     verbose_proxy_logger.debug(f"updated llm_router: {llm_router}")
             else:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -1665,6 +1665,48 @@ class TestAddAndDeleteModelLifecycle:
             assert str(exc_info.value.code) == "400"
 
 
+class TestDBRouterRebuildCaching:
+    @pytest.mark.asyncio
+    async def test_update_llm_router_enables_cache_responses_when_litellm_cache_exists(
+        self,
+    ):
+        from litellm.proxy.proxy_server import ProxyConfig
+
+        db_model = LiteLLM_ProxyModelTable(
+            model_id="db-cache-model-1",
+            model_name="cached-db-model",
+            litellm_params={"model": "openai/gpt-4.1-nano", "api_key": "sk-test"},
+            model_info={"id": "db-cache-model-1"},
+            created_by="admin",
+            updated_by="admin",
+        )
+        created_router = MagicMock()
+        created_router.get_model_list.return_value = ["cached-db-model"]
+        router_constructor = MagicMock(return_value=created_router)
+        proxy_config = ProxyConfig()
+        proxy_config._add_callbacks_from_db_config = MagicMock()
+        proxy_config._add_general_settings_from_db_config = MagicMock()
+        proxy_config._add_router_settings_from_db_config = AsyncMock()
+        mock_config = MagicMock()
+        mock_config.get_config = AsyncMock(return_value={})
+
+        with (
+            patch("litellm.proxy.proxy_server.llm_router", None),
+            patch("litellm.proxy.proxy_server.llm_model_list", []),
+            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.proxy_config", mock_config),
+            patch("litellm.proxy.proxy_server.litellm.cache", object()),
+            patch("litellm.proxy.proxy_server.litellm.Router", router_constructor),
+        ):
+            await proxy_config._update_llm_router(
+                new_models=[db_model],
+                proxy_logging_obj=MagicMock(),
+            )
+
+        assert router_constructor.call_args.kwargs["cache_responses"] is True
+
+
 class TestDeleteTeamBYOKModelGhost:
     """Regression for issue #22594.
 


### PR DESCRIPTION
## Relevant issues

Fixes #32106

## Linear ticket
N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug happens when the proxy rebuilds the router from DB-backed deployments with `store_model_in_db: true`.

The static router initialization path already enables response caching when `litellm.cache` is initialized:

```python
cache_responses=litellm.cache is not None
```

Before this fix, the DB-backed router rebuild path created a new `litellm.Router` without passing `cache_responses`, so the rebuilt router had `cache_responses=False` even when Redis/LiteLLM response caching was configured.

After this fix, the DB-backed router rebuild path mirrors the static router path and preserves response caching on the rebuilt router.

Focused regression test run locally:

```powershell
.venv\Scripts\uv.exe run --no-sync pytest tests\test_litellm\proxy\management_endpoints\test_model_management_endpoints.py::TestDBRouterRebuildCaching::test_update_llm_router_enables_cache_responses_when_litellm_cache_exists -q
```

Result:

```text
1 passed, 1 warning
```

Full relevant test file run locally:

```powershell
.venv\Scripts\uv.exe run --no-sync pytest tests\test_litellm\proxy\management_endpoints\test_model_management_endpoints.py -q
```

Result:

```text
72 passed, 3 warnings
```

Additional local checks:

```powershell
.venv\Scripts\uv.exe run --no-sync python -m py_compile litellm\proxy\proxy_server.py tests\test_litellm\proxy\management_endpoints\test_model_management_endpoints.py
git diff --check
```

Both passed.

## Type
🐛 Bug Fix
✅ Test

## Changes
Pass `cache_responses=litellm.cache is not None` when rebuilding `litellm.Router` from DB-backed deployments.

This mirrors the static router initialization path and keeps Redis/LiteLLM response caching enabled after router rebuilds when `store_model_in_db=True`.

Add regression coverage for the DB router rebuild path to verify `cache_responses` is enabled whenever `litellm.cache` is initialized.