### PR TITLE
fix(proxy): apply explicit user_id/key_alias as global filters in /key/list (#32062)

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5222,6 +5222,10 @@ async def list_keys(
         use_substring_matching = substring_matching and is_proxy_admin
 
         # Admins may omit user_id to list all keys; non-admins are scoped to self.
+        # Capture whether user_id was an explicit filter BEFORE applying the
+        # self-default below, so an explicit ?user_id= narrows results (issue
+        # #32062) while the implicit self-scope does not filter out team keys.
+        user_id_provided_as_filter = user_id is not None
         if not user_id and not is_proxy_admin:
             user_id = user_api_key_dict.user_id
 
@@ -5246,6 +5250,7 @@ async def list_keys(
             access_group_id=access_group_id,
             agent_id=agent_id,
             use_substring_matching=use_substring_matching,
+            apply_user_id_filter=user_id_provided_as_filter,
         )
 
         verbose_proxy_logger.debug("Successfully prepared response")
@@ -5467,6 +5472,7 @@ def _build_key_filter_conditions(
     access_group_id: Optional[str] = None,
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    apply_user_id_filter: bool = False,
 ) -> Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]]:
     """Build filter conditions for key listing.
 
@@ -5540,9 +5546,17 @@ def _build_key_filter_conditions(
             # direct _list_key_helper callers like Prometheus)
             or_conditions.append({"created_by": user_id})
 
+    # Track whether an unfiltered team-visibility OR-branch is added below.
+    # Explicit user_id/key_alias filters are only unioned away (issue #32062)
+    # when such a branch exists; in the single-branch (own keys) case the
+    # filters are already applied inside that branch and get flattened into the
+    # top-level where dict, so we must not re-wrap them there.
+    team_visibility_branch_added = False
+
     # Add condition for admin team keys (admins see ALL team keys)
     if admin_team_ids:
         or_conditions.append({"team_id": {"in": admin_team_ids}})
+        team_visibility_branch_added = True
 
     # Add condition for member team service accounts (members only see keys with user_id=NULL)
     if member_team_ids:
@@ -5557,6 +5571,7 @@ def _build_key_filter_conditions(
                     ]
                 }
             )
+            team_visibility_branch_added = True
 
     # Combine conditions with OR if we have multiple conditions
     if len(or_conditions) > 1:
@@ -5574,6 +5589,39 @@ def _build_key_filter_conditions(
         where = {"AND": [where, {"access_group_ids": {"hasSome": [access_group_id]}}]}
     if agent_id and isinstance(agent_id, str):
         where = {"AND": [where, {"agent_id": agent_id}]}
+
+    # When an unfiltered team-visibility OR-branch is present, explicit
+    # user_id/key_alias query params would otherwise be unioned away and return
+    # all team keys (issue #32062). Re-apply them as global AND filters so they
+    # narrow across every visibility branch, exactly like team_id/project_id do
+    # above. In the single-branch (own keys) case the filters are already applied
+    # inside that branch, so we leave the flattened structure untouched.
+    #
+    # key_alias is always an explicit filter. user_id also doubles as the
+    # implicit self-scope for non-admins, so it is only narrowed here when the
+    # caller explicitly passed it (apply_user_id_filter); otherwise a team admin
+    # who omits user_id would be wrongly restricted to their own keys.
+    if team_visibility_branch_added:
+        if key_alias and isinstance(key_alias, str):
+            if use_substring_matching:
+                where = {
+                    "AND": [
+                        where,
+                        {"key_alias": {"contains": key_alias, "mode": "insensitive"}},
+                    ]
+                }
+            else:
+                where = {"AND": [where, {"key_alias": key_alias}]}
+        if apply_user_id_filter and user_id and isinstance(user_id, str):
+            if use_substring_matching:
+                where = {
+                    "AND": [
+                        where,
+                        {"user_id": {"contains": user_id, "mode": "insensitive"}},
+                    ]
+                }
+            else:
+                where = {"AND": [where, {"user_id": user_id}]}
 
     verbose_proxy_logger.debug(f"Filter conditions: {where}")
     return where
@@ -5603,6 +5651,7 @@ async def _list_key_helper(
     access_group_id: Optional[str] = None,
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    apply_user_id_filter: bool = False,
 ) -> KeyListResponseObject:
     """
     Helper function to list keys
@@ -5640,6 +5689,7 @@ async def _list_key_helper(
         access_group_id=access_group_id,
         agent_id=agent_id,
         use_substring_matching=use_substring_matching,
+        apply_user_id_filter=apply_user_id_filter,
     )
 
     # Calculate skip for pagination

