### PR TITLE
feat(vertex_ai): cache resolved explicit context-cache ids in-memory to skip cachedContents discovery

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -359,6 +359,7 @@ enable_key_alias_format_validation: bool = (
 enable_gemini_default_thinking_level_low: bool = (
     False  # opt-in: force thinkingLevel low/minimal for Gemini 3 thinking param mapping
 )
+enable_vertex_context_cache_id_caching: bool = False  # opt-in: in-memory cache of resolved Vertex/Gemini explicit context-cache ids, skips the per-request cachedContents LIST
 ####################
 logging: bool = True
 enable_loadbalancing_on_batch_endpoints: Optional[bool] = None

--- a/litellm/llms/vertex_ai/context_caching/README.md
+++ b/litellm/llms/vertex_ai/context_caching/README.md
@@ -1,0 +1,27 @@
+# Vertex / Gemini explicit context caching
+
+Handles the `cachedContents` (explicit context cache) flow for Vertex AI, Vertex AI Beta, and Gemini (Google AI Studio). When a request marks a prefix with `cache_control` breakpoints instead of passing a flat `cached_content` id, the discovery path in `vertex_ai_context_caching.py` resolves the cachedContent id by hashing the messages and issuing a live `cachedContents` LIST.
+
+## In-memory cache of resolved cache ids
+
+That LIST is a control-plane round trip (p50 1552ms) paid on every request. `id_cache.py` caches the resolved cachedContent `name` in-memory so a warm request skips it. Off by default; enable with
+
+```yaml
+litellm_settings:
+  enable_vertex_context_cache_id_caching: true
+```
+
+or from the SDK
+
+```python
+import litellm
+litellm.enable_vertex_context_cache_id_caching = True
+```
+
+It covers both Vertex AI and Gemini/AI Studio; the p50 1552ms saving is measured on Vertex.
+
+Correctness properties, enforced by `id_cache.py`:
+
+- Each entry's ttl is derived from the backing cachedContent's real `expireTime` (minus a 5s safety margin), never a fixed span from insertion, so a cache hit can never outlive its backing cachedContent (which would fail downstream `generateContent` with NOT_FOUND). If `expireTime` is absent or unparseable the entry is not stored, degrading safely to always-LIST
+- The key is namespaced by `(custom_llm_provider, vertex_project, vertex_location, api_base, credential-hash)`, so an id created under one provider/project/location/endpoint/credential is never served to another
+- The cache is bounded and in-memory (no Redis), so each process holds its own copy; a cold process still LISTs and so still dedups against caches created by peers

--- a/litellm/llms/vertex_ai/context_caching/id_cache.py
+++ b/litellm/llms/vertex_ai/context_caching/id_cache.py
@@ -1,0 +1,124 @@
+"""
+In-memory cache of resolved Vertex/Gemini explicit context-cache ids.
+
+The discovery path in ``vertex_ai_context_caching.py`` otherwise re-resolves the
+cachedContent id on every request via a live ``cachedContents`` LIST (p50 1552ms). This
+caches the resolved ``name`` in-memory so a warm request skips that round trip.
+
+Off by default; enable via ``litellm.enable_vertex_context_cache_id_caching``.
+
+Correctness invariants:
+- Each entry's ttl is derived from the backing cachedContent's real ``expireTime``
+  minus a safety margin, never a fixed span from insertion, so a hit can never
+  outlive its backing cache (which would fail downstream generateContent with NOT_FOUND).
+- The key is namespaced by the resolving endpoint/tenant so an id created under one
+  provider/project/location/endpoint/credential is never served to another.
+"""
+
+import hashlib
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+import litellm
+from litellm.caching.in_memory_cache import InMemoryCache
+
+SAFETY_MARGIN_SECONDS = 5
+_MAX_ENTRIES = 1024
+
+_EXPLICIT_CACHE_ID_CACHE = InMemoryCache(max_size_in_memory=_MAX_ENTRIES)
+
+_RFC3339_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d+))?(Z|[+-]\d{2}:?\d{2})$")
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCacheId:
+    name: str
+    expire_time: Optional[str]
+
+
+def _rfc3339_to_epoch(expire_time: str) -> Optional[float]:
+    """Vertex/Gemini return e.g. ``2024-10-02T15:01:23.045123456Z`` (nanosecond, Z).
+
+    ``datetime.fromisoformat`` only tolerates the ``Z`` suffix and >6 fractional
+    digits on Python 3.11+, but litellm supports 3.10, so normalize first.
+    """
+    match = _RFC3339_RE.match(expire_time.strip())
+    if match is None:
+        return None
+    base, frac, tz = match.group(1), match.group(2), match.group(3)
+    micros = frac[:6].ljust(6, "0") if frac else "000000"
+    if tz == "Z":
+        offset = "+00:00"
+    elif ":" in tz:
+        offset = tz
+    else:
+        offset = f"{tz[:3]}:{tz[3:]}"
+    try:
+        return datetime.fromisoformat(f"{base}.{micros}{offset}").timestamp()
+    except ValueError:
+        return None
+
+
+def expire_time_to_ttl(expire_time: Optional[str], now: Optional[float] = None) -> Optional[float]:
+    """Seconds until ``expire_time`` minus the safety margin, or ``None`` when the
+    value is absent, unparseable, or already within the margin (i.e. not cacheable)."""
+    if not expire_time:
+        return None
+    epoch = _rfc3339_to_epoch(expire_time)
+    if epoch is None:
+        return None
+    ttl = epoch - (time.time() if now is None else now) - SAFETY_MARGIN_SECONDS
+    return ttl if ttl > 0 else None
+
+
+def make_cache_id_key(
+    content_key: str,
+    custom_llm_provider: str,
+    vertex_project: Optional[str],
+    vertex_location: Optional[str],
+    api_base: Optional[str],
+    api_key: Optional[str],
+) -> str:
+    """Namespace the content hash by everything that determines which cachedContents
+    endpoint/tenant the LIST would target, so ids never leak across tenants.
+
+    The credential is folded in as a stable, non-reversible hash (never the raw secret).
+    """
+    auth_id = hashlib.sha256((api_key or "").encode()).hexdigest()[:16]
+    return "|".join(
+        (
+            custom_llm_provider,
+            vertex_project or "",
+            vertex_location or "",
+            api_base or "",
+            auth_id,
+            content_key,
+        )
+    )
+
+
+def lookup_cache_id(key: str) -> Optional[str]:
+    """Resolved cachedContent name for a live entry, else ``None``. No-op (miss) when
+    the feature is disabled. ``str(...)`` guards ``InMemoryCache.get_cache``'s
+    ``json.loads`` coercion, which would turn a numeric Gemini id into an int."""
+    if not litellm.enable_vertex_context_cache_id_caching:
+        return None
+    hit = _EXPLICIT_CACHE_ID_CACHE.get_cache(key)
+    if hit is None:
+        return None
+    return str(hit)
+
+
+def store_cache_id(key: str, name: Optional[str], expire_time: Optional[str], now: Optional[float] = None) -> None:
+    """Cache ``name`` under ``key`` with a ttl bounded by ``expire_time``. No-op when the
+    feature is disabled, the name is empty, or the ttl is not derivable (safe degrade to
+    always-LIST)."""
+    if not name or not litellm.enable_vertex_context_cache_id_caching:
+        return
+    ttl = expire_time_to_ttl(expire_time, now=now)
+    if ttl is None:
+        return
+    _EXPLICIT_CACHE_ID_CACHE.set_cache(key, name, ttl=ttl)

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -15,12 +15,19 @@ from litellm._logging import verbose_logger
 from litellm.llms.openai.openai import AllMessageValues
 from litellm.utils import is_prompt_caching_valid_prompt
 from litellm.types.llms.vertex_ai import (
+    CachedContent,
     CachedContentListAllResponseBody,
     VertexAICachedContentResponseObject,
 )
 
 from ..common_utils import VertexAIError, get_vertex_base_url
 from ..vertex_llm_base import VertexBase
+from .id_cache import (
+    ResolvedCacheId,
+    lookup_cache_id,
+    make_cache_id_key,
+    store_cache_id,
+)
 from .transformation import (
     separate_cached_messages,
     transform_openai_messages_to_gemini_context_caching,
@@ -29,6 +36,35 @@ from .transformation import (
 local_cache_obj = Cache(type=LiteLLMCacheType.LOCAL)  # only used for calling 'get_cache_key' function
 
 MAX_PAGINATION_PAGES = 100  # Reasonable upper bound for pagination
+
+
+def _find_matching_cache(cached_items: list[CachedContent], cache_key: str) -> Optional[ResolvedCacheId]:
+    for cached_item in cached_items:
+        display_name = cached_item.get("displayName")
+        if display_name is not None and display_name == cache_key:
+            name = cached_item.get("name")
+            if name is None:
+                return None
+            return ResolvedCacheId(name=name, expire_time=cached_item.get("expireTime"))
+    return None
+
+
+def _record_id_cache_status(logging_obj: Logging, hit: bool) -> None:
+    """Surface the in-memory id-cache outcome in SpendLogs/UI as the typed
+    `explicit_context_cache_id_hit` metadata field. No-op when the feature is off or the
+    logging metadata is not a dict."""
+    if not litellm.enable_vertex_context_cache_id_caching:
+        return
+    model_call_details = getattr(logging_obj, "model_call_details", None)
+    if not isinstance(model_call_details, dict):
+        return
+    litellm_params = model_call_details.get("litellm_params")
+    if not isinstance(litellm_params, dict):
+        return
+    metadata = litellm_params.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    metadata["explicit_context_cache_id_hit"] = hit
 
 
 class ContextCachingEndpoints(VertexBase):
@@ -102,7 +138,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
         model: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Optional[ResolvedCacheId]:
         """
         Checks if content already cached.
 
@@ -167,11 +203,9 @@ class ContextCachingEndpoints(VertexBase):
             if "cachedContents" not in all_cached_items:
                 return None
 
-            # Check current page for matching cache_key
-            for cached_item in all_cached_items["cachedContents"]:
-                display_name = cached_item.get("displayName")
-                if display_name is not None and display_name == cache_key:
-                    return cached_item.get("name")
+            match = _find_matching_cache(all_cached_items["cachedContents"], cache_key)
+            if match is not None:
+                return match
 
             # Check if there are more pages
             page_token = all_cached_items.get("nextPageToken")
@@ -194,7 +228,7 @@ class ContextCachingEndpoints(VertexBase):
         vertex_location: Optional[str],
         vertex_auth_header: Optional[str],
         model: Optional[str] = None,
-    ) -> Optional[str]:
+    ) -> Optional[ResolvedCacheId]:
         """
         Checks if content already cached.
 
@@ -259,11 +293,9 @@ class ContextCachingEndpoints(VertexBase):
             if "cachedContents" not in all_cached_items:
                 return None
 
-            # Check current page for matching cache_key
-            for cached_item in all_cached_items["cachedContents"]:
-                display_name = cached_item.get("displayName")
-                if display_name is not None and display_name == cache_key:
-                    return cached_item.get("name")
+            match = _find_matching_cache(all_cached_items["cachedContents"], cache_key)
+            if match is not None:
+                return match
 
             # Check if there are more pages
             page_token = all_cached_items.get("nextPageToken")
@@ -360,7 +392,20 @@ class ContextCachingEndpoints(VertexBase):
         generated_cache_key = local_cache_obj.get_cache_key(
             messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
-        google_cache_name = self.check_cache(
+        id_cache_key = make_cache_id_key(
+            content_key=generated_cache_key,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        cached_id = lookup_cache_id(id_cache_key)
+        if cached_id is not None:
+            _record_id_cache_status(logging_obj, True)
+            return non_cached_messages, optional_params, cached_id
+        _record_id_cache_status(logging_obj, False)
+        resolved_cache = self.check_cache(
             cache_key=generated_cache_key,
             client=client,
             headers=headers,
@@ -373,8 +418,9 @@ class ContextCachingEndpoints(VertexBase):
             vertex_auth_header=vertex_auth_header,
             model=model,
         )
-        if google_cache_name:
-            return non_cached_messages, optional_params, google_cache_name
+        if resolved_cache is not None:
+            store_cache_id(id_cache_key, resolved_cache.name, resolved_cache.expire_time)
+            return non_cached_messages, optional_params, resolved_cache.name
 
         ## TRANSFORM REQUEST
         cached_content_request_body = transform_openai_messages_to_gemini_context_caching(
@@ -418,10 +464,12 @@ class ContextCachingEndpoints(VertexBase):
         cached_content_response_obj = VertexAICachedContentResponseObject(
             name=raw_response_cached.get("name"), model=raw_response_cached.get("model")
         )
+        created_name = cached_content_response_obj["name"]
+        store_cache_id(id_cache_key, created_name, raw_response_cached.get("expireTime"))
         return (
             non_cached_messages,
             optional_params,
-            cached_content_response_obj["name"],
+            created_name,
         )
 
     async def async_check_and_create_cache(
@@ -506,7 +554,20 @@ class ContextCachingEndpoints(VertexBase):
         generated_cache_key = local_cache_obj.get_cache_key(
             messages=cached_messages, tools=tools, tool_choice=tool_choice, model=model
         )
-        google_cache_name = await self.async_check_cache(
+        id_cache_key = make_cache_id_key(
+            content_key=generated_cache_key,
+            custom_llm_provider=custom_llm_provider,
+            vertex_project=vertex_project,
+            vertex_location=vertex_location,
+            api_base=api_base,
+            api_key=api_key,
+        )
+        cached_id = lookup_cache_id(id_cache_key)
+        if cached_id is not None:
+            _record_id_cache_status(logging_obj, True)
+            return non_cached_messages, optional_params, cached_id
+        _record_id_cache_status(logging_obj, False)
+        resolved_cache = await self.async_check_cache(
             cache_key=generated_cache_key,
             client=client,
             headers=headers,
@@ -520,8 +581,9 @@ class ContextCachingEndpoints(VertexBase):
             model=model,
         )
 
-        if google_cache_name:
-            return non_cached_messages, optional_params, google_cache_name
+        if resolved_cache is not None:
+            store_cache_id(id_cache_key, resolved_cache.name, resolved_cache.expire_time)
+            return non_cached_messages, optional_params, resolved_cache.name
 
         ## TRANSFORM REQUEST
         cached_content_request_body = transform_openai_messages_to_gemini_context_caching(
@@ -565,10 +627,12 @@ class ContextCachingEndpoints(VertexBase):
         cached_content_response_obj = VertexAICachedContentResponseObject(
             name=raw_response_cached.get("name"), model=raw_response_cached.get("model")
         )
+        created_name = cached_content_response_obj["name"]
+        store_cache_id(id_cache_key, created_name, raw_response_cached.get("expireTime"))
         return (
             non_cached_messages,
             optional_params,
-            cached_content_response_obj["name"],
+            created_name,
         )
 
     def get_cache(self):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3101,6 +3101,9 @@ class SpendLogsMetadata(TypedDict):
     attempted_retries: Optional[int]  # Number of retries attempted (0 = first attempt succeeded)
     max_retries: Optional[int]  # Max retries configured for this request
     cost_breakdown: Optional[CostBreakdown]  # Detailed cost breakdown (input_cost, output_cost, margin, discount, etc.)
+    explicit_context_cache_id_hit: Optional[
+        bool
+    ]  # Vertex/Gemini explicit context-cache id resolved from the in-memory cache (True) vs re-listed (False)
 
 
 class SpendLogsPayload(TypedDict):

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -109,6 +109,7 @@ def _get_spend_logs_metadata(
             max_retries=None,
             cost_breakdown=None,
             litellm_call_id=litellm_call_id,
+            explicit_context_cache_id_hit=None,
         )
     verbose_proxy_logger.debug(
         "getting payload for SpendLogs, available keys in metadata: " + str(list(metadata.keys()))

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_id_cache.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_id_cache.py
@@ -1,0 +1,185 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+from litellm.llms.vertex_ai.context_caching import id_cache
+from litellm.llms.vertex_ai.context_caching.id_cache import (
+    SAFETY_MARGIN_SECONDS,
+    ResolvedCacheId,
+    _rfc3339_to_epoch,
+    expire_time_to_ttl,
+    lookup_cache_id,
+    make_cache_id_key,
+    store_cache_id,
+)
+
+FUTURE = "2099-01-01T00:00:00Z"
+FUTURE_EPOCH = _rfc3339_to_epoch(FUTURE)
+
+
+@pytest.fixture
+def enabled():
+    """Enable the feature and start from an empty cache; restore afterwards."""
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = True
+    id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        yield
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+        id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+
+def _key(**overrides):
+    base = dict(
+        content_key="hash",
+        custom_llm_provider="vertex_ai",
+        vertex_project="proj",
+        vertex_location="us-central1",
+        api_base=None,
+        api_key="k",
+    )
+    base.update(overrides)
+    return make_cache_id_key(**base)
+
+
+# --- ttl derivation (spec: entry lifetime bounded by expireTime) ---
+
+def test_ttl_uses_expiretime_minus_margin():
+    # expireTime 3600s out -> ttl is 3600 - margin, measured against expireTime, not insertion
+    ttl = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 3600)
+    assert ttl == pytest.approx(3600 - SAFETY_MARGIN_SECONDS)
+
+
+def test_ttl_scales_with_expiretime_not_constant():
+    # regression guard: a near-expiry cache must get a SMALL ttl, not a fixed span.
+    near = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 90)
+    far = expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - 3600)
+    assert near == pytest.approx(90 - SAFETY_MARGIN_SECONDS)
+    assert far == pytest.approx(3600 - SAFETY_MARGIN_SECONDS)
+    assert near < far  # fails if ttl is ever a hardcoded constant
+
+
+@pytest.mark.parametrize(
+    "expire_time",
+    [None, "", "not-a-date", "2024-13-45T99:99:99Z"],
+)
+def test_ttl_none_when_unusable(expire_time):
+    assert expire_time_to_ttl(expire_time, now=0) is None
+
+
+def test_ttl_none_when_within_margin():
+    # expiry inside the SAFETY_MARGIN_SECONDS window -> not worth caching
+    assert expire_time_to_ttl(FUTURE, now=FUTURE_EPOCH - (SAFETY_MARGIN_SECONDS - 1)) is None
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        "2024-10-02T15:01:23Z",
+        "2024-10-02T15:01:23.045Z",
+        "2024-10-02T15:01:23.045123456Z",  # nanoseconds (Vertex form)
+        "2024-10-02T15:01:23+00:00",
+        "2024-10-02T15:01:23+0000",
+    ],
+)
+def test_rfc3339_parses_provider_shapes(ts):
+    assert _rfc3339_to_epoch(ts) is not None
+
+
+# --- flag gating (spec: off by default) ---
+
+def test_disabled_lookup_and_store_are_noops():
+    prev = litellm.enable_vertex_context_cache_id_caching
+    litellm.enable_vertex_context_cache_id_caching = False
+    id_cache._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+    try:
+        key = _key()
+        store_cache_id(key, "cachedContents/1", FUTURE)
+        assert lookup_cache_id(key) is None
+        assert id_cache._EXPLICIT_CACHE_ID_CACHE.get_cache(key) is None
+    finally:
+        litellm.enable_vertex_context_cache_id_caching = prev
+
+
+def test_flag_defaults_off():
+    # guard: nobody flips the default to on without an explicit decision
+    fresh = litellm.__dict__.get("enable_vertex_context_cache_id_caching")
+    assert fresh is False
+
+
+# --- round trip + expiry (spec: cache the id; never serve expired) ---
+
+def test_store_then_lookup_round_trip(enabled):
+    key = _key()
+    store_cache_id(key, "projects/p/locations/l/cachedContents/9", FUTURE)
+    assert lookup_cache_id(key) == "projects/p/locations/l/cachedContents/9"
+
+
+def test_numeric_gemini_id_round_trips_as_string(enabled):
+    key = _key(custom_llm_provider="gemini")
+    store_cache_id(key, "7096536676058529792", FUTURE)
+    got = lookup_cache_id(key)
+    assert got == "7096536676058529792"
+    assert isinstance(got, str)  # fails without the str() guard (json.loads -> int)
+
+
+def test_expired_entry_is_a_miss(enabled):
+    key = _key()
+    # already-expired entry: lookup must treat it as absent
+    id_cache._EXPLICIT_CACHE_ID_CACHE.set_cache(key, "cachedContents/1", ttl=-1)
+    assert lookup_cache_id(key) is None
+
+
+def test_within_margin_expiry_is_not_stored(enabled):
+    key = _key()
+    store_cache_id(key, "cachedContents/1", FUTURE, now=FUTURE_EPOCH - (SAFETY_MARGIN_SECONDS - 1))
+    assert lookup_cache_id(key) is None
+
+
+# --- key scoping (spec: scoped to endpoint/tenant) ---
+
+def test_same_inputs_same_key():
+    assert _key() == _key()
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"custom_llm_provider": "gemini"},
+        {"vertex_project": "other"},
+        {"vertex_location": "europe-west1"},
+        {"api_base": "https://passthrough.example"},
+        {"api_key": "different"},
+        {"content_key": "other-hash"},
+    ],
+)
+def test_distinct_scope_distinct_key(override):
+    assert _key() != _key(**override)
+
+
+def test_cross_tenant_entry_is_not_served(enabled):
+    # project A stores its id; a byte-identical request under project B must miss
+    key_a = _key(vertex_project="A")
+    key_b = _key(vertex_project="B")
+    store_cache_id(key_a, "projects/A/.../cachedContents/1", FUTURE)
+    assert lookup_cache_id(key_b) is None
+    assert lookup_cache_id(key_a) == "projects/A/.../cachedContents/1"
+
+
+def test_key_does_not_leak_raw_api_key():
+    key = _key(api_key="super-secret-token")
+    assert "super-secret-token" not in key
+
+
+# --- bounded (spec: bounded) ---
+
+def test_cache_is_bounded(enabled):
+    cap = id_cache._MAX_ENTRIES
+    for i in range(cap * 2):
+        store_cache_id(_key(content_key=f"h{i}"), f"cachedContents/{i}", FUTURE)
+    assert len(id_cache._EXPLICIT_CACHE_ID_CACHE.cache_dict) <= cap

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -10,12 +10,17 @@ sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
 
+import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.vertex_ai.common_utils import VertexAIError
+from litellm.llms.vertex_ai.context_caching import id_cache as id_cache_module
+from litellm.llms.vertex_ai.context_caching.id_cache import ResolvedCacheId
 from litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching import (
     MAX_PAGINATION_PAGES,
     ContextCachingEndpoints,
+    _find_matching_cache,
+    _record_id_cache_status,
 )
 
 
@@ -173,7 +178,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = (cached_messages, non_cached_messages)
 
         mock_cache_obj.get_cache_key.return_value = "test_cache_key"
-        mock_check_cache.return_value = "existing_cache_name"
+        mock_check_cache.return_value = ResolvedCacheId(name="existing_cache_name", expire_time=None)
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
@@ -449,7 +454,7 @@ class TestContextCachingEndpoints:
         mock_separate.return_value = (cached_messages, non_cached_messages)
 
         mock_cache_obj.get_cache_key.return_value = "test_cache_key"
-        mock_async_check_cache.return_value = "existing_cache_name"
+        mock_async_check_cache.return_value = ResolvedCacheId(name="existing_cache_name", expire_time=None)
 
         optional_params = self.sample_optional_params.copy()
         test_project = "test_project"
@@ -652,7 +657,7 @@ class TestContextCachingEndpoints:
 
             # Mock the check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
-                self.context_caching, "check_cache", return_value="existing_cache"
+                self.context_caching, "check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 # Execute
                 result = self.context_caching.check_and_create_cache(
@@ -782,7 +787,7 @@ class TestContextCachingEndpoints:
 
             # Mock the async_check_cache to return existing cache so we don't make HTTP calls
             with patch.object(
-                self.context_caching, "async_check_cache", return_value="existing_cache"
+                self.context_caching, "async_check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 # Execute
                 result = await self.context_caching.async_check_and_create_cache(
@@ -824,7 +829,7 @@ class TestContextCachingEndpoints:
             optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
-                self.context_caching, "check_cache", return_value="existing_cache"
+                self.context_caching, "check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 self.context_caching.check_and_create_cache(
                     messages=self.sample_messages,
@@ -895,7 +900,7 @@ class TestContextCachingEndpoints:
             optional_params["tool_choice"] = {"functionCallingConfig": {"mode": "ANY"}}
 
             with patch.object(
-                self.context_caching, "async_check_cache", return_value="existing_cache"
+                self.context_caching, "async_check_cache", return_value=ResolvedCacheId(name="existing_cache", expire_time=None)
             ):
                 await self.context_caching.async_check_and_create_cache(
                     messages=self.sample_messages,
@@ -1318,7 +1323,7 @@ class TestContextCachingEndpoints:
         cached_messages = [self.sample_messages[0]]
         non_cached_messages = [self.sample_messages[1]]
         mock_separate.return_value = (cached_messages, non_cached_messages)
-        mock_check_cache.return_value = "existing_cache"
+        mock_check_cache.return_value = ResolvedCacheId(name="existing_cache", expire_time=None)
 
         auto_tool_choice = {"functionCallingConfig": {"mode": "AUTO"}}
         any_tool_choice = {"functionCallingConfig": {"mode": "ANY"}}
@@ -1512,7 +1517,7 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_client.get.call_count == 2
         # Check that second call includes pageToken
         second_call_url = self.mock_client.get.call_args_list[1].kwargs["url"]
@@ -1606,7 +1611,7 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_client.get.call_count == 3
 
     @pytest.mark.asyncio
@@ -1661,7 +1666,7 @@ class TestCheckCachePagination:
         )
 
         # Assert
-        assert result == "cache_3"
+        assert result is not None and result.name == "cache_3"
         assert self.mock_async_client.get.call_count == 2
         # Check that second call includes pageToken
         second_call_url = self.mock_async_client.get.call_args_list[1].kwargs["url"]
@@ -1971,3 +1976,209 @@ class TestContextCachingMultiRegionUrls:
 
         assert url.startswith("https://aiplatform.googleapis.com/")
         assert "/locations/global/cachedContents" in url
+
+
+_FAR_FUTURE = "2099-01-01T00:00:00Z"
+
+
+class TestContextCachingIdCacheWiring:
+    """Discovery-path wiring of the in-memory explicit-cache-id cache.
+
+    These assert the id cache is consulted/populated at the right points and
+    that it is scoped per endpoint/tenant, by counting LIST (check_cache) and
+    create (client.post) calls across successive resolutions.
+    """
+
+    def setup_method(self):
+        self.context_caching = ContextCachingEndpoints()
+        self.mock_logging = MagicMock(spec=Logging)
+        self.mock_client = MagicMock(spec=HTTPHandler)
+        self._token_check_patcher = patch(
+            "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.is_prompt_caching_valid_prompt",
+            return_value=True,
+        )
+        self._token_check_patcher.start()
+        self._prev_flag = litellm.enable_vertex_context_cache_id_caching
+        litellm.enable_vertex_context_cache_id_caching = True
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+        self.messages = [
+            {
+                "role": "system",
+                "content": "You are a helpful assistant",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {"role": "user", "content": "Hello"},
+        ]
+
+    def teardown_method(self):
+        self._token_check_patcher.stop()
+        litellm.enable_vertex_context_cache_id_caching = self._prev_flag
+        id_cache_module._EXPLICIT_CACHE_ID_CACHE.flush_cache()
+
+    def _resolve(self, provider="vertex_ai", project="proj", location="us-central1"):
+        return self.context_caching.check_and_create_cache(
+            messages=self.messages,
+            optional_params={},
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=provider,
+            vertex_project=project,
+            vertex_location=location,
+            vertex_auth_header="Bearer token",
+        )
+
+    @pytest.mark.parametrize("provider", ["vertex_ai", "gemini"])
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_warm_hit_skips_the_list(self, mock_check_cache, provider):
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/1", expire_time=_FAR_FUTURE
+        )
+
+        first = self._resolve(provider=provider)
+        second = self._resolve(provider=provider)
+
+        assert first[2] == "cachedContents/1"
+        assert second[2] == "cachedContents/1"
+        # second resolution served from the id cache -> LIST issued only once
+        assert mock_check_cache.call_count == 1
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_disabled_flag_always_lists(self, mock_check_cache):
+        litellm.enable_vertex_context_cache_id_caching = False
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/1", expire_time=_FAR_FUTURE
+        )
+
+        self._resolve()
+        self._resolve()
+
+        assert mock_check_cache.call_count == 2  # no id-cache skip
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_different_project_does_not_reuse_id(self, mock_check_cache):
+        mock_check_cache.return_value = ResolvedCacheId(
+            name="cachedContents/A", expire_time=_FAR_FUTURE
+        )
+
+        self._resolve(project="A")
+        self._resolve(project="B")  # identical content, different tenant
+
+        # project B must not be served project A's cached id -> it LISTs again
+        assert mock_check_cache.call_count == 2
+
+    @patch.object(ContextCachingEndpoints, "_get_token_and_url_context_caching")
+    @patch(
+        "litellm.llms.vertex_ai.context_caching.vertex_ai_context_caching.transform_openai_messages_to_gemini_context_caching"
+    )
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_created_id_is_cached_and_skips_create_next_time(
+        self, mock_check_cache, mock_transform, mock_get_token_url
+    ):
+        mock_check_cache.return_value = None  # nothing existing
+        mock_get_token_url.return_value = ("token", "https://test-url.com")
+        mock_transform.return_value = {"model": "gemini-1.5-pro", "contents": []}
+        post_response = MagicMock()
+        post_response.json.return_value = {
+            "name": "cachedContents/new",
+            "model": "gemini-1.5-pro",
+            "expireTime": _FAR_FUTURE,
+        }
+        self.mock_client.post.return_value = post_response
+
+        first = self._resolve()
+        second = self._resolve()
+
+        assert first[2] == "cachedContents/new"
+        assert second[2] == "cachedContents/new"
+        # create happened once; second resolution served from the id cache
+        assert self.mock_client.post.call_count == 1
+        assert mock_check_cache.call_count == 1
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_miss_then_hit_stamp_explicit_context_cache_id_hit_metadata(self, mock_check_cache):
+        mock_check_cache.return_value = ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE)
+        md = {"litellm_params": {"metadata": {}}}
+        self.mock_logging.model_call_details = md
+
+        self._resolve()  # cold: id-cache miss -> stamps False
+        assert md["litellm_params"]["metadata"]["explicit_context_cache_id_hit"] is False
+
+        self._resolve()  # warm: id-cache hit -> stamps True
+        assert md["litellm_params"]["metadata"]["explicit_context_cache_id_hit"] is True
+
+    @patch.object(ContextCachingEndpoints, "check_cache")
+    def test_disabled_flag_does_not_stamp_metadata(self, mock_check_cache):
+        litellm.enable_vertex_context_cache_id_caching = False
+        mock_check_cache.return_value = ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE)
+        md = {"litellm_params": {"metadata": {}}}
+        self.mock_logging.model_call_details = md
+
+        self._resolve()
+        assert "explicit_context_cache_id_hit" not in md["litellm_params"]["metadata"]
+
+    async def _resolve_async(self, provider="vertex_ai", project="proj", location="us-central1"):
+        return await self.context_caching.async_check_and_create_cache(
+            messages=self.messages,
+            optional_params={},
+            api_key="test_key",
+            api_base=None,
+            model="gemini-1.5-pro",
+            client=AsyncMock(spec=AsyncHTTPHandler),
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            custom_llm_provider=provider,
+            vertex_project=project,
+            vertex_location=location,
+            vertex_auth_header="Bearer token",
+        )
+
+    @pytest.mark.asyncio
+    @patch.object(ContextCachingEndpoints, "async_check_cache")
+    async def test_async_miss_then_hit_skips_list_and_stamps_metadata(self, mock_async_check_cache):
+        mock_async_check_cache.return_value = ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE)
+        md = {"litellm_params": {"metadata": {}}}
+        self.mock_logging.model_call_details = md
+
+        first = await self._resolve_async()  # cold: id-cache miss -> LIST + stamp False
+        assert md["litellm_params"]["metadata"]["explicit_context_cache_id_hit"] is False
+
+        second = await self._resolve_async()  # warm: id-cache hit -> skip LIST + stamp True
+        assert md["litellm_params"]["metadata"]["explicit_context_cache_id_hit"] is True
+
+        assert first[2] == "cachedContents/1"
+        assert second[2] == "cachedContents/1"
+        assert mock_async_check_cache.call_count == 1
+
+    @pytest.mark.parametrize(
+        "model_call_details",
+        [None, {"litellm_params": None}, {"litellm_params": {"metadata": None}}],
+    )
+    def test_record_status_noops_on_malformed_logging_state(self, model_call_details):
+        # Flag is on (setup), so the isinstance guards are what must bail before
+        # touching a non-dict. Dropping any guard turns these into an
+        # AttributeError/TypeError, so "does not raise" kills that mutation.
+        obj = MagicMock(spec=Logging)
+        obj.model_call_details = model_call_details
+        assert _record_id_cache_status(obj, True) is None
+
+
+class TestFindMatchingCache:
+    def test_matches_displayname_and_returns_resolved_id(self):
+        items = [
+            {"displayName": "other", "name": "cachedContents/0"},
+            {"displayName": "k", "name": "cachedContents/1", "expireTime": _FAR_FUTURE},
+        ]
+        resolved = _find_matching_cache(items, "k")
+        assert resolved == ResolvedCacheId(name="cachedContents/1", expire_time=_FAR_FUTURE)
+
+    def test_matched_but_nameless_entry_is_treated_as_miss(self):
+        # a displayName match with no `name` must not resolve to a partial id;
+        # returning None forces the normal create path instead of a broken cachedContent
+        assert _find_matching_cache([{"displayName": "k"}], "k") is None
+
+    def test_no_displayname_match_returns_none(self):
+        assert _find_matching_cache([{"displayName": "other", "name": "cachedContents/1"}], "k") is None

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -449,6 +449,7 @@ ignored_keys = [
     "metadata.additional_usage_values.iterations",
     "metadata.litellm_overhead_time_ms",
     "metadata.cost_breakdown",
+    "metadata.explicit_context_cache_id_hit",
     "metadata.user_api_key",
     "metadata.user_api_key_alias",
     "metadata.user_api_key_team_id",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible
- [ ] I have requested a Greptile review and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Live proxy against real Vertex (`gemini-3.1-flash-lite`, `global`), same request twice with a `cache_control` prefix over the min-token floor:

```
req 1 (cold): 6.45s   cachedContents LIST + create, overhead ~4000ms, explicit_context_cache_id_hit=false
req 2 (warm): 1.20s   reused from the in-memory id cache, overhead ~3ms, no LIST/create, explicit_context_cache_id_hit=true
```

Across 46 real requests that read an explicit cache, cache id (context cache name) discovery added median 1552ms / p99 4132ms of LiteLLM overhead; the id cache turns each into a single-digit-ms warm hit.

## Type

🆕 New Feature

## Changes

Vertex/Gemini explicit context caching returns a `cachedContents` id you pass on later requests. Callers using `cache_control` breakpoints instead of holding that id make LiteLLM re-discover it every turn via a live `cachedContents` LIST (p50 1552ms/p99 4132ms), plus a create on a cold prefix

Adds an in-memory (`InMemoryCache`), bounded, TTL-aware cache of resolved ids in `litellm/llms/vertex_ai/context_caching/id_cache.py`, consulted before the LIST in both the sync and async paths, covering Vertex AI, Vertex AI Beta, and Gemini. Each entry's ttl is the cachedContent's real `expireTime` minus a 5s safety margin (never a fixed span), and the key is namespaced by provider/project/location/api_base/credential, so a warm cache can never serve an expired or cross-tenant id.

Two knobs, both `id_cache.py` module constants. `SAFETY_MARGIN_SECONDS = 5` is subtracted from `expireTime` when computing the ttl and absorbs clock skew plus the in-flight time between resolving the id and the downstream `generateContent`, so an entry nearing expiry is dropped rather than handed out and failing with NOT_FOUND; an `expireTime` already inside that window is never stored. `_MAX_ENTRIES = 1024` bounds the cache (`InMemoryCache(max_size_in_memory=1024)`), so memory stays flat under many distinct prefixes and the oldest entries evict; a cold or evicted entry just falls back to the normal LIST. Off by default behind `litellm.enable_vertex_context_cache_id_caching`; on a miss the path is byte-for-byte unchanged, so the server-side displayName dedup and cache creation are preserved. The hit/miss is recorded as a typed `explicit_context_cache_id_hit` field on `SpendLogsMetadata` for UI visibility

Tests in `tests/test_litellm/llms/vertex_ai/context_caching/` cover the warm-hit LIST-skip, the `expireTime`-derived ttl with a fixed-span regression guard, tenant/content key isolation, the off-by-default flag, and the hit/miss stamping
