### PR TITLE
fix(proxy): apply user_id/key_alias as narrowing filters in /key/list

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5245,6 +5245,8 @@ async def list_keys(
         # by default restores the prior behavior; the dashboard opts in explicitly.
         use_substring_matching = substring_matching and is_proxy_admin
 
+        user_id_is_filter = user_id is not None
+
         # Admins may omit user_id to list all keys; non-admins are scoped to self.
         if not user_id and not is_proxy_admin:
             user_id = user_api_key_dict.user_id
@@ -5270,6 +5272,7 @@ async def list_keys(
             access_group_id=access_group_id,
             agent_id=agent_id,
             use_substring_matching=use_substring_matching,
+            user_id_is_filter=user_id_is_filter,
         )
 
         verbose_proxy_logger.debug("Successfully prepared response")
@@ -5491,6 +5494,7 @@ def _build_key_filter_conditions(
     access_group_id: Optional[str] = None,
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    user_id_is_filter: bool = False,
 ) -> Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]]:
     """Build filter conditions for key listing.
 
@@ -5501,6 +5505,16 @@ def _build_key_filter_conditions(
       teams (via member_team_ids). This prevents leaking other members' spend data.
     - created_by visibility is scoped to teams the user currently belongs to,
       so former members cannot see service accounts they created after leaving.
+
+    Filter vs. visibility:
+    - key_alias is a pure filter: it must narrow (AND) across every visibility
+      branch, so it is applied as a global AND rather than embedded in the
+      own-keys branch (which would let an unfiltered team-visibility branch
+      OR it away).
+    - user_id doubles as the own-keys visibility floor. It only narrows when it
+      is an explicit query filter (user_id_is_filter=True); when it was
+      auto-filled to scope a bare non-admin call to self, it must stay a
+      visibility branch so team admins still see all of their team's keys.
     """
     # Prepare filter conditions
     where: Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]] = {}
@@ -5519,14 +5533,6 @@ def _build_key_filter_conditions(
             }
         else:
             user_condition["user_id"] = user_id
-    if key_alias and isinstance(key_alias, str):
-        if use_substring_matching:
-            user_condition["key_alias"] = {
-                "contains": key_alias,
-                "mode": "insensitive",
-            }
-        else:
-            user_condition["key_alias"] = key_alias
     if exclude_team_id and isinstance(exclude_team_id, str):
         user_condition["team_id"] = {"not": exclude_team_id}
     if organization_id and isinstance(organization_id, str):
