### PR TITLE
fix(caching): fall back to EVAL, not SCRIPT LOAD, on missing Lua script

### DIFF
--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -567,14 +567,30 @@ class RedisCache(BaseCache):
 
         Kept separate from async_register_script so each loop caches its own
         executor; see that method for why the binding must be per loop.
+
+        The standalone executor runs EVALSHA and, when the script is not cached
+        server-side, retries with EVAL rather than the SCRIPT LOAD that redis-py's
+        Script.__call__ falls back to. Redis proxies such as Codis and Twemproxy
+        forward EVAL/EVALSHA but reject SCRIPT, so the built-in fallback fails
+        with "unknown command 'SCRIPT'"; the rate limiter then swallows the error
+        and silently drops to per-pod in-memory limits. EVAL both runs and caches
+        the script, so the following EVALSHA calls hit.
         """
+        from redis.exceptions import NoScriptError, ResponseError
+
         _redis_client: Any = self.init_async_client()
         if hasattr(_redis_client, "register_script"):
-            registered_script = _redis_client.register_script(script)
+            script_sha = hashlib.sha1(script.encode(), usedforsecurity=False).hexdigest()
 
             async def standalone_executor(keys: Sequence[str], args: Sequence[Any], client: Any = None) -> Any:
+                target = client if client is not None else _redis_client
                 namespaced_keys = tuple(self.check_and_fix_namespace(key=key) for key in keys)
-                return await registered_script(keys=namespaced_keys, args=args, client=client)
+                try:
+                    return await target.evalsha(script_sha, len(namespaced_keys), *namespaced_keys, *args)
+                except ResponseError as e:
+                    if isinstance(e, NoScriptError) or "NOSCRIPT" in str(e).upper():
+                        return await target.eval(script, len(namespaced_keys), *namespaced_keys, *args)
+                    raise
 
             return standalone_executor
 

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -582,19 +583,20 @@ async def test_async_register_script_namespaces_keys(
     monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
     redis_cache = RedisCache(namespace=namespace)
 
-    registered_script = AsyncMock(return_value="ok")
+    script_text = "return 1"
     mock_redis_instance = MagicMock()
-    mock_redis_instance.register_script = MagicMock(return_value=registered_script)
+    mock_redis_instance.evalsha = AsyncMock(return_value="ok")
 
     with patch.object(
         redis_cache, "init_async_client", return_value=mock_redis_instance
     ):
-        script = redis_cache.async_register_script("return 1")
+        script = redis_cache.async_register_script(script_text)
         result = await script(keys=raw_keys, args=[60])
 
     assert result == "ok"
-    registered_script.assert_awaited_once_with(
-        keys=tuple(expected_keys), args=[60], client=None
+    expected_sha = hashlib.sha1(script_text.encode()).hexdigest()
+    mock_redis_instance.evalsha.assert_awaited_once_with(
+        expected_sha, len(expected_keys), *expected_keys, 60
     )
 
 
@@ -616,11 +618,13 @@ def test_async_register_script_binds_per_event_loop(namespace, monkeypatch):
 
     def make_client():
         client = MagicMock()
-        client.register_script = MagicMock(return_value=AsyncMock(return_value="ok"))
+        client.evalsha = AsyncMock(return_value="ok")
         clients_built.append(client)
         return client
 
     unique_script = "return 'lit3298'"
+    expected_key = f"{namespace}:{{k:v}}:tokens" if namespace else "{k:v}:tokens"
+    expected_sha = hashlib.sha1(unique_script.encode()).hexdigest()
 
     with patch.object(redis_cache, "init_async_client", side_effect=make_client):
         script = redis_cache.async_register_script(unique_script)
@@ -647,7 +651,7 @@ def test_async_register_script_binds_per_event_loop(namespace, monkeypatch):
     assert result_b == "ok"
     assert len(clients_built) == 2
     for client in clients_built:
-        client.register_script.assert_called_once_with(unique_script)
+        client.evalsha.assert_awaited_once_with(expected_sha, 1, expected_key, 60)
 
 
 @pytest.mark.asyncio
@@ -661,14 +665,13 @@ async def test_async_register_script_not_shared_across_namespaces(
     cache_a = RedisCache(namespace="ns_a")
     cache_b = RedisCache(namespace="ns_b")
 
-    reg_a = AsyncMock(return_value="a")
     client_a = MagicMock()
-    client_a.register_script = MagicMock(return_value=reg_a)
-    reg_b = AsyncMock(return_value="b")
+    client_a.evalsha = AsyncMock(return_value="a")
     client_b = MagicMock()
-    client_b.register_script = MagicMock(return_value=reg_b)
+    client_b.evalsha = AsyncMock(return_value="b")
 
     same_script = "return redis.call('GET', KEYS[1])"
+    expected_sha = hashlib.sha1(same_script.encode()).hexdigest()
     with patch.object(
         cache_a, "init_async_client", return_value=client_a
     ), patch.object(cache_b, "init_async_client", return_value=client_b):
@@ -678,8 +681,8 @@ async def test_async_register_script_not_shared_across_namespaces(
         result_b = await script_b(keys=["k"], args=[])
 
     assert (result_a, result_b) == ("a", "b")
-    reg_a.assert_awaited_once_with(keys=("ns_a:k",), args=[], client=None)
-    reg_b.assert_awaited_once_with(keys=("ns_b:k",), args=[], client=None)
+    client_a.evalsha.assert_awaited_once_with(expected_sha, 1, "ns_a:k")
+    client_b.evalsha.assert_awaited_once_with(expected_sha, 1, "ns_b:k")
 
 
 @pytest.mark.asyncio
@@ -722,6 +725,130 @@ async def test_async_register_script_raises_for_unsupported_client(
         script = redis_cache.async_register_script("return 'x'")
         with pytest.raises(ValueError, match="does not support Lua script"):
             await script(keys=["k"], args=[1])
+
+
+def _make_script_blocking_proxy_client(eval_result):
+    """Async Redis client backed by a SCRIPT-blocking proxy (Codis, Twemproxy,
+    Kedis, ...). Such a proxy presents a single standalone endpoint, so the
+    client exposes register_script; redis-py's Script.__call__ recovers from an
+    uncached script by issuing SCRIPT LOAD, which the proxy rejects with
+    "unknown command 'SCRIPT'". register_script here returns a real redis-py
+    AsyncScript so the pre-fix path drives EVALSHA -> SCRIPT LOAD and blows up
+    exactly as it would in production; EVALSHA on the uncached sha returns
+    NOSCRIPT, SCRIPT LOAD is rejected, and only EVAL succeeds.
+    """
+    from redis._parsers.encoders import Encoder
+    from redis.commands.core import AsyncScript
+    from redis.exceptions import NoScriptError, ResponseError
+
+    client = MagicMock()
+    client.connection_pool.get_encoder.return_value = Encoder("utf-8", "strict", False)
+    client.register_script = lambda script: AsyncScript(client, script)
+    client.evalsha = AsyncMock(
+        side_effect=NoScriptError("No matching script. Please use EVAL.")
+    )
+    client.script_load = AsyncMock(
+        side_effect=ResponseError("unknown command 'SCRIPT'")
+    )
+    client.eval = AsyncMock(return_value=eval_result)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_async_register_script_proxy_falls_back_to_eval_not_script_load(
+    monkeypatch, redis_no_ping
+):
+    """On NOSCRIPT the executor must retry with EVAL, never SCRIPT LOAD, so it
+    survives proxies that block the SCRIPT command. Without this the rate
+    limiter, pod-lock release, and budget limiters silently drop to per-pod
+    in-memory limits behind such a proxy."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace="ns")
+    script_text = "return 1"
+    client = _make_script_blocking_proxy_client(eval_result="proxy-ok")
+
+    with patch.object(redis_cache, "init_async_client", return_value=client):
+        script = redis_cache.async_register_script(script_text)
+        result = await script(keys=["{k:v}:tokens"], args=[5, 60])
+
+    expected_sha = hashlib.sha1(script_text.encode()).hexdigest()
+    assert result == "proxy-ok"
+    client.evalsha.assert_awaited_once_with(expected_sha, 1, "ns:{k:v}:tokens", 5, 60)
+    client.eval.assert_awaited_once_with(script_text, 1, "ns:{k:v}:tokens", 5, 60)
+    client.script_load.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_register_script_falls_back_on_noscript_response_error(
+    monkeypatch, redis_no_ping
+):
+    """Some proxies surface the miss as a bare ResponseError whose message
+    contains NOSCRIPT rather than the typed NoScriptError; that must still fall
+    back to EVAL."""
+    from redis.exceptions import ResponseError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace="ns")
+    script_text = "return 2"
+    client = MagicMock()
+    client.evalsha = AsyncMock(
+        side_effect=ResponseError("NOSCRIPT No matching script. Please use EVAL.")
+    )
+    client.eval = AsyncMock(return_value="evaled")
+
+    with patch.object(redis_cache, "init_async_client", return_value=client):
+        script = redis_cache.async_register_script(script_text)
+        result = await script(keys=["k"], args=[7])
+
+    assert result == "evaled"
+    client.eval.assert_awaited_once_with(script_text, 1, "ns:k", 7)
+
+
+@pytest.mark.asyncio
+async def test_async_register_script_propagates_non_noscript_error(
+    monkeypatch, redis_no_ping
+):
+    """A non-NOSCRIPT failure (e.g. WRONGTYPE) must propagate untouched; the EVAL
+    fallback exists only for the missing-script case, not to mask every error."""
+    from redis.exceptions import ResponseError
+
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace="ns")
+    client = MagicMock()
+    client.evalsha = AsyncMock(
+        side_effect=ResponseError("WRONGTYPE Operation against a key")
+    )
+    client.eval = AsyncMock(return_value="should-not-be-used")
+
+    with patch.object(redis_cache, "init_async_client", return_value=client):
+        script = redis_cache.async_register_script("return 3")
+        with pytest.raises(ResponseError, match="WRONGTYPE"):
+            await script(keys=["k"], args=[1])
+
+    client.eval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_register_script_uses_evalsha_when_script_cached(
+    monkeypatch, redis_no_ping
+):
+    """When the script is already cached server-side, EVALSHA succeeds and EVAL
+    is never issued; keys are still namespaced."""
+    monkeypatch.setenv("REDIS_HOST", "https://my-test-host")
+    redis_cache = RedisCache(namespace="ns")
+    script_text = "return 4"
+    client = MagicMock()
+    client.evalsha = AsyncMock(return_value="cached-ok")
+    client.eval = AsyncMock(return_value="should-not-be-used")
+
+    with patch.object(redis_cache, "init_async_client", return_value=client):
+        script = redis_cache.async_register_script(script_text)
+        result = await script(keys=["{k:v}:tokens"], args=[9])
+
+    expected_sha = hashlib.sha1(script_text.encode()).hexdigest()
+    assert result == "cached-ok"
+    client.evalsha.assert_awaited_once_with(expected_sha, 1, "ns:{k:v}:tokens", 9)
+    client.eval.assert_not_called()
 
 
 @pytest.mark.parametrize("namespace, expected", [(None, "k"), ("ns", "ns:k")])


