### PR TITLE
fix(proxy): invalidate end_user cache on customer create/update/delete (#31838)

### DIFF
--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -222,6 +222,25 @@ async def _handle_customer_object_permission_update(
             update_end_user_table_data["object_permission_id"] = object_permission_id
 
 
+async def _invalidate_end_user_cache(user_ids: list[str]) -> None:
+    """Drop the cached end-user object(s) after a customer create/update/delete.
+
+    Budget enforcement reads the end-user from ``user_api_key_cache`` under
+    ``end_user_id:{id}`` (TTL 300s); without invalidation it keeps serving the
+    stale budget/spend for up to the TTL after the DB changes (issue #31838).
+    """
+    if not user_ids:
+        return
+    try:
+        from litellm.proxy.proxy_server import user_api_key_cache
+
+        for user_id in user_ids:
+            if user_id:
+                await user_api_key_cache.async_delete_cache(key=f"end_user_id:{user_id}")
+    except Exception as e:  # noqa: BLE001 - cache invalidation must never fail the customer op
+        verbose_proxy_logger.debug(f"Failed to invalidate end_user cache: {e}")
+
+
 @router.post(
     "/end_user/new",
     tags=["Customer Management"],
@@ -390,6 +409,7 @@ async def new_end_user(
             include={"litellm_budget_table": True, "object_permission": True},
         )
 
+        await _invalidate_end_user_cache([data.user_id])
         return _to_customer_response(end_user_record)
     except Exception as e:
         verbose_proxy_logger.exception(
@@ -636,6 +656,7 @@ async def update_end_user(
                 raise ValueError(f"Failed updating customer data. User ID does not exist passed user_id={data.user_id}")
             verbose_proxy_logger.debug(f"received response from updating prisma client. response={response}")
 
+            await _invalidate_end_user_cache([data.user_id])
             return _to_customer_response(response)
         else:
             raise ValueError(f"user_id is required, passed user_id = {data.user_id}")
@@ -711,6 +732,7 @@ async def delete_end_user(
                 where={"user_id": {"in": data.user_ids}}
             )
             verbose_proxy_logger.debug(f"received response from updating prisma client. response={response}")
+            await _invalidate_end_user_cache(data.user_ids)
             return DeleteCustomersResponse(
                 deleted_customers=response,
                 message="Successfully deleted customers with ids: " + str(data.user_ids),

--- a/tests/test_litellm/proxy/management_endpoints/test_customer_cache_invalidation.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_customer_cache_invalidation.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for end-user cache invalidation on customer CUD (issue #31838).
+
+Budget enforcement reads the end-user from ``user_api_key_cache`` under
+``end_user_id:{id}`` (TTL 300s). The /customer/new, /customer/update and
+/customer/delete endpoints must drop that key so a create/update/delete is
+reflected immediately instead of serving a stale budget for up to the TTL.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.proxy.management_endpoints.customer_endpoints import (
+    _invalidate_end_user_cache,
+)
+
+
+@pytest.fixture
+def patched_cache(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server
+
+    cache = MagicMock()
+    cache.async_delete_cache = AsyncMock()
+    monkeypatch.setattr(proxy_server, "user_api_key_cache", cache, raising=False)
+    return cache
+
+
+def _deleted_keys(cache):
+    return [call.kwargs["key"] for call in cache.async_delete_cache.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_invalidates_each_user_id(patched_cache):
+    await _invalidate_end_user_cache(["alice", "bob"])
+    assert _deleted_keys(patched_cache) == ["end_user_id:alice", "end_user_id:bob"]
+
+
+@pytest.mark.asyncio
+async def test_empty_list_is_noop(patched_cache):
+    await _invalidate_end_user_cache([])
+    patched_cache.async_delete_cache.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skips_empty_user_ids(patched_cache):
+    await _invalidate_end_user_cache(["alice", "", None])
+    assert _deleted_keys(patched_cache) == ["end_user_id:alice"]
+
+
+@pytest.mark.asyncio
+async def test_swallows_cache_errors(patched_cache):
+    patched_cache.async_delete_cache.side_effect = RuntimeError("redis down")
+    # Must not raise — cache invalidation failures should not break the endpoint.
+    await _invalidate_end_user_cache(["alice"])


### PR DESCRIPTION
## What / Why

Closes #31838.

Budget enforcement reads the end-user object from `user_api_key_cache` under `end_user_id:{id}` (TTL 300s, in `get_end_user_object` → `auth_checks.py`). The `/customer/new`, `/customer/update` and `/customer/delete` endpoints write the DB but never invalidate that key, so a customer's budget/spend change is not reflected for up to 5 minutes — e.g. after raising `max_budget`, requests keep returning `429 ExceededBudget` against the old value (full repro in the issue).

## Change
- Add `_invalidate_end_user_cache(user_ids)` in `customer_endpoints.py` that calls `user_api_key_cache.async_delete_cache(key=f"end_user_id:{user_id}")` for each id (shared Redis entry + local copy). Cache-invalidation failures are swallowed so they can never fail the customer operation.
- Call it after the DB write in:
  - `new_end_user` → `[data.user_id]`
  - `update_end_user` → `[data.user_id]`
  - `delete_end_user` → `data.user_ids`

## Testing
```
pytest tests/test_litellm/proxy/management_endpoints/test_customer_cache_invalidation.py   # 4 passed
pytest tests/test_litellm/proxy/management_endpoints/test_customer_endpoints.py            # 28 passed (no regression)
```
Added unit tests: each id is invalidated with the correct `end_user_id:{id}` key, empty list is a no-op, empty/None ids are skipped, and cache errors are swallowed.
