### PR TITLE
fix(budget-limiter): derive custom_llm_provider for /v1/messages and /v1/embeddings routes

### DIFF
--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -420,11 +420,13 @@ class RouterBudgetLimiting(CustomLogger):
                 if isinstance(_litellm_params, dict)
                 else getattr(_litellm_params, "model", "") or ""
             )
-            try:
-                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
-                    model=str(_model),
-                    litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
-                )
+            # litellm_params may not carry `model` for /v1/messages and
+            # /v1/embeddings routes (LoggedLiteLLMParams gap). Fall back to
+            # the top-level model field and then the standard logging payload
+            # so budget enforcement is not silently skipped.
+            # See: https://github.com/BerriAI/litellm/issues/26701
+            if not _model:
+                _model = kwargs.get("model", "") or standard_logging_payload.get("model", "") or ""
             try:
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(
                     model=str(_model),
@@ -432,8 +434,7 @@ class RouterBudgetLimiting(CustomLogger):
                 )
             except Exception as e:
                 verbose_router_logger.debug(
-                    "RouterBudgetLimiting: could not derive custom_llm_provider "
-                    "from model string %r: %s",
+                    "RouterBudgetLimiting: could not derive custom_llm_provider from model string %r: %s",
                     _model,
                     e,
                 )

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -425,9 +425,15 @@ class RouterBudgetLimiting(CustomLogger):
                     model=str(_model),
                     litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
                 )
+            try:
+                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                    model=str(_model),
+                    litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
+                )
             except Exception as e:
                 verbose_router_logger.debug(
-                    "RouterBudgetLimiting: could not derive custom_llm_provider from model string %r: %s",
+                    "RouterBudgetLimiting: could not derive custom_llm_provider "
+                    "from model string %r: %s",
                     _model,
                     e,
                 )

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -432,7 +432,7 @@ class RouterBudgetLimiting(CustomLogger):
                     model=str(_model),
                     litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 verbose_router_logger.debug(
                     "RouterBudgetLimiting: could not derive custom_llm_provider from model string %r: %s",
                     _model,

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -409,6 +409,25 @@ class RouterBudgetLimiting(CustomLogger):
         model_id: str = str(standard_logging_payload.get("model_id", ""))
         custom_llm_provider: str = kwargs.get("litellm_params", {}).get("custom_llm_provider", None)
         if custom_llm_provider is None:
+            # /v1/messages and /v1/embeddings routes do not inject
+            # custom_llm_provider into litellm_params the way
+            # /v1/chat/completions does. Derive it from the model string
+            # so budget tracking is not silently skipped for those routes.
+            # See: https://github.com/BerriAI/litellm/issues/26701
+            _litellm_params = kwargs.get("litellm_params") or {}
+            _model = (
+                _litellm_params.get("model", "")
+                if isinstance(_litellm_params, dict)
+                else getattr(_litellm_params, "model", "") or ""
+            )
+            try:
+                _, custom_llm_provider, _, _ = litellm.get_llm_provider(
+                    model=str(_model),
+                    litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
+                )
+            except Exception:
+                custom_llm_provider = None
+        if custom_llm_provider is None:
             raise ValueError("custom_llm_provider is required")
 
         budget_config = self._get_budget_config_for_provider(custom_llm_provider)

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -425,7 +425,12 @@ class RouterBudgetLimiting(CustomLogger):
                     model=str(_model),
                     litellm_params=_LiteLLMParamsDictView(_litellm_params if isinstance(_litellm_params, dict) else {}),
                 )
-            except Exception:
+            except Exception as e:
+                verbose_router_logger.debug(
+                    "RouterBudgetLimiting: could not derive custom_llm_provider from model string %r: %s",
+                    _model,
+                    e,
+                )
                 custom_llm_provider = None
         if custom_llm_provider is None:
             raise ValueError("custom_llm_provider is required")

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -408,7 +408,15 @@ class RouterBudgetLimiting(CustomLogger):
 
         response_cost: Final[float] = standard_logging_payload.get("response_cost", 0)
         model_id: Final[str] = str(standard_logging_payload.get("model_id", ""))
