### PR TITLE
fix: correct embed-multilingual-light-v3.0 pricing (1000x too high)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -14569,7 +14569,7 @@
         "supports_embedding_image_input": true
     },
     "embed-multilingual-light-v3.0": {
-        "input_cost_per_token": 0.0001,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
         "max_tokens": 1024,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -14569,7 +14569,7 @@
         "supports_embedding_image_input": true
     },
     "embed-multilingual-light-v3.0": {
-        "input_cost_per_token": 0.0001,
+        "input_cost_per_token": 1e-07,
         "litellm_provider": "cohere",
         "max_input_tokens": 1024,
         "max_tokens": 1024,


### PR DESCRIPTION
## What

`embed-multilingual-light-v3.0` (cohere) has `input_cost_per_token: 0.0001`, i.e. $100 per 1M tokens, 1000x the real price. It looks like the per-1K price ($0.0001/1K) was entered as a per-token value.

## Evidence

- Cohere prices all Embed v3 models, light included, at **$0.10 per 1M tokens** = `1e-07` per token: https://cohere.com/pricing
- Every sibling entry in this file already says `1e-07`: `embed-english-light-v3.0`, `embed-english-v3.0`, `embed-multilingual-v3.0`
- This model's own OCI mirror in this file, `oci/cohere.embed-multilingual-light-v3.0`, also says `1e-07`

## Change

`0.0001` -> `1e-07` for `embed-multilingual-light-v3.0`, in both `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`. No other fields touched.

We caught this while auditing our own catalog's litellm-sourced prices against this file (we mirror it), and this entry stood out at 1000x its siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)