### PR TITLE
fix: enforce tool_permission on raw passthrough responses

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -779,8 +779,10 @@ class ToolPermissionGuardrail(CustomGuardrail):
 
             error_messages: list[str] = []
             filtered_tool_calls = []
-            for tool_call in message.get("tool_calls") or []:
-                tool_call_id = self._get_mapping_value(tool_call, "id")
+            for tool_index, tool_call in enumerate(message.get("tool_calls") or []):
+                tool_call_id = self._get_mapping_value(tool_call, "id") or (
+                    f"raw_openai_tool_call_{choice_index}_{tool_index}"
+                )
                 error_message = error_messages_by_id.get(tool_call_id)
                 if error_message is not None:
                     error_messages.append(error_message)
@@ -811,8 +813,8 @@ class ToolPermissionGuardrail(CustomGuardrail):
 
         filtered_content = []
         error_messages = []
-        for block in content:
-            tool_call_id = self._get_mapping_value(block, "id")
+        for block_index, block in enumerate(content):
+            tool_call_id = self._get_mapping_value(block, "id") or f"raw_anthropic_tool_use_{block_index}"
             error_message = error_messages_by_id.get(tool_call_id)
             if self._get_mapping_value(block, "type") == "tool_use" and error_message is not None:
                 error_messages.append(error_message)

--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, AsyncGenerator, Dict, List, Literal, Optional, Union
+from typing import Any, AsyncGenerator, Literal, Optional, Union
 
 from fastapi import HTTPException
 

--- a/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/tool_permission.py
@@ -37,7 +37,7 @@ GUARDRAIL_NAME = "tool_permission"
 class ToolPermissionGuardrail(CustomGuardrail):
     def __init__(
         self,
-        rules: Optional[List[Dict]] = None,
+        rules: Optional[list[dict]] = None,
         default_action: Literal["deny", "allow"] = "deny",
         on_disallowed_action: Literal["block", "rewrite"] = "block",
         **kwargs,
@@ -74,7 +74,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
             self.default_action,
         )
 
-    def _load_rules(self, rules: Optional[List[Any]]) -> None:
+    def _load_rules(self, rules: Optional[list[Any]]) -> None:
         """Parse ``rules`` and (re)build the compiled target/pattern lookups.
 
         ``self.rules`` plus ``_compiled_rule_targets`` / ``_compiled_rule_patterns``
@@ -83,14 +83,14 @@ class ToolPermissionGuardrail(CustomGuardrail):
         single source of truth, so an in-place update (PUT /guardrails, immediate
         sync) reflects rule changes instead of keeping the construction-time maps.
         """
-        parsed_rules: List[ToolPermissionRule] = []
-        compiled_targets: Dict[str, Dict[str, Optional[re.Pattern]]] = {}
-        compiled_patterns: Dict[str, Dict[str, re.Pattern]] = {}
+        parsed_rules: list[ToolPermissionRule] = []
+        compiled_targets: dict[str, dict[str, Optional[re.Pattern]]] = {}
+        compiled_patterns: dict[str, dict[str, re.Pattern]] = {}
 
         for rule_item in rules or []:
             rule = rule_item if isinstance(rule_item, ToolPermissionRule) else ToolPermissionRule(**rule_item)
 
-            target_patterns: Dict[str, Optional[re.Pattern]] = {
+            target_patterns: dict[str, Optional[re.Pattern]] = {
                 "tool_name": None,
                 "tool_type": None,
             }
@@ -105,7 +105,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
                 except re.error as exc:
                     raise ValueError(f"Invalid regex for tool_type in rule '{rule.id}': {exc}") from exc
 
-            rule_patterns: Dict[str, re.Pattern] = {}
+            rule_patterns: dict[str, re.Pattern] = {}
             for path, pattern in (rule.allowed_param_patterns or {}).items():
                 try:
                     rule_patterns[path] = re.compile(pattern)
@@ -264,7 +264,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
 
     def _parse_tool_call_arguments(
         self, tool_call: ChatCompletionMessageToolCall
-    ) -> tuple[Optional[Dict[str, Any]], Optional[str]]:
+    ) -> tuple[Optional[dict[str, Any]], Optional[str]]:
         arguments = getattr(tool_call.function, "arguments", None)
         if not arguments:
             return None, "missing arguments"