-        custom_llm_provider: Final[str] = kwargs.get("litellm_params", {}).get("custom_llm_provider", None)
+        # `/v1/chat/completions` injects `custom_llm_provider` into `litellm_params`,
+        # but `/v1/messages` and `/v1/embeddings` do not. The standard logging payload
+        # carries it for every route (it is built from the top-level call details), so
+        # fall back to that instead of raising before any spend counter is incremented.
+        # See https://github.com/BerriAI/litellm/issues/26701.
+        custom_llm_provider: Final[str | None] = (
+            kwargs.get("litellm_params", {}).get("custom_llm_provider", None)
+            or standard_logging_payload["custom_llm_provider"]
+        )
         if custom_llm_provider is None:
             raise ValueError("custom_llm_provider is required")
 

--- a/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
@@ -146,3 +146,39 @@ async def test_unresolvable_model_string_raises_value_error_with_debug_log():
                 start_time=None,
                 end_time=None,
             )
+
+
+@pytest.mark.asyncio
+async def test_provider_derived_from_top_level_model_when_litellm_params_missing_model():
+    """
+    Regression for veria-ai review comment on #32180:
+    LoggedLiteLLMParams for /v1/messages does not include `model`, so
+    litellm_params.get("model") returns "". Must fall back to kwargs["model"]
+    so that provider spend is actually incremented (budget enforced).
+    """
+    limiter = _make_limiter()
+
+    kwargs = {
+        "model": "anthropic/claude-haiku-4-5-20251001",  # top-level, always present
+        "litellm_params": {
+            # model key absent — this is the LoggedLiteLLMParams gap
+        },
+        "standard_logging_object": {
+            "response_cost": 0.001,
+            "model_id": "deployment-abc123",
+        },
+    }
+
+    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock) as mock_increment, \
+         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
+         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+        # Budget spend MUST be incremented — if it isn't, budget enforcement is broken
+        mock_increment.assert_called_once()

--- a/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
@@ -46,9 +46,13 @@ async def test_messages_route_no_custom_provider_does_not_raise():
     limiter = _make_limiter()
     kwargs = _kwargs_without_custom_provider("anthropic/claude-haiku-4-5-20251001")
 
-    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock) as mock_increment, \
-         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
-         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+    with (
+        patch.object(
+            limiter, "_increment_spend_for_key", new_callable=AsyncMock
+        ) as mock_increment,
+        patch.object(limiter, "_get_budget_config_for_deployment", return_value=None),
+        patch.object(limiter, "_get_budget_config_for_tag", return_value=None),
+    ):
 
         # Before the fix this raises: ValueError("custom_llm_provider is required")
         await limiter.async_log_success_event(
@@ -68,9 +72,11 @@ async def test_embeddings_route_no_custom_provider_does_not_raise():
     limiter = _make_limiter()
     kwargs = _kwargs_without_custom_provider("openai/text-embedding-3-small")
 
-    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock), \
-         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
-         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+    with (
+        patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock),
+        patch.object(limiter, "_get_budget_config_for_deployment", return_value=None),
+        patch.object(limiter, "_get_budget_config_for_tag", return_value=None),
+    ):
 
         await limiter.async_log_success_event(
             kwargs=kwargs,
@@ -99,9 +105,13 @@ async def test_chat_completions_with_explicit_provider_still_works():
         },
     }
 
-    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock) as mock_increment, \
-         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
-         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+    with (
+        patch.object(
+            limiter, "_increment_spend_for_key", new_callable=AsyncMock
+        ) as mock_increment,
+        patch.object(limiter, "_get_budget_config_for_deployment", return_value=None),
+        patch.object(limiter, "_get_budget_config_for_tag", return_value=None),
+    ):
 
         await limiter.async_log_success_event(
             kwargs=kwargs,
@@ -111,3 +121,28 @@ async def test_chat_completions_with_explicit_provider_still_works():
         )
 
         mock_increment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_model_string_raises_value_error_with_debug_log():
+    """
+    When both the dict lookup and litellm.get_llm_provider() fail
+    (completely unrecognisable model string), ValueError must still be raised
+    and the debug log must fire — covering the except branch added in #26701.
+    """
+    limiter = _make_limiter()
+    kwargs = _kwargs_without_custom_provider("totally-unresolvable-garbage-xyz-123")
+
+    with (
+        patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock),
+        patch.object(limiter, "_get_budget_config_for_deployment", return_value=None),
+        patch.object(limiter, "_get_budget_config_for_tag", return_value=None),
+    ):
+
+        with pytest.raises(ValueError, match="custom_llm_provider is required"):
+            await limiter.async_log_success_event(
+                kwargs=kwargs,
+                response_obj=None,
+                start_time=None,
+                end_time=None,
+            )

--- a/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
@@ -1,0 +1,113 @@
+"""
+Regression tests for #26701
+
+/v1/messages and /v1/embeddings routes don't inject custom_llm_provider into
+litellm_params (unlike /v1/chat/completions). async_log_success_event must
+derive the provider from the model string instead of raising ValueError.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+
+
+def _make_limiter():
+    return RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={
+            "anthropic": {"budget_limit": 5.0, "time_period": "24h"}
+        },
+    )
+
+
+def _kwargs_without_custom_provider(model_str: str) -> dict:
+    """Simulates what /v1/messages and /v1/embeddings produce — no custom_llm_provider."""
+    return {
+        "model": model_str,
+        "litellm_params": {
+            "model": model_str,
+            # custom_llm_provider deliberately absent — this is the bug scenario
+        },
+        "standard_logging_object": {
+            "response_cost": 0.001,
+            "model_id": "deployment-abc123",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_messages_route_no_custom_provider_does_not_raise():
+    """
+    /v1/messages kwargs missing custom_llm_provider must not raise ValueError.
+    Provider should be derived from the model string 'anthropic/...' instead.
+    """
+    limiter = _make_limiter()
+    kwargs = _kwargs_without_custom_provider("anthropic/claude-haiku-4-5-20251001")
+
+    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock) as mock_increment, \
+         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
+         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+
+        # Before the fix this raises: ValueError("custom_llm_provider is required")
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+        # Provider was correctly derived → spend increment was called
+        mock_increment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_embeddings_route_no_custom_provider_does_not_raise():
+    """/v1/embeddings has the same gap — openai provider should be derived cleanly."""
+    limiter = _make_limiter()
+    kwargs = _kwargs_without_custom_provider("openai/text-embedding-3-small")
+
+    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock), \
+         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
+         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_with_explicit_provider_still_works():
+    """
+    /v1/chat/completions path that already sets custom_llm_provider must
+    continue to work exactly as before — no regression.
+    """
+    limiter = _make_limiter()
+    kwargs = {
+        "model": "claude-haiku-direct",
+        "litellm_params": {
+            "model": "anthropic/claude-haiku-4-5-20251001",
+            "custom_llm_provider": "anthropic",  # set by chat/completions route
+        },
+        "standard_logging_object": {
+            "response_cost": 0.001,
+            "model_id": "deployment-abc123",
+        },
+    }
+
+    with patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock) as mock_increment, \
+         patch.object(limiter, "_get_budget_config_for_deployment", return_value=None), \
+         patch.object(limiter, "_get_budget_config_for_tag", return_value=None):
+
+        await limiter.async_log_success_event(
+            kwargs=kwargs,
+            response_obj=None,
+            start_time=None,
+            end_time=None,
+        )
+
+        mock_increment.assert_called_once()

--- a/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
+++ b/tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py
@@ -1,0 +1,125 @@
+"""
+Regression tests for #26701.
+
+`/v1/chat/completions` injects `custom_llm_provider` into `litellm_params`, but
+`/v1/messages` and `/v1/embeddings` do not. Before the fix,
+`RouterBudgetLimiting.async_log_success_event` raised
+`ValueError("custom_llm_provider is required")` before incrementing any spend
+counter, so provider budgets (and deployment-level `max_budget`, which sits
+below the same guard) silently never accrued on those routes.
+
+The standard logging payload carries `custom_llm_provider` for every route --
+it is built from the top-level call details rather than from `litellm_params` --
+so the limiter falls back to it.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
+
+
+def _make_limiter() -> RouterBudgetLimiting:
+    return RouterBudgetLimiting(
+        dual_cache=DualCache(),
+        provider_budget_config={
+            "anthropic": {"budget_limit": 5.0, "time_period": "24h"},
+            "openai": {"budget_limit": 5.0, "time_period": "24h"},
+        },
+    )
+
+
+def _payload(provider: str | None) -> dict:
+    return {
+        "response_cost": 0.001,
+        "model_id": "deployment-abc123",
+        "custom_llm_provider": provider,
+    }
+
+
+def _patched(limiter: RouterBudgetLimiting):
+    """Isolate the provider-budget path from deployment/tag budget lookups."""
+    return (
+        patch.object(limiter, "_increment_spend_for_key", new_callable=AsyncMock),
+        patch.object(limiter, "_get_budget_config_for_deployment", return_value=None),
+        patch.object(limiter, "_get_budget_config_for_tag", return_value=None),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route", "model", "provider"),
+    [
+        ("/v1/messages", "anthropic/claude-haiku-4-5-20251001", "anthropic"),
+        ("/v1/embeddings", "openai/text-embedding-3-small", "openai"),
+    ],
+)
+async def test_provider_falls_back_to_logging_payload(route: str, model: str, provider: str):
+    """
+    Routes that omit `custom_llm_provider` from `litellm_params` must still
+    accrue spend, using the provider recorded on the standard logging payload.
+    """
+    limiter = _make_limiter()
+    kwargs = {
+        "model": model,
+        # `litellm_params` on these routes carries no `custom_llm_provider`.
+        "litellm_params": {"model": model},
+        "standard_logging_object": _payload(provider),
+    }
+
+    increment, _dep, _tag = _patched(limiter)
+    with increment as mock_increment, _dep, _tag:
+        # Before the fix this raised ValueError before any counter moved.
+        await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=None, end_time=None)
+
+    assert mock_increment.await_count >= 1, f"{route}: provider spend was never incremented"
+    spend_keys = [call.kwargs.get("spend_key", "") for call in mock_increment.await_args_list]
+    assert any(f"provider_spend:{provider}:" in key for key in spend_keys), (
+        f"{route}: expected a provider_spend key for {provider!r}, got {spend_keys}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_litellm_params_provider_takes_precedence():
+    """
+    `/v1/chat/completions` already sets `custom_llm_provider` in `litellm_params`;
+    that value must keep winning over the payload so behaviour is unchanged.
+    """
+    limiter = _make_limiter()
+    kwargs = {
+        "model": "claude-haiku-direct",
+        "litellm_params": {
+            "model": "anthropic/claude-haiku-4-5-20251001",
+            "custom_llm_provider": "anthropic",
+        },
+        # Deliberately disagrees, to prove precedence rather than coincidence.
+        "standard_logging_object": _payload("openai"),
+    }
+
+    increment, _dep, _tag = _patched(limiter)
+    with increment as mock_increment, _dep, _tag:
+        await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=None, end_time=None)
+
+    spend_keys = [call.kwargs.get("spend_key", "") for call in mock_increment.await_args_list]
+    assert any("provider_spend:anthropic:" in key for key in spend_keys), spend_keys
+    assert not any("provider_spend:openai:" in key for key in spend_keys), spend_keys
+
+
+@pytest.mark.asyncio
+async def test_missing_provider_everywhere_still_raises():
+    """
+    With no provider in `litellm_params` and none on the payload there is
+    nothing to attribute spend to; the existing contract must be preserved.
+    """
+    limiter = _make_limiter()
+    kwargs = {
+        "model": "totally-unresolvable-garbage-xyz-123",
+        "litellm_params": {},
+        "standard_logging_object": _payload(None),
+    }
+
+    increment, _dep, _tag = _patched(limiter)
+    with increment, _dep, _tag, pytest.raises(ValueError, match="custom_llm_provider is required"):
+        await limiter.async_log_success_event(kwargs=kwargs, response_obj=None, start_time=None, end_time=None)


### PR DESCRIPTION
## Summary

`/v1/chat/completions` injects `custom_llm_provider` into `litellm_params`, but `/v1/messages` and `/v1/embeddings` do not. `RouterBudgetLimiting.async_log_success_event` read it only from `litellm_params`, so on those routes it raised `ValueError("custom_llm_provider is required")` **before** incrementing any spend counter — provider budgets silently never accrued. Deployment-level `max_budget` sits below the same guard, so it was disabled too.

@henricook independently hit this in production on `v1.83.14-stable` routing Claude Code traffic through a Vertex+Azure router with `provider_budget_config`.

Fixes #26701. Same root cause as #30276.

## What changed since the first revision

This PR originally derived the provider from the model string via `litellm.get_llm_provider(...)` wrapped in try/except (+31 lines). While rebasing onto current `litellm_internal_staging` I found that `StandardLoggingPayload` **already carries** `custom_llm_provider`, and that it is populated for every route — it is built from the top-level call details (`litellm_logging.py`, `kwargs.get("custom_llm_provider")`) rather than from `litellm_params`. All three `update_environment_variables` call sites in `main.py` pass it through.

So the derivation was unnecessary. The fix is now three lines:

```python
custom_llm_provider: Final[str | None] = (
    kwargs.get("litellm_params", {}).get("custom_llm_provider", None)
    or standard_logging_payload["custom_llm_provider"]
)
```

`litellm_params` keeps precedence, and the `ValueError` is preserved when neither source has a provider.

Subscript rather than `.get()` is deliberate: `StandardLoggingPayload` is a total `TypedDict` in which `custom_llm_provider: str | None` is a required key, and the subscript form is the one that type-checks cleanly under the current strict config.

## Rebase notes

The branch was 6887 commits behind. Git reported the merge as clean, but the old revision no longer builds against current staging:

- `custom_llm_provider` is now declared `Final[str]`, and the previous revision reassigned it twice — **+15 new basedpyright errors**, including two `"custom_llm_provider" is declared as Final and cannot be reassigned`.
- `typing.cast` is now banned by `ruff-strict.toml` (TID251), ruling out the obvious workaround.

The current revision is a single commit on top of `litellm_internal_staging`.

## Tests

Rewrote the regression tests around the payload fallback and verified they actually fail without the fix.

- [x] `.venv/bin/python -m pytest tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py -q` → **4 passed**
- [x] Same file against unpatched staging → **2 failed** with exactly `ValueError: custom_llm_provider is required` (the two `/v1/messages` and `/v1/embeddings` cases); the precedence and still-raises cases pass in both, as they assert unchanged behaviour
- [x] `.venv/bin/python -m pytest tests/test_litellm/router_strategy/test_budget_limiter_hotpath.py tests/test_litellm/router_strategy/test_budget_limiter_provider_derivation.py -q` → **13 passed**
- [x] `basedpyright litellm/router_strategy/budget_limiter.py` → **144 diagnostics, identical to staging** (zero delta, no rule regressed)
- [x] `ruff check --config ruff-strict.toml` → **zero delta vs staging**; `ruff format --check` clean

## Model evals

Not run. This is a spend-accounting fix in a router callback and does not change model outputs.

## Assistance

Claude Code was used to rebase this PR, investigate why the original approach no longer type-checked, find the simpler payload-based fix, and rewrite the tests. The human submitter reviewed the changed lines and the test results.
