### PR TITLE
fix(mcp_server): coerce integer progressToken before slicing in debug log

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -176,6 +176,11 @@ def _mcp_session_id_from_headers(
     return None
 
 
+def _format_progress_token_for_log(progress_token: object) -> str:
+    """Short, log-safe form of an MCP progressToken (str or int per spec)."""
+    return f"{str(progress_token)[:8]}..."
+
+
 def _jsonrpc_text_has_top_level_method(text: str) -> bool:
     """Whether a (possibly truncated) JSON-RPC envelope has a ``method`` key at
     the root object's top level.
@@ -732,7 +737,7 @@ if MCP_AVAILABLE:
             except Exception as e:
                 verbose_logger.error(f"Failed to forward progress to Host: {e}")
 
-        verbose_logger.debug(f"Host progressToken captured: {host_token[:8]}...")
+        verbose_logger.debug(f"Host progressToken captured: {_format_progress_token_for_log(host_token)}")
         return forward_progress
 
     async def _build_virtual_call_logging_obj(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6592,3 +6592,16 @@ async def test_get_active_submitted_mcp_server_ids_for_user_empty_user_id_skips_
 
     assert await get_active_submitted_mcp_server_ids_for_user(prisma_client, "") == []
     prisma_client.db.litellm_mcpservertable.find_many.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "token, expected",
+    [(123456789, "12345678..."), ("abcdefghij", "abcdefgh...")],
+)
+def test_format_progress_token_for_log_handles_int_and_str(token, expected):
+    # Regression for #32181: an integer progressToken crashed host_token[:8].
+    from litellm.proxy._experimental.mcp_server.server import (
+        _format_progress_token_for_log,
+    )
+
+    assert _format_progress_token_for_log(token) == expected


### PR DESCRIPTION
## Summary

MCP `tools/call` through the proxy crashes with `TypeError: 'int' object is not subscriptable` when the client sends an **integer** `progressToken`. The MCP spec allows `progressToken` to be `string | integer`, but `_capture_host_progress_callback` logged `host_token[:8]`, which only works for strings. Because the f-string is built before `verbose_logger.debug(...)` runs, it raises even with debug logging disabled, and the exception aborts the whole tool call **before the backend server is dispatched** (backend logs stay clean, so it looks like a gateway/auth fault).

Fixes #32181.

## Changes

- Extract the token formatting into `_format_progress_token_for_log()`, coercing the token to `str` before slicing.
- Add a parametrized regression test covering integer and string tokens.

## Reproduce

Call any tool with an integer `_meta.progressToken` (e.g. `{"progressToken": 1}`). Clients such as Claude Code send monotonically increasing integer tokens by default. A string or absent token does not trigger it.

## Testing

`_format_progress_token_for_log(123456789)` → `"12345678..."` (previously raised); `"abcdefghij"` → `"abcdefgh..."` unchanged.