@@ -298,7 +298,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
         self,
         value: Any,
         current_path: str,
-        collected: Dict[str, List[Any]],
+        collected: dict[str, list[Any]],
         depth: int = 0,
     ) -> None:
         from litellm.constants import DEFAULT_MAX_RECURSE_DEPTH
@@ -322,7 +322,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
     def _patterns_match_for_rule(
         self,
         *,
-        arguments: Dict[str, Any],
+        arguments: dict[str, Any],
         rule: ToolPermissionRule,
         tool_name: Optional[str],
     ) -> tuple[bool, Optional[str]]:
@@ -330,7 +330,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
         if not compiled_patterns:
             return True, None
 
-        path_value_map: Dict[str, List[Any]] = {}
+        path_value_map: dict[str, list[Any]] = {}
         self._collect_argument_paths(arguments, "", path_value_map)
 
         for path, compiled_pattern in compiled_patterns.items():
@@ -444,7 +444,130 @@ class ToolPermissionGuardrail(CustomGuardrail):
             function={"name": function_name, "arguments": arguments},
         )
 
-    def _extract_tool_calls_from_response(self, response: ModelResponse) -> List[ChatCompletionMessageToolCall]:
+    @staticmethod
+    def _raw_arguments_to_json(arguments: Any) -> str:
+        if arguments is None:
+            return ""
+        if isinstance(arguments, str):
+            return arguments
+        try:
+            return json.dumps(arguments)
+        except TypeError:
+            return json.dumps(str(arguments))
+
+    def _raw_tool_call_to_standard_tool_call(
+        self,
+        *,
+        tool_name: Optional[str],
+        arguments: Any,
+        tool_call_id: Optional[str],
+        fallback_id: str,
+    ) -> Optional[ChatCompletionMessageToolCall]:
+        if not tool_name:
+            return None
+
+        return ChatCompletionMessageToolCall(
+            id=tool_call_id or fallback_id,
+            type="function",
+            function={
+                "name": tool_name,
+                "arguments": self._raw_arguments_to_json(arguments),
+            },
+        )
+
+    def _extract_openai_raw_tool_calls(self, response: dict[str, Any]) -> list[ChatCompletionMessageToolCall]:
+        tool_calls: list[ChatCompletionMessageToolCall] = []
+        for choice_index, choice in enumerate(response.get("choices") or []):
+            message = self._get_mapping_value(choice, "message") or {}
+            for tool_index, tool_call in enumerate(self._get_mapping_value(message, "tool_calls") or []):
+                function = self._get_mapping_value(tool_call, "function") or {}
+                standard_tool_call = self._raw_tool_call_to_standard_tool_call(
+                    tool_name=self._get_mapping_value(function, "name"),
+                    arguments=self._get_mapping_value(function, "arguments"),
+                    tool_call_id=self._get_mapping_value(tool_call, "id"),
+                    fallback_id=f"raw_openai_tool_call_{choice_index}_{tool_index}",
+                )
+                if standard_tool_call is not None:
+                    tool_calls.append(standard_tool_call)
+
+            legacy_tool_call = self._legacy_function_call_to_tool_call(
+                self._get_mapping_value(message, "function_call"), choice_index
+            )
+            if legacy_tool_call is not None:
+                tool_calls.append(legacy_tool_call)
+        return tool_calls
+
+    def _extract_anthropic_raw_tool_calls(self, response: dict[str, Any]) -> list[ChatCompletionMessageToolCall]:
+        tool_calls: list[ChatCompletionMessageToolCall] = []
+        for block_index, block in enumerate(response.get("content") or []):
+            if self._get_mapping_value(block, "type") != "tool_use":
+                continue
+            standard_tool_call = self._raw_tool_call_to_standard_tool_call(
+                tool_name=self._get_mapping_value(block, "name"),
+                arguments=self._get_mapping_value(block, "input"),
+                tool_call_id=self._get_mapping_value(block, "id"),
+                fallback_id=f"raw_anthropic_tool_use_{block_index}",
+            )
+            if standard_tool_call is not None:
+                tool_calls.append(standard_tool_call)
+        return tool_calls
+
+    def _extract_gemini_raw_tool_calls(self, response: dict[str, Any]) -> list[ChatCompletionMessageToolCall]:
+        tool_calls: list[ChatCompletionMessageToolCall] = []
+        for candidate_index, candidate in enumerate(response.get("candidates") or []):
+            content = self._get_mapping_value(candidate, "content") or {}
+            for part_index, part in enumerate(self._get_mapping_value(content, "parts") or []):
+                function_call = self._get_mapping_value(part, "functionCall")
+                if function_call is None:
+                    continue
+                standard_tool_call = self._raw_tool_call_to_standard_tool_call(
+                    tool_name=self._get_mapping_value(function_call, "name"),
+                    arguments=self._get_mapping_value(function_call, "args"),
+                    tool_call_id=None,
+                    fallback_id=f"raw_gemini_function_call_{candidate_index}_{part_index}",
+                )
+                if standard_tool_call is not None:
+                    tool_calls.append(standard_tool_call)
+        return tool_calls
+
+    def _extract_bedrock_raw_tool_calls(self, response: dict[str, Any]) -> list[ChatCompletionMessageToolCall]:
+        tool_calls: list[ChatCompletionMessageToolCall] = []
+        output = response.get("output")
+        output_message = self._get_mapping_value(output, "message") if isinstance(output, dict) else None
+        bedrock_content = (
+            self._get_mapping_value(output_message, "content") if isinstance(output_message, dict) else None
+        )
+        for block_index, block in enumerate(bedrock_content or []):
+            tool_use = self._get_mapping_value(block, "toolUse")
+            if not isinstance(tool_use, dict):
+                continue
+            standard_tool_call = self._raw_tool_call_to_standard_tool_call(
+                tool_name=self._get_mapping_value(tool_use, "name"),
+                arguments=self._get_mapping_value(tool_use, "input"),
+                tool_call_id=self._get_mapping_value(tool_use, "toolUseId"),
+                fallback_id=f"raw_bedrock_tool_use_{block_index}",
+            )
+            if standard_tool_call is not None:
+                tool_calls.append(standard_tool_call)
+        return tool_calls
+
+    def _extract_tool_calls_from_raw_response(self, response: dict[str, Any]) -> list[ChatCompletionMessageToolCall]:
+        """
+        Extract tool calls from provider-native pass-through responses.
+
+        Pass-through endpoints hand post-call guardrails the raw upstream JSON,
+        not LiteLLM's normalized ModelResponse. Keep this parser narrow and
+        provider-shape based so tool_permission can still enforce post-call
+        rules without changing pass-through response semantics.
+        """
+        return [
+            *self._extract_openai_raw_tool_calls(response),
+            *self._extract_anthropic_raw_tool_calls(response),
+            *self._extract_gemini_raw_tool_calls(response),
+            *self._extract_bedrock_raw_tool_calls(response),
+        ]
+
+    def _extract_tool_calls_from_response(self, response: ModelResponse) -> list[ChatCompletionMessageToolCall]:
         """
         Extract tool_calls from all choices in a model response.
 
@@ -498,8 +621,8 @@ class ToolPermissionGuardrail(CustomGuardrail):
             return function_call
         return self._get_mapping_value(function_call, "name")
 
-    def _collect_request_tools(self, data: dict) -> List[tuple[str, Optional[str]]]:
-        request_tools: List[tuple[str, Optional[str]]] = []
+    def _collect_request_tools(self, data: dict) -> list[tuple[str, Optional[str]]]:
+        request_tools: list[tuple[str, Optional[str]]] = []
 
         for tool in data.get("tools") or []:
             tool_name, tool_type = self._get_request_tool_name(tool)
@@ -523,7 +646,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
     def _modify_request_with_permission_errors(
         self,
         data: dict,
-        denied_tool_names: List[str],
+        denied_tool_names: list[str],
     ):
         """
         Modify the request to replace denied tool_calls blocks with error results
