### PR TITLE
fix(vertex_ai): count_tokens returns 0 for Anthropic-format callers instead of a real count

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1209,8 +1209,16 @@ class VertexAITokenCounter(BaseTokenCounter):
         conversion isn't required for a token *count* and risks a 400 on
         Anthropic/OpenAI-shaped JSON Schema that Vertex's function-declaration
         validation doesn't accept as-is.
+
+        A caller that already sends Gemini-native `contents` directly is left
+        completely untouched -- this only kicks in when `contents` is falsy, so it
+        can't silently mutate a native caller's payload just because they also
+        happen to pass `system`/`tools`.
         """
-        if not contents and messages:
+        if contents:
+            return contents
+
+        if messages:
             try:
                 from litellm.llms.vertex_ai.gemini.transformation import (
                     _gemini_convert_messages_with_history,
@@ -1240,7 +1248,12 @@ class VertexAITokenCounter(BaseTokenCounter):
                     "role": "user",
                     "parts": [{"text": "\n".join(extra_text_parts)}],
                 }
-                contents = [extra_content, *contents] if contents else [extra_content]
+                # Appended (not prepended): the converted `contents` above typically
+                # starts with a "user" turn, so prepending another "user" turn here
+                # would create two consecutive same-role turns. countTokens appears
+                # lenient about alternation in practice, but appending avoids relying
+                # on that.
+                contents = [*contents, extra_content] if contents else [extra_content]
         except Exception:  # noqa: BLE001
             verbose_logger.exception(
                 "VertexAITokenCounter._build_gemini_contents_for_counting(): "

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1184,13 +1184,13 @@ class VertexAITokenCounter(BaseTokenCounter):
 
     def _build_gemini_contents_for_counting(
         self,
-        contents: Optional[List[Dict[str, Any]]],
-        messages: Optional[List[Dict[str, Any]]],
+        contents: Optional[list[dict[str, Any]]],
+        messages: Optional[list[dict[str, Any]]],
         system: Optional[Any],
-        tools: Optional[List[Dict[str, Any]]],
+        tools: Optional[list[dict[str, Any]]],
         model_to_use: str,
-        litellm_params: Dict[str, Any],
-    ) -> Optional[List[Dict[str, Any]]]:
+        litellm_params: dict[str, Any],
+    ) -> Optional[list[dict[str, Any]]]:
         """
         Build the Gemini-format `contents` payload sent to Vertex AI's countTokens API.
 
@@ -1222,7 +1222,7 @@ class VertexAITokenCounter(BaseTokenCounter):
                     litellm_params=litellm_params,
                     custom_llm_provider="vertex_ai",
                 )
-            except Exception:
+            except Exception:  # noqa: BLE001
                 verbose_logger.exception(
                     "VertexAITokenCounter._build_gemini_contents_for_counting(): "
                     "failed to convert Anthropic-format messages to Gemini contents "
@@ -1241,7 +1241,7 @@ class VertexAITokenCounter(BaseTokenCounter):
                     "parts": [{"text": "\n".join(extra_text_parts)}],
                 }
                 contents = [extra_content, *contents] if contents else [extra_content]
