### PR TITLE
feat: add azure_ai/mistral-ocr-2503 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7775,6 +7775,15 @@
         ],
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
     },
+    "azure_ai/mistral-ocr-2503": {
+        "litellm_provider": "azure_ai",
+        "ocr_cost_per_page": 0.004,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/"
+    },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
         "ocr_cost_per_page": 0.0015,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7775,6 +7775,15 @@
         ],
         "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/"
     },
+    "azure_ai/mistral-ocr-2503": {
+        "litellm_provider": "azure_ai",
+        "ocr_cost_per_page": 0.004,
+        "mode": "ocr",
+        "supported_endpoints": [
+            "/v1/ocr"
+        ],
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/"
+    },
     "azure_ai/doc-intelligence/prebuilt-read": {
         "litellm_provider": "azure_ai",
         "ocr_cost_per_page": 0.0015,

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_mistral_ocr_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_mistral_ocr_metadata.py
@@ -1,0 +1,66 @@
+"""
+Metadata / pricing tests for the Azure AI Foundry Mistral OCR model
+(azure_ai/mistral-ocr-2503).
+
+Regresses that the entry exists in both the main and backup cost maps with
+the expected OCR pricing, and that get_model_info resolves it against the
+local cost map.
+"""
+
+import json
+from importlib.resources import files
+from pathlib import Path
+
+import pytest
+
+MODEL = "azure_ai/mistral-ocr-2503"
+OCR_COST_PER_PAGE = 0.004
+
+REPO_ROOT = Path(__file__).parents[4]
+MAIN_COST_MAP = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_COST_MAP = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+
+@pytest.mark.parametrize("cost_map_path", [MAIN_COST_MAP, BACKUP_COST_MAP])
+def test_azure_ai_mistral_ocr_pricing_entry(cost_map_path: Path) -> None:
+    with open(cost_map_path) as f:
+        info = json.load(f).get(MODEL)
+
+    assert info is not None, f"{MODEL} missing from {cost_map_path.name}"
+    assert info["litellm_provider"] == "azure_ai"
+    assert info["mode"] == "ocr"
+    assert info["supported_endpoints"] == ["/v1/ocr"]
+    assert info["ocr_cost_per_page"] == OCR_COST_PER_PAGE
+
+
+@pytest.fixture
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm")
+        .joinpath("model_prices_and_context_window_backup.json")
+        .read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+def test_azure_ai_mistral_ocr_model_info(use_local_model_cost_map) -> None:
+    info = use_local_model_cost_map.get_model_info(model=MODEL)
+
+    assert info["litellm_provider"] == "azure_ai"
+    assert info["mode"] == "ocr"
+    assert info["ocr_cost_per_page"] == OCR_COST_PER_PAGE


### PR DESCRIPTION
## What / Why

Closes #32033.

Adds the Azure AI Foundry Mistral OCR deployment **`azure_ai/mistral-ocr-2503`** (Mistral OCR 25.03) to the cost map. This is a real Foundry catalog model ([ai.azure.com/catalog/models/mistral-ocr-2503](https://ai.azure.com/catalog/models/mistral-ocr-2503)) that was missing.

### Note on naming (why not `mistral-ocr-4-0`)

The issue title asks for `azure/mistral-ocr-4-0`, but on Azure AI Foundry:
- Mistral's **OCR-4** ships as *"Mistral Document AI"* (per Microsoft's blog *"Mistral Document AI (with OCR 4) … arrive in Microsoft Foundry"*) and **already exists** in the cost map as `azure_ai/mistral-document-ai-2512`.
- Foundry serverless Mistral uses the `azure_ai/` prefix, not `azure/`.
- Azure does not expose a deployment literally named `mistral-ocr-4-0`.

So this PR adds the genuinely-missing real deployment (`mistral-ocr-2503`) rather than an alias that wouldn't resolve. Happy to adjust if maintainers prefer a different scope.

## Changes
- `model_prices_and_context_window.json` — add `azure_ai/mistral-ocr-2503`
- `litellm/model_prices_and_context_window_backup.json` — same entry (kept identical)
- `tests/test_litellm/llms/azure_ai/test_azure_ai_mistral_ocr_metadata.py` — metadata/pricing regression test

Pricing: `$0.004`/page ([Azure Foundry Mistral pricing](https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/mistral-ai/); matches the repo's existing OCR-4 rate).

## Testing
```
pytest tests/test_litellm/llms/azure_ai/test_azure_ai_mistral_ocr_metadata.py
# 3 passed
```
