### PR TITLE
fix(streaming): surface in-body error payloads on OpenAI-compatible streams

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -782,8 +782,30 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
                 delta["reasoning_content"] = delta.pop("reasoning")
         return choices
 
+    @staticmethod
+    def _extract_error_from_chunk(chunk: dict) -> Optional[tuple[str, int]]:
+        """OpenAI-compatible backends (vLLM, sglang) can return an HTTP 200
+        stream whose body carries an error payload, e.g.
+        ``data: {"error": {"message": "...", "code": 400}}``."""
+        error = chunk.get("error")
+        if not error:
+            return None
+        if not isinstance(error, dict):
+            return str(error), 500
+        message = error.get("message")
+        code = error.get("code")
+        status_code = code if isinstance(code, int) and 400 <= code < 600 else 500
+        return (message if isinstance(message, str) else str(error)), status_code
+
     def chunk_parser(self, chunk: dict) -> ModelResponseStream:
         try:
+            error_details = self._extract_error_from_chunk(chunk)
+            if error_details is not None:
+                error_message, error_status_code = error_details
+                raise OpenAIError(
+                    status_code=error_status_code,
+                    message=error_message,
+                )
             choices = chunk.get("choices", [])
             choices = self._map_reasoning_to_reasoning_content(choices)
 

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -2,6 +2,7 @@
 Support for gpt model family
 """
 
+import json
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -795,7 +796,7 @@ class OpenAIChatCompletionStreamingHandler(BaseModelResponseIterator):
         message = error.get("message")
         code = error.get("code")
         status_code = code if isinstance(code, int) and 400 <= code < 600 else 500
-        return (message if isinstance(message, str) else str(error)), status_code
+        return (message if isinstance(message, str) else json.dumps(error)), status_code
 
     def chunk_parser(self, chunk: dict) -> ModelResponseStream:
         try:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -986,6 +986,86 @@ async def test_bedrock_validation_error_raises_directly(logging_obj: Logging):
     assert getattr(excinfo.value, "status_code", None) == 400
 
 
+def _hosted_vllm_stream_wrapper(logging_obj: Logging, error_payload: dict) -> CustomStreamWrapper:
+    """A CustomStreamWrapper over the real OpenAI-compatible line iterator,
+    fed an HTTP 200 SSE body that carries an in-body error payload the way
+    vLLM/sglang emit it."""
+    from litellm.llms.openai.chat.gpt_transformation import (
+        OpenAIChatCompletionStreamingHandler,
+    )
+
+    async def _stream():
+        yield f"data: {json.dumps(error_payload)}"
+        yield "data: [DONE]"
+
+    completion_stream = OpenAIChatCompletionStreamingHandler(
+        streaming_response=_stream(), sync_stream=False
+    )
+    return CustomStreamWrapper(
+        completion_stream=completion_stream,
+        model="qwen-vl",
+        logging_obj=logging_obj,
+        custom_llm_provider="hosted_vllm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_in_body_stream_error_400_raises_bad_request(logging_obj: Logging):
+    """Regression for https://github.com/BerriAI/litellm/issues/25492: a 400
+    error returned inside a 200 SSE body must surface as BadRequestError with
+    the provider's message, not be parsed as an empty chunk that silently
+    ends the stream (and never as an internal MidStreamFallbackError)."""
+    from litellm.exceptions import MidStreamFallbackError
+
+    response = _hosted_vllm_stream_wrapper(
+        logging_obj,
+        {
+            "error": {
+                "object": "error",
+                "message": "The model is not multimodal. Please remove image inputs.",
+                "type": "BadRequestError",
+                "param": None,
+                "code": 400,
+            }
+        },
+    )
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        await response.__anext__()
+
+    assert not isinstance(excinfo.value, MidStreamFallbackError)
+    assert excinfo.value.status_code == 400
+    assert "not multimodal" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_in_body_stream_error_500_wraps_for_midstream_fallback(
+    logging_obj: Logging,
+):
+    """An in-body 5xx error wraps into MidStreamFallbackError so the Router's
+    FallbackStreamWrapper can switch to a configured fallback deployment."""
+    from litellm.exceptions import MidStreamFallbackError
+
+    response = _hosted_vllm_stream_wrapper(
+        logging_obj,
+        {
+            "error": {
+                "object": "error",
+                "message": "internal engine crash",
+                "type": "InternalServerError",
+                "param": None,
+                "code": 500,
+            }
+        },
+    )
+
+    with pytest.raises(MidStreamFallbackError) as excinfo:
+        await response.__anext__()
+
+    assert excinfo.value.is_pre_first_chunk is True
+    assert "internal engine crash" in str(excinfo.value)
+
+
 @pytest.mark.asyncio
 async def test_async_streaming_read_timeout_triggers_midstream_fallback(
     logging_obj: Logging,

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -235,6 +235,11 @@ class TestOpenAIChatCompletionStreamingHandler:
         assert excinfo.value.status_code == 500
         assert "plain string error" in excinfo.value.message
 
+        with pytest.raises(OpenAIError) as excinfo:
+            handler.chunk_parser({"error": {"type": "overloaded", "code": 503}})
+        assert excinfo.value.status_code == 503
+        assert excinfo.value.message == '{"type": "overloaded", "code": 503}'
+
     def test_chunk_parser_tolerates_null_error_field(self):
         """A chunk that carries "error": null alongside real data must parse
         normally, not raise."""

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -187,6 +187,79 @@ class TestOpenAIChatCompletionStreamingHandler:
         assert result.usage.completion_tokens == 350
         assert result.usage.total_tokens == 14147
 
+    def test_chunk_parser_raises_on_in_body_error_payload(self):
+        """vLLM/sglang return HTTP 200 streams whose body carries the error,
+        e.g. data: {"error": {..., "code": 400}}. chunk_parser must surface it
+        as a provider error instead of parsing an empty chunk that silently
+        ends the stream (https://github.com/BerriAI/litellm/issues/25492)."""
+        from litellm.llms.openai.common_utils import OpenAIError
+
+        handler = OpenAIChatCompletionStreamingHandler(
+            streaming_response=None, sync_stream=True
+        )
+
+        error_chunk = {
+            "error": {
+                "object": "error",
+                "message": "The model is not multimodal. Please remove image inputs.",
+                "type": "BadRequestError",
+                "param": None,
+                "code": 400,
+            }
+        }
+
+        with pytest.raises(OpenAIError) as excinfo:
+            handler.chunk_parser(error_chunk)
+
+        assert excinfo.value.status_code == 400
+        assert "not multimodal" in excinfo.value.message
+
+    def test_chunk_parser_error_payload_without_usable_code_maps_to_500(self):
+        """OpenAI-style error payloads may carry a string code (e.g.
+        "invalid_api_key") or none at all; those must map to 500, not crash."""
+        from litellm.llms.openai.common_utils import OpenAIError
+
+        handler = OpenAIChatCompletionStreamingHandler(
+            streaming_response=None, sync_stream=True
+        )
+
+        with pytest.raises(OpenAIError) as excinfo:
+            handler.chunk_parser(
+                {"error": {"message": "engine crashed", "code": "server_error"}}
+            )
+        assert excinfo.value.status_code == 500
+        assert "engine crashed" in excinfo.value.message
+
+        with pytest.raises(OpenAIError) as excinfo:
+            handler.chunk_parser({"error": "plain string error"})
+        assert excinfo.value.status_code == 500
+        assert "plain string error" in excinfo.value.message
+
+    def test_chunk_parser_tolerates_null_error_field(self):
+        """A chunk that carries "error": null alongside real data must parse
+        normally, not raise."""
+        handler = OpenAIChatCompletionStreamingHandler(
+            streaming_response=None, sync_stream=True
+        )
+
+        chunk = {
+            "id": "gen-123",
+            "created": 1234567890,
+            "model": "openai/gpt-4o-mini",
+            "object": "chat.completion.chunk",
+            "error": None,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hello"},
+                    "finish_reason": None,
+                }
+            ],
+        }
+
+        result = handler.chunk_parser(chunk)
+        assert result.choices[0].delta.content == "Hello"
+
     def test_chunk_parser_without_usage(self):
         """Test that chunk_parser works normally for chunks without usage."""
         handler = OpenAIChatCompletionStreamingHandler(


### PR DESCRIPTION
## Relevant issues

Fixes #25492. Related: #26015 (the CPU-spin half of the same customer report; already resolved by #31298, verified not reproducible on current staging during this investigation)

## Linear ticket

Resolves LIT-4211

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

vLLM and sglang report some request errors inside an HTTP 200 SSE stream instead of a real 4xx/5xx status, e.g. sending an image to a non-multimodal model:

```
data: {"error": {"object": "error", "message": "The model is not multimodal. Please remove image inputs.", "type": "BadRequestError", "param": null, "code": 400}}
data: [DONE]
```

Repro setup: a local upstream on `127.0.0.1:41893` that emits exactly that body (a misbehaving upstream is required to reproduce, so this stands in for vLLM), plus a real OpenAI fallback, proxied by `python litellm/proxy/proxy_cli.py --config msf_config.yaml --port 41894 --detailed_debug`:

```yaml
model_list:
  - model_name: vllm-vision
    litellm_params:
      model: hosted_vllm/qwen-vl-mock
      api_base: http://127.0.0.1:41893/v1
      api_key: fake-key
  - model_name: gpt-fallback
    litellm_params:
      model: openai/gpt-5.5
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  fallbacks:
    - vllm-vision:
        - gpt-fallback
```

Before the fix, the error payload parsed into an empty chunk and the client received a silent empty 200 stream; the provider's message was lost and the configured fallback was never attempted:

```
$ curl -s -N http://127.0.0.1:41894/v1/chat/completions \
    -H "Authorization: Bearer sk-msf-test-1234" -H "Content-Type: application/json" \
    -d '{"model":"vllm-vision","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"describe this image"},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}}]}]}'
data: {"id":"chatcmpl-f359f14b-7977-4968-8e73-290bd649b280","object":"chat.completion.chunk","created":1783328811,"model":"vllm-vision","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: [DONE]
```

After the fix, the same request surfaces the provider's error as a clean 400:

```
$ curl -s -w "\nHTTP %{http_code}\n" -N http://127.0.0.1:41894/v1/chat/completions \
    -H "Authorization: Bearer sk-msf-test-1234" -H "Content-Type: application/json" \
    -d '{"model":"vllm-vision","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"what color is this image? one word."},{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="}}]}]}'
{"error":{"message":"litellm.BadRequestError: Hosted_vllmException - The model is not multimodal. Please remove image inputs.","type":null,"param":null,"code":"400"}}
HTTP 400
```

And an in-body 5xx (vLLM engine crash shape, `"code": 500`) now wraps into `MidStreamFallbackError`, so the router serves the request from the configured fallback (real OpenAI API call, real spend):

```
$ curl -s -N http://127.0.0.1:41894/v1/chat/completions \
    -H "Authorization: Bearer sk-msf-test-1234" -H "Content-Type: application/json" \
    -d '{"model":"vllm-vision","stream":true,"messages":[{"role":"user","content":"servererror: reply with the single word pong"}]}' \
    | grep -o '"content":"[^"]*"'
"content":""
"content":"pong"
```

Independent e2e recording using mock vLLM upstream and the LiteLLM proxy from this branch, covering all three scenarios (400 surfaced, 500 fallback, normal stream) plus pytest regression tests: [video recording](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWEzZjQ5MTAtZjFjZi00NDNmLThlMjctNDU2YTNhZDE5MGEwIiwiaWF0IjoxNzgzMzMwNDU5LCJleHAiOjE3ODM5MzUyNTksImZpbGVuYW1lIjoicmVjLWIyZWFiNWJmLWE5YTAtNDRhYi05ZjdiLTM5NDU2ODg3OGI3YS1lZGl0ZWQubXA0In0.IUFq5bYCW7ZKPAMSV54--cJPF_G8cpUmpf4lLmqXH3E)

## Type

🐛 Bug Fix

## Changes

`OpenAIChatCompletionStreamingHandler.chunk_parser` (shared by hosted_vllm, openai_like, groq, xai, mistral, fireworks_ai and every other provider that reuses the OpenAI-compatible streaming iterator) had no detection for an `{"error": ...}` SSE payload. On the version in issue #25492 this crashed with `KeyError: 'id'` and leaked a 503 `MidStreamFallbackError` to the client; since #23931 switched to `chunk.get("id")`, the payload instead parsed into an empty `ModelResponseStream` and the stream ended silently with HTTP 200

This PR detects the payload in `chunk_parser` and raises `OpenAIError` carrying the upstream message and status code (integer `code` in the 4xx/5xx range is honored, anything else maps to 500; a `"error": null` field on a normal chunk is tolerated). From there the existing mid-stream gate in `streaming_handler._handle_stream_fallback_error` applies unchanged: 4xx other than 429 surface directly to the client, 429 and 5xx wrap into `MidStreamFallbackError` so the router runs configured fallbacks

One deliberate scope note: for an in-body 400 with a fallback configured, the client now gets the 400 directly rather than a fallback response. That matches the existing, test-pinned mid-stream contract from #22375 (non-retriable 4xx skip fallback). Making pre-first-chunk 4xx eligible for fallbacks would align streaming with how the same provider error is treated when it arrives as a real HTTP 400 pre-call, but that is a semantics change across all providers and belongs in its own discussion

Regression tests fail without the fix and pass with it: parser-level tests in `tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py` (vLLM 400 shape, string/absent `code` mapping to 500, `"error": null` tolerance) and gate-level tests in `tests/test_litellm/litellm_core_utils/test_streaming_handler.py` driving the real iterator through `CustomStreamWrapper` (400 surfaces as `BadRequestError`, 500 wraps for mid-stream fallback)

Link to Devin session: https://app.devin.ai/sessions/280f53a344ef4e7d8460adc0ff3bd7c0
