### PR TITLE
fix(mcp): preserve per-user OAuth Authorization over signer JWT on tools/call (#31977)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -241,6 +241,71 @@ def _without_authorization(
     return filtered or None
 
 
+def _merge_hook_extra_headers_with_precedence(
+    extra_headers: dict[str, str] | None,
+    hook_extra_headers: dict[str, str],
+    server_auth_header: str | None,
+    mcp_auth_header: str | None,
+    mcp_server: MCPServer,
+) -> dict[str, str]:
+    """Merge ``pre_mcp_call`` guardrail headers into ``extra_headers`` while
+    preserving a per-user OAuth ``Authorization`` credential.
+
+    ``mcp_jwt_signer`` injects a signed JWT as ``Authorization`` in
+    ``hook_extra_headers``. A per-user OAuth token must take precedence over that
+    JWT, so when one is present — the server ``auth_value``
+    (``server_auth_header``), the per-user ``mcp_auth_header``, or a non-static
+    ``Authorization`` already in ``extra_headers`` on an OAuth-backed server —
+    the hook's ``Authorization`` is dropped and only its other headers are
+    applied. This mirrors the ``tools/list`` path (see ``list_tools``) and fixes
+    #31977, where the JWT clobbered the user's OAuth token on ``tools/call`` so
+    OAuth-backed servers rejected the request.
+
+    The signer JWT still overrides an admin-configured *static* ``Authorization``
+    header (``server.static_headers``), preserving the existing behavior that
+    the signer supersedes static credentials.
+    """
+    merged: dict[str, str] = dict(extra_headers) if extra_headers else {}
+    headers_to_apply: dict[str, str] = dict(hook_extra_headers)
+
+    def _has_authorization(headers: dict[str, str] | None) -> bool:
+        return any(isinstance(k, str) and k.lower() == "authorization" for k in (headers or {}))
+
+    if _has_authorization(headers_to_apply):
+        static_headers = getattr(mcp_server, "static_headers", None) or {}
+        is_oauth_server = getattr(mcp_server, "auth_type", None) == MCPAuth.oauth2
+        # On an OAuth-backed server, a non-static Authorization already in
+        # extra_headers is the user's resolved OAuth token — preserve it. For
+        # non-OAuth servers the signer JWT stays authoritative, so a
+        # caller-forwarded Authorization does not suppress it.
+        extra_oauth_authorization = (
+            is_oauth_server and _has_authorization(merged) and not _has_authorization(static_headers)
+        )
+        preserve_existing_authorization = (
+            server_auth_header is not None or bool(mcp_auth_header) or extra_oauth_authorization
+        )
+        if preserve_existing_authorization:
+            verbose_logger.debug(
+                "MCPServerManager: preserving per-user OAuth Authorization header for MCP "
+                "server '%s'; the mcp_jwt_signer JWT will not overwrite it (see #31977).",
+                mcp_server.server_name or mcp_server.name,
+            )
+            headers_to_apply = {
+                k: v for k, v in headers_to_apply.items() if not (isinstance(k, str) and k.lower() == "authorization")
+            }
+        elif _has_authorization(merged):
+            # The signer JWT is overriding an existing (static) Authorization —
+            # keep the original warning so admins know it supersedes it.
+            verbose_logger.warning(
+                "MCPServerManager: mcp_jwt_signer 'Authorization' overrides the existing "
+                "static Authorization header for MCP server '%s'; the hook JWT takes precedence.",
+                mcp_server.server_name or mcp_server.name,
+            )
+
+    merged.update(headers_to_apply)
+    return merged
+
+
 def _extract_upstream_auth_failure(
     exc: BaseException,
 ) -> Optional[Tuple[int, Optional[str]]]:
@@ -3325,29 +3390,16 @@ class MCPServerManager:
             extra_headers.update(resolved_static_headers)
 
         if hook_extra_headers:
-            if extra_headers is None:
-                extra_headers = {}
-            if "Authorization" in hook_extra_headers:
-                if "Authorization" in extra_headers:
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers 'Authorization' will overwrite "
-                        "the existing Authorization header from static_headers. "
-                        "The hook JWT will take precedence."
-                    )
-                elif server_auth_header is not None:
-                    # server_auth_header is passed separately to _create_mcp_client as
-                    # auth_value.  Both will reach the upstream server — warn so admins
-                    # know two Authorization credentials are being sent.
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers injects 'Authorization' while "
-                        "server '%s' already has a configured authentication_token. "
-                        "Both credentials will be sent; the hook header is in extra_headers "
-                        "and the server token is in auth_value — the upstream server decides "
-                        "which one wins.  Consider unsetting authentication_token if you want "
-                        "the hook JWT to be the sole credential.",
-                        mcp_server.server_name or mcp_server.name,
-                    )
-            extra_headers.update(hook_extra_headers)
+            # Per-user OAuth / admin static auth take precedence over the signer
+            # JWT — don't let hook_extra_headers overwrite an existing
+            # Authorization credential (mirrors the tools/list path). See #31977.
+            extra_headers = _merge_hook_extra_headers_with_precedence(
+                extra_headers=extra_headers,
+                hook_extra_headers=hook_extra_headers,
+                server_auth_header=server_auth_header,
+                mcp_auth_header=mcp_auth_header,
+                mcp_server=mcp_server,
+            )
 
         # Reset to None if no headers were actually added
         if extra_headers is not None and len(extra_headers) == 0:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_hook_headers_precedence.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_hook_headers_precedence.py