### PR DESCRIPTION
## Relevant issues

Fixes #32232

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The fix is about how the Redis Lua path recovers from a cache miss, so the realistic repro is a Redis that forwards EVAL/EVALSHA but rejects SCRIPT, exactly like the proxies (Codis, Twemproxy, Kedis) that trip this. A stock Redis with the `script` command revoked via ACL reproduces that condition without standing up a full proxy.

1. Start a Redis that blocks SCRIPT but still serves EVAL/EVALSHA, and confirm the condition
```
docker run -d --name redis-noscript -p 6379:6379 redis:7 redis-server --appendonly no
docker exec redis-noscript redis-cli ACL SETUSER default on nopass '~*' '&*' '+@all' '-script'
docker exec redis-noscript redis-cli SCRIPT LOAD "return 1"   # NOPERM ... no permissions to run the 'script' command
docker exec redis-noscript redis-cli EVAL "return 1" 0        # (integer) 1
```

2. Point the proxy at that Redis and run it
```
export REDIS_HOST=localhost REDIS_PORT=6379
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

3. Mint a key with a small rpm and drive it past the limit
```
KEY=$(curl -s http://localhost:4000/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"models": ["anthropic-haiku-4-5"], "rpm_limit": 3}' | jq -r .key)
for i in $(seq 1 4); do
  curl -s -o /dev/null -w "request $i -> %{http_code}\n" http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "anthropic-haiku-4-5", "messages": [{"role": "user", "content": "hi"}]}'
