### PR TITLE
feat: Support multiple API keys with rotation for search tools

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -98,6 +98,7 @@ from litellm.router_utils.batch_utils import (
     should_replace_model_in_jsonl,
 )
 from litellm.router_utils.client_initalization_utils import InitalizeCachedClient
+from litellm.router_utils.search_api_router import SearchAPIRouter
 from litellm.router_utils.clientside_credential_handler import (
     get_dynamic_litellm_params,
     is_clientside_credential,
@@ -408,7 +409,7 @@ class Router:
         self.router_general_settings: RouterGeneralSettings = router_general_settings or RouterGeneralSettings()
 
         self.assistants_config = assistants_config
-        self.search_tools = search_tools or []
+        self.search_tools = SearchAPIRouter._expand_search_tools(search_tools or [])
         self.guardrail_list = guardrail_list or []
         self.deployment_names: List = []  # names of models under litellm_params. ex. azure/chatgpt-v-2
         self.deployment_latency_map = {}

--- a/litellm/router_utils/search_api_router.py
+++ b/litellm/router_utils/search_api_router.py
@@ -5,7 +5,6 @@ Handles search tool selection, load balancing, and fallback logic for search req
 """
 
 import asyncio
-import random
 import traceback
 from functools import partial
 from typing import Any, Callable, Dict, Optional, Tuple
@@ -43,6 +42,29 @@ class SearchAPIRouter:
         return resolved_api_key, resolved_api_base
 
     @staticmethod
+    def _expand_search_tools(search_tools: list) -> list:
+        expanded_tools = []
+        for tool in search_tools:
+            litellm_params = tool.get("litellm_params", {})
+            api_keys = litellm_params.get("api_keys")
+            if api_keys and isinstance(api_keys, list):
+                for idx, api_key in enumerate(api_keys):
+                    new_tool = dict(tool)
+                    new_params = dict(litellm_params)
+                    new_params["api_key"] = api_key
+                    new_params.pop("api_keys", None)
+                    
+                    new_tool["search_tool_id"] = f"{tool.get('search_tool_id') or tool.get('search_tool_name')}_key_{idx}"
+                    new_tool["litellm_params"] = new_params
+                    expanded_tools.append(new_tool)
+            else:
+                new_tool = dict(tool)
+                new_tool["litellm_params"] = dict(litellm_params)
+                new_tool.setdefault("search_tool_id", tool.get("search_tool_name"))
+                expanded_tools.append(new_tool)
+        return expanded_tools
+
+    @staticmethod
     async def update_router_search_tools(router_instance: Any, search_tools: list):
         """
         Update the router with search tools from the database.
@@ -71,9 +93,9 @@ class SearchAPIRouter:
                 router_search_tools.append(router_search_tool)
 
             # Update the router's search_tools list
-            router_instance.search_tools = router_search_tools
+            router_instance.search_tools = SearchAPIRouter._expand_search_tools(router_search_tools)
 
-            verbose_router_logger.info(f"Successfully updated router with {len(router_search_tools)} search tool(s)")
+            verbose_router_logger.info(f"Successfully updated router with {len(router_instance.search_tools)} search tool(s) ({len(router_search_tools)} configured)")
 
         except Exception as e:
             verbose_router_logger.exception(f"Error updating router with search tools: {str(e)}")
@@ -197,12 +219,64 @@ class SearchAPIRouter:
                 search_tool_name=search_tool_name,
             )
 
-            # Simple random selection for load balancing across multiple providers with same name
-            # For search tools, we use simple random choice since they don't have TPM/RPM constraints
-            selected_tool = random.choice(matching_tools)
+            from litellm.router_utils.cooldown_cache import _async_get_cooldown_deployments
+            from litellm.router_strategy.simple_shuffle import simple_shuffle
+            from litellm.types.router import RouterRateLimitError
+
+            cooldown_deployments = await _async_get_cooldown_deployments(
+                litellm_router_instance=router_instance,
+                parent_otel_span=None
+            )
+
+            
+            deployments = [{
+                "model_name": search_tool_name,
+                "litellm_params": {"model": search_tool_name, **tool.get("litellm_params", {})},
+                "model_info": {"id": tool.get("search_tool_id") or tool.get("search_tool_name")}
+            } for tool in matching_tools]
+
+            healthy_deployments = router_instance._filter_cooldown_deployments(
+                healthy_deployments=deployments,
+                cooldown_deployments=cooldown_deployments
+            )
+
+            if not healthy_deployments:
+                raise RouterRateLimitError(
+                    model=search_tool_name,
+                    cooldown_time=0,
+                    enable_pre_call_checks=False,
+                    cooldown_list=cooldown_deployments,
+                )
+
+            # Use router strategy for load balancing
+            strategy, strategy_selector = router_instance._get_routing_context(search_tool_name)
+            
+            if strategy == "simple-shuffle":
+                selected_deployment = simple_shuffle(
+                    llm_router_instance=router_instance,
+                    healthy_deployments=healthy_deployments,
+                    model=search_tool_name
+                )
+            else:
+                selected_deployment = await router_instance._select_deployment_async(
+                    strategy=strategy,
+                    selector=strategy_selector,
+                    model=search_tool_name,
+                    healthy_deployments=healthy_deployments,
+                    messages=kwargs.get("messages", []),
+                    input=kwargs.get("input"),
+                    request_kwargs=kwargs,
+                )
+                if selected_deployment is None:
+                    # Fallback to simple shuffle if strategy selection fails
+                    selected_deployment = simple_shuffle(
+                        llm_router_instance=router_instance,
+                        healthy_deployments=healthy_deployments,
+                        model=search_tool_name
+                    )
 
             # Extract search provider and other params from litellm_params
