### PR TITLE
fix(ci): use gh api --slurp to parse paginated issues in close_duplicate_issues.py

### DIFF
--- a/.github/scripts/close_duplicate_issues.py
+++ b/.github/scripts/close_duplicate_issues.py
@@ -40,27 +40,17 @@ def gh(*args: str) -> str:
 
 
 def fetch_open_issues(repo: str | None) -> list[dict]:
-    """Fetch all open issues (excluding PRs) via gh api --paginate."""
+    """Fetch all open issues (excluding PRs) via gh api --paginate --slurp."""
     if repo:
         endpoint = (
             f"repos/{repo}/issues?state=open&per_page=100&sort=created&direction=asc"
         )
     else:
         endpoint = "repos/{owner}/{repo}/issues?state=open&per_page=100&sort=created&direction=asc"
-    cmd = ["api", "--paginate", endpoint]
 
-    raw = gh(*cmd)
-    # gh --paginate concatenates JSON arrays, so we may get multiple arrays
-    issues = []
-    for line in raw.strip().splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        parsed = json.loads(line)
-        if isinstance(parsed, list):
-            issues.extend(parsed)
-        else:
-            issues.append(parsed)
+    raw = gh("api", "--paginate", "--slurp", endpoint)
+    pages = json.loads(raw)
+    issues = [issue for page in pages for issue in page]
 
     # Filter out pull requests (they also appear in the issues endpoint)
     return [i for i in issues if "pull_request" not in i]

--- a/tests/test_litellm/test_github_close_duplicate_issues.py
+++ b/tests/test_litellm/test_github_close_duplicate_issues.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / ".github" / "scripts" / "close_duplicate_issues.py"
+
+
+@pytest.fixture(scope="module")
+def closer_module():
+    spec = importlib.util.spec_from_file_location("close_duplicate_issues", SCRIPT_PATH)
+    assert spec and spec.loader, f"Could not load spec for {SCRIPT_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["close_duplicate_issues"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _issue(number: int, title: str, body: str = "") -> dict:
+    return {"number": number, "title": title, "body": body}
+
+
+def _fake_gh_cli(pages: list[list[dict]]):
+    def fake_gh(*args: str) -> str:
+        assert args[0] == "api"
+        assert "--paginate" in args
+        if "--slurp" in args:
+            return json.dumps(pages, ensure_ascii=False)
+        return "".join(json.dumps(page, ensure_ascii=False) for page in pages)
+
+    return fake_gh
+
+
+class TestFetchOpenIssues:
+    def test_should_parse_multi_page_payload_with_unescaped_line_separators(self, closer_module, monkeypatch):
+        pages = [
+            [_issue(1, "first bug", body="traceback\u2028line two\u2028line three")],
+            [_issue(2, "second bug"), _issue(3, "third bug")],
+        ]
+        monkeypatch.setattr(closer_module, "gh", _fake_gh_cli(pages))
+
+        issues = closer_module.fetch_open_issues("BerriAI/litellm")
+
+        assert [i["number"] for i in issues] == [1, 2, 3]
+
+    def test_should_request_slurp_mode(self, closer_module, monkeypatch):
+        calls: list[tuple[str, ...]] = []
+
+        def recording_gh(*args: str) -> str:
+            calls.append(args)
+            return json.dumps([[]])
+
+        monkeypatch.setattr(closer_module, "gh", recording_gh)
+
+        closer_module.fetch_open_issues("BerriAI/litellm")
+
+        assert len(calls) == 1
+        assert "--slurp" in calls[0]
+
+    def test_should_filter_out_pull_requests(self, closer_module, monkeypatch):
+        pages = [
+            [
+                _issue(1, "real issue"),
+                {**_issue(2, "a pr"), "pull_request": {"url": "https://x"}},
+            ]
+        ]
+        monkeypatch.setattr(closer_module, "gh", _fake_gh_cli(pages))
+
+        issues = closer_module.fetch_open_issues("BerriAI/litellm")
+
+        assert [i["number"] for i in issues] == [1]


### PR DESCRIPTION

## Relevant issues

Fixes #32217

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, every issues event failed at the "Auto-close if high-confidence duplicate" step with `json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 1043331`, e.g. https://github.com/BerriAI/litellm/actions/runs/28764474972/job/85285925468

After the fix, running exactly what the workflow runs (minus --close) against the live GitHub API parses the full paginated issue list without error:

    python3 .github/scripts/close_duplicate_issues.py --issue-number 32217 --repo BerriAI/litellm --threshold 0.85

The definitive proof is the next Check Duplicate Issues run going green after this merges, since the crash reproduces only with the real payload size of this repo's open issue list

## Type

🐛 Bug Fix

## Changes

fetch_open_issues used to split `gh api --paginate` output with splitlines() and json.loads each line. gh concatenates pages without guaranteeing each physical line is a self-contained JSON document, and splitlines() also breaks on unescaped Unicode line separators (U+2028/U+2029) that the GitHub API returns raw inside issue bodies, so once the payload got large enough the workflow crashed on every issues event. The fix fetches with `--slurp`, which emits one well-formed JSON array of pages, and flattens it. Regression tests in tests/test_litellm/test_github_close_duplicate_issues.py emulate both gh output modes; the parsing test fails with JSONDecodeError on the old code and passes on the new