done
```
Expected: the first three return `200` and the fourth returns `429`, so the limit is enforced through Redis.

4. Confirm the Lua path ran clean, with no SCRIPT rejection and no silent drop to per-pod in-memory limits
```
grep -iE "unknown command 'SCRIPT'|no permissions to run the 'script'|Redis Lua script failed" litellm.log   # no matches
```

Before this change, step 3 would let requests through beyond the limit on any single pod and step 4 would surface the SCRIPT error followed by the in-memory fallback.

## Type

🐛 Bug Fix

## Changes

Behind a Redis proxy that blocks the `SCRIPT` command (see #32232 for the full symptom and impact), the rate limiter's Lua path fails on every call and silently drops to per-pod in-memory limits. This changes how a missing script is recovered so that path survives such a proxy.

`async_register_script` in `litellm/caching/redis_cache.py` returned redis-py's `Script` object and invoked it, so a cache miss triggered `SCRIPT LOAD`, which these proxies reject. The standalone executor now computes the script SHA itself and runs `EVALSHA` directly, retrying with `EVAL` rather than `SCRIPT LOAD` on a miss. `EVAL` both runs and caches the script server side, so the following `EVALSHA` calls hit, and it is a command every SCRIPT-blocking proxy already forwards. The Redis Cluster branch is left as it was.

A miss is detected both by the typed `NoScriptError` and by a `NOSCRIPT` substring on a bare `ResponseError`. Both are needed: redis-py strips the `NOSCRIPT` prefix off the message before raising `NoScriptError`, so a substring check alone would never match a real typed miss, while some proxies surface the miss as a plain `ResponseError` that the `isinstance` check would not catch. Any other `ResponseError`, such as `WRONGTYPE`, still propagates so real failures are not masked.

Tests live in `tests/test_litellm/caching/test_redis_cache.py`. The headline test reproduces the exact production failure through a real redis-py `AsyncScript` (`EVALSHA` miss -> `SCRIPT LOAD` -> `unknown command 'SCRIPT'`) and passes only with the fix. The rest cover the bare-`ResponseError` substring path, propagation of a non-`NOSCRIPT` error, the already-cached happy path where `EVAL` is never issued, and the existing per-namespace and per-loop key-namespacing guarantees.