@@ -5598,6 +5604,12 @@ def _build_key_filter_conditions(
         where = {"AND": [where, {"access_group_ids": {"hasSome": [access_group_id]}}]}
     if agent_id and isinstance(agent_id, str):
         where = {"AND": [where, {"agent_id": agent_id}]}
+    if key_alias:
+        key_alias_condition = {"contains": key_alias, "mode": "insensitive"} if use_substring_matching else key_alias
+        where = {"AND": [where, {"key_alias": key_alias_condition}]}
+    if user_id_is_filter and user_id:
+        user_id_condition = {"contains": user_id, "mode": "insensitive"} if use_substring_matching else user_id
+        where = {"AND": [where, {"user_id": user_id_condition}]}
 
     verbose_proxy_logger.debug(f"Filter conditions: {where}")
     return where
@@ -5627,6 +5639,7 @@ async def _list_key_helper(
     access_group_id: Optional[str] = None,
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
+    user_id_is_filter: bool = False,
 ) -> KeyListResponseObject:
     """
     Helper function to list keys
@@ -5664,6 +5677,7 @@ async def _list_key_helper(
         access_group_id=access_group_id,
         agent_id=agent_id,
         use_substring_matching=use_substring_matching,
+        user_id_is_filter=user_id_is_filter,
     )
 
     # Calculate skip for pagination

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -95,6 +95,49 @@ async def test_list_keys():
 
 
 @pytest.mark.asyncio
+def _find_or_conditions(where):
+    """Locate the visibility OR-branch list anywhere in a (possibly nested)
+    AND/OR where clause. Global AND filters (key_alias, team_id, ...) wrap the
+    OR structure, so the OR can live several levels deep. The session-token
+    filter is also an OR, so match only the OR that carries visibility branches
+    (own keys / created_by / admin-team keys)."""
+
+    def _is_visibility_or(candidate):
+        return isinstance(candidate, list) and any(
+            isinstance(branch, dict)
+            and (
+                "user_id" in branch
+                or "created_by" in branch
+                or (isinstance(branch.get("team_id"), dict) and "in" in branch["team_id"])
+                or "AND" in branch
+            )
+            for branch in candidate
+        )
+
+    if not isinstance(where, dict):
+        return None
+    if "OR" in where and _is_visibility_or(where["OR"]):
+        return where["OR"]
+    if "AND" in where:
+        for part in where["AND"]:
+            found = _find_or_conditions(part)
+            if found is not None:
+                return found
+    return None
+
+
+def _and_filter_dicts(where):
+    """Flatten every leaf condition reachable through nested AND wrappers.
+    A global AND filter (e.g. {"user_id": x}) appears here as a leaf; the
+    visibility OR is a leaf too (it has no "AND" key)."""
+    if not isinstance(where, dict):
+        return []
+    if "AND" in where:
+        return [leaf for part in where["AND"] for leaf in _and_filter_dicts(part)]
+    return [where]
+
+
+@pytest.mark.asyncio
 async def test_list_keys_include_created_by_keys():
     """
     Test that include_created_by_keys parameter correctly includes keys created by the user
@@ -138,11 +181,12 @@ async def test_list_keys_include_created_by_keys():
     where_condition = mock_find_many.call_args.kwargs["where"]
     print(f"where_condition with include_created_by_keys=True: {where_condition}")
 
-    # Verify the structure contains AND with OR conditions
-    assert "AND" in where_condition
-    assert "OR" in where_condition["AND"][1]
+    # key_alias is now a global AND filter (not part of the own-keys branch),
+    # so it wraps the visibility OR structure one level deeper.
+    assert {"key_alias": test_key_alias} in where_condition["AND"]
 
-    or_conditions = where_condition["AND"][1]["OR"]
+    or_conditions = _find_or_conditions(where_condition)
+    assert or_conditions is not None
 
     # Should have 2 OR conditions: user's own keys and created_by keys
     assert len(or_conditions) == 2
@@ -160,10 +204,11 @@ async def test_list_keys_include_created_by_keys():
     assert user_condition is not None, "User condition should be present"
     assert created_by_condition is not None, "Created by condition should be present"
 
-    # Verify user condition has all the filters
+    # Verify user condition has all the filters (key_alias is now applied as a
+    # global AND, not embedded in the own-keys branch)
     assert user_condition["user_id"] == test_user_id
     assert user_condition["organization_id"] == test_org_id
-    assert user_condition["key_alias"] == test_key_alias
+    assert "key_alias" not in user_condition
     assert user_condition["token"] == test_key_hash
 
     # Verify created_by condition only has the created_by filter (no other filters applied)
@@ -215,7 +260,8 @@ async def test_list_keys_include_created_by_keys():
     where_condition_with_exclude = mock_find_many.call_args.kwargs["where"]
     print(f"where_condition with exclude_team_id: {where_condition_with_exclude}")
 
-    or_conditions_with_exclude = where_condition_with_exclude["AND"][1]["OR"]
+    or_conditions_with_exclude = _find_or_conditions(where_condition_with_exclude)
+    assert or_conditions_with_exclude is not None
 
     # Find the user condition and created_by condition
     user_condition_with_exclude = None
@@ -6047,6 +6093,240 @@ def test_build_key_filter_conditions_agent_id_narrows_visibility():
     assert "agent_id" not in json.dumps(where_without)
 
 
+def test_build_key_filter_explicit_user_id_narrows_admin_team_visibility():
+    """
+    Core of the /key/list filter-ignored bug: with team-wide visibility
+    (admin_team_ids populated) AND an explicit user_id filter, user_id must be
+    applied as a top-level AND so it intersects (narrows) the team branch. The
+    bug embedded user_id inside the own-keys OR branch, where the unfiltered
+    {"team_id": {"in": admin_team_ids}} branch OR'd it away and the query
+    degenerated to "all team keys".
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    where = _build_key_filter_conditions(
+        user_id="me",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-a"],
+        member_team_ids=None,
+        include_created_by_keys=False,
+        user_id_is_filter=True,
+    )
+
+    assert {"user_id": "me"} in where["AND"], f"explicit user_id not ANDed: {where}"
+
+
+def test_build_key_filter_auto_scoped_user_id_preserves_admin_team_visibility():
+    """
+    Guard against over-fixing: when user_id was auto-scoped to self (not an
+    explicit filter), it must NOT be ANDed globally. Otherwise a team admin
+    calling include_team_keys with no user_id (auto-filled to their own id)
+    would have every team key AND'd away and see only their own keys.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    where = _build_key_filter_conditions(
+        user_id="me",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-a"],
+        member_team_ids=None,
+        include_created_by_keys=False,
+        user_id_is_filter=False,
+    )
+
+    assert {"user_id": "me"} not in _and_filter_dicts(where), (
+        f"auto-scoped user_id must not be a global AND: {where}"
+    )
+    or_conditions = _find_or_conditions(where)
+    assert or_conditions is not None
+    assert {"user_id": "me"} in or_conditions
+    assert {"team_id": {"in": ["team-a"]}} in or_conditions
+
+
+def test_build_key_filter_key_alias_narrows_admin_team_visibility():
+    """
+    key_alias is a pure filter and must narrow across all visibility branches.
+    With admin_team_ids populated it must be a global AND, never buried inside
+    the own-keys OR branch (where the team branch would OR it away).
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    where = _build_key_filter_conditions(
+        user_id="me",
+        team_id=None,
+        organization_id=None,
+        key_alias="prod-key",
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-a"],
+        member_team_ids=None,
+        include_created_by_keys=False,
+    )
+
+    assert {"key_alias": "prod-key"} in where["AND"], f"key_alias not ANDed: {where}"
+    or_conditions = _find_or_conditions(where)
+    assert or_conditions is not None
+    assert all("key_alias" not in branch for branch in or_conditions), (
+        f"key_alias must not sit inside a visibility OR branch: {where}"
+    )
+
+
+async def _capture_list_keys_where(
+    user_api_key_dict,
+    team_objects,
+    *,
+    user_id=None,
+    key_alias=None,
+    include_team_keys=True,
+):
+    """
+    Run list_keys end-to-end (real _list_key_helper, mocked prisma) and return
+    the WHERE clause passed to the DB. Unlike
+    _invoke_list_keys_and_capture_helper_kwargs this exercises WHERE-building,
+    so it captures how user_id/key_alias filters combine with team visibility.
+    """
+    from unittest.mock import Mock, patch
+
+    from litellm.proxy._types import LiteLLM_UserTable
+
+    mock_prisma_client = AsyncMock()
+    mock_find_many = AsyncMock(return_value=[])
+    mock_count = AsyncMock(return_value=0)
+    mock_prisma_client.db.litellm_verificationtoken.find_many = mock_find_many
+    mock_prisma_client.db.litellm_verificationtoken.count = mock_count
+    mock_user_info = LiteLLM_UserTable(
+        user_id=user_api_key_dict.user_id,
+        user_email="member@example.com",
+        teams=[t.team_id for t in team_objects],
+        organization_memberships=[],
+    )
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.validate_key_list_check",
+            return_value=mock_user_info,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._fetch_user_team_objects",
+            AsyncMock(return_value=team_objects),
+        ),
+    ):
+        await list_keys(
+            request=Mock(),
+            user_api_key_dict=user_api_key_dict,
+            page=1,
+            size=10,
+            user_id=user_id,
+            team_id=None,
+            organization_id=None,
+            key_hash=None,
+            key_alias=key_alias,
+            return_full_object=True,
+            include_team_keys=include_team_keys,
+            include_created_by_keys=False,
+            sort_by=None,
+            sort_order="desc",
+            expand=None,
+            status=None,
+            project_id=None,
+            access_group_id=None,
+            agent_id=None,
+            substring_matching=False,
+        )
+    mock_find_many.assert_called_once()
+    return mock_find_many.call_args.kwargs["where"]
+
+
+@pytest.mark.asyncio
+async def test_list_keys_user_id_filter_narrows_team_visibility_regression():
+    """
+    Regression (issue: /key/list user_id filter ignored with team visibility):
+    a regular member of a team that grants /key/list filters by their own
+    user_id with include_team_keys (exactly what the UI sends). The explicit
+    user_id filter must AND-narrow, not be OR'd away by the team branch.
+    Before the fix this returned every team key regardless of user_id.
+    """
+    member_user_id = "member-user-regression"
+    team_id = "shared-team"
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id=member_user_id,
+    )
+    team_objects = [
+        _make_member_team_table(
+            team_id=team_id,
+            member_user_id=member_user_id,
+            member_role="user",
+            team_member_permissions=["/key/list"],
+        )
+    ]
+
+    where = await _capture_list_keys_where(
+        user_api_key_dict=user_api_key_dict,
+        team_objects=team_objects,
+        user_id=member_user_id,
+        include_team_keys=True,
+    )
+
+    assert {"user_id": member_user_id} in _and_filter_dicts(where), (
+        "explicit user_id filter must narrow the team-visibility branch, "
+        f"got where={where}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_keys_key_alias_filter_narrows_team_visibility_regression():
+    """
+    Regression: same team-visibility scenario, filtering by key_alias. The
+    key_alias filter must AND-narrow. user_id is auto-scoped here (no explicit
+    user_id), so it must remain a visibility branch and NOT be ANDed globally
+    (which would drop the team keys the member is allowed to see).
+    """
+    member_user_id = "member-user-alias"
+    team_id = "shared-team-alias"
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id=member_user_id,
+    )
+    team_objects = [
+        _make_member_team_table(
+            team_id=team_id,
+            member_user_id=member_user_id,
+            member_role="user",
+            team_member_permissions=["/key/list"],
+        )
+    ]
+
+    where = await _capture_list_keys_where(
+        user_api_key_dict=user_api_key_dict,
+        team_objects=team_objects,
+        key_alias="some-alias",
+        include_team_keys=True,
+    )
+
+    and_filters = _and_filter_dicts(where)
+    assert {"key_alias": "some-alias"} in and_filters, (
+        f"key_alias filter must narrow the team-visibility branch, got where={where}"
+    )
+    assert {"user_id": member_user_id} not in and_filters, (
+        f"auto-scoped user_id must stay a visibility branch, got where={where}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_generate_key_negative_max_budget():
     """
