### PR TITLE
fix(websearch_interception): emit native web_search blocks on the short-circuit path

### DIFF
--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -163,17 +163,6 @@ class WebSearchInterceptionLogger(CustomLogger):
             f"WebSearchInterception: Short-circuit search detected (provider={provider_str}, query='{query}')"
         )
 
-        # Native clients (Claude Desktop / Cowork / Anthropic SDK) make a
-        # standalone /v1/messages sub-request just for the search, and they
-        # expect the response in native shape with server_tool_use +
-        # web_search_tool_result content blocks so the citations panel can
-        # render. The agentic-loop post-hook never fires on this path because
-        # there is no model call — emit the native blocks here instead.
-        native_tool = next(
-            (t for t in tools if is_anthropic_native_web_search_tool(t)),
-            None,
-        )
-
         # Execute search — keep the structured SearchResponse so the native
         # block can carry per-result url/title/page_age.
         try:
@@ -185,27 +174,35 @@ class WebSearchInterceptionLogger(CustomLogger):
             verbose_logger.error(f"WebSearchInterception: Short-circuit search failed: {e}")
             search_result_text, structured = f"Search failed: {e}", None
 
-        content: List[Dict[str, Any]] = []
-        if native_tool is not None:
-            tool_use_id = f"srvtoolu_{uuid.uuid4().hex}"
-            tool_name = native_tool.get("name") or "web_search"
-            content.append(
-                {
-                    "type": "server_tool_use",
-                    "id": tool_use_id,
-                    "name": tool_name,
-                    "input": {"query": query},
-                }
-            )
-            content.append(
-                WebSearchTransformation.build_web_search_tool_result_block(
-                    tool_use_id=tool_use_id,
-                    search_response=structured,
-                )
-            )
-        # Keep the text block so non-native short-circuit callers (Claude Code,
-        # github_copilot, etc.) see the same payload they always have.
-        content.append({"type": "text", "text": search_result_text})
+        # Native clients (Claude Desktop / Cowork / Anthropic SDK) make a
+        # standalone /v1/messages sub-request just for the search, and expect
+        # the response in native shape: a server_tool_use block (which Claude
+        # Code counts to report "Did N searches") followed by a
+        # web_search_tool_result block carrying the sources (which citation
+        # panels render). The agentic-loop post-hook never fires on this path
+        # because there is no model call, so emit the native blocks here.
+        #
+        # These are emitted unconditionally: reaching this point means every
+        # tool is a web-search tool and we are short-circuiting for a provider
+        # that cannot run web_search natively. The pre-request hook has already
+        # renamed any native web_search_* tool to litellm_web_search, so we
+        # cannot re-detect the original Anthropic type here — the short-circuit
+        # contract itself is what tells us native blocks are expected.
+        tool_use_id = f"srvtoolu_{uuid.uuid4().hex}"
+        content: List[Dict[str, Any]] = [
+            {
+                "type": "server_tool_use",
+                "id": tool_use_id,
+                "name": "web_search",
+                "input": {"query": query},
+            },
+            WebSearchTransformation.build_web_search_tool_result_block(
+                tool_use_id=tool_use_id,
+                search_response=structured,
+            ),
+            # Keep the text block so non-native short-circuit callers still see it.
+            {"type": "text", "text": search_result_text},
+        ]
 
         response: Dict[str, Any] = {
             "id": f"msg_{str(uuid.uuid4())}",
@@ -215,13 +212,17 @@ class WebSearchInterceptionLogger(CustomLogger):
             "content": content,
             "stop_reason": "end_turn",
             "stop_sequence": None,
-            "usage": {"input_tokens": 0, "output_tokens": 0},
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "server_tool_use": {"web_search_requests": 1},
+            },
         }
 
         verbose_logger.debug(
             "WebSearchInterception: Short-circuit search completed, "
             f"returning synthetic response ({len(search_result_text)} chars, "
-            f"native_blocks={native_tool is not None})"
+            "native_blocks=True)"
         )
         return response
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py
@@ -113,6 +113,40 @@ class FakeAnthropicMessagesStreamIterator:
             }
             chunks.append(f"event: content_block_delta\ndata: {json.dumps(content_block_delta)}\n\n".encode())
 