@@ -542,7 +665,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
         for tool_use in denied_tool_names:
             error_tool_names.add(tool_use)
 
-        tools: Optional[List[ChatCompletionToolParam]] = data.get("tools")
+        tools: Optional[list[ChatCompletionToolParam]] = data.get("tools")
         if tools is not None:
             new_tools = []
             for tool in tools:
@@ -590,7 +713,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
     def _modify_response_with_permission_errors(
         self,
         response: ModelResponse,
-        denied_tools: List[tuple[ChatCompletionMessageToolCall, PermissionError]],
+        denied_tools: list[tuple[ChatCompletionMessageToolCall, PermissionError]],
     ) -> None:
         """
         Modify the response to replace denied tool_calls blocks with error results
@@ -643,6 +766,129 @@ class ToolPermissionGuardrail(CustomGuardrail):
                         choice.message.content = existing_content + "\n\n" + "\n".join(error_messages)
                     else:
                         choice.message.content = "\n".join(error_messages)
+
+    def _rewrite_openai_raw_response(
+        self,
+        response: dict[str, Any],
+        error_messages_by_id: dict[str, str],
+    ) -> None:
+        for choice_index, choice in enumerate(response.get("choices") or []):
+            message = self._get_mapping_value(choice, "message")
+            if not isinstance(message, dict):
+                continue
+
+            error_messages: list[str] = []
+            filtered_tool_calls = []
+            for tool_call in message.get("tool_calls") or []:
+                tool_call_id = self._get_mapping_value(tool_call, "id")
+                error_message = error_messages_by_id.get(tool_call_id)
+                if error_message is not None:
+                    error_messages.append(error_message)
+                else:
+                    filtered_tool_calls.append(tool_call)
+
+            if "tool_calls" in message:
+                message["tool_calls"] = filtered_tool_calls or None
+
+            legacy_error_message = error_messages_by_id.get(self._legacy_function_call_id(choice_index))
+            if legacy_error_message is not None:
+                message["function_call"] = None
+                error_messages.append(legacy_error_message)
+
+            if error_messages:
+                existing_content = message.get("content")
+                error_text = "\n".join(error_messages)
+                message["content"] = f"{existing_content}\n\n{error_text}" if existing_content else error_text
+
+    def _rewrite_anthropic_raw_response(
+        self,
+        response: dict[str, Any],
+        error_messages_by_id: dict[str, str],
+    ) -> None:
+        content = response.get("content")
+        if not isinstance(content, list):
+            return
+
+        filtered_content = []
+        error_messages = []
+        for block in content:
+            tool_call_id = self._get_mapping_value(block, "id")
+            error_message = error_messages_by_id.get(tool_call_id)
+            if self._get_mapping_value(block, "type") == "tool_use" and error_message is not None:
+                error_messages.append(error_message)
+            else:
+                filtered_content.append(block)
+        if error_messages:
+            filtered_content.append({"type": "text", "text": "\n".join(error_messages)})
+            response["content"] = filtered_content
+
+    def _rewrite_gemini_raw_response(
+        self,
+        response: dict[str, Any],
+        error_messages_by_id: dict[str, str],
+    ) -> None:
+        for candidate_index, candidate in enumerate(response.get("candidates") or []):
+            content = self._get_mapping_value(candidate, "content")
+            if not isinstance(content, dict):
+                continue
+
+            filtered_parts = []
+            error_messages = []
+            for part_index, part in enumerate(content.get("parts") or []):
+                tool_call_id = f"raw_gemini_function_call_{candidate_index}_{part_index}"
+                error_message = error_messages_by_id.get(tool_call_id)
+                if self._get_mapping_value(part, "functionCall") is not None and error_message is not None:
+                    error_messages.append(error_message)
+                else:
+                    filtered_parts.append(part)
+            if error_messages:
+                filtered_parts.append({"text": "\n".join(error_messages)})
+                content["parts"] = filtered_parts
+
+    def _rewrite_bedrock_raw_response(
+        self,
+        response: dict[str, Any],
+        error_messages_by_id: dict[str, str],
+    ) -> None:
+        output = response.get("output")
+        output_message = self._get_mapping_value(output, "message") if isinstance(output, dict) else None
+        bedrock_content = (
+            self._get_mapping_value(output_message, "content") if isinstance(output_message, dict) else None
+        )
+        if not isinstance(bedrock_content, list):
+            return
+
+        filtered_content = []
+        error_messages = []
+        for block_index, block in enumerate(bedrock_content):
+            tool_use = self._get_mapping_value(block, "toolUse")
+            tool_call_id = self._get_mapping_value(tool_use, "toolUseId") if isinstance(tool_use, dict) else None
+            error_message = error_messages_by_id.get(tool_call_id or f"raw_bedrock_tool_use_{block_index}")
+            if isinstance(tool_use, dict) and error_message is not None:
+                error_messages.append(error_message)
+            else:
+                filtered_content.append(block)
+        if error_messages:
+            filtered_content.append({"text": "\n".join(error_messages)})
+            output_message["content"] = filtered_content
+
+    def _modify_raw_response_with_permission_errors(
+        self,
+        response: dict[str, Any],
+        denied_tools: list[tuple[ChatCompletionMessageToolCall, PermissionError]],
+    ) -> None:
+        if not denied_tools:
+            return
+
+        error_messages_by_id = {
+            tool_call.id: self._create_permission_error_result(tool_call, error).content
+            for tool_call, error in denied_tools
+        }
+
+        self._rewrite_openai_raw_response(response, error_messages_by_id)
+        self._rewrite_anthropic_raw_response(response, error_messages_by_id)
+        self._rewrite_gemini_raw_response(response, error_messages_by_id)
+        self._rewrite_bedrock_raw_response(response, error_messages_by_id)
 
     @log_guardrail_information
     async def async_pre_call_hook(
@@ -710,17 +956,18 @@ class ToolPermissionGuardrail(CustomGuardrail):
             user_api_key_dict: User API key information (unused but required by interface)
             response: The model response to check
         """
