### PR TITLE
fix(ui): search request logs by request_id server-side

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.test.tsx
@@ -166,6 +166,22 @@ describe("SpendLogsTable", () => {
       await waitForWindowSeconds(15);
     });
 
+    it("passes request_id to uiSpendLogsCall when searching by Request ID", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(<SpendLogsTable {...defaultProps} />);
+
+      const searchInput = screen.getByPlaceholderText("Search by Request ID");
+      await user.type(searchInput, "req-off-page");
+
+      await waitFor(
+        () => {
+          const lastCall = vi.mocked(uiSpendLogsCall).mock.calls.at(-1)?.[0];
+          expect(lastCall?.params?.request_id).toBe("req-off-page");
+        },
+        { timeout: 1000 },
+      );
+    });
+
     it("should update the time-range button label to 'Last Minute' after selecting it", async () => {
       const user = userEvent.setup();
       renderWithProviders(<SpendLogsTable {...defaultProps} />);

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -12,7 +12,7 @@ import AuditLogs from "./audit_logs";
 import { createColumns, LogEntry, type LogsSortField } from "./columns";
 import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
 import { getLogFilterOptions } from "./filter_options";
-import { useLogFilterLogic, defaultFilters, type LogFilterState } from "./log_filter_logic";
+import { useLogFilterLogic, defaultFilters, type LogFilterState, FILTER_KEYS } from "./log_filter_logic";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
 import { LogsTableToolbar } from "./LogsTableToolbar";
 import { DataTable } from "./table";
@@ -112,8 +112,16 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     currentPage,
   });
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      handleFilterChange({ [FILTER_KEYS.REQUEST_ID]: searchTerm.trim() });
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm, handleFilterChange]);
+
   const handleFilterReset = useCallback(() => {
     handleFilterResetFromHook();
+    setSearchTerm("");
     setStartTime(moment().subtract(24, "hours").format("YYYY-MM-DDTHH:mm"));
     setEndTime(moment().format("YYYY-MM-DDTHH:mm"));
     setIsCustomDate(false);
@@ -133,16 +141,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
   );
 
   const filteredData = useMemo(() => {
-    const searchedLogs = filteredLogs.data.filter((log) => {
-      const matchesSearch =
-        !searchTerm ||
-        log.request_id.includes(searchTerm) ||
-        log.model.includes(searchTerm) ||
-        (log.user && log.user.includes(searchTerm));
-
-      // No need for additional filtering since we're now handling this in the API call
-      return matchesSearch;
-    });
+    const searchedLogs = filteredLogs.data;
 
     const sessionCompositionById = searchedLogs.reduce<Record<string, { llm: number; agent: number; mcp: number }>>(
       (acc, log) => {
@@ -200,7 +199,7 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
           return sessionRepresentativeMap.get(log.session_id)?.requestId === log.request_id;
         })
     );
-  }, [filteredLogs.data, searchTerm]);
+  }, [filteredLogs.data]);
 
   // Keep the Fetch button busy until the table has actually committed the new
   // rows. `keepPreviousData` leaves logsQuery.isLoading false on refetch, so

--- a/ui/litellm-dashboard/src/components/view_logs/index.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/index.tsx
@@ -27,7 +27,6 @@ interface SpendLogsTableProps {
 }
 
 export default function SpendLogsTable({ accessToken, token, userRole, userID, premiumUser }: SpendLogsTableProps) {
-  const [searchTerm, setSearchTerm] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize] = useState(50);
 
@@ -112,16 +111,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
     currentPage,
   });
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      handleFilterChange({ [FILTER_KEYS.REQUEST_ID]: searchTerm.trim() });
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchTerm, handleFilterChange]);
-
   const handleFilterReset = useCallback(() => {
     handleFilterResetFromHook();
-    setSearchTerm("");
     setStartTime(moment().subtract(24, "hours").format("YYYY-MM-DDTHH:mm"));
     setEndTime(moment().format("YYYY-MM-DDTHH:mm"));
     setIsCustomDate(false);
@@ -263,8 +254,8 @@ export default function SpendLogsTable({ accessToken, token, userRole, userID, p
                 />
                 <div className="bg-white rounded-lg shadow-sm w-full max-w-full box-border">
                   <LogsTableToolbar
-                    searchTerm={searchTerm}
-                    onSearchChange={setSearchTerm}
+                    searchTerm={filters[FILTER_KEYS.REQUEST_ID]}
+                    onSearchChange={(value) => handleFilterChange({ [FILTER_KEYS.REQUEST_ID]: value })}
                     startTime={startTime}
                     onStartTimeChange={setStartTime}
                     endTime={endTime}


### PR DESCRIPTION
## Summary
- Wire the top-level **Search by Request ID** field to the existing `/spend/logs/ui?request_id=` backend filter
- Reset pagination via the existing filter handler when the search term changes
- Remove client-side-only filtering that only searched the current page

Fixes #32047

## Test plan
- [x] `npm test -- --run src/components/view_logs/index.test.tsx`
- [x] Added test: typing in Request ID search passes `request_id` to `uiSpendLogsCall`

Made with [Cursor](https://cursor.com)