### PR TITLE
test: de-flake langfuse callbacks-in-db e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2201,6 +2201,7 @@ jobs:
           # the OTEL test - should get this as a trace
           command: |
             docker run -d \
+              --restart on-failure \
               -p 4000:4000 \
               -e DATABASE_URL=postgresql://postgres:postgres@host.docker.internal:5432/circle_test \
               -e STORE_MODEL_IN_DB="True" \

--- a/tests/store_model_in_db_tests/test_callbacks_in_db.py
+++ b/tests/store_model_in_db_tests/test_callbacks_in_db.py
@@ -15,17 +15,30 @@ import os
 import dotenv
 from dotenv import load_dotenv
 import pytest
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, APIConnectionError
 from openai.types.chat import ChatCompletion
 
 load_dotenv()
 
 # used for testing
 LANGFUSE_BASE_URL = "https://exampleopenaiendpoint-production-c715.up.railway.app"
+PROXY_BASE_URL = "http://127.0.0.1:4000"
+
+
+async def wait_for_proxy_ready(session, timeout: int = 60):
+    for _ in range(timeout):
+        try:
+            async with session.get(f"{PROXY_BASE_URL}/health/liveliness") as response:
+                if response.status == 200:
+                    return
+        except aiohttp.ClientError:
+            pass
+        await asyncio.sleep(1)
+    raise RuntimeError(f"Proxy at {PROXY_BASE_URL} not ready after {timeout}s")
 
 
 async def config_update(session, routing_strategy=None):
-    url = "http://0.0.0.0:4000/config/update"
+    url = f"{PROXY_BASE_URL}/config/update"
     headers = {"Authorization": "Bearer sk-1234", "Content-Type": "application/json"}
     print("routing_strategy: ", routing_strategy)
     data = {
@@ -62,32 +75,41 @@ async def check_langfuse_request(response_id: str):
 
 
 async def make_chat_completions_request() -> ChatCompletion:
-    client = AsyncOpenAI(api_key="sk-1234", base_url="http://0.0.0.0:4000")
-    response = await client.chat.completions.create(
-        model="fake-openai-endpoint",
-        messages=[{"role": "user", "content": "Hello, world!"}],
+    client = AsyncOpenAI(api_key="sk-1234", base_url=PROXY_BASE_URL)
+    last_error = None
+    for _ in range(10):
+        try:
+            response = await client.chat.completions.create(
+                model="fake-openai-endpoint",
+                messages=[{"role": "user", "content": "Hello, world!"}],
+            )
+            print(response)
+            return response
+        except APIConnectionError as e:
+            last_error = e
+            await asyncio.sleep(2)
+    raise AssertionError(
+        f"Proxy at {PROXY_BASE_URL} unreachable after retries: {last_error!r}"
     )
-    print(response)
-    return response
 
 
 @pytest.mark.asyncio
 async def test_e2e_langfuse_callbacks_in_db():
 
-    session = aiohttp.ClientSession()
+    async with aiohttp.ClientSession() as session:
+        # add langfuse callback to DB
+        await config_update(session)
 
-    # add langfuse callback to DB
-    await config_update(session)
+        # wait 20 seconds for the callback to be loaded into the instance
+        await asyncio.sleep(20)
+        await wait_for_proxy_ready(session)
 
-    # wait 20 seconds for the callback to be loaded into the instance
+        # make a /chat/completions request to the proxy
+        response = await make_chat_completions_request()
+        print(response)
+        response_id = response.id
+        print("response_id: ", response_id)
+
     await asyncio.sleep(20)
-
-    # make a /chat/completions request to the proxy
-    response = await make_chat_completions_request()
-    print(response)
-    response_id = response.id
-    print("response_id: ", response_id)
-
-    await asyncio.sleep(11)
     # check if the request is logged in Langfuse
     await check_langfuse_request(response_id)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The failure this addresses is `proxy_store_model_in_db_tests` dying on `test_e2e_langfuse_callbacks_in_db` with `openai.APIConnectionError: Connection error` while opening a connection to the proxy, one recent example being [this run](https://app.circleci.com/pipelines/github/BerriAI/litellm/85539/workflows/9b2cc5be-5fdd-460b-9ef2-92b67c634ea4/jobs/1991733). The captured stdout shows `/config/update` returning 200, then twenty seconds later the single chat request cannot open a TCP connection, so the whole job stops there under `pytest -x`

This is a CI-timing fix rather than a request/response behavior change, so the proof is the job itself. Before, a momentary window where the single-process proxy is not accepting connections fails the one blind request outright. After, the request waits on `/health/liveliness` and retries transient connection errors, and the container can restart if it crashed, so that window no longer sinks the run. The most direct validation is re-running `proxy_store_model_in_db_tests` and watching it stay green

## Type

🐛 Bug Fix

✅ Test

## Changes

`tests/store_model_in_db_tests/test_callbacks_in_db.py` gets four reliability changes. The chat request is now gated behind a `/health/liveliness` poll so it never fires while the worker is mid-cycle, and it retries on `openai.APIConnectionError` only, which means a real HTTP error or a failed Langfuse assertion still fails the test rather than being masked. The previously leaked `aiohttp.ClientSession` is wrapped in `async with`, clearing the `Unclosed client session` warning. Requests target `127.0.0.1:4000` instead of the `0.0.0.0` bind address

`.circleci/config.yml` gives the `my-app` proxy container `--restart on-failure`. The proxy runs as a single process with no supervisor, so an intermittent crash previously left port 4000 dead for the rest of the job; with the restart policy the container comes back and the readiness poll rides out the gap

The Langfuse assertion path is unchanged, so the test still verifies that the callback actually logs the request
