### PR TITLE
fix(main): stop per-request custom pricing from clobbering shared model_cost pricing

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1081,6 +1081,54 @@ def _build_custom_pricing_entry(
     return entry
 
 
+def _get_router_deployment_id(kwargs: dict) -> Optional[str]:
+    for metadata_key in ("litellm_metadata", "metadata"):
+        metadata = kwargs.get(metadata_key) or {}
+        if not isinstance(metadata, dict):
+            continue
+        deployment_model_info = metadata.get("model_info") or {}
+        if not isinstance(deployment_model_info, dict):
+            continue
+        deployment_id = deployment_model_info.get("id")
+        if deployment_id is not None:
+            return str(deployment_id)
+    return None
+
+
+def _register_custom_pricing_for_request(
+    model: str,
+    custom_llm_provider: str,
+    kwargs: dict,
+    model_info: Optional[dict],
+) -> None:
+    """Register per-request custom pricing in litellm.model_cost.
+
+    Router-originated requests (identified by the deployment id the router puts
+    in metadata) get their full pricing registered under that unique id only;
+    the shared ``{provider}/{model}`` key receives the entry with pricing fields
+    stripped, mirroring Router._create_deployment. This keeps one deployment's
+    pricing overrides (e.g. a zero-cost wildcard) from clobbering built-in
+    pricing used by sibling deployments of the same backend model. Direct SDK
+    calls keep the legacy behavior of registering the shared key with pricing.
+    """
+    entry = _build_custom_pricing_entry(
+        custom_llm_provider=custom_llm_provider,
+        kwargs=kwargs,
+        model_info=model_info,
+    )
+    shared_key = f"{custom_llm_provider}/{model}"
+    deployment_id = _get_router_deployment_id(kwargs)
+    if deployment_id is None:
+        litellm.register_model({shared_key: entry})
+        return
+    litellm.register_model(
+        {
+            deployment_id: entry,
+            shared_key: CustomPricingLiteLLMParams.strip_custom_pricing_fields(entry),
+        }
+    )
+
+
 def _complete_azure(ctx: _CompletionDispatchContext) -> _CompletionDispatchResult:
     _azure_detection_model = ctx._azure_detection_model
     acompletion = ctx.acompletion
@@ -5107,14 +5155,11 @@ def completion(  # type: ignore
         if (
             input_cost_per_token is not None and output_cost_per_token is not None
         ) or input_cost_per_second is not None:
-            litellm.register_model(
-                {
-                    f"{custom_llm_provider}/{model}": _build_custom_pricing_entry(
-                        custom_llm_provider=custom_llm_provider,
-                        kwargs=kwargs,
-                        model_info=model_info,
-                    )
-                }
+            _register_custom_pricing_for_request(
+                model=model,
+                custom_llm_provider=custom_llm_provider,
+                kwargs=kwargs,
+                model_info=model_info,
             )
         ### BUILD CUSTOM PROMPT TEMPLATE -- IF GIVEN ###
         custom_prompt_dict = {}  # type: ignore
@@ -5957,14 +6002,11 @@ def embedding(
 
     ### REGISTER CUSTOM MODEL PRICING -- IF GIVEN ###
     if (input_cost_per_token is not None and output_cost_per_token is not None) or input_cost_per_second is not None:
-        litellm.register_model(
-            {
-                f"{custom_llm_provider}/{model}": _build_custom_pricing_entry(
-                    custom_llm_provider=custom_llm_provider,
-                    kwargs=kwargs,
-                    model_info=kwargs.get("model_info"),
-                )
-            }
+        _register_custom_pricing_for_request(
+            model=model,
+            custom_llm_provider=custom_llm_provider,
+            kwargs=kwargs,
+            model_info=kwargs.get("model_info"),
         )
 
     litellm_params_dict = get_litellm_params(**kwargs)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7354,8 +7354,7 @@ class Router:
             # deployment sharing the same backend model name.
             # Each deployment's full pricing is already stored under its
             # unique model_id above.
-            _custom_pricing_fields = CustomPricingLiteLLMParams.model_fields.keys()
-            _shared_model_info = {k: v for k, v in _model_info.items() if k not in _custom_pricing_fields}
+            _shared_model_info = CustomPricingLiteLLMParams.strip_custom_pricing_fields(_model_info)
             _existing_shared_mode = (cast(Optional[dict], litellm.model_cost.get(_model_name, {})) or {}).get("mode")
             _deployment_mode = _shared_model_info.get("mode")
             # Keep the built-in bridge mode stable for shared backend keys.
@@ -8019,8 +8018,7 @@ class Router:
         # deployment sharing the same backend model name.
         # Each deployment's full pricing is already stored under its
         # unique model_id above (when present).
-        _custom_pricing_fields = CustomPricingLiteLLMParams.model_fields.keys()
-        _shared_model_info = {k: v for k, v in _model_info_dict.items() if k not in _custom_pricing_fields}
+        _shared_model_info = CustomPricingLiteLLMParams.strip_custom_pricing_fields(_model_info_dict)
         _backend_alias_cost = {_model_name: _shared_model_info}
         if "responses/" in _model_name:
             _stripped_model_name = _model_name.replace("responses/", "")

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3048,6 +3048,17 @@ class CustomPricingLiteLLMParams(BaseModel):
     regional_processing_uplift_multiplier_eu: Optional[float] = None
     regional_processing_uplift_multiplier_us: Optional[float] = None
 
+    @classmethod
+    def strip_custom_pricing_fields(cls, model_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a copy of ``model_info`` without per-deployment custom pricing fields.
+
+        Used when registering a deployment's info under the shared
+        ``{provider}/{model}`` key in ``litellm.model_cost``, so one deployment's
+        pricing overrides don't pollute sibling deployments that share the same
+        backend model. Full pricing stays under the deployment's unique model id.
+        """
+        return {k: v for k, v in model_info.items() if k not in cls.model_fields}
+
 
 # Server-controlled fields that bound or drive an interceptor's agentic loop
 # (depth, cycle fingerprints, ceiling, code-interpreter sandbox state). Listed

--- a/tests/local_testing/test_cost_calc.py
+++ b/tests/local_testing/test_cost_calc.py
@@ -101,7 +101,16 @@ def test_run(model: str):
         pytest.skip(
             "LLM API returning inconsistent usage"
         )  # handles transient openai errors
-    streaming_cost_calc = completion_cost(response) * 100
+    streaming_cost_calc = (
+        completion_cost(
+            response,
+            custom_cost_per_token={
+                "input_cost_per_token": kwargs["input_cost_per_token"],
+                "output_cost_per_token": kwargs["output_cost_per_token"],
+            },
+        )
+        * 100
+    )
     print(f"Stream output    : {output}")
 
     print(f"Stream usage     : {response.usage}")  # type: ignore

--- a/tests/local_testing/test_router_fallbacks.py
+++ b/tests/local_testing/test_router_fallbacks.py
@@ -1330,6 +1330,8 @@ def test_router_fallbacks_with_custom_model_costs():
     Goal: make sure custom model doesn't override default model costs.
     """
 
+    default_model_info = litellm.get_model_info(model="claude-sonnet-4-5-20250929")
+
     model_list = [
         {
             "model_name": "claude-sonnet-4-5-20250929",
@@ -1383,8 +1385,8 @@ def test_router_fallbacks_with_custom_model_costs():
 
     print(f"key: {model_info['key']}")
 
-    assert model_info["input_cost_per_token"] == 30
-    assert model_info["output_cost_per_token"] == 60
+    assert model_info["input_cost_per_token"] == default_model_info["input_cost_per_token"]
+    assert model_info["output_cost_per_token"] == default_model_info["output_cost_per_token"]
 
 
 @pytest.mark.parametrize("sync_mode", [True, False])

--- a/tests/test_litellm/test_register_model_custom_pricing.py
+++ b/tests/test_litellm/test_register_model_custom_pricing.py
@@ -9,8 +9,11 @@ mode, and supports_prompt_caching were dropped, causing incorrect cost
 calculations for DB-sourced models with prompt caching pricing.
 """
 
+import copy
 import os
 import sys
+
+import pytest
 
 sys.path.insert(
     0, os.path.abspath("../..")
@@ -18,6 +21,20 @@ sys.path.insert(
 
 import litellm
 from litellm.main import _build_custom_pricing_entry
+from litellm.utils import _invalidate_model_cost_lowercase_map
+
+
+def _snapshot_model_cost_entries(keys):
+    return {key: copy.deepcopy(litellm.model_cost.get(key)) for key in keys}
+
+
+def _restore_model_cost_entries(original_entries):
+    for key, value in original_entries.items():
+        if value is None:
+            litellm.model_cost.pop(key, None)
+        else:
+            litellm.model_cost[key] = value
+    _invalidate_model_cost_lowercase_map()
 
 
 def test_build_custom_pricing_entry_includes_all_kwargs_fields():
@@ -471,3 +488,166 @@ def test_register_model_router_add_deployment_custom_pricing_applies():
         litellm.model_cost.pop(model_key, None)
         litellm.model_cost.pop(deployment_model, None)
         del router
+
+
+def test_embedding_router_zero_pricing_does_not_clobber_builtin_pricing():
+    """LIT-3991: a router-originated embedding request that carries explicit
+    zero custom pricing (e.g. resolved through an ``openai/*`` wildcard
+    deployment with ``input_cost_per_token: 0``) must not overwrite the shared
+    ``openai/text-embedding-3-small`` entry in ``litellm.model_cost``. Before
+    the fix, one call through the wildcard poisoned the shared key and every
+    sibling deployment relying on built-in pricing logged $0 until restart.
+    """
+    shared_key = "openai/text-embedding-3-small"
+    deployment_id = "lit3991-wildcard-embed-zero"
+    snapshot = _snapshot_model_cost_entries(
+        [shared_key, "text-embedding-3-small", deployment_id]
+    )
+    builtin_input_cost = litellm.get_model_info(model=shared_key)[
+        "input_cost_per_token"
+    ]
+    assert builtin_input_cost > 0
+
+    try:
+        litellm.embedding(
+            model=shared_key,
+            input=["hello"],
+            api_key="fake-key",
+            input_cost_per_token=0.0,
+            output_cost_per_token=0.0,
+            model_info={"id": deployment_id},
+            metadata={"model_info": {"id": deployment_id}},
+            mock_response=[0.1, 0.2],
+        )
+
+        assert (
+            litellm.get_model_info(model=shared_key)["input_cost_per_token"]
+            == builtin_input_cost
+        ), "wildcard deployment's zero pricing leaked into the shared model_cost key"
+        assert litellm.model_cost[deployment_id]["input_cost_per_token"] == 0.0
+        assert litellm.model_cost[deployment_id]["output_cost_per_token"] == 0.0
+
+        sibling_response = litellm.embedding(
+            model=shared_key,
+            input=["hello"],
+            api_key="fake-key",
+            mock_response=[0.1, 0.2],
+        )
+        sibling_cost = litellm.completion_cost(
+            completion_response=sibling_response, call_type="embedding"
+        )
+        assert sibling_cost == pytest.approx(10 * builtin_input_cost)
+    finally:
+        _restore_model_cost_entries(snapshot)
+
+
+def test_embedding_router_custom_pricing_costs_request_via_deployment_id():
+    """The request that carries custom pricing must still be costed with that
+    pricing (via its deployment id entry), while the shared backend key keeps
+    the built-in rate for siblings.
+    """
+    shared_key = "openai/text-embedding-3-small"
+    deployment_id = "lit3991-wildcard-embed-custom"
+    override_input_cost = 5e-05
+    snapshot = _snapshot_model_cost_entries(
+        [shared_key, "text-embedding-3-small", deployment_id]
+    )
+    builtin_input_cost = litellm.get_model_info(model=shared_key)[
+        "input_cost_per_token"
+    ]
+    assert builtin_input_cost != override_input_cost
+
+    try:
+        response = litellm.embedding(
+            model=shared_key,
+            input=["hello"],
+            api_key="fake-key",
+            input_cost_per_token=override_input_cost,
+            output_cost_per_token=override_input_cost * 2,
+            model_info={"id": deployment_id},
+            metadata={"model_info": {"id": deployment_id}},
+            mock_response=[0.1, 0.2],
+        )
+
+        request_cost = litellm.completion_cost(
+            completion_response=response,
+            model=shared_key,
+            custom_llm_provider="openai",
+            call_type="embedding",
+            custom_pricing=True,
+            router_model_id=deployment_id,
+        )
+        assert request_cost == pytest.approx(10 * override_input_cost)
+        assert (
+            litellm.get_model_info(model=shared_key)["input_cost_per_token"]
+            == builtin_input_cost
+        )
+    finally:
+        _restore_model_cost_entries(snapshot)
+
+
+def test_completion_router_zero_pricing_does_not_clobber_builtin_pricing():
+    """Same isolation as the embedding path, exercised through completion()."""
+    shared_key = "openai/gpt-4o-mini"
+    deployment_id = "lit3991-wildcard-chat-zero"
+    snapshot = _snapshot_model_cost_entries(
+        [shared_key, "gpt-4o-mini", deployment_id]
+    )
+    builtin_input_cost = litellm.get_model_info(model=shared_key)[
+        "input_cost_per_token"
+    ]
+    assert builtin_input_cost > 0
+
+    try:
+        litellm.completion(
+            model=shared_key,
+            messages=[{"role": "user", "content": "hello"}],
+            api_key="fake-key",
+            input_cost_per_token=0.0,
+            output_cost_per_token=0.0,
+            model_info={"id": deployment_id},
+            metadata={"model_info": {"id": deployment_id}},
+            mock_response="hello back",
+        )
+
+        assert (
+            litellm.get_model_info(model=shared_key)["input_cost_per_token"]
+            == builtin_input_cost
+        ), "wildcard deployment's zero pricing leaked into the shared model_cost key"
+        assert litellm.model_cost[deployment_id]["input_cost_per_token"] == 0.0
+    finally:
+        _restore_model_cost_entries(snapshot)
+
+
+def test_embedding_direct_sdk_custom_pricing_still_registers_shared_key():
+    """Direct SDK calls (no router deployment id in metadata) keep the legacy
+    behavior: custom pricing is registered under ``{provider}/{model}`` and the
+    request is costed with it.
+    """
+    model_key = "openai/lit3991-direct-sdk-embed-model"
+    override_input_cost = 3e-05
+    try:
+        response = litellm.embedding(
+            model=model_key,
+            input=["hello"],
+            api_key="fake-key",
+            input_cost_per_token=override_input_cost,
+            output_cost_per_token=override_input_cost * 2,
+            mock_response=[0.1, 0.2],
+        )
+
+        assert (
+            litellm.model_cost[model_key]["input_cost_per_token"]
+            == override_input_cost
+        )
+        cost = litellm.completion_cost(
+            completion_response=response,
+            model=model_key,
+            custom_llm_provider="openai",
+            call_type="embedding",
+            custom_pricing=True,
+        )
+        assert cost == pytest.approx(10 * override_input_cost)
+    finally:
+        litellm.model_cost.pop(model_key, None)
+        _invalidate_model_cost_lowercase_map()

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -681,3 +681,76 @@ def test_custom_pricing_isolated_from_sibling_via_proxy_model_info_path():
         assert resolved["gemini-2.5-flash"] != resolved["custom-priced-flash"]
     finally:
         _restore_model_cost_entries(model_keys)
+
+
+def test_wildcard_zero_cost_request_does_not_poison_named_deployment_pricing():
+    """LIT-3991 end to end: a proxy has a named text-embedding-3-small
+    deployment relying on built-in pricing plus an ``openai/*`` wildcard with
+    explicit zero pricing. One embedding call routed through the wildcard must
+    not clobber the shared ``openai/text-embedding-3-small`` pricing; requests
+    to the named deployment afterwards must still cost non-zero.
+    """
+    shared_key = "openai/text-embedding-3-small"
+    model_keys = {
+        shared_key: copy.deepcopy(litellm.model_cost.get(shared_key)),
+        "text-embedding-3-small": copy.deepcopy(
+            litellm.model_cost.get("text-embedding-3-small")
+        ),
+        "openai/*": copy.deepcopy(litellm.model_cost.get("openai/*")),
+        "lit3991-named": litellm.model_cost.get("lit3991-named"),
+        "lit3991-wildcard": litellm.model_cost.get("lit3991-wildcard"),
+    }
+    builtin_input_cost = litellm.get_model_info(model=shared_key)[
+        "input_cost_per_token"
+    ]
+    assert builtin_input_cost > 0
+
+    try:
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "text-embedding-3-small",
+                    "litellm_params": {
+                        "model": "openai/text-embedding-3-small",
+                        "api_key": "fake-key-named",
+                    },
+                    "model_info": {"id": "lit3991-named"},
+                },
+                {
+                    "model_name": "openai/*",
+                    "litellm_params": {
+                        "model": "openai/*",
+                        "api_key": "fake-key-wildcard",
+                        "input_cost_per_token": 0.0,
+                        "output_cost_per_token": 0.0,
+                    },
+                    "model_info": {"id": "lit3991-wildcard"},
+                },
+            ],
+        )
+
+        router.embedding(
+            model="openai/text-embedding-3-small",
+            input=["hello"],
+            mock_response=[0.1, 0.2],
+        )
+
+        assert (
+            litellm.get_model_info(model=shared_key)["input_cost_per_token"]
+            == builtin_input_cost
+        ), (
+            "one call through the zero-cost wildcard poisoned the shared "
+            f"{shared_key} pricing for the named deployment"
+        )
+
+        named_response = router.embedding(
+            model="text-embedding-3-small",
+            input=["hello"],
+            mock_response=[0.1, 0.2],
+        )
+        named_cost = litellm.completion_cost(
+            completion_response=named_response, call_type="embedding"
+        )
+        assert named_cost == pytest.approx(10 * builtin_input_cost)
+    finally:
+        _restore_model_cost_entries(model_keys)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3991

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

End-to-end demonstration against a live proxy hitting the real OpenAI API; no mocks, no database, no caching. Two deployments share the `openai/text-embedding-3-small` backend: the named `text-embedding-3-small` with no explicit pricing (built-in pricing applies) and an `openai/*` wildcard with explicit zero pricing. Cost is read from the `x-litellm-response-cost*` response headers; note the proxy omits the plain `x-litellm-response-cost` header when the computed cost is 0, in which case `x-litellm-response-cost-original: 0.0` is the signal. Every request uses a distinct input string to rule out any caching

qa_config.yaml:

```yaml
model_list:
  - model_name: text-embedding-3-small
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY
  - model_name: openai/*
    litellm_params:
      model: openai/*
      api_key: os.environ/OPENAI_API_KEY
      input_cost_per_token: 0
      output_cost_per_token: 0
general_settings:
  master_key: sk-1234
```

Setup: a fresh checkout with its own venv (`uv venv .venv && uv pip install -e ".[proxy]"`), `OPENAI_API_KEY` exported by sourcing a local `.env`, and a random free port

```console
$ python -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1])'
50609
$ set -a; . ./.env; set +a
$ .venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 50609 2>&1 | tee proxy_before.log
```

### Before (base 26c0c93dec)

Step 1, named deployment. Built-in pricing applies, cost is 2.8e-07

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "text-embedding-3-small", "input": "before-run step1 named deployment baseline cost check 7f3a"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost: 2.8e-07
x-litellm-response-cost-original: 2.8e-07
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

Step 2, wildcard route. Cost is 0.0 as configured on the wildcard

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "openai/text-embedding-3-small", "input": "before-run step2 wildcard route zero cost expected 9c1d"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

Step 3, named deployment again. This is the bug: one wildcard request poisoned the shared pricing entry and the named deployment now reports 0.0

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "text-embedding-3-small", "input": "before-run step3 named deployment after wildcard poisoning check 4e8b"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

### After (this PR)

Same worktree after `git checkout origin/litellm_lit3991_wildcard_zero_cost_poisoning`, proxy restarted with the same command (logged to proxy_after.log)

Step 1, named deployment. Cost is 2.6e-07, built-in pricing as before

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "text-embedding-3-small", "input": "after-run step1 named deployment baseline cost check a2f6"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost: 2.6e-07
x-litellm-response-cost-original: 2.6e-07
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

Step 2, wildcard route. Still 0.0 as configured

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "openai/text-embedding-3-small", "input": "after-run step2 wildcard route zero cost expected d5c3"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost-original: 0.0
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

Step 3, named deployment again. Fixed: cost stays at built-in pricing (3e-07, same magnitude as step 1) instead of dropping to 0

```console
$ curl -sS -D - -o /dev/null http://127.0.0.1:50609/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "text-embedding-3-small", "input": "after-run step3 named deployment stays priced post wildcard 1b9e"}' \
    | grep -i x-litellm-response-cost
x-litellm-response-cost: 3e-07
x-litellm-response-cost-original: 3e-07
x-litellm-response-cost-discount-amount: 0.0
x-litellm-response-cost-margin-amount: 0.0
x-litellm-response-cost-margin-percent: 0.0
```

## Type

🐛 Bug Fix

## Changes

When a proxy has a named deployment that relies on built-in pricing (e.g. model_name `text-embedding-3-small` backed by `openai/text-embedding-3-small`) plus an `openai/*` wildcard deployment with explicit `input_cost_per_token: 0` and `output_cost_per_token: 0`, a single call routed through the wildcard rewrote the shared `openai/text-embedding-3-small` entry in `litellm.model_cost` with the zero pricing. Every subsequent call to the named deployment was then logged at $0 cost until process restart

Router startup already isolates per-deployment custom pricing: `_create_deployment` registers the full pricing under the deployment's unique model id and strips custom pricing fields from the shared `{provider}/{model}` key. The request-time registration in `completion()` and `embedding()` did not follow that isolation; it wrote the full custom pricing entry onto the shared key on every request carrying input/output cost overrides

This PR aligns the request-time registration with the startup isolation. Requests that carry a router deployment id (in metadata `model_info`, the same signal the cost calculator uses for `router_model_id` resolution) now register the full pricing under that unique id only, while the shared key receives the entry with custom pricing fields stripped. The request itself is still costed with its own pricing because the cost calculator resolves custom pricing through the deployment id entry. Direct SDK calls without a router deployment id keep the existing behavior of registering the shared key with the given pricing, so `litellm.completion` / `litellm.embedding` users passing `input_cost_per_token` / `output_cost_per_token` are unaffected, and `_is_model_cost_zero` (which reads router deployment info) is untouched

The stripping logic is shared through `CustomPricingLiteLLMParams.strip_custom_pricing_fields` and reused by `Router._create_deployment` and `Router.add_deployment` instead of being duplicated inline

New regression tests in `tests/test_litellm/test_register_model_custom_pricing.py` cover the embedding and completion paths (zero pricing must not clobber the built-in entry, the custom-priced request is still costed via its deployment id, direct SDK behavior preserved), and `tests/test_litellm/test_router_model_cost_isolation.py` adds the full scenario through a Router with a named deployment plus a zero-cost `openai/*` wildcard. They fail on the base commit (except the direct SDK guard, which protects existing behavior) and pass with the fix


Two legacy tests encoded the leak as expected behavior and are updated to the corrected semantics. `tests/local_testing/test_router_fallbacks.py::test_router_fallbacks_with_custom_model_costs` asserted that calling a deployment with 30/60 per-token pricing rewrote the shared `claude-sonnet-4-5-20250929` entry, contradicting its own stated goal ("make sure custom model doesn't override default model costs"); it now asserts the shared entry keeps the built-in pricing while the request itself is still costed at the deployment's rate. `tests/local_testing/test_cost_calc.py::test_run` recomputed the streaming cost with a bare `completion_cost(response)`, which only matched the non-stream cost while the shared `gpt-3.5-turbo` entry was poisoned by the per-request pricing; it now passes that pricing explicitly via `custom_cost_per_token`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global `litellm.model_cost` registration and billing-related paths for router-originated requests; behavior is intentionally different from the buggy legacy path but direct SDK pricing registration is preserved.
> 
> **Overview**
> Fixes **LIT-3991**: router/proxy requests that register custom per-token pricing during `completion()` / `embedding()` no longer overwrite the shared `{provider}/{model}` entry in `litellm.model_cost`, so a zero-cost wildcard deployment cannot zero out built-in pricing for sibling deployments on the same backend.
> 
> Request-time registration now mirrors router startup: **`_register_custom_pricing_for_request`** detects a router deployment id in metadata, registers **full** pricing under that id, and updates the shared key with **`CustomPricingLiteLLMParams.strip_custom_pricing_fields`**. Direct SDK calls without a deployment id still register custom pricing on the shared key unchanged. Router **`_create_deployment`** / **`add_deployment`** use the same strip helper instead of inline field filtering.
> 
> Tests add LIT-3991 regression coverage (embedding/completion/router wildcard scenarios) and adjust legacy tests that previously treated shared-key pollution as expected behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58df1167fc9ad9b55c384e85e0685332decbf960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->