### PR TITLE
fix(proxy): document /mcp-rest/tools/call request body in OpenAPI (#32121)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -16,6 +16,7 @@ from typing import (
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from pydantic import BaseModel, ConfigDict, Field
 
 from litellm._logging import verbose_logger
 from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthError
@@ -45,6 +46,35 @@ router = APIRouter(
     prefix="/mcp-rest",
     tags=["mcp"],
 )
+
+
+class MCPToolCallRequest(BaseModel):
+    """Request body for ``POST /mcp-rest/tools/call``.
+
+    Declares the parameters the endpoint expects so they are documented in the
+    generated OpenAPI spec (issue #32121); previously the body was read as an
+    untyped dict, so the spec listed no parameters and clients generating MCP
+    tools from it could not call the endpoint.
+
+    Fields are optional and extra keys are allowed because the same route also
+    serves the built-in tool-search / tool-call helper flows, which send a
+    different set of keys.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    server_id: str | None = Field(
+        default=None,
+        description=("ID, name, or alias of the MCP server hosting the tool. Required for a standard tool call."),
+    )
+    name: str | None = Field(
+        default=None,
+        description="Name of the MCP tool to invoke. Required for a standard tool call.",
+    )
+    arguments: dict[str, Any] | None = Field(
+        default=None,
+        description="Arguments to pass to the tool, as a JSON object.",
+    )
 
 
 def _connection_error_message(exc: BaseException) -> str:
@@ -738,6 +768,7 @@ if MCP_AVAILABLE:
     @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
     async def call_tool_rest_api(
         request: Request,
+        body: MCPToolCallRequest | None = None,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     ):
         """

--- a/tests/test_litellm/proxy/experimental/mcp_server/test_rest_endpoints_openapi.py
+++ b/tests/test_litellm/proxy/experimental/mcp_server/test_rest_endpoints_openapi.py
@@ -1,0 +1,54 @@
+"""
+OpenAPI documentation test for ``POST /mcp-rest/tools/call`` (issue #32121).
+
+The endpoint used to read its body as an untyped ``await request.json()``, so
+FastAPI generated no request-body schema — the OpenAPI spec listed no params,
+which broke clients (and LLMs) generating MCP tool calls from the spec. It now
+declares an ``MCPToolCallRequest`` body model, so the params are documented.
+"""
+
+import pytest
+from fastapi import FastAPI
+
+from litellm.proxy._experimental.mcp_server import rest_endpoints
+
+pytestmark = pytest.mark.skipif(
+    not rest_endpoints.MCP_AVAILABLE,
+    reason="MCP REST routes only register when the `mcp` package is available",
+)
+
+
+def _tools_call_post_spec():
+    app = FastAPI()
+    app.include_router(rest_endpoints.router)
+    spec = app.openapi()
+    return spec, spec["paths"]["/mcp-rest/tools/call"]["post"]
+
+
+def test_tools_call_documents_request_body():
+    spec, post = _tools_call_post_spec()
+
+    assert "requestBody" in post, "POST /mcp-rest/tools/call must document a request body"
+    schema = post["requestBody"]["content"]["application/json"]["schema"]
+    # Optional body -> FastAPI may emit a direct $ref or an anyOf wrapping it.
+    refs = [schema["$ref"]] if "$ref" in schema else [s["$ref"] for s in schema.get("anyOf", []) if "$ref" in s]
+    assert any(r.endswith("/MCPToolCallRequest") for r in refs), schema
+
+    props = spec["components"]["schemas"]["MCPToolCallRequest"]["properties"]
+    assert {"server_id", "name", "arguments"} <= set(props)
+
+
+def test_tool_call_request_model_allows_extra_and_optional_fields():
+    # Fields are optional + extra keys allowed, so the tool-search / tool-call
+    # helper flows that share this route are not rejected with 422.
+    model = rest_endpoints.MCPToolCallRequest(server_id="s1", name="t", extra_key="ok")
+    dumped = model.model_dump()
+    assert dumped["server_id"] == "s1"
+    assert dumped["name"] == "t"
+    assert dumped["extra_key"] == "ok"
+    # all declared fields default to None when omitted
+    assert rest_endpoints.MCPToolCallRequest().model_dump() == {
+        "server_id": None,
+        "name": None,
+        "arguments": None,
+    }


### PR DESCRIPTION
## What / Why

Closes #32121.

`POST /mcp-rest/tools/call` read its body as an untyped `data = await request.json()`, so FastAPI generated **no request-body schema**. The OpenAPI spec listed no parameters, so clients (and LLMs) generating MCP tool calls from the spec couldn't call the endpoint — it 500'd because they didn't know to send `server_id` / `name` / `arguments`.

## Change
- Add an `MCPToolCallRequest` pydantic model (`server_id`, `name`, `arguments`) and declare it as the endpoint's body param **for documentation**.
- Fields are **optional** with `extra="allow"` on purpose: the same route also serves the built-in tool-search / tool-call helper flows, which send a different set of keys — a strict/required model would start returning 422 for those.
- The body param is **optional** (`MCPToolCallRequest | None = None`) so it does not change how the handler runs: `data = await request.json()` is left unchanged (Starlette caches the body, so re-reading it is free). The only new validation is that a non-JSON-object body (e.g. a bare array/string) is now rejected with 422; any JSON object still passes (fields optional + `extra="allow"`). Optional also keeps the existing direct-invocation unit tests working.

Verified in isolation that the route now emits the correct `requestBody`:
```json
"requestBody": {"content": {"application/json": {"schema": {"$ref": "#/components/schemas/MCPToolCallRequest"}}}, "required": true}
```

## Note for maintainers — regenerating the served spec
The MCP REST feature is lazy: its router is gated behind `if MCP_AVAILABLE:` and isn't mounted on the main `app`, so the served OpenAPI for these paths is injected from the checked-in **`litellm/proxy/_lazy_openapi_snapshot.json`** (fragments `mcp_rest` / `mcp_app`), not from the live route. To surface the new schema in the served spec, that snapshot needs regenerating (`python -m litellm.proxy._lazy_openapi_snapshot`) in a full-deps environment — I couldn't do that cleanly here without truncating unrelated feature fragments, so I've left it for a maintainer build. Happy to include a regenerated snapshot if you'd like me to.

## Testing
```
pytest tests/test_litellm/proxy/experimental/mcp_server/test_rest_endpoints_openapi.py
# 2 passed
```
Added a regression test asserting the endpoint documents `server_id` / `name` / `arguments`, and that the model stays optional + allows extra keys.