-        if not isinstance(response, ModelResponse):
-            return response
-
         verbose_proxy_logger.debug("Tool Permission Guardrail Post-Call Hook: Checking response")
 
         if not self.should_run_guardrail(data=data, event_type=GuardrailEventHooks.post_call):
             verbose_proxy_logger.debug("Tool Permission Guardrail: Skipping check (not enabled)")
             return response
 
-        # Extract tool_calls from the response
-        tool_calls = self._extract_tool_calls_from_response(response)
+        if isinstance(response, ModelResponse):
+            tool_calls = self._extract_tool_calls_from_response(response)
+        elif isinstance(response, dict):
+            tool_calls = self._extract_tool_calls_from_raw_response(response)
+        else:
+            return response
 
         if not tool_calls:
             verbose_proxy_logger.debug("Tool Permission Guardrail: No tool uses found")
@@ -757,7 +1004,10 @@ class ToolPermissionGuardrail(CustomGuardrail):
                 )
 
         if denied_tools:
-            self._modify_response_with_permission_errors(response, denied_tools)
+            if isinstance(response, ModelResponse):
+                self._modify_response_with_permission_errors(response, denied_tools)
+            else:
+                self._modify_raw_response_with_permission_errors(response, denied_tools)
         else:
             verbose_proxy_logger.debug("Tool Permission Guardrail Post-Call Hook: All tools allowed")
 