-            litellm_params = selected_tool.get("litellm_params", {})
+            litellm_params = selected_deployment.get("litellm_params", {})
             search_provider = litellm_params.get("search_provider")
             if not search_provider:
                 raise ValueError(f"search_provider not found in litellm_params for search tool '{search_tool_name}'")
@@ -211,7 +285,14 @@ class SearchAPIRouter:
                 tool_litellm_params=litellm_params,
             )
 
-            verbose_router_logger.debug(f"Selected search tool with provider: {search_provider}")
+            verbose_router_logger.debug(f"Selected search tool with provider: {search_provider}, id: {selected_deployment['model_info']['id']}")
+
+            # Update kwargs so the router's error handler knows which deployment failed (for cooldown)
+            router_instance._update_kwargs_with_deployment(
+                deployment=selected_deployment, 
+                kwargs=kwargs, 
+                function_name="_asearch_with_fallbacks_helper"
+            )
 
             # Call the original search function with the provider config
             response = await original_generic_function(

--- a/litellm/types/search.py
+++ b/litellm/types/search.py
@@ -23,6 +23,7 @@ class SearchToolLiteLLMParams(TypedDict, total=False):
 
     search_provider: Required[str]
     api_key: Optional[str]
+    api_keys: Optional[List[str]]
     api_base: Optional[str]
     timeout: Optional[float]
     max_retries: Optional[int]

--- a/tests/search_tests/test_search_api_router_expansion.py
+++ b/tests/search_tests/test_search_api_router_expansion.py
@@ -1,0 +1,40 @@
+from litellm.router_utils.search_api_router import SearchAPIRouter
+
+def test_expand_search_tools():
+    # Setup test data with multiple keys
+    search_tools_config = [
+        {
+            "search_tool_name": "tavily-pool",
+            "litellm_params": {
+                "search_provider": "tavily",
+                "api_keys": ["key1", "key2"]
+            }
+        },
+        {
+            "search_tool_name": "single-tavily",
+            "litellm_params": {
+                "search_provider": "tavily",
+                "api_key": "key3"
+            }
+        }
+    ]
+
+    # Run the expansion logic
+    expanded = SearchAPIRouter._expand_search_tools(search_tools_config)
+
+    # Assertions
+    assert len(expanded) == 3, f"Expected 3 tools, got {len(expanded)}"
+    
+    pool_tools = [t for t in expanded if t["search_tool_name"] == "tavily-pool"]
+    assert len(pool_tools) == 2, "Expected 2 tools from the pool"
+    
+    assert pool_tools[0]["litellm_params"]["api_key"] == "key1"
+    assert pool_tools[0]["search_tool_id"] == "tavily-pool_key_0"
+    assert "api_keys" not in pool_tools[0]["litellm_params"], "api_keys should be removed from expanded dict"
+
+    assert pool_tools[1]["litellm_params"]["api_key"] == "key2"
+    assert pool_tools[1]["search_tool_id"] == "tavily-pool_key_1"
+
+    single_tool = [t for t in expanded if t["search_tool_name"] == "single-tavily"][0]
+    assert single_tool["litellm_params"]["api_key"] == "key3"
+    assert single_tool["search_tool_id"] == "single-tavily"


### PR DESCRIPTION
## Relevant issues
Fixes #32118
## Linear ticket
## Pre-Submission checklist
**Please complete all items before asking a LiteLLM maintainer to review your PR**
- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
## Delays in PR merge?
If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Type
🆕 New Feature
## Changes
For search providers with hard rate-limits or monthly quotas per key, such as Tavily's free tier, users wanting higher effective throughput previously had to maintain N separately-named tools and manually rotate them on the client side. The SearchToolRegistry bound each tool name to exactly one provider and one key, and the internal fallback logic bypassed the advanced routing capabilities of LiteLLM.
The search endpoint resolved search tools using a basic random selection inside SearchAPIRouter.async_search_with_fallbacks_helper. Because it did not utilize _get_routing_context or _select_deployment_async, search tools missed out on existing load balancing strategies, health tracking, and cooldown caching for 429 errors.
This change introduces api_keys support to SearchToolLiteLLMParams in litellm/types/search.py. At initialization, configurations containing an api_keys array are automatically flattened into independent internal search tool records, each receiving a synthesized unique ID.
The async_search_with_fallbacks_helper maps these search tools into DeploymentTypedDict structures under the hood. It passes them through the native cooldown deployment filters and delegates selection to the configured routing strategy.
By calling the router update kwargs method, the selected search tool ID is injected into the context. If the provider throws a 429 quota exhaustion error, the main router deployment callback on failure successfully catches it and cools down that specific API key before failing over to the next key.
This approach is fully backwards compatible; if a user only defines a single api_key for a tool, the logic handles it cleanly without modification. It provides architectural safety by translating search tools into LLM deployments just-in-time, allowing the existing router core to do the load balancing and cooldown tracking natively.