### PR TITLE
fix: correct Gemini 2.5 Flash TTS / Native Audio pricing to match Google's published rates

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18445,11 +18445,11 @@
         "supports_image_size": false
     },
     "gemini/gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ],
@@ -42509,15 +42509,16 @@
         "gemini_native_audio": true
     },
     "gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_audio_token": 1.2e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -42621,15 +42622,16 @@
         "gemini_native_audio": true
     },
     "gemini/gemini-2.5-flash-native-audio-preview-12-2025": {
-        "input_cost_per_audio_token": 1e-06,
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_audio_token": 3e-06,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 2e-06,
+        "output_cost_per_audio_token": 1.2e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/realtime"
         ],
@@ -42683,11 +42685,11 @@
         "gemini_audio_only_live": true
     },
     "gemini-2.5-flash-preview-tts": {
-        "input_cost_per_token": 3e-07,
+        "input_cost_per_token": 5e-07,
         "litellm_provider": "gemini",
         "mode": "audio_speech",
-        "output_cost_per_token": 2.5e-06,
-        "source": "https://ai.google.dev/pricing",
+        "output_cost_per_token": 1e-05,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing",
         "supported_endpoints": [
             "/v1/audio/speech"
         ]


### PR DESCRIPTION
Fixes the pricing mismatches reported in #32111.

Updates 4 entries (`gemini-2.5-flash-preview-tts`, `gemini-2.5-flash-native-audio-preview-12-2025`, and their `gemini/`-prefixed keys) to match Google's published prices at https://ai.google.dev/gemini-api/docs/pricing (accessed 2026-07-04):

**gemini-2.5-flash-preview-tts** (mode: audio_speech)
| field | before | after | Google's page |
|---|---|---|---|
| `input_cost_per_token` | 3e-07 | 5e-07 | "Input price ... $0.50 (text)" |
| `output_cost_per_token` | 2.5e-06 | 1e-05 | "Output price ... $10.00 (audio)" |

**gemini-2.5-flash-native-audio-preview-12-2025**
| field | before | after | Google's page |
|---|---|---|---|
| `input_cost_per_token` | 3e-07 | 5e-07 | "$0.50 (text)" |
| `input_cost_per_audio_token` | 1e-06 | 3e-06 | "$3.00 (audio / video)" |
| `output_cost_per_token` | 2.5e-06 | 2e-06 | "$2.00 (text)" |
| `output_cost_per_audio_token` | (absent) | 1.2e-05 | "$12.00 (audio)" |

Also updated `source` to the current pricing docs URL (the old `https://ai.google.dev/pricing` redirects).

Values were cross-verified against the primary source while building FactQuire (https://factquire.com), a source-verified facts feed for LLM APIs — each entry there carries the verbatim provider quote if useful for review: https://factquire.com/models/google/gemini-2_5-flash-preview-tts.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)