@@ -785,7 +1035,7 @@ class ToolPermissionGuardrail(CustomGuardrail):
         from litellm.types.utils import TextCompletionResponse
 
         # Collect all chunks to process them together
-        all_chunks: List[ModelResponseStream] = []
+        all_chunks: list[ModelResponseStream] = []
         async for chunk in response:
             all_chunks.append(chunk)
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -67,9 +67,7 @@ class TestToolPermissionGuardrail:
         assert len(self.guardrail.rules) == 5
         assert self.guardrail.default_action == "deny"
         assert self.guardrail.on_disallowed_action == "block"
-        assert GuardrailEventHooks.post_call in (
-            self.guardrail.supported_event_hooks or []
-        )
+        assert GuardrailEventHooks.post_call in (self.guardrail.supported_event_hooks or [])
 
     def test_matches_regex_helper(self):
         pattern = re.compile(r"^Read$")
@@ -162,9 +160,7 @@ class TestToolPermissionGuardrail:
         assert rule_id == "allow_bash"
         assert "allowed" in (msg or "")
 
-        is_allowed, rule_id, _ = self.guardrail._check_tool_permission(
-            "mcp__github_add_issue_comment"
-        )
+        is_allowed, rule_id, _ = self.guardrail._check_tool_permission("mcp__github_add_issue_comment")
         assert is_allowed is True
         assert rule_id == "allow_github"
 
