### PR TITLE
fix(proxy): stop CacheCodec dropping null fields on cache round-trip

### DIFF
--- a/litellm/models/managed_files.py
+++ b/litellm/models/managed_files.py
@@ -51,12 +51,12 @@ class LiteLLM_ManagedVectorStoreTable(LiteLLMPydanticObjectBase):
 class LiteLLM_ManagedVectorStoresTable(LiteLLMPydanticObjectBase):
     vector_store_id: str
     custom_llm_provider: str
-    vector_store_name: Optional[str]
-    vector_store_description: Optional[str]
-    vector_store_metadata: Optional[Dict[str, Any]]
-    created_at: Optional[datetime]
-    updated_at: Optional[datetime]
-    litellm_credential_name: Optional[str]
-    litellm_params: Optional[Dict[str, Any]]
-    team_id: Optional[str]
-    user_id: Optional[str]
+    vector_store_name: Optional[str] = None
+    vector_store_description: Optional[str] = None
+    vector_store_metadata: Optional[Dict[str, Any]] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    litellm_credential_name: Optional[str] = None
+    litellm_params: Optional[Dict[str, Any]] = None
+    team_id: Optional[str] = None
+    user_id: Optional[str] = None

--- a/litellm/proxy/common_utils/cache_pydantic_utils.py
+++ b/litellm/proxy/common_utils/cache_pydantic_utils.py
@@ -42,7 +42,7 @@ class CacheCodec:
         Encode a value for DualCache / Redis (``json.dumps``-safe).
 
         If ``model_type`` is set, the payload is validated with that model, then
-        ``model_dump(mode="json", exclude_none=True)`` — symmetric with ``deserialize``.
+        ``model_dump(mode="json")`` — symmetric with ``deserialize``.
 
         If the value is already an instance of ``model_type`` (or a subclass),
         ``model_validate`` is skipped to avoid an unnecessary Pydantic copy — the
@@ -54,12 +54,12 @@ class CacheCodec:
         if model_type is not None:
             if isinstance(value, model_type):
                 # Already the right type: dump directly, skip re-validation copy.
-                return value.model_dump(mode="json", exclude_none=True)
+                return value.model_dump(mode="json")
             if isinstance(value, (dict, BaseModel)):
-                return model_type.model_validate(value).model_dump(mode="json", exclude_none=True)
+                return model_type.model_validate(value).model_dump(mode="json")
             return value
         if isinstance(value, BaseModel):
-            return value.model_dump(mode="json", exclude_none=True)
+            return value.model_dump(mode="json")
         return value
 
     @staticmethod

--- a/tests/test_litellm/proxy/common_utils/test_cache_codec.py
+++ b/tests/test_litellm/proxy/common_utils/test_cache_codec.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 from unittest.mock import patch
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from litellm.models.managed_files import LiteLLM_ManagedVectorStoresTable
 from litellm.proxy.common_utils.cache_pydantic_utils import CacheCodec
 
 
@@ -15,6 +16,11 @@ class _SampleModel(BaseModel):
 
 class _SampleSubModel(_SampleModel):
     pass
+
+
+class _RequiredNullableModel(BaseModel):
+    id: str
+    budget_table: Optional[Dict[str, Any]]
 
 
 class TestCacheCodecSerialize:
@@ -37,12 +43,12 @@ class TestCacheCodecSerialize:
     def test_with_model_type_base_model_validated_and_dumped(self):
         m = _SampleModel(name="c", count=None)
         out = CacheCodec.serialize(m, model_type=_SampleModel)
-        assert out == {"name": "c"}
+        assert out == {"name": "c", "count": None}
 
-    def test_with_model_type_exclude_none_on_dump(self):
+    def test_with_model_type_none_field_preserved_on_dump(self):
         out = CacheCodec.serialize({"name": "d"}, model_type=_SampleModel)
-        assert out == {"name": "d"}
-        assert "count" not in out
+        assert out == {"name": "d", "count": None}
+        assert "count" in out
 
     def test_with_model_type_non_dict_non_model_passthrough(self):
         assert CacheCodec.serialize("raw", model_type=_SampleModel) == "raw"
@@ -124,3 +130,39 @@ class TestCacheCodecDeserialize:
             for r in caplog.records
             if r.levelno >= logging.WARNING
         ), f"Expected deserialize validation warning. Records: {[r.message for r in caplog.records]}"
