### PR TITLE
ci: disable coderabbit automatic reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    enabled: false
+    auto_incremental_review: false


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

CodeRabbit already proved it on this very PR: it picked up the new config and posted "Review skipped. Auto reviews are disabled on this repository" with "Configuration used: Path: .coderabbit.yaml" instead of auto reviewing. Commenting `@coderabbitai review` still triggers a review on demand

## Type

🚄 Infrastructure

## Changes

Adds a root `.coderabbit.yaml` that sets `reviews.auto_review.enabled: false` and `auto_incremental_review: false`, making CodeRabbit manual invoke only. It no longer reviews new PRs or pushed commits automatically; it runs only when someone explicitly comments `@coderabbitai review` (or `full review`) on a PR. Tests are not applicable since this is a bot config file with no code paths