@@ -427,6 +423,246 @@ class TestToolPermissionGuardrail:
         assert "berri" in choice.message.content
 
     @pytest.mark.asyncio
+    async def test_async_post_call_blocks_raw_anthropic_tool_use(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[
+                {
+                    "id": "allow_safe_bash",
+                    "tool_name": r"^Bash$",
+                    "decision": "allow",
+                    "allowed_param_patterns": {
+                        "command": r"^(?!.*(rm\s+-rf|terraform\s+destroy|kubectl\s+delete)).*$",
+                    },
+                }
+            ],
+            default_action="deny",
+            on_disallowed_action="block",
+        )
+        response = {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-x",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Bash",
+                    "input": {"command": "rm -rf /"},
+                }
+            ],
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            with pytest.raises(GuardrailRaisedException):
+                await guardrail.async_post_call_success_hook(
+                    data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                    user_api_key_dict=UserAPIKeyAuth(),
+                    response=response,
+                )
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_anthropic_tool_use(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_read", "tool_name": r"^Read$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-x",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "Read",
+                    "input": {"file": "/etc/passwd"},
+                }
+            ],
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        assert result is response
+        assert response["content"] == [
+            {
+                "type": "text",
+                "text": "Permission denied: Tool 'Read' denied by rule 'deny_read' (Rule: deny_read)",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_openai_tool_call(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_delete", "tool_name": r"^delete_file$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "I should remove it.",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "delete_file",
+                                    "arguments": {"path": "/tmp/report.txt"},
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        message = response["choices"][0]["message"]
+        assert result is response
+        assert message["tool_calls"] is None
+        assert "I should remove it." in message["content"]
+        assert "Permission denied: Tool 'delete_file' denied by rule 'deny_delete'" in message["content"]
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_gemini_function_call(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_delete", "tool_name": r"^delete_file$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {
+                                "functionCall": {
+                                    "name": "delete_file",
+                                    "args": {"path": "/tmp/report.txt"},
+                                }
+                            },
+                            {"text": "done"},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        parts = response["candidates"][0]["content"]["parts"]
+        assert result is response
+        assert parts == [
+            {"text": "done"},
+            {
+                "text": "Permission denied: Tool 'delete_file' denied by rule 'deny_delete' (Rule: deny_delete)",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_blocks_raw_bedrock_converse_tool_use(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_shell", "tool_name": r"^shell$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="block",
+        )
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "tooluse_1",
+                                "name": "shell",
+                                "input": {"command": "rm -rf /"},
+                            }
+                        }
+                    ],
+                }
+            },
+            "stopReason": "tool_use",
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            with pytest.raises(GuardrailRaisedException):
+                await guardrail.async_post_call_success_hook(
+                    data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                    user_api_key_dict=UserAPIKeyAuth(),
+                    response=response,
+                )
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_bedrock_converse_tool_use(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_shell", "tool_name": r"^shell$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "output": {
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "toolUse": {
+                                "toolUseId": "tooluse_1",
+                                "name": "shell",
+                                "input": {"command": "rm -rf /"},
+                            }
+                        },
+                        {"text": "after"},
+                    ],
+                }
+            },
+            "stopReason": "tool_use",
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        content = response["output"]["message"]["content"]
+        assert result is response
+        assert content == [
+            {"text": "after"},
+            {
+                "text": "Permission denied: Tool 'shell' denied by rule 'deny_shell' (Rule: deny_shell)",
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_async_post_call_success_hook_missing_arguments_blocks_param_rule(
         self,
     ):
@@ -468,9 +704,7 @@ class TestToolPermissionGuardrail:
             '["owner@berri.ai"]',
         ],
     )