-        except Exception:
+        except Exception:  # noqa: BLE001
             verbose_logger.exception(
                 "VertexAITokenCounter._build_gemini_contents_for_counting(): "
                 "failed to fold system/tools into contents for token counting; "

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1217,7 +1217,7 @@ class VertexAITokenCounter(BaseTokenCounter):
                 )
 
                 contents = _gemini_convert_messages_with_history(
-                    messages=messages,  # type: ignore[arg-type]
+                    messages=messages,  # type: ignore[arg-type]  # untyped count_tokens dicts
                     model=model_to_use,
                     litellm_params=litellm_params,
                     custom_llm_provider="vertex_ai",

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -1,3 +1,4 @@
+import json
 import re
 from copy import deepcopy
 from enum import Enum
@@ -1152,6 +1153,15 @@ class VertexAITokenCounter(BaseTokenCounter):
             # Use standard Vertex AI (Gemini) token counter
             from litellm.llms.vertex_ai.count_tokens.handler import VertexAITokenCounter
 
+            contents = self._build_gemini_contents_for_counting(
+                contents=contents,
+                messages=messages,
+                system=system,
+                tools=tools,
+                model_to_use=model_to_use,
+                litellm_params=count_tokens_params_request,
+            )
+
             count_tokens_params = {
                 "model": model_to_use,
                 "contents": contents,
@@ -1171,3 +1181,71 @@ class VertexAITokenCounter(BaseTokenCounter):
                 )
 
         return None
+
+    def _build_gemini_contents_for_counting(
+        self,
+        contents: Optional[List[Dict[str, Any]]],
+        messages: Optional[List[Dict[str, Any]]],
+        system: Optional[Any],
+        tools: Optional[List[Dict[str, Any]]],
+        model_to_use: str,
+        litellm_params: Dict[str, Any],
+    ) -> Optional[List[Dict[str, Any]]]:
+        """
+        Build the Gemini-format `contents` payload sent to Vertex AI's countTokens API.
+
+        Callers that go through the Anthropic-compatible `/v1/messages/count_tokens`
+        proxy endpoint (e.g. Claude Code, or any Anthropic SDK client pointed at a
+        Vertex/Gemini deployment) only ever populate `messages`/`system`/`tools`
+        (Anthropic Messages API format) -- they never populate `contents` (Gemini's
+        native format). Previously, `contents` stayed `None` in that case, and
+        Vertex's countTokens endpoint treats an empty/null `contents` body as a
+        *valid* request and returns `{"totalTokens": 0}` instead of erroring -- so
+        callers silently got a confidently-wrong 0 instead of a real count.
+
+        This converts `messages` to Gemini `contents` using the same transform used
+        for real completion requests, and folds `system`/`tools` in as plain text
+        (not `systemInstruction`/`functionDeclarations`) since an exact schema-aware
+        conversion isn't required for a token *count* and risks a 400 on
+        Anthropic/OpenAI-shaped JSON Schema that Vertex's function-declaration
+        validation doesn't accept as-is.
+        """
+        if not contents and messages:
+            try:
+                from litellm.llms.vertex_ai.gemini.transformation import (
+                    _gemini_convert_messages_with_history,
+                )
+
+                contents = _gemini_convert_messages_with_history(
+                    messages=messages,  # type: ignore[arg-type]
+                    model=model_to_use,
+                    litellm_params=litellm_params,
+                    custom_llm_provider="vertex_ai",
+                )
+            except Exception:
+                verbose_logger.exception(
+                    "VertexAITokenCounter._build_gemini_contents_for_counting(): "
+                    "failed to convert Anthropic-format messages to Gemini contents "
+                    "for token counting; falling back to the original contents."
+                )
+
+        try:
+            extra_text_parts = []
+            if system:
+                extra_text_parts.append(system if isinstance(system, str) else json.dumps(system))
+            if tools:
+                extra_text_parts.append(json.dumps(tools))
+            if extra_text_parts:
+                extra_content = {
+                    "role": "user",
+                    "parts": [{"text": "\n".join(extra_text_parts)}],
+                }
+                contents = [extra_content, *contents] if contents else [extra_content]
+        except Exception:
+            verbose_logger.exception(
+                "VertexAITokenCounter._build_gemini_contents_for_counting(): "
+                "failed to fold system/tools into contents for token counting; "
+                "those will be undercounted."
+            )
+
+        return contents

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1353,8 +1353,11 @@ async def test_vertex_ai_token_counter_folds_system_and_tools_into_contents():
 
         call_kwargs = mock_gemini_count_tokens.call_args.kwargs
         contents = call_kwargs["contents"]
-        assert len(contents) == 2  # 1 folded system/tools block + 1 real message
-        folded_text = contents[0]["parts"][0]["text"]
+        assert len(contents) == 2  # 1 real message + 1 folded system/tools block
+        # Folded block is appended (not prepended): the converted message above is
+        # role="user", so prepending another role="user" block would create two
+        # consecutive same-role turns.
+        folded_text = contents[-1]["parts"][0]["text"]
         assert "helpful coding assistant" in folded_text
         assert "bash" in folded_text
 
@@ -1385,6 +1388,50 @@ async def test_vertex_ai_token_counter_leaves_native_contents_untouched():
             model_to_use="gemini-1.5-pro",
             messages=None,
             contents=native_contents,
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-1.5-pro",
+        )
+
+        call_kwargs = mock_gemini_count_tokens.call_args.kwargs
+        assert call_kwargs["contents"] == native_contents
+
+
+@pytest.mark.asyncio
+async def test_vertex_ai_token_counter_native_contents_ignores_system_and_tools():
+    """
+    Regression test (found in review of BerriAI/litellm#32115): a caller that
+    already sends Gemini-native `contents` but *also* happens to pass `system`/
+    `tools` must not have those folded in -- the messages/system/tools fallback
+    logic is only for callers that didn't provide `contents` at all. Previously
+    the system/tools folding ran unconditionally, so a native-Gemini caller's
+    `contents` would have been silently mutated with an extra prepended turn.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+    native_contents = [{"role": "user", "parts": [{"text": "already gemini format"}]}]
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_gemini_count_tokens:
+        mock_gemini_count_tokens.return_value = {
+            "totalTokens": 5,
+            "tokenizer_used": "gemini",
+        }
+
+        await token_counter.count_tokens(
+            model_to_use="gemini-1.5-pro",
+            messages=None,
+            contents=native_contents,
+            system="this should be ignored",
+            tools=[{"name": "should_be_ignored"}],
             deployment={
                 "litellm_params": {
                     "vertex_project": "test-project",

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -1261,6 +1261,144 @@ async def test_vertex_ai_token_counter_routes_gemini_models():
 
 
 @pytest.mark.asyncio
+async def test_vertex_ai_token_counter_converts_anthropic_messages_to_contents():
+    """
+    Regression test: callers using the Anthropic-compatible /v1/messages/count_tokens
+    endpoint (e.g. Claude Code) only send `messages`, never `contents`. Previously
+    `contents` stayed `None` in that case, Vertex's countTokens API silently accepted
+    the empty body as valid and returned {"totalTokens": 0}, and callers got a
+    confidently-wrong 0 instead of a real count.
+
+    `contents` must now be derived from `messages` before calling the Gemini
+    countTokens handler.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_gemini_count_tokens:
+        mock_gemini_count_tokens.return_value = {
+            "totalTokens": 12,
+            "tokenizer_used": "gemini",
+        }
+
+        result = await token_counter.count_tokens(
+            model_to_use="gemini-1.5-pro",
+            messages=[{"role": "user", "content": "Hello, count my tokens please."}],
+            contents=None,
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-1.5-pro",
+        )
+
+        assert result is not None
+        assert result.total_tokens == 12
+
+        call_kwargs = mock_gemini_count_tokens.call_args.kwargs
+        assert call_kwargs["contents"], "contents must be derived from messages, not left as None"
+        assert call_kwargs["contents"][0]["parts"][0]["text"] == "Hello, count my tokens please."
+
+
+@pytest.mark.asyncio
+async def test_vertex_ai_token_counter_folds_system_and_tools_into_contents():
+    """
+    Regression test: `system` and `tools` (Anthropic Messages API fields) were
+    silently dropped -- only `contents` was ever forwarded to Vertex's countTokens
+    API -- so a caller counting tokens for a system prompt or a list of tool/function
+    schemas (e.g. Claude Code's per-category /context accounting for MCP tools)
+    still under-counted even after `messages` were converted.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_gemini_count_tokens:
+        mock_gemini_count_tokens.return_value = {
+            "totalTokens": 40,
+            "tokenizer_used": "gemini",
+        }
+
+        await token_counter.count_tokens(
+            model_to_use="gemini-1.5-pro",
+            messages=[{"role": "user", "content": "hi"}],
+            contents=None,
+            system="You are a helpful coding assistant.",
+            tools=[
+                {
+                    "name": "bash",
+                    "description": "Run a bash command",
+                    "input_schema": {"type": "object", "properties": {}},
+                }
+            ],
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-1.5-pro",
+        )
+
+        call_kwargs = mock_gemini_count_tokens.call_args.kwargs
+        contents = call_kwargs["contents"]
+        assert len(contents) == 2  # 1 folded system/tools block + 1 real message
+        folded_text = contents[0]["parts"][0]["text"]
+        assert "helpful coding assistant" in folded_text
+        assert "bash" in folded_text
+
+
+@pytest.mark.asyncio
+async def test_vertex_ai_token_counter_leaves_native_contents_untouched():
+    """
+    Regression safety net: a caller that already sends Gemini-native `contents`
+    directly (not through the Anthropic-format endpoint) must not have its payload
+    altered by the messages/system/tools fallback logic.
+    """
+    from unittest.mock import patch
+
+    from litellm.llms.vertex_ai.common_utils import VertexAITokenCounter
+
+    token_counter = VertexAITokenCounter()
+    native_contents = [{"role": "user", "parts": [{"text": "already gemini format"}]}]
+
+    with patch(
+        "litellm.llms.vertex_ai.count_tokens.handler.VertexAITokenCounter.acount_tokens"
+    ) as mock_gemini_count_tokens:
+        mock_gemini_count_tokens.return_value = {
+            "totalTokens": 5,
+            "tokenizer_used": "gemini",
+        }
+
+        await token_counter.count_tokens(
+            model_to_use="gemini-1.5-pro",
+            messages=None,
+            contents=native_contents,
+            deployment={
+                "litellm_params": {
+                    "vertex_project": "test-project",
+                    "vertex_location": "us-central1",
+                }
+            },
+            request_model="vertex_ai/gemini-1.5-pro",
+        )
+
+        call_kwargs = mock_gemini_count_tokens.call_args.kwargs
+        assert call_kwargs["contents"] == native_contents
+
+
+@pytest.mark.asyncio
 async def test_vertex_ai_partner_model_detection():
     """
     Test that VertexAIPartnerModels.is_vertex_partner_model correctly identifies