--- a/tests/test_litellm/proxy/management_endpoints/test_key_list_filter_conditions.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_list_filter_conditions.py
@@ -1,0 +1,99 @@
+"""
+Regression tests for `_build_key_filter_conditions` (issue #32062).
+
+Explicit `user_id` / `key_alias` query filters must narrow the result set
+across ALL visibility branches (own keys, admin-team keys, member service
+accounts) instead of being unioned away by an unfiltered team-visibility
+branch. At the same time, the implicit self-scope (`user_id` defaulted for a
+non-admin) must NOT be applied as a filter, or a team admin who omits
+`user_id` would be wrongly restricted to their own keys.
+"""
+
+from litellm.proxy.management_endpoints.key_management_endpoints import (
+    _build_key_filter_conditions,
+)
+
+
+def _all_and_clauses(where):
+    """Flatten every clause combined via (possibly nested) AND.
+
+    Each global filter wraps the prior ``where`` in a new ``{"AND": [...]}``,
+    so filters end up at different nesting depths but are all AND-combined.
+    Nested ORs are treated as opaque leaves (not descended into), so a
+    ``user_id`` that only appears inside a visibility OR-branch is NOT counted
+    as a top-level filter.
+    """
+    out = []
+
+    def walk(node):
+        if isinstance(node, dict) and isinstance(node.get("AND"), list):
+            for clause in node["AND"]:
+                walk(clause)
+        else:
+            out.append(node)
+
+    walk(where)
+    return out
+
+
+def test_explicit_user_id_narrows_across_team_visibility():
+    # Caller has team-wide visibility (admin_team_ids) AND explicitly filters by
+    # user_id -> the filter must be AND'd globally so only that user's keys show.
+    where = _build_key_filter_conditions(
+        user_id="alice",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-1"],
+        apply_user_id_filter=True,
+    )
+    assert {"user_id": "alice"} in _all_and_clauses(where)
+
+
+def test_explicit_key_alias_narrows_across_team_visibility():
+    where = _build_key_filter_conditions(
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        key_alias="my-alias",
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-1"],
+    )
+    assert {"key_alias": "my-alias"} in _all_and_clauses(where)
+
+
+def test_implicit_self_scope_does_not_filter_team_keys():
+    # Team admin omitted user_id -> it was defaulted to self (apply_user_id_filter
+    # is False). It must NOT be applied as a global AND, otherwise the admin would
+    # only see their own keys instead of ALL team keys.
+    where = _build_key_filter_conditions(
+        user_id="admin-user",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-1"],
+        apply_user_id_filter=False,
+    )
+    assert {"user_id": "admin-user"} not in _all_and_clauses(where)
+
+
+def test_substring_matching_uses_contains_for_global_filters():
+    where = _build_key_filter_conditions(
+        user_id="ali",
+        team_id=None,
+        organization_id=None,
+        key_alias="ali-key",
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-1"],
+        apply_user_id_filter=True,
+        use_substring_matching=True,
+    )
+    clauses = _all_and_clauses(where)
+    assert {"key_alias": {"contains": "ali-key", "mode": "insensitive"}} in clauses
+    assert {"user_id": {"contains": "ali", "mode": "insensitive"}} in clauses


### PR DESCRIPTION
## What / Why

Closes #32062.

`GET /key/list` (and the Virtual Keys UI) **ignored `user_id` / `key_alias` filters** whenever the caller had team-wide key visibility — a team admin, or a regular member whose team grants `/key/list` in `team_member_permissions`. The filtered response was byte-identical to the unfiltered one (e.g. all ~4,000 team keys).

### Root cause

In `_build_key_filter_conditions`, `user_id` / `key_alias` were only applied inside the **own-keys OR-branch**, while team visibility was added as a **separate, unfiltered OR-branch** (`{"team_id": {"in": admin_team_ids}}`). Combined with `OR`, the unfiltered team branch unioned the filter away. By contrast `team_id` / `project_id` / `agent_id` are already applied as **global `AND`** filters — exactly the behavior `user_id` / `key_alias` need.

### Fix

Apply `user_id` / `key_alias` as global `AND` filters alongside `team_id`, so explicit filters **narrow within** the caller's visibility instead of being unioned away.

One subtlety: `user_id` does double duty — for non-admins it is **defaulted to self** as the implicit visibility scope (`list_keys`). Applying that defaulted value as a filter would wrongly restrict a team admin (who omits `user_id`) to only their own keys, and hide team service accounts (`user_id=NULL`) from members. So:

- **`key_alias`** is always an explicit filter → applied globally whenever present.
- **`user_id`** is applied globally **only when the caller explicitly passed it**, tracked via a new `apply_user_id_filter` flag captured in `list_keys` *before* the self-default.

This is a monotonic narrowing (it can only reduce results, never widen visibility), so it cannot introduce a data leak.

## Changes
- `litellm/proxy/management_endpoints/key_management_endpoints.py`
  - `_build_key_filter_conditions`: apply `key_alias` (always) and `user_id` (when explicit) as global `AND` filters; new `apply_user_id_filter` param.
  - `_list_key_helper`: thread `apply_user_id_filter` through.
  - `list_keys`: capture whether `user_id` was explicitly provided (before the self-default) and pass it down.
- `tests/test_litellm/proxy/management_endpoints/test_key_list_filter_conditions.py` — regression tests: explicit `user_id`/`key_alias` narrow across team visibility, implicit self-scope does **not** filter team keys, and substring matching is preserved.

## Testing
```
pytest tests/test_litellm/proxy/management_endpoints/test_key_list_filter_conditions.py
# 4 passed
```
