### PR TITLE
fix(proxy): map non-standard SSE error codes (>=600) to 502 for failure handling

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -239,10 +239,38 @@ async def _parse_event_data_for_error(event_line: Union[str, bytes]) -> Optional
                         # Not a valid integer string, treat as if no valid code was found for this check
                         pass
 
-                # Ensure error_code is a valid HTTP status code
-                if error_code is not None and 100 <= error_code <= 599:
-                    return error_code
-                elif error_code_raw is not None:  # Log if original code was present but not valid
+                if error_code is not None:
+                    if 100 <= error_code <= 599:
+                        # Standard HTTP status code
+                        return error_code
+                    elif error_code >= 600:
+                        # Vendor-specific error codes outside the standard HTTP
+                        # range (e.g., ZAI/ZhipuAI 1302 rate limit, DashScope
+                        # throttling codes). Previously these were silently
+                        # dropped (returned None), causing the proxy to treat
+                        # the SSE chunk as normal content — the error was
+                        # forwarded to the client as a 200 response, and router
+                        # fallback/cooldown never triggered.
+                        #
+                        # Map to 502 (Bad Gateway) so that failure handling
+                        # (retry, fallback, cooldown) fires correctly. The
+                        # original vendor code is preserved in the warning log
+                        # for debugging.
+                        verbose_proxy_logger.warning(
+                            f"SSE error code {error_code} is outside standard HTTP range "
+                            f"(100-599); mapping to 502 for failure handling"
+                        )
+                        return 502
+                    else:
+                        # Integer code below 100 (or negative) — likely corrupt data
+                        # but keep the original behaviour of returning None while
+                        # emitting the diagnostic warning (preserved from the
+                        # original elif error_code_raw is not None: branch).
+                        verbose_proxy_logger.warning(f"Error has invalid or non-convertible code: {error_code}")
+                elif error_code_raw is not None:
+                    # error_code could not be coerced to int from the raw value
+                    # (e.g., a non-numeric string). Log the original raw value
+                    # for debugging and fall through to return None.
                     verbose_proxy_logger.warning(f"Error has invalid or non-convertible code: {error_code_raw}")
         except (orjson.JSONDecodeError, json.JSONDecodeError):
             # not a known error chunk

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1118,11 +1118,15 @@ class TestCommonRequestProcessingHelpers:
             (
                 'data: {"error": {"code": 99, "message": "too low"}}',
                 None,
-            ),  # Integer code too low
+            ),  # Integer code too low (< 100, likely invalid data)
             (
-                'data: {"error": {"code": 600, "message": "too high"}}',
-                None,
-            ),  # Integer code too high
+                'data: {"error": {"code": 600, "message": "vendor error"}}',
+                502,
+            ),  # Non-standard code >= 600 → mapped to 502 for failure handling
+            (
+                'data: {"error": {"code": 1302, "message": "rate limit"}}',
+                502,
+            ),  # Vendor-specific rate limit code (ZAI/ZhipuAI) → mapped to 502
             (
                 'data: {"id": "123", "content": "hello"}',
                 None,


### PR DESCRIPTION
## Summary

Fixes #31284

Re-opens PR #31291 with a rebase to current `litellm_oss_staging` and
collapses the two fix commits into a single, focused commit. The
old PR was held up by an increasingly stale base (254 commits
behind) and the force-pushed `litellm_oss_staging` had carried in
a number of unrelated UP045/style commits from other contributors'
branches.

This PR is a clean rebase with one commit, 2 files, +45/-9:

- `litellm/proxy/common_request_processing.py` — adds the
  `error_code >= 600` branch mapping vendor codes to 502 for
  failure handling
- `tests/test_litellm/proxy/test_common_request_processing.py` —
  updates the existing parametrize cases to expect 502 for code
  600 and 1302 (ZAI rate limit), and keeps the code 99 case at
  None while preserving its diagnostic warning

The P2 fix from the original PR (preserve the "invalid code"
warning for integer codes below 100) is folded into the same
single commit so the if/elif structure remains coherent and the
behaviour matches the original PR's intent.

## Why rebase and re-open

The original PR #31291 base is now 254 commits behind and the
branch was force-pushed during the UP045 cleanup, so a normal
rebase would have produced massive lint conflicts. The cleanest
path forward is this minimal rebase + new branch + close old PR.

## Production evidence

This fix has been running in production on a v1.89.0 source-mount
deployment with ZAI/ZhipuAI as the primary provider for 1+ days.
Before the fix, ZAI 1302 (rate limit) errors appeared 855 times in
anomaly logs with zero cooldown/fallback triggers. After the fix,
rate-limit errors correctly trigger deployment cooldown, and
subsequent requests are routed to fallback providers.

## Companion PR

#31291 (original) — will be closed once this rebase is verified
to pass CI. @mateo-berri is already in the review queue for that
one; this rebase targets the same reviewer.

## Test plan

- [x] `ruff check` passes on the modified file
- [x] `ruff format --check` shows no new drift in
      `common_request_processing.py` (the existing test file
      drift is pre-existing on `litellm_oss_staging` and not
      introduced by this PR)
- [ ] Full pytest run requires Python 3.10+ (local env is 3.9,
      this is a known local infra limitation; CI is the source
      of truth)
