### PR TITLE
ci: run proxy containers without debug logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1746,13 +1746,13 @@ jobs:
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
               -e RECORDER_OPENAI_BASE_URL=http://host.docker.internal:8090/v1 \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/proxy_server_config.yaml:/app/config.yaml \
               my-app:latest \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -1832,13 +1832,13 @@ jobs:
               -e LANGFUSE_PROJECT2_PUBLIC=$LANGFUSE_PROJECT2_PUBLIC \
               -e LANGFUSE_PROJECT1_SECRET=$LANGFUSE_PROJECT1_SECRET \
               -e LANGFUSE_PROJECT2_SECRET=$LANGFUSE_PROJECT2_SECRET \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/oai_misc_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -1911,14 +1911,14 @@ jobs:
               -e COHERE_API_KEY=$COHERE_API_KEY \
               -e RECORDER_COHERE_BASE_URL=http://host.docker.internal:8090/__recorder_upstream/api.cohere.com \
               -e GCS_FLUSH_INTERVAL="1" \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/otel_test_config.yaml:/app/config.yaml \
               -v $(pwd)/litellm/proxy/example_config_yaml/custom_guardrail.py:/app/custom_guardrail.py \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -1960,13 +1960,13 @@ jobs:
               -e OPENAI_API_KEY=$OPENAI_API_KEY \
               -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE="bad-license" \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app-3 \
               -v $(pwd)/litellm/proxy/example_config_yaml/enterprise_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug
+              --port 4000
 
       - run:
           name: Start outputting logs for second container
@@ -2041,13 +2041,13 @@ jobs:
               -e DD_SITE=$DD_SITE \
               -e AWS_REGION_NAME=$AWS_REGION_NAME \
               -e PROXY_BATCH_WRITE_AT=2 \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/spend_tracking_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2117,13 +2117,13 @@ jobs:
               -e USE_DDTRACE=True \
               -e DD_API_KEY=$DD_API_KEY \
               -e DD_SITE=$DD_SITE \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/multi_instance_simple_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Run Docker container 2
           command: |
@@ -2139,13 +2139,13 @@ jobs:
               -e USE_DDTRACE=True \
               -e DD_API_KEY=$DD_API_KEY \
               -e DD_SITE=$DD_SITE \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app-2 \
               -v $(pwd)/litellm/proxy/example_config_yaml/multi_instance_simple_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4001 \
-              --detailed_debug
+              --port 4001
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2207,13 +2207,13 @@ jobs:
               -e LITELLM_MASTER_KEY="sk-1234" \
               -e FAKE_OPENAI_API_BASE=http://host.docker.internal:8190 \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/store_model_db_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2289,13 +2289,13 @@ jobs:
               -e DD_API_KEY=$DD_API_KEY \
               -e DD_SITE=$DD_SITE \
               -e GCS_FLUSH_INTERVAL="1" \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/docker/build_from_pip/litellm_config.yaml:/app/config.yaml \
               my-app:latest \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2365,14 +2365,14 @@ jobs:
               -e DD_SITE=$DD_SITE \
               -e LITELLM_LICENSE=$LITELLM_LICENSE \
               -e LITELLM_USE_CHAT_COMPLETIONS_URL_FOR_ANTHROPIC_MESSAGES=true \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/litellm/proxy/example_config_yaml/pass_through_config.yaml:/app/config.yaml \
               -v $(pwd)/litellm/proxy/example_config_yaml/custom_auth_basic.py:/app/custom_auth_basic.py \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug \
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app
@@ -2499,13 +2499,13 @@ jobs:
               -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
               -e AWS_REGION_NAME="us-east-1" \
               -e LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS="True" \
+              -e LITELLM_LOG=ERROR \
               --add-host host.docker.internal:host-gateway \
               --name my-app \
               -v $(pwd)/tests/proxy_e2e_anthropic_messages_tests/test_config.yaml:/app/config.yaml \
               litellm-docker-database:ci \
               --config /app/config.yaml \
-              --port 4000 \
-              --detailed_debug
+              --port 4000
       - run:
           name: Start outputting logs
           command: docker logs -f my-app


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Not applicable; this only changes CI proxy container startup flags. The change is visible in the diff and in CircleCI job logs, which will no longer stream litellm DEBUG output for these containers

## Type

🚄 Infrastructure

## Changes

The CircleCI jobs that boot a proxy container passed `--detailed_debug`, and litellm's log level defaults to `DEBUG` when `LITELLM_LOG` is unset (litellm/_logging.py), so those containers emitted very verbose debug logs for no real benefit

This drops `--detailed_debug` from the 11 proxy containers that used it and sets `LITELLM_LOG=ERROR` on them instead. Removing the flag alone would not have quieted anything since the default is already `DEBUG`, hence the explicit env var. `ERROR` rather than fully silencing keeps genuine failures visible in CI when something breaks

The schema-seed run and the bad-schema container are intentionally left alone; the latter asserts on a specific startup message in its container logs, so its logging is untouched