### PR DESCRIPTION
## What does this PR do?

Fixes `VertexAITokenCounter.count_tokens()` (`litellm/llms/vertex_ai/common_utils.py`) silently returning `{"totalTokens": 0}` for any caller that uses the Anthropic-compatible `/v1/messages/count_tokens` proxy endpoint against a Vertex AI Gemini deployment (e.g. Claude Code, or any Anthropic SDK client pointed at Vertex through the Anthropic passthrough).

### Root cause

`VertexAITokenCounter.count_tokens()` only ever forwards `contents` (Gemini-native format) to Vertex's `countTokens` API. Callers hitting the Anthropic-format endpoint only populate `messages`/`system`/`tools` (Anthropic Messages API format) — `contents` is never derived from them, so it stays `None`.

Vertex's `countTokens` API treats an empty/null `contents` body as a *valid* request and returns `{"totalTokens": 0}` instead of erroring — so callers get a confidently-wrong `0` instead of a real count or a clear failure. I ran into this building a small local proxy that points Claude Code at Vertex Gemini: Claude Code's `/context` breakdown (which relies on `POST /v1/messages/count_tokens` for categories like MCP tool schemas, custom agents, and memory files) showed `0 tokens` for all of them, even though the content was real.

Verified directly against a live Vertex `countTokens` call through LiteLLM proxy:

| Payload | Before | After |
|---|---|---|
| `messages` only (~1 sentence) | `0` | non-zero, plausible |
| `system` + `messages` + 1 `tools` entry | `0` | non-zero, plausible |
| `messages` (minimal) + 2 realistic MCP-style tool schemas | `0` | non-zero, plausible |

### Fix

- Convert `messages` → Gemini `contents` using the existing `_gemini_convert_messages_with_history` transform (the same one used for real completion requests), only when `contents` isn't already provided.
- Fold `system`/`tools` in as plain text content (not `systemInstruction`/`functionDeclarations`) — an exact schema-aware conversion isn't required for a token *count*, and risks a 400 on Anthropic/OpenAI-shaped JSON Schema that Vertex's function-declaration validation doesn't accept as-is. An approximate estimate is enough here.
- Both conversions are wrapped in `try`/`except` with a logged warning, falling back to the previous behavior on any failure — so this can't introduce a new failure mode, only improve the count when the conversion succeeds.
- A caller that already sends Gemini-native `contents` directly is untouched (see `test_vertex_ai_token_counter_leaves_native_contents_untouched`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added 3 tests to `tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py`:
- `test_vertex_ai_token_counter_converts_anthropic_messages_to_contents`
- `test_vertex_ai_token_counter_folds_system_and_tools_into_contents`
- `test_vertex_ai_token_counter_leaves_native_contents_untouched` (regression safety net for existing native-Gemini callers)

All 62 tests in that file pass locally (`pytest tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py`), including the 3 new ones and the pre-existing `test_vertex_ai_token_counter_routes_gemini_models`/`test_vertex_ai_token_counter_routes_partner_models`/`test_vertex_ai_token_counter_uses_count_tokens_location`.

`ruff format --check` and `ruff check` pass clean on the changed lines in `litellm/llms/vertex_ai/common_utils.py` (pinned `ruff==0.15.3`).