### PR TITLE
feat(mcp): let users select the entra_obo token_exchange profile in the UI and API

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260703120000_add_token_exchange_profile_to_mcp_servers/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260703120000_add_token_exchange_profile_to_mcp_servers/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_MCPServerTable" ADD COLUMN IF NOT EXISTS "token_exchange_profile" TEXT;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -334,6 +334,7 @@ model LiteLLM_MCPServerTable {
   // RFC 8707 resource indicators are a separate concept, named "resource" in the v2 egress types.
   audience           String?
   subject_token_type String?
+  token_exchange_profile String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/litellm/models/mcp_server.py
+++ b/litellm/models/mcp_server.py
@@ -91,6 +91,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     token_exchange_endpoint: Optional[str] = None
     audience: Optional[str] = None
     subject_token_type: Optional[str] = None
+    token_exchange_profile: Optional[str] = None
     allow_all_keys: bool = False
     available_on_public_internet: bool = True
     delegate_auth_to_upstream: bool = False

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -55,6 +55,7 @@ _AUTH_FLOW_SCOPED_FIELDS: frozenset = frozenset(
         "token_exchange_endpoint",
         "audience",
         "subject_token_type",
+        "token_exchange_profile",
     }
 )
 
@@ -70,6 +71,7 @@ _TOKEN_EXCHANGE_COLUMN_FIELDS: frozenset = frozenset(
         "token_exchange_endpoint",
         "audience",
         "subject_token_type",
+        "token_exchange_profile",
     }
 )
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1358,7 +1358,8 @@ class MCPServerManager:
             subject_token_type=mcp_server.subject_token_type
             or (credentials_dict.get("subject_token_type") if credentials_dict else None)
             or DEFAULT_SUBJECT_TOKEN_TYPE,
-            token_exchange_profile=(credentials_dict.get("token_exchange_profile") if credentials_dict else None)
+            token_exchange_profile=mcp_server.token_exchange_profile
+            or (credentials_dict.get("token_exchange_profile") if credentials_dict else None)
             or "rfc8693",
             timeout=getattr(mcp_server, "timeout", None),
             max_concurrent_requests=getattr(mcp_server, "max_concurrent_requests", None),
@@ -4637,6 +4638,7 @@ class MCPServerManager:
             token_exchange_endpoint=server.token_exchange_endpoint,
             audience=server.audience,
             subject_token_type=server.subject_token_type,
+            token_exchange_profile=server.token_exchange_profile,
             allow_all_keys=server.allow_all_keys,
             instructions=server.instructions,
             timeout=server.timeout,
@@ -4744,6 +4746,7 @@ class MCPServerManager:
             token_exchange_endpoint=server.token_exchange_endpoint,
             audience=server.audience,
             subject_token_type=server.subject_token_type,
+            token_exchange_profile=server.token_exchange_profile,
             allow_all_keys=server.allow_all_keys,
             available_on_public_internet=server.available_on_public_internet,
             delegate_auth_to_upstream=server.delegate_auth_to_upstream,

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1262,6 +1262,7 @@ class NewMCPServerRequest(LiteLLMPydanticObjectBase):
     token_exchange_endpoint: Optional[str] = None
     audience: Optional[str] = None
     subject_token_type: Optional[str] = None
+    token_exchange_profile: Optional[str] = None
     allow_all_keys: bool = False
     available_on_public_internet: bool = True
     delegate_auth_to_upstream: bool = False
@@ -1355,6 +1356,7 @@ class UpdateMCPServerRequest(LiteLLMPydanticObjectBase):
     token_exchange_endpoint: Optional[str] = None
     audience: Optional[str] = None
     subject_token_type: Optional[str] = None
+    token_exchange_profile: Optional[str] = None
     allow_all_keys: bool = False
     available_on_public_internet: bool = True
     delegate_auth_to_upstream: bool = False

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -540,6 +540,7 @@ if MCP_AVAILABLE:
         sanitized.token_exchange_endpoint = None
         sanitized.audience = None
         sanitized.subject_token_type = None
+        sanitized.token_exchange_profile = None
         # Drop env vars entirely rather than only blanking global values: the
         # names alone (DB_PASSWORD, GITHUB_API_KEY, ...) leak what secrets the
         # admin configured. Non-admins get the per-user vars they must fill in
@@ -584,6 +585,7 @@ if MCP_AVAILABLE:
         sanitized.token_exchange_endpoint = None
         sanitized.audience = None
         sanitized.subject_token_type = None