+
+
+class TestCacheCodecRoundTripPreservesNoneFields:
+    def test_none_value_kept_as_null_not_dropped(self):
+        out = CacheCodec.serialize(
+            _RequiredNullableModel(id="x", budget_table=None),
+            model_type=_RequiredNullableModel,
+        )
+        assert out == {"id": "x", "budget_table": None}
+        assert "budget_table" in out
+
+    def test_required_nullable_none_field_survives_round_trip(self):
+        original = _RequiredNullableModel(id="x", budget_table=None)
+        wire = CacheCodec.serialize(original, model_type=_RequiredNullableModel)
+        restored = CacheCodec.deserialize(wire, model_type=_RequiredNullableModel)
+        assert restored == original
+
+    def test_managed_vector_store_row_round_trips_with_optional_fields_none(self):
+        vs = LiteLLM_ManagedVectorStoresTable(
+            vector_store_id="vs_1",
+            custom_llm_provider="openai",
+            vector_store_name=None,
+            vector_store_description=None,
+            vector_store_metadata=None,
+            created_at=None,
+            updated_at=None,
+            litellm_credential_name=None,
+            litellm_params=None,
+            team_id=None,
+            user_id=None,
+        )
+        wire = CacheCodec.serialize(vs, model_type=LiteLLM_ManagedVectorStoresTable)
+        assert wire.get("vector_store_name", "MISSING") is None
+        assert wire.get("team_id", "MISSING") is None
+        restored = CacheCodec.deserialize(wire, model_type=LiteLLM_ManagedVectorStoresTable)
+        assert restored == vs


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3277
Resolves LIT-3427

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`CacheCodec.serialize` wrote cached Pydantic models with `model_dump(exclude_none=True)`, which drops any `None`-valued key, while `deserialize` does a strict `model_validate`. When a cached model has a required-but-nullable field (`Optional[X]` with no default), a `None` value is written as an absent key and then fails `model_validate` on read with `Field required`, so the entry can never be read back

`LiteLLM_ManagedVectorStoresTable` is such a model, so this is live today on any deployment that resolves a managed vector store (the cache read in `get_managed_vector_store_rows_by_uuids` runs on the request path)

Repro config (Redis-backed cache + DB):

```yaml
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  database_url: os.environ/DATABASE_URL
  store_model_in_db: true
litellm_settings:
  cache: true
  cache_params: { type: redis, host: localhost, port: 6379 }
```

**Before (current `litellm_internal_staging`)**

```bash
# 1) create a managed vector store whose optional columns are null
curl -s $BASE/vector_store/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"vector_store_id":"vs_lit3277_repro","custom_llm_provider":"openai"}'

# 2) resolve it 5x (the search reads the store from cache before anything else)
for i in 1 2 3 4 5; do
  curl -s $BASE/v1/vector_stores/vs_lit3277_repro/search -H "Authorization: Bearer $MASTER_KEY" \
    -H "Content-Type: application/json" -d '{"query":"hello world"}' -o /dev/null -w "search #$i -> HTTP %{http_code}\n"
done

# 3) how many cache reads failed to deserialize?
grep -c "CacheCodec.deserialize: validation failed" proxy.log
```

```
search #1 -> HTTP 500
search #2 -> HTTP 500
search #3 -> HTTP 500
search #4 -> HTTP 500
search #5 -> HTTP 500
4
```

Every read after the first logged:

```
ERROR ... UserApiKeyCache.async_get_cache failed to deserialize cached value for
  key='managed_vector_store_id:vs_lit3277_repro' model_type=LiteLLM_ManagedVectorStoresTable
WARNING ... CacheCodec.deserialize: validation failed for LiteLLM_ManagedVectorStoresTable (5 validation errors ...
  vector_store_name / vector_store_description / vector_store_metadata / litellm_credential_name / team_id
  Field required [type=missing] ...)
```

The `HTTP 500` is the downstream provider call (there is no real `openai` vector store behind this id) and is unrelated; the cache read runs first, fails, and forces a DB re-query on every request so the cache never serves the row

**After (this PR)**

Same flow, same searches, count of deserialize failures is `0`:

```
search #1 -> HTTP 500
search #2 -> HTTP 500
search #3 -> HTTP 500
search #4 -> HTTP 500
search #5 -> HTTP 500
0
```

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/common_utils/cache_pydantic_utils.py`: `CacheCodec.serialize` no longer passes `exclude_none=True`, so `serialize` and `deserialize` are a lossless pair and `None` fields are written as `null`. This is the root fix and covers every cached model, not just the one below
- `litellm/models/managed_files.py`: give the nine `Optional` fields on `LiteLLM_ManagedVectorStoresTable` a `None` default, matching every other cached model; this is the one cached model still declared required-but-nullable
- `tests/test_litellm/proxy/common_utils/test_cache_codec.py`: flip the two tests that asserted `None` keys were dropped, and add regression tests that fail under the old `exclude_none` behavior (a required-nullable `None` field must survive `serialize` then `deserialize`, and a real `LiteLLM_ManagedVectorStoresTable` with all optional fields null round-trips without a validation warning)

Out of scope here to keep this isolated: three readers still rebuild a cached model from the raw dict without the typed codec (`budget_reservation.py`, the budget path in `auth_checks.py`, `mcp_server_manager.py`). After this fix the cached dict is complete so they no longer break, but routing them through the typed codec would make a future schema drift degrade to a cache miss instead of an uncaught error; I can do that in a separate PR
