### PR TITLE
bump: litellm-enterprise 0.1.46 -> 0.1.47

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.46"
+version = "0.1.47"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.46"
+version = "0.1.47"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.26.0,<2.0",
     "litellm-proxy-extras==0.4.75",
-    "litellm-enterprise==0.1.46",
+    "litellm-enterprise==0.1.47",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "polars>=1.38.1,<2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-30T05:26:52.796531Z"
+exclude-newer = "2026-07-01T21:29:59.740039Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3639,7 +3639,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.46"
+version = "0.1.47"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Not applicable; this is a version-bump-only change

## Type

🚄 Infrastructure

## Changes

The `litellm-enterprise` package picked up a code change since the last release (the duplicate budget-alert email fix in #32011) without a corresponding version bump, so its published version no longer reflects its contents. This bumps `litellm-enterprise` from 0.1.46 to 0.1.47 across `enterprise/pyproject.toml`, the root `pyproject.toml` dependency pin, and `uv.lock`

`litellm-proxy-extras` is unchanged between the last release and staging, so it is intentionally left at 0.4.75
