### PR TITLE
fix(bedrock): preserve stream param and decode SSE for bedrock mantle streaming

### DIFF
--- a/litellm/llms/bedrock/chat/mantle/transformation.py
+++ b/litellm/llms/bedrock/chat/mantle/transformation.py
@@ -7,13 +7,14 @@ The bedrock-mantle endpoint uses the Anthropic Messages API format but is served
 at a different endpoint (bedrock-mantle.{region}.api.aws) with AWS SigV4 auth.
 """
 
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, List, Optional
 
 from litellm.llms.bedrock.chat.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeConfig,
 )
 from litellm.llms.bedrock.common_utils import build_mantle_messages_url
 from litellm.types.llms.openai import AllMessageValues
+from litellm.types.utils import ModelResponse
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
@@ -91,10 +92,14 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
             litellm_params=litellm_params,
             headers=headers,
         )
-        # The parent strips "model" from the body (Invoke API puts it in URL).
-        # The mantle endpoint (Messages API) requires "model" in the body.
-        request["model"] = model_id
-        return request
+        # The parent strips "model" and "stream" from the body (Invoke API puts
+        # the model in the URL and streams via a dedicated endpoint). The mantle
+        # endpoint (Messages API) requires both in the body.
+        return self._restore_mantle_body_fields(
+            request=request,
+            model_id=model_id,
+            optional_params=optional_params,
+        )
 
     async def async_transform_request(
         self,
@@ -114,5 +119,31 @@ class AmazonMantleConfig(AmazonAnthropicClaudeConfig):
             headers=headers,
         )
         await self._async_convert_document_url_sources_to_base64(request)
-        request["model"] = model_id
-        return request
+        return self._restore_mantle_body_fields(
+            request=request,
+            model_id=model_id,
+            optional_params=optional_params,
+        )
+
+    @staticmethod
+    def _restore_mantle_body_fields(request: dict, model_id: str, optional_params: dict) -> dict:
+        stream_fields: dict = {"stream": True} if optional_params.get("stream") is True else {}
+        return {**request, "model": model_id, **stream_fields}
+
+    @property
+    def has_custom_stream_wrapper(self) -> bool:
+        return False
+
+    def get_model_response_iterator(
+        self,
+        streaming_response: Iterator[str] | AsyncIterator[str] | ModelResponse,
+        sync_stream: bool,
+        json_mode: Optional[bool] = False,
+    ) -> Any:
+        from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+
+        return ModelResponseIterator(
+            streaming_response=streaming_response,
+            sync_stream=sync_stream,
+            json_mode=json_mode,
+        )

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -6,8 +6,13 @@ AmazonAnthropicClaudeMessagesConfig. Overrides only the URL and model-prefix
 stripping that are specific to the bedrock-mantle endpoint.
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, AsyncIterator, Dict, List, Optional, Tuple
 
+import httpx
+
+from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+    AnthropicMessagesConfig,
+)
 from litellm.llms.bedrock.common_utils import build_mantle_messages_url
 from litellm.llms.bedrock.messages.invoke_transformations.anthropic_claude3_transformation import (
     AmazonAnthropicClaudeMessagesConfig,
@@ -89,8 +94,26 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
             headers=headers,
         )
 
-        # Parent (AmazonAnthropicClaudeMessagesConfig) removes "model" from the
-        # body (Bedrock Invoke puts model in the URL). The mantle endpoint
-        # (Messages API) requires "model" in the request body.
-        request["model"] = model_id
-        return request
+        # Parent (AmazonAnthropicClaudeMessagesConfig) removes "model" and
+        # "stream" from the body (Bedrock Invoke puts the model in the URL and
+        # streams via a dedicated endpoint). The mantle endpoint (Messages API)
+        # requires both in the request body.
+        stream_fields: dict[str, bool] = (
+            {"stream": True} if anthropic_messages_optional_request_params.get("stream") is True else {}
+        )
+        return {**request, "model": model_id, **stream_fields}
+
+    def get_async_streaming_response_iterator(
+        self,
+        model: str,
+        httpx_response: httpx.Response,
+        request_body: dict,
+        litellm_logging_obj: LiteLLMLoggingObj,
+    ) -> AsyncIterator:
+        return AnthropicMessagesConfig.get_async_streaming_response_iterator(
+            self=self,
+            model=model,
+            httpx_response=httpx_response,
+            request_body=request_body,
+            litellm_logging_obj=litellm_logging_obj,
+        )

--- a/litellm/llms/bedrock/messages/mantle_transformation.py
+++ b/litellm/llms/bedrock/messages/mantle_transformation.py
@@ -111,7 +111,7 @@ class AmazonMantleMessagesConfig(AmazonAnthropicClaudeMessagesConfig):
         litellm_logging_obj: LiteLLMLoggingObj,
     ) -> AsyncIterator:
         return AnthropicMessagesConfig.get_async_streaming_response_iterator(
-            self=self,
+            self,
             model=model,
             httpx_response=httpx_response,
             request_body=request_body,

--- a/tests/test_litellm/llms/bedrock/test_mantle.py
+++ b/tests/test_litellm/llms/bedrock/test_mantle.py
@@ -204,6 +204,88 @@ def test_mantle_transform_request_strips_prefix_and_adds_model():
     )
     assert request["model"] == "anthropic.claude-mythos-preview"
     assert "mantle/" not in request["model"]
+    assert "stream" not in request
+
+
+def test_mantle_transform_request_keeps_stream_in_body():
+    config = AmazonMantleConfig()
+    request = config.transform_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={"max_tokens": 100, "stream": True},
+        litellm_params={},
+        headers={},
+    )
+    assert request["stream"] is True
+    assert request["model"] == "anthropic.claude-mythos-preview"
+
+
+@pytest.mark.asyncio
+async def test_mantle_async_transform_request_keeps_stream_in_body():
+    config = AmazonMantleConfig()
+    request = await config.async_transform_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={"max_tokens": 100, "stream": True},
+        litellm_params={},
+        headers={},
+    )
+    assert request["stream"] is True
+    assert request["model"] == "anthropic.claude-mythos-preview"
+
+
+@pytest.mark.asyncio
+async def test_mantle_async_transform_request_omits_stream_when_not_streaming():
+    config = AmazonMantleConfig()
+    request = await config.async_transform_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={"max_tokens": 100},
+        litellm_params={},
+        headers={},
+    )
+    assert "stream" not in request
+
+
+def test_mantle_messages_transform_request_keeps_stream_in_body():
+    from litellm.types.router import GenericLiteLLMParams
+
+    config = AmazonMantleMessagesConfig()
+    request = config.transform_anthropic_messages_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 100, "stream": True},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert request["stream"] is True
+    assert request["model"] == "anthropic.claude-mythos-preview"
+
+
+def test_mantle_messages_transform_request_omits_stream_when_not_streaming():
+    from litellm.types.router import GenericLiteLLMParams
+
+    config = AmazonMantleMessagesConfig()
+    request = config.transform_anthropic_messages_request(
+        model="mantle/anthropic.claude-mythos-preview",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params={"max_tokens": 100},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+    assert "stream" not in request
+
+
+def test_mantle_chat_streaming_uses_anthropic_sse_iterator():
+    from litellm.llms.anthropic.chat.handler import ModelResponseIterator
+
+    config = AmazonMantleConfig()
+    assert config.has_custom_stream_wrapper is False
+    iterator = config.get_model_response_iterator(
+        streaming_response=iter([]),
+        sync_stream=True,
+    )
+    assert isinstance(iterator, ModelResponseIterator)
 
 
 def test_mantle_validate_environment_sets_workspace_header():
@@ -347,3 +429,164 @@ async def test_mantle_anthropic_messages_routes_to_vpc_api_base():
     assert len(urls) == 1
     assert urls[0] == f"{_VPC_ENDPOINT}/anthropic/v1/messages"
     assert "api.aws" not in urls[0]
+
+
+_ANTHROPIC_SSE_EVENTS = (
+    (
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": "msg_stream_test",
+                "type": "message",
+                "role": "assistant",
+                "model": "anthropic.claude-mythos-preview",
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 10, "output_tokens": 1},
+            },
+        },
+    ),
+    (
+        "content_block_start",
+        {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "text", "text": ""},
+        },
+    ),
+    (
+        "content_block_delta",
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "pong"},
+        },
+    ),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    (
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+            "usage": {"output_tokens": 2},
+        },
+    ),
+    ("message_stop", {"type": "message_stop"}),
+)
+
+
+def _anthropic_sse_bytes() -> bytes:
+    return "".join(
+        f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+        for event, payload in _ANTHROPIC_SSE_EVENTS
+    ).encode()
+
+
+def _anthropic_sse_response(url: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        content=_anthropic_sse_bytes(),
+        headers={"content-type": "text/event-stream"},
+        request=httpx.Request("POST", url),
+    )
+
+
+def test_mantle_completion_streaming_sends_stream_and_decodes_sse():
+    import litellm
+
+    requests = []
+
+    def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_sse_response(url)
+
+    with patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post", mock_post):
+        response = litellm.completion(
+            model="bedrock/mantle/anthropic.claude-mythos-preview",
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=10,
+            stream=True,
+            aws_access_key_id="fake-key",
+            aws_secret_access_key="fake-secret",
+            aws_region_name="us-east-1",
+        )
+        chunks = list(response)
+
+    assert len(requests) == 1
+    assert requests[0]["body"]["stream"] is True
+    content = "".join(chunk.choices[0].delta.content or "" for chunk in chunks)
+    assert content == "pong"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_mantle_acompletion_streaming_sends_stream_and_decodes_sse():
+    import litellm
+
+    requests = []
+
+    async def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_sse_response(url)
+
+    try:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new=mock_post,
+        ):
+            response = await litellm.acompletion(
+                model="bedrock/mantle/anthropic.claude-mythos-preview",
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=10,
+                stream=True,
+                aws_access_key_id="fake-key",
+                aws_secret_access_key="fake-secret",
+                aws_region_name="us-east-1",
+            )
+            chunks = [chunk async for chunk in response]
+    finally:
+        await litellm.close_litellm_async_clients()
+
+    assert len(requests) == 1
+    assert requests[0]["body"]["stream"] is True
+    content = "".join(chunk.choices[0].delta.content or "" for chunk in chunks)
+    assert content == "pong"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+@pytest.mark.asyncio
+async def test_mantle_anthropic_messages_streaming_sends_stream_and_passes_through_sse():
+    import litellm
+
+    requests = []
+
+    async def mock_post(self, url, data=None, headers=None, **kwargs):
+        requests.append(_capture_request(url=url, headers=headers or {}, data=data))
+        return _anthropic_sse_response(str(url))
+
+    try:
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new=mock_post,
+        ):
+            response = await litellm.anthropic_messages(
+                model="bedrock/mantle/anthropic.claude-mythos-preview",
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=10,
+                stream=True,
+                aws_access_key_id="fake-key",
+                aws_secret_access_key="fake-secret",
+                aws_region_name="us-east-1",
+            )
+            raw = b"".join([chunk async for chunk in response])
+    finally:
+        await litellm.close_litellm_async_clients()
+
+    assert len(requests) == 1
+    assert requests[0]["body"]["stream"] is True
+    text = raw.decode()
+    assert "event: message_start" in text
+    assert '"text": "pong"' in text
+    assert "event: message_stop" in text


### PR DESCRIPTION
## Relevant issues

Resolves LIT-4330
Fixes #31845

## Linear ticket

Resolves LIT-4190

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified end to end against the real Bedrock Mantle us-east-1 endpoint with zero mocks: the litellm proxy was run from source in a fresh venv, once detached at the base commit 4bd579cf6f and once at the PR head be402cc321, with the same config, same venv, and same port (61632) for both runs. The config points `mantle-claude` at `bedrock/mantle/anthropic.claude-opus-4-7` via `aws_profile_name`, so requests are SigV4-signed with real AWS credentials and cost real money

```yaml
model_list:
  - model_name: mantle-claude
    litellm_params:
      model: bedrock/mantle/anthropic.claude-opus-4-7
      aws_profile_name: litellm-dev
      aws_region_name: us-east-1

general_settings:
  master_key: sk-lit4190-qa
```

### Before (proxy at base commit 4bd579cf6f)

Non-streaming control, proving config, auth, and model access are all fine

```bash
curl -sS --max-time 120 http://localhost:61632/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","messages":[{"role":"user","content":"Reply with exactly the word pong"}],"max_tokens":32}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"id":"chatcmpl-736270b8-e9a6-4fba-8726-08893bedaaae","created":1783192888,"model":"mantle-claude","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","provider_specific_fields":{"citations":null,"thinking_blocks":null}}}],"usage":{"completion_tokens":6,"prompt_tokens":22,"total_tokens":28,...}}
HTTP 200
```

Streaming on /v1/chat/completions fails with HTTP 500 ChecksumMismatch

```bash
curl -sS -N --max-time 120 http://localhost:61632/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","messages":[{"role":"user","content":"Reply with exactly the word pong"}],"max_tokens":32,"stream":true}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"error":{"message":"litellm.APIConnectionError: Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\nTraceback (most recent call last):\n  File \".../litellm/llms/bedrock/chat/invoke_handler.py\", line 1631, in aiter_bytes\n    for event in event_stream_buffer:\n... (traceback elided) ...\n  File \".../botocore/eventstream.py\", line 289, in _validate_checksum\n    raise ChecksumMismatch(checksum, computed_checksum)\nbotocore.eventstream.ChecksumMismatch: Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\n","type":null,"param":null,"code":"500"}}
HTTP 500
```

Streaming on /v1/messages fails the same way

```bash
curl -sS -N --max-time 120 http://localhost:61632/v1/messages \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly the word pong"}]}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"error":{"message":"Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\n\nTraceback (most recent call last):\n... (traceback elided) ...\n  File \".../litellm/llms/bedrock/chat/invoke_handler.py\", line 1631, in aiter_bytes\n    for event in event_stream_buffer:\n... (traceback elided) ...\nbotocore.eventstream.ChecksumMismatch: Checksum mismatch: expected 0x3a22636c, calculated 0x85428ad2\n","type":"None","param":"None","code":"500"}}
HTTP 500
```

### After (proxy at PR head be402cc321, same port, same venv, same commands)

Streaming on /v1/chat/completions now returns real SSE chunks ending in [DONE]

```bash
curl -sS -N --max-time 120 http://localhost:61632/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","messages":[{"role":"user","content":"Reply with exactly the word pong"}],"max_tokens":32,"stream":true}' \
  -w '\nHTTP %{http_code}\n'
```

```
data: {"id":"chatcmpl-cc7c985e-9237-4668-b30a-9fb483b12f71","object":"chat.completion.chunk","created":1783192948,"model":"mantle-claude","choices":[{"index":0,"delta":{"role":"assistant","content":"p"}}]}

data: {"id":"chatcmpl-cc7c985e-9237-4668-b30a-9fb483b12f71","object":"chat.completion.chunk","created":1783192948,"model":"mantle-claude","choices":[{"index":0,"delta":{"content":"ong"}}]}

data: {"id":"chatcmpl-cc7c985e-9237-4668-b30a-9fb483b12f71","object":"chat.completion.chunk","created":1783192948,"model":"mantle-claude","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: [DONE]

HTTP 200
```

Streaming on /v1/messages now returns native Anthropic SSE events from message_start through message_stop

```bash
curl -sS -N --max-time 120 http://localhost:61632/v1/messages \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","max_tokens":32,"stream":true,"messages":[{"role":"user","content":"Reply with exactly the word pong"}]}' \
  -w '\nHTTP %{http_code}\n'
```

```
event: message_start
data: {"type":"message_start","message":{"model":"claude-opus-4-7","id":"msg_bdrk_i7gpetjef4prkikdt6d4pmkhbasgesup4cminbfbtal4lby52dya","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"stop_details":null,"usage":{"input_tokens":22,...}}}

event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"p"}}

event: content_block_delta
data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ong"}}

event: content_block_stop
data: {"type":"content_block_stop","index":0}

event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null,"stop_details":null},"usage":{"input_tokens":22,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":6,"output_tokens_details":{"thinking_tokens":0}}}

event: message_stop
data: {"type":"message_stop"}

HTTP 200
```

Non-streaming control still works after the fix

```bash
curl -sS --max-time 120 http://localhost:61632/v1/chat/completions \
  -H "Authorization: Bearer sk-lit4190-qa" -H "Content-Type: application/json" \
  -d '{"model":"mantle-claude","messages":[{"role":"user","content":"Reply with exactly the word pong"}],"max_tokens":32}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"id":"chatcmpl-85ad45f3-d203-46ad-9d19-3587f8c4c500","created":1783192963,"model":"mantle-claude","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"pong","role":"assistant","provider_specific_fields":{"citations":null,"thinking_blocks":null}}}],"usage":{"completion_tokens":6,"prompt_tokens":22,"total_tokens":28,...}}
HTTP 200
```

## Type

Bug Fix

## Changes

Streaming requests to `bedrock/mantle/...` models failed with an HTTP 500 `botocore.eventstream.ChecksumMismatch` error on both the `/v1/chat/completions` and `/v1/messages` surfaces, while non-streaming requests worked fine. Two problems compounded

First, the outbound request body never carried `stream`. The mantle transforms build the body via the shared Bedrock Invoke Anthropic base, which strips both `model` and `stream` because Bedrock Invoke puts the model in the URL and streams via the dedicated `invoke-with-response-stream` endpoint. The mantle configs restored `model` but not `stream`, so the bedrock-mantle endpoint (which speaks the native Anthropic Messages API and needs `"stream": true` in the body) returned a plain JSON response instead of SSE. Both mantle transforms (chat sync/async and the `/v1/messages` transform) now restore `stream` into the body when the caller streams, before SigV4 signing so the signature stays valid

Second, even with `stream` restored, the response was decoded with botocore's binary AWS event-stream parser, which crashes with `ChecksumMismatch` when fed the `text/event-stream` bytes that the mantle endpoint actually returns. The chat config now opts out of the Bedrock custom stream wrapper and reuses the existing Anthropic SSE iterator (`litellm/llms/anthropic/chat/handler.py`'s `ModelResponseIterator`), and the `/v1/messages` config reuses the native `AnthropicMessagesConfig` streaming iterator that passes the SSE bytes through, instead of the `AmazonAnthropicClaudeMessagesStreamDecoder` binary path

Regression tests cover `stream` being present in the transformed body for both surfaces (sync and async), its absence when not streaming, the SSE iterator selection for the chat path, and full mocked-SSE streaming flows for `completion`, `acompletion`, and `anthropic_messages` that fail with the old binary decoder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved streaming support for Mantle chat and message-based requests.
  * Streaming responses are now handled more consistently across sync and async usage.

* **Bug Fixes**
  * Fixed request payload handling so streaming is only included when enabled.
  * Improved SSE decoding so streamed output is delivered as expected, including final completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoped to mantle Bedrock routing and streaming paths with regression tests; wrong decoder or body fields could still break mantle-only streaming without affecting standard Bedrock Invoke.
> 
> **Overview**
> Fixes **streaming for `bedrock/mantle/...`** on chat completions and Anthropic `/messages`, which previously failed with `botocore.eventstream.ChecksumMismatch` because the client treated mantle responses like Bedrock Invoke binary event streams.
> 
> **Request bodies** now re-add **`stream: true`** (along with `model`) when the caller streams, via shared `_restore_mantle_body_fields` on the chat config and the same pattern on `AmazonMantleMessagesConfig`, since the Invoke base strips both fields.
> 
> **Response handling** switches mantle chat streaming to Anthropic **`ModelResponseIterator`** (`has_custom_stream_wrapper` → `False`) and mantle messages streaming to **`AnthropicMessagesConfig`**’s async SSE pass-through instead of the Bedrock binary stream decoder.
> 
> Tests cover body shaping, iterator choice, and end-to-end mocked SSE for `completion`, `acompletion`, and `anthropic_messages`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be402cc321e55fde79a932b2ea0d93498a2f5c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->