### PR TITLE
feat(provider): add Manifest as a JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -715,6 +715,7 @@ openai_compatible_endpoints: List = [
     "https://api.clarifai.com/v2/ext/openai/v1",
     "https://api.libertai.io/v1",
     "https://pinstripes.io/v1",
+    "https://app.manifest.build/v1",
 ]
 
 
@@ -781,6 +782,7 @@ openai_compatible_providers: List = [
     "ragflow",
     "pinstripes",  # Pinstripes - JSON-configured provider
     "darkbloom",
+    "manifest",  # Manifest - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: List = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -123,6 +123,15 @@
       "max_completion_tokens": "max_tokens"
     }
   },
+  "manifest": {
+    "base_url": "https://app.manifest.build/v1",
+    "api_key_env": "MANIFEST_API_KEY",
+    "api_base_env": "MANIFEST_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
+  },
   "neosantara": {
     "base_url": "https://api.neosantara.xyz/v1",
     "api_key_env": "NEOSANTARA_API_KEY",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -43650,6 +43650,24 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "manifest/auto": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "manifest",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 0,
+        "source": "https://manifest.build/docs",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "deepseek/deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 3.625e-09,

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -1852,6 +1852,23 @@
         "a2a": false
       }
     },
+    "manifest": {
+      "display_name": "Manifest (`manifest`)",
+      "url": "https://docs.litellm.ai/docs/providers/manifest",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "predibase": {
       "display_name": "Predibase (`predibase`)",
       "url": "https://docs.litellm.ai/docs/providers/predibase",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3370,6 +3370,7 @@ class LlmProviders(str, Enum):
     LIBERTAI = "libertai"
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
+    MANIFEST = "manifest"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -44038,6 +44038,24 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "manifest/auto": {
+        "input_cost_per_token": 0,
+        "litellm_provider": "manifest",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 0,
+        "source": "https://manifest.build/docs",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2052,6 +2052,23 @@
         "a2a": false
       }
     },
+    "manifest": {
+      "display_name": "Manifest (`manifest`)",
+      "url": "https://docs.litellm.ai/docs/providers/manifest",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "predibase": {
       "display_name": "Predibase (`predibase`)",
       "url": "https://docs.litellm.ai/docs/providers/predibase",

--- a/tests/test_litellm/llms/openai_like/test_manifest_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_manifest_provider.py
@@ -1,0 +1,116 @@
+"""
+Tests for Manifest provider configuration and integration.
+
+Manifest is a JSON-configured OpenAI-compatible gateway that resolves the
+served model server-side, so callers always target the single ``auto`` model.
+"""
+
+import litellm
+
+
+class TestManifestProviderConfig:
+    """Test Manifest provider configuration"""
+
+    def test_manifest_in_provider_list(self):
+        """manifest is registered as a first-class provider"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "MANIFEST")
+        assert LlmProviders.MANIFEST.value == "manifest"
+        assert "manifest" in litellm.provider_list
+
+    def test_manifest_json_config(self):
+        """providers.json carries the gateway endpoint and env vars"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("manifest")
+
+        manifest = JSONProviderRegistry.get("manifest")
+        assert manifest is not None
+        assert manifest.base_url == "https://app.manifest.build/v1"
+        assert manifest.api_key_env == "MANIFEST_API_KEY"
+        assert manifest.api_base_env == "MANIFEST_API_BASE"
+        assert manifest.param_mappings.get("max_completion_tokens") == "max_tokens"
+
+    def test_manifest_supports_responses_api(self):
+        """Manifest declares /v1/responses, so the Responses API is wired"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.supports_responses_api("manifest") is True
+
+    def test_manifest_provider_resolution(self):
+        """auto model resolves to the manifest provider and default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="manifest/auto",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "auto"
+        assert provider == "manifest"
+        assert api_base == "https://app.manifest.build/v1"
+
+    def test_manifest_api_base_override(self):
+        """explicit api_base / api_key win over the defaults (self-hosted Manifest)"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="manifest/auto",
+            custom_llm_provider=None,
+            api_base="https://manifest.internal.example.com/v1",
+            api_key="mnfst_test",
+        )
+
+        assert provider == "manifest"
+        assert api_base == "https://manifest.internal.example.com/v1"
+        assert api_key == "mnfst_test"
+
+    def test_manifest_auto_in_model_cost_map(self):
+        """the single auto model is present and priced as a passthrough gateway"""
+        model_cost = litellm.model_cost
+
+        assert "manifest/auto" in model_cost
+        info = model_cost["manifest/auto"]
+        assert info["litellm_provider"] == "manifest"
+        assert info["mode"] == "chat"
+        assert info["input_cost_per_token"] == 0
+        assert info["output_cost_per_token"] == 0
+        assert info["supports_function_calling"] is True
+
+    def test_manifest_router_config(self):
+        """manifest/auto is usable from Router model_list"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "manifest-auto",
+                    "litellm_params": {
+                        "model": "manifest/auto",
+                        "api_key": "mnfst_test",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "manifest-auto"
+
+    def test_manifest_supported_endpoints_matrix(self):
+        """the runtime-served backup matrix advertises chat + responses, not messages"""
+        import json
+        from pathlib import Path
+
+        import litellm as _litellm
+
+        backup_path = Path(_litellm.__file__).parent / "provider_endpoints_support_backup.json"
+        matrix = json.loads(backup_path.read_text())
+
+        assert "manifest" in matrix["providers"]
+        endpoints = matrix["providers"]["manifest"]["endpoints"]
+        assert endpoints["chat_completions"] is True
+        assert endpoints["responses"] is True
+        assert endpoints["messages"] is False


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Adds Manifest (https://manifest.build) as a JSON-configured OpenAI-compatible provider. Manifest is an open-source gateway that sits in front of multiple providers (API keys, subscriptions, local models) and resolves the served model server-side, so callers always target the single `auto` model id

Registration follows the existing JSON-provider pattern (`litellm/llms/openai_like/providers.json`), same as the recently merged LibertAI and darkbloom providers. The provider declares `/v1/chat/completions` and `/v1/responses`, both of which Manifest serves natively

Usage once merged

```python
import litellm

response = litellm.completion(
    model="manifest/auto",
    api_key="YOUR_MANIFEST_API_KEY",
    messages=[{"role": "user", "content": "Hello"}],
)
```

Proxy config

```yaml
model_list:
  - model_name: manifest-auto
    litellm_params:
      model: manifest/auto
      api_key: os.environ/MANIFEST_API_KEY
```

## Type

🆕 New Feature

## Changes

- register `manifest` in `litellm/llms/openai_like/providers.json` (base url `https://app.manifest.build/v1`, `MANIFEST_API_KEY`, `MANIFEST_API_BASE` override, responses endpoint enabled)
- add `MANIFEST` to the `LlmProviders` enum and to the `openai_compatible_providers` / `openai_compatible_endpoints` lists in `constants.py`
- add the `manifest/auto` entry to the model cost map (both the root and backup copies), priced as a passthrough gateway since callers bring their own provider keys
- add the `manifest` row to `provider_endpoints_support.json` and its backup
- add `tests/test_litellm/llms/openai_like/test_manifest_provider.py` covering provider registration, JSON config, provider resolution, api_base override, the model cost entry, Router usage, responses support, and the endpoint-support matrix
