### PR TITLE
fix(bedrock): emit SSE error event when invoke Messages stream ends without message_stop

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -12,6 +12,29 @@ from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
 
 GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ = PassThroughEndpointLogging()
 
+INCOMPLETE_STREAM_ERROR_MESSAGE = (
+    "Provider stream ended before emitting a message_stop event; "
+    "the response is incomplete and any partial content (e.g. tool_use input JSON) may be truncated."
+)
+
+
+def _is_message_stop_chunk(chunk: object) -> bool:
+    if isinstance(chunk, dict):
+        return chunk.get("type") == "message_stop"
+    if isinstance(chunk, (bytes, bytearray)):
+        return b"message_stop" in chunk
+    return False
+
+
+def _incomplete_stream_error_sse_event() -> bytes:
+    payload = json.dumps(
+        {
+            "type": "error",
+            "error": {"type": "api_error", "message": INCOMPLETE_STREAM_ERROR_MESSAGE},
+        }
+    )
+    return f"event: error\ndata: {payload}\n\n".encode()
+
 
 class BaseAnthropicMessagesStreamingIterator:
     """
@@ -102,13 +125,18 @@ class BaseAnthropicMessagesStreamingIterator:
         This method provides the common logic for both Anthropic and Bedrock implementations.
         """
         collected_chunks = []
+        saw_message_stop = False
 
         async for chunk in completion_stream:
             if self.completion_start_time is None:
                 self.completion_start_time = datetime.now()
+            saw_message_stop = saw_message_stop or _is_message_stop_chunk(chunk)
             encoded_chunk = self._convert_chunk_to_sse_format(chunk)
             collected_chunks.append(encoded_chunk)
             yield encoded_chunk
+
+        if not saw_message_stop:
+            yield _incomplete_stream_error_sse_event()
 
         # Handle logging after all chunks are processed
         await self._handle_streaming_logging(collected_chunks)

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -22,8 +22,20 @@ def _is_message_stop_chunk(chunk: object) -> bool:
     if isinstance(chunk, dict):
         return chunk.get("type") == "message_stop"
     if isinstance(chunk, (bytes, bytearray)):
-        return b"message_stop" in chunk
+        return any(line == b"event: message_stop" for line in chunk.splitlines())
     return False
+
+
+def _is_provider_error_chunk(chunk: object) -> bool:
+    if isinstance(chunk, dict):
+        return chunk.get("type") == "error"
+    if isinstance(chunk, (bytes, bytearray)):
+        return any(line == b"event: error" for line in chunk.splitlines())
+    return False
+
+
+def _is_terminal_stream_chunk(chunk: object) -> bool:
+    return _is_message_stop_chunk(chunk) or _is_provider_error_chunk(chunk)
 
 
 def _incomplete_stream_error_sse_event() -> bytes:
@@ -125,17 +137,17 @@ class BaseAnthropicMessagesStreamingIterator:
         This method provides the common logic for both Anthropic and Bedrock implementations.
         """
         collected_chunks = []
-        saw_message_stop = False
+        saw_terminal_event = False
 
         async for chunk in completion_stream:
             if self.completion_start_time is None:
                 self.completion_start_time = datetime.now()
-            saw_message_stop = saw_message_stop or _is_message_stop_chunk(chunk)
+            saw_terminal_event = saw_terminal_event or _is_terminal_stream_chunk(chunk)
             encoded_chunk = self._convert_chunk_to_sse_format(chunk)
             collected_chunks.append(encoded_chunk)
             yield encoded_chunk
 
-        if not saw_message_stop:
+        if not saw_terminal_event:
             yield _incomplete_stream_error_sse_event()
 
         # Handle logging after all chunks are processed

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -1,0 +1,146 @@
+import json
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+    INCOMPLETE_STREAM_ERROR_MESSAGE,
+    BaseAnthropicMessagesStreamingIterator,
+    _incomplete_stream_error_sse_event,
+    _is_message_stop_chunk,
+)
+
+
+def _make_logging_obj(test_name: str) -> LiteLLMLoggingObj:
+    return LiteLLMLoggingObj(
+        model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="chat",
+        start_time=datetime.now(),
+        litellm_call_id=test_name,
+        function_id=test_name,
+    )
+
+
+def _make_iterator(test_name: str) -> BaseAnthropicMessagesStreamingIterator:
+    return BaseAnthropicMessagesStreamingIterator(
+        litellm_logging_obj=_make_logging_obj(test_name),
+        request_body={},
+    )
+
+
+async def _collect(iterator, stream):
+    return [chunk async for chunk in iterator.async_sse_wrapper(stream)]
+
+
+TRUNCATED_TOOL_USE_EVENTS = (
+    {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 10, "output_tokens": 1}}},
+    {
+        "type": "content_block_start",
+        "index": 0,
+        "content_block": {"type": "tool_use", "id": "tooluse_1", "name": "write", "input": {}},
+    },
+    {
+        "type": "content_block_delta",
+        "index": 0,
+        "delta": {"type": "input_json_delta", "partial_json": '{"path": "/builder/docs/QUAL'},
+    },
+)
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_emits_error_event_when_stream_ends_without_message_stop():
+    """
+    Regression test for LIT-3724: a Bedrock stream that goes silent
+    mid tool_use must not be passed through as a successful, complete
+    SSE stream. An `error` SSE event must be appended so strict clients
+    (Anthropic SDK, Claude Code) surface the truncation instead of
+    crashing on unterminated tool-call JSON.
+    """
+
+    async def _truncated_stream():
+        for event in TRUNCATED_TOOL_USE_EVENTS:
+            yield event
+
+    iterator = _make_iterator("test_truncated_stream_emits_error")
+    chunks = await _collect(iterator, _truncated_stream())
+
+    assert len(chunks) == len(TRUNCATED_TOOL_USE_EVENTS) + 1
+    error_chunk = chunks[-1].decode()
+    assert error_chunk.startswith("event: error\n")
+    assert error_chunk.endswith("\n\n")
+
+    error_payload = json.loads(error_chunk.split("data: ", 1)[1])
+    assert error_payload["type"] == "error"
+    assert error_payload["error"]["type"] == "api_error"
+    assert error_payload["error"]["message"] == INCOMPLETE_STREAM_ERROR_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_no_error_event_on_complete_stream():
+    async def _complete_stream():
+        for event in TRUNCATED_TOOL_USE_EVENTS:
+            yield event
+        yield {"type": "content_block_stop", "index": 0}
+        yield {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"output_tokens": 5}}
+        yield {"type": "message_stop"}
+
+    iterator = _make_iterator("test_complete_stream_no_error")
+    chunks = await _collect(iterator, _complete_stream())
+
+    assert len(chunks) == len(TRUNCATED_TOOL_USE_EVENTS) + 3
+    decoded = [chunk.decode() for chunk in chunks]
+    assert decoded[-1].startswith("event: message_stop\n")
+    assert not any(chunk.startswith("event: error\n") for chunk in decoded)
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_emits_error_event_on_empty_stream():
+    async def _empty_stream():
+        return
+        yield
+
+    iterator = _make_iterator("test_empty_stream_emits_error")
+    chunks = await _collect(iterator, _empty_stream())
+
+    assert len(chunks) == 1
+    assert chunks[0].decode().startswith("event: error\n")
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_treats_message_stop_bytes_as_complete():
+    async def _byte_stream():
+        yield b'event: message_start\ndata: {"type": "message_start"}\n\n'
+        yield b'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+
+    iterator = _make_iterator("test_byte_stream_message_stop")
+    chunks = await _collect(iterator, _byte_stream())
+
+    assert len(chunks) == 2
+    assert not any(chunk.startswith(b"event: error\n") for chunk in chunks)
+
+
+def test_is_message_stop_chunk():
+    assert _is_message_stop_chunk({"type": "message_stop"}) is True
+    assert _is_message_stop_chunk({"type": "message_delta"}) is False
+    assert _is_message_stop_chunk(b'event: message_stop\ndata: {}\n\n') is True
+    assert _is_message_stop_chunk(b"raw-bytes") is False
+    assert _is_message_stop_chunk("message_stop") is False
+
+
+def test_incomplete_stream_error_sse_event_is_valid_anthropic_error():
+    event = _incomplete_stream_error_sse_event().decode()
+    lines = event.split("\n")
+    assert lines[0] == "event: error"
+    payload = json.loads(lines[1].removeprefix("data: "))
+    assert payload == {
+        "type": "error",
+        "error": {"type": "api_error", "message": INCOMPLETE_STREAM_ERROR_MESSAGE},
+    }
+    assert event.endswith("\n\n")

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -16,6 +16,15 @@ from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterato
 )
 
 
+class _RecordingLoggingIterator(BaseAnthropicMessagesStreamingIterator):
+    def __init__(self, litellm_logging_obj: LiteLLMLoggingObj, request_body: dict):
+        super().__init__(litellm_logging_obj=litellm_logging_obj, request_body=request_body)
+        self.logged_chunks: list = []
+
+    async def _handle_streaming_logging(self, collected_chunks):
+        self.logged_chunks = list(collected_chunks)
+
+
 def _make_logging_obj(test_name: str) -> LiteLLMLoggingObj:
     return LiteLLMLoggingObj(
         model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
@@ -205,6 +214,23 @@ async def test_async_sse_wrapper_does_not_double_error_on_provider_error_bytes()
     assert len(chunks) == 2
     error_frames = [c for c in chunks if c.startswith(b"event: error\n")]
     assert len(error_frames) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_excludes_synthetic_error_event_from_logged_chunks():
+    async def _truncated_stream():
+        for event in TRUNCATED_TOOL_USE_EVENTS:
+            yield event
+
+    iterator = _RecordingLoggingIterator(
+        litellm_logging_obj=_make_logging_obj("test_synthetic_error_not_logged"),
+        request_body={},
+    )
+    chunks = await _collect(iterator, _truncated_stream())
+
+    assert chunks[-1].startswith(b"event: error\n")
+    assert iterator.logged_chunks == chunks[:-1]
+    assert not any(chunk.startswith(b"event: error\n") for chunk in iterator.logged_chunks)
 
 
 def test_incomplete_stream_error_sse_event_is_valid_anthropic_error():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_streaming_iterator.py
@@ -134,6 +134,79 @@ def test_is_message_stop_chunk():
     assert _is_message_stop_chunk("message_stop") is False
 
 
+def test_is_message_stop_chunk_ignores_substring_in_payload():
+    """
+    Regression: a `content_block_delta` frame whose payload happens to contain
+    the literal string `message_stop` (e.g. inside a tool's partial_json) must
+    not be treated as a terminal stop event.
+    """
+    delta_frame_with_substring = (
+        b'event: content_block_delta\n'
+        b'data: {"type": "content_block_delta", "delta": '
+        b'{"type": "input_json_delta", "partial_json": "\\"message_stop\\""}}\n\n'
+    )
+    assert _is_message_stop_chunk(delta_frame_with_substring) is False
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_emits_error_when_bytes_stream_only_mentions_message_stop_in_payload():
+    """
+    Regression for the bytes-branch substring false positive: a stream whose
+    payload text contains `message_stop` (but never emits the actual
+    `event: message_stop` frame) must still be flagged as incomplete.
+    """
+    async def _byte_stream():
+        yield b'event: message_start\ndata: {"type": "message_start"}\n\n'
+        yield (
+            b'event: content_block_delta\n'
+            b'data: {"type": "content_block_delta", "delta": '
+            b'{"type": "input_json_delta", "partial_json": "\\"message_stop\\""}}\n\n'
+        )
+
+    iterator = _make_iterator("test_bytes_substring_does_not_mark_complete")
+    chunks = await _collect(iterator, _byte_stream())
+
+    assert len(chunks) == 3
+    assert chunks[-1].decode().startswith("event: error\n")
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_does_not_double_error_on_provider_error_dict():
+    """
+    Regression: when the provider itself terminates the stream with an
+    `error` event (without a `message_stop`), the wrapper must forward that
+    error and not append a second synthetic incomplete-stream error.
+    """
+    provider_error = {"type": "error", "error": {"type": "overloaded_error", "message": "boom"}}
+
+    async def _error_terminated_stream():
+        yield {"type": "message_start", "message": {"id": "msg_1"}}
+        yield provider_error
+
+    iterator = _make_iterator("test_provider_error_terminal_dict")
+    chunks = await _collect(iterator, _error_terminated_stream())
+
+    assert len(chunks) == 2
+    error_frames = [c for c in chunks if c.startswith(b"event: error\n")]
+    assert len(error_frames) == 1
+    payload = json.loads(error_frames[0].decode().split("data: ", 1)[1])
+    assert payload == provider_error
+
+
+@pytest.mark.asyncio
+async def test_async_sse_wrapper_does_not_double_error_on_provider_error_bytes():
+    async def _byte_stream():
+        yield b'event: message_start\ndata: {"type": "message_start"}\n\n'
+        yield b'event: error\ndata: {"type": "error", "error": {"type": "overloaded_error"}}\n\n'
+
+    iterator = _make_iterator("test_provider_error_terminal_bytes")
+    chunks = await _collect(iterator, _byte_stream())
+
+    assert len(chunks) == 2
+    error_frames = [c for c in chunks if c.startswith(b"event: error\n")]
+    assert len(error_frames) == 1
+
+
 def test_incomplete_stream_error_sse_event_is_valid_anthropic_error():
     event = _incomplete_stream_error_sse_event().decode()
     lines = event.split("\n")

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -91,6 +91,87 @@ async def test_bedrock_sse_wrapper_encodes_dict_chunks():
 
 
 @pytest.mark.asyncio
+async def test_bedrock_sse_wrapper_appends_error_event_when_stream_truncates_mid_tool_use():
+    """
+    Regression test for LIT-3724: Bedrock invoke streams that go silent
+    mid tool_use (no content_block_stop / message_delta / message_stop)
+    used to be closed as a successful SSE stream, handing clients
+    unterminated tool-call JSON with HTTP 200. The stream must now end
+    with an Anthropic-protocol `error` SSE event.
+    """
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    async def _truncated_stream():
+        yield {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 3, "output_tokens": 1}}}
+        yield {
+            "type": "content_block_start",
+            "index": 0,
+            "content_block": {"type": "tool_use", "id": "tooluse_1", "name": "write", "input": {}},
+        }
+        yield {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "input_json_delta", "partial_json": '{"path": "/builder/docs/QUAL'},
+        }
+
+    collected: list[bytes] = []
+    async for chunk in cfg.bedrock_sse_wrapper(
+        _truncated_stream(),
+        litellm_logging_obj=LiteLLMLoggingObj(
+            model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "user", "content": "write the file"}],
+            stream=True,
+            call_type="chat",
+            start_time=datetime.now(),
+            litellm_call_id="test_bedrock_sse_wrapper_truncated_tool_use",
+            function_id="test_bedrock_sse_wrapper_truncated_tool_use",
+        ),
+        request_body={},
+    ):
+        collected.append(chunk)
+
+    assert len(collected) == 4
+    error_event = collected[-1].decode()
+    assert error_event.startswith("event: error\n")
+    error_payload = json.loads(error_event.split("data: ", 1)[1])
+    assert error_payload["type"] == "error"
+    assert error_payload["error"]["type"] == "api_error"
+
+
+@pytest.mark.asyncio
+async def test_bedrock_sse_wrapper_no_error_event_when_stream_ends_with_message_stop():
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+
+    async def _complete_stream():
+        yield {"type": "message_start", "message": {"id": "msg_1", "usage": {"input_tokens": 3, "output_tokens": 1}}}
+        yield {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+        yield {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "hi"}}
+        yield {"type": "content_block_stop", "index": 0}
+        yield {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 2}}
+        yield {"type": "message_stop"}
+
+    collected: list[bytes] = []
+    async for chunk in cfg.bedrock_sse_wrapper(
+        _complete_stream(),
+        litellm_logging_obj=LiteLLMLoggingObj(
+            model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+            call_type="chat",
+            start_time=datetime.now(),
+            litellm_call_id="test_bedrock_sse_wrapper_complete_stream",
+            function_id="test_bedrock_sse_wrapper_complete_stream",
+        ),
+        request_body={},
+    ):
+        collected.append(chunk)
+
+    assert len(collected) == 6
+    assert collected[-1].startswith(b"event: message_stop\n")
+    assert not any(chunk.startswith(b"event: error\n") for chunk in collected)
+
+
+@pytest.mark.asyncio
 async def test_bedrock_sse_wrapper_keeps_usage_in_message_start_and_message_delta():
     """Regression test: usage should be available on both message_start and message_delta SSE events."""
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3724 (issue 1: silent end-of-iterator)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Bedrock cannot be forced to truncate on demand (the customer's truncation was intermittent, ultimately caused by an ALB buffering timeout between their gateway and Bedrock), so the truncation is reproduced end to end with a local mock Bedrock endpoint that streams valid `application/vnd.amazon.eventstream` frames for a `tool_use` block and then closes the connection mid `input_json_delta`, exactly like the customer's evidence logs. The proxy config points `aws_bedrock_runtime_endpoint` at it:

```yaml
model_list:
  - model_name: bedrock-claude-truncating
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-sonnet-4-5-20250929-v1:0
      aws_bedrock_runtime_endpoint: http://127.0.0.1:9200
      aws_region_name: us-east-1
      aws_access_key_id: mock
      aws_secret_access_key: mock
  - model_name: bedrock-claude-real
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-opus-4-1-20250805-v1:0
      aws_region_name: us-east-1
      aws_profile_name: litellm-dev
```

Truncating stream, before this fix (proxy on `litellm_internal_staging`): the stream just stops after the partial tool JSON, HTTP 200, no terminal event

```
$ curl -sN http://127.0.0.1:4003/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-truncating", "max_tokens": 1024, "stream": true, "tools": [{"name": "write", "description": "write a file", "input_schema": {"type": "object", "properties": {"filePath": {"type": "string"}}}}], "messages": [{"role": "user", "content": "write the QUAL doc"}]}' | tail -4

event: content_block_delta
data: {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "AL"}}
```

Same request, after this fix (proxy on this branch): the client now receives an Anthropic-protocol `error` event instead of a silent close

```
$ curl -sN http://127.0.0.1:4001/v1/messages ... (same request) | tail -7

event: content_block_delta
data: {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "AL"}}

event: error
data: {"type": "error", "error": {"type": "api_error", "message": "Provider stream ended before emitting a message_stop event; the response is incomplete and any partial content (e.g. tool_use input JSON) may be truncated."}}
```

Real Bedrock (live API, `us.anthropic.claude-opus-4-1-20250805-v1:0`), proving healthy streams are untouched: full tool call streams to completion and ends with `message_stop`, no error event anywhere in the stream

```
$ curl -sN http://127.0.0.1:4001/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-real", "max_tokens": 200, "stream": true, "tools": [{"name": "write", "description": "write a file", "input_schema": {"type": "object", "properties": {"filePath": {"type": "string"}}}}], "messages": [{"role": "user", "content": "Use the write tool to create /docs/hello.md"}]}' | tail -8

event: content_block_stop
data: {"type": "content_block_stop", "index": 1}

event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "tool_use", "stop_sequence": null}, "usage": {"output_tokens": 72, "input_tokens": 376, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}

event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 376, "output_tokens": 72}}
```

### QA rerun (e2e, real Bedrock)

Independent end-to-end rerun of both scenarios on a live proxy started from a fresh venv (`pip install -e ".[proxy]"`), with the before leg on the base branch at `26c0c93dece5182921e11387253a39dd8086db6e` and the after leg on this PR's head at `fe243dfe27639913382cc813892b56a27d467345`, same commands both times. Every call below streams real Opus 4.1 tokens from the real Bedrock API. For the truncation scenario the proxy's `aws_bedrock_runtime_endpoint` points at a small local relay that re-signs the incoming request with SigV4 against the real `bedrock-runtime.us-east-1.amazonaws.com`, streams the real response bytes back to the proxy, and hard-closes the connection after ~12KB of eventstream bytes, which lands mid `input_json_delta` of a large `write` tool call; the tokens are real Bedrock output and only the connection cut is synthetic, reproducing the customer's middlebox failure. The healthy scenario hits Bedrock directly with no endpoint override

Request body used for all four calls (`req_healthy.json` is identical except `"model": "bedrock-healthy"`):

```json
{
  "model": "bedrock-truncating",
  "max_tokens": 3000,
  "stream": true,
  "tools": [
    {
      "name": "write",
      "description": "Write a document to a path on disk",
      "input_schema": {
        "type": "object",
        "properties": {
          "path": {"type": "string"},
          "content": {"type": "string"}
        },
        "required": ["path", "content"]
      }
    }
  ],
  "messages": [
    {
      "role": "user",
      "content": "Use the write tool to save a detailed 1500-word QA runbook about testing streaming LLM proxies to /builder/docs/QUALITY.md. Call the tool exactly once, putting the entire document in the content field."
    }
  ]
}
```

Truncating stream, before (base `26c0c93dec`): HTTP 200, the stream just stops mid `input_json_delta`, and grep over the full 131-line capture finds 0 `event: message_stop` and 0 `event: error`

```
$ curl -sN -w '\n[curl http_code=%{http_code}]\n' http://localhost:64769/v1/messages \
    -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
    -d @req_truncating.json | tail -8

event: content_block_delta
data: {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "e testing of"}}

event: content_block_delta
data: {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": " s"}}


[curl http_code=200]
```

Relay log for that call, confirming the upstream was the real Bedrock API and the cut happened mid-stream:

```
[relay] POST /model/us.anthropic.claude-opus-4-1-20250805-v1:0/invoke-with-response-stream body=538B
[relay] upstream status=200
[relay] HARD CUT after 12328 bytes of real Bedrock eventstream
```

Truncating stream, after (head `fe243dfe27`): the identical request now ends with the Anthropic-protocol `error` event

```
$ curl -sN -w '\n[curl http_code=%{http_code}]\n' http://localhost:64769/v1/messages \
    -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
    -d @req_truncating.json | tail -8

event: content_block_delta
data: {"type": "content_block_delta", "index": 1, "delta": {"type": "input_json_delta", "partial_json": "rve as"}}

event: error
data: {"type": "error", "error": {"type": "api_error", "message": "Provider stream ended before emitting a message_stop event; the response is incomplete and any partial content (e.g. tool_use input JSON) may be truncated."}}


[curl http_code=200]
```

Healthy stream direct to real Bedrock, before (base `26c0c93dec`): completes a 2068-output-token tool call and ends with `message_stop`; grep over the full 4100-line capture finds 1 `event: message_stop` and 0 `event: error`

```
$ curl -sN -w '\n[curl http_code=%{http_code}]\n' http://localhost:64769/v1/messages \
    -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
    -d @req_healthy.json | tail -8

event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "tool_use", "stop_sequence": null}, "usage": {"output_tokens": 2068, "input_tokens": 438, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}

event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 438, "output_tokens": 2068}}


[curl http_code=200]
```

Healthy stream, after (head `fe243dfe27`): unchanged behavior; grep over the full 4742-line capture finds 1 `event: message_stop` and 0 `event: error`

```
$ curl -sN -w '\n[curl http_code=%{http_code}]\n' http://localhost:64769/v1/messages \
    -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
    -d @req_healthy.json | tail -8

event: message_delta
data: {"type": "message_delta", "delta": {"stop_reason": "tool_use", "stop_sequence": null}, "usage": {"output_tokens": 2025, "input_tokens": 438, "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0}}

event: message_stop
data: {"type": "message_stop", "usage": {"input_tokens": 438, "output_tokens": 2025}}


[curl http_code=200]
```

## Type

🐛 Bug Fix

## Changes

When a Bedrock invoke `/v1/messages` stream ends without a `message_stop` event (Bedrock or a middlebox drops the connection mid tool call), `BaseAnthropicMessagesStreamingIterator.async_sse_wrapper` used to pass through whatever events had arrived and close the downstream SSE as a clean HTTP 200. Strict clients (Anthropic SDK, Claude Code) then crash parsing unterminated `tool_use` input JSON, and operators cannot tell the failure from a success

`async_sse_wrapper` now tracks whether a terminal event was seen; if the upstream iterator is exhausted without one, it appends an Anthropic-protocol `error` SSE event (`{"type": "error", "error": {"type": "api_error", ...}}`) so clients surface the truncation instead of treating the response as complete. Complete streams are unaffected. Both `message_stop` and provider-sent `error` events count as terminal, so a stream the provider already ended with an `error` event does not get a second synthetic error appended. For raw-bytes chunks the detection matches only exact `event: message_stop` / `event: error` SSE lines rather than a substring search, so payload text that merely mentions `message_stop` cannot suppress the truncation error. The synthetic error event is deliberately excluded from the chunks handed to the logging pipeline because response reconstruction raises on `{"type": "error"}` events, which would drop the spend log for the tokens that did stream

Regression tests cover the truncated tool_use stream (the exact customer scenario), the complete stream, the empty stream, raw-bytes passthrough chunks, the payload-mention false positive, provider-error-terminated streams (dict and bytes), and the logging exclusion, both at the `BaseAnthropicMessagesStreamingIterator` level and through `AmazonAnthropicClaudeMessagesConfig.bedrock_sse_wrapper`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow streaming guardrail with clear success criteria; only affects streams missing message_stop, with broad test coverage and no auth or request-path changes.
> 
> **Overview**
> Fixes **LIT-3724**: when a Bedrock (or proxy) `/v1/messages` stream stops early—e.g. mid `tool_use` / partial `input_json_delta`—clients used to get HTTP 200 with no terminal event, so Anthropic SDK / Claude Code could treat the response as complete and fail on broken tool JSON.
> 
> **`BaseAnthropicMessagesStreamingIterator.async_sse_wrapper`** now tracks whether any chunk is a **`message_stop`** (dict `type` or raw bytes containing `message_stop`). If the upstream iterator finishes without one, it **appends** an Anthropic-style SSE **`error`** event (`api_error` with a fixed incomplete-stream message). Normal streams that end with `message_stop` are unchanged.
> 
> Regression tests cover truncated tool-use, complete streams, empty streams, and byte passthrough at the base iterator and via **`bedrock_sse_wrapper`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 478b837d9c697b821ec81deaefba476269ad6037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming termination handling: if a streamed response ends without the expected final stop signal, the system now appends a clear SSE `error` event describing the incomplete stream.
  * Truncated tool-use or mid-stream content now surfaces an error payload rather than silently completing.
  * Complete streams continue to end normally without any added `error` SSE event.
* **Tests**
  * Added/expanded tests covering incomplete vs complete streaming, including empty and byte-encoded streams, plus regression coverage for Bedrock Anthropic unified streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

