### PR TITLE
fix(mcp): forward short OAuth state upstream, keep session in a cookie

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -1,6 +1,7 @@
 import asyncio
 import html as _html
 import json
+import secrets
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
@@ -8,7 +9,7 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import httpx
 from fastapi import APIRouter, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel, ValidationError
 
 from litellm._logging import verbose_logger
@@ -135,6 +136,72 @@ def decode_state_hash(encrypted_state: str) -> dict:
 
     state_data = json.loads(decrypted_json)
     return state_data
+
+
+# LIT-4197: some upstream authorization servers reject an over-long ``state``
+# (the encrypted OAuth session blob routinely exceeds their limit). The upstream
+# only needs an opaque value it echoes back on ``/callback``, so we forward a
+# short random handle and keep the encrypted session in a per-flow HttpOnly
+# cookie bound to that handle. The browser carries the cookie across the
+# upstream round trip, so the flow stays correct with no server-side session
+# store (works across proxy replicas, unlike an in-process map).
+_OAUTH_STATE_COOKIE_PREFIX = "mcp_oauth_state_"
+_OAUTH_STATE_COOKIE_TTL_SECONDS = 600
+_OAUTH_STATE_HANDLE_BYTES = 32
+
+
+def _oauth_state_cookie_name(relay_state: str) -> str:
+    return f"{_OAUTH_STATE_COOKIE_PREFIX}{relay_state}"
+
+
+def _oauth_state_cookie_path_and_secure(request: Request) -> tuple[str, bool]:
+    parsed = urlparse(get_request_base_url(request))
+    return parsed.path or "/", parsed.scheme == "https"
+
+
+def _set_oauth_state_cookie(
+    response: Response,
+    request: Request,
+    relay_state: str,
+    encoded_state: str,
+) -> None:
+    path, secure = _oauth_state_cookie_path_and_secure(request)
+    response.set_cookie(
+        key=_oauth_state_cookie_name(relay_state),
+        value=encoded_state,
+        max_age=_OAUTH_STATE_COOKIE_TTL_SECONDS,
+        path=path,
+        secure=secure,
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _resolve_encoded_oauth_state(request: Request, state: str) -> str:
+    """Return the encrypted OAuth session for a ``/callback`` request.
+
+    New flows carry it in a per-flow cookie keyed by the short handle we
+    forwarded upstream (the IdP echoes that handle back as ``state``). Flows
+    started before this change - or in flight across a deploy - carry the
+    encrypted blob directly in ``state``, so fall back to it when the cookie
+    is absent.
+    """
+    cookie_value = request.cookies.get(_oauth_state_cookie_name(state))
+    return cookie_value if cookie_value else state
+
+
+def _clear_oauth_state_cookie(response: Response, request: Request, state: str) -> None:
+    cookie_name = _oauth_state_cookie_name(state)
+    if cookie_name not in request.cookies:
+        return
+    path, secure = _oauth_state_cookie_path_and_secure(request)
+    response.delete_cookie(
+        key=cookie_name,
+        path=path,
+        secure=secure,
+        httponly=True,
+        samesite="lax",
+    )
 
 
 def _get_validated_client_redirect_uri(request: Request, state_data: Dict[str, Any]) -> str:
@@ -462,11 +529,12 @@ async def authorize_with_server(
         code_challenge_method=code_challenge_method,
         client_redirect_uri=redirect_uri,
     )
+    relay_state = secrets.token_urlsafe(_OAUTH_STATE_HANDLE_BYTES)
 
     params = {
         "client_id": mcp_server.client_id if mcp_server.client_id else client_id,
         "redirect_uri": f"{request_base_url}/callback",
-        "state": encoded_state,
+        "state": relay_state,
         "response_type": response_type or "code",
     }
     if scope:
@@ -483,7 +551,9 @@ async def authorize_with_server(
     existing_params = dict(parse_qsl(parsed_auth_url.query))
     existing_params.update(params)
     final_url = urlunparse(parsed_auth_url._replace(query=urlencode(existing_params)))
-    return RedirectResponse(final_url)
+    response = RedirectResponse(final_url)
+    _set_oauth_state_cookie(response, request, relay_state, encoded_state)
+    return response
 
 
 async def exchange_token_with_server(
@@ -1016,17 +1086,19 @@ async def callback(
             error_description,
         )
         if state:
+            encoded_state = _resolve_encoded_oauth_state(request, state)
             try:
-                state_data = decode_state_hash(state)
+                state_data = decode_state_hash(encoded_state)
                 original_state = state_data.get("original_state")
                 redirect_uri = _get_validated_client_redirect_uri(request, state_data)
-            except HTTPException:
-                # Untrusted/invalid client redirect_uri — surface inline rather
-                # than blindly forwarding the error to an attacker-controlled URL.
-                return _render_oauth_error_html(error, error_description)
             except Exception:
-                # State could not be decrypted (expired key, tampered, etc.).
-                return _render_oauth_error_html(error, error_description)
+                # Untrusted/invalid client redirect_uri (HTTPException), or an
+                # undecryptable state (expired key, tampered): surface the IdP
+                # error inline rather than forwarding it to an attacker-controlled
+                # URL, and drop the one-time cookie we can no longer consume.
+                response = _render_oauth_error_html(error, error_description)
+                _clear_oauth_state_cookie(response, request, state)
+                return response
 
             params: Dict[str, str] = {"error": error}
             if error_description:
@@ -1036,7 +1108,9 @@ async def callback(
             if original_state is not None:
                 params["state"] = original_state
             complete_returned_url = _append_query_params(redirect_uri, params)
-            return RedirectResponse(url=complete_returned_url, status_code=302)
+            response = RedirectResponse(url=complete_returned_url, status_code=302)
+            _clear_oauth_state_cookie(response, request, state)
+            return response
 
         # No state — nothing to round-trip to. Show the user the error.
         return _render_oauth_error_html(error, error_description)
@@ -1052,7 +1126,8 @@ async def callback(
 
     # 3. Successful authorization response.
     try:
-        state_data = decode_state_hash(state)
+        encoded_state = _resolve_encoded_oauth_state(request, state)
+        state_data = decode_state_hash(encoded_state)
         original_state = state_data["original_state"]
 
         # Re-validate the client redirect URI at the sink. /authorize
@@ -1065,14 +1140,18 @@ async def callback(
 
         params = {"code": code, "state": original_state}
         complete_returned_url = _append_query_params(redirect_uri, params)
-        return RedirectResponse(url=complete_returned_url, status_code=302)
+        response = RedirectResponse(url=complete_returned_url, status_code=302)
+        _clear_oauth_state_cookie(response, request, state)
+        return response
 
     except HTTPException:
         # Re-raise so a non-loopback base_url surfaces as 400 instead of
         # a generic "authentication incomplete" redirect.
         raise
     except Exception:
-        return HTMLResponse("<html><body>Authentication incomplete. You can close this window.</body></html>")
+        response = HTMLResponse("<html><body>Authentication incomplete. You can close this window.</body></html>")
+        _clear_oauth_state_cookie(response, request, state)
+        return response
 
 
 # ------------------------------

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -35,6 +35,7 @@ def _mock_callback_request(base_url: str = "http://localhost:3000/"):
     req = MagicMock()
     req.base_url = base_url
     req.headers = {}
+    req.cookies = {}
     return req
 
 
@@ -2628,6 +2629,107 @@ async def test_oauth_callback_accepts_same_origin_ui_redirect():
     assert "https://proxy.example.com/ui/mcp/oauth/callback" in response.headers["location"]
     assert "code=auth-code-123" in response.headers["location"]
     assert "state=state-123" in response.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_authorize_forwards_short_state_and_round_trips_via_cookie(monkeypatch):
+    """LIT-4197: the ``state`` sent to the upstream authorization server must be
+    a short opaque handle, not the long encrypted OAuth session (some IdPs
+    reject an over-long state). The session must instead ride in a per-flow
+    HttpOnly cookie so ``/callback`` still recovers the client's original state
+    and redirects back to the client's redirect_uri."""
+    from http.cookies import SimpleCookie
+    from urllib.parse import parse_qs, urlparse
+
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _oauth_state_cookie_name,
+        authorize_with_server,
+        callback,
+        decode_state_hash,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    # Real encryption so the cookie value is a genuine encrypted session.
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-for-LIT-4197")
+
+    client_state = "ee230e3dfd4f19c7441941684f39c8a4e0e2c3c61a088e33403df5662b4047b8"
+    client_redirect_uri = "http://127.0.0.1:6274/oauth/callback/debug"
+
+    server = MCPServer(
+        server_id="leanix_server",
+        name="leanix",
+        server_name="leanix",
+        alias="leanix",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="upstream-client-id",
+        authorization_url="https://idp.example.com/oauth/authorize",
+        token_url="https://idp.example.com/oauth/token",
+    )
+
+    authorize_request = MagicMock(spec=Request)
+    authorize_request.base_url = "https://proxy.example.com/"
+    authorize_request.headers = {}
+
+    authorize_response = await authorize_with_server(
+        request=authorize_request,
+        mcp_server=server,
+        client_id="upstream-client-id",
+        redirect_uri=client_redirect_uri,
+        state=client_state,
+        code_challenge="challenge",
+        code_challenge_method="S256",
+    )
+
+    location = authorize_response.headers["location"]
+    upstream_state = parse_qs(urlparse(location).query)["state"][0]
+
+    # The upstream must receive a short handle, not the encrypted session blob.
+    assert len(upstream_state) <= 64
+    assert upstream_state != client_state
+
+    # The encrypted session rides in a per-flow HttpOnly cookie bound to it.
+    jar = SimpleCookie()
+    jar.load(authorize_response.headers["set-cookie"])
+    cookie_name = _oauth_state_cookie_name(upstream_state)
+    assert cookie_name in jar
+    morsel = jar[cookie_name]
+    assert morsel["httponly"]
+    assert morsel["samesite"].lower() == "lax"
+    assert len(morsel.value) > len(upstream_state)
+    session = decode_state_hash(morsel.value)
+    assert session["original_state"] == client_state
+    assert session["client_redirect_uri"] == client_redirect_uri
+
+    # /callback recovers the original state from the cookie (not the handle) and
+    # redirects back to the client with the client's own state.
+    callback_request = MagicMock(spec=Request)
+    callback_request.base_url = "https://proxy.example.com/"
+    callback_request.headers = {}
+    callback_request.cookies = {cookie_name: morsel.value}
+
+    callback_response = await callback(
+        request=callback_request,
+        code="upstream-auth-code",
+        state=upstream_state,
+    )
+
+    assert callback_response.status_code == 302
+    cb_query = parse_qs(urlparse(callback_response.headers["location"]).query)
+    assert callback_response.headers["location"].startswith(client_redirect_uri)
+    assert cb_query["code"] == ["upstream-auth-code"]
+    assert cb_query["state"] == [client_state]
+
+    # The one-time cookie is expired on the callback response so it cannot be replayed.
+    cleared = SimpleCookie()
+    cleared.load(callback_response.headers["set-cookie"])
+    assert cookie_name in cleared
+    assert cleared[cookie_name].value == ""
+    assert cleared[cookie_name]["max-age"] == "0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -2733,6 +2733,61 @@ async def test_authorize_forwards_short_state_and_round_trips_via_cookie(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_callback_error_path_reads_cookie_and_clears_it(monkeypatch):
+    """LIT-4197: an IdP error routed through /callback must recover the client's
+    original state from the cookie (not the short handle), propagate the error to
+    the client's redirect_uri, and expire the one-time cookie."""
+    from http.cookies import SimpleCookie
+    from urllib.parse import parse_qs, urlparse
+
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        _oauth_state_cookie_name,
+        callback,
+        encode_state_with_base_url,
+    )
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-for-LIT-4197")
+
+    client_state = "client-original-state-abc"
+    client_redirect_uri = "http://127.0.0.1:6274/oauth/callback/debug"
+    handle = "shortRelayHandle123"
+    encoded_state = encode_state_with_base_url(
+        base_url=client_redirect_uri,
+        original_state=client_state,
+        client_redirect_uri=client_redirect_uri,
+    )
+    cookie_name = _oauth_state_cookie_name(handle)
+
+    request = MagicMock(spec=Request)
+    request.base_url = "https://proxy.example.com/"
+    request.headers = {}
+    request.cookies = {cookie_name: encoded_state}
+
+    response = await callback(
+        request=request,
+        error="access_denied",
+        error_description="User declined access",
+        state=handle,
+    )
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith(client_redirect_uri)
+    query = parse_qs(urlparse(location).query)
+    assert query["error"] == ["access_denied"]
+    # The client's own state is echoed back, recovered from the cookie.
+    assert query["state"] == [client_state]
+
+    cleared = SimpleCookie()
+    cleared.load(response.headers["set-cookie"])
+    assert cookie_name in cleared
+    assert cleared[cookie_name].value == ""
+    assert cleared[cookie_name]["max-age"] == "0"
+
+
+@pytest.mark.asyncio
 async def test_oauth_authorize_includes_scopes_from_server_config():
     """Test that authorize endpoint includes scopes from server configuration."""
     try:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4197

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy on `localhost:4000` with one `auth_type: oauth2` MCP server whose `authorization_url` points at an upstream IdP. The request below is the exact interactive `/authorize` an MCP client (mcp-inspector, Claude Code, Cursor, the LiteLLM UI connect button) makes, with a native loopback `redirect_uri`.

Before the fix, LiteLLM forwards its own long encrypted session as the upstream `state`:

```
$ curl -sS -D - -o /dev/null -G "http://localhost:4000/test_oauth_mcp/authorize" \
    --data-urlencode "response_type=code" \
    --data-urlencode "client_id=upstream-client-id-123" \
    --data-urlencode "code_challenge=gtt1Df7li2G3EF8y3Yzh4oP7SxKyTtKcbgzrA5qqpCs" \
    --data-urlencode "code_challenge_method=S256" \
    --data-urlencode "redirect_uri=http://127.0.0.1:6274/oauth/callback/debug" \
    --data-urlencode "state=ee230e3dfd4f19c7441941684f39c8a4e0e2c3c61a088e33403df5662b4047b8" \
    --data-urlencode "scope=mcp"

HTTP/1.1 307 Temporary Redirect
location: https://idp.example.com/oauth/authorize?client_id=upstream-client-id-123&redirect_uri=http%3A%2F%2Flocalhost%3A4000%2Fcallback&state=aytF9XRabR8VARNc...(468 chars)...&response_type=code&scope=mcp&code_challenge=gtt1Df7li2G3EF8y3Yzh4oP7SxKyTtKcbgzrA5qqpCs&code_challenge_method=S256

# upstream `state` is 468 chars and there is no Set-Cookie; strict IdPs reject it as "state parameter too long"
```

After the fix, the same request forwards a short handle upstream and moves the encrypted session into a per-flow HttpOnly cookie:

```
$ curl ... (identical /authorize request)

HTTP/1.1 307 Temporary Redirect
location: https://idp.example.com/oauth/authorize?client_id=upstream-client-id-123&redirect_uri=http%3A%2F%2Flocalhost%3A4000%2Fcallback&state=9bXVl-kzaK_5Z4C1...(43 chars)...&response_type=code&scope=mcp&code_challenge=gtt1Df7li2G3EF8y3Yzh4oP7SxKyTtKcbgzrA5qqpCs&code_challenge_method=S256
set-cookie: mcp_oauth_state_9bXVl-kzaK_5Z4C1...=oMom-SmuBH-7aK5W...(encrypted session)...; HttpOnly; Max-Age=600; Path=/; SameSite=lax

# upstream `state` is now 43 chars; `code_challenge` is still forwarded (PKCE stays a transparent pass-through)
```

The IdP redirects back to `/callback` with the handle; the browser replays the cookie, so LiteLLM recovers the session and returns the client's own original `state` plus the code, then clears the one-time cookie:

```
$ curl -sS -D - -o /dev/null -H "Cookie: mcp_oauth_state_9bXVl-kzaK_5Z4C1...=oMom-SmuBH-7aK5W..." \
    "http://localhost:4000/callback?code=upstream-auth-code-xyz&state=9bXVl-kzaK_5Z4C1..."

HTTP/1.1 302 Found
location: http://127.0.0.1:6274/oauth/callback/debug?code=upstream-auth-code-xyz&state=ee230e3dfd4f19c7441941684f39c8a4e0e2c3c61a088e33403df5662b4047b8
set-cookie: mcp_oauth_state_9bXVl-kzaK_5Z4C1...=""; expires=...; Max-Age=0; Path=/; SameSite=lax

# the client gets its OWN 64-char state back (not our handle), the auth code, and the cookie is deleted
```

Flows started before the change (or in flight across a rolling deploy) still carry the encrypted blob directly in `state` with no cookie; `/callback` falls back to decoding it, so they keep working:

```
$ curl -sS -D - -o /dev/null \
    "http://localhost:4000/callback?code=legacy-code-abc&state=<legacy 468-char encrypted state, no cookie>"

HTTP/1.1 302 Found
location: http://127.0.0.1:6274/oauth/callback/debug?code=legacy-code-abc&state=ee230e3dfd4f19c7441941684f39c8a4e0e2c3c61a088e33403df5662b4047b8
```

## Type

🐛 Bug Fix

## Changes

When LiteLLM proxies an interactive `authorization_code` OAuth flow to an upstream MCP authorization server, it needs to remember two things for `/callback`: the client's original `state` (to echo back so the client's CSRF check passes) and the client's `redirect_uri` (to know where to send the browser). The upstream only reflects the one `state` value it is given, so the old code packed the whole session (`base_url`, original state, PKCE fields, client redirect_uri) into an encrypted blob and sent that blob upstream as `state`. That blob runs a few hundred characters, and some authorization servers reject an over-long `state`, which is the "state parameter too long" failure

`authorize_with_server` now forwards a short random handle as the upstream `state` and stores the existing encrypted session in a per-flow HttpOnly, `SameSite=lax` cookie keyed by that handle. The browser carries the cookie across the upstream round trip, so `/callback` recovers the session with no server-side store, which keeps the flow correct across proxy replicas the same way the stateless-state design did. The handle is server-generated rather than the client's own `state` so it is unique per flow (no cross-flow cookie collisions) and unguessable, and the client still receives its own original `state` back at its `redirect_uri` because `/callback` restores it from the cookie

`/callback` reads the session from the cookie when present and falls back to decoding `state` directly otherwise, so states minted before this change keep working. PKCE is unchanged; `code_challenge` and `code_verifier` are still forwarded to the upstream, and they were never read back on `/callback`, so nothing depends on them surviving inside `state`

The change is confined to `authorize_with_server` and the shared `/callback`, so it covers both the discoverable `/authorize` (used by MCP clients) and the UI `/server/oauth/{server_id}/authorize` flow. Pass-through servers (`auth_type` none, upstream-delegated discovery), `client_credentials`, static-header auth, and the BYOK authorization-server endpoints do not route through these functions and are untouched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth authorize/callback and redirect/cookie handling on a security-sensitive path; behavior is backward-compatible but cookie loss or cross-site edge cases could break interactive MCP login.
> 
> **Overview**
> Fixes **LIT-4197**: strict upstream IdPs were rejecting LiteLLM’s MCP OAuth proxy because the upstream `state` carried a long encrypted session blob.
> 
> **`/authorize`** (`authorize_with_server`) now sends a short random handle as upstream `state` and stores the same encrypted session in a per-flow **HttpOnly**, **SameSite=lax** cookie (`mcp_oauth_state_<handle>`, 10‑minute TTL). The browser carries that cookie through the IdP redirect, so no server-side session store is needed and multi-replica proxies still work.
> 
> **`/callback`** resolves the session via `_resolve_encoded_oauth_state` (cookie when present, otherwise the legacy value in `state` for in-flight or pre-deploy flows), then **clears** the one-time cookie on success, IdP error propagation, and failure paths.
> 
> Tests cover the full authorize→callback round trip, IdP error handling with cookie cleanup, and mock request cookies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 444446e070a74486dc1e8052a53d35d082ef577c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->