### PR TITLE
fix(openai): raise after 422 retry exhaustion instead of implicitly returning None

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -648,6 +648,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if custom_llm_provider is not None and custom_llm_provider != "openai":
                 model_response.model = f"{custom_llm_provider}/{model}"
 
+            last_exception: Optional[Exception] = None
             for _ in range(2):  # if call fails due to alternating messages, retry with reformatted message
                 try:
                     max_retries = inference_params.pop("max_retries", 2)
@@ -778,11 +779,13 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 except openai.UnprocessableEntityError as e:
                     ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
                     if litellm.drop_params is True or drop_params is True:
+                        last_exception = e
                         inference_params = drop_params_from_unprocessable_entity_error(e, inference_params)
                     else:
                         raise e
                     # e.message
                 except Exception as e:
+                    last_exception = e
                     if print_verbose is not None:
                         print_verbose(f"openai.py: Received openai error - {str(e)}")
                     if (
@@ -810,6 +813,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                         litellm.remove_index_from_tool_calls(messages=messages)
                     else:
                         raise e
+
+            # retries exhausted without a successful response - raise the last
+            # captured error instead of implicitly returning None
+            if last_exception is not None:
+                raise last_exception
+            raise OpenAIError(
+                status_code=500,
+                message="Retries exhausted without a successful response",
+            )
         except OpenAIError as e:
             raise e
         except Exception as e:
@@ -857,6 +869,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             litellm_params=litellm_params,
             headers=headers or {},
         )
+        last_exception: Optional[Exception] = None
         for _ in range(2):  # if call fails due to alternating messages, retry with reformatted message
             try:
                 openai_aclient: AsyncOpenAI = self._get_openai_client(  # type: ignore
@@ -930,6 +943,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             except openai.UnprocessableEntityError as e:
                 ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
                 if litellm.drop_params is True or drop_params is True:
+                    last_exception = e
                     data = drop_params_from_unprocessable_entity_error(e, data)
                 else:
                     raise e
@@ -949,6 +963,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     headers=error_headers,
                     body=exception_body,
                 )
+
+        # retries exhausted without a successful response - raise the last
+        # captured error instead of implicitly returning None
+        if last_exception is not None:
+            raise last_exception
+        raise OpenAIError(
+            status_code=500,
+            message="Retries exhausted without a successful response",
+        )
 
     def streaming(
         self,
@@ -1037,6 +1060,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         )
         data["stream"] = True
         data.update(self.get_stream_options(stream_options=stream_options, api_base=api_base))
+        last_exception: Optional[Exception] = None
         for _ in range(2):
             try:
                 openai_aclient: AsyncOpenAI = self._get_openai_client(  # type: ignore
@@ -1081,6 +1105,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             except openai.UnprocessableEntityError as e:
                 ## check if body contains unprocessable params - related issue https://github.com/BerriAI/litellm/issues/4800
                 if litellm.drop_params is True or drop_params is True:
+                    last_exception = e
                     data = drop_params_from_unprocessable_entity_error(e, data)
                 else:
                     raise e
@@ -1125,6 +1150,15 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                             headers=error_headers,
                             body=exception_body,
                         )
+
+        # retries exhausted without a successful response - raise the last
+        # captured error instead of implicitly returning None
+        if last_exception is not None:
+            raise last_exception
+        raise OpenAIError(
+            status_code=500,
+            message="Retries exhausted without a successful response",
+        )
 
     def get_stream_options(self, stream_options: Optional[dict], api_base: Optional[str]) -> dict:
         """

--- a/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
+++ b/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
@@ -94,3 +94,27 @@ def test_completion_raises_after_422_retry_exhaustion(enable_drop_params):
 
     assert mock_create.call_count == 2
     assert getattr(exc_info.value, "status_code", None) == 422
+
+
+@pytest.mark.asyncio
+async def test_acompletion_streaming_raises_after_422_retry_exhaustion(
+    enable_drop_params,
+):
+    """Same as above for the async streaming path (async_streaming retry loop)."""
+    client = AsyncOpenAI(api_key="fake-api-key")
+
+    with patch.object(
+        client.chat.completions.with_raw_response,
+        "create",
+        side_effect=_make_unprocessable_entity_error(),
+    ) as mock_create:
+        with pytest.raises(Exception) as exc_info:
+            await litellm.acompletion(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "Hello"}],
+                stream=True,
+                client=client,
+            )
+
+    assert mock_create.call_count == 2
+    assert getattr(exc_info.value, "status_code", None) == 422

--- a/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
+++ b/tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py
@@ -1,0 +1,96 @@
+"""
+Test that the 422 drop_params retry loop raises after exhaustion
+instead of implicitly returning None.
+
+When an OpenAI-compatible endpoint returns HTTP 422 with a body that has no
+structured `detail` param list (e.g. content-moderation rejections),
+`drop_params_from_unprocessable_entity_error` cannot drop anything, the
+retry loop exhausts, and prior to the fix the handler fell off the end of
+the function and returned None - which the proxy then serialized as
+HTTP 200 with body `null`.
+"""
+
+import os
+import sys
+from unittest.mock import patch
+
+import httpx
+import openai
+import pytest
+from openai import AsyncOpenAI, OpenAI
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import litellm
+
+
+def _make_unprocessable_entity_error() -> openai.UnprocessableEntityError:
+    """Build a 422 error whose body has no structured `detail` param list."""
+    request = httpx.Request(
+        method="POST", url="https://api.openai.com/v1/chat/completions"
+    )
+    response = httpx.Response(
+        status_code=422,
+        request=request,
+        json={"error": {"message": "content moderation rejected the request"}},
+    )
+    return openai.UnprocessableEntityError(
+        message="Error code: 422 - content moderation rejected the request",
+        response=response,
+        body={"message": "content moderation rejected the request"},
+    )
+
+
+@pytest.fixture
+def enable_drop_params():
+    """Enable drop_params globally, as `litellm_settings: drop_params: true` does on the proxy."""
+    original = litellm.drop_params
+    litellm.drop_params = True
+    yield
+    litellm.drop_params = original
+
+
+@pytest.mark.asyncio
+async def test_acompletion_raises_after_422_retry_exhaustion(enable_drop_params):
+    """
+    If every attempt raises a 422 that drop_params cannot fix,
+    acompletion must raise - not return None.
+    """
+    client = AsyncOpenAI(api_key="fake-api-key")
+
+    with patch.object(
+        client.chat.completions.with_raw_response,
+        "create",
+        side_effect=_make_unprocessable_entity_error(),
+    ) as mock_create:
+        with pytest.raises(Exception) as exc_info:
+            await litellm.acompletion(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "Hello"}],
+                client=client,
+            )
+
+    # both attempts of the retry loop were consumed
+    assert mock_create.call_count == 2
+    # the surfaced error preserves the upstream 422
+    assert getattr(exc_info.value, "status_code", None) == 422
+
+
+def test_completion_raises_after_422_retry_exhaustion(enable_drop_params):
+    """Same as above for the sync path."""
+    client = OpenAI(api_key="fake-api-key")
+
+    with patch.object(
+        client.chat.completions.with_raw_response,
+        "create",
+        side_effect=_make_unprocessable_entity_error(),
+    ) as mock_create:
+        with pytest.raises(Exception) as exc_info:
+            litellm.completion(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "Hello"}],
+                client=client,
+            )
+
+    assert mock_create.call_count == 2
+    assert getattr(exc_info.value, "status_code", None) == 422


### PR DESCRIPTION
## Relevant issues

Fixes #32221

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Production reproduction (v1.90.0, MiniMax openai-compatible upstream returning 422 for content-moderation rejections, `drop_params: true` on the proxy):

**Before the fix** — proxy returns HTTP 200 with a 4-byte body `null`; reverse-proxy access log shows 33 such responses (`status=200`, `body_bytes_sent=4`, `upstream_status=200`); the corresponding requests have **no row at all** in `LiteLLM_SpendLogs` (neither success nor failure), no failure callbacks fired, and router fallbacks were never attempted. Downstream `openai` SDK clients crash deserializing `response=None`.

Minimal repro on `main` before this patch (returns `None` instead of raising):

```python
import asyncio, httpx, openai, litellm
from unittest.mock import patch
from openai import AsyncOpenAI

litellm.drop_params = True
err = openai.UnprocessableEntityError(
    message="Error code: 422 - content moderation rejected the request",
    response=httpx.Response(
        422,
        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
        json={"error": {"message": "content moderation rejected the request"}},
    ),
    body={"message": "content moderation rejected the request"},
)
client = AsyncOpenAI(api_key="fake")
with patch.object(client.chat.completions.with_raw_response, "create", side_effect=err):
    print(asyncio.run(litellm.acompletion(
        model="openai/gpt-4o-mini",
        messages=[{"role": "user", "content": "hi"}],
        client=client,
    )))  # before: None ; after: raises 422
```

**After the fix** — the same call raises the upstream 422 (`litellm.UnprocessableEntityError`), so the proxy returns a real error response, spend logs and failure callbacks fire, and router fallbacks can trigger.

Verification run locally on this branch:

```
$ pytest tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py -q
2 passed

# with the openai.py change reverted, both tests fail with
# "DID NOT RAISE" (the call returned None) - confirming the regression coverage
$ pytest tests/test_litellm/llms/openai/ -q   # (excluding 3 files that fail collection
                                              # locally for missing dev deps, e.g. respx)
478 passed, 8 failed  # the same 8 fail identically on clean main (env-related,
                      # realtime/data-residency), unrelated to this change
```

Note: this bug is only reachable when the upstream deterministically 422s, so an e2e proof requires an upstream that rejects the request (e.g. provider-side content moderation); the production evidence above is exactly that scenario.

## Type

🐛 Bug Fix

## Changes

`litellm/llms/openai/openai.py` has three `for _ in range(2):` retry loops (sync `completion`, `acompletion`, `async_streaming`). When `drop_params` is enabled, `openai.UnprocessableEntityError` is caught and `drop_params_from_unprocessable_entity_error()` is called before retrying. If the 422 body carries no structured `detail` param list, that helper returns the request data unchanged, the retry 422s identically, the loop exhausts, and the function **fell off the end — implicitly returning `None`** instead of raising. The proxy then serialized that `None` as HTTP 200 + `null`.

- Capture the last caught exception in each of the three retry loops and `raise` it after the loop exhausts (plus a defensive `OpenAIError(500)` if somehow none was captured).
- In the sync loop this also covers the message-reformat retry path, which could exhaust the loop the same way.
- Added mocked regression tests (`tests/test_litellm/llms/openai/test_openai_422_retry_exhaustion.py`) asserting `litellm.completion` / `litellm.acompletion` raise (with `status_code == 422`, after exactly 2 upstream attempts) instead of returning `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
