### PR TITLE
feat(ui): flag experimental dashboard pages on the draft deprecation list

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/api-reference/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-reference/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import APIReferenceView from "@/app/(dashboard)/api-reference/APIReferenceView";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
 
@@ -8,7 +9,12 @@ const APIReferencePage = () => {
   const { accessToken } = useAuthorized();
   const proxySettings = useProxySettings(accessToken);
 
-  return <APIReferenceView proxySettings={proxySettings} />;
+  return (
+    <>
+      <DeprecationBanner featureName="The API Reference tab" />
+      <APIReferenceView proxySettings={proxySettings} />
+    </>
+  );
 };
 
 export default APIReferencePage;

--- a/ui/litellm-dashboard/src/app/(dashboard)/memory/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/memory/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { MemoryView } from "./components/MemoryView";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function Memory() {
   const { accessToken, userRole, userId } = useAuthorized();
-  return <MemoryView accessToken={accessToken} userID={userId} userRole={userRole} />;
+  return (
+    <>
+      <DeprecationBanner featureName="Memory" />
+      <MemoryView accessToken={accessToken} userID={userId} userRole={userRole} />
+    </>
+  );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/old-usage/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import Usage from "@/components/usage";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function OldUsagePage() {
   const { accessToken, token, userRole, userId: userID, premiumUser } = useAuthorized();
   return (
-    <Usage
-      accessToken={accessToken}
-      token={token}
-      userRole={userRole}
-      userID={userID}
-      keys={null}
-      premiumUser={premiumUser}
-    />
+    <>
+      <DeprecationBanner featureName="The old Usage page" />
+      <Usage
+        accessToken={accessToken}
+        token={token}
+        userRole={userRole}
+        userID={userID}
+        keys={null}
+        premiumUser={premiumUser}
+      />
+    </>
   );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
@@ -6,6 +6,7 @@ import ChatUI from "@/app/(dashboard)/playground/components/chat_ui/ChatUI";
 import CompareUI from "@/app/(dashboard)/playground/components/compareUI/CompareUI";
 import ComplianceUI from "@/app/(dashboard)/playground/components/complianceUI/ComplianceUI";
 import { TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { fetchProxySettings } from "@/utils/proxyUtils";
 
@@ -61,6 +62,7 @@ export default function PlaygroundPage() {
             <ComplianceUI accessToken={accessToken} disabledPersonalKeyCreation={disabledPersonalKeyCreation} />
           </TabPanel>
           <TabPanel className="h-full">
+            <DeprecationBanner featureName="The Playground's Agent Builder" />
             <AgentBuilderView
               accessToken={accessToken}
               token={token}

--- a/ui/litellm-dashboard/src/app/(dashboard)/prompts/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/prompts/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import PromptsPanel from "./components";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function Prompts() {
   const { accessToken, userRole } = useAuthorized();
-  return <PromptsPanel accessToken={accessToken} userRole={userRole} />;
+  return (
+    <>
+      <DeprecationBanner featureName="Prompt Management" />
+      <PromptsPanel accessToken={accessToken} userRole={userRole} />
+    </>
+  );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/workflows/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import WorkflowRuns from "./WorkflowRuns";
+import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 export default function Workflows() {
   const { accessToken } = useAuthorized();
-  return <WorkflowRuns accessToken={accessToken} />;
+  return (
+    <>
+      <DeprecationBanner featureName="Workflows" />
+      <WorkflowRuns accessToken={accessToken} />
+    </>
+  );
 }

--- a/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
@@ -16,9 +16,7 @@ export const DeprecationBanner: React.FC<DeprecationBannerProps> = ({ featureNam
     message={`${featureName} is on a draft deprecation list`}
     description={
       <>
-        {featureName} is one of several experimental features we&apos;re considering removing, potentially as early as{" "}
-        {DEPRECATION_TARGET_DATE}. This list is a draft and is not final. If you rely on this feature, please share
-        feedback on the{" "}
+        {`${featureName} is one of several experimental features we're considering removing, potentially as early as ${DEPRECATION_TARGET_DATE}. This list is a draft and is not final. If you rely on this feature, please share feedback on the `}
         <Link href={DEPRECATION_DISCUSSION_URL} target="_blank" rel="noopener noreferrer">
           deprecation discussion
         </Link>

--- a/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Alert } from "antd";
 
 const DEPRECATION_DISCUSSION_URL = "https://github.com/BerriAI/litellm/discussions/32090";
+const DEPRECATION_TARGET_DATE = "September 1, 2026";
 
 interface DeprecationBannerProps {
   featureName: string;

--- a/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import Link from "next/link";
 import { Alert } from "antd";
 
 const DEPRECATION_DISCUSSION_URL = "https://github.com/BerriAI/litellm/discussions/32090";
@@ -15,12 +16,12 @@ export const DeprecationBanner: React.FC<DeprecationBannerProps> = ({ featureNam
     message={`${featureName} is on a draft deprecation list`}
     description={
       <>
-        {featureName} is one of several experimental features we&apos;re considering removing, potentially as early as
-        September 1, 2026. This list is a draft and is not final. If you rely on this feature, please share feedback on
-        the{" "}
-        <a href={DEPRECATION_DISCUSSION_URL} target="_blank" rel="noopener noreferrer">
+        {featureName} is one of several experimental features we&apos;re considering removing, potentially as early as{" "}
+        {DEPRECATION_TARGET_DATE}. This list is a draft and is not final. If you rely on this feature, please share
+        feedback on the{" "}
+        <Link href={DEPRECATION_DISCUSSION_URL} target="_blank" rel="noopener noreferrer">
           deprecation discussion
-        </a>
+        </Link>
         .
       </>
     }
@@ -30,4 +31,3 @@ export const DeprecationBanner: React.FC<DeprecationBannerProps> = ({ featureNam
     style={{ marginBottom: 16 }}
   />
 );
-

--- a/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import React from "react";
+import { Alert } from "antd";
+
+const DEPRECATION_DISCUSSION_URL = "https://github.com/BerriAI/litellm/discussions/32090";
+
+interface DeprecationBannerProps {
+  featureName: string;
+}
+
+export const DeprecationBanner: React.FC<DeprecationBannerProps> = ({ featureName }) => (
+  <Alert
+    message={`${featureName} is on a draft deprecation list`}
+    description={
+      <>
+        {featureName} is one of several experimental features we&apos;re considering removing, potentially as early as
+        September 1, 2026. This list is a draft and is not final. If you rely on this feature, please share feedback on
+        the{" "}
+        <a href={DEPRECATION_DISCUSSION_URL} target="_blank" rel="noopener noreferrer">
+          deprecation discussion
+        </a>
+        .
+      </>
+    }
+    type="info"
+    showIcon
+    closable
+    style={{ marginBottom: 16 }}
+  />
+);
+
+export default DeprecationBanner;

--- a/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
+++ b/ui/litellm-dashboard/src/components/DeprecationBanner.tsx
@@ -31,4 +31,3 @@ export const DeprecationBanner: React.FC<DeprecationBannerProps> = ({ featureNam
   />
 );
 
-export default DeprecationBanner;

--- a/ui/litellm-dashboard/src/components/mcp_tools/MCPNetworkSettings.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/MCPNetworkSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Select, Button, Card, Typography, Spin, Tag } from "antd";
 import { SaveOutlined, PlusOutlined } from "@ant-design/icons";
+import { DeprecationBanner } from "../DeprecationBanner";
 import {
   getGeneralSettingsCall,
   updateConfigFieldSetting,
@@ -93,6 +94,7 @@ const MCPNetworkSettings: React.FC<MCPNetworkSettingsProps> = ({ accessToken }) 
 
   return (
     <div className="space-y-6 p-4">
+      <DeprecationBanner featureName="MCP Network Settings and the internal-network-only flag" />
       <div>
         <Text className="text-lg font-semibold">Private IP Ranges</Text>
         <p className="text-sm text-gray-500 mt-1">


### PR DESCRIPTION
## Relevant issues

Draft deprecation discussion: https://github.com/BerriAI/litellm/discussions/32090

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a UI-only change. To verify, run the dashboard and visit each page below; a light blue, dismissible info banner should appear at the top linking to the discussion, and the copy makes clear the list is a draft and not final

1. Workflows -> http://localhost:4000/ui/?page=workflows
2. Memory -> http://localhost:4000/ui/?page=memory
3. Prompt Management -> http://localhost:4000/ui/?page=prompts
4. Old Usage -> http://localhost:4000/ui/?page=usage
5. API Reference -> http://localhost:4000/ui/?page=api_ref
6. Playground, then the "Agent Builder (Experimental)" tab -> http://localhost:4000/ui/?page=llm-playground
7. MCP Servers, then the "Network Settings" tab -> http://localhost:4000/ui/?page=mcp-servers

<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/e2b03631-0fcf-49c1-a2dc-cab8a48b3d3e" />


## Type

🆕 New Feature

## Changes

The draft deprecation list in discussion #32090 proposes retiring several experimental dashboard features on September 1, 2026. This adds a low-key heads-up on each affected page so users find out in-product without it being blatant, and can weigh in before anything is final

A single reusable `DeprecationBanner` component renders an antd `Alert` (`type="info"`, `showIcon`, `closable`) that names the feature, notes it is on a draft list that is not final, and links to the discussion. It is placed on Workflows, Memory, Prompt Management, the old Usage page, the API Reference tab, the Playground's Agent Builder tab, and the MCP Network Settings tab (which also covers the internal-network-only flag)

Two open questions for reviewers. First, "Learning Resources" is also on the draft list but it is a sidebar link to the external cookbook rather than a dashboard page, so there is nowhere to host a banner; it is left untouched for now. Second, the banner reappears on every visit since dismissal is not persisted; happy to switch to remembered dismissal or a yellow warning style if preferred
