### PR TITLE
feat(ui): add cost optimization feedback banner to models page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.test.tsx
@@ -126,7 +126,7 @@ describe("ModelsAndEndpointsView", () => {
     expect(await findByText("Model Management", {}, { timeout: 10000 })).toBeInTheDocument();
   });
 
-  it("should show Missing provider banner by default", async () => {
+  it("should show Cost Optimization feedback banner by default", async () => {
     localStorageMock.clear();
     const queryClient = createQueryClient();
     const { findByText } = render(
@@ -134,10 +134,10 @@ describe("ModelsAndEndpointsView", () => {
         <ModelsAndEndpointsView premiumUser={false} teams={[]} />
       </QueryClientProvider>,
     );
-    expect(await findByText("Missing a provider?", {}, { timeout: 10000 })).toBeInTheDocument();
+    expect(await findByText("Help shape cost optimization", {}, { timeout: 10000 })).toBeInTheDocument();
   });
 
-  it("should hide Missing provider banner when dismiss button is clicked and persist to localStorage", async () => {
+  it("should hide Cost Optimization feedback banner when dismiss button is clicked and persist to localStorage", async () => {
     localStorageMock.clear();
     const queryClient = createQueryClient();
     const { findByText, queryByText, container } = render(
@@ -147,7 +147,7 @@ describe("ModelsAndEndpointsView", () => {
     );
 
     // Wait for banner to appear
-    expect(await findByText("Missing a provider?", {}, { timeout: 10000 })).toBeInTheDocument();
+    expect(await findByText("Help shape cost optimization", {}, { timeout: 10000 })).toBeInTheDocument();
 
     // Find and click dismiss button (X button)
     const dismissButton = container.querySelector('button[aria-label="Dismiss banner"]');
@@ -155,15 +155,15 @@ describe("ModelsAndEndpointsView", () => {
     fireEvent.click(dismissButton!);
 
     // Banner should be hidden
-    expect(queryByText("Missing a provider?")).not.toBeInTheDocument();
+    expect(queryByText("Help shape cost optimization")).not.toBeInTheDocument();
 
     // LocalStorage should be updated
-    expect(localStorageMock.getItem("hideMissingProviderBanner")).toBe("true");
+    expect(localStorageMock.getItem("hideCostOptimizationFeedbackBanner")).toBe("true");
   });
 
-  it("should show compact Request Provider button when banner is dismissed", async () => {
+  it("should keep Cost Optimization feedback banner hidden across remounts once dismissed", async () => {
     // Set localStorage to hide banner
-    localStorageMock.setItem("hideMissingProviderBanner", "true");
+    localStorageMock.setItem("hideCostOptimizationFeedbackBanner", "true");
     const queryClient = createQueryClient();
     const { findByText, queryByText } = render(
       <QueryClientProvider client={queryClient}>
@@ -175,12 +175,7 @@ describe("ModelsAndEndpointsView", () => {
     await findByText("Model Management", {}, { timeout: 10000 });
 
     // Banner should not be visible
-    expect(queryByText("Missing a provider?")).not.toBeInTheDocument();
-
-    // Compact Request Provider button should be visible in header
-    const requestProviderLinks = document.querySelectorAll('a[href="https://models.litellm.ai/?request=true"]');
-    // There should be a compact button when banner is hidden
-    expect(requestProviderLinks.length).toBeGreaterThan(0);
+    expect(queryByText("Help shape cost optimization")).not.toBeInTheDocument();
   });
 
   it("should pass model IDs (not model names) to HealthCheckComponent as all_models_on_proxy", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/ModelsAndEndpointsView.tsx
@@ -4,6 +4,7 @@ import { useModelsInfo } from "@/app/(dashboard)/hooks/models/useModels";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
 import { useUpdateRetryPolicy } from "@/app/(dashboard)/hooks/routerSettings/useUpdateRetryPolicy";
 import AllModelsTab from "@/app/(dashboard)/models-and-endpoints/components/AllModelsTab";
+import CostOptimizationFeedbackBanner from "@/components/molecules/cost_optimization_feedback_banner";
 import ModelRetrySettingsTab from "@/app/(dashboard)/models-and-endpoints/components/ModelRetrySettingsTab";
 import PriceDataManagementTab from "@/app/(dashboard)/models-and-endpoints/components/PriceDataManagementTab";
 import { handleAddModelSubmit } from "@/components/add_model/handle_add_model_submit";
@@ -19,7 +20,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Col, Grid, Icon, Tab, TabGroup, TabList, TabPanel, TabPanels } from "@tremor/react";
 import type { UploadProps } from "antd";
 import { Form } from "antd";
-import { PlusCircleOutlined } from "@ant-design/icons";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import AddModelTab from "../../../components/add_model/add_model_tab";
 import HealthCheckComponent from "../../../components/model_dashboard/HealthCheckComponent";
@@ -70,12 +70,6 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [healthCurrentPage, setHealthCurrentPage] = useState(1);
-  const [showMissingProviderBanner, setShowMissingProviderBanner] = useState(() => {
-    if (typeof window !== "undefined") {
-      return localStorage.getItem("hideMissingProviderBanner") !== "true";
-    }
-    return true;
-  });
 
   const queryClient = useQueryClient();
   const { data: modelDataResponse, isLoading: isLoadingModels, refetch: refetchModels } = useModelsInfo();
@@ -315,75 +309,10 @@ const ModelsAndEndpointsView: React.FC<ModelDashboardProps> = ({ premiumUser, te
                 <p className="text-sm text-gray-600">Add and manage models for the proxy</p>
               )}
             </div>
-            {!showMissingProviderBanner && (
-              <a
-                href="https://models.litellm.ai/?request=true"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[#6366f1] hover:text-[#5558e3] border border-[#6366f1] hover:border-[#5558e3] rounded-lg transition-colors"
-              >
-                <PlusCircleOutlined style={{ fontSize: "12px" }} />
-                Request Provider
-              </a>
-            )}
           </div>
 
-          {/* Missing Provider Banner */}
-          {showMissingProviderBanner && (
-            <div className="mb-4 px-4 py-3 bg-blue-50 rounded-lg border border-blue-100 flex items-center gap-4">
-              <div className="shrink-0 w-10 h-10 bg-white rounded-full flex items-center justify-center border border-blue-200">
-                <PlusCircleOutlined style={{ fontSize: "18px", color: "#6366f1" }} />
-              </div>
-              <div className="flex-1 min-w-0">
-                <h4 className="text-gray-900 font-semibold text-sm m-0">Missing a provider?</h4>
-                <p className="text-gray-500 text-xs m-0 mt-0.5">
-                  The LiteLLM engineering team is constantly adding support for new LLM models, providers, endpoints. If
-                  you don&apos;t see the one you need, let us know and we&apos;ll prioritize it.
-                </p>
-              </div>
-              <a
-                href="https://models.litellm.ai/?request=true"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="shrink-0 inline-flex items-center gap-2 px-4 py-2 bg-[#6366f1] hover:bg-[#5558e3] text-white text-sm font-medium rounded-lg transition-colors"
-              >
-                Request Provider
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-4 w-4"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                  />
-                </svg>
-              </a>
-              <button
-                onClick={() => {
-                  setShowMissingProviderBanner(false);
-                  localStorage.setItem("hideMissingProviderBanner", "true");
-                }}
-                className="shrink-0 p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="Dismiss banner"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  className="h-5 w-5"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                  strokeWidth={2}
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-          )}
+          {/* Cost Optimization Feedback Banner */}
+          <CostOptimizationFeedbackBanner />
           {selectedModelId && !isLoading ? (
             <ModelInfoView
               modelId={selectedModelId}

--- a/ui/litellm-dashboard/src/components/molecules/cost_optimization_feedback_banner.test.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/cost_optimization_feedback_banner.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import CostOptimizationFeedbackBanner from "./cost_optimization_feedback_banner";
+
+const STORAGE_KEY = "hideCostOptimizationFeedbackBanner";
+
+describe("CostOptimizationFeedbackBanner", () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("renders with a link to the feedback discussion", () => {
+    const { getByText } = render(<CostOptimizationFeedbackBanner />);
+    const link = getByText("Share Feedback").closest("a");
+    expect(link).toHaveAttribute("href", "https://github.com/BerriAI/litellm/discussions/32172");
+  });
+
+  it("hides itself and persists the dismissal when the dismiss button is clicked", () => {
+    const { queryByText, getByLabelText } = render(<CostOptimizationFeedbackBanner />);
+    expect(queryByText("Help shape cost optimization")).toBeInTheDocument();
+
+    fireEvent.click(getByLabelText("Dismiss banner"));
+
+    expect(queryByText("Help shape cost optimization")).not.toBeInTheDocument();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("stays dismissed on remount once persisted", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    const { queryByText } = render(<CostOptimizationFeedbackBanner />);
+    expect(queryByText("Help shape cost optimization")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/molecules/cost_optimization_feedback_banner.tsx
+++ b/ui/litellm-dashboard/src/components/molecules/cost_optimization_feedback_banner.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import { CommentOutlined } from "@ant-design/icons";
+
+const STORAGE_KEY = "hideCostOptimizationFeedbackBanner";
+const DISCUSSION_URL = "https://github.com/BerriAI/litellm/discussions/32172";
+
+const CostOptimizationFeedbackBanner: React.FC = () => {
+  const [dismissed, setDismissed] = useState(() => {
+    if (typeof window !== "undefined") {
+      return localStorage.getItem(STORAGE_KEY) === "true";
+    }
+    return false;
+  });
+
+  if (dismissed) {
+    return null;
+  }
+
+  return (
+    <div className="mb-4 px-4 py-3 bg-blue-50 rounded-lg border border-blue-100 flex items-center gap-4">
+      <div className="shrink-0 w-10 h-10 bg-white rounded-full flex items-center justify-center border border-blue-200">
+        <CommentOutlined style={{ fontSize: "18px", color: "#6366f1" }} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <h4 className="text-gray-900 font-semibold text-sm m-0">Help shape cost optimization</h4>
+        <p className="text-gray-500 text-xs m-0 mt-0.5">
+          We&apos;re collecting suggestions for cost optimization improvements across routing, budgets, and more. Let us
+          know what you&apos;d like to see.
+        </p>
+      </div>
+      <a
+        href={DISCUSSION_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 inline-flex items-center gap-2 px-4 py-2 bg-[#6366f1] hover:bg-[#5558e3] text-white text-sm font-medium rounded-lg transition-colors"
+      >
+        Share Feedback
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+          />
+        </svg>
+      </a>
+      <button
+        onClick={() => {
+          setDismissed(true);
+          localStorage.setItem(STORAGE_KEY, "true");
+        }}
+        className="shrink-0 p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-full transition-colors"
+        aria-label="Dismiss banner"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+};
+
+export default CostOptimizationFeedbackBanner;


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

To verify: start the proxy on localhost:4000 with any config, and the dashboard dev server (npm run dev in ui/litellm-dashboard). Log into the UI, go to `Models + Endpoints`. A dismissible banner titled "Help shape cost optimization" appears at the top of the page with a "Share Feedback" button linking to https://github.com/BerriAI/litellm/discussions/32172. It stays visible across the All Models / Add Model / Add Auto Router tabs (single instance, not duplicated), and dismissing it persists via localStorage across reloads.

## Type

🆕 New Feature

## Changes

Adds a dismissible banner on the Models + Endpoints page asking users for feedback on cost optimization improvements (routing, budgets, and more), linking out to a new GitHub discussion. Previously this lived only behind an Auto Router-specific banner that showed up twice when an auto-router model was configured while on the Add Auto Router tab; this replaces it with a single, always-present banner with broader scope. The prior "Missing a provider?" banner and its Request Provider fallback link are intentionally removed as part of this change.