### PR TITLE
fix(deepseek): fill reasoning_content on anthropic-compatible endpoint for multi-turn thinking conversations

### DIFF
--- a/litellm/llms/deepseek/messages/transformation.py
+++ b/litellm/llms/deepseek/messages/transformation.py
@@ -164,19 +164,17 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
 
     def _thinking_mode_active(self, model: str, optional_params: dict) -> bool:
         """
-        Returns True only when thinking mode is actually active for this request:
-          - model supports reasoning (capability check)
-          - user explicitly passed thinking={"type": "enabled"} (opt-in check)
+        Returns True only when the request explicitly carries
+        `thinking: {"type": "enabled"}` — the same opt-in signal the
+        upstream DeepSeek anthropic-compat endpoint enforces.
 
-        Mirrors `DeepSeekChatConfig._thinking_mode_active` so behaviour is
-        symmetric across the two DeepSeek endpoints.
+        Unlike the chat-side `DeepSeekChatConfig._thinking_mode_active`,
+        we do NOT gate on `supports_reasoning(model, custom_llm_provider)`.
+        The anthropic-compat endpoint accepts the native anthropic message
+        shape (where `thinking` is always opt-in), so any request that
+        actually turns thinking on is one we must backfill for.
         """
-        return (
-            litellm.utils.supports_reasoning(
-                model=model, custom_llm_provider="deepseek"
-            )
-            and (optional_params.get("thinking") or {}).get("type") == "enabled"
-        )
+        return (optional_params.get("thinking") or {}).get("type") == "enabled"
 
     def transform_anthropic_messages_request(
         self,

--- a/litellm/llms/deepseek/messages/transformation.py
+++ b/litellm/llms/deepseek/messages/transformation.py
@@ -5,6 +5,7 @@ DeepSeek Anthropic-compatible messages transformation config.
 from typing import Any, Dict, List, Optional, Tuple
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
 )
@@ -110,6 +111,73 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
                 sanitized_tools.append(tool)
         return sanitized_tools
 
+    def _fill_reasoning_content(
+        self, messages: List[Dict]
+    ) -> List[Dict]:
+        """
+        DeepSeek thinking mode requires `reasoning_content` to be passed back on
+        every assistant message in multi-turn conversations. If it is missing,
+        the anthropic-compatible API returns:
+          "The reasoning_content in the thinking mode must be passed back to the API."
+
+        This mirrors `DeepSeekChatConfig._fill_reasoning_content`
+        (litellm/llms/deepseek/chat/transformation.py) for the anthropic-compat
+        endpoint — both endpoints enforce the same requirement, but only the
+        OpenAI-compat path filled the field.
+
+        For each assistant message that is missing `reasoning_content`:
+          1. Promote it from `provider_specific_fields["reasoning_content"]` if
+             present (LiteLLM stores provider-specific response fields there).
+          2. Otherwise inject a single space — the minimum value the API accepts.
+        """
+        result: List[Dict] = []
+        for msg in messages:
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and not msg.get("reasoning_content")
+            ):
+                patched = dict(msg)
+                provider_fields = patched.get("provider_specific_fields") or {}
+                stored = provider_fields.get("reasoning_content")
+                if stored:
+                    patched["reasoning_content"] = stored
+                    cleaned = dict(provider_fields)
+                    cleaned.pop("reasoning_content", None)
+                    patched["provider_specific_fields"] = cleaned
+                else:
+                    verbose_logger.warning(
+                        "DeepSeek thinking mode: assistant message is missing "
+                        "`reasoning_content` and none was saved in "
+                        "`provider_specific_fields`. A single-space placeholder "
+                        "is being injected to satisfy API validation, but the "
+                        "model will receive a blank reasoning chain for this turn, "
+                        "which may silently degrade multi-turn response quality. "
+                        "Preserve `reasoning_content` from the original assistant "
+                        "response when building multi-turn conversation history."
+                    )
+                    patched["reasoning_content"] = " "
+                result.append(patched)
+            else:
+                result.append(msg)
+        return result
+
+    def _thinking_mode_active(self, model: str, optional_params: dict) -> bool:
+        """
+        Returns True only when thinking mode is actually active for this request:
+          - model supports reasoning (capability check)
+          - user explicitly passed thinking={"type": "enabled"} (opt-in check)
+
+        Mirrors `DeepSeekChatConfig._thinking_mode_active` so behaviour is
+        symmetric across the two DeepSeek endpoints.
+        """
+        return (
+            litellm.utils.supports_reasoning(
+                model=model, custom_llm_provider="deepseek"
+            )
+            and (optional_params.get("thinking") or {}).get("type") == "enabled"
+        )
+
     def transform_anthropic_messages_request(
         self,
         model: str,
@@ -126,5 +194,13 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
             headers=headers,
         )
         if "tools" in anthropic_messages_request:
-            anthropic_messages_request["tools"] = self._sanitize_tools_for_deepseek(anthropic_messages_request["tools"])
+            anthropic_messages_request["tools"] = self._sanitize_tools_for_deepseek(
+                anthropic_messages_request["tools"]
+            )
+        if self._thinking_mode_active(
+            model=model, optional_params=anthropic_messages_optional_request_params
+        ) and "messages" in anthropic_messages_request:
+            anthropic_messages_request["messages"] = self._fill_reasoning_content(
+                anthropic_messages_request["messages"]
+            )
         return anthropic_messages_request

--- a/litellm/llms/deepseek/messages/transformation.py
+++ b/litellm/llms/deepseek/messages/transformation.py
@@ -2,7 +2,7 @@
 DeepSeek Anthropic-compatible messages transformation config.
 """
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import litellm
 from litellm._logging import verbose_logger
@@ -111,9 +111,7 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
                 sanitized_tools.append(tool)
         return sanitized_tools
 
-    def _fill_reasoning_content(
-        self, messages: List[Dict]
-    ) -> List[Dict]:
+    def _fill_reasoning_content(self, messages: list[dict]) -> list[dict]:
         """
         DeepSeek thinking mode requires `reasoning_content` to be passed back on
         every assistant message in multi-turn conversations. If it is missing,
@@ -130,13 +128,9 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
              present (LiteLLM stores provider-specific response fields there).
           2. Otherwise inject a single space — the minimum value the API accepts.
         """
-        result: List[Dict] = []
+        result: list[dict] = []
         for msg in messages:
-            if (
-                isinstance(msg, dict)
-                and msg.get("role") == "assistant"
-                and not msg.get("reasoning_content")
-            ):
+            if isinstance(msg, dict) and msg.get("role") == "assistant" and not msg.get("reasoning_content"):
                 patched = dict(msg)
                 provider_fields = patched.get("provider_specific_fields") or {}
                 stored = provider_fields.get("reasoning_content")
@@ -179,11 +173,11 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
     def transform_anthropic_messages_request(
         self,
         model: str,
-        messages: List[Dict],
-        anthropic_messages_optional_request_params: Dict,
+        messages: list[dict],
+        anthropic_messages_optional_request_params: dict,
         litellm_params: GenericLiteLLMParams,
         headers: dict,
-    ) -> Dict:
+    ) -> dict:
         anthropic_messages_request = super().transform_anthropic_messages_request(
             model=model,
             messages=messages,
@@ -192,12 +186,11 @@ class DeepSeekAnthropicMessagesConfig(AnthropicMessagesConfig):
             headers=headers,
         )
         if "tools" in anthropic_messages_request:
-            anthropic_messages_request["tools"] = self._sanitize_tools_for_deepseek(
-                anthropic_messages_request["tools"]
-            )
-        if self._thinking_mode_active(
-            model=model, optional_params=anthropic_messages_optional_request_params
-        ) and "messages" in anthropic_messages_request:
+            anthropic_messages_request["tools"] = self._sanitize_tools_for_deepseek(anthropic_messages_request["tools"])
+        if (
+            self._thinking_mode_active(model=model, optional_params=anthropic_messages_optional_request_params)
+            and "messages" in anthropic_messages_request
+        ):
             anthropic_messages_request["messages"] = self._fill_reasoning_content(
                 anthropic_messages_request["messages"]
             )

--- a/tests/test_litellm/llms/deepseek/messages/test_deepseek_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/deepseek/messages/test_deepseek_anthropic_messages_transformation.py
@@ -297,3 +297,28 @@ def test_transform_does_not_backfill_when_thinking_disabled():
         headers={},
     )
     assert "reasoning_content" not in out["messages"][1]
+
+
+def test_thinking_mode_active_returns_true_only_when_explicitly_enabled():
+    """Guard must fire ONLY on `thinking: {type: enabled}`, not other shapes."""
+    config = DeepSeekAnthropicMessagesConfig()
+    # explicit enabled -> fill
+    assert config._thinking_mode_active(
+        model="deepseek-v4-pro",
+        optional_params={"thinking": {"type": "enabled", "budget_tokens": 1024}},
+    ) is True
+    # type=disabled -> no fill
+    assert config._thinking_mode_active(
+        model="deepseek-v4-pro",
+        optional_params={"thinking": {"type": "disabled"}},
+    ) is False
+    # thinking absent -> no fill (most common non-thinking case)
+    assert config._thinking_mode_active(
+        model="deepseek-v4-pro",
+        optional_params={"max_tokens": 100},
+    ) is False
+    # thinking present but not a dict (defensive) -> no fill
+    assert config._thinking_mode_active(
+        model="deepseek-v4-pro",
+        optional_params={"thinking": None},
+    ) is False

--- a/tests/test_litellm/llms/deepseek/messages/test_deepseek_anthropic_messages_transformation.py
+++ b/tests/test_litellm/llms/deepseek/messages/test_deepseek_anthropic_messages_transformation.py
@@ -120,7 +120,15 @@ def test_deepseek_anthropic_messages_headers_use_deepseek_key():
     assert headers["content-type"] == "application/json"
 
 
-def test_deepseek_anthropic_messages_preserves_thinking_and_sanitizes_custom_tools():
+def test_deepseek_anthropic_messages_preserves_thinking_sanitizes_tools_and_backfills_reasoning_content():
+    """
+    Thinking-mode request through the DeepSeek anthropic endpoint:
+      - thinking blocks in assistant history are preserved (untouched)
+      - custom tool discriminator is stripped (existing behaviour)
+      - assistant messages missing `reasoning_content` get a placeholder
+        backfill so DeepSeek does not reject the request with
+        "The reasoning_content in the thinking mode must be passed back"
+    """
     config = DeepSeekAnthropicMessagesConfig()
     messages = [
         {
@@ -179,11 +187,113 @@ def test_deepseek_anthropic_messages_preserves_thinking_and_sanitizes_custom_too
         headers={},
     )
 
-    assert request["messages"] == messages
+    # thinking param preserved
     assert request["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+
+    # tools sanitized (custom stripped, hosted tool kept)
     assert request["tools"][0] == {
         "name": "get_weather",
         "description": "Get weather",
         "input_schema": {"type": "object"},
     }
     assert request["tools"][1]["type"] == "web_search_20260209"
+
+    # user + tool_result messages unchanged
+    assert request["messages"][0] == messages[0]
+    assert request["messages"][2] == messages[2]
+
+    # assistant message: thinking block content preserved, reasoning_content backfilled
+    assistant = request["messages"][1]
+    assert assistant["content"] == messages[1]["content"]
+    assert assistant["reasoning_content"] == " "
+
+
+# ---------------------------------------------------------------------------
+# reasoning_content backfill unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_fill_reasoning_content_injects_placeholder_when_missing():
+    config = DeepSeekAnthropicMessagesConfig()
+    out = config._fill_reasoning_content(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    )
+    assert out[1]["reasoning_content"] == " "
+    assert "reasoning_content" not in out[0]
+
+
+def test_fill_reasoning_content_preserves_existing_value():
+    config = DeepSeekAnthropicMessagesConfig()
+    out = config._fill_reasoning_content(
+        [
+            {
+                "role": "assistant",
+                "content": "x",
+                "reasoning_content": "real chain",
+            }
+        ]
+    )
+    assert out[0]["reasoning_content"] == "real chain"
+
+
+def test_fill_reasoning_content_promotes_from_provider_specific_fields():
+    config = DeepSeekAnthropicMessagesConfig()
+    out = config._fill_reasoning_content(
+        [
+            {
+                "role": "assistant",
+                "content": "x",
+                "provider_specific_fields": {
+                    "reasoning_content": "stored chain",
+                    "other": "keep",
+                },
+            }
+        ]
+    )
+    assert out[0]["reasoning_content"] == "stored chain"
+    assert "reasoning_content" not in out[0]["provider_specific_fields"]
+    assert out[0]["provider_specific_fields"]["other"] == "keep"
+
+
+def test_fill_reasoning_content_skips_non_assistant_messages():
+    config = DeepSeekAnthropicMessagesConfig()
+    out = config._fill_reasoning_content(
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "sys"},
+        ]
+    )
+    assert "reasoning_content" not in out[0]
+    assert "reasoning_content" not in out[1]
+
+
+def test_fill_reasoning_content_handles_empty_list():
+    config = DeepSeekAnthropicMessagesConfig()
+    assert config._fill_reasoning_content([]) == []
+
+
+def test_fill_reasoning_content_does_not_mutate_input():
+    config = DeepSeekAnthropicMessagesConfig()
+    src = [{"role": "assistant", "content": "x"}]
+    src_snapshot = dict(src[0])
+    config._fill_reasoning_content(src)
+    assert src[0] == src_snapshot
+
+
+def test_transform_does_not_backfill_when_thinking_disabled():
+    """Non-thinking requests must not get spurious reasoning_content injection."""
+    config = DeepSeekAnthropicMessagesConfig()
+    out = config.transform_anthropic_messages_request(
+        model="deepseek-v4-pro",
+        messages=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [{"type": "text", "text": "hello"}]},
+        ],
+        anthropic_messages_optional_request_params={"max_tokens": 100},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert "reasoning_content" not in out["messages"][1]


### PR DESCRIPTION
## Summary

Fixes #31439

Re-opens PR #31440 with a clean rebase to current `litellm_oss_staging`.
The old PR was 213 commits behind and the force-pushed `litellm_oss_staging`
had carried in a number of unrelated UP045/style commits from other
contributors' branches, so a normal rebase would have been mostly lint
conflicts.

This PR preserves the original 4-commit history (fix + test + small
refactor + test) but rebases them onto the current `litellm_oss_staging`
HEAD (`710f6b2dcd`). 2 files, +212/-3, all ruff checks pass.

## Why rebase and re-open

The original PR #31440 base is now 213 commits behind and the
branch was force-pushed during the UP045 cleanup, so a normal
rebase would have produced massive lint conflicts. The cleanest
path forward is this minimal rebase + new branch + close old PR.

## Changes

The four commits are:

1. `fix(deepseek): fill reasoning_content on anthropic-compatible endpoint` —
   adds `_fill_reasoning_content` and `_thinking_mode_active` methods to
   `DeepSeekAnthropicMessagesConfig`, mirroring the OpenAI-compat path's
   `_fill_reasoning_content` (`litellm/llms/deepseek/chat/transformation.py:67-107`).
2. `test(deepseek): cover reasoning_content backfill on anthropic endpoint` —
   7 unit tests covering placeholder injection, provider_specific_fields
   promotion, mutation safety, and the non-thinking passthrough path.
3. `fix(deepseek): drop supports_reasoning gate from _thinking_mode_active` —
   simplifies the active-mode predicate to only check `thinking.type == "enabled"`.
4. `test(deepseek): cover _thinking_mode_active guard variants` — 2 unit
   tests covering the simplified predicate.

All changes are scoped to the DeepSeek anthropic provider only; the
base `AnthropicMessagesConfig` and other providers are untouched.

## Reproduction (before the fix)

```bash
curl http://localhost:4000/v1/messages -H "Authorization: Bearer ***" \
  -H "Content-Type: application/json" -H "anthropic-version: 2023-06-01" -d '{
  "model": "claude-ds",
  "max_tokens": 200,
  "thinking": {"type": "enabled", "budget_tokens": 5000},
  "messages": [
    {"role": "user", "content": "List files in /tmp"},
    {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "ls /tmp"}}]},
    {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "file1.txt\nfile2.txt"}]},
    {"role": "user", "content": "What files did you see?"}
  ]
}'
```

Returns 400:
```json
{"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API.","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}
```

After the fix the same request returns 200 with the model answering correctly.

## Companion PR

#31440 (original) — will be closed once this rebase is verified
to pass CI. @mateo-berri is already in the review queue for that
one; this rebase targets the same reviewer.

## Test plan

- [x] `ruff check` passes on both modified files
- [x] `ruff format --check` shows no new drift (verified)
- [ ] Full pytest run requires Python 3.10+ (local env is 3.9,
      this is a known local infra limitation; CI is the source
      of truth)