-    async def test_async_post_call_success_hook_malformed_arguments_blocks_param_rule(
-        self, arguments
-    ):
+    async def test_async_post_call_success_hook_malformed_arguments_blocks_param_rule(self, arguments):
         guardrail = ToolPermissionGuardrail(
             guardrail_name="mail-guardrail",
             rules=[
@@ -699,9 +933,7 @@ class TestToolPermissionGuardrail:
         async def _fake_stream():
             yield text_chunk
 
-        assembled = ModelResponse(
-            choices=[Choices(message={"content": "Hello, world!"})]
-        )
+        assembled = ModelResponse(choices=[Choices(message={"content": "Hello, world!"})])
 
         with patch("litellm.main.stream_chunk_builder", return_value=assembled):
             chunks = []
@@ -713,22 +945,16 @@ class TestToolPermissionGuardrail:
                 chunks.append(chunk)
 
         assert len(chunks) >= 1, (
-            "Hook must yield at least one chunk for plain-text responses; "
-            "got none — bare return bug"
+            "Hook must yield at least one chunk for plain-text responses; got none — bare return bug"
         )
         assert chunks[0].choices[0].delta.content == "Hello, world!", (
-            "Hook must preserve the original response content; "
-            f"got: {chunks[0].choices[0].delta.content!r}"
+            f"Hook must preserve the original response content; got: {chunks[0].choices[0].delta.content!r}"
         )
 
     def test_modify_response_with_permission_errors(self):
         # Setup a response with one tool_call
-        tool_call = ChatCompletionMessageToolCall(
-            function={"name": "Read", "arguments": "{}"}, id="call_123"
-        )
-        response = ModelResponse(
-            choices=[Choices(message={"tool_calls": [tool_call], "content": ""})]
-        )
+        tool_call = ChatCompletionMessageToolCall(function={"name": "Read", "arguments": "{}"}, id="call_123")
+        response = ModelResponse(choices=[Choices(message={"tool_calls": [tool_call], "content": ""})])
 
         # Denied tools tuple of (tool_call, PermissionError)
         denied_tools = [
@@ -916,10 +1142,7 @@ class TestToolPermissionGuardrailInMemoryUpdate:
             on_disallowed_action="block",
         )
         # No pattern yet: any Bash command is allowed.
-        assert (
-            guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0]
-            is True
-        )
+        assert guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0] is True
 
         guardrail.update_in_memory_litellm_params(
             LitellmParams(
@@ -932,9 +1155,7 @@ class TestToolPermissionGuardrailInMemoryUpdate:
                         "id": "native-bash",
                         "tool_name": r"^Bash$",
                         "decision": "allow",
-                        "allowed_param_patterns": {
-                            "command": r"^(?!(echo blockme)$).*$"
-                        },
+                        "allowed_param_patterns": {"command": r"^(?!(echo blockme)$).*$"},
                     }
                 ],
             )
@@ -942,13 +1163,8 @@ class TestToolPermissionGuardrailInMemoryUpdate:
 
         # The compiled map must be rebuilt, and enforcement must reflect it.
         assert "command" in guardrail._compiled_rule_patterns.get("native-bash", {})
