### PR TITLE
feat(vertex_ai): cache resolved explicit context-cache ids in-memory to skip cachedContents discovery

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -359,6 +359,7 @@ enable_key_alias_format_validation: bool = (
 enable_gemini_default_thinking_level_low: bool = (
     False  # opt-in: force thinkingLevel low/minimal for Gemini 3 thinking param mapping
 )
+enable_vertex_context_cache_id_caching: bool = False  # opt-in: in-memory cache of resolved Vertex/Gemini explicit context-cache ids, skips the per-request cachedContents LIST
 ####################
 logging: bool = True
 enable_loadbalancing_on_batch_endpoints: Optional[bool] = None

--- a/litellm/llms/vertex_ai/context_caching/README.md
+++ b/litellm/llms/vertex_ai/context_caching/README.md
@@ -1,0 +1,28 @@
+# Vertex / Gemini explicit context caching
+
+Handles the `cachedContents` (explicit context cache) flow for Vertex AI, Vertex AI Beta, and Gemini (Google AI Studio). When a request marks a prefix with `cache_control` breakpoints instead of passing a flat `cached_content` id, the discovery path in `vertex_ai_context_caching.py` resolves the cachedContent id by hashing the messages and issuing a live `cachedContents` LIST.
+
+## In-memory cache of resolved cache ids
+
+That LIST is a control-plane round trip (p50 1552ms) paid on every request. `id_cache.py` caches the resolved cachedContent `name` in-memory so a warm request skips it. Off by default; enable with
+
+```yaml
+litellm_settings:
+  enable_vertex_context_cache_id_caching: true
+```
+
+or from the SDK
+
+```python
+import litellm
+litellm.enable_vertex_context_cache_id_caching = True
+```
+
+It covers both Vertex AI and Gemini/AI Studio; the p50 1552ms saving is measured on Vertex.
+
+Correctness properties, enforced by `id_cache.py`:
+
+- Each entry's ttl is derived from the backing cachedContent's real `expireTime` (minus a 5s safety margin), never a fixed span from insertion, so a cache hit can never outlive its backing cachedContent (which would fail downstream `generateContent` with NOT_FOUND). If `expireTime` is absent or unparseable the entry is not stored, degrading safely to always-LIST
+- The key is namespaced by `(custom_llm_provider, vertex_project, vertex_location, api_base, credential-hash)`, so an id created under one provider/project/location/endpoint/credential is never served to another
+- The cache is bounded and in-memory (no Redis), so each process holds its own copy; a cold process still LISTs and so still dedups against caches created by peers
+- ttl bounds natural expiry, but a cachedContent can also be deleted/revoked server-side before then. When generateContent then rejects a warm-hit id (Vertex reports a deleted cache as HTTP 400 INVALID_ARGUMENT, "Invalid resource state for cache content <id>", not a 404), the completion handler invalidates that entry (`invalidate_cache_id`) by matching the served id in the error body, so the next request re-resolves via LIST/create instead of re-serving the dead id

--- a/litellm/llms/vertex_ai/context_caching/id_cache.py
+++ b/litellm/llms/vertex_ai/context_caching/id_cache.py
@@ -1,0 +1,135 @@
+"""
+In-memory cache of resolved Vertex/Gemini explicit context-cache ids.
+
+The discovery path in ``vertex_ai_context_caching.py`` otherwise re-resolves the
+cachedContent id on every request via a live ``cachedContents`` LIST (p50 1552ms). This
+caches the resolved ``name`` in-memory so a warm request skips that round trip.
+
+Off by default; enable via ``litellm.enable_vertex_context_cache_id_caching``.
+
+Correctness invariants:
+- Each entry's ttl is derived from the backing cachedContent's real ``expireTime``
+  minus a safety margin, never a fixed span from insertion, so a hit can never
+  outlive its backing cache (which would fail downstream generateContent with NOT_FOUND).
+- The key is namespaced by the resolving endpoint/tenant so an id created under one
+  provider/project/location/endpoint/credential is never served to another.
+- ttl bounds natural expiry, but a cachedContent can also be deleted/revoked server-side
+  before then. ``invalidate_cache_id`` drops such a poisoned entry when generateContent
+  rejects it downstream (Vertex reports a deleted cache as HTTP 400 INVALID_ARGUMENT,
+  "Invalid resource state for cache content <id>"), so the next request re-resolves.
+"""
+
+import hashlib
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import litellm
+from litellm.caching.in_memory_cache import InMemoryCache
+
+SAFETY_MARGIN_SECONDS = 5
+_MAX_ENTRIES = 1024
+
+_EXPLICIT_CACHE_ID_CACHE = InMemoryCache(max_size_in_memory=_MAX_ENTRIES)
+
+_RFC3339_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})$")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCacheId:
+    name: str
+    expire_time: Optional[str]
+
+
+def _rfc3339_to_epoch(expire_time: str) -> Optional[float]:
+    """Vertex/Gemini return e.g. ``2024-10-02T15:01:23.045123456Z`` (nanosecond, Z).
+
+    ``datetime.fromisoformat`` only tolerates the ``Z`` suffix and >6 fractional
+    digits on Python 3.11+, but litellm supports 3.10, so normalize first.
+    """
+    match = _RFC3339_RE.match(expire_time.strip())
+    if match is None:
+        return None
+    base, frac, tz = match.group(1), match.group(2), match.group(3)
+    micros = frac[:6].ljust(6, "0") if frac else "000000"
+    if tz == "Z":
+        offset = "+00:00"
+    elif ":" in tz:
+        offset = tz
+    else:
+        offset = f"{tz[:3]}:{tz[3:]}"
+    try:
+        return datetime.fromisoformat(f"{base}.{micros}{offset}").timestamp()
+    except ValueError:
+        return None
+
+
+def expire_time_to_ttl(expire_time: Optional[str], now: Optional[float] = None) -> Optional[float]:
+    """Seconds until ``expire_time`` minus the safety margin, or ``None`` when the
+    value is absent, unparseable, or already within the margin (i.e. not cacheable)."""
+    if not expire_time:
+        return None
+    epoch = _rfc3339_to_epoch(expire_time)
+    if epoch is None:
+        return None
+    ttl = epoch - (time.time() if now is None else now) - SAFETY_MARGIN_SECONDS
+    return ttl if ttl > 0 else None
+
+
+def make_cache_id_key(
+    content_key: str,
+    custom_llm_provider: str,
+    vertex_project: Optional[str],
+    vertex_location: Optional[str],
+    api_base: Optional[str],
+    api_key: Optional[str],
+) -> str:
+    """Namespace the content hash by everything that determines which cachedContents
+    endpoint/tenant the LIST would target, so ids never leak across tenants.
+
+    The credential is folded in as a stable, non-reversible hash (never the raw secret).
+    """
+    auth_id = hashlib.sha256((api_key or "").encode()).hexdigest()[:16]
+    return "|".join(
+        (
+            custom_llm_provider,
+            vertex_project or "",
+            vertex_location or "",
+            api_base or "",
+            auth_id,
+            content_key,
+        )
+    )
+
+
+def lookup_cache_id(key: str) -> Optional[str]:
+    """Resolved cachedContent name for a live entry, else ``None``. No-op (miss) when
+    the feature is disabled. ``str(...)`` guards ``InMemoryCache.get_cache``'s
+    ``json.loads`` coercion, which would turn a numeric Gemini id into an int."""
+    if not litellm.enable_vertex_context_cache_id_caching:
+        return None
+    hit = _EXPLICIT_CACHE_ID_CACHE.get_cache(key)
+    if hit is None:
+        return None
+    return str(hit)
+
+
+def store_cache_id(key: str, name: Optional[str], expire_time: Optional[str], now: Optional[float] = None) -> None:
+    """Cache ``name`` under ``key`` with a ttl bounded by ``expire_time``. No-op when the
+    feature is disabled, the name is empty, or the ttl is not derivable (safe degrade to
+    always-LIST)."""
+    if not name or not litellm.enable_vertex_context_cache_id_caching:
+        return
+    ttl = expire_time_to_ttl(expire_time, now=now)
+    if ttl is None:
+        return
+    _EXPLICIT_CACHE_ID_CACHE.set_cache(key, name, ttl=ttl)
+
+
+def invalidate_cache_id(key: str) -> None:
+    """Drop a resolved id after a downstream NOT_FOUND (server-side deleted/revoked
+    cachedContent), so the next request re-resolves via LIST/create instead of re-serving
+    the dead id. Safe no-op when the entry is already absent."""
+    _EXPLICIT_CACHE_ID_CACHE.delete_cache(key)

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
 
 import httpx
