### PR TITLE
feat(helm): support user-defined volumes and volumeMounts in microservices chart

### DIFF
--- a/.github/workflows/helm_unit_test.yml
+++ b/.github/workflows/helm_unit_test.yml
@@ -38,4 +38,6 @@ jobs:
           echo "Helm unittest plugin integrity verified: $ACTUAL_SHA"
 
       - name: Run unit tests
-        run: helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm
+        run: |
+          helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm
+          helm unittest -f 'tests/*.yaml' helm/litellm

--- a/helm/litellm/templates/backend/deployment.yaml
+++ b/helm/litellm/templates/backend/deployment.yaml
@@ -45,11 +45,16 @@ spec:
               value: /app/config/config.yaml
             {{- end }}
           {{- include "litellm.envFrom" .Values.backend | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if or .Values.gateway.config.create .Values.backend.volumeMounts }}
           volumeMounts:
+            {{- if .Values.gateway.config.create }}
             - name: gateway-config
               mountPath: /app/config/config.yaml
               subPath: config.yaml
+            {{- end }}
+            {{- with .Values.backend.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.backend.livenessProbe }}
           livenessProbe:
@@ -61,11 +66,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.backend.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if or .Values.gateway.config.create .Values.backend.volumes }}
       volumes:
+        {{- if .Values.gateway.config.create }}
         - name: gateway-config
           configMap:
             name: {{ include "litellm.gateway.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.backend.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.backend.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/templates/gateway/deployment.yaml
+++ b/helm/litellm/templates/gateway/deployment.yaml
@@ -47,11 +47,16 @@ spec:
               value: {{ .Values.gateway.numWorkers | quote }}
             {{- end }}
           {{- include "litellm.envFrom" .Values.gateway | nindent 10 }}
-          {{- if .Values.gateway.config.create }}
+          {{- if or .Values.gateway.config.create .Values.gateway.volumeMounts }}
           volumeMounts:
+            {{- if .Values.gateway.config.create }}
             - name: gateway-config
               mountPath: /app/config/config.yaml
               subPath: config.yaml
+            {{- end }}
+            {{- with .Values.gateway.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- with .Values.gateway.livenessProbe }}
           livenessProbe:
@@ -63,11 +68,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.gateway.resources | nindent 12 }}
-      {{- if .Values.gateway.config.create }}
+      {{- if or .Values.gateway.config.create .Values.gateway.volumes }}
       volumes:
+        {{- if .Values.gateway.config.create }}
         - name: gateway-config
           configMap:
             name: {{ include "litellm.gateway.fullname" . }}-config
