### PR TITLE
fix: correct offset when expanding multiple multi_tool_use.parallel tool calls

### DIFF
--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -402,7 +402,9 @@ def _handle_invalid_parallel_tool_calls(
         shift = 0
         for i, replacement in replacements.items():
             tool_calls[:] = tool_calls[: i + shift] + replacement + tool_calls[i + shift + 1 :]
-            shift += len(replacement)
+            # Each splice removes one element and inserts len(replacement), so the
+            # net change to subsequent indices is len(replacement) - 1.
+            shift += len(replacement) - 1
 
         return tool_calls
     except json.JSONDecodeError:

--- a/tests/test_litellm/litellm_core_utils/llm_response_utils/test_handle_invalid_parallel_tool_calls.py
+++ b/tests/test_litellm/litellm_core_utils/llm_response_utils/test_handle_invalid_parallel_tool_calls.py
@@ -1,0 +1,86 @@
+"""
+Tests for ``_handle_invalid_parallel_tool_calls`` in
+``litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response``.
+
+The function replaces each hallucinated ``multi_tool_use.parallel`` tool call
+with the real tool calls it encoded. These tests focus on the case where a
+single message carries more than one ``multi_tool_use.parallel`` call, which
+exercises the running-offset bookkeeping used to splice replacements in place.
+"""
+
+import json
+
+from litellm.litellm_core_utils.llm_response_utils.convert_dict_to_response import (
+    _handle_invalid_parallel_tool_calls,
+)
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
+
+
+def _multi_tool_use(call_id, tool_uses):
+    return ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(
+            name="multi_tool_use.parallel",
+            arguments=json.dumps({"tool_uses": tool_uses}),
+        ),
+    )
+
+
+def test_multiple_multi_tool_use_parallel_all_expanded():
+    """Two multi_tool_use.parallel calls in one message must both be expanded."""
+    tool_calls = [
+        _multi_tool_use(
+            "call_1",
+            [
+                {"recipient_name": "functions.get_weather", "parameters": {"city": "NYC"}},
+                {"recipient_name": "functions.get_time", "parameters": {"tz": "EST"}},
+            ],
+        ),
+        _multi_tool_use(
+            "call_2",
+            [
+                {"recipient_name": "functions.get_stock", "parameters": {"ticker": "AAPL"}},
+            ],
+        ),
+    ]
+
+    result = _handle_invalid_parallel_tool_calls(tool_calls)
+
+    # No hallucinated wrapper call should survive.
+    assert all(tc.function.name != "multi_tool_use.parallel" for tc in result)
+
+    names = [tc.function.name for tc in result]
+    assert names == ["get_weather", "get_time", "get_stock"]
+
+    ids = [tc.id for tc in result]
+    assert ids == ["call_1_0", "call_1_1", "call_2_0"]
+
+
+def test_multi_tool_use_parallel_interleaved_with_real_call():
+    """A real tool call between two parallel calls keeps its position and value."""
+    tool_calls = [
+        _multi_tool_use(
+            "call_1",
+            [
+                {"recipient_name": "functions.get_weather", "parameters": {"city": "NYC"}},
+            ],
+        ),
+        ChatCompletionMessageToolCall(
+            id="call_real",
+            type="function",
+            function=Function(name="lookup", arguments='{"q": "x"}'),
+        ),
+        _multi_tool_use(
+            "call_3",
+            [
+                {"recipient_name": "functions.get_stock", "parameters": {"ticker": "AAPL"}},
+            ],
+        ),
+    ]
+
+    result = _handle_invalid_parallel_tool_calls(tool_calls)
+
+    assert all(tc.function.name != "multi_tool_use.parallel" for tc in result)
+    assert [tc.function.name for tc in result] == ["get_weather", "lookup", "get_stock"]
+    assert [tc.id for tc in result] == ["call_1_0", "call_real", "call_3_0"]


### PR DESCRIPTION
## Relevant issues

N/A - self-contained bug found by code inspection.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

This is a pure, offline list-transformation fix (no network/LLM call), so the proof is a unit test that fails on `main` and passes on this branch.

```
pytest tests/test_litellm/litellm_core_utils/llm_response_utils/test_handle_invalid_parallel_tool_calls.py
```

- On `main` (before the fix): both tests fail - a second `multi_tool_use.parallel` call is left unexpanded in the output.
- On this branch (after the fix): both tests pass. The rest of the file's test directory (31 tests) still passes.

## Type

🐛 Bug Fix

## Changes

`_handle_invalid_parallel_tool_calls` rewrites each hallucinated `multi_tool_use.parallel` tool call into the real calls it encoded, splicing the replacements into `tool_calls` in place:

```python
tool_calls[:] = tool_calls[: i + shift] + replacement + tool_calls[i + shift + 1 :]
shift += len(replacement)
```

Each splice removes one element (the wrapper) and inserts `len(replacement)`, so the net change to the positions of later elements is `len(replacement) - 1`. The running `shift` advanced by the full `len(replacement)`, over-shifting by one for every replacement after the first.

With a single `multi_tool_use.parallel` call the bug is latent, because `shift` is never reused. With two or more in the same message, the second and later wrappers are not removed and their real calls land at the wrong offset.

Example - two `multi_tool_use.parallel` calls that expand to `[get_weather, get_time]` and `[get_stock]`:

- before: `[get_weather, get_time, multi_tool_use.parallel, get_stock]` (the second wrapper survives, `get_stock` is appended at the end)
- after: `[get_weather, get_time, get_stock]`

Fix: accumulate `len(replacement) - 1`.

Tests added in `tests/test_litellm/litellm_core_utils/llm_response_utils/test_handle_invalid_parallel_tool_calls.py` cover two `multi_tool_use.parallel` calls in one message and a real tool call interleaved between two parallel calls.