### PR TITLE
fix(proxy): return upstream error bodies unchanged in passthrough

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1053,11 +1053,6 @@ async def pass_through_request(
 
                 response = await async_client.send(req, stream=stream)
 
-            try:
-                response.raise_for_status()
-            except httpx.HTTPStatusError as e:
-                raise HTTPException(status_code=e.response.status_code, detail=await e.response.aread())
-
             # Call response headers hook for streaming pass-through
             _response_headers = HttpPassThroughEndpointHelpers.get_response_headers(
                 headers=response.headers,
@@ -1112,11 +1107,6 @@ async def pass_through_request(
             logging_obj.stream = True
             logging_obj.model_call_details["stream"] = True
 
-            try:
-                response.raise_for_status()
-            except httpx.HTTPStatusError as e:
-                raise HTTPException(status_code=e.response.status_code, detail=await e.response.aread())
-
             # Call response headers hook for detected streaming pass-through
             _response_headers = HttpPassThroughEndpointHelpers.get_response_headers(
                 headers=response.headers,
@@ -1145,19 +1135,13 @@ async def pass_through_request(
                 status_code=response.status_code,
             )
 
-        try:
-            response.raise_for_status()
-        except httpx.HTTPStatusError as e:
-            raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
-
-        if response.status_code >= 300:
-            raise HTTPException(status_code=response.status_code, detail=response.text)
-
         content = await response.aread()
 
         ## POST-CALL GUARDRAILS ##
+        # Upstream errors (4xx/5xx) must reach the client unchanged; guardrails
+        # and managed-id rewriting only apply to successful upstream responses.
         _content_modified = False
-        response_body: Optional[dict] = get_response_body(response)
+        response_body: Optional[dict] = get_response_body(response) if response.status_code < 400 else None
         if response_body is not None and guardrails_to_run:
             # Build an enriched data dict: _parsed_body has been stripped of
             # `metadata` by both pre_call_hook and _init_kwargs_for_pass_through_endpoint,
@@ -1187,7 +1171,7 @@ async def pass_through_request(
                 )
         elif response_body is None:
             verbose_proxy_logger.debug(
-                "pass_through_endpoint: response body not JSON-parseable, skipping post-call guardrails"
+                "pass_through_endpoint: response not JSON-parseable or upstream error, skipping post-call guardrails"
             )
 
         ## PASSTHROUGH MANAGED ID MINTING (OUTPUT) ##

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -676,6 +676,64 @@ def _carry_guardrail_logging_info(request_data: dict, guardrail_data: Optional[d
     metadata.setdefault("standard_logging_guardrail_information", list(entries))
 
 
+def _build_passthrough_failure_request_payload(
+    parsed_body: Optional[dict],
+    kwargs: Optional[dict],
+    logging_obj: Optional[LiteLLMLoggingObj],
+    custom_llm_provider: Optional[str],
+) -> dict:
+    """Build the ``request_data`` dict passed to ``post_call_failure_hook``.
+
+    Shared by the outer exception handler (LiteLLM-internal failures) and
+    upstream HTTP error logging, so both failure paths report the same shape
+    of request data (model, custom_llm_provider, litellm_logging_obj, ...).
+    """
+    request_payload: dict = dict(parsed_body or {})
+    if kwargs:
+        request_payload.update(kwargs)
+    if logging_obj is not None:
+        request_payload["litellm_logging_obj"] = logging_obj
+    if "model" not in request_payload and parsed_body and isinstance(parsed_body, dict):
+        request_payload["model"] = parsed_body.get("model", "")
+    if "custom_llm_provider" not in request_payload and custom_llm_provider:
+        request_payload["custom_llm_provider"] = custom_llm_provider
+    return request_payload
+
+
+async def _log_passthrough_upstream_failure(
+    response: httpx.Response,
+    user_api_key_dict: UserAPIKeyAuth,
+    request_payload: dict,
+) -> None:
+    """Fire LiteLLM-side failure hooks (spend tracking, alerting callbacks) for
+    an upstream 4xx/5xx passthrough response.
+
+    Passthrough must return the upstream status/body/headers to the client
+    unchanged, so this never raises or transforms the response - it only
+    mirrors the monitoring side effect that ``post_call_failure_hook`` would
+    have received had the error originated inside LiteLLM.
+    """
+    if response.status_code < 400:
+        return
+    from litellm.proxy.proxy_server import proxy_logging_obj
+
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as e:
+        try:
+            await proxy_logging_obj.post_call_failure_hook(
+                user_api_key_dict=user_api_key_dict,
+                original_exception=e,
+                request_data=request_payload,
+                traceback_str=traceback.format_exc(limit=MAXIMUM_TRACEBACK_LINES_TO_LOG),
+            )
+        except Exception:  # noqa: BLE001 - a failing logging callback must never break the passthrough response
+            verbose_proxy_logger.warning(
+                "pass_through_endpoint: post_call_failure_hook raised for upstream error",
+                exc_info=True,
+            )
+
+
 from litellm.passthrough.timeout_utils import (
     DEFAULT_PASS_THROUGH_REQUEST_TIMEOUT_SECONDS,  # noqa: F401 - re-exported for backward compat
     resolve_llm_passthrough_timeout,  # noqa: F401 - re-exported for backward compat
@@ -1053,6 +1111,17 @@ async def pass_through_request(
 
                 response = await async_client.send(req, stream=stream)
 
+            await _log_passthrough_upstream_failure(
+                response=response,
+                user_api_key_dict=user_api_key_dict,
+                request_payload=_build_passthrough_failure_request_payload(
+                    parsed_body=_parsed_body,
+                    kwargs=kwargs,
+                    logging_obj=logging_obj,
+                    custom_llm_provider=custom_llm_provider,
+                ),
+            )
+
             # Call response headers hook for streaming pass-through
             _response_headers = HttpPassThroughEndpointHelpers.get_response_headers(
                 headers=response.headers,
@@ -1107,6 +1176,17 @@ async def pass_through_request(
             logging_obj.stream = True
             logging_obj.model_call_details["stream"] = True
 
+            await _log_passthrough_upstream_failure(
+                response=response,
+                user_api_key_dict=user_api_key_dict,
+                request_payload=_build_passthrough_failure_request_payload(
+                    parsed_body=_parsed_body,
+                    kwargs=kwargs,
+                    logging_obj=logging_obj,
+                    custom_llm_provider=custom_llm_provider,
+                ),
+            )
+
             # Call response headers hook for detected streaming pass-through
             _response_headers = HttpPassThroughEndpointHelpers.get_response_headers(
                 headers=response.headers,
@@ -1135,14 +1215,26 @@ async def pass_through_request(
                 status_code=response.status_code,
             )
 
+        await _log_passthrough_upstream_failure(
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            request_payload=_build_passthrough_failure_request_payload(
+                parsed_body=_parsed_body,
+                kwargs=kwargs,
+                logging_obj=logging_obj,
+                custom_llm_provider=custom_llm_provider,
+            ),
+        )
+
         content = await response.aread()
 
         ## POST-CALL GUARDRAILS ##
-        # Upstream errors (4xx/5xx) must reach the client unchanged; guardrails
-        # and managed-id rewriting only apply to successful upstream responses.
+        # Guardrails and managed-id rewriting only apply to successful upstream
+        # responses; response_body itself is parsed unconditionally so the
+        # success-handler log payload still reflects upstream error bodies.
         _content_modified = False
-        response_body: Optional[dict] = get_response_body(response) if response.status_code < 400 else None
-        if response_body is not None and guardrails_to_run:
+        response_body: Optional[dict] = get_response_body(response)
+        if response.status_code < 400 and response_body is not None and guardrails_to_run:
             # Build an enriched data dict: _parsed_body has been stripped of
             # `metadata` by both pre_call_hook and _init_kwargs_for_pass_through_endpoint,
             # so we re-attach the configured guardrails here so should_run_guardrail
@@ -1171,7 +1263,7 @@ async def pass_through_request(
                 )
         elif response_body is None:
             verbose_proxy_logger.debug(
-                "pass_through_endpoint: response not JSON-parseable or upstream error, skipping post-call guardrails"
+                "pass_through_endpoint: response body not JSON-parseable, skipping post-call guardrails"
             )
 
         ## PASSTHROUGH MANAGED ID MINTING (OUTPUT) ##

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -719,11 +719,22 @@ async def _log_passthrough_upstream_failure(
 
     try:
         response.raise_for_status()
-    except httpx.HTTPStatusError as e:
+    except httpx.HTTPStatusError:
+        # Reported as an HTTPException, not the raw httpx error: ProxyLogging's
+        # alerting path only excludes HTTPException/ProxyException from its
+        # "High" severity llm_exceptions alert, treating everything else as an
+        # operational LLM-API failure. An upstream 4xx/5xx returned unchanged
+        # to the client is a user-facing error like any other, not something
+        # ops needs paged for, so it must be excluded the same way auth and
+        # rate-limit errors already are.
+        synthetic_exception = HTTPException(
+            status_code=response.status_code,
+            detail=f"Upstream passthrough request failed with status {response.status_code}",
+        )
         try:
             await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
-                original_exception=e,
+                original_exception=synthetic_exception,
                 request_data=request_payload,
                 traceback_str=traceback.format_exc(limit=MAXIMUM_TRACEBACK_LINES_TO_LOG),
             )
@@ -1215,25 +1226,28 @@ async def pass_through_request(
                 status_code=response.status_code,
             )
 
-        await _log_passthrough_upstream_failure(
-            response=response,
-            user_api_key_dict=user_api_key_dict,
-            request_payload=_build_passthrough_failure_request_payload(
-                parsed_body=_parsed_body,
-                kwargs=kwargs,
-                logging_obj=logging_obj,
-                custom_llm_provider=custom_llm_provider,
-            ),
-        )
-
         content = await response.aread()
 
         ## POST-CALL GUARDRAILS ##
         # Guardrails and managed-id rewriting only apply to successful upstream
         # responses; response_body itself is parsed unconditionally so the
-        # success-handler log payload still reflects upstream error bodies.
+        # failure-hook log payload below still reflects upstream error bodies.
         _content_modified = False
         response_body: Optional[dict] = get_response_body(response)
+
+        failure_request_payload = _build_passthrough_failure_request_payload(
+            parsed_body=_parsed_body,
+            kwargs=kwargs,
+            logging_obj=logging_obj,
+            custom_llm_provider=custom_llm_provider,
+        )
+        failure_request_payload["response_body"] = response_body
+        await _log_passthrough_upstream_failure(
+            response=response,
+            user_api_key_dict=user_api_key_dict,
+            request_payload=failure_request_payload,
+        )
+
         if response.status_code < 400 and response_body is not None and guardrails_to_run:
             # Build an enriched data dict: _parsed_body has been stripped of
             # `metadata` by both pre_call_hook and _init_kwargs_for_pass_through_endpoint,
@@ -1325,23 +1339,28 @@ async def pass_through_request(
                 )
 
         ## LOG SUCCESS
+        # Upstream errors are already logged via _log_passthrough_upstream_failure
+        # above; the success handler has no status-code awareness of its own; so
+        # calling it here for a 4xx/5xx would double-log the same request as both
+        # a failure and a success (corrupting spend tracking).
         passthrough_logging_payload["response_body"] = response_body
         end_time = datetime.now()
-        GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
-            async_coroutine=pass_through_endpoint_logging.pass_through_async_success_handler(
-                httpx_response=response,
-                response_body=response_body,
-                url_route=str(url),
-                result="",
-                start_time=start_time,
-                end_time=end_time,
-                logging_obj=logging_obj,
-                cache_hit=False,
-                request_body=_parsed_body or {},
-                custom_llm_provider=custom_llm_provider,
-                **kwargs,
+        if response.status_code < 400:
+            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+                async_coroutine=pass_through_endpoint_logging.pass_through_async_success_handler(
+                    httpx_response=response,
+                    response_body=response_body,
+                    url_route=str(url),
+                    result="",
+                    start_time=start_time,
+                    end_time=end_time,
+                    logging_obj=logging_obj,
+                    cache_hit=False,
+                    request_body=_parsed_body or {},
+                    custom_llm_provider=custom_llm_provider,
+                    **kwargs,
+                )
             )
-        )
 
         ## CUSTOM HEADERS - `x-litellm-*`
         custom_headers = ProxyBaseLLMRequestProcessing.get_custom_headers(

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -89,7 +89,11 @@ class PassThroughStreamingHandler:
             # GeneratorExit (raised on client disconnect) is not caught by
             # `except Exception`; the finally block ensures partial usage
             # still gets logged for spend tracking. See LIT-2642.
-            if not logging_scheduled and raw_bytes:
+            # Upstream 4xx/5xx responses are already logged as a failure by
+            # the caller before this generator starts (see
+            # _log_passthrough_upstream_failure); logging them again here as
+            # a success would double-log the same request.
+            if not logging_scheduled and raw_bytes and response.status_code < 400:
                 logging_scheduled = True
                 try:
                     GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(

--- a/tests/pass_through_unit_tests/test_unit_test_streaming.py
+++ b/tests/pass_through_unit_tests/test_unit_test_streaming.py
@@ -50,6 +50,7 @@ async def test_chunk_processor_yields_raw_bytes(endpoint_type, url_route):
     """
     # Mock inputs
     response = AsyncMock(spec=httpx.Response)
+    response.status_code = 200
     raw_chunks = [
         b'{"id": "1", "content": "Hello"}',
         b'{"id": "2", "content": "World"}',

--- a/tests/pass_through_unit_tests/test_vertex_ai_anthropic_streaming_cost_injection.py
+++ b/tests/pass_through_unit_tests/test_vertex_ai_anthropic_streaming_cost_injection.py
@@ -39,6 +39,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_enabled():
     try:
         # Mock response with Anthropic SSE format chunks
         response = AsyncMock(spec=httpx.Response)
+        response.status_code = 200
 
         # Create chunks with message_delta event containing usage
         chunks_with_usage = [
@@ -120,6 +121,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_disabled():
     try:
         # Mock response with Anthropic SSE format chunks
         response = AsyncMock(spec=httpx.Response)
+        response.status_code = 200
 
         chunks_with_usage = [
             b'data: {"type": "message_delta", "usage": {"input_tokens": 10, "output_tokens": 5}}\n\n',
@@ -178,6 +180,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_no_usage_chunk():
 
     try:
         response = AsyncMock(spec=httpx.Response)
+        response.status_code = 200
 
         # Chunks without usage (should not be modified)
         chunks_without_usage = [
@@ -233,6 +236,7 @@ async def test_vertex_ai_anthropic_streaming_model_extraction():
 
     try:
         response = AsyncMock(spec=httpx.Response)
+        response.status_code = 200
 
         chunks = [
             b'data: {"type": "message_delta", "usage": {"input_tokens": 10, "output_tokens": 5}}\n\n',

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import sys
@@ -3619,3 +3620,219 @@ async def test_non_guardrail_exception_still_logs_with_traceback():
     assert (
         logger.warning.call_count == 0
     ), "a genuine failure must not be downgraded to WARNING"
+
+
+# Regression: generic config-based passthrough (`pass_through_request`) used to
+# call `response.raise_for_status()` on upstream errors and re-raise as an
+# `HTTPException`, which the outer `except` block then reshaped into a
+# `ProxyException` (`{"error": {"message": "<stringified upstream body>", ...}}`).
+# Upstream error responses must reach the client byte-for-byte, with the
+# original status code, exactly like success responses already do.
+_UPSTREAM_ERROR_BODY = {
+    "error": "Permission denied",
+    "error_code": "ACCESS_DENIED",
+    "request_id": "req_mock_403",
+    "trace_id": "trace_mock_403",
+}
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_non_streaming_upstream_error_returned_unchanged():
+    upstream_content = json.dumps(_UPSTREAM_ERROR_BODY).encode("utf-8")
+    upstream_response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "application/json"},
+        content=upstream_content,
+        request=httpx.Request("POST", "http://target-api.com/api/denied"),
+    )
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.ProxyBaseLLMRequestProcessing"
+            ) as mock_processing:
+                with patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler"
+                ) as mock_success_handler:
+                    mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+                    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+                    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(
+                        return_value=None
+                    )
+                    mock_processing.get_custom_headers.return_value = {}
+                    mock_success_handler.return_value = None
+
+                    async_client = MagicMock()
+                    async_client.request = AsyncMock(return_value=upstream_response)
+                    mock_get_client.return_value = MagicMock(client=async_client)
+
+                    mock_request = MagicMock(spec=Request)
+                    mock_request.method = "POST"
+                    mock_request.url = "http://test-proxy.com/mock-upstream/api/denied"
+                    mock_request.body = AsyncMock(return_value=b'{"action": "read"}')
+                    mock_request.headers = Headers({"content-type": "application/json"})
+                    mock_request.query_params = QueryParams({})
+
+                    response = await pass_through_request(
+                        request=mock_request,
+                        target="http://target-api.com/api/denied",
+                        custom_headers={},
+                        user_api_key_dict=MagicMock(),
+                    )
+                    await asyncio.sleep(0)
+
+    assert response.status_code == 403
+    body = json.loads(response.body)
+    # Exact dict equality proves the upstream body was forwarded verbatim,
+    # not stringified into a ProxyException's `error.message` field.
+    assert body == _UPSTREAM_ERROR_BODY
+    assert set(body.keys()) != {"error"} or not isinstance(body["error"], dict)
+    mock_success_handler.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_streaming_upstream_error_returned_unchanged():
+    from fastapi.responses import StreamingResponse
+
+    upstream_content = json.dumps(_UPSTREAM_ERROR_BODY).encode("utf-8")
+    upstream_response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "application/json"},
+        content=upstream_content,
+        request=httpx.Request("GET", "http://target-api.com/api/stream-denied"),
+    )
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler"
+            ) as mock_success_handler:
+                mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+                mock_proxy_logging.post_call_failure_hook = AsyncMock()
+                mock_proxy_logging.post_call_response_headers_hook = AsyncMock(
+                    return_value=None
+                )
+                mock_success_handler.return_value = None
+
+                async_client = MagicMock()
+                async_client.build_request = MagicMock(return_value=MagicMock())
+                async_client.send = AsyncMock(return_value=upstream_response)
+                mock_get_client.return_value = MagicMock(client=async_client)
+
+                mock_request = MagicMock(spec=Request)
+                mock_request.method = "GET"
+                mock_request.url = "http://test-proxy.com/mock-upstream/api/stream-denied"
+                mock_request.body = AsyncMock(return_value=b"")
+                mock_request.headers = Headers({})
+                mock_request.query_params = QueryParams({})
+
+                response = await pass_through_request(
+                    request=mock_request,
+                    target="http://target-api.com/api/stream-denied",
+                    custom_headers={},
+                    user_api_key_dict=MagicMock(),
+                    stream=True,
+                )
+
+    assert isinstance(response, StreamingResponse)
+    assert response.status_code == 403
+
+    streamed_chunks = [chunk async for chunk in response.body_iterator]
+    await asyncio.sleep(0)
+    streamed_bytes = b"".join(
+        chunk if isinstance(chunk, bytes) else chunk.encode("utf-8")
+        for chunk in streamed_chunks
+    )
+    assert streamed_bytes == upstream_content
+    assert json.loads(streamed_bytes) == _UPSTREAM_ERROR_BODY
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_non_streaming_success_unchanged():
+    """Success (2xx) passthrough behavior must remain unchanged by the error fix."""
+    upstream_success_body = {"status": "ok", "message": "mock upstream success"}
+    upstream_content = json.dumps(upstream_success_body).encode("utf-8")
+    upstream_response = httpx.Response(
+        status_code=200,
+        headers={"content-type": "application/json"},
+        content=upstream_content,
+        request=httpx.Request("GET", "http://target-api.com/api/success"),
+    )
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.ProxyBaseLLMRequestProcessing"
+            ) as mock_processing:
+                with patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler"
+                ) as mock_success_handler:
+                    mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+                    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+                    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(
+                        return_value=None
+                    )
+                    mock_processing.get_custom_headers.return_value = {}
+                    mock_success_handler.return_value = None
+
+                    async_client = MagicMock()
+                    async_client.request = AsyncMock(return_value=upstream_response)
+                    mock_get_client.return_value = MagicMock(client=async_client)
+
+                    mock_request = MagicMock(spec=Request)
+                    mock_request.method = "GET"
+                    mock_request.url = "http://test-proxy.com/mock-upstream/api/success"
+                    mock_request.body = AsyncMock(return_value=b"")
+                    mock_request.headers = Headers({})
+                    mock_request.query_params = QueryParams({})
+
+                    response = await pass_through_request(
+                        request=mock_request,
+                        target="http://target-api.com/api/success",
+                        custom_headers={},
+                        user_api_key_dict=MagicMock(),
+                    )
+                    await asyncio.sleep(0)
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == upstream_success_body
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_internal_failure_still_raises_proxy_exception():
+    """
+    Internal proxy failures (e.g. a hook raising before any upstream request is
+    made) must still surface as ProxyException, distinct from upstream
+    passthrough errors which are now returned unchanged.
+    """
+    from litellm.proxy._types import ProxyException
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        mock_proxy_logging.pre_call_hook = AsyncMock(
+            side_effect=RuntimeError("auth backend unavailable")
+        )
+        mock_proxy_logging.post_call_failure_hook = AsyncMock()
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.method = "GET"
+        mock_request.url = "http://test-proxy.com/mock-upstream/api/success"
+        mock_request.body = AsyncMock(return_value=b"")
+        mock_request.headers = Headers({})
+        mock_request.query_params = QueryParams({})
+
+        with pytest.raises(ProxyException) as exc_info:
+            await pass_through_request(
+                request=mock_request,
+                target="http://target-api.com/api/success",
+                custom_headers={},
+                user_api_key_dict=MagicMock(),
+            )
+
+    assert int(exc_info.value.code) == 500
+    assert "auth backend unavailable" in exc_info.value.message

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -3691,6 +3691,20 @@ async def test_pass_through_request_non_streaming_upstream_error_returned_unchan
     assert set(body.keys()) != {"error"} or not isinstance(body["error"], dict)
     mock_success_handler.assert_called_once()
 
+    # Regression: post_call_failure_hook (spend-tracking, alerting callbacks)
+    # must still fire for upstream errors even though the client-facing
+    # response is unchanged and no ProxyException is raised.
+    mock_proxy_logging.post_call_failure_hook.assert_called_once()
+    failure_call_kwargs = mock_proxy_logging.post_call_failure_hook.call_args.kwargs
+    assert isinstance(failure_call_kwargs["original_exception"], httpx.HTTPStatusError)
+    assert failure_call_kwargs["original_exception"].response.status_code == 403
+
+    # Regression: the log payload's response_body must reflect the upstream
+    # error JSON, not None, so downstream spend-tracking/logging integrations
+    # can see what the upstream actually returned.
+    success_call_kwargs = mock_success_handler.call_args.kwargs
+    assert success_call_kwargs["response_body"] == _UPSTREAM_ERROR_BODY
+
 
 @pytest.mark.asyncio
 async def test_pass_through_request_streaming_upstream_error_returned_unchanged():
@@ -3750,6 +3764,13 @@ async def test_pass_through_request_streaming_upstream_error_returned_unchanged(
     assert streamed_bytes == upstream_content
     assert json.loads(streamed_bytes) == _UPSTREAM_ERROR_BODY
 
+    # Regression: post_call_failure_hook must still fire for streaming
+    # upstream errors, mirroring the non-streaming behavior.
+    mock_proxy_logging.post_call_failure_hook.assert_called_once()
+    failure_call_kwargs = mock_proxy_logging.post_call_failure_hook.call_args.kwargs
+    assert isinstance(failure_call_kwargs["original_exception"], httpx.HTTPStatusError)
+    assert failure_call_kwargs["original_exception"].response.status_code == 403
+
 
 @pytest.mark.asyncio
 async def test_pass_through_request_non_streaming_success_unchanged():
@@ -3802,6 +3823,9 @@ async def test_pass_through_request_non_streaming_success_unchanged():
 
     assert response.status_code == 200
     assert json.loads(response.body) == upstream_success_body
+    # Regression guard: the failure hook must only fire for upstream errors,
+    # never for a successful upstream response.
+    mock_proxy_logging.post_call_failure_hook.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -3689,21 +3689,90 @@ async def test_pass_through_request_non_streaming_upstream_error_returned_unchan
     # not stringified into a ProxyException's `error.message` field.
     assert body == _UPSTREAM_ERROR_BODY
     assert set(body.keys()) != {"error"} or not isinstance(body["error"], dict)
-    mock_success_handler.assert_called_once()
+
+    # Regression: the success handler has no status-code awareness, so it must
+    # never be called for a 4xx/5xx upstream response - otherwise the same
+    # request gets recorded as both a failure and a success in SpendLogs.
+    mock_success_handler.assert_not_called()
 
     # Regression: post_call_failure_hook (spend-tracking, alerting callbacks)
     # must still fire for upstream errors even though the client-facing
     # response is unchanged and no ProxyException is raised.
+    from fastapi import HTTPException
+
     mock_proxy_logging.post_call_failure_hook.assert_called_once()
     failure_call_kwargs = mock_proxy_logging.post_call_failure_hook.call_args.kwargs
-    assert isinstance(failure_call_kwargs["original_exception"], httpx.HTTPStatusError)
-    assert failure_call_kwargs["original_exception"].response.status_code == 403
+    # Must be reported as HTTPException, not the raw httpx error: ProxyLogging's
+    # alerting only excludes HTTPException/ProxyException from its "High"
+    # severity llm_exceptions alert, so a raw HTTPStatusError here would page
+    # ops for every routine upstream 4xx returned through passthrough.
+    assert isinstance(failure_call_kwargs["original_exception"], HTTPException)
+    assert failure_call_kwargs["original_exception"].status_code == 403
 
-    # Regression: the log payload's response_body must reflect the upstream
-    # error JSON, not None, so downstream spend-tracking/logging integrations
-    # can see what the upstream actually returned.
-    success_call_kwargs = mock_success_handler.call_args.kwargs
-    assert success_call_kwargs["response_body"] == _UPSTREAM_ERROR_BODY
+    # Regression: the failure-hook log payload's response_body must reflect
+    # the upstream error JSON, not None, so downstream spend-tracking/logging
+    # integrations can see what the upstream actually returned.
+    assert failure_call_kwargs["request_data"]["response_body"] == _UPSTREAM_ERROR_BODY
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_upstream_error_failure_hook_exception_is_swallowed():
+    """
+    A broken failure-hook callback (e.g. a misconfigured alerting integration)
+    must never take down the passthrough response - the upstream error body
+    must still reach the client unchanged, and the callback's exception must
+    only be logged, not raised.
+    """
+    upstream_content = json.dumps(_UPSTREAM_ERROR_BODY).encode("utf-8")
+    upstream_response = httpx.Response(
+        status_code=403,
+        headers={"content-type": "application/json"},
+        content=upstream_content,
+        request=httpx.Request("POST", "http://target-api.com/api/denied"),
+    )
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_proxy_logging:
+        with patch(
+            "litellm.proxy.pass_through_endpoints.pass_through_endpoints.get_async_httpx_client"
+        ) as mock_get_client:
+            with patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.ProxyBaseLLMRequestProcessing"
+            ) as mock_processing:
+                with patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging.pass_through_async_success_handler"
+                ) as mock_success_handler:
+                    mock_proxy_logging.pre_call_hook = AsyncMock(return_value={})
+                    mock_proxy_logging.post_call_failure_hook = AsyncMock(
+                        side_effect=RuntimeError("alerting integration misconfigured")
+                    )
+                    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(
+                        return_value=None
+                    )
+                    mock_processing.get_custom_headers.return_value = {}
+                    mock_success_handler.return_value = None
+
+                    async_client = MagicMock()
+                    async_client.request = AsyncMock(return_value=upstream_response)
+                    mock_get_client.return_value = MagicMock(client=async_client)
+
+                    mock_request = MagicMock(spec=Request)
+                    mock_request.method = "POST"
+                    mock_request.url = "http://test-proxy.com/mock-upstream/api/denied"
+                    mock_request.body = AsyncMock(return_value=b'{"action": "read"}')
+                    mock_request.headers = Headers({"content-type": "application/json"})
+                    mock_request.query_params = QueryParams({})
+
+                    response = await pass_through_request(
+                        request=mock_request,
+                        target="http://target-api.com/api/denied",
+                        custom_headers={},
+                        user_api_key_dict=MagicMock(),
+                    )
+                    await asyncio.sleep(0)
+
+    mock_proxy_logging.post_call_failure_hook.assert_called_once()
+    assert response.status_code == 403
+    assert json.loads(response.body) == _UPSTREAM_ERROR_BODY
 
 
 @pytest.mark.asyncio
@@ -3764,12 +3833,22 @@ async def test_pass_through_request_streaming_upstream_error_returned_unchanged(
     assert streamed_bytes == upstream_content
     assert json.loads(streamed_bytes) == _UPSTREAM_ERROR_BODY
 
+    # Regression: chunk_processor's end-of-stream success logging has no
+    # status-code awareness, so it must never fire for a 4xx/5xx upstream
+    # response - otherwise the same request gets recorded as both a failure
+    # (via the hook below) and a success in SpendLogs.
+    mock_success_handler.assert_not_called()
+
     # Regression: post_call_failure_hook must still fire for streaming
-    # upstream errors, mirroring the non-streaming behavior.
+    # upstream errors, mirroring the non-streaming behavior, and must also
+    # report an HTTPException (not the raw httpx error) to avoid triggering
+    # a "High" severity llm_exceptions alert for a routine upstream 4xx.
+    from fastapi import HTTPException
+
     mock_proxy_logging.post_call_failure_hook.assert_called_once()
     failure_call_kwargs = mock_proxy_logging.post_call_failure_hook.call_args.kwargs
-    assert isinstance(failure_call_kwargs["original_exception"], httpx.HTTPStatusError)
-    assert failure_call_kwargs["original_exception"].response.status_code == 403
+    assert isinstance(failure_call_kwargs["original_exception"], HTTPException)
+    assert failure_call_kwargs["original_exception"].status_code == 403
 
 
 @pytest.mark.asyncio
@@ -3826,6 +3905,9 @@ async def test_pass_through_request_non_streaming_success_unchanged():
     # Regression guard: the failure hook must only fire for upstream errors,
     # never for a successful upstream response.
     mock_proxy_logging.post_call_failure_hook.assert_not_called()
+    # ...and the success handler must still fire exactly once for a 2xx,
+    # proving the status_code gate doesn't also swallow real successes.
+    mock_success_handler.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -94,6 +94,41 @@ async def test_chunk_processor_logs_on_client_disconnect():
 
 
 @pytest.mark.asyncio
+async def test_chunk_processor_does_not_schedule_success_logging_for_upstream_error():
+    """A 4xx/5xx upstream response is already logged as a failure by the caller
+    before this generator starts; scheduling success logging here too would
+    double-log the same request in SpendLogs."""
+    chunks = [b'{"error": "denied"}']
+    response = _make_streaming_response(chunks)
+    response.status_code = 403
+
+    mock_logging_obj = MagicMock()
+    mock_passthrough_handler = MagicMock()
+
+    with patch.object(
+        PassThroughStreamingHandler,
+        "_route_streaming_logging_to_handler",
+        new=AsyncMock(),
+    ) as mock_route:
+        received = []
+        async for chunk in PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "claude-3-haiku"},
+            litellm_logging_obj=mock_logging_obj,
+            endpoint_type=EndpointType.GENERIC,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=mock_passthrough_handler,
+            url_route="/bedrock/model/claude/invoke-with-response-stream",
+        ):
+            received.append(chunk)
+
+        await asyncio.sleep(0)
+
+    assert received == chunks
+    mock_route.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_chunk_processor_does_not_schedule_logging_when_no_chunks():
     response = _make_streaming_response([])
 


### PR DESCRIPTION
Resolves LIT-4200
Issue
Generic config-based passthrough endpoints (pass_through_endpoints in config) do not return upstream error responses as-is. When the upstream returns a 403 with custom JSON like:

```
{"error": "Permission denied", "error_code": "xxx", "request_id": "xxx", "trace_id": "xxx"}
the LiteLLM proxy returns:

```
```
{
  "error": {
    "message": "{\"error\": \"Permission denied\", ...}",
    "type": "None",
    "param": "None",
    "code": "403"
  }
}
```
Success responses (2xx) pass through correctly. Only upstream 4xx/5xx get reshaped into the proxy's OpenAI-style ProxyException format, for both non-streaming and streaming passthrough

Cause
In pass_through_request() (litellm/proxy/pass_through_endpoints/pass_through_endpoints.py), upstream HTTP errors trigger response.raise_for_status(), which raises httpx.HTTPStatusError. That is caught and re-raised as HTTPException(status_code=..., detail=response.text). The outer except Exception block then converts any HTTPException into ProxyException, and the global openai_exception_handler in proxy_server.py serializes it as {"error": {...}} with the upstream JSON stringified into error.message

This happens in three places: explicit streaming (stream=True), detected streaming (SSE content-type), and non-streaming responses

Fix
Remove raise_for_status() and the HTTPException re-raise for upstream responses in all three passthrough paths. Upstream 4xx/5xx now flow through the same return path as 2xx: Response(content=..., status_code=..., headers=...) for non-streaming and StreamingResponse(..., status_code=...) for streaming, preserving upstream body and status unchanged

Post-call guardrails and managed-id output rewriting are scoped to status_code < 400 so they do not run on upstream error bodies. Internal proxy failures (auth, config, guardrails, network errors before any upstream response) still raise ProxyException as before

Regression tests added in tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py for non-streaming 403, streaming 403, unchanged 200 success, and internal failure still using ProxyException

Follow-up fix
Review feedback flagged two gaps in the initial fix: post_call_failure_hook was skipped entirely for upstream errors, so spend-tracking and alerting callbacks never fired for them, and response_body in the log payload was hardcoded to None for every upstream error, so logging integrations never saw what the upstream actually returned

Added _log_passthrough_upstream_failure, which calls post_call_failure_hook for upstream 4xx/5xx responses without altering the client-facing response, and response_body is now parsed unconditionally so the success-handler log payload reflects upstream error bodies too; guardrails and managed-id rewriting remain scoped to status_code < 400

Added regression tests asserting post_call_failure_hook fires (and does not fire) for upstream error and success responses, and that the logged response_body matches the upstream error JSON

Second follow-up fix
Further review caught two more issues from the first follow-up: the success handler (both the non-streaming path and chunk_processor's end-of-stream logging) has no status-code awareness, so it kept firing for upstream 4xx/5xx too, meaning the same request got logged as both a failure and a success and corrupted SpendLogs/cost tracking; separately, post_call_failure_hook was passed the raw httpx.HTTPStatusError, and ProxyLogging's alerting only excludes HTTPException/ProxyException from its "High" severity llm_exceptions alert, so a routine upstream 403 would page ops the same as a real LLM API outage

Gated the success handler in both the non-streaming path and chunk_processor to status_code < 400, and now report upstream failures to post_call_failure_hook as an HTTPException (matching how auth/rate-limit errors are already excluded from alerting) instead of the raw httpx error. response_body is now threaded into the failure-hook payload for the non-streaming path instead of the success handler's, since the success handler no longer runs for errors

Added regression tests proving the success handler is not called for upstream errors (streaming and non-streaming) and is still called for real successes, that a failing post_call_failure_hook callback can't break the passthrough response, and a chunk_processor-level test proving end-of-stream success logging is skipped for a 4xx/5xx

Proof:
Direct call to passthrough:
<img width="574" height="128" alt="Screenshot 2026-07-04 at 11 22 04 AM" src="https://github.com/user-attachments/assets/bec72ec8-90c5-4e1d-b7d2-d2b64bf8cb73" />

Passthrough via LiteLLM
Before:
<img width="591" height="193" alt="Screenshot 2026-07-04 at 11 24 00 AM" src="https://github.com/user-attachments/assets/4cad6321-8e87-4630-a17e-4c279f67fe5b" />

After:
<img width="586" height="153" alt="Screenshot 2026-07-04 at 11 21 07 AM" src="https://github.com/user-attachments/assets/9b85a231-2baa-4836-a777-78495a68cbcc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes proxy passthrough response semantics and spend/alert hooks on a widely used path; mitigated by extensive regression tests and unchanged behavior for 2xx and internal proxy failures.
> 
> **Overview**
> **Generic config passthrough** no longer turns upstream **4xx/5xx** into LiteLLM **`ProxyException`** / OpenAI-style `{"error": {...}}` bodies. **`raise_for_status()`** and client-facing **`HTTPException`** re-raises were removed so streaming and non-streaming responses keep the upstream **status, headers, and body**.
> 
> Upstream failures still run **`post_call_failure_hook`** via **`_log_passthrough_upstream_failure`**, with a shared **`_build_passthrough_failure_request_payload`** shape. Failures are reported as **`HTTPException`** (not raw **`httpx.HTTPStatusError`**) so routine upstream errors don’t trigger high-severity ops alerts. Callback errors are swallowed so the passthrough response is never broken.
> 
> **Post-call guardrails**, managed-id output rewrite, and **success** spend logging (non-streaming handler and **`chunk_processor` end-of-stream**) run only when **`status_code < 400`**, avoiding double failure+success SpendLogs entries. Non-streaming failure hooks include parsed **`response_body`** from the upstream error JSON.
> 
> Regression tests cover unchanged 403 bodies (stream/non-stream), success path, internal **`ProxyException`**, failure-hook resilience, and streaming success logging skipped on 4xx/5xx.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbfba17b1c8923796604bc72f5598ca3408c962e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->