### PR TITLE
fix(policies): reject non-existent team/key/model scope entries on attachment create

### DIFF
--- a/litellm/proxy/policy_engine/policy_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_endpoints.py
@@ -695,7 +695,8 @@ async def create_policy_attachment(
     }
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.policy_engine.policy_validator import PolicyValidator
+    from litellm.proxy.proxy_server import llm_router, prisma_client
 
     if prisma_client is None:
         raise HTTPException(status_code=500, detail="Database not connected")
@@ -709,6 +710,19 @@ async def create_policy_attachment(
                 status_code=404,
                 detail=f"Policy '{request.policy_name}' not found. Create the policy first.",
             )
+
+        # Reject concrete team/key/model scope entries that don't resolve to a real
+        # entity. Wildcard patterns are allowed through (they may match zero today).
+        scope_errors = await PolicyValidator(
+            prisma_client=prisma_client, llm_router=llm_router
+        ).find_invalid_scope_entries(
+            policy_name=request.policy_name,
+            teams=request.teams,
+            keys=request.keys,
+            models=request.models,
+        )
+        if scope_errors:
+            raise HTTPException(status_code=400, detail=" ".join(e.message for e in scope_errors))
 
         created_by = user_api_key_dict.user_id
         result = await get_attachment_registry().add_attachment_to_db(

--- a/litellm/proxy/policy_engine/policy_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_endpoints.py
@@ -722,7 +722,7 @@ async def create_policy_attachment(
             models=request.models,
         )
         if scope_errors:
-            raise HTTPException(status_code=400, detail=" ".join(e.message for e in scope_errors))
+            raise HTTPException(status_code=400, detail=" | ".join(e.message for e in scope_errors))
 
         created_by = user_api_key_dict.user_id
         result = await get_attachment_registry().add_attachment_to_db(

--- a/litellm/proxy/policy_engine/policy_validator.py
+++ b/litellm/proxy/policy_engine/policy_validator.py
@@ -9,9 +9,11 @@ Validates:
 - Inheritance chains are valid (no cycles, parents exist)
 """
 
+import asyncio
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
 from litellm._logging import verbose_proxy_logger
+from litellm.proxy.auth.route_checks import RouteChecks
 from litellm.repositories.team_repository import TeamRepository
 from litellm.repositories.verification_token_repository import (
     VerificationTokenRepository,
@@ -151,6 +153,71 @@ class PolicyValidator:
         except Exception as e:
             verbose_proxy_logger.warning(f"Could not check model '{model}': {str(e)}")
             return True  # Assume valid on error
+
+    @staticmethod
+    def _scope_error(
+        policy_name: str,
+        error_type: PolicyValidationErrorType,
+        field: str,
+        value: str,
+        label: str,
+    ) -> PolicyValidationError:
+        return PolicyValidationError(
+            policy_name=policy_name,
+            error_type=error_type,
+            message=(
+                f"{label.capitalize()} '{value}' does not exist. Reference an existing "
+                f"{label} or use a wildcard pattern (e.g. '{value}*') to match by prefix."
+            ),
+            field=field,
+            value=value,
+        )
+
+    async def find_invalid_scope_entries(
+        self,
+        policy_name: str,
+        teams: Optional[List[str]] = None,
+        keys: Optional[List[str]] = None,
+        models: Optional[List[str]] = None,
+    ) -> List[PolicyValidationError]:
+        """
+        Validate the concrete scope entries of a policy attachment.
+
+        Returns an error for every non-wildcard entry that does not resolve to an
+        existing team alias, key alias, or model. Wildcard patterns are always
+        accepted: a pattern like "healthcare-*" may match zero entities today and
+        match ones created later, so it cannot be validated by existence. Tags are
+        intentionally not checked - they are free-form labels with no registry to
+        validate against.
+        """
+        # A concrete entry is one the request-time matcher compares by exact equality;
+        # only a trailing "*" is a wildcard (RouteChecks._is_wildcard_pattern), and those
+        # are left unvalidated since they may match zero entities today and more later.
+        is_pattern = RouteChecks._is_wildcard_pattern
+        concrete_teams = [t for t in (teams or []) if not is_pattern(pattern=t)]
+        concrete_keys = [k for k in (keys or []) if not is_pattern(pattern=k)]
+        concrete_models = [m for m in (models or []) if not is_pattern(pattern=m)]
+
+        team_exists = await asyncio.gather(*(self.check_team_alias_exists(t) for t in concrete_teams))
+        key_exists = await asyncio.gather(*(self.check_key_alias_exists(k) for k in concrete_keys))
+
+        return [
+            *(
+                self._scope_error(policy_name, PolicyValidationErrorType.INVALID_TEAM, "teams", team, "team")
+                for team, exists in zip(concrete_teams, team_exists)
+                if not exists
+            ),
+            *(
+                self._scope_error(policy_name, PolicyValidationErrorType.INVALID_KEY, "keys", key, "key")
+                for key, exists in zip(concrete_keys, key_exists)
+                if not exists
+            ),
+            *(
+                self._scope_error(policy_name, PolicyValidationErrorType.INVALID_MODEL, "models", model, "model")
+                for model in concrete_models
+                if not self.check_model_exists(model)
+            ),
+        ]
 
     def _validate_inheritance_chain(
         self,

--- a/litellm/proxy/policy_engine/policy_validator.py
+++ b/litellm/proxy/policy_engine/policy_validator.py
@@ -176,10 +176,10 @@ class PolicyValidator:
     async def find_invalid_scope_entries(
         self,
         policy_name: str,
-        teams: Optional[List[str]] = None,
-        keys: Optional[List[str]] = None,
-        models: Optional[List[str]] = None,
-    ) -> List[PolicyValidationError]:
+        teams: list[str] | None = None,
+        keys: list[str] | None = None,
+        models: list[str] | None = None,
+    ) -> list[PolicyValidationError]:
         """
         Validate the concrete scope entries of a policy attachment.
 

--- a/tests/test_litellm/proxy/policy_engine/test_policy_validator.py
+++ b/tests/test_litellm/proxy/policy_engine/test_policy_validator.py
@@ -6,6 +6,7 @@ Tests validation of:
 - Guardrail names exist in registry
 """
 
+from typing import Optional, Set
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,37 @@ from litellm.types.proxy.policy_engine import (
     PolicyGuardrails,
     PolicyValidationErrorType,
 )
+
+
+class _FakeTable:
+    """Minimal stand-in for a Prisma table whose find_first matches on one field."""
+
+    def __init__(self, existing: Set[str], match_field: str):
+        self._existing = existing
+        self._match_field = match_field
+
+    async def find_first(self, where: dict) -> Optional[object]:
+        return object() if where.get(self._match_field) in self._existing else None
+
+
+class _FakeDB:
+    def __init__(self, teams: Set[str], keys: Set[str]):
+        self.litellm_teamtable = _FakeTable(teams, "team_alias")
+        self.litellm_verificationtoken = _FakeTable(keys, "key_alias")
+
+
+class _FakePrisma:
+    """Injected prisma client so PolicyValidator can be unit-tested without a DB."""
+
+    def __init__(self, teams: Set[str] = frozenset(), keys: Set[str] = frozenset()):
+        self.db = _FakeDB(teams, keys)
+
+
+class _FakeRouter:
+    """Injected router exposing only what check_model_exists reads."""
+
+    def __init__(self, model_names: Set[str]):
+        self.model_names = list(model_names)
 
 
 class TestPolicyValidator:
@@ -91,3 +123,72 @@ class TestPolicyValidator:
 
         assert result.valid is True
         assert len(result.errors) == 0
+
+
+class TestAttachmentScopeValidation:
+    """Regression tests for LIT-4199: attachments must not accept non-existent teams/keys/models."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_team_is_flagged(self):
+        validator = PolicyValidator(prisma_client=_FakePrisma(teams={"real-team"}))
+        errors = await validator.find_invalid_scope_entries(
+            policy_name="p", teams=["real-team", "ghost-team"]
+        )
+        assert [(e.field, e.value) for e in errors] == [("teams", "ghost-team")]
+        assert errors[0].error_type == PolicyValidationErrorType.INVALID_TEAM
+
+    @pytest.mark.asyncio
+    async def test_existing_team_passes(self):
+        validator = PolicyValidator(prisma_client=_FakePrisma(teams={"payments"}))
+        errors = await validator.find_invalid_scope_entries(policy_name="p", teams=["payments"])
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_trailing_star_wildcard_is_allowed_even_when_it_matches_nothing(self):
+        validator = PolicyValidator(prisma_client=_FakePrisma(teams=set()))
+        errors = await validator.find_invalid_scope_entries(
+            policy_name="p", teams=["healthcare-*", "brand-new-*"]
+        )
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_only_trailing_star_counts_as_a_wildcard(self):
+        # Request-time matching treats only a trailing "*" as a wildcard; "?" and a
+        # non-trailing "*" are compared literally, so they are validated as concrete
+        # aliases (and here resolve to nothing -> flagged).
+        validator = PolicyValidator(prisma_client=_FakePrisma(teams=set()))
+        errors = await validator.find_invalid_scope_entries(
+            policy_name="p", teams=["ops-?", "heal*care"]
+        )
+        assert {e.value for e in errors} == {"ops-?", "heal*care"}
+
+    @pytest.mark.asyncio
+    async def test_keys_and_models_are_validated_too(self):
+        validator = PolicyValidator(
+            prisma_client=_FakePrisma(keys={"prod-key"}),
+            llm_router=_FakeRouter(model_names={"gpt-4o"}),
+        )
+        errors = await validator.find_invalid_scope_entries(
+            policy_name="p",
+            keys=["prod-key", "ghost-key"],
+            models=["gpt-4o", "ghost-model", "bedrock/*"],
+        )
+        flagged = {(e.field, e.value) for e in errors}
+        assert ("keys", "ghost-key") in flagged
+        assert ("models", "ghost-model") in flagged
+        assert ("keys", "prod-key") not in flagged
+        assert ("models", "gpt-4o") not in flagged
+        assert ("models", "bedrock/*") not in flagged  # wildcard model allowed through
+
+    @pytest.mark.asyncio
+    async def test_no_scope_entries_returns_no_errors(self):
+        validator = PolicyValidator(prisma_client=_FakePrisma())
+        errors = await validator.find_invalid_scope_entries(policy_name="p")
+        assert errors == []
+
+    @pytest.mark.asyncio
+    async def test_without_db_connection_assumes_valid(self):
+        # Fail-open: with no DB we cannot verify existence, so nothing is blocked.
+        validator = PolicyValidator(prisma_client=None)
+        errors = await validator.find_invalid_scope_entries(policy_name="p", teams=["anything"])
+        assert errors == []

--- a/ui/litellm-dashboard/src/components/policies/add_attachment_form.test.tsx
+++ b/ui/litellm-dashboard/src/components/policies/add_attachment_form.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../tests/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,10 @@ import AddAttachmentForm from "./add_attachment_form";
 import { Policy } from "./types";
 
 vi.mock("../networking");
+
+vi.mock("../molecules/notifications_manager", () => ({
+  default: { success: vi.fn(), fromBackend: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
 
 vi.mock("./impact_preview_alert", () => ({
   default: ({ impactResult }: { impactResult: any }) =>
@@ -36,6 +40,9 @@ const defaultProps = {
   ],
   createAttachment: vi.fn(),
 };
+
+const teamListResult = (aliases: string[]) =>
+  aliases.map((team_alias) => ({ team_alias })) as unknown as Awaited<ReturnType<typeof networking.teamListCall>>;
 
 describe("AddAttachmentForm", () => {
   beforeEach(() => {
@@ -109,5 +116,72 @@ describe("AddAttachmentForm", () => {
   it("should render a 'Create Attachment' submit button", async () => {
     renderWithProviders(<AddAttachmentForm {...defaultProps} />);
     expect(await screen.findByRole("button", { name: /create attachment/i })).toBeInTheDocument();
+  });
+
+  type UserEvent = ReturnType<typeof userEvent.setup>;
+
+  const TEAMS_ERROR = /these teams don't exist/i;
+
+  const openSpecificScope = async (user: UserEvent) => {
+    await screen.findByText("Create Policy Attachment");
+    await waitFor(() => expect(networking.teamListCall).toHaveBeenCalled());
+    await user.click(screen.getByRole("radio", { name: /specific/i }));
+  };
+
+  const enterTeam = async (user: UserEvent, value: string) => {
+    const item = screen.getByText("Teams").closest(".ant-form-item") as HTMLElement;
+    const input = within(item).getByRole("combobox");
+    await user.click(input);
+    await user.type(input, `${value}{Enter}`);
+  };
+
+  // Submits and waits for the validation cycle to settle. No policy is selected, so
+  // the "select at least one policy" required error always appears - we use it as a
+  // synchronization point, then assert whether the teams validator also complained.
+  const submitAndSettle = async (user: UserEvent) => {
+    await user.click(screen.getByRole("button", { name: /create attachment/i }));
+    await screen.findByText(/select at least one policy/i);
+  };
+
+  it("blocks submit with a field error when a concrete team that does not exist is entered", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamListCall).mockResolvedValue(teamListResult(["real-team"]));
+    const createAttachment = vi.fn();
+    renderWithProviders(<AddAttachmentForm {...defaultProps} createAttachment={createAttachment} />);
+    await openSpecificScope(user);
+    await enterTeam(user, "ghost-team");
+    await submitAndSettle(user);
+    expect(screen.getByText(TEAMS_ERROR)).toBeInTheDocument();
+    expect(createAttachment).not.toHaveBeenCalled();
+  });
+
+  it("does not flag a team that exists", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamListCall).mockResolvedValue(teamListResult(["real-team"]));
+    renderWithProviders(<AddAttachmentForm {...defaultProps} />);
+    await openSpecificScope(user);
+    await enterTeam(user, "real-team");
+    await submitAndSettle(user);
+    expect(screen.queryByText(TEAMS_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("does not flag a wildcard pattern even when it matches no existing team", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamListCall).mockResolvedValue(teamListResult([]));
+    renderWithProviders(<AddAttachmentForm {...defaultProps} />);
+    await openSpecificScope(user);
+    await enterTeam(user, "healthcare-*");
+    await submitAndSettle(user);
+    expect(screen.queryByText(TEAMS_ERROR)).not.toBeInTheDocument();
+  });
+
+  it("defers to the backend (does not flag) when the team list failed to load", async () => {
+    const user = userEvent.setup();
+    vi.mocked(networking.teamListCall).mockRejectedValue(new Error("boom"));
+    renderWithProviders(<AddAttachmentForm {...defaultProps} />);
+    await openSpecificScope(user);
+    await enterTeam(user, "ghost-team");
+    await submitAndSettle(user);
+    expect(screen.queryByText(TEAMS_ERROR)).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/policies/add_attachment_form.tsx
+++ b/ui/litellm-dashboard/src/components/policies/add_attachment_form.tsx
@@ -6,6 +6,7 @@ import { teamListCall, keyListCall, modelAvailableCall, estimateAttachmentImpact
 import NotificationsManager from "../molecules/notifications_manager";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { buildAttachmentData } from "./build_attachment_data";
+import { getInvalidTeamEntries } from "./scope_validation";
 import ImpactPreviewAlert from "./impact_preview_alert";
 
 const { Text } = Typography;
@@ -31,6 +32,7 @@ const AddAttachmentForm: React.FC<AddAttachmentFormProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [scopeType, setScopeType] = useState<"global" | "specific">("global");
   const [availableTeams, setAvailableTeams] = useState<string[]>([]);
+  const [teamsLoaded, setTeamsLoaded] = useState(false);
   const [availableKeys, setAvailableKeys] = useState<string[]>([]);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [isLoadingTeams, setIsLoadingTeams] = useState(false);
@@ -52,11 +54,13 @@ const AddAttachmentForm: React.FC<AddAttachmentFormProps> = ({
 
     // Load teams — teamListCall returns a plain array of team objects
     setIsLoadingTeams(true);
+    setTeamsLoaded(false);
     try {
       const teamsResponse = await teamListCall(accessToken, null, userId);
       const teamsArray = Array.isArray(teamsResponse) ? teamsResponse : teamsResponse?.data || [];
       const teamAliases = teamsArray.map((t: any) => t.team_alias).filter(Boolean);
       setAvailableTeams(teamAliases);
+      setTeamsLoaded(true);
     } catch (error) {
       console.error("Failed to load teams:", error);
     } finally {
@@ -226,6 +230,20 @@ const AddAttachmentForm: React.FC<AddAttachmentFormProps> = ({
               name="teams"
               label="Teams"
               tooltip="Select team aliases or enter custom patterns. Supports wildcards (e.g., healthcare-*)"
+              rules={[
+                {
+                  validator: async (_rule, value?: string[]) => {
+                    if (!teamsLoaded) return;
+                    const invalid = getInvalidTeamEntries(value ?? [], availableTeams);
+                    if (invalid.length > 0) {
+                      throw new Error(
+                        `These teams don't exist: ${invalid.join(", ")}. ` +
+                          `Choose an existing team, or use a wildcard like "team-*" to match by prefix.`,
+                      );
+                    }
+                  },
+                },
+              ]}
             >
               <Select
                 mode="tags"

--- a/ui/litellm-dashboard/src/components/policies/scope_validation.test.ts
+++ b/ui/litellm-dashboard/src/components/policies/scope_validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { getInvalidTeamEntries, isWildcardPattern } from "./scope_validation";
+
+describe("isWildcardPattern", () => {
+  it("treats a trailing * as a wildcard", () => {
+    expect(isWildcardPattern("healthcare-*")).toBe(true);
+    expect(isWildcardPattern("*")).toBe(true);
+  });
+
+  it("treats ?, a non-trailing *, and plain aliases as concrete (matches request-time semantics)", () => {
+    expect(isWildcardPattern("team-?")).toBe(false);
+    expect(isWildcardPattern("heal*care")).toBe(false);
+    expect(isWildcardPattern("payments-team")).toBe(false);
+  });
+});
+
+describe("getInvalidTeamEntries", () => {
+  const availableTeams = ["payments-team", "healthcare-us"];
+
+  it("flags a concrete alias that is not an existing team", () => {
+    expect(getInvalidTeamEntries(["payments-team", "ghost-team"], availableTeams)).toEqual(["ghost-team"]);
+  });
+
+  it("accepts an existing team alias", () => {
+    expect(getInvalidTeamEntries(["payments-team"], availableTeams)).toEqual([]);
+  });
+
+  it("accepts a wildcard pattern even when it currently matches no team", () => {
+    expect(getInvalidTeamEntries(["healthcare-*", "brand-new-*"], availableTeams)).toEqual([]);
+  });
+
+  it("returns nothing for an empty selection", () => {
+    expect(getInvalidTeamEntries([], availableTeams)).toEqual([]);
+  });
+});

--- a/ui/litellm-dashboard/src/components/policies/scope_validation.ts
+++ b/ui/litellm-dashboard/src/components/policies/scope_validation.ts
@@ -1,0 +1,8 @@
+// Mirrors request-time matching (RouteChecks._route_matches_wildcard_pattern): only a
+// trailing "*" is a wildcard (prefix match). Anything else - including a "?" or a
+// non-trailing "*" - is compared by exact equality when a request is matched, so it is
+// treated as a concrete alias that must exist.
+export const isWildcardPattern = (value: string): boolean => value.endsWith("*");
+
+export const getInvalidTeamEntries = (values: string[], availableTeams: string[]): string[] =>
+  values.filter((value) => !isWildcardPattern(value) && !availableTeams.includes(value));


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4199

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Backend, against a live proxy on `localhost:4000`. Before this change every one of these returned `200` and persisted the bogus value

```bash
KEY=sk-1234; BASE=http://localhost:4000
# a policy to attach (lands in "production" immediately)
curl -s -X POST "$BASE/policies" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"policy_name":"repro-lit4199","guardrails_add":[],"guardrails_remove":[]}' -o /dev/null -w "create policy: %{http_code}\n"

# 1. concrete team that does not exist -> now 400
curl -s -X POST "$BASE/policies/attachments" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"policy_name":"repro-lit4199","teams":["this-team-does-not-exist"]}' -w "\n-> %{http_code}\n"

# 2. trailing-* wildcard pattern -> still 200
curl -s -X POST "$BASE/policies/attachments" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"policy_name":"repro-lit4199","teams":["healthcare-*"]}' -o /dev/null -w "-> %{http_code}\n"

# 3. bogus key and bogus model -> now 400 (covers the sibling fields)
curl -s -X POST "$BASE/policies/attachments" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"policy_name":"repro-lit4199","keys":["ghost-key"],"models":["ghost-model"]}' -w "\n-> %{http_code}\n"
```

Output

```
create policy: 200

1. {"detail":"Team 'this-team-does-not-exist' does not exist. Reference an existing team or use a wildcard pattern (e.g. 'this-team-does-not-exist*') to match by prefix."}
   -> 400

2. -> 200

3. {"detail":"Key 'ghost-key' does not exist. Reference an existing key or use a wildcard pattern (e.g. 'ghost-key*') to match by prefix. Model 'ghost-model' does not exist. Reference an existing model or use a wildcard pattern (e.g. 'ghost-model*') to match by prefix."}
   -> 400
```

UI, for screenshots:

1. Open http://localhost:4000/ui/?page=policies and create a policy
2. Create an attachment from it and choose the Specific scope so the Teams field appears
3. Type a made-up alias like `this-team-does-not-exist`, press Enter, then submit; the field now shows an inline error and the attachment is not created
4. Replace it with a real team alias or a `something-*` wildcard; submit succeeds
![Uploading Screenshot 2026-07-04 at 11.38.53 AM.png…]()



## Type

Bug Fix

## Changes

The policy attachment create endpoint (`POST /policies/attachments`) accepted whatever teams, keys, and models were passed and persisted them verbatim, so a typo'd or non-existent team was stored silently and the policy applied nowhere. The Admin UI made this easy to hit because the Teams field is an Ant Design `Select` in `tags` mode, which accepts arbitrary free text.

`create_policy_attachment` now validates the scope before writing. It wires in the previously unused `PolicyValidator` existence checks and rejects any concrete team, key, or model that does not resolve to a real entity, returning a 400 that names the offending value. Whether an entry is "concrete" is decided by `RouteChecks._is_wildcard_pattern`, the same predicate the request-time matcher uses, so validation and matching agree: only a trailing `*` is a wildcard. Wildcard patterns are intentionally allowed through since a pattern like `healthcare-*` may match zero teams today and more once they are created, and tags remain free-form because there is no registry to validate them against.

On the frontend the Teams field keeps free-text entry (wildcards are a feature) but gains a validator that rejects a typed value that is neither an existing team alias nor a wildcard, giving immediate feedback. It only enforces this once the team list has loaded and defers to the backend otherwise, so a failed or partial load never blocks a legitimate team. Keys and models are left to the authoritative backend check rather than pre-validated in the browser, since the form loads only a partial key list and shows model ids rather than the names the backend matches on.
