### PR TITLE
fix(spend): filter /global/spend/report by team_id when group_by=team

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -27,6 +27,7 @@ from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 # module while common_utils may pull proxy_server during init, which can leave
 # those names undefined. Import the helpers locally where they are used.
 from litellm.proxy.spend_tracking.spend_tracking_utils import (
+    get_spend_by_team,
     get_spend_by_team_and_customer,
 )
 from litellm.proxy.utils import handle_exception_on_proxy
@@ -1131,68 +1132,7 @@ async def get_global_spend_report(
                 start_date_obj, end_date_obj, team_id, customer_id, prisma_client
             )
         if group_by == "team":
-            # first get data from spend logs -> SpendByModelApiKey
-            # then read data from "SpendByModelApiKey" to format the response obj
-            sql_query = """
-
-            WITH SpendByModelApiKey AS (
-                SELECT
-                    date_trunc('day', sl."startTime") AS group_by_day,
-                    COALESCE(tt.team_alias, 'Unassigned Team') AS team_name,
-                    sl.model,
-                    sl.api_key,
-                    SUM(sl.spend) AS model_api_spend,
-                    SUM(sl.total_tokens) AS model_api_tokens
-                FROM 
-                    "LiteLLM_SpendLogs" sl
-                LEFT JOIN 
-                    "LiteLLM_TeamTable" tt 
-                ON 
-                    sl.team_id = tt.team_id
-                WHERE
-                    sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
-                    AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
-                GROUP BY
-                    date_trunc('day', sl."startTime"),
-                    tt.team_alias,
-                    sl.model,
-                    sl.api_key
-            )
-                SELECT
-                    group_by_day,
-                    jsonb_agg(jsonb_build_object(
-                        'team_name', team_name,
-                        'total_spend', total_spend,
-                        'metadata', metadata
-                    )) AS teams
-                FROM (
-                    SELECT
-                        group_by_day,
-                        team_name,
-                        SUM(model_api_spend) AS total_spend,
-                        jsonb_agg(jsonb_build_object(
-                            'model', model,
-                            'api_key', api_key,
-                            'spend', model_api_spend,
-                            'total_tokens', model_api_tokens
-                        )) AS metadata
-                    FROM 
-                        SpendByModelApiKey
-                    GROUP BY
-                        group_by_day,
-                        team_name
-                ) AS aggregated
-                GROUP BY
-                    group_by_day
-                ORDER BY
-                    group_by_day;
-                """
-
-            db_response = await prisma_client.db.query_raw(sql_query, start_date_obj, end_date_obj)
-            if db_response is None:
-                return []
-
-            return db_response
+            return await get_spend_by_team(start_date_obj, end_date_obj, team_id, prisma_client)
 
         elif group_by == "customer":
             sql_query = """

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -485,6 +485,74 @@ def _ensure_datetime_utc(timestamp: datetime) -> datetime:
     return timestamp
 
 
+async def get_spend_by_team(
+    start_date: dt,
+    end_date: dt,
+    team_id: Optional[str],
+    prisma_client: PrismaClient,
+):
+    sql_query = """
+    WITH SpendByModelApiKey AS (
+        SELECT
+            date_trunc('day', sl."startTime") AS group_by_day,
+            COALESCE(tt.team_alias, 'Unassigned Team') AS team_name,
+            sl.model,
+            sl.api_key,
+            SUM(sl.spend) AS model_api_spend,
+            SUM(sl.total_tokens) AS model_api_tokens
+        FROM
+            "LiteLLM_SpendLogs" sl
+        LEFT JOIN
+            "LiteLLM_TeamTable" tt
+        ON
+            sl.team_id = tt.team_id
+        WHERE
+            sl."startTime" >= ($1::timestamptz AT TIME ZONE 'UTC')
+            AND sl."startTime" <  (($2::timestamptz + INTERVAL '1 day') AT TIME ZONE 'UTC')
+            AND ($3::text IS NULL OR sl.team_id = $3)
+        GROUP BY
+            date_trunc('day', sl."startTime"),
+            tt.team_alias,
+            sl.model,
+            sl.api_key
+    )
+        SELECT
+            group_by_day,
+            jsonb_agg(jsonb_build_object(
+                'team_name', team_name,
+                'total_spend', total_spend,
+                'metadata', metadata
+            )) AS teams
+        FROM (
+            SELECT
+                group_by_day,
+                team_name,
+                SUM(model_api_spend) AS total_spend,
+                jsonb_agg(jsonb_build_object(
+                    'model', model,
+                    'api_key', api_key,
+                    'spend', model_api_spend,
+                    'total_tokens', model_api_tokens
+                )) AS metadata
+            FROM
+                SpendByModelApiKey
+            GROUP BY
+                group_by_day,
+                team_name
+        ) AS aggregated
+        GROUP BY
+            group_by_day
+        ORDER BY
+            group_by_day;
+    """
+
+    db_response = await prisma_client.db.query_raw(sql_query, start_date, end_date, team_id)
+    if db_response is None:
+        return []
+
+    return db_response
+
+
 async def get_spend_by_team_and_customer(
     start_date: dt,
     end_date: dt,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_query_optimization.py
@@ -16,6 +16,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../../.."))
 
 from litellm.proxy.spend_tracking.spend_tracking_utils import (
+    get_spend_by_team,
     get_spend_by_team_and_customer,
 )
 
@@ -60,31 +61,17 @@ async def test_spend_query_uses_timestamp_filtering():
     params = call_args[1:]
 
     # 1) SQL should NOT cast the startTime column to DATE (prevents index usage)
-    assert (
-        "::date" not in sql.lower()
-    ), "SQL should not use '::date' casting which prevents index usage"
-    assert (
-        "date(" not in sql.lower()
-    ), "SQL should not use DATE() function which prevents index usage"
+    assert "::date" not in sql.lower(), "SQL should not use '::date' casting which prevents index usage"
+    assert "date(" not in sql.lower(), "SQL should not use DATE() function which prevents index usage"
 
     # 2) SQL should use timestamp-range filtering pattern for index optimization
-    assert (
-        '"startTime" >=' in sql or '"startTime">=' in sql
-    ), "SQL should use >= operator for lower bound"
-    assert (
-        '"startTime" <' in sql or '"startTime"<' in sql
-    ), "SQL should use < operator for upper bound"
-    assert (
-        "interval '1 day'" in sql.lower()
-    ), "SQL should use INTERVAL for date arithmetic"
+    assert '"startTime" >=' in sql or '"startTime">=' in sql, "SQL should use >= operator for lower bound"
+    assert '"startTime" <' in sql or '"startTime"<' in sql, "SQL should use < operator for upper bound"
+    assert "interval '1 day'" in sql.lower(), "SQL should use INTERVAL for date arithmetic"
 
     # 3) Parameters should be datetime objects (not date objects)
-    assert isinstance(
-        params[0], datetime.datetime
-    ), "First parameter (start_date) should be datetime object"
-    assert isinstance(
-        params[1], datetime.datetime
-    ), "Second parameter (end_date) should be datetime object"
+    assert isinstance(params[0], datetime.datetime), "First parameter (start_date) should be datetime object"
+    assert isinstance(params[1], datetime.datetime), "Second parameter (end_date) should be datetime object"
     assert params[0].tzinfo is not None, "start_date should be timezone-aware"
     assert params[1].tzinfo is not None, "end_date should be timezone-aware"
 
@@ -130,12 +117,8 @@ async def test_global_activity_wraps_params_in_at_time_zone_utc(monkeypatch):
     # 2) Params must still be tz-aware UTC datetimes (preserves existing contract).
     assert isinstance(params[0], datetime.datetime)
     assert isinstance(params[1], datetime.datetime)
-    assert params[0].tzinfo is not None and params[0].utcoffset() == datetime.timedelta(
-        0
-    )
-    assert params[1].tzinfo is not None and params[1].utcoffset() == datetime.timedelta(
-        0
-    )
+    assert params[0].tzinfo is not None and params[0].utcoffset() == datetime.timedelta(0)
+    assert params[1].tzinfo is not None and params[1].utcoffset() == datetime.timedelta(0)
 
 
 @pytest.mark.asyncio
@@ -158,9 +141,7 @@ async def test_global_activity_internal_user_wraps_params_in_at_time_zone_utc(
 
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
 
-    auth = UserAPIKeyAuth(
-        user_role=LitellmUserRoles.INTERNAL_USER, user_id="internal_user_1"
-    )
+    auth = UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER, user_id="internal_user_1")
 
     await get_global_activity(
         start_date="2026-02-16",
@@ -171,8 +152,7 @@ async def test_global_activity_internal_user_wraps_params_in_at_time_zone_utc(
     assert mock_prisma.db.query_raw.called
     sql = mock_prisma.db.query_raw.call_args[0][0]
     assert sql.count("AT TIME ZONE 'UTC'") >= 2, (
-        "Internal-user branch must also wrap date bounds with "
-        f"`AT TIME ZONE 'UTC'`. SQL was:\n{sql}"
+        f"Internal-user branch must also wrap date bounds with `AT TIME ZONE 'UTC'`. SQL was:\n{sql}"
     )
 
 
@@ -219,8 +199,7 @@ async def test_spend_logs_ui_wraps_params_in_at_time_zone_utc(monkeypatch):
     assert mock_prisma.db.query_raw.called, "query_raw should have been called"
     sql = mock_prisma.db.query_raw.call_args[0][0]
     assert sql.count("AT TIME ZONE 'UTC'") >= 2, (
-        "/spend/logs/ui must wrap both `startTime` bounds with "
-        f"`AT TIME ZONE 'UTC'`. SQL was:\n{sql}"
+        f"/spend/logs/ui must wrap both `startTime` bounds with `AT TIME ZONE 'UTC'`. SQL was:\n{sql}"
     )
 
 
@@ -281,10 +260,7 @@ async def test_spend_logs_ui_folds_count_into_window_function(monkeypatch):
     assert response["total_pages"] == (137 + 50 - 1) // 50
 
     for row in response["data"]:
-        assert "total_count" not in row, (
-            "the window-function helper column must be stripped before "
-            "serialising rows"
-        )
+        assert "total_count" not in row, "the window-function helper column must be stripped before serialising rows"
 
 
 @pytest.mark.asyncio
@@ -373,3 +349,86 @@ async def test_spend_logs_ui_out_of_range_page_falls_back_to_count(monkeypatch):
     mock_prisma.db.litellm_spendlogs.count.assert_called_once()
     assert response["total"] == 7
     assert response["total_pages"] == (7 + 2 - 1) // 2
+
+
+@pytest.mark.asyncio
+async def test_get_spend_by_team_binds_optional_team_filter():
+    """
+    get_spend_by_team must bind team_id as query parameter $3 behind an
+    `IS NULL OR` predicate: a provided team_id narrows the result to that team,
+    a None team_id short-circuits the filter and returns every team. Regression
+    guard for LIT-4125 (the team query previously carried no team_id predicate).
+    """
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_query_raw = AsyncMock(return_value=[])
+    mock_prisma.db.query_raw = mock_query_raw
+
+    start_date = datetime.datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end_date = datetime.datetime(2024, 1, 31, tzinfo=timezone.utc)
+
+    await get_spend_by_team(
+        start_date=start_date,
+        end_date=end_date,
+        team_id="test_team",
+        prisma_client=mock_prisma,
+    )
+
+    assert mock_query_raw.called, "query_raw should have been called"
+    sql = mock_query_raw.call_args[0][0]
+    params = mock_query_raw.call_args[0][1:]
+
+    # team_id is bound as parameter $3 (not string-interpolated) and referenced in WHERE
+    assert "sl.team_id = $3" in sql, f"WHERE must filter on team_id. SQL was:\n{sql}"
+    assert "$3::text IS NULL OR" in sql, (
+        f"the team filter must be optional via an IS NULL short-circuit. SQL was:\n{sql}"
+    )
+    assert params[2] == "test_team", "team_id must be forwarded as the third query param"
+
+    # None team_id still forwards param $3 (as None) so the predicate no-ops
+    mock_query_raw.reset_mock()
+    await get_spend_by_team(
+        start_date=start_date,
+        end_date=end_date,
+        team_id=None,
+        prisma_client=mock_prisma,
+    )
+    assert mock_query_raw.call_args[0][1:][2] is None
+
+
+@pytest.mark.asyncio
+async def test_global_spend_report_team_group_forwards_team_id(monkeypatch):
+    """
+    GET /global/spend/report?group_by=team&team_id=X must filter to team X.
+
+    Before LIT-4125 the group_by=team branch ran a query with no team_id
+    predicate, so spend for every team in the range was returned regardless of
+    team_id (team_id was only honored when a customer_id was also supplied).
+    This asserts the endpoint forwards team_id into the DB query.
+    """
+    from litellm.proxy.spend_tracking.spend_management_endpoints import (
+        get_global_spend_report,
+    )
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.query_raw = AsyncMock(return_value=[])
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma)
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+
+    await get_global_spend_report(
+        start_date="2026-07-01",
+        end_date="2026-07-03",
+        group_by="team",
+        api_key=None,
+        internal_user_id=None,
+        team_id="team_x",
+        customer_id=None,
+    )
+
+    assert mock_prisma.db.query_raw.called, "query_raw should have been called"
+    sql = mock_prisma.db.query_raw.call_args[0][0]
+    params = mock_prisma.db.query_raw.call_args[0][1:]
+    assert "team_x" in params, "team_id must be forwarded into the DB query params"
+    assert "sl.team_id = $3" in sql, f"team query must filter on team_id. SQL was:\n{sql}"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4125

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`GET /global/spend/report?group_by=team&team_id=X` was returning every team's spend for the range instead of just team X. Verified against a local proxy seeded with two teams (`lit4125_alpha` with spend 15, `lit4125_beta` with spend 7); this endpoint reads spend rows straight from the DB, so the repro seeds spend logs rather than making LLM calls

Before the fix, filtering by a single team returned both teams:

```
$ curl -s "http://localhost:4011/global/spend/report?start_date=2026-07-01&end_date=2026-07-03&group_by=team&team_id=lit4125_alpha" \
    -H "Authorization: Bearer sk-1234"
# day 2026-07-02 -> teams: ['LIT4125 Alpha Team', 'LIT4125 Beta Team']  total: 22
```

After the fix, the same request returns only the requested team:

```
$ curl -s "http://localhost:4011/global/spend/report?start_date=2026-07-01&end_date=2026-07-03&group_by=team&team_id=lit4125_alpha" \
    -H "Authorization: Bearer sk-1234"
# day 2026-07-02 -> teams: ['LIT4125 Alpha Team']  total: 15
```

The unfiltered case (no `team_id`) still returns every team, `group_by=customer` is unchanged, and the `team_id` + `customer_id` path is unaffected

## Type

🐛 Bug Fix

## Changes

The `group_by=team` branch of `/global/spend/report` ran a query with only a date-range filter, so `team_id` was ignored and spend for every team came back. `team_id` was honored only in the separate branch that also required a `customer_id`, which is why filtering by team alone silently did nothing

The team query now lives in a `get_spend_by_team` helper alongside its existing sibling `get_spend_by_team_and_customer`, with `team_id` bound as an optional predicate (`AND ($3::text IS NULL OR sl.team_id = $3)`). A provided `team_id` narrows the result to that team while a null `team_id` returns every team, so the unfiltered behavior is preserved. The endpoint now just calls the helper, dropping the inline SQL block that had drifted out of sync with its sibling

Added regression coverage in `test_spend_query_optimization.py`: one test asserting the endpoint forwards `team_id` into the DB query (fails on the pre-fix code), and one asserting the helper binds `team_id` as an optional `$3` filter