+        {{- end }}
+        {{- with .Values.gateway.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:

--- a/helm/litellm/templates/ui/deployment.yaml
+++ b/helm/litellm/templates/ui/deployment.yaml
@@ -46,6 +46,10 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- include "litellm.envFrom" .Values.ui | nindent 10 }}
+          {{- with .Values.ui.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.ui.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -56,6 +60,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
+      {{- with .Values.ui.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.ui.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/litellm/tests/deployment_volumes_tests.yaml
+++ b/helm/litellm/tests/deployment_volumes_tests.yaml
@@ -1,0 +1,172 @@
+suite: test deployment volumes and volumeMounts
+templates:
+  - gateway/deployment.yaml
+  - gateway/configmap.yaml
+  - backend/deployment.yaml
+  - ui/deployment.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: gateway renders only the config volume by default
+    template: gateway/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: gateway-config
+              configMap:
+                name: RELEASE-NAME-litellm-gateway-config
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: gateway-config
+              mountPath: /app/config/config.yaml
+              subPath: config.yaml
+
+  - it: gateway merges user volumes and volumeMounts with the config volume
+    template: gateway/deployment.yaml
+    set:
+      gateway.volumes:
+        - name: custom-callbacks
+          configMap:
+            name: custom-callbacks
+      gateway.volumeMounts:
+        - name: custom-callbacks
+          mountPath: /app/custom_callbacks.py
+          subPath: custom_callbacks.py
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: gateway-config
+      - equal:
+          path: spec.template.spec.volumes[1]
+          value:
+            name: custom-callbacks
+            configMap:
+              name: custom-callbacks
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: gateway-config
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+          value:
+            name: custom-callbacks
+            mountPath: /app/custom_callbacks.py
+            subPath: custom_callbacks.py
+
+  - it: gateway renders user volumes even when config creation is disabled
+    template: gateway/deployment.yaml
+    set:
+      gateway.config.create: false
+      gateway.volumes:
+        - name: certs
+          secret:
+            secretName: tls-certs
+      gateway.volumeMounts:
+        - name: certs
+          mountPath: /etc/certs
+          readOnly: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: certs
+              secret:
+                secretName: tls-certs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: certs
+              mountPath: /etc/certs
+              readOnly: true
+
+  - it: gateway omits volumes when config creation is disabled and no user volumes are set
+    template: gateway/deployment.yaml
+    set:
+      gateway.config.create: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: backend merges user volumes and volumeMounts with the shared config volume
+    template: backend/deployment.yaml
+    set:
+      backend.volumes:
+        - name: sso-handler
+          configMap:
+            name: sso-handler
+      backend.volumeMounts:
+        - name: sso-handler
+          mountPath: /app/custom_sso.py
+          subPath: custom_sso.py
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: gateway-config
+      - equal:
+          path: spec.template.spec.volumes[1]
+          value:
+            name: sso-handler
+            configMap:
+              name: sso-handler
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1]
+          value:
+            name: sso-handler
+            mountPath: /app/custom_sso.py
+            subPath: custom_sso.py
+
+  - it: backend renders user volumes even when config creation is disabled
+    template: backend/deployment.yaml
+    set:
+      gateway.config.create: false
+      backend.volumes:
+        - name: data
+          emptyDir: {}
+      backend.volumeMounts:
+        - name: data
+          mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: data
+              emptyDir: {}
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: data
+              mountPath: /data
+
+  - it: ui renders no volumes by default
+    template: ui/deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: ui renders user volumes and volumeMounts
+    template: ui/deployment.yaml
+    set:
+      ui.volumes:
+        - name: nginx-config
+          configMap:
+            name: custom-nginx
+      ui.volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: nginx-config
+              configMap:
+                name: custom-nginx
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d

--- a/helm/litellm/tests/values/required.yaml
+++ b/helm/litellm/tests/values/required.yaml
@@ -1,0 +1,4 @@
+database:
+  writer:
+    host: postgres.example.com
+    dbname: litellm

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -124,6 +124,11 @@ gateway:
   extraEnv: [] # Add extra environment variables to the gateway
   envConfigMaps: [] # Add extra environment variables to the gateway from config maps
   envSecrets: [] # Add extra environment variables to the gateway from secrets
+  # Additional volumes on the gateway Deployment (e.g. a ConfigMap holding
+  # custom callback / SSO handler code, mounted next to the proxy config).
+  volumes: []
+  # Additional volumeMounts on the gateway container.
+  volumeMounts: []
   config:
     create: true
     proxy_config: {}
@@ -167,6 +172,10 @@ backend:
   extraEnv: []
   envConfigMaps: []
   envSecrets: []
+  # Additional volumes on the backend Deployment.
+  volumes: []
+  # Additional volumeMounts on the backend container.
+  volumeMounts: []
   image:
     repository: ghcr.io/berriai/litellm-backend
     tag: ""
@@ -206,6 +215,10 @@ ui:
   extraEnv: []
   envConfigMaps: []
   envSecrets: []
+  # Additional volumes on the ui Deployment.
+  volumes: []
+  # Additional volumeMounts on the ui container.
+  volumeMounts: []
   image:
     repository: ghcr.io/berriai/litellm-ui
     tag: ""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4209

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A user setting up a custom SSO handler with the microservices chart could not follow the [mounting custom callbacks docs](https://docs.litellm.ai/docs/proxy/logging#step-2c---mounting-custom-callbacks-in-helmkubernetes-alternative), which only work on the monolithic chart's top-level `volumes`/`volumeMounts` values. The exact end user flow is `helm template`/`helm upgrade` with those values set, so the proof is the rendered manifests before and after

Values file matching the docs' custom callback setup, extended to all three components:

```yaml
# custom-values.yaml
database:
  writer:
    host: postgres.example.com
    dbname: litellm
gateway:
  volumes:
    - name: custom-callbacks
      configMap:
        name: custom-callbacks
  volumeMounts:
    - name: custom-callbacks
      mountPath: /app/custom_callbacks.py
      subPath: custom_callbacks.py
backend:
  volumes:
    - name: custom-sso
      configMap:
        name: custom-sso-handler
  volumeMounts:
    - name: custom-sso
      mountPath: /app/custom_sso.py
      subPath: custom_sso.py
ui:
  volumes:
    - name: nginx-config
      configMap:
        name: custom-nginx
  volumeMounts:
    - name: nginx-config
      mountPath: /etc/nginx/conf.d
```

Before (chart at the base commit): the values are silently ignored

```
$ helm template litellm helm/litellm -f custom-values.yaml | grep -c "custom-callbacks\|custom-sso\|nginx-config"
0
```

After (this branch): every deployment renders the user volumes, merged with the existing gateway-config volume

```
$ helm template litellm helm/litellm -f custom-values.yaml | grep -c "custom-callbacks\|custom-sso\|nginx-config"
8

litellm-litellm-gateway
  volumes: ['gateway-config', 'custom-callbacks']
  mounts:  [('gateway-config', '/app/config/config.yaml'), ('custom-callbacks', '/app/custom_callbacks.py')]
litellm-litellm-backend
  volumes: ['gateway-config', 'custom-sso']
  mounts:  [('gateway-config', '/app/config/config.yaml'), ('custom-sso', '/app/custom_sso.py')]
litellm-litellm-ui
  volumes: ['nginx-config']
  mounts:  [('nginx-config', '/etc/nginx/conf.d')]
```

`helm lint helm/litellm` passes and the new helm-unittest suite covers the merge, the config-disabled path, and the untouched defaults:

```
$ helm unittest -f 'tests/*.yaml' helm/litellm
 PASS  test deployment volumes and volumeMounts  helm/litellm/tests/deployment_volumes_tests.yaml
Tests:       8 passed, 8 total
```

Reverting only the template changes makes 5 of the 8 tests fail, so the suite is a real regression guard rather than a rubber stamp. The old chart's suite still passes (54 tests)

### Independent end to end verification on a live cluster

This change was re-verified end to end on a fresh kind cluster with helm 3.21.2 and the helm-unittest plugin v0.4.4, exactly as a chart user would run it. `helm unittest -f 'tests/*.yaml' helm/litellm` reports 8 of 8 passing and `helm lint helm/litellm` passes. Rendering the chart with a values file that sets `gateway`, `backend` and `ui` volumes and volumeMounts against ConfigMaps for a custom callback, a custom SSO handler and an nginx config, then piping through `kubectl apply --dry-run=server`, is accepted by the live API server for every object. Inspecting the three applied Deployments with kubectl confirms each user volume and volumeMount is appended after the chart's own gateway-config entry on gateway and backend, while ui carries only its user volume. The workload images for appVersion 0.1.0 are not published, so the containers were retargeted to a stock image purely to get pods scheduled with the same rendered volume spec; execing into the running gateway, backend and ui pods and cat-ing `/app/custom_callbacks.py`, `/app/custom_sso.py` and `/etc/nginx/conf.d/default.conf` returns the exact ConfigMap contents, proving the mounts resolve at runtime. Backwards compatibility holds: with default values the `helm template` output for `helm/litellm` is byte-identical between base branch litellm_internal_staging and this branch, so `diff` reports zero differences

Terminal walk-through of the full flow:

![e2e terminal walk-through](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvOWNjMjZiYzUtYzg3NC00NTFhLTk0OTItZWRmYjgyM2E0MjQyIiwiaWF0IjoxNzgzMzI3ODM0LCJleHAiOjE3ODM5MzI2MzQsImZpbGVuYW1lIjoiZGVtby5naWYifQ.CFZsH8W9RyBWj7FzDl6iV8eBq81BQm0T-lUn1T6pbuA)

helm-unittest suite passing:

![helm unittest 8 of 8 passing](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvOGIwZmQ0YjItYjI2OC00Nzg4LTljNjEtNGU0MzQ2YTZiYjg0IiwiaWF0IjoxNzgzMzI3ODM0LCJleHAiOjE3ODM5MzI2MzQsImZpbGVuYW1lIjoic3RpbGwxLnBuZyJ9.te0oN3Dwe9PCtEyd0m8ujJRZzk2B3T6a1GULTanYnvU)

Rendered gateway Deployment showing the user volume merged after the chart's gateway-config entry:

![rendered gateway Deployment merged volumes](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZjkxOWVlMDctNmM4MS00YzE2LWI1ZmUtNzc2ZGU4YWNmZTdkIiwiaWF0IjoxNzgzMzI3ODM0LCJleHAiOjE3ODM5MzI2MzQsImZpbGVuYW1lIjoic3RpbGwyLnBuZyJ9.7nuvSYTeBvQ1lSgHna5fFTU2RJ6TDMTR8XhAxp68N7c)

Zero-diff backwards compatibility check against the base branch with default values:

![zero diff backcompat](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvM2Y2ODIwNGUtOTVhMi00OWUyLWE5YTEtNzcyMTdmZWUzMzMwIiwiaWF0IjoxNzgzMzI3ODM0LCJleHAiOjE3ODM5MzI2MzQsImZpbGVuYW1lIjoic3RpbGwzLnBuZyJ9.d-QEWO1ArKLBNF8Y1Qef_W6thfUIPtRHT_MhxqAgiCE)

## Type

🆕 New Feature

## Changes

Adds per-component `volumes` and `volumeMounts` values to the microservices chart (`helm/litellm`) for the gateway, backend, and ui deployments. User entries are appended after the chart-managed `gateway-config` volume on gateway and backend, and the block is omitted entirely when nothing would render, preserving the current output for existing installs (default values render byte-identical manifests)

Also adds a helm-unittest suite for the microservices chart (it previously had none) and wires it into the existing helm unit test workflow next to the monolithic chart's suite

Link to Devin session: https://app.devin.ai/sessions/6e1bcd559cab4c5eadfd8d3e4192ac8d