### PR TITLE
fix(proxy): handle list-valued guardrail_mode in compliance checks

### DIFF
--- a/litellm/proxy/compliance_checks.py
+++ b/litellm/proxy/compliance_checks.py
@@ -41,7 +41,7 @@ class ComplianceChecker:
             # If no mode specified, default to pre_call
             if g_mode is None and mode == "pre_call":
                 result.append(g)
-            elif g_mode == mode:
+            elif g_mode == mode or (isinstance(g_mode, list) and mode in g_mode):
                 result.append(g)
         return result
 

--- a/tests/test_litellm/proxy/test_compliance_checks.py
+++ b/tests/test_litellm/proxy/test_compliance_checks.py
@@ -1,0 +1,44 @@
+from typing import List, Optional, Union
+
+from litellm.proxy.compliance_checks import ComplianceChecker
+from litellm.types.proxy.compliance_endpoints import ComplianceCheckRequest
+
+
+def _make_checker(guardrail_mode: Optional[Union[str, List[str]]]) -> ComplianceChecker:
+    return ComplianceChecker(
+        ComplianceCheckRequest(
+            request_id="req-1",
+            user_id="user-1",
+            model="gpt-5.2",
+            timestamp="2026-07-05T00:00:00Z",
+            guardrail_information=[
+                {
+                    "guardrail_name": "my-pii-guardrail",
+                    "guardrail_mode": guardrail_mode,
+                    "guardrail_status": "success",
+                }
+            ],
+        )
+    )
+
+
+def test_list_mode_counts_as_pre_call():
+    checker = _make_checker(["pre_call", "post_call"])
+    assert len(checker._get_guardrails_by_mode("pre_call")) == 1
+    assert all(check.passed for check in checker.check_gdpr())
+    assert all(check.passed for check in checker.check_eu_ai_act())
+
+
+def test_list_mode_without_requested_mode_is_excluded():
+    checker = _make_checker(["post_call"])
+    assert checker._get_guardrails_by_mode("pre_call") == []
+
+
+def test_string_mode_matching_still_works():
+    assert len(_make_checker("pre_call")._get_guardrails_by_mode("pre_call")) == 1
+    assert _make_checker("post_call")._get_guardrails_by_mode("pre_call") == []
+
+
+def test_missing_mode_defaults_to_pre_call():
+    assert len(_make_checker(None)._get_guardrails_by_mode("pre_call")) == 1
+    assert _make_checker(None)._get_guardrails_by_mode("post_call") == []


### PR DESCRIPTION
Fixes #32206

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Changes

- Handle list-valued `guardrail_mode` in compliance checks
- Add regression test for `["pre_call", "post_call"]`

## Test

- `pytest <test_compliance_checks.py>`