@@ -15,12 +16,20 @@ from litellm._logging import verbose_logger
 from litellm.llms.openai.openai import AllMessageValues
 from litellm.utils import is_prompt_caching_valid_prompt
 from litellm.types.llms.vertex_ai import (
+    CachedContent,
     CachedContentListAllResponseBody,
     VertexAICachedContentResponseObject,
 )
 
 from ..common_utils import VertexAIError, get_vertex_base_url
 from ..vertex_llm_base import VertexBase
+from .id_cache import (
+    ResolvedCacheId,
+    invalidate_cache_id,
+    lookup_cache_id,
+    make_cache_id_key,
+    store_cache_id,
+)
 from .transformation import (
     separate_cached_messages,
     transform_openai_messages_to_gemini_context_caching,
@@ -29,6 +38,64 @@ from .transformation import (
 local_cache_obj = Cache(type=LiteLLMCacheType.LOCAL)  # only used for calling 'get_cache_key' function
 
 MAX_PAGINATION_PAGES = 100  # Reasonable upper bound for pagination
+
+
+@dataclass(frozen=True, slots=True)
+class _PageMatch:
+    # A displayName match was found on this page; stop paginating. ``resolved`` is None
+    # when the matched item had no usable ``name`` (treat as miss, but still stop early,
+    # since displayName is unique so no later page can match).
+    resolved: Optional[ResolvedCacheId]
+
+
+def _find_matching_cache(cached_items: list[CachedContent], cache_key: str) -> Optional[_PageMatch]:
+    for cached_item in cached_items:
+        display_name = cached_item.get("displayName")
+        if display_name is not None and display_name == cache_key:
+            name = cached_item.get("name")
+            resolved = None if name is None else ResolvedCacheId(name=name, expire_time=cached_item.get("expireTime"))
+            return _PageMatch(resolved=resolved)
+    return None
+
+
+_CONTEXT_CACHE_ID_KEY_FIELD = "_vertex_context_cache_id_key"
+
+
+def _stash_context_cache_id_key(logging_obj: Logging, key: str) -> None:
+    """Record the resolving id-cache key on the logging object so a downstream NOT_FOUND
+    (server-side deleted/revoked cachedContent) can invalidate it via
+    `maybe_invalidate_stale_context_cache`. No-op when the feature is off or
+    model_call_details is not a dict."""
+    if not litellm.enable_vertex_context_cache_id_caching:
+        return
+    model_call_details = getattr(logging_obj, "model_call_details", None)
+    if isinstance(model_call_details, dict):
+        model_call_details[_CONTEXT_CACHE_ID_KEY_FIELD] = key
+
+
+def maybe_invalidate_stale_context_cache(logging_obj: Logging, status_code: int, response_text: str) -> None:
+    """If a request's resolved cachedContent is rejected downstream because it was
+    deleted/revoked server-side, drop the cached id so the next request re-resolves it.
+
+    Vertex reports a deleted cache as HTTP 400 INVALID_ARGUMENT ("Invalid resource state
+    for cache content <id>"), not 404, so we key off the *served id* appearing in the error
+    body rather than the status text: it names our exact id, so unrelated 4xx never evict a
+    live entry, and it doesn't matter which 4xx wording Vertex uses."""
+    if status_code not in (400, 403, 404):
+        return
+    model_call_details = getattr(logging_obj, "model_call_details", None)
+    if not isinstance(model_call_details, dict):
+        return
+    key = model_call_details.get(_CONTEXT_CACHE_ID_KEY_FIELD)
+    if not isinstance(key, str):
+        return
+    served_name = lookup_cache_id(key)
+    if served_name is None:
+        return
+    served_id = served_name.rsplit("/", 1)[-1]
+    if served_id not in response_text and served_name not in response_text:
+        return
+    invalidate_cache_id(key)
 
 
 class ContextCachingEndpoints(VertexBase):
@@ -102,7 +169,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
         model: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Optional[ResolvedCacheId]:
         """
         Checks if content already cached.
 
@@ -167,11 +234,9 @@ class ContextCachingEndpoints(VertexBase):
             if "cachedContents" not in all_cached_items:
                 return None
 
-            # Check current page for matching cache_key
-            for cached_item in all_cached_items["cachedContents"]:
-                display_name = cached_item.get("displayName")
-                if display_name is not None and display_name == cache_key:
-                    return cached_item.get("name")
+            match = _find_matching_cache(all_cached_items["cachedContents"], cache_key)
+            if match is not None:
+                return match.resolved
 
             # Check if there are more pages
             page_token = all_cached_items.get("nextPageToken")
@@ -194,7 +259,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
         model: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Optional[ResolvedCacheId]:
         """
         Checks if content already cached.
 
@@ -259,11 +324,9 @@ class ContextCachingEndpoints(VertexBase):
             if "cachedContents" not in all_cached_items:
                 return None
 
-            # Check current page for matching cache_key
-            for cached_item in all_cached_items["cachedContents"]:
-                display_name = cached_item.get("displayName")
-                if display_name is not None and display_name == cache_key:
-                    return cached_item.get("name")
+            match = _find_matching_cache(all_cached_items["cachedContents"], cache_key)
+            if match is not None:
+                return match.resolved
 
             # Check if there are more pages
             page_token = all_cached_items.get("nextPageToken")
@@ -360,7 +423,19 @@ class ContextCachingEndpoints(VertexBase):
         generated_cache_key = local_cache_obj.get_cache_key(
             messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
-        google_cache_name = self.check_cache(
+        id_cache_key = make_cache_id_key(
+            content_key=generated_cache_key,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        _stash_context_cache_id_key(logging_obj, id_cache_key)
+        cached_id = lookup_cache_id(id_cache_key)
+        if cached_id is not None:
+            return non_cached_messages, optional_params, cached_id
+        resolved_cache = self.check_cache(
             cache_key=generated_cache_key,
             client=client,
             headers=headers,
@@ -373,8 +448,9 @@ class ContextCachingEndpoints(VertexBase):
             vertex_auth_header=vertex_auth_header,
             model=model,
         )
-        if google_cache_name:
-            return non_cached_messages, optional_params, google_cache_name
+        if resolved_cache is not None:
+            store_cache_id(id_cache_key, resolved_cache.name, resolved_cache.expire_time)
+            return non_cached_messages, optional_params, resolved_cache.name
 
         ## TRANSFORM REQUEST
         cached_content_request_body = transform_openai_messages_to_gemini_context_caching(
@@ -418,10 +494,12 @@ class ContextCachingEndpoints(VertexBase):
         cached_content_response_obj = VertexAICachedContentResponseObject(
             name=raw_response_cached.get("name"), model=raw_response_cached.get("model")
         )
+        created_name = cached_content_response_obj["name"]
+        store_cache_id(id_cache_key, created_name, raw_response_cached.get("expireTime"))
         return (
             non_cached_messages,
             optional_params,
-            cached_content_response_obj["name"],
+            created_name,
         )
 
     async def async_check_and_create_cache(
@@ -506,7 +584,19 @@ class ContextCachingEndpoints(VertexBase):
         generated_cache_key = local_cache_obj.get_cache_key(
             messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
-        google_cache_name = await self.async_check_cache(
+        id_cache_key = make_cache_id_key(
+            content_key=generated_cache_key,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        _stash_context_cache_id_key(logging_obj, id_cache_key)
+        cached_id = lookup_cache_id(id_cache_key)
+        if cached_id is not None:
+            return non_cached_messages, optional_params, cached_id
+        resolved_cache = await self.async_check_cache(
             cache_key=generated_cache_key,
             client=client,
             headers=headers,
@@ -520,8 +610,9 @@ class ContextCachingEndpoints(VertexBase):
             model=model,
         )
 
-        if google_cache_name:
-            return non_cached_messages, optional_params, google_cache_name
+        if resolved_cache is not None:
+            store_cache_id(id_cache_key, resolved_cache.name, resolved_cache.expire_time)
+            return non_cached_messages, optional_params, resolved_cache.name
 
         ## TRANSFORM REQUEST
         cached_content_request_body = transform_openai_messages_to_gemini_context_caching(
@@ -565,10 +656,12 @@ class ContextCachingEndpoints(VertexBase):
         cached_content_response_obj = VertexAICachedContentResponseObject(
             name=raw_response_cached.get("name"), model=raw_response_cached.get("model")
         )
+        created_name = cached_content_response_obj["name"]
+        store_cache_id(id_cache_key, created_name, raw_response_cached.get("expireTime"))
         return (
             non_cached_messages,
             optional_params,
-            cached_content_response_obj["name"],
+            created_name,
         )
 
     def get_cache(self):

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -108,6 +108,17 @@ from .transformation import (
     sync_transform_request_body,
 )
 
+
+def _invalidate_stale_context_cache(logging_obj, status_code: int, response_text: str) -> None:
+    """Lazy wrapper: ``context_caching`` can't be imported at module load (circular import via
+    its module-level Cache()), so defer the import to call time like ``transformation`` does."""
+    from ..context_caching.vertex_ai_context_caching import (
+        maybe_invalidate_stale_context_cache,
+    )
+
+    maybe_invalidate_stale_context_cache(logging_obj, status_code, response_text)
+
+
 if TYPE_CHECKING:
     from pydantic import BaseModel
 
@@ -2574,6 +2585,7 @@ async def make_call(
         response.raise_for_status()
     except httpx.HTTPStatusError as e:
         exception_string = str(await e.response.aread())
+        _invalidate_stale_context_cache(logging_obj, e.response.status_code, exception_string)
         raise VertexAIError(
             status_code=e.response.status_code,
             message=VertexGeminiConfig().translate_exception_str(exception_string),
@@ -2622,9 +2634,11 @@ def make_sync_call(
     response = client.post(api_base, headers=headers, data=data, stream=True, logging_obj=logging_obj)
 
     if response.status_code != 200 and response.status_code != 201:
+        error_text = str(response.read())
+        _invalidate_stale_context_cache(logging_obj, response.status_code, error_text)
         raise VertexAIError(
             status_code=response.status_code,
-            message=str(response.read()),
+            message=error_text,
             headers=response.headers,
         )
 
@@ -2841,6 +2855,7 @@ class VertexLLM(VertexBase):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code = err.response.status_code
+            _invalidate_stale_context_cache(logging_obj, error_code, err.response.text)
             raise VertexAIError(
                 status_code=error_code,
                 message=err.response.text,
@@ -3046,6 +3061,7 @@ class VertexLLM(VertexBase):
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code = err.response.status_code
+            _invalidate_stale_context_cache(logging_obj, error_code, err.response.text)
             raise VertexAIError(
                 status_code=error_code,
                 message=err.response.text,

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_id_cache.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_id_cache.py
@@ -1,0 +1,185 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.llms.vertex_ai.context_caching import id_cache
+from litellm.llms.vertex_ai.context_caching.id_cache import (
+    SAFETY_MARGIN_SECONDS,
+    ResolvedCacheId,
+    _rfc3339_to_epoch,
+    expire_time_to_ttl,
+    lookup_cache_id,
+    make_cache_id_key,
+    store_cache_id,
+)
+
+FUTURE = "2099-01-01T00:00:00Z"
+FUTURE_EPOCH = _rfc3339_to_epoch(FUTURE)
+
+
+@pytest.fixture
+def enabled():
+    """Enable the feature and start from an empty cache; restore afterwards."""
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        yield
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+
+def _key(**overrides):
+    base = dict(
+        content_key="hash",
+        custom_llm_provider="vertex_ai",
+        vertex_project="proj",
+        vertex_location="us-central1",
+        api_base=None,
+        api_key="k",
+    )
+    base.update(overrides)
+    return make_cache_id_key(**base)
+
+
+# --- ttl derivation (spec: entry lifetime bounded by expireTime) ---
+
+def test_ttl_uses_expiretime_minus_margin():
+    # expireTime 3600s out -> ttl is 3600 - margin, measured against expireTime, not insertion
+    ttl = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 3600)
+    assert ttl == pytest.approx(3600 - SAFETY_MARGIN_SECONDS)
+
+
+def test_ttl_scales_with_expiretime_not_constant():
+    # regression guard: a near-expiry cache must get a SMALL ttl, not a fixed span.
+    near = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 90)
+    far = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 3600)
+    assert near == pytest.approx(90 - SAFETY_MARGIN_SECONDS)
+    assert far == pytest.approx(3600 - SAFETY_MARGIN_SECONDS)
+    assert near < far  # fails if ttl is ever a hardcoded constant
+
+
+@pytest.mark.parametrize(
+    "expire_time",
+    [None, "", "not-a-date", "2024-13-45T99:99:99Z"],
+)
+def test_ttl_none_when_unusable(expire_time):
+    assert expire_time_to_ttl(expire_time, now=0) is None
+
+
+def test_ttl_none_when_within_margin():
+    # expiry inside the SAFETY_MARGIN_SECONDS window -> not worth caching
+    assert expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - (SAFETY_MARGIN_SECONDS - 1)) is None
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        "2024-10-02T15:01:23Z",
+        "2024-10-02T15:01:23.045Z",
+        "2024-10-02T15:01:23.045123456Z",  # nanoseconds (Vertex form)
+        "2024-10-02T15:01:23+00:00",
+        "2024-10-02T15:01:23+0000",
+    ],
+)
+def test_rfc3339_parses_provider_shapes(ts):
+    assert _rfc3339_to_epoch(ts) is not None
+
+
+# --- flag gating (spec: off by default) ---
+
+def test_disabled_lookup_and_store_are_noops():
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = False
+    id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = _key()
+        store_cache_id(key, "cachedContents/1", FUTURE)
+        assert lookup_cache_id(key) is None
+        assert id_cache._EXPLICIT_CACHE_ID_CACHE.get_cache(key) is None
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+
+
+def test_flag_defaults_off():
+    # guard: nobody flips the default to on without an explicit decision
+    fresh = litellm.__dict__.get("enable_vertex_context_cache_id_caching")
+    assert fresh is False
+
+
+# --- round trip + expiry (spec: cache the id; never serve expired) ---
+
+def test_store_then_lookup_round_trip(enabled):
+    key = _key()
+    store_cache_id(key, "projects/p/locations/l/cachedContents/9", FUTURE)
+    assert lookup_cache_id(key) == "projects/p/locations/l/cachedContents/9"
+
+
+def test_numeric_gemini_id_round_trips_as_string(enabled):
+    key = _key(custom_llm_provider="gemini")
+    store_cache_id(key, "7096536676058529792", FUTURE)
+    got = lookup_cache_id(key)
+    assert got == "7096536676058529792"
+    assert isinstance(got, str)  # fails without the str() guard (json.loads -> int)
+
+
+def test_expired_entry_is_a_miss(enabled):
+    key = _key()
+    # already-expired entry: lookup must treat it as absent
+    id_cache._EXPLICIT_CACHE_ID_CACHE.set_cache(key, "cachedContents/1", ttl=-1)
+    assert lookup_cache_id(key) is None
+
+
+def test_within_margin_expiry_is_not_stored(enabled):
+    key = _key()
+    store_cache_id(key, "cachedContents/1", FUTURE, now=FUTURE_EPOCH - (SAFETY_MARGIN_SECONDS - 1))
+    assert lookup_cache_id(key) is None
+
+
+# --- key scoping (spec: scoped to endpoint/tenant) ---
+
+def test_same_inputs_same_key():
+    assert _key() == _key()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"custom_llm_provider": "gemini"},
+        {"vertex_project": "other"},
+        {"vertex_location": "europe-west1"},
+        {"api_base": "https://passthrough.example"},
+        {"api_key": "different"},
+        {"content_key": "other-hash"},
+    ],
+)
+def test_distinct_scope_distinct_key(override):
+    assert _key() != _key(**override)
+
+
+def test_cross_tenant_entry_is_not_served(enabled):
+    # project A stores its id; a byte-identical request under project B must miss
+    key_a = _key(vertex_project="A")
+    key_b = _key(vertex_project="B")
+    store_cache_id(key_a, "projects/A/.../cachedContents/1", FUTURE)
+    assert lookup_cache_id(key_b) is None
+    assert lookup_cache_id(key_a) == "projects/A/.../cachedContents/1"
+
+
+def test_key_does_not_leak_raw_api_key():
+    key = _key(api_key="super-secret-token")
+    assert "super-secret-token" not in key
+
+
+# --- bounded (spec: bounded) ---
+
+def test_cache_is_bounded(enabled):
+    cap = id_cache._MAX_ENTRIES
+    for i in range(cap * 2):
+        store_cache_id(_key(content_key=f"h{i}"), f"cachedContents/{i}", FUTURE)
+    assert len(id_cache._EXPLICIT_CACHE_ID_CACHE.cache_dict) <= cap

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -10,12 +10,19 @@ sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.vertex_ai.common_utils import VertexAIError
+from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+from litellm.llms.vertex_ai.context_caching.id_cache import ResolvedCacheId
 from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import (
     MAX_PAGINATION_PAGES,
     ContextCachingEndpoints,
+    _find_matching_cache,
+    _PageMatch,
+    _stash_context_cache_id_key,
+    maybe_invalidate_stale_context_cache,
 )
 
 
@@ -173,7 +180,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = (cached_messages, non_cached_messages)
 
         mock_cache_obj.get_cache_key.return_value = "test_cache_key"
-        mock_check_cache.return_value = "existing_cache_name"
+        mock_check_cache.return_value = ResolvedCacheId(name="existing_cache_name", expire_time=None)
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
@@ -449,7 +456,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = (cached_messages, non_cached_messages)
 
         mock_cache_obj.get_cache_key.return_value = "test_cache_key"
-        mock_async_check_cache.return_value = "existing_cache_name"
+        mock_async_check_cache.return_value = ResolvedCacheId(name="existing_cache_name", expire_time=None)
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
@@ -652,7 +659,7 @@ class TestContextCachingEndpoints:
 
             # Mock the check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
-                self.context_caching, "check_cache", return_value="existing_cache"
+                self.context_caching, "check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 # Execute
                 result = self.context_caching.check_and_create_cache(
@@ -782,7 +789,7 @@ class TestContextCachingEndpoints:
 
             # Mock the async_check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
-                self.context_caching, "async_check_cache", return_value="existing_cache"
+                self.context_caching, "async_check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 # Execute
                 result = await self.context_caching.async_check_and_create_cache(
@@ -824,7 +831,7 @@ class TestContextCachingEndpoints:
             optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
-                self.context_caching, "check_cache", return_value="existing_cache"
+                self.context_caching, "check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 self.context_caching.check_and_create_cache(
                     messages=self.sample_messages,
@@ -895,7 +902,7 @@ class TestContextCachingEndpoints:
             optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
-                self.context_caching, "async_check_cache", return_value="existing_cache"
+                self.context_caching, "async_check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 await self.context_caching.async_check_and_create_cache(
                     messages=self.sample_messages,
@@ -1318,7 +1325,7 @@ class TestContextCachingEndpoints:
         cached_messages = [self.sample_messages[0]]
         non_cached_messages = [self.sample_messages[1]]
         mock_separate.return_value = (cached_messages, non_cached_messages)
-        mock_check_cache.return_value = "existing_cache"
+        mock_check_cache.return_value = ResolvedCacheId(name="existing_cache", expire_time=None)
 
         auto_tool_choice = {"functionCallingConfig": {"mode": "AUTO"}}
         any_tool_choice = {"functionCallingConfig": {"mode": "ANY"}}
@@ -1512,11 +1519,46 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_client.get.call_count == 2
         # Check that second call includes pageToken
         second_call_url = self.mock_client.get.call_args_list[1].kwargs["url"]
         assert "pageToken=token_page_2" in second_call_url
+
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    def test_check_cache_nameless_match_stops_pagination(self, mock_get_token_url):
+        """A displayName match with a null name is a miss, but must STOP pagination early
+        (displayName is unique), not fall through and fetch later pages."""
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        cache_key_to_find = "target_cache_key"
+
+        first_page_response = MagicMock()
+        first_page_response.json.return_value = {
+            "cachedContents": [{"displayName": cache_key_to_find}],  # matches displayName, no name
+            "nextPageToken": "token_page_2",
+        }
+        # If pagination wrongly continues, this page's usable id would be returned.
+        second_page_response = MagicMock()
+        second_page_response.json.return_value = {
+            "cachedContents": [{"name": "must_not_be_used", "displayName": cache_key_to_find}],
+        }
+        self.mock_client.get.side_effect = [first_page_response, second_page_response]
+
+        result = self.context_caching.check_cache(
+            cache_key=cache_key_to_find,
+            client=self.mock_client,
+            headers={"Authorization": "Bearer token"},
+            api_key="test_key",
+            api_base=None,
+            logging_obj=self.mock_logging,
+            custom_llm_provider="vertex_ai",
+            vertex_project="test_project",
+            vertex_location="us-central1",
+            vertex_auth_header="Bearer test-token",
+        )
+
+        assert result is None  # nameless match -> miss
+        assert self.mock_client.get.call_count == 1  # stopped early, never fetched page 2
 
     @pytest.mark.parametrize(
         "custom_llm_provider", ["gemini", "vertex_ai", "vertex_ai_beta"]
@@ -1606,7 +1648,7 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_client.get.call_count == 3
 
     @pytest.mark.asyncio
@@ -1661,7 +1703,7 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_async_client.get.call_count == 2
         # Check that second call includes pageToken
         second_call_url = self.mock_async_client.get.call_args_list[1].kwargs["url"]
@@ -1971,3 +2013,256 @@ class TestContextCachingMultiRegionUrls:
 
         assert url.startswith("https://aiplatform.googleapis.com/")
         assert "/locations/global/cachedContents" in url
+
+
+_FAR_FUTURE = "2099-01-01T00:00:00Z"
+
+# The real shape Vertex returns when a resolved cachedContent was deleted/revoked server-side.
+_STALE_ID = "1973906229814099968"
+_STALE_NAME = f"cachedContents/{_STALE_ID}"
+
+
+def _deleted_cache_error(cache_id: str) -> str:
+    return (
+        '{"error": {"code": 400, "message": "Invalid resource state for cache content '
+        + cache_id
+        + '.", "status": "INVALID_ARGUMENT"}}'
+    )
+
+
+class TestContextCachingIdCacheWiring:
+    """Discovery-path wiring of the in-memory explicit-cache-id cache.
+
+    These assert the id cache is consulted/populated at the right points and
+    that it is scoped per endpoint/tenant, by counting LIST (check_cache) and
+    create (client.post) calls across successive resolutions.
+    """
+
+    def setup_method(self):
+        self.context_caching = ContextCachingEndpoints()
+        self.mock_logging = MagicMock(spec=Logging)
+        self.mock_client = MagicMock(spec=HTTPHandler)
+        self._token_check_patcher = patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.is_prompt_caching_valid_prompt",
+            return_value=True,
+        )
+        self._token_check_patcher.start()
+        self._prev_flag = litellm.enable_vertex_context_cache_id_caching
+        litellm.enable_vertex_context_cache_id_caching = True
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+        self.messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def teardown_method(self):
+        self._token_check_patcher.stop()
+        litellm.enable_vertex_context_cache_id_caching = self._prev_flag
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+    def _resolve(self, provider="vertex_ai", project="proj", location="us-central1"):
+        return self.context_caching.check_and_create_cache(
+            messages=self.messages,
+            optional_params={},
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=provider,
+            vertex_project=project,
+            vertex_location=location,
+            vertex_auth_header="Bearer token",
+        )
+
+    @pytest.mark.parametrize("provider", ["vertex_ai", "gemini"])
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_warm_hit_skips_the_list(self, mock_check_cache, provider):
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/1", expire_time=_FAR_FUTURE
+        )
+
+        first = self._resolve(provider=provider)
+        second = self._resolve(provider=provider)
+
+        assert first[2] == "cachedContents/1"
+        assert second[2] == "cachedContents/1"
+        # second resolution served from the id cache -> LIST issued only once
+        assert mock_check_cache.call_count == 1
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_disabled_flag_always_lists(self, mock_check_cache):
+        litellm.enable_vertex_context_cache_id_caching = False
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/1", expire_time=_FAR_FUTURE
+        )
+
+        self._resolve()
+        self._resolve()
+
+        assert mock_check_cache.call_count == 2  # no id-cache skip
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_different_project_does_not_reuse_id(self, mock_check_cache):
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/A", expire_time=_FAR_FUTURE
+        )
+
+        self._resolve(project="A")
+        self._resolve(project="B")  # identical content, different tenant
+
+        # project B must not be served project A's cached id -> it LISTs again
+        assert mock_check_cache.call_count == 2
+
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_created_id_is_cached_and_skips_create_next_time(
+        self, mock_check_cache, mock_transform, mock_get_token_url
+    ):
+        mock_check_cache.return_value = None  # nothing existing
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+        post_response = MagicMock()
+        post_response.json.return_value = {
+            "name": "cachedContents/new",
+            "model": "gemini-1.5-pro",
+            "expireTime": _FAR_FUTURE,
+        }
+        self.mock_client.post.return_value = post_response
+
+        first = self._resolve()
+        second = self._resolve()
+
+        assert first[2] == "cachedContents/new"
+        assert second[2] == "cachedContents/new"
+        # create happened once; second resolution served from the id cache
+        assert self.mock_client.post.call_count == 1
+        assert mock_check_cache.call_count == 1
+
+    async def _resolve_async(self, provider="vertex_ai", project="proj", location="us-central1"):
+        return await self.context_caching.async_check_and_create_cache(
+            messages=self.messages,
+            optional_params={},
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=AsyncMock(spec=AsyncHTTPHandler),
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=provider,
+            vertex_project=project,
+            vertex_location=location,
+            vertex_auth_header="Bearer token",
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(ContextCachingEndpoints, "async_check_cache")
+    async def test_async_warm_hit_skips_the_list(self, mock_async_check_cache):
+        mock_async_check_cache.return_value = ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE)
+
+        first = await self._resolve_async()  # cold: LIST
+        second = await self._resolve_async()  # warm: served from the id cache
+
+        assert first[2] == "cachedContents/1"
+        assert second[2] == "cachedContents/1"
+        assert mock_async_check_cache.call_count == 1
+
+    # --- self-healing: stash the resolving key, invalidate on downstream NOT_FOUND ---
+
+    def test_stash_records_key_when_enabled(self):
+        obj = MagicMock(spec=Logging)
+        obj.model_call_details = {}
+        _stash_context_cache_id_key(obj, "the-key")
+        assert obj.model_call_details["_vertex_context_cache_id_key"] == "the-key"
+
+    def test_stash_is_noop_when_disabled(self):
+        litellm.enable_vertex_context_cache_id_caching = False
+        obj = MagicMock(spec=Logging)
+        obj.model_call_details = {}
+        _stash_context_cache_id_key(obj, "the-key")
+        assert obj.model_call_details == {}
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_stale_id_invalidated_then_relists(self, mock_check_cache):
+        mock_check_cache.return_value = ResolvedCacheId(name=_STALE_NAME, expire_time=_FAR_FUTURE)
+        self.mock_logging.model_call_details = {"litellm_params": {"metadata": {}}}
+
+        self._resolve()  # cold: LIST + store + stash key
+        self._resolve()  # warm: served from cache
+        assert mock_check_cache.call_count == 1
+
+        # A cache deleted server-side is reported by Vertex as HTTP 400 INVALID_ARGUMENT,
+        # not 404, and the id appears without the "cachedContents/" prefix. Using the real
+        # shape here is the regression guard: the previous 403/404 + "cachedcontent" match
+        # would not have fired on this.
+        maybe_invalidate_stale_context_cache(self.mock_logging, 400, _deleted_cache_error(_STALE_ID))
+
+        self._resolve()  # entry evicted -> re-LISTs (self-heal)
+        assert mock_check_cache.call_count == 2
+
+    @pytest.mark.parametrize(
+        "model_call_details",
+        [None, {}],  # non-dict details; a dict but no key stashed (request never used the id cache)
+    )
+    def test_invalidate_noops_without_a_stashed_key(self, model_call_details):
+        obj = MagicMock(spec=Logging)
+        obj.model_call_details = model_call_details
+        # must bail before touching the cache; "does not raise" kills the guard mutations
+        assert maybe_invalidate_stale_context_cache(obj, 400, _deleted_cache_error(_STALE_ID)) is None
+
+    def test_invalidate_noops_when_key_has_no_cache_entry(self):
+        # key stashed but nothing cached under it (e.g. already evicted) -> lookup miss -> bail
+        obj = MagicMock(spec=Logging)
+        obj.model_call_details = {}
+        _stash_context_cache_id_key(obj, "some|unstored|key")
+        assert maybe_invalidate_stale_context_cache(obj, 400, _deleted_cache_error(_STALE_ID)) is None
+
+    @pytest.mark.parametrize(
+        "status_code, body",
+        [
+            (500, _deleted_cache_error(_STALE_ID)),  # names our id, but a 5xx (not evicted)
+            (400, "RESOURCE_EXHAUSTED: quota exceeded, retry later"),  # right status, our id absent
+        ],
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_unrelated_error_keeps_cached_id(self, mock_check_cache, status_code, body):
+        mock_check_cache.return_value = ResolvedCacheId(name=_STALE_NAME, expire_time=_FAR_FUTURE)
+        self.mock_logging.model_call_details = {"litellm_params": {"metadata": {}}}
+
+        self._resolve()
+        self._resolve()
+        assert mock_check_cache.call_count == 1
+
+        maybe_invalidate_stale_context_cache(self.mock_logging, status_code, body)
+
+        self._resolve()  # still warm -> no extra LIST
+        assert mock_check_cache.call_count == 1
+
+
+class TestFindMatchingCache:
+    def test_matches_displayname_and_returns_resolved_id(self):
+        items = [
+            {"displayName": "other", "name": "cachedContents/0"},
+            {"displayName": "k", "name": "cachedContents/1", "expireTime": _FAR_FUTURE},
+        ]
+        match = _find_matching_cache(items, "k")
+        assert match == _PageMatch(resolved=ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE))
+
+    def test_matched_but_nameless_entry_stops_paging_as_miss(self):
+        # A displayName match with a null name must still signal "matched this page"
+        # (a _PageMatch, not None) so the caller stops paginating, while resolving to
+        # None (miss -> recreate). Conflating it with "no match" is the regression this guards.
+        match = _find_matching_cache([{"displayName": "k"}], "k")
+        assert match is not None
+        assert match == _PageMatch(resolved=None)
+
+    def test_no_displayname_match_returns_none(self):
+        assert _find_matching_cache([{"displayName": "other", "name": "cachedContents/1"}], "k") is None

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5248,3 +5248,243 @@ def test_process_candidates_merges_thought_signatures_and_server_side_tools():
     fields = model_response.choices[-1].message.provider_specific_fields
     assert fields["thought_signatures"] == ["sig-text"]
     assert fields["server_side_tool_invocations"][0]["id"] == "tool-1"
+
+
+def test_make_sync_call_invalidates_stale_cachedcontent_on_400():
+    """A 400 INVALID_ARGUMENT referencing a cachedContent on the sync streaming path drops the
+    resolved id from the in-memory cache (self-heal), so the next resolve re-LISTs."""
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+    from litellm.llms.vertex_ai.context_caching.id_cache import lookup_cache_id, store_cache_id
+    from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import _CONTEXT_CACHE_ID_KEY_FIELD
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import make_sync_call
+
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = "vertex_ai|proj|us-central1||auth|hash"
+        store_cache_id(key, "cachedContents/1973906229814099968", "2099-01-01T00:00:00Z")
+        assert lookup_cache_id(key) == "cachedContents/1973906229814099968"
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {_CONTEXT_CACHE_ID_KEY_FIELD: key}
+
+        response = MagicMock()
+        response.status_code = 400
+        response.read.return_value = (
+            b'{"error": {"code": 400, "message": "Invalid resource state for cache content'
+            b' 1973906229814099968.", "status": "INVALID_ARGUMENT"}}'
+        )
+        response.headers = {}
+        client = MagicMock(spec=HTTPHandler)
+        client.post.return_value = response
+
+        with pytest.raises(VertexAIError):
+            make_sync_call(
+                client=client,
+                gemini_client=None,
+                api_base="https://example.com",
+                headers={},
+                data="{}",
+                model="gemini-pro",
+                messages=[],
+                logging_obj=logging_obj,
+            )
+
+        assert lookup_cache_id(key) is None  # evicted -> next request re-LISTs
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+
+@pytest.mark.asyncio
+async def test_make_call_invalidates_stale_cachedcontent_on_400():
+    """Async streaming equivalent: a 400 INVALID_ARGUMENT referencing a cachedContent evicts the id."""
+    from unittest.mock import AsyncMock
+
+    import httpx
+
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+    from litellm.llms.vertex_ai.context_caching.id_cache import lookup_cache_id, store_cache_id
+    from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import _CONTEXT_CACHE_ID_KEY_FIELD
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import make_call
+
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = "vertex_ai|proj|us-central1||auth|hash"
+        store_cache_id(key, "cachedContents/1973906229814099968", "2099-01-01T00:00:00Z")
+        assert lookup_cache_id(key) == "cachedContents/1973906229814099968"
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {_CONTEXT_CACHE_ID_KEY_FIELD: key}
+
+        err_response = MagicMock()
+        err_response.status_code = 400
+        err_response.aread = AsyncMock(
+            return_value=b'{"error": {"code": 400, "message": "Invalid resource state for cache content'
+            b' 1973906229814099968.", "status": "INVALID_ARGUMENT"}}'
+        )
+        err_response.headers = {}
+        post_response = MagicMock()
+        post_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "e", request=MagicMock(), response=err_response
+        )
+        client = MagicMock(spec=AsyncHTTPHandler)
+        client.post = AsyncMock(return_value=post_response)
+
+        with pytest.raises(VertexAIError):
+            await make_call(
+                client=client,
+                gemini_client=None,
+                api_base="https://example.com",
+                headers={},
+                data="{}",
+                model="gemini-pro",
+                messages=[],
+                logging_obj=logging_obj,
+            )
+
+        assert lookup_cache_id(key) is None
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+
+def test_completion_invalidates_stale_cachedcontent_on_400():
+    """Non-streaming sync path: a 400 INVALID_ARGUMENT referencing a cachedContent evicts the id."""
+    import httpx
+
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+    from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+    from litellm.llms.vertex_ai.context_caching.id_cache import lookup_cache_id, store_cache_id
+    from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import _CONTEXT_CACHE_ID_KEY_FIELD
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
+
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = "vertex_ai|proj|us-central1||auth|hash"
+        store_cache_id(key, "cachedContents/1973906229814099968", "2099-01-01T00:00:00Z")
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {_CONTEXT_CACHE_ID_KEY_FIELD: key}
+
+        err_response = MagicMock()
+        err_response.status_code = 400
+        err_response.text = (
+            '{"error": {"code": 400, "message": "Invalid resource state for cache content'
+            ' 1973906229814099968.", "status": "INVALID_ARGUMENT"}}'
+        )
+        err_response.headers = {}
+        client = MagicMock(spec=HTTPHandler)
+        client.post.side_effect = httpx.HTTPStatusError("e", request=MagicMock(), response=err_response)
+
+        with patch.object(VertexLLM, "_ensure_access_token", return_value=("auth", "proj")), patch.object(
+            VertexLLM, "_get_token_and_url", return_value=("auth", "https://x/y")
+        ), patch(
+            "litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini.VertexGeminiConfig.validate_environment",
+            return_value={},
+        ), patch(
+            "litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini.sync_transform_request_body",
+            return_value={"contents": []},
+        ):
+            with pytest.raises(VertexAIError):
+                VertexLLM().completion(
+                    model="gemini-pro",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model_response=litellm.ModelResponse(),
+                    print_verbose=lambda *a, **k: None,
+                    custom_llm_provider="vertex_ai",
+                    encoding=MagicMock(),
+                    logging_obj=logging_obj,
+                    optional_params={},
+                    acompletion=False,
+                    timeout=30.0,
+                    vertex_project="proj",
+                    vertex_location="us-central1",
+                    vertex_credentials=None,
+                    gemini_api_key=None,
+                    litellm_params={},
+                    client=client,
+                )
+
+        assert lookup_cache_id(key) is None
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+
+@pytest.mark.asyncio
+async def test_async_completion_invalidates_stale_cachedcontent_on_400():
+    """Non-streaming async path: a 400 INVALID_ARGUMENT referencing a cachedContent evicts the id."""
+    from unittest.mock import AsyncMock
+
+    import httpx
+
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+    from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+    from litellm.llms.vertex_ai.context_caching.id_cache import lookup_cache_id, store_cache_id
+    from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import _CONTEXT_CACHE_ID_KEY_FIELD
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import VertexLLM
+
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = "vertex_ai|proj|us-central1||auth|hash"
+        store_cache_id(key, "cachedContents/1973906229814099968", "2099-01-01T00:00:00Z")
+
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {_CONTEXT_CACHE_ID_KEY_FIELD: key}
+
+        err_response = MagicMock()
+        err_response.status_code = 400
+        err_response.text = (
+            '{"error": {"code": 400, "message": "Invalid resource state for cache content'
+            ' 1973906229814099968.", "status": "INVALID_ARGUMENT"}}'
+        )
+        err_response.headers = {}
+        post_response = MagicMock()
+        post_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "e", request=MagicMock(), response=err_response
+        )
+        client = MagicMock(spec=AsyncHTTPHandler)
+        client.post = AsyncMock(return_value=post_response)
+
+        with patch.object(
+            VertexLLM, "_ensure_access_token_async", new=AsyncMock(return_value=("auth", "proj"))
+        ), patch.object(VertexLLM, "_get_token_and_url", return_value=("auth", "https://x/y")), patch(
+            "litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini.VertexGeminiConfig.validate_environment",
+            return_value={},
+        ), patch(
+            "litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini.async_transform_request_body",
+            new=AsyncMock(return_value={"contents": []}),
+        ):
+            with pytest.raises(VertexAIError):
+                await VertexLLM().async_completion(
+                    model="gemini-pro",
+                    messages=[{"role": "user", "content": "hi"}],
+                    model_response=litellm.ModelResponse(),
+                    print_verbose=lambda *a, **k: None,
+                    data={},
+                    custom_llm_provider="vertex_ai",
+                    timeout=30.0,
+                    encoding=MagicMock(),
+                    logging_obj=logging_obj,
+                    stream=False,
+                    optional_params={},
+                    litellm_params={},
+                    vertex_project="proj",
+                    vertex_location="us-central1",
+                    client=client,
+                )
+
+        assert lookup_cache_id(key) is None
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible
- [x] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Across 46 real requests that read an explicit cache, cache id (context cache name) discovery added median 1552ms / p99 4132ms of LiteLLM overhead; the id cache turns each into a single-digit-ms warm hit.

Live proxy against real Vertex (`gemini-3.1-flash-lite`, `global`), same request twice with a `cache_control` prefix over the min-token floor:

```
req 1 (cold): 6.45s   cachedContents LIST + create, overhead ~4000ms
req 2 (warm): 1.20s   reused from the in-memory id cache, overhead ~3ms, no LIST/create
```

Self-healing on a server-side deletion (the `invalidate_cache_id` fix): warm the cache, delete the cachedContent through the Vertex API, then replay the same request. Vertex rejects the dead id with HTTP 400 `INVALID_ARGUMENT`; the id cache evicts it and the next request re-creates and succeeds, instead of failing until the ttl expires:

```
req 1 (cold): 5.00s   create cachedContent + cache the resolved id
req 2 (warm): 1.13s   id-cache hit, skips LIST
DELETE .../cachedContents/1973906229814099968  ->  200   (deleted server-side)
req 3 (warm): 0.34s   400 INVALID_ARGUMENT "Invalid resource state for cache content ..."  ->  id invalidated
req 4 (heal): 4.39s   id evicted -> re-LIST/create -> 200
req 5 (warm): 1.22s   warm hit on the freshly-created id
```

## Type

🆕 New Feature

## Changes

Vertex/Gemini explicit context caching returns a `cachedContents` id you pass on later requests. Callers using `cache_control` breakpoints instead of holding that id make LiteLLM re-discover it every turn via a live `cachedContents` LIST (p50 1552ms/p99 4132ms), plus a create on a cold prefix

Adds an in-memory (`InMemoryCache`), bounded, TTL-aware cache of resolved ids in `litellm/llms/vertex_ai/context_caching/id_cache.py`, consulted before the LIST in both the sync and async paths, covering Vertex AI, Vertex AI Beta, and Gemini. Each entry's ttl is the cachedContent's real `expireTime` minus a 5s safety margin (never a fixed span), and the key is namespaced by provider/project/location/api_base/credential, so a warm cache can never serve an expired or cross-tenant id.

Two knobs, both `id_cache.py` module constants. `SAFETY_MARGIN_SECONDS = 5` is subtracted from `expireTime` when computing the ttl and absorbs clock skew plus the in-flight time between resolving the id and the downstream `generateContent`, so an entry nearing expiry is dropped rather than handed out and failing with NOT_FOUND; an `expireTime` already inside that window is never stored. `_MAX_ENTRIES = 1024` bounds the cache (`InMemoryCache(max_size_in_memory=1024)`), so memory stays flat under many distinct prefixes and the oldest entries evict; a cold or evicted entry just falls back to the normal LIST. Off by default behind `litellm.enable_vertex_context_cache_id_caching`; on a miss the path is byte-for-byte unchanged, so the server-side displayName dedup and cache creation are preserved

ttl bounds natural expiry, but a cachedContent can also be deleted or revoked server-side before then. The old per-request LIST re-verified existence and so implicitly self-healed; a warm hit skips that LIST, so a dead id would fail downstream with no recovery. `id_cache` exposes `invalidate_cache_id` and the completion handler drops the offending entry when generateContent rejects it. Vertex reports a deleted cache as HTTP 400 `INVALID_ARGUMENT` ("Invalid resource state for cache content <id>"), not a 404, so the handler matches the served id in the error body rather than a status/message substring; the next request then re-resolves via LIST/create instead of re-serving the dead id. Verified live: warm hit -> delete the cachedContent server-side -> the next request 400s once and invalidates, then the following request self-heals by re-creating. The pagination helper also distinguishes a displayName match with a null name (stop early, treat as miss) from no match on the page (keep paging), preserving the original stop-early semantics

Tests in `tests/test_litellm/llms/vertex_ai/context_caching/` cover the warm-hit LIST-skip (sync and async), the `expireTime`-derived ttl with a fixed-span regression guard, tenant/content key isolation, the off-by-default flag, bounded eviction, stale-id invalidation and re-LIST when generateContent rejects a deleted cache with the real HTTP 400 `INVALID_ARGUMENT` error (and that unrelated errors keep the entry), and the null-name pagination stop-early behavior