+        sanitized.token_exchange_profile = None
 
         sanitized.health_check_error = None
         sanitized.last_health_check = None

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -334,6 +334,7 @@ model LiteLLM_MCPServerTable {
   // RFC 8707 resource indicators are a separate concept, named "resource" in the v2 egress types.
   audience           String?
   subject_token_type String?
+  token_exchange_profile String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -166,6 +166,10 @@ class MCPCredentials(TypedDict, total=False):
     Token exchange wire dialect: "rfc8693" (default, the standard token-exchange grant) or
     "entra_obo" (Microsoft Entra On-Behalf-Of, the RFC 7523 jwt-bearer grant + requested_token_use
     extension). Not a secret; stored unencrypted.
+
+    Legacy input shape: lifted into the dedicated ``token_exchange_profile`` column on
+    write and stripped from the stored blob; the column is authoritative. Prefer the
+    top-level request field.
     """
 
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -334,6 +334,7 @@ model LiteLLM_MCPServerTable {
   // RFC 8707 resource indicators are a separate concept, named "resource" in the v2 egress types.
   audience           String?
   subject_token_type String?
+  token_exchange_profile String?
   allow_all_keys Boolean @default(false)
   available_on_public_internet Boolean @default(true)
   delegate_auth_to_upstream Boolean @default(false)

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1559,6 +1559,7 @@ async def test_add_update_server_with_alias():
     mock_mcp_server.token_exchange_endpoint = None
     mock_mcp_server.audience = None
     mock_mcp_server.subject_token_type = None
+    mock_mcp_server.token_exchange_profile = None
     # Additional fields used by build_mcp_server_from_table
     mock_mcp_server.extra_headers = None
     mock_mcp_server.allow_all_keys = False
@@ -1621,6 +1622,7 @@ async def test_add_update_server_without_alias():
     mock_mcp_server.token_exchange_endpoint = None
     mock_mcp_server.audience = None
     mock_mcp_server.subject_token_type = None
+    mock_mcp_server.token_exchange_profile = None
     # Additional fields used by build_mcp_server_from_table
     mock_mcp_server.extra_headers = None
     mock_mcp_server.allow_all_keys = False
@@ -1683,6 +1685,7 @@ async def test_add_update_server_fallback_to_server_id():
     mock_mcp_server.token_exchange_endpoint = None
     mock_mcp_server.audience = None
     mock_mcp_server.subject_token_type = None
+    mock_mcp_server.token_exchange_profile = None
     # Additional fields used by build_mcp_server_from_table - set explicitly
     # to avoid MagicMock objects being passed to Pydantic MCPServer constructor
     mock_mcp_server.extra_headers = None

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_db_credentials.py
@@ -740,6 +740,7 @@ def test_prepare_mcp_server_data_create_carries_token_exchange_columns():
         token_exchange_endpoint="https://idp.example.com/oauth2/token",
         audience="https://upstream.example.com",
         subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+        token_exchange_profile="entra_obo",
         credentials={"client_id": "te-client", "client_secret": "te-secret"},
     )
 
@@ -748,6 +749,7 @@ def test_prepare_mcp_server_data_create_carries_token_exchange_columns():
     assert data["token_exchange_endpoint"] == "https://idp.example.com/oauth2/token"
     assert data["audience"] == "https://upstream.example.com"
     assert data["subject_token_type"] == "urn:ietf:params:oauth:token-type:jwt"
+    assert data["token_exchange_profile"] == "entra_obo"
 
 
 def test_prepare_mcp_server_data_update_carries_token_exchange_columns():
@@ -761,6 +763,7 @@ def test_prepare_mcp_server_data_update_carries_token_exchange_columns():
         token_exchange_endpoint="https://idp.example.com/oauth2/token",
         audience="https://upstream.example.com",
         subject_token_type="urn:ietf:params:oauth:token-type:jwt",
+        token_exchange_profile="entra_obo",
     )
 
     data = _prepare_mcp_server_data(request, exclude_unset=True)
@@ -768,3 +771,4 @@ def test_prepare_mcp_server_data_update_carries_token_exchange_columns():
     assert data["token_exchange_endpoint"] == "https://idp.example.com/oauth2/token"
     assert data["audience"] == "https://upstream.example.com"
     assert data["subject_token_type"] == "urn:ietf:params:oauth:token-type:jwt"
+    assert data["token_exchange_profile"] == "entra_obo"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_partial_update.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_partial_update.py
@@ -204,6 +204,7 @@ async def test_auth_type_switch_clears_stale_flow_scoped_fields():
         "token_exchange_endpoint",
         "audience",
         "subject_token_type",
+        "token_exchange_profile",
     ):
         assert data_dict[stale_field] is None, f"{stale_field} must be cleared on auth_type switch"
     assert data_dict["credentials"] is None
@@ -235,6 +236,7 @@ async def test_auth_type_switch_back_to_oauth2_clears_token_exchange_fields():
     assert data_dict["token_exchange_endpoint"] is None
     assert data_dict["audience"] is None
     assert data_dict["subject_token_type"] is None
+    assert data_dict["token_exchange_profile"] is None
 
 
 @pytest.mark.asyncio
@@ -257,6 +259,7 @@ async def test_unchanged_auth_type_does_not_clear_flow_fields():
         "token_exchange_endpoint",
         "audience",
         "subject_token_type",
+        "token_exchange_profile",
     ):
         assert flow_field not in data_dict
 
@@ -309,6 +312,7 @@ def _existing_row(auth_type: str, credentials: dict | None = None):
     existing.token_exchange_endpoint = None
     existing.audience = None
     existing.subject_token_type = None
+    existing.token_exchange_profile = None
     return existing
 
 
@@ -328,6 +332,7 @@ async def test_create_lifts_blob_token_exchange_settings_into_columns():
             "token_exchange_endpoint": "https://idp.example.com/oauth2/token",
             "audience": "api://upstream",
             "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "token_exchange_profile": "entra_obo",
         },
     )
 
@@ -337,8 +342,9 @@ async def test_create_lifts_blob_token_exchange_settings_into_columns():
     assert data_dict["token_exchange_endpoint"] == "https://idp.example.com/oauth2/token"
     assert data_dict["audience"] == "api://upstream"
     assert data_dict["subject_token_type"] == "urn:ietf:params:oauth:token-type:jwt"
+    assert data_dict["token_exchange_profile"] == "entra_obo"
     stored_blob = json.loads(data_dict["credentials"])
-    for te_field in ("token_exchange_endpoint", "audience", "subject_token_type"):
+    for te_field in ("token_exchange_endpoint", "audience", "subject_token_type", "token_exchange_profile"):
         assert te_field not in stored_blob
     assert "client_id" in stored_blob
 
@@ -374,6 +380,7 @@ async def test_credentials_merge_migrates_legacy_blob_te_settings():
             "client_id": "enc-old-cid",
             "token_exchange_endpoint": "https://legacy-idp.example.com/token",
             "audience": "api://legacy",
+            "token_exchange_profile": "entra_obo",
         },
     )
     mock_prisma.db.litellm_mcpservertable.find_unique = AsyncMock(return_value=existing)
@@ -388,8 +395,9 @@ async def test_credentials_merge_migrates_legacy_blob_te_settings():
 
     assert data_dict["token_exchange_endpoint"] == "https://legacy-idp.example.com/token"
     assert data_dict["audience"] == "api://legacy"
+    assert data_dict["token_exchange_profile"] == "entra_obo"
     merged_blob = json.loads(data_dict["credentials"])
-    for te_field in ("token_exchange_endpoint", "audience", "subject_token_type"):
+    for te_field in ("token_exchange_endpoint", "audience", "subject_token_type", "token_exchange_profile"):
         assert te_field not in merged_blob
 
 
@@ -465,6 +473,7 @@ async def test_auth_type_switch_clears_flow_fields_with_external_fields_set():
         "token_exchange_endpoint",
         "audience",
         "subject_token_type",
+        "token_exchange_profile",
     ):
         assert data_dict[stale_field] is None, f"{stale_field} must be cleared via the fields_set path"
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -5187,6 +5187,7 @@ async def test_list_tools_with_legacy_db_m2m_server_resolves_oauth2_flow():
     legacy_server.token_exchange_endpoint = None
     legacy_server.audience = None
     legacy_server.subject_token_type = None
+    legacy_server.token_exchange_profile = None
     legacy_server.token_url = "https://oauth.example.com/token"
     legacy_server.authorization_url = None
     legacy_server.client_id = "client-id"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1773,6 +1773,66 @@ class TestMCPServerManager:
         assert result.error.tag == "misconfigured"
 
     @pytest.mark.asyncio
+    async def test_load_servers_from_config_reads_all_token_exchange_fields(self):
+        """Every token-exchange setting is configurable through config.yaml as a top-level
+        key (the config counterpart of the REST/UI columns) and reaches the resolver spec;
+        omitted keys resolve to their documented defaults. token_exchange servers need no
+        oauth2_flow (that requirement is oauth2-only)."""
+        from litellm.types.mcp import DEFAULT_SUBJECT_TOKEN_TYPE
+
+        manager = MCPServerManager()
+        config = {
+            "te_full": {
+                "url": "https://up.example.com/mcp",
+                "transport": MCPTransport.http,
+                "auth_type": MCPAuth.oauth2_token_exchange,
+                "token_exchange_endpoint": "https://idp.example.com/oauth2/token",
+                "audience": "api://upstream",
+                "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+                "token_exchange_profile": "entra_obo",
+                "client_id": "cid",
+                "client_secret": "csec",
+                "scopes": ["api://upstream/.default"],
+            },
+            "te_minimal": {
+                "url": "https://up2.example.com/mcp",
+                "transport": MCPTransport.http,
+                "auth_type": MCPAuth.oauth2_token_exchange,
+                "token_exchange_endpoint": "https://idp2.example.com/oauth2/token",
+                "client_id": "cid2",
+                "client_secret": "csec2",
+            },
+        }
+
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=None)):
+            await manager.load_servers_from_config(config)
+
+        by_name = {s.server_name: s for s in manager.config_mcp_servers.values()}
+
+        full = by_name["te_full"]
+        assert full.token_exchange_endpoint == "https://idp.example.com/oauth2/token"
+        assert full.audience == "api://upstream"
+        assert full.subject_token_type == "urn:ietf:params:oauth:token-type:jwt"
+        assert full.token_exchange_profile == "entra_obo"
+
+        minimal = by_name["te_minimal"]
+        assert minimal.audience is None
+        assert minimal.subject_token_type == DEFAULT_SUBJECT_TOKEN_TYPE
+        assert minimal.token_exchange_profile == "rfc8693"
+
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import to_server_spec
+
+        spec = to_server_spec(full)
+        assert spec is not None
+        assert spec.config.token_exchange_endpoint == "https://idp.example.com/oauth2/token"
+        assert spec.config.profile == "entra_obo"
+
+        minimal_spec = to_server_spec(minimal)
+        assert minimal_spec is not None
+        assert minimal_spec.config.subject_token_type == DEFAULT_SUBJECT_TOKEN_TYPE
+        assert minimal_spec.config.profile == "rfc8693"
+
+    @pytest.mark.asyncio
     async def test_config_oauth_initialize_tool_name_to_mcp_server_name_mapping(self):
         manager = MCPServerManager()
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -4482,6 +4482,81 @@ class TestMCPServerTokenExchangeColumns:
         assert rebuilt_table.audience == "https://upstream.example.com"
         assert rebuilt_table.subject_token_type == "urn:ietf:params:oauth:token-type:jwt"
 
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_reads_token_exchange_profile_column(self):
+        """The profile dialect selector (rfc8693 vs entra_obo) is read from its dedicated column
+        so a server created via the REST API/UI as entra_obo resolves to the Entra dialect."""
+        manager = MCPServerManager()
+
+        table_record = LiteLLM_MCPServerTable(
+            server_id="te-profile",
+            server_name="te_profile",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+            token_exchange_profile="entra_obo",
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+
+        assert mcp_server.token_exchange_profile == "entra_obo"
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_token_exchange_profile_defaults_rfc8693(self):
+        """token_exchange_profile falls back to rfc8693 when neither column nor blob sets it."""
+        manager = MCPServerManager()
+
+        table_record = LiteLLM_MCPServerTable(
+            server_id="te-profile-default",
+            server_name="te_profile_default",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_endpoint="https://idp.example.com/oauth2/token",
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+
+        assert mcp_server.token_exchange_profile == "rfc8693"
+
+    @pytest.mark.asyncio
+    async def test_build_mcp_server_from_table_token_exchange_profile_blob_fallback(self):
+        """Backwards compatibility: a server with the profile only in the credentials blob still loads."""
+        manager = MCPServerManager()
+
+        table_record = LiteLLM_MCPServerTable(
+            server_id="te-profile-blob",
+            server_name="te_profile_blob",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            credentials={"token_exchange_profile": "entra_obo"},
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+
+        assert mcp_server.token_exchange_profile == "entra_obo"
+
+    @pytest.mark.asyncio
+    async def test_round_trip_token_exchange_profile_preserved(self):
+        """token_exchange_profile survives LiteLLM_MCPServerTable -> MCPServer -> LiteLLM_MCPServerTable."""
+        manager = MCPServerManager()
+
+        table_record = LiteLLM_MCPServerTable(
+            server_id="te-profile-rt",
+            server_name="te_profile_rt",
+            url="https://upstream.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2_token_exchange,
+            token_exchange_profile="entra_obo",
+        )
+
+        mcp_server = await manager.build_mcp_server_from_table(table_record)
+        rebuilt_table = manager._build_mcp_server_table(mcp_server)
+
+        assert rebuilt_table.token_exchange_profile == "entra_obo"
+
 
 class TestInternalDelegatePkceWarningLog:
     @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_sigv4_auth.py
@@ -859,6 +859,7 @@ class TestSigV4BuildFromTable:
         table_record.token_exchange_endpoint = None
         table_record.audience = None
         table_record.subject_token_type = None
+        table_record.token_exchange_profile = None
         table_record.instructions = None
         table_record.source_url = None
 
@@ -921,6 +922,7 @@ class TestSigV4BuildFromTable:
         table_record.token_exchange_endpoint = None
         table_record.audience = None
         table_record.subject_token_type = None
+        table_record.token_exchange_profile = None
         table_record.instructions = None
         table_record.source_url = None
 

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -3775,6 +3775,7 @@ def test_sanitize_mcp_server_for_non_admin_clears_credential_fields():
     server.token_exchange_endpoint = "https://idp/token-exchange"
     server.audience = "https://upstream/api"
     server.subject_token_type = "urn:ietf:params:oauth:token-type:jwt"
+    server.token_exchange_profile = "entra_obo"
 
     sanitized = _sanitize_mcp_server_for_non_admin(server)
 
@@ -3795,6 +3796,7 @@ def test_sanitize_mcp_server_for_non_admin_clears_credential_fields():
     assert sanitized.token_exchange_endpoint is None
     assert sanitized.audience is None
     assert sanitized.subject_token_type is None
+    assert sanitized.token_exchange_profile is None
 
     # Identity / metadata fields are preserved so the UI can list the
     # server without exposing secrets.
@@ -3858,6 +3860,7 @@ def test_sanitize_virtual_key_clears_token_exchange_endpoint_and_audience():
     server.token_exchange_endpoint = "https://idp/token-exchange"
     server.audience = "https://upstream/api"
     server.subject_token_type = "urn:ietf:params:oauth:token-type:jwt"
+    server.token_exchange_profile = "entra_obo"
 
     sanitized = mgmt._sanitize_mcp_server_for_virtual_key(server)
 
@@ -3865,6 +3868,7 @@ def test_sanitize_virtual_key_clears_token_exchange_endpoint_and_audience():
     assert sanitized.token_exchange_endpoint is None
     assert sanitized.audience is None
     assert sanitized.subject_token_type is None
+    assert sanitized.token_exchange_profile is None
 
 
 def _server_with_env_vars(server_id: str = "srv-env"):

--- a/ui/litellm-dashboard/src/components/mcp_tools/TokenExchangeFormFields.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/TokenExchangeFormFields.tsx
@@ -25,6 +25,25 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
       <Form.Item
         label={
           <FieldLabel
+            label="Profile"
+            tooltip="Token-exchange wire dialect. RFC 8693 is the standard token-exchange grant. Microsoft Entra OBO uses Entra's On-Behalf-Of dialect (the RFC 7523 jwt-bearer grant with requested_token_use=on_behalf_of) and carries the target resource in a scope like api://<app-id>/.default."
+          />
+        }
+        name="token_exchange_profile"
+        {...(isEditing ? {} : { initialValue: "rfc8693" })}
+      >
+        <Select className="rounded-lg" size="large">
+          <Select.Option value="rfc8693">
+            <span className="font-medium">RFC 8693 (standard)</span>
+          </Select.Option>
+          <Select.Option value="entra_obo">
+            <span className="font-medium">Microsoft Entra OBO</span>
+          </Select.Option>
+        </Select>
+      </Form.Item>
+      <Form.Item
+        label={
+          <FieldLabel
             label="Token Exchange Endpoint (optional)"
             tooltip="RFC 8693 token endpoint. The proxy exchanges the user's incoming token here for a scoped token used to call the upstream MCP server. Leave blank to auto-discover it from the upstream's protected-resource metadata (RFC 9728 then RFC 8414)."
           />
@@ -57,33 +76,71 @@ const TokenExchangeFormFields: React.FC<TokenExchangeFormFieldsProps> = ({ isEdi
       >
         <Input.Password placeholder={`Enter OAuth client secret${placeholderSuffix}`} className={fieldClassName} />
       </Form.Item>
-      <Form.Item
-        label={
-          <FieldLabel
-            label="Audience (optional)"
-            tooltip="Target audience for the exchanged token (RFC 8693 audience). Identifies the upstream MCP server the token is for."
-          />
-        }
-        name="audience"
-      >
-        <Input placeholder="https://upstream.example.com" className={fieldClassName} />
-      </Form.Item>
-      <Form.Item
-        label={
-          <FieldLabel
-            label="Subject Token Type (optional)"
-            tooltip="Type of the user's incoming token (RFC 8693 subject_token_type). Defaults to urn:ietf:params:oauth:token-type:access_token."
-          />
-        }
-        name="subject_token_type"
-      >
-        <Input placeholder="urn:ietf:params:oauth:token-type:access_token" className={fieldClassName} />
-      </Form.Item>
-      <Form.Item
-        label={<FieldLabel label="Scopes (optional)" tooltip="Optional scopes to request during the token exchange." />}
-        name={["credentials", "scopes"]}
-      >
-        <Select mode="tags" tokenSeparators={[","]} placeholder="Add scopes" className="rounded-lg" size="large" />
+      <Form.Item noStyle shouldUpdate={(prev, cur) => prev.token_exchange_profile !== cur.token_exchange_profile}>
+        {({ getFieldValue }) => {
+          const isEntraObo = getFieldValue("token_exchange_profile") === "entra_obo";
+          return (
+            <>
+              {!isEntraObo && (
+                <>
+                  <Form.Item
+                    label={
+                      <FieldLabel
+                        label="Audience (optional)"
+                        tooltip="Target audience for the exchanged token (RFC 8693 audience). Identifies the upstream MCP server the token is for."
+                      />
+                    }
+                    name="audience"
+                  >
+                    <Input placeholder="https://upstream.example.com" className={fieldClassName} />
+                  </Form.Item>
+                  <Form.Item
+                    label={
+                      <FieldLabel
+                        label="Subject Token Type (optional)"
+                        tooltip="Type of the user's incoming token (RFC 8693 subject_token_type). Defaults to urn:ietf:params:oauth:token-type:access_token."
+                      />
+                    }
+                    name="subject_token_type"
+                  >
+                    <Input placeholder="urn:ietf:params:oauth:token-type:access_token" className={fieldClassName} />
+                  </Form.Item>
+                </>
+              )}
+              <Form.Item
+                label={
+                  <FieldLabel
+                    label={isEntraObo ? "Scopes" : "Scopes (optional)"}
+                    tooltip={
+                      isEntraObo
+                        ? "Microsoft Entra OBO carries the target resource in the scope, so at least one is required (e.g. api://<app-id>/.default)."
+                        : "Optional scopes to request during the token exchange."
+                    }
+                  />
+                }
+                name={["credentials", "scopes"]}
+                rules={
+                  isEntraObo
+                    ? [
+                        {
+                          required: true,
+                          message: "Microsoft Entra OBO requires a scope, e.g. api://<app-id>/.default",
+                        },
+                      ]
+                    : []
+                }
+              >
+                <Select
+                  mode="tags"
+                  tokenSeparators={[","]}
+                  placeholder={isEntraObo ? "api://<app-id>/.default" : "Add scopes"}
+                  className="rounded-lg"
+                  size="large"
+                />
+              </Form.Item>
+            </>
+          );
+        }}
       </Form.Item>
     </>
   );

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -399,10 +399,47 @@ describe("CreateMCPServer", () => {
       const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
       expect(payload.auth_type).toBe("oauth2_token_exchange");
       expect(payload.token_exchange_endpoint).toBe("https://idp.example.com/oauth2/token");
+      expect(payload.token_exchange_profile).toBe("rfc8693");
       expect(payload.credentials).toMatchObject({
         client_id: "te-client-id",
         client_secret: "te-client-secret",
       });
+    });
+
+    it("makes scope required when the Entra OBO profile is selected", async () => {
+      await selectHttpTransport();
+
+      const user = userEvent.setup({ delay: null });
+
+      await user.type(getServerNameInput(), "Entra_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://upstream.example.com/mcp");
+
+      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("https://idp.example.com/oauth2/token")).toBeInTheDocument();
+      });
+
+      await selectAntOption("Profile", "Microsoft Entra OBO");
+
+      await user.type(
+        screen.getByPlaceholderText("https://idp.example.com/oauth2/token"),
+        "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
+      );
+      await user.type(screen.getByPlaceholderText("Enter OAuth client ID"), "entra-client");
+      await user.type(screen.getByPlaceholderText("Enter OAuth client secret"), "entra-secret");
+
+      // Selecting Entra OBO makes the scope required; submitting without one is blocked by validation
+      // (rfc8693 would not require it), which confirms the profile selection took effect.
+      const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText("Microsoft Entra OBO requires a scope, e.g. api://<app-id>/.default"),
+        ).toBeInTheDocument();
+      });
+      expect(networking.createMCPServer).not.toHaveBeenCalled();
     });
 
     it("enforces the allowlist when the user explicitly deselects every tool", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -651,7 +651,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           : {}),
         ...(mcpServer.auth_type === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE &&
         restValues.auth_type !== AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE
-          ? { token_exchange_endpoint: null, audience: null, subject_token_type: null }
+          ? { token_exchange_endpoint: null, audience: null, subject_token_type: null, token_exchange_profile: null }
           : {}),
         server_id: mcpServer.server_id,
         mcp_info: {

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -241,6 +241,7 @@ export interface MCPServer {
   token_exchange_endpoint?: string | null;
   audience?: string | null;
   subject_token_type?: string | null;
+  token_exchange_profile?: string | null;
   mcp_info?: MCPInfo | null;
   created_at: string;
   created_by: string;


### PR DESCRIPTION
## Relevant issues

Stacked on #31772 (the token-exchange config UI/API PR); its base is that branch and it retargets down the stack as the parents merge. This completes the frontend/API parity for the `entra_obo` backend added in #31983 (LIT-4163): that PR taught the token-exchange arm Microsoft Entra's On-Behalf-Of dialect, but the profile could only be set through config.yaml

## Linear ticket

Complements LIT-4163

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `localhost:4000` backed by Postgres (master key `sk-1234`). Create an entra_obo server and an rfc8693 (default) server through the API, then read them back and inspect the DB column

```
curl -s -X POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_name":"entra_demo","url":"https://graph.microsoft.com/mcp","transport":"http","auth_type":"oauth2_token_exchange","token_exchange_profile":"entra_obo","token_exchange_endpoint":"https://login.microsoftonline.com/tenant/oauth2/v2.0/token","credentials":{"client_id":"entra-app-id","client_secret":"entra-secret","scopes":["api://graph/.default"]}}'
# [201]

curl -s -X POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_name":"rfc_demo","url":"https://up.example.com/mcp","transport":"http","auth_type":"oauth2_token_exchange","token_exchange_endpoint":"https://idp.example.com/oauth2/token","credentials":{"client_id":"cid","client_secret":"sec"}}'
# [201]
```

The DB column holds the selected dialect for the entra server and stays null for the default, and the read path fills in rfc8693 for the null case

```
SELECT server_name, auth_type, token_exchange_profile FROM "LiteLLM_MCPServerTable" WHERE server_name IN ('entra_demo','rfc_demo');
 server_name |       auth_type       | token_exchange_profile
-------------+-----------------------+------------------------
 entra_demo  | oauth2_token_exchange | entra_obo
 rfc_demo    | oauth2_token_exchange |

GET /v1/mcp/server
 entra_demo -> token_exchange_profile = 'entra_obo'
 rfc_demo   -> token_exchange_profile = 'rfc8693'
```

Dashboard: at http://localhost:4000/ui/?page=mcp-servers, Add New MCP Server, pick Streamable HTTP, choose auth type "OAuth Token Exchange (OBO)", then set Profile to "Microsoft Entra OBO". The Scope field becomes required (hinting api://<app-id>/.default) and Audience/Subject Token Type hide since that dialect ignores them; fill Client ID/Secret and a scope, then create

### Dashboard Profile selector (before / after)

Rendered from the real create-form components on the parent branch head `ff6dc33291` (before) vs this PR's head `de8debc750` (after), same steps each time: Add New MCP Server, Streamable HTTP, auth type "OAuth Token Exchange (OBO)"

Before (parent #31772): the token-exchange section has no dialect control, so a dashboard user can only ever create an rfc8693 server

![before: token-exchange section with no Profile control](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZGRkNWMxNTUtZWQzNi00ZDI1LThmOWUtNzU2NzI3ZDI0YjRhIiwiaWF0IjoxNzgzNDY1NzY4LCJleHAiOjE3ODQwNzA1NjgsImZpbGVuYW1lIjoiYmVmb3JlX3Rva2VuX2V4Y2hhbmdlLnBuZyJ9.b6ejgVWLMfmbGIUaf43mEotisd9IQ2TNR4a4hB2W1xk)

After: a Profile dropdown appears, defaulting to "RFC 8693 (standard)" with the standard Audience, Subject Token Type and optional Scopes fields intact

![after: Profile dropdown defaulting to RFC 8693, standard fields intact](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNmEwYTEwNjEtN2VjYi00NTVlLWJjNjMtZWFjNWIzOWUzMTYwIiwiaWF0IjoxNzgzNDY1NzY4LCJleHAiOjE3ODQwNzA1NjgsImZpbGVuYW1lIjoiYWZ0ZXJfcmZjODY5My5wbmcifQ.EuQtAE2b6sr_4nFVTGv8MCyHZSya-HRUGcJ-nWUojSg)

The dropdown offers the two wire dialects

![after: Profile dropdown open showing RFC 8693 and Microsoft Entra OBO](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMmUzYzFkMWUtMTIyZS00ODRlLWE5MGMtY2NhZDc3NjZjMDUyIiwiaWF0IjoxNzgzNDY1NzY4LCJleHAiOjE3ODQwNzA1NjgsImZpbGVuYW1lIjoiYWZ0ZXJfcHJvZmlsZV9kcm9wZG93bi5wbmcifQ.Ejhh-aMjLSI-dKQk7jhrIr-kQh2LIyRFWvO-iBE4RWM)

After, Microsoft Entra OBO selected: Audience and Subject Token Type disappear (that dialect ignores them) and Scopes flips to required with the `api://<app-id>/.default` hint

![after: Microsoft Entra OBO selected, Audience/Subject Token Type hidden, Scopes required](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvYzQ4ZjM2YjktZjQ0MS00MWI1LWEzZWItZDIyYTAxZjU4YjEzIiwiaWF0IjoxNzgzNDY1NzY4LCJleHAiOjE3ODQwNzA1NjgsImZpbGVuYW1lIjoiYWZ0ZXJfZW50cmFfb2JvLnBuZyJ9.7ALb3rwYsZ-AjppD_CAWPFh0cjLTYVkm6J-TL3kehx8)

## Type

🆕 New Feature

## Changes

The token-exchange arm supports two wire dialects through `token_exchange_profile`: `rfc8693` (the default standard token-exchange grant) and `entra_obo` (Microsoft Entra On-Behalf-Of, the RFC 7523 jwt-bearer grant with `requested_token_use=on_behalf_of`). The backend already reads it from config.yaml and the credentials blob, but the create/update REST API and the dashboard had no way to set it, so dashboard and API users could only ever create rfc8693 servers. This surfaces the selector, completing the parity the parent PR started for the other token-exchange fields

`token_exchange_profile` becomes a dedicated column on `LiteLLM_MCPServerTable`, mirroring the sibling fields exactly. It is added to `NewMCPServerRequest`/`UpdateMCPServerRequest`, read column-first in `build_mcp_server_from_table` with the credentials blob as a back-compat fallback and a default of `rfc8693`, and carried through both runtime-to-table builders so a registry round-trip preserves it. Although it is a non-secret dialect selector, it is scrubbed from non-admin and virtual-key responses like every other token-exchange setting: those views receive no token-exchange config at all, matching the uniformity rule #31772 settled on for `subject_token_type`

On the dashboard a Profile dropdown is added to the token-exchange section. Selecting Microsoft Entra OBO makes the scope required, since that dialect carries the target resource in the scope and the exchanger fails closed without one, and hides Audience and Subject Token Type since the Entra dialect ignores them

Tests cover the profile column read, the credentials-blob fallback, the rfc8693 default, the table round-trip, the REST create and partial-update write paths carrying `token_exchange_profile=entra_obo`, and the dashboard making the scope required when Entra OBO is selected

## Storage contract: token-exchange settings (blob → columns)

`token_exchange_profile` follows the storage contract #31772 establishes for the other token-exchange settings: the **dedicated column is authoritative**, and the same key inside `credentials` is the **legacy pre-column shape** — still accepted, but lifted into the column on write and stripped from the stored blob (an explicit top-level value, including an explicit null, always wins). The `column or blob` read fallback therefore only serves untouched pre-column rows. A null column means the `rfc8693` default, applied at the egress build site — the backend never persists the default on its own (REST creates that omit the field leave the column null). The dashboard, by contrast, persists the admin's visible selection, which may equal the default: the create form preselects "RFC 8693 (standard)", so dashboard creates stamp `rfc8693` explicitly. Stamped-`rfc8693` and null are behaviorally identical at every read site, and the write path must support persisting `rfc8693` regardless, since editing an `entra_obo` server back to the standard dialect has to write something. The lift for `token_exchange_profile` is implemented in this PR's second commit, together with restricted-view scrubbing (both sanitizers) and auth-switch clearing (`_AUTH_FLOW_SCOPED_FIELDS` + the edit form's payload nulling).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth token-exchange configuration persistence and runtime spec building (dialect selection), but follows established column/lift patterns and is covered by broad tests including auth-switch and sanitization paths.
> 
> **Overview**
> Adds **`token_exchange_profile`** as a first-class MCP server setting so operators can choose **`rfc8693`** vs **`entra_obo`** through the REST API and dashboard, not only `config.yaml` or the legacy `credentials` blob.
> 
> A new **`LiteLLM_MCPServerTable.token_exchange_profile`** column (with migration) is wired through request/response models, DB prepare/lift/strip logic (same contract as other token-exchange columns), **`build_mcp_server_from_table`** (column → blob fallback → default **`rfc8693`**), and table round-trips. Auth-type switches clear the field; restricted API views scrub it like other token-exchange settings.
> 
> The dashboard **Profile** control on the token-exchange form defaults to RFC 8693; **Microsoft Entra OBO** hides Audience/Subject Token Type and **requires** scopes. Tests cover create/update, blob migration, config load, and UI validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77fffd59194dffaa40946bd431185442a0bfb8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102