+        elif block_type == "server_tool_use":
+            content_block_start = {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {
+                    "type": "server_tool_use",
+                    "id": block_dict.get("id"),
+                    "name": block_dict.get("name"),
+                    "input": {},
+                },
+            }
+            chunks.append(f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode())
+            content_block_delta = {
+                "type": "content_block_delta",
+                "index": index,
+                "delta": {
+                    "type": "input_json_delta",
+                    "partial_json": json.dumps(block_dict.get("input", {})),
+                },
+            }
+            chunks.append(f"event: content_block_delta\ndata: {json.dumps(content_block_delta)}\n\n".encode())
+
+        elif block_type == "web_search_tool_result":
+            content_block_start = {
+                "type": "content_block_start",
+                "index": index,
+                "content_block": {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": block_dict.get("tool_use_id"),
+                    "content": block_dict.get("content", []),
+                },
+            }
+            chunks.append(f"event: content_block_start\ndata: {json.dumps(content_block_start)}\n\n".encode())
+
         content_block_stop = {"type": "content_block_stop", "index": index}
         chunks.append(f"event: content_block_stop\ndata: {json.dumps(content_block_stop)}\n\n".encode())
         return chunks

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_native_blocks.py
@@ -379,8 +379,16 @@ class TestShortCircuitEmitsNativeBlocks:
         assert tool_result["content"][0]["url"] == "https://docs.litellm.ai/"
 
     @pytest.mark.asyncio
-    async def test_litellm_standard_tool_short_circuit_stays_text_only(self):
-        """Non-native tool → existing text-only short-circuit, no regression."""
+    async def test_litellm_standard_tool_short_circuit_emits_blocks(self):
+        """Post-conversion ``litellm_web_search`` tool must emit native blocks.
+
+        This is the shape the short-circuit receives in production: the
+        pre-request hook rewrites every native ``web_search_*`` tool to
+        ``litellm_web_search`` *before* ``try_short_circuit_search`` runs, so
+        the standard-tool case is not a "non-native client" — it is the only
+        case real requests ever take. Emitting text-only here is what made
+        Claude Code report "Did 0 searches" and discard the results.
+        """
         logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
 
         with patch.object(
@@ -406,7 +414,10 @@ class TestShortCircuitEmitsNativeBlocks:
 
         assert result is not None
         block_types = [b["type"] for b in result["content"]]
-        assert block_types == ["text"]
+        assert block_types == ["server_tool_use", "web_search_tool_result", "text"]
+        server_use, tool_result, _ = result["content"]
+        assert server_use["input"] == {"query": "search query"}
+        assert tool_result["tool_use_id"] == server_use["id"]
 
     @pytest.mark.asyncio
     async def test_native_short_circuit_failure_still_emits_blocks(self):

--- a/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
+++ b/tests/test_litellm/integrations/websearch_interception/test_websearch_short_circuit.py
@@ -5,6 +5,7 @@ Tests the short-circuit path that detects web-search-only /v1/messages requests
 and executes the search directly without routing through the backend LLM.
 """
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -212,6 +213,95 @@ class TestTryShortCircuitSearch:
         assert "usage" in result
         assert "content" in result
 
+    @pytest.mark.asyncio
+    async def test_emits_native_blocks_for_post_conversion_tool(self):
+        """Regression: native blocks must be emitted even when the tool has
+        already been renamed to ``litellm_web_search`` by the pre-request hook.
+
+        In production, ``async_pre_request_hook`` converts the client's native
+        ``web_search_20250305`` tool to the LiteLLM standard ``litellm_web_search``
+        *before* ``try_short_circuit_search`` runs. The other tests in this class
+        pass the pre-conversion Anthropic shape, which no longer reaches this
+        function on the real request path — so they did not catch that the
+        short-circuit emitted a text-only response for every real request,
+        causing Claude Code to report "Did 0 searches" and discard the results.
+        """
+        from litellm.integrations.websearch_interception.tools import (
+            get_litellm_web_search_tool,
+        )
+
+        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+
+        with patch.object(
+            logger, "_execute_search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ("search results text", None)
+
+            result = await logger.try_short_circuit_search(
+                model="github_copilot/claude-sonnet-4",
+                messages=[{"role": "user", "content": "Search for X"}],
+                # The post-conversion shape the real pipeline delivers here.
+                tools=[get_litellm_web_search_tool()],
+                custom_llm_provider="github_copilot",
+            )
+
+        assert result is not None
+        block_types = [b["type"] for b in result["content"]]
+        assert "server_tool_use" in block_types
+        assert "web_search_tool_result" in block_types
+        assert "text" in block_types
+        # server_tool_use carries the executed query so the client pairs it.
+        stu = next(b for b in result["content"] if b["type"] == "server_tool_use")
+        assert stu["input"]["query"] == "Search for X"
+        # usage advertises the search so clients that read counts see 1.
+        assert (
+            result["usage"]["server_tool_use"]["web_search_requests"] == 1
+        )
+        mock_search.assert_called_once_with("Search for X")
+
+    @pytest.mark.asyncio
+    async def test_native_result_block_carries_sources(self):
+        """The web_search_tool_result block must carry the structured sources
+        (url/title) returned by the search provider, not just text."""
+        from litellm.llms.base_llm.search.transformation import (
+            SearchResponse,
+            SearchResult,
+        )
+
+        logger = WebSearchInterceptionLogger(enabled_providers=["github_copilot"])
+
+        structured = SearchResponse(
+            results=[
+                SearchResult(
+                    title="Kubernetes Releases",
+                    url="https://kubernetes.io/releases",
+                    snippet="Latest stable release information.",
+                )
+            ]
+        )
+
+        with patch.object(
+            logger, "_execute_search", new_callable=AsyncMock
+        ) as mock_search:
+            mock_search.return_value = ("formatted text", structured)
+
+            result = await logger.try_short_circuit_search(
+                model="github_copilot/claude-sonnet-4",
+                messages=[{"role": "user", "content": "k8s releases"}],
+                tools=[{"type": "web_search_20250305", "name": "web_search"}],
+                custom_llm_provider="github_copilot",
+            )
+
+        wstr = next(
+            b for b in result["content"] if b["type"] == "web_search_tool_result"
+        )
+        assert len(wstr["content"]) == 1
+        assert wstr["content"][0]["url"] == "https://kubernetes.io/releases"
+        assert wstr["content"][0]["title"] == "Kubernetes Releases"
+        # tool_use_id must pair with the server_tool_use block.
+        stu = next(b for b in result["content"] if b["type"] == "server_tool_use")
+        assert wstr["tool_use_id"] == stu["id"]
+
 
 # ---------------------------------------------------------------------------
 # Query extraction tests
@@ -392,3 +482,98 @@ class TestShortCircuitEntryPoint:
         assert result is not None
         text_block = next(b for b in result["content"] if b["type"] == "text")
         assert text_block["text"] == "results"
+
+
+# ---------------------------------------------------------------------------
+# Streaming serialization of native blocks
+# ---------------------------------------------------------------------------
+
+
+class TestFakeStreamIteratorNativeBlocks:
+    """The FakeAnthropicMessagesStreamIterator must serialize the native
+    server_tool_use and web_search_tool_result blocks the short-circuit emits.
+
+    Claude Code issues its WebSearch sub-request with stream=True, so the
+    synthetic dict is rebuilt into SSE by this iterator. Before this fix the
+    iterator only knew text/thinking/tool_use block types and dropped the two
+    web-search block types (emitting a bare content_block_stop with no
+    matching content_block_start), so the client never saw the search.
+    """
+
+    def _collect_sse(self, response: dict):
+        from litellm.llms.anthropic.experimental_pass_through.messages.fake_stream_iterator import (
+            FakeAnthropicMessagesStreamIterator,
+        )
+
+        it = FakeAnthropicMessagesStreamIterator(response)
+        events = []
+        for raw in it.chunks:
+            text = raw.decode()
+            for line in text.splitlines():
+                if line.startswith("data:"):
+                    events.append(json.loads(line[len("data:"):].strip()))
+        return events
+
+    def test_serializes_server_tool_use_and_result_blocks(self):
+        response = {
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "model": "github_copilot/claude-sonnet-4",
+            "content": [
+                {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_abc",
+                    "name": "web_search",
+                    "input": {"query": "kubernetes latest"},
+                },
+                {
+                    "type": "web_search_tool_result",
+                    "tool_use_id": "srvtoolu_abc",
+                    "content": [
+                        {
+                            "type": "web_search_result",
+                            "url": "https://kubernetes.io/releases",
+                            "title": "Releases",
+                            "page_age": None,
+                            "encrypted_content": "",
+                        }
+                    ],
+                },
+                {"type": "text", "text": "Kubernetes 1.34 is latest."},
+            ],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 0, "output_tokens": 0},
+        }
+
+        events = self._collect_sse(response)
+        starts = [e for e in events if e["type"] == "content_block_start"]
+        stops = [e for e in events if e["type"] == "content_block_stop"]
+
+        # Every emitted block gets a well-formed start/stop pair.
+        assert len(starts) == 3
+        assert len(stops) == 3
+        started_types = [e["content_block"]["type"] for e in starts]
+        assert started_types == [
+            "server_tool_use",
+            "web_search_tool_result",
+            "text",
+        ]
+
+        # server_tool_use carries id/name and the query arrives via input_json_delta.
+        stu_start = starts[0]["content_block"]
+        assert stu_start["id"] == "srvtoolu_abc"
+        assert stu_start["name"] == "web_search"
+        deltas = [e for e in events if e["type"] == "content_block_delta"]
+        json_deltas = [
+            json.loads(e["delta"]["partial_json"])
+            for e in deltas
+            if e["delta"]["type"] == "input_json_delta"
+        ]
+        assert {"query": "kubernetes latest"} in json_deltas
+
+        # web_search_tool_result carries the tool_use_id and sources.
+        wstr_start = starts[1]["content_block"]
+        assert wstr_start["tool_use_id"] == "srvtoolu_abc"
+        assert wstr_start["content"][0]["url"] == "https://kubernetes.io/releases"


### PR DESCRIPTION
## Relevant issues

Fixes #31902

## Linear ticket

<!-- leave blank, external contributor -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

End-to-end against a local `litellm` proxy → GitHub Copilot backend → Tavily search (real API calls, no mocks). Same streaming `web_search` sub-request Claude Code issues, before vs. after:

**Before (unpatched `main` / `1.91.0rc1`)** — response stream is text-only:
```
$ curl -sN -X POST 'http://localhost:4200/v1/messages?beta=true' \
    -H 'Authorization: Bearer …' -H 'anthropic-version: 2023-06-01' \
    -d '{"model":"claude-opus-4-8","stream":true,"max_tokens":1024,
         "tools":[{"type":"web_search_20250305","name":"web_search"}],
         "messages":[{"role":"user","content":"Perform a web search for the query: newest Kubernetes minor version release 2026"}]}'

content_block types: ["text"]          # ← no server_tool_use, no web_search_tool_result
→ Claude Code reports: "Did 0 searches", discards results, falls back to WebFetch
```

**After (this PR)** — native blocks present, sources carried:
```
content_block types: ["server_tool_use", "web_search_tool_result", "text"]
  server_tool_use.input.query = "…newest Kubernetes minor version release 2026"
  web_search_tool_result.content = 5 sources (url + title each)
SSE: 3 content_block_start / 3 content_block_stop, balanced, valid JSON
→ Claude Code reports: "Did 1 search"
```

## Type

🐛 Bug Fix

## Changes

- `litellm/integrations/websearch_interception/handler.py` — emit `server_tool_use` + `web_search_tool_result` + `text` unconditionally on the short-circuit path; advertise `usage.server_tool_use.web_search_requests = 1`.
- `litellm/llms/anthropic/experimental_pass_through/messages/fake_stream_iterator.py` — serialize the `server_tool_use` and `web_search_tool_result` block types (previously dropped → malformed SSE under `stream=true`).
- Tests — updated `test_litellm_standard_tool_short_circuit_*` to the correct post-conversion contract; added regression tests for the post-conversion shape, structured-source passthrough, and streaming serialization.