@@ -1,0 +1,98 @@
+"""
+Unit tests for MCP pre_mcp_call hook-header precedence (issue #31977).
+
+``mcp_jwt_signer`` injects a signed JWT as ``Authorization`` in the
+``pre_mcp_call`` hook. On the ``tools/call`` path it must NOT overwrite a
+per-user OAuth ``Authorization`` credential (it already doesn't on
+``tools/list``) — otherwise OAuth-backed MCP servers reject the call. It should
+still override an admin-configured *static* ``Authorization``, and on a
+non-OAuth server a caller-forwarded ``Authorization`` must not suppress it.
+"""
+
+from types import SimpleNamespace
+
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+    _merge_hook_extra_headers_with_precedence,
+)
+from litellm.types.mcp import MCPAuth
+
+_JWT = "Bearer litellm-signed-jwt"
+_OAUTH = "Bearer user-oauth-token"
+_STATIC = "Bearer static-token"
+
+
+def _server(static_headers=None, auth_type=None):
+    return SimpleNamespace(server_name="test-mcp", name="test-mcp", static_headers=static_headers, auth_type=auth_type)
+
+
+def _merge(extra=None, hook=None, server_auth=None, mcp_auth=None, static_headers=None, auth_type=None):
+    return _merge_hook_extra_headers_with_precedence(
+        extra_headers=extra,
+        hook_extra_headers=hook or {},
+        server_auth_header=server_auth,
+        mcp_auth_header=mcp_auth,
+        mcp_server=_server(static_headers=static_headers, auth_type=auth_type),
+    )
+
+
+def test_caller_oauth_authorization_is_preserved_on_oauth_server():
+    # OAuth token resolved into extra_headers on an OAuth-backed server.
+    result = _merge(
+        extra={"Authorization": _OAUTH},
+        hook={"Authorization": _JWT, "X-Extra": "keep"},
+        auth_type=MCPAuth.oauth2,
+    )
+    assert result["Authorization"] == _OAUTH  # OAuth wins, JWT dropped
+    assert result["X-Extra"] == "keep"  # non-auth hook headers still applied
+
+
+def test_server_auth_header_preserves_credential():
+    result = _merge(hook={"Authorization": _JWT}, server_auth=_OAUTH)
+    assert "Authorization" not in result  # JWT dropped; server auth_value carries it
+
+
+def test_mcp_auth_header_preserves_credential():
+    result = _merge(hook={"Authorization": _JWT}, mcp_auth=_OAUTH)
+    assert "Authorization" not in result
+
+
+def test_jwt_applied_when_no_existing_credential():
+    result = _merge(hook={"Authorization": _JWT})
+    assert result["Authorization"] == _JWT  # signer JWT is the sole credential
+
+
+def test_jwt_still_overrides_static_authorization():
+    # The signer supersedes an admin-configured static Authorization.
+    result = _merge(
+        extra={"Authorization": _STATIC},
+        hook={"Authorization": _JWT},
+        static_headers={"Authorization": _STATIC},
+    )
+    assert result["Authorization"] == _JWT
+
+
+def test_non_oauth_server_caller_authorization_does_not_suppress_jwt():
+    # On a non-OAuth server, a caller-forwarded Authorization must NOT suppress
+    # the signer JWT — the JWT stays authoritative (issue #31977 review).
+    result = _merge(
+        extra={"Authorization": "Bearer caller-supplied"},
+        hook={"Authorization": _JWT},
+        auth_type=None,
+    )
+    assert result["Authorization"] == _JWT
+
+
+def test_non_authorization_hook_headers_always_applied():
+    result = _merge(extra={"Authorization": _OAUTH}, hook={"X-Signed": "1"}, auth_type=MCPAuth.oauth2)
+    assert result["Authorization"] == _OAUTH
+    assert result["X-Signed"] == "1"
+
+
+def test_authorization_match_is_case_insensitive():
+    result = _merge(
+        extra={"authorization": _OAUTH},  # lowercase caller OAuth
+        hook={"Authorization": _JWT},  # uppercase hook
+        auth_type=MCPAuth.oauth2,
+    )
+    assert result["authorization"] == _OAUTH
+    assert "Authorization" not in result  # hook's uppercase variant not added


### PR DESCRIPTION
## What / Why

Closes #31977.

When `mcp_jwt_signer` runs as a `pre_mcp_call` guardrail, `tools/call` to an OAuth-backed MCP server failed: the signer's JWT **overwrote the user's OAuth `Authorization` header**, so the upstream server rejected the request. `tools/list` already handles this correctly (per #28227) — it skips JWT injection when an Authorization credential is already present, because per-user OAuth must take precedence. The `tools/call` path (`_call_regular_mcp_tool`) never got the same protection: it only logged a warning, then ran `extra_headers.update(hook_extra_headers)` and clobbered the token.

## Change
- Extract the hook-header merge in `_call_regular_mcp_tool` into a pure helper, `_merge_hook_extra_headers_with_precedence(...)`, and give it the same precedence rule as the `tools/list` path:
  - A **per-user OAuth** `Authorization` — the server `auth_value` (`server_auth_header`), the per-user `mcp_auth_header`, or a caller-supplied (non-static) `Authorization` already in `extra_headers` — is **preserved**; the hook's `Authorization` is dropped (its other headers still apply).
  - The signer JWT **still overrides** an admin-configured **static** `Authorization` (`server.static_headers`), preserving existing behavior.
- Authorization matching is case-insensitive.

## Testing
```
pytest tests/test_litellm/proxy/experimental/mcp_server/test_hook_headers_precedence.py   # 7 passed
pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py    # 29 passed
```
Added unit tests for the precedence (OAuth via extra_headers / `server_auth_header` / `mcp_auth_header` preserved; JWT applied when no credential; JWT still overrides static; non-Authorization hook headers always applied; case-insensitive). The existing `test_hook_headers_override_static_headers` still passes, confirming static-override behavior is unchanged.