-        assert (
-            guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0]
-            is False
-        )
-        assert (
-            guardrail._get_permission_for_tool_call(self._bash("echo hello"))[0] is True
-        )
+        assert guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0] is False
+        assert guardrail._get_permission_for_tool_call(self._bash("echo hello"))[0] is True
 
     def test_update_in_memory_recompiles_tool_name_target(self):
         guardrail = ToolPermissionGuardrail(
@@ -1003,10 +1219,7 @@ class TestToolPermissionGuardrailInMemoryUpdate:
 
         assert len(guardrail.rules) == 1
         assert "command" in guardrail._compiled_rule_patterns.get("native-bash", {})
-        assert (
-            guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0]
-            is False
-        )
+        assert guardrail._get_permission_for_tool_call(self._bash("echo blockme"))[0] is False
 
     def test_update_in_memory_rejects_invalid_regex_and_keeps_previous_rules(self):
         """Regression: a live update whose rules contain an invalid regex must be

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
@@ -503,6 +503,41 @@ class TestToolPermissionGuardrail:
         ]
 
     @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_anthropic_tool_use_without_id(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_read", "tool_name": r"^Read$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "name": "Read",
+                    "input": {"file": "/etc/passwd"},
+                },
+                {"type": "text", "text": "after"},
+            ],
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        assert result is response
+        assert response["content"] == [
+            {"type": "text", "text": "after"},
+            {
+                "type": "text",
+                "text": "Permission denied: Tool 'Read' denied by rule 'deny_read' (Rule: deny_read)",
+            },
+        ]
+
+    @pytest.mark.asyncio
     async def test_async_post_call_rewrites_raw_openai_tool_call(self):
         guardrail = ToolPermissionGuardrail(
             guardrail_name="tool-firewall",
@@ -542,6 +577,47 @@ class TestToolPermissionGuardrail:
         assert message["tool_calls"] is None
         assert "I should remove it." in message["content"]
         assert "Permission denied: Tool 'delete_file' denied by rule 'deny_delete'" in message["content"]
+
+    @pytest.mark.asyncio
+    async def test_async_post_call_rewrites_raw_openai_tool_call_without_id(self):
+        guardrail = ToolPermissionGuardrail(
+            guardrail_name="tool-firewall",
+            rules=[{"id": "deny_delete", "tool_name": r"^delete_file$", "decision": "deny"}],
+            default_action="allow",
+            on_disallowed_action="rewrite",
+        )
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "delete_file",
+                                    "arguments": {"path": "/tmp/report.txt"},
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+
+        with patch.object(guardrail, "should_run_guardrail", return_value=True):
+            result = await guardrail.async_post_call_success_hook(
+                data={"metadata": {"guardrails": {"tool-firewall": True}}},
+                user_api_key_dict=UserAPIKeyAuth(),
+                response=response,
+            )
+
+        message = response["choices"][0]["message"]
+        assert result is response
+        assert message["tool_calls"] is None
+        assert (
+            message["content"]
+            == "Permission denied: Tool 'delete_file' denied by rule 'deny_delete' (Rule: deny_delete)"
+        )
 
     @pytest.mark.asyncio
     async def test_async_post_call_rewrites_raw_gemini_function_call(self):


### PR DESCRIPTION
Summary
- enforce tool_permission against provider-native pass-through response bodies, not only normalized ModelResponse objects
- parse raw OpenAI tool calls, Anthropic tool_use blocks, Gemini functionCall parts, and Bedrock Converse toolUse blocks through the existing permission path
- preserve rewrite mode for raw responses by removing denied tool-use blocks and appending the permission error
- add regression coverage for raw Anthropic block/rewrite and Bedrock Converse block paths

Tests
- python -m py_compile litellm/proxy/guardrails/guardrail_hooks/tool_permission.py tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
- python -m ruff format --check litellm/proxy/guardrails/guardrail_hooks/tool_permission.py tests/test_litellm/proxy/guardrails/guardrail_hooks/test_tool_permission.py
- git diff --check upstream/litellm_oss_staging...HEAD

Closes #32201