### PR TITLE
fix(anthropic_messages): forward provider response headers on streaming /v1/messages responses

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/agentic_streaming_iterator.py
@@ -193,6 +193,14 @@ class AgenticAnthropicStreamingIterator:
 
         raise StopAsyncIteration
 
+    async def aclose(self) -> None:
+        from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+            aclose_if_supported,
+        )
+
+        await aclose_if_supported(self._inner)
+        await aclose_if_supported(self._follow_up_iterator)
+
     async def _process_agentic_hooks(self) -> None:
         """Rebuild the Anthropic response from collected SSE bytes and call hooks."""
         if self._hook_processing_done:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -56,6 +56,11 @@ class AnthropicMessagesStreamingResponse:
     async def __anext__(self) -> bytes:
         return await self.completion_stream.__anext__()
 
+    async def aclose(self) -> None:
+        inner_aclose = getattr(self.completion_stream, "aclose", None)
+        if inner_aclose is not None:
+            await inner_aclose()
+
 
 class BaseAnthropicMessagesStreamingIterator:
     """

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from datetime import datetime
-from typing import Any, AsyncIterator, List, Union
+from typing import Any, AsyncIterator, List, Protocol, Union, runtime_checkable
 
 import httpx
 from pydantic import TypeAdapter
@@ -20,6 +20,16 @@ GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ = PassThroughEndpointLogging()
 
 class AnthropicMessagesStreamHiddenParams(TypedDict):
     additional_headers: dict[str, str]
+
+
+@runtime_checkable
+class SupportsAclose(Protocol):
+    async def aclose(self) -> None: ...
+
+
+async def aclose_if_supported(stream: object) -> None:
+    if isinstance(stream, SupportsAclose):
+        await stream.aclose()
 
 
 _RESPONSE_HEADERS_ADAPTER: TypeAdapter[dict[str, str]] = TypeAdapter(dict[str, str])
@@ -57,9 +67,7 @@ class AnthropicMessagesStreamingResponse:
         return await self.completion_stream.__anext__()
 
     async def aclose(self) -> None:
-        inner_aclose = getattr(self.completion_stream, "aclose", None)
-        if inner_aclose is not None:
-            await inner_aclose()
+        await aclose_if_supported(self.completion_stream)
 
 
 class BaseAnthropicMessagesStreamingIterator:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/streaming_iterator.py
@@ -3,6 +3,11 @@ import json
 from datetime import datetime
 from typing import Any, AsyncIterator, List, Union
 
+import httpx
+from pydantic import TypeAdapter
+from typing_extensions import TypedDict
+
+from litellm.litellm_core_utils.core_helpers import process_response_headers
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.proxy.pass_through_endpoints.success_handler import (
     PassThroughEndpointLogging,
@@ -11,6 +16,45 @@ from litellm.types.passthrough_endpoints.pass_through_endpoints import EndpointT
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
 
 GLOBAL_PASS_THROUGH_SUCCESS_HANDLER_OBJ = PassThroughEndpointLogging()
+
+
+class AnthropicMessagesStreamHiddenParams(TypedDict):
+    additional_headers: dict[str, str]
+
+
+_RESPONSE_HEADERS_ADAPTER: TypeAdapter[dict[str, str]] = TypeAdapter(dict[str, str])
+
+
+def anthropic_messages_stream_hidden_params(
+    response_headers: httpx.Headers,
+) -> AnthropicMessagesStreamHiddenParams:
+    return AnthropicMessagesStreamHiddenParams(
+        additional_headers=_RESPONSE_HEADERS_ADAPTER.validate_python(process_response_headers(response_headers))
+    )
+
+
+class AnthropicMessagesStreamingResponse:
+    """
+    Wraps the /v1/messages SSE byte stream so upstream provider response
+    headers (e.g. Bedrock's x-amzn-requestid / x-amzn-trace-id) survive as
+    ``_hidden_params["additional_headers"]``, which the proxy forwards to
+    clients as ``llm_provider-*`` response headers. Bare async generators
+    cannot carry attributes, so header context was previously dropped.
+    """
+
+    def __init__(
+        self,
+        completion_stream: AsyncIterator[bytes],
+        hidden_params: AnthropicMessagesStreamHiddenParams,
+    ) -> None:
+        self.completion_stream = completion_stream
+        self._hidden_params = hidden_params
+
+    def __aiter__(self) -> "AnthropicMessagesStreamingResponse":
+        return self
+
+    async def __anext__(self) -> bytes:
+        return await self.completion_stream.__anext__()
 
 
 class BaseAnthropicMessagesStreamingIterator:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2084,12 +2084,18 @@ class BaseLLMHTTPHandler:
 
         initial_response: Union[AsyncIterator, AnthropicMessagesResponse]
         if stream:
+            from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+                AnthropicMessagesStreamingResponse,
+                anthropic_messages_stream_hidden_params,
+            )
+
             completion_stream = anthropic_messages_provider_config.get_async_streaming_response_iterator(
                 model=model,
                 httpx_response=response,
                 request_body=request_body,
                 litellm_logging_obj=logging_obj,
             )
+            stream_hidden_params = anthropic_messages_stream_hidden_params(response.headers)
 
             if not self._has_agentic_completion_hook(logging_obj):
                 # No callback overrides async_should_run_agentic_loop, so the
@@ -2097,7 +2103,10 @@ class BaseLLMHTTPHandler:
                 # and rebuilding the response from SSE at end-of-stream to call
                 # hooks that all return (False, {}). Stream through directly and
                 # skip that per-chunk + end-of-stream overhead.
-                return completion_stream
+                return AnthropicMessagesStreamingResponse(
+                    completion_stream=completion_stream,
+                    hidden_params=stream_hidden_params,
+                )
 
             from litellm.llms.anthropic.experimental_pass_through.messages.agentic_streaming_iterator import (
                 AgenticAnthropicStreamingIterator,
@@ -2114,7 +2123,10 @@ class BaseLLMHTTPHandler:
                 custom_llm_provider=custom_llm_provider,
                 kwargs={**kwargs, "api_key": api_key} if api_key else kwargs,
             )
-            return initial_response
+            return AnthropicMessagesStreamingResponse(
+                completion_stream=initial_response,
+                hidden_params=stream_hidden_params,
+            )
         else:
             initial_response = anthropic_messages_provider_config.transform_anthropic_messages_response(
                 model=model,

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -498,6 +498,165 @@ async def test_async_anthropic_messages_handler_streaming_forwards_provider_resp
 
 
 @pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_agentic_streaming_forwards_provider_response_headers():
+    """
+    Companion to the test above for the agentic branch: when a callback
+    overrides async_should_run_agentic_loop, the handler wraps
+    AgenticAnthropicStreamingIterator in AnthropicMessagesStreamingResponse.
+    That wrapping must still expose the provider headers and delegate
+    iteration through the two-phase agentic iterator unchanged.
+    """
+    from collections.abc import AsyncIterator as ABCAsyncIterator
+
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.llms.anthropic.experimental_pass_through.messages.agentic_streaming_iterator import (
+        AgenticAnthropicStreamingIterator,
+    )
+    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+        AnthropicMessagesConfig,
+    )
+
+    class NoOpAgenticCallback(CustomLogger):
+        async def async_should_run_agentic_loop(
+            self,
+            response,
+            model,
+            messages,
+            tools,
+            stream,
+            custom_llm_provider,
+            kwargs,
+        ):
+            return False, {}
+
+    handler = BaseLLMHTTPHandler()
+
+    sse_body = (
+        b'event: message_start\ndata: {"type": "message_start"}\n\n'
+        b'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    )
+    upstream_response = httpx.Response(
+        200,
+        headers={"x-amzn-requestid": "amzn-req-456"},
+        content=sse_body,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+    mock_client = AsyncMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=upstream_response)
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.model_call_details = {}
+    mock_logging_obj.dynamic_success_callbacks = [NoOpAgenticCallback()]
+
+    result = await handler.async_anthropic_messages_handler(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_provider_config=AnthropicMessagesConfig(),
+        anthropic_messages_optional_request_params={"max_tokens": 32},
+        custom_llm_provider="anthropic",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=mock_logging_obj,
+        client=mock_client,
+        api_key="sk-test",
+        stream=True,
+        kwargs={},
+    )
+
+    assert isinstance(result, ABCAsyncIterator)
+    assert isinstance(result.completion_stream, AgenticAnthropicStreamingIterator)
+    assert result._hidden_params["additional_headers"]["llm_provider-x-amzn-requestid"] == "amzn-req-456"
+
+    collected = b"".join([chunk async for chunk in result])
+    assert b"message_start" in collected
+    assert b"message_stop" in collected
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_streaming_response_aclose_closes_upstream_stream():
+    """
+    Regression test: the proxy's streaming cleanup calls aclose on the
+    handler's return value (see _finalize_streaming_generator_cleanup's
+    hasattr(response, "aclose") check). The wrapper must forward aclose to
+    the upstream stream so provider connections are released on client
+    disconnect instead of lingering until garbage collection.
+    """
+    from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+        AnthropicMessagesStreamingResponse,
+    )
+
+    class UpstreamTracker:
+        def __init__(self):
+            self.closed = False
+
+    tracker = UpstreamTracker()
+
+    async def upstream():
+        try:
+            yield b'data: {"type": "message_start"}\n\n'
+            yield b'data: {"type": "message_stop"}\n\n'
+        finally:
+            tracker.closed = True
+
+    stream = AnthropicMessagesStreamingResponse(
+        completion_stream=upstream(),
+        hidden_params={"additional_headers": {}},
+    )
+
+    first_chunk = await stream.__anext__()
+    assert b"message_start" in first_chunk
+    assert tracker.closed is False
+
+    await stream.aclose()
+    assert tracker.closed is True
+
+
+@pytest.mark.asyncio
+async def test_anthropic_messages_streaming_response_aclose_closes_agentic_upstream_stream():
+    from litellm.llms.anthropic.experimental_pass_through.messages.agentic_streaming_iterator import (
+        AgenticAnthropicStreamingIterator,
+    )
+    from litellm.llms.anthropic.experimental_pass_through.messages.streaming_iterator import (
+        AnthropicMessagesStreamingResponse,
+    )
+
+    class UpstreamTracker:
+        def __init__(self):
+            self.closed = False
+
+    tracker = UpstreamTracker()
+
+    async def upstream():
+        try:
+            yield b'data: {"type": "message_start"}\n\n'
+            yield b'data: {"type": "message_stop"}\n\n'
+        finally:
+            tracker.closed = True
+
+    agentic_iterator = AgenticAnthropicStreamingIterator(
+        completion_stream=upstream(),
+        http_handler=Mock(),
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_provider_config=Mock(),
+        anthropic_messages_optional_request_params={},
+        logging_obj=Mock(),
+        custom_llm_provider="anthropic",
+        kwargs={},
+    )
+    stream = AnthropicMessagesStreamingResponse(
+        completion_stream=agentic_iterator,
+        hidden_params={"additional_headers": {}},
+    )
+
+    first_chunk = await stream.__anext__()
+    assert b"message_start" in first_chunk
+    assert tracker.closed is False
+
+    await stream.aclose()
+    assert tracker.closed is True
+
+
+@pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_passes_litellm_metadata():
     """Ensure litellm_metadata from kwargs is forwarded via update_from_kwargs.
 

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -436,6 +436,68 @@ async def test_async_anthropic_messages_handler_extra_headers():
 
 
 @pytest.mark.asyncio
+async def test_async_anthropic_messages_handler_streaming_forwards_provider_response_headers():
+    """
+    Regression test for LIT-3724 (issue 2): streaming /v1/messages responses
+    dropped the upstream provider's HTTP response headers, so Bedrock's
+    x-amzn-requestid / x-amzn-trace-id never reached clients even with
+    `return_response_headers: true`. The returned stream object must carry
+    them in `_hidden_params["additional_headers"]` (llm_provider-* prefixed),
+    which the proxy merges into the client-facing response headers.
+    """
+    from collections.abc import AsyncIterator as ABCAsyncIterator
+
+    from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
+        AnthropicMessagesConfig,
+    )
+
+    handler = BaseLLMHTTPHandler()
+
+    sse_body = (
+        b'event: message_start\ndata: {"type": "message_start"}\n\n'
+        b'event: message_stop\ndata: {"type": "message_stop"}\n\n'
+    )
+    upstream_response = httpx.Response(
+        200,
+        headers={
+            "x-amzn-requestid": "amzn-req-123",
+            "x-amzn-trace-id": "Root=1-abc-def",
+        },
+        content=sse_body,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+    mock_client = AsyncMock(spec=AsyncHTTPHandler)
+    mock_client.post = AsyncMock(return_value=upstream_response)
+
+    mock_logging_obj = Mock()
+    mock_logging_obj.model_call_details = {}
+
+    result = await handler.async_anthropic_messages_handler(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_provider_config=AnthropicMessagesConfig(),
+        anthropic_messages_optional_request_params={"max_tokens": 32},
+        custom_llm_provider="anthropic",
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=mock_logging_obj,
+        client=mock_client,
+        api_key="sk-test",
+        stream=True,
+        kwargs={},
+    )
+
+    assert isinstance(result, ABCAsyncIterator)
+
+    additional_headers = result._hidden_params["additional_headers"]
+    assert additional_headers["llm_provider-x-amzn-requestid"] == "amzn-req-123"
+    assert additional_headers["llm_provider-x-amzn-trace-id"] == "Root=1-abc-def"
+
+    collected = b"".join([chunk async for chunk in result])
+    assert b"message_start" in collected
+    assert b"message_stop" in collected
+
+
+@pytest.mark.asyncio
 async def test_async_anthropic_messages_handler_passes_litellm_metadata():
     """Ensure litellm_metadata from kwargs is forwarded via update_from_kwargs.
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Part of LIT-3724 (issue 2: `x-amzn-RequestId` / `x-amzn-trace-id` not returned for Bedrock)

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy with a Bedrock invoke model (real Bedrock API, `us.anthropic.claude-opus-4-1-20250805-v1:0`):

```yaml
model_list:
  - model_name: bedrock-claude-real
    litellm_params:
      model: bedrock/invoke/us.anthropic.claude-opus-4-1-20250805-v1:0
      aws_region_name: us-east-1
      aws_profile_name: litellm-dev
```

Before (proxy on `litellm_internal_staging`, port 4003): a streaming `/v1/messages` call returns zero provider headers, so there is no way to get the Bedrock request id for an AWS support case

```
$ curl -s -D - -o /dev/null http://127.0.0.1:4003/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-real", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hello in three words"}]}' | grep -icE "amzn|llm_provider"
0
```

After (proxy on this branch, port 4002): the same call surfaces Bedrock's response headers, including the request id AWS support asks for

```
$ curl -s -D - -o /dev/null http://127.0.0.1:4002/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-real", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hello in three words"}]}' | grep -iE "^HTTP|amzn|llm_provider"

HTTP/1.1 200 OK
llm_provider-date: Sat, 04 Jul 2026 23:32:29 GMT
llm_provider-content-type: application/vnd.amazon.eventstream
llm_provider-transfer-encoding: chunked
llm_provider-connection: keep-alive
llm_provider-x-amzn-requestid: 77fd030e-ef64-4cc3-b782-9f4cd82673f0
llm_provider-x-amzn-bedrock-content-type: application/json
```

### QA rerun (e2e, real Bedrock)

Independent end-to-end rerun against the real Bedrock API (`us.anthropic.claude-opus-4-1-20250805-v1:0`, us-east-1) through a fresh venv and a fresh proxy on a random port (64843), same config and identical commands on both legs. The before leg ran with the worktree checked out at base `26c0c93dece5182921e11387253a39dd8086db6e` (origin/litellm_internal_staging) and the after leg at PR head `af067b10c9289124a323f8b520aac6f41004535b`, restarting the proxy between legs

Before, at the base SHA, the streaming call returns no provider headers (`grep -icE "amzn|llm_provider"` counts 0)

```
$ curl -s -D - -o /dev/null http://127.0.0.1:64843/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-real", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hello in three words"}]}' | grep -iE "^HTTP|amzn|llm_provider"

HTTP/1.1 200 OK
```

After, at the PR head, the identical call surfaces the Bedrock headers (count 6)

```
$ curl -s -D - -o /dev/null http://127.0.0.1:64843/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "bedrock-claude-real", "max_tokens": 100, "stream": true, "messages": [{"role": "user", "content": "Say hello in three words"}]}' | grep -iE "^HTTP|amzn|llm_provider"

HTTP/1.1 200 OK
llm_provider-date: Sun, 05 Jul 2026 00:30:21 GMT
llm_provider-content-type: application/vnd.amazon.eventstream
llm_provider-transfer-encoding: chunked
llm_provider-connection: keep-alive
llm_provider-x-amzn-requestid: ecc93c7a-db50-4dc6-b179-2b2ba5633a2b
llm_provider-x-amzn-bedrock-content-type: application/json
```

A non-streaming (`"stream": false`) call was also run on both legs and behaves identically before and after (no `llm_provider-*` headers on either, matching the non-streaming limitation described under Changes)

## Type

🐛 Bug Fix

## Changes

Streaming `/v1/messages` responses were returned to the proxy as bare async generators, which cannot carry `_hidden_params`, so the upstream provider's HTTP response headers were dropped and `return_response_headers: true` had no effect on this route. For Bedrock that meant `x-amzn-RequestId` / `x-amzn-trace-id` were never surfaced, which customers need to open AWS support cases about streaming failures

`async_anthropic_messages_handler` now wraps the streaming return (both the direct stream and the agentic iterator) in `AnthropicMessagesStreamingResponse`, a thin async-iterator wrapper that carries `_hidden_params["additional_headers"]` built from the upstream `httpx` response headers via the existing `process_response_headers` helper (same mechanism `CustomStreamWrapper` and the google_genai streaming path use). The proxy's existing header plumbing in `base_process_llm_request` picks these up unchanged and emits them as `llm_provider-*` response headers on the SSE response for every provider on this route (Bedrock `x-amzn-*`, Anthropic `request-id`, etc)

Non-streaming `/v1/messages` responses are a `TypedDict` that cannot carry `_hidden_params` at all (a known limitation, see `_response_cost_from_logging_obj`); forwarding headers there needs proxy-side plumbing changes and is intentionally left out of this PR's scope

The wrapper also forwards `aclose` to the wrapped stream, and `AgenticAnthropicStreamingIterator` closes its inner and follow-up streams, so the proxy's streaming cleanup (the `hasattr(response, "aclose")` check in `_finalize_streaming_generator_cleanup`) still releases the upstream provider connection on client disconnect instead of leaving it to garbage collection

The added tests drive `async_anthropic_messages_handler` with an injected mock HTTP client whose response carries `x-amzn-requestid` / `x-amzn-trace-id`, for both the direct streaming branch and the agentic branch (a callback overriding `async_should_run_agentic_loop`), and assert the returned stream satisfies the async-iterator protocol the proxy detects, exposes the `llm_provider-*` prefixed headers in `_hidden_params["additional_headers"]`, and still yields the SSE bytes unchanged. Two aclose regression tests assert that closing the wrapper closes the upstream generator on both branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the proxy-facing streaming path for all /v1/messages providers; behavior change is additive (headers + cleanup) with regression tests, but mis-wrapped streams could still affect disconnect handling.
> 
> **Overview**
> Fixes **LIT-3724** where streaming **`/v1/messages`** dropped upstream provider HTTP headers (e.g. Bedrock **`x-amzn-requestid`**) because the handler returned bare async generators with no **`_hidden_params`**.
> 
> **`async_anthropic_messages_handler`** now wraps both the direct SSE stream and the agentic **`AgenticAnthropicStreamingIterator`** in **`AnthropicMessagesStreamingResponse`**, which keeps **`_hidden_params["additional_headers"]`** (via **`process_response_headers`**, same pattern as other streaming paths) so the proxy can emit **`llm_provider-*`** headers on the SSE response. SSE bytes are unchanged.
> 
> The wrapper and agentic iterator implement **`aclose`** (via **`aclose_if_supported`**) so proxy streaming cleanup still tears down the upstream connection on client disconnect. Non-streaming header forwarding is out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af067b10c9289124a323f8b520aac6f41004535b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming responses now preserve provider response headers for passthrough use.
  * Improved handling of streamed Anthropic Messages responses so header context stays available during iteration.

* **Bug Fixes**
  * Fixed a regression where important upstream headers could be lost when using streamed message responses.
  * Ensured streamed content still arrives normally while metadata is retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


