### PR TITLE
fix(logging): pass request input instead of Python builtin to logging callbacks

### DIFF
--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1119,7 +1119,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
         model_response: Optional[ImageResponse],
         azure_client_params: dict,
         api_key: str,
-        input: list,
+        input: str,
         logging_obj: LiteLLMLoggingObj,
         headers: dict,
         client=None,

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -1257,7 +1257,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             if aimg_generation is True:
                 return self.aimage_generation(
                     data=data,
-                    input=input,
+                    input=prompt,
                     logging_obj=logging_obj,
                     model_response=model_response,
                     api_key=api_key,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2724,7 +2724,7 @@ class BaseLLMHTTPHandler:
 
         ## LOGGING
         logging_obj.pre_call(
-            input=input,
+            input=response_id,
             api_key="",
             additional_args={
                 "complete_input_dict": data,
@@ -2814,7 +2814,7 @@ class BaseLLMHTTPHandler:
 
         ## LOGGING
         logging_obj.pre_call(
-            input=input,
+            input=response_id,
             api_key="",
             additional_args={
                 "complete_input_dict": data,

--- a/litellm/llms/jina_ai/embedding/transformation.py
+++ b/litellm/llms/jina_ai/embedding/transformation.py
@@ -137,7 +137,7 @@ class JinaAIEmbeddingConfig(BaseEmbeddingConfig):
         response_json = raw_response.json()
         ## LOGGING
         logging_obj.post_call(
-            input=input,
+            input=request_data.get("input"),
             api_key=api_key,
             additional_args={"complete_input_dict": request_data},
             original_response=response_json,

--- a/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
+++ b/tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py
@@ -440,3 +440,38 @@ async def test_azure_aimage_generation_base_model_vs_deployment_name():
         wire_json = post_kwargs.get("json") or {}
         assert "model" not in wire_json
         assert data.get("model") == base_model
+
+
+@pytest.mark.asyncio
+async def test_azure_image_generation_async_wrapper_logs_prompt():
+    azure_chat_completion = AzureChatCompletion()
+    prompt = "A precise watercolor of a skyline"
+    mock_response = MagicMock()
+
+    with patch.object(
+        azure_chat_completion,
+        "initialize_azure_sdk_client",
+        return_value={
+            "api_base": "https://example.openai.azure.com",
+            "api_version": "2024-07-01-preview",
+        },
+    ), patch.object(
+        azure_chat_completion,
+        "aimage_generation",
+        new=AsyncMock(return_value=mock_response),
+    ) as mock_aimage_generation:
+        response = await azure_chat_completion.image_generation(
+            prompt=prompt,
+            timeout=60.0,
+            optional_params={"n": 1},
+            logging_obj=MagicMock(),
+            headers={},
+            model="gpt-image-15",
+            api_key="test-api-key",
+            api_base="https://example.openai.azure.com",
+            api_version="2024-07-01-preview",
+            aimg_generation=True,
+        )
+
+    assert response is mock_response
+    assert mock_aimage_generation.call_args.kwargs["input"] == prompt

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1071,6 +1071,71 @@ def test_sync_delete_responses_sets_json_content_type():
     assert _content_type(captured["headers"]) == "application/json"
 
 
+@pytest.mark.asyncio
+async def test_async_delete_response_api_handler_logs_response_id():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://api.openai.com/v1/responses"
+    config.transform_delete_response_api_request.return_value = (
+        "https://api.openai.com/v1/responses/resp_xyz",
+        {},
+    )
+    config.transform_delete_response_api_response.return_value = "deleted"
+    logging_obj = Mock()
+    client = AsyncHTTPHandler()
+    client.delete = AsyncMock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("DELETE", "https://api.openai.com/v1/responses/resp_xyz"),
+        )
+    )
+
+    response = await handler.async_delete_response_api_handler(
+        response_id="resp_xyz",
+        responses_api_provider_config=config,
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        client=client,
+    )
+
+    assert response == "deleted"
+    assert logging_obj.pre_call.call_args.kwargs["input"] == "resp_xyz"
+
+
+def test_sync_delete_response_api_handler_logs_response_id():
+    handler = BaseLLMHTTPHandler()
+    config = Mock()
+    config.validate_environment.return_value = {}
+    config.get_complete_url.return_value = "https://api.openai.com/v1/responses"
+    config.transform_delete_response_api_request.return_value = (
+        "https://api.openai.com/v1/responses/resp_xyz",
+        {},
+    )
+    config.transform_delete_response_api_response.return_value = "deleted"
+    logging_obj = Mock()
+    client = HTTPHandler()
+    client.delete = Mock(
+        return_value=httpx.Response(
+            200,
+            request=httpx.Request("DELETE", "https://api.openai.com/v1/responses/resp_xyz"),
+        )
+    )
+
+    response = handler.delete_response_api_handler(
+        response_id="resp_xyz",
+        responses_api_provider_config=config,
+        litellm_params=GenericLiteLLMParams(),
+        logging_obj=logging_obj,
+        custom_llm_provider="openai",
+        client=client,
+    )
+
+    assert response == "deleted"
+    assert logging_obj.pre_call.call_args.kwargs["input"] == "resp_xyz"
+
+
 # ---------------------------------------------------------------------------
 # Parity tests: request-body is serialized once and reused for the wire.
 # (_async_post_anthropic_messages_with_http_error_retry)

--- a/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
+++ b/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
@@ -2,11 +2,14 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import httpx
+
 sys.path.insert(
     0, os.path.abspath("../../../../../..")
 )  # Adds the parent directory to the system path
 
 from litellm.llms.jina_ai.embedding.transformation import JinaAIEmbeddingConfig
+from litellm.types.utils import EmbeddingResponse
 
 
 class TestJinaAIEmbeddingTransform:
@@ -86,3 +89,36 @@ class TestJinaAIEmbeddingTransform:
             "input": expected_input,
         }
         assert result == expected_result
+
+    def test_transform_embedding_response_logs_request_input(self):
+        request_data = {"model": self.model, "input": ["hello world"]}
+        raw_response = httpx.Response(
+            200,
+            json={
+                "object": "list",
+                "data": [
+                    {
+                        "object": "embedding",
+                        "embedding": [0.1, 0.2, 0.3],
+                        "index": 0,
+                    }
+                ],
+                "model": self.model,
+                "usage": {"prompt_tokens": 1, "total_tokens": 1},
+            },
+            request=httpx.Request("POST", "https://api.jina.ai/v1/embeddings"),
+        )
+
+        response = self.config.transform_embedding_response(
+            model=self.model,
+            raw_response=raw_response,
+            model_response=EmbeddingResponse(),
+            logging_obj=self.logging_obj,
+            api_key="test-api-key",
+            request_data=request_data,
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert response.model == self.model
+        assert self.logging_obj.post_call.call_args.kwargs["input"] == ["hello world"]


### PR DESCRIPTION
## Relevant issues

Follow-up to #31334, which fixed the same defect in the async transcription error paths

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

These values are internal logging metadata passed to `logging_obj.pre_call` / `post_call`, so they never appear in the HTTP response; the regression tests assert the exact logging argument instead

Focused regression tests, one per fixed call site:

```shell
python -m pytest \
  tests/test_litellm/llms/azure/image_generation/test_azure_image_generation_init.py::test_azure_image_generation_async_wrapper_logs_prompt \
  tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py::test_async_delete_response_api_handler_logs_response_id \
  tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py::test_sync_delete_response_api_handler_logs_response_id \
  "tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py::TestJinaAIEmbeddingTransform::test_transform_embedding_response_logs_request_input" \
  -q
```

Result:

```
4 passed
```

All four tests fail on the previous implementation with `assert <built-in function input> == ...`, verified by reverting the source fixes and rerunning

## Type

Bug Fix
Test

## Changes

After fixing the async transcription error paths in #31334, I swept the codebase with an AST check for the same defect class: `input=input` inside a function that has no `input` binding, which silently passes Python's builtin `input` function to logging callbacks instead of the request input. The sweep found four more call sites

`litellm/llms/azure/azure.py`: `image_generation` passed `input=input` to `aimage_generation`, whose success and error `post_call` logging then recorded the builtin for every async Azure image generation call. It now passes `prompt`, matching the sync path which already logs `input=prompt`. Per review feedback, `aimage_generation`'s `input` annotation is corrected from `list` to `str` to match; the fixed call site is its only caller

`litellm/llms/custom_httpx/llm_http_handler.py`: both `async_delete_response_api_handler` and `delete_response_api_handler` logged `input=input` in `pre_call`. They now log the `response_id` being deleted

`litellm/llms/jina_ai/embedding/transformation.py`: `transform_embedding_response` logged `input=input` in `post_call`. It now logs `request_data.get("input")`, the actual embedding input

Each fix has a focused regression test in the mapped test file that asserts the exact value passed to the logging call, so reintroducing the builtin fails the test
