### PR TITLE
fix(mcp): document /mcp-rest/tools/call request body in OpenAPI schema

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -735,7 +735,44 @@ if MCP_AVAILABLE:
                 "message": f"An unexpected error occurred: {str(e)}",
             }
 
-    @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
+    @router.post(
+        "/tools/call",
+        dependencies=[Depends(user_api_key_auth)],
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                                "server_id": {
+                                    "type": "string",
+                                    "description": "ID of the MCP server that owns the tool. Required unless calling a virtual tool (mcp_tool_search or mcp_tool_call).",
+                                },
+                                "name": {
+                                    "type": "string",
+                                    "description": "Name of the MCP tool to invoke.",
+                                },
+                                "arguments": {
+                                    "type": "object",
+                                    "description": "Key-value arguments forwarded to the tool.",
+                                    "additionalProperties": True,
+                                    "default": {},
+                                },
+                            },
+                        },
+                        "example": {
+                            "server_id": "17a4490465f74d3696caf12b30220166",
+                            "name": "places_api-getPlaces",
+                            "arguments": {"query": "coffee shops in London"},
+                        },
+                    }
+                },
+            }
+        },
+    )
     async def call_tool_rest_api(
         request: Request,
         user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),


### PR DESCRIPTION
## Problem

`/mcp-rest/tools/call` reads its body via raw `Request.json()` so FastAPI never sees the parameter types. The generated OpenAPI spec shows **no body parameters**, which means:
- The Swagger UI shows an empty schema.
- LLMs consuming `openapi.json` as an MCP tool source generate calls with empty bodies → HTTP 500.

Reported in #32121.

## Root cause

FastAPI infers request body schemas from typed Pydantic parameters. When a handler takes only `request: Request`, no body schema is generated, even if the handler reads `request.json()` internally.

## Fix

Add `openapi_extra` to the `@router.post` decorator with an explicit `requestBody` schema for `server_id`, `name`, and `arguments`, plus a concrete usage example.

No behavioral changes — the body is still consumed via `await request.json()` so the raw-request flexibility (pass-through to MCP servers, dynamic field access) is preserved.

**Before:**
```json
{}
```

**After:**
```json
{
  "requestBody": {
    "required": true,
    "content": {
      "application/json": {
        "schema": {
          "type": "object",
          "required": ["name"],
          "properties": {
            "server_id": { "type": "string" },
            "name": { "type": "string" },
            "arguments": { "type": "object" }
          }
        },
        "example": {
          "server_id": "17a4490465f74d3696caf12b30220166",
          "name": "places_api-getPlaces",
          "arguments": { "query": "coffee shops in London" }
        }
      }
    }
  }
}
```

Fixes #32121