@@ -8556,9 +8836,10 @@ async def test_build_key_filter_admin_substring_matching():
         use_substring_matching=True,
     )
 
-    # Single OR condition is flattened into the top-level where dict
-    assert where["user_id"] == {"contains": user_id, "mode": "insensitive"}
-    assert where["key_alias"] == {"contains": key_alias, "mode": "insensitive"}
+    # key_alias is applied as a global AND filter; user_id remains the
+    # (single) own-keys visibility branch flattened into the inner where.
+    assert where["AND"][1] == {"key_alias": {"contains": key_alias, "mode": "insensitive"}}
+    assert where["AND"][0]["user_id"] == {"contains": user_id, "mode": "insensitive"}
 
 
 @pytest.mark.asyncio
@@ -8588,10 +8869,10 @@ async def test_build_key_filter_non_admin_exact_matching():
         use_substring_matching=False,
     )
 
-    # Single OR condition is flattened into the top-level where dict
-    # Exact match — no contains/insensitive wrapping
-    assert where["user_id"] == user_id
-    assert where["key_alias"] == key_alias
+    # key_alias is applied as a global AND filter (exact match — no
+    # contains/insensitive wrapping); user_id remains the own-keys branch.
+    assert where["AND"][1] == {"key_alias": key_alias}
+    assert where["AND"][0]["user_id"] == user_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Alternative fix for #32062

This targets the same issue as #32123, taking a more complete approach. #32123 applies user_id as a global AND filter, which fixes the reported case but breaks a normal flow: list_keys auto-fills user_id to the caller's own id for a bare non-admin call as a visibility floor, so unconditionally AND'ing user_id makes a team admin calling include_team_keys (with no user_id) see only their own keys instead of the whole team. This PR distinguishes an explicit user_id filter from that auto-scoped self value and only narrows on the former

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduction against a live proxy (team T grants `/key/list` in `team_member_permissions`; T has keys from multiple users). Output to be added

```bash
# as a regular member of T, before this change every filtered call returned all team keys
curl -s "http://localhost:4000/key/list?user_id=$ME&include_team_keys=true&return_full_object=true" \
  -H "Authorization: Bearer $MEMBER_KEY" | jq '.total_count'

curl -s "http://localhost:4000/key/list?key_alias=$OTHER_ALIAS&include_team_keys=true" \
  -H "Authorization: Bearer $MEMBER_KEY" | jq '.total_count'