### PR TITLE
fix(responses): stop scheduling sync success_handler concurrently with async_success_handler

### DIFF
--- a/litellm/a2a_protocol/streaming_iterator.py
+++ b/litellm/a2a_protocol/streaming_iterator.py
@@ -11,7 +11,6 @@ from litellm._logging import verbose_logger
 from litellm.a2a_protocol.cost_calculator import A2ACostCalculator
 from litellm.a2a_protocol.utils import A2ARequestUtils
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
-from litellm.litellm_core_utils.thread_pool_executor import executor
 
 if TYPE_CHECKING:
     from a2a.types import SendStreamingMessageRequest, SendStreamingMessageResponse
@@ -128,20 +127,13 @@ class A2AStreamingIterator:
 
             # Call success handlers - they will build standard_logging_object
             asyncio.create_task(
-                self.logging_obj.async_success_handler(
-                    result=result,
+                self.logging_obj.dispatch_success_handlers(
+                    result,
                     start_time=self.start_time,
                     end_time=end_time,
                     cache_hit=None,
+                    prefer_async_handlers=True,
                 )
-            )
-
-            executor.submit(
-                self.logging_obj.success_handler,
-                result=result,
-                cache_hit=None,
-                start_time=self.start_time,
-                end_time=end_time,
             )
 
             verbose_logger.info(

--- a/litellm/interactions/streaming_iterator.py
+++ b/litellm/interactions/streaming_iterator.py
@@ -174,20 +174,13 @@ class InteractionsAPIStreamingIterator(BaseInteractionsAPIStreamingIterator):
         logging_response = copy.deepcopy(self.completed_response)
 
         asyncio.create_task(
-            self.logging_obj.async_success_handler(
-                result=logging_response,
+            self.logging_obj.dispatch_success_handlers(
+                logging_response,
                 start_time=self.start_time,
                 end_time=datetime.now(),
                 cache_hit=None,
+                prefer_async_handlers=True,
             )
-        )
-
-        executor.submit(
-            self.logging_obj.success_handler,
-            result=logging_response,
-            cache_hit=None,
-            start_time=self.start_time,
-            end_time=datetime.now(),
         )
 
 

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -1,5 +1,4 @@
 import asyncio
-import concurrent.futures
 import json
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Protocol, Union, cast
 
@@ -24,9 +23,6 @@ if TYPE_CHECKING:
     CLIENT_CONNECTION_CLASS = ClientConnection
 else:
     CLIENT_CONNECTION_CLASS = Any
-
-# Create a thread pool with a maximum of 10 threads
-executor = concurrent.futures.ThreadPoolExecutor(max_workers=10)
 
 
 class RealtimeEventNormalizer(Protocol):
@@ -315,13 +311,12 @@ class RealTimeStreaming:
             if self.session_tools or self.tool_calls:
                 self.logging_obj.model_call_details["realtime_tools"] = self.session_tools
                 self.logging_obj.model_call_details["realtime_tool_calls"] = self.tool_calls
-            ## ASYNC LOGGING
             # Route through the bounded logging worker (per-coroutine timeout +
             # concurrency cap) instead of a bare create_task, so a slow callback
             # can't leave suspended tasks pinning each call's response in memory.
-            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(self.logging_obj.async_success_handler(self.messages))
-            ## SYNC LOGGING
-            executor.submit(self.logging_obj.success_handler(self.messages))
+            GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
+                self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True)
+            )
 
     async def _send_to_backend(self, message: str) -> bool:
         """Send a message to the backend WebSocket.

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -284,11 +284,12 @@ class BaseResponsesAPIStreamingIterator:
         end_time = datetime.now()
         if is_async:
             asyncio.create_task(
-                self.logging_obj.async_success_handler(
-                    result=logging_response,
+                self.logging_obj.dispatch_success_handlers(
+                    logging_response,
                     start_time=self.start_time,
                     end_time=end_time,
                     cache_hit=self._completed_response_cache_hit,
+                    prefer_async_handlers=True,
                 )
             )
         else:
@@ -299,14 +300,13 @@ class BaseResponsesAPIStreamingIterator:
                 end_time=end_time,
                 cache_hit=self._completed_response_cache_hit,
             )
-
-        executor.submit(
-            self.logging_obj.success_handler,
-            result=logging_response,
-            cache_hit=self._completed_response_cache_hit,
-            start_time=self.start_time,
-            end_time=end_time,
-        )
+            executor.submit(
+                self.logging_obj.success_handler,
+                result=logging_response,
+                cache_hit=self._completed_response_cache_hit,
+                start_time=self.start_time,
+                end_time=end_time,
+            )
         self._run_post_success_hooks(end_time=end_time)
 
     def _handle_logging_completed_response(self):
@@ -1133,7 +1133,6 @@ def _build_synthetic_response_events(
 # ---------------------------------------------------------------------------
 
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.thread_pool_executor import executor as _ws_executor
 
 RESPONSES_WS_LOGGED_EVENT_TYPES = [
     "response.created",
@@ -1248,8 +1247,7 @@ class ResponsesWebSocketStreaming:
         if self.input_messages:
             self.logging_obj.model_call_details["messages"] = self.input_messages
         if self.messages:
-            asyncio.create_task(self.logging_obj.async_success_handler(self.messages))
-            _ws_executor.submit(self.logging_obj.success_handler, self.messages)
+            asyncio.create_task(self.logging_obj.dispatch_success_handlers(self.messages, prefer_async_handlers=True))
 
     async def backend_to_client(self) -> None:
         """Forward events from backend WebSocket to the client."""

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -636,9 +636,10 @@ class TestBaseResponsesAPIStreamingIterator:
             assert result.type == ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE
             assert iterator.completed_response == result
 
-            # Success handler should have been called (via _handle_logging_completed_response)
+            # Success handlers are dispatched as one async task (via _handle_logging_completed_response);
+            # the sync handler must never be submitted to the executor concurrently (LIT-4210)
             mock_create_task.assert_called_once()
-            mock_executor.submit.assert_called_once()
+            mock_executor.submit.assert_not_called()
 
             # Failure handlers should NOT have been called
             mock_logging_obj.async_failure_handler.assert_not_called()

--- a/tests/llm_responses_api_testing/test_responses_hooks.py
+++ b/tests/llm_responses_api_testing/test_responses_hooks.py
@@ -37,6 +37,11 @@ class _FakeLoggingObj:
         self.model_call_details = {"litellm_params": {}}
 
     # Signature alignment with Logging handlers
+    async def dispatch_success_handlers(self, *args, **kwargs):
+        kwargs.pop("prefer_async_handlers", None)
+        await self.async_success_handler(*args, **kwargs)
+        self.success_handler(*args, **kwargs)
+
     def success_handler(self, *args, **kwargs):
         self.success_calls += 1
         self.last_success_kwargs = kwargs

--- a/tests/test_litellm/a2a_protocol/test_a2a_streaming_iterator.py
+++ b/tests/test_litellm/a2a_protocol/test_a2a_streaming_iterator.py
@@ -6,6 +6,7 @@ async_success_handler (cross-thread pydantic mutation segfaults pydantic-core).
 
 import asyncio
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -87,7 +88,9 @@ async def test_custom_logger_only_never_submits_sync_success_handler(monkeypatch
 
     iterator = A2AStreamingIterator(
         stream=_empty_stream(),
-        request=object(),
+        request=SimpleNamespace(
+            params=SimpleNamespace(message={"role": "user", "parts": [{"kind": "text", "text": "hi"}]})
+        ),
         logging_obj=logging_obj,
         agent_name="test-agent",
     )

--- a/tests/test_litellm/a2a_protocol/test_a2a_streaming_iterator.py
+++ b/tests/test_litellm/a2a_protocol/test_a2a_streaming_iterator.py
@@ -1,0 +1,99 @@
+"""
+Regression test for LIT-4210: completing an A2A stream must not run the sync
+success_handler on the thread-pool executor concurrently with
+async_success_handler (cross-thread pydantic mutation segfaults pydantic-core).
+"""
+
+import asyncio
+import time
+
+import pytest
+
+import litellm
+from litellm.a2a_protocol import streaming_iterator as a2a_streaming_iterator_module
+from litellm.a2a_protocol.streaming_iterator import A2AStreamingIterator
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils import thread_pool_executor as thread_pool_executor_module
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+
+
+class RecordingCustomLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.async_hook_fired = False
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.async_hook_fired = True
+
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
+        self.async_hook_fired = True
+
+
+class RecordingExecutor:
+    def __init__(self, inner):
+        self._inner = inner
+        self.submits: list = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submits.append(fn)
+        return self._inner.submit(fn, *args, **kwargs)
+
+    def submitted_for(self, logging_obj) -> list:
+        return [fn for fn in self.submits if getattr(fn, "__self__", None) is logging_obj]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_callbacks():
+    saved = (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    )
+    yield
+    (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    ) = saved
+
+
+@pytest.mark.asyncio
+async def test_custom_logger_only_never_submits_sync_success_handler(monkeypatch):
+    recording_executor = RecordingExecutor(thread_pool_executor_module.executor)
+    monkeypatch.setattr(thread_pool_executor_module, "executor", recording_executor)
+    monkeypatch.setattr(a2a_streaming_iterator_module, "executor", recording_executor, raising=False)
+
+    recorder = RecordingCustomLogger()
+    litellm.success_callback = [recorder]
+    litellm._async_success_callback = [recorder]
+
+    logging_obj = LitellmLogging(
+        model="a2a/test-agent",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="a2a_send_message_streaming",
+        start_time=time.time(),
+        litellm_call_id="lit-4210-test",
+        function_id="lit-4210-test",
+    )
+
+    async def _empty_stream():
+        return
+        yield
+
+    iterator = A2AStreamingIterator(
+        stream=_empty_stream(),
+        request=object(),
+        logging_obj=logging_obj,
+        agent_name="test-agent",
+    )
+
+    await iterator._handle_stream_complete()
+    await asyncio.sleep(0.5)
+
+    assert recorder.async_hook_fired is True
+    assert recording_executor.submitted_for(logging_obj) == []

--- a/tests/test_litellm/interactions/test_interactions_streaming_iterator.py
+++ b/tests/test_litellm/interactions/test_interactions_streaming_iterator.py
@@ -1,0 +1,97 @@
+"""
+Regression test for LIT-4210: completing an async Interactions API stream must
+not run the sync success_handler on the thread-pool executor concurrently with
+async_success_handler (cross-thread pydantic mutation segfaults pydantic-core).
+"""
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.interactions import streaming_iterator as interactions_streaming_iterator_module
+from litellm.interactions.streaming_iterator import InteractionsAPIStreamingIterator
+from litellm.litellm_core_utils import thread_pool_executor as thread_pool_executor_module
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.types.interactions import InteractionsAPIStreamingResponse
+
+
+class RecordingCustomLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.async_hook_fired = False
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        self.async_hook_fired = True
+
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
+        self.async_hook_fired = True
+
+
+class RecordingExecutor:
+    def __init__(self, inner):
+        self._inner = inner
+        self.submits: list = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submits.append(fn)
+        return self._inner.submit(fn, *args, **kwargs)
+
+    def submitted_for(self, logging_obj) -> list:
+        return [fn for fn in self.submits if getattr(fn, "__self__", None) is logging_obj]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_callbacks():
+    saved = (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    )
+    yield
+    (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    ) = saved
+
+
+@pytest.mark.asyncio
+async def test_custom_logger_only_never_submits_sync_success_handler(monkeypatch):
+    recording_executor = RecordingExecutor(thread_pool_executor_module.executor)
+    monkeypatch.setattr(thread_pool_executor_module, "executor", recording_executor)
+    monkeypatch.setattr(interactions_streaming_iterator_module, "executor", recording_executor)
+
+    recorder = RecordingCustomLogger()
+    litellm.success_callback = [recorder]
+    litellm._async_success_callback = [recorder]
+
+    logging_obj = LitellmLogging(
+        model="gemini/gemini-3-pro-preview",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="ainteraction",
+        start_time=time.time(),
+        litellm_call_id="lit-4210-test",
+        function_id="lit-4210-test",
+    )
+    iterator = InteractionsAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="gemini/gemini-3-pro-preview",
+        interactions_api_config=None,
+        logging_obj=logging_obj,
+    )
+    iterator.completed_response = InteractionsAPIStreamingResponse()
+
+    iterator._handle_logging_completed_response()
+    await asyncio.sleep(0.5)
+
+    assert recorder.async_hook_fired is True
+    assert recording_executor.submitted_for(logging_obj) == []

--- a/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
+++ b/tests/test_litellm/litellm_core_utils/test_realtime_streaming.py
@@ -2961,10 +2961,13 @@ async def test_log_messages_routes_async_logging_through_bounded_worker():
     with (
         patch("litellm.litellm_core_utils.realtime_streaming.GLOBAL_LOGGING_WORKER") as mock_worker,
         patch("litellm.litellm_core_utils.realtime_streaming.asyncio.create_task") as mock_create_task,
-        patch("litellm.litellm_core_utils.realtime_streaming.executor.submit"),
     ):
         await streaming.log_messages()
 
         mock_worker.ensure_initialized_and_enqueue.assert_called_once()
+        enqueued = mock_worker.ensure_initialized_and_enqueue.call_args
+        assert (enqueued.args or tuple(enqueued.kwargs.values()))[0] is logging_obj.dispatch_success_handlers.return_value
+        logging_obj.dispatch_success_handlers.assert_called_once_with(streaming.messages, prefer_async_handlers=True)
+        logging_obj.success_handler.assert_not_called()
         # the bare create_task path must no longer be used for success logging
         mock_create_task.assert_not_called()

--- a/tests/test_litellm/responses/test_responses_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_responses_streaming_iterator.py
@@ -1,0 +1,158 @@
+"""
+Regression tests for LIT-4210: the streaming iterators must never run the sync
+success_handler on the thread-pool executor concurrently with
+async_success_handler. Concurrent mutation of the shared response object /
+model_call_details from two threads segfaults pydantic-core (customer pods
+crashed with exit 139 whenever any CustomLogger was registered).
+"""
+
+import asyncio
+import time
+
+import httpx
+import pytest
+
+import litellm
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.litellm_core_utils import thread_pool_executor as thread_pool_executor_module
+from litellm.responses import streaming_iterator as responses_streaming_iterator_module
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.types.llms.openai import ResponsesAPIResponse
+
+
+class RecordingCustomLogger(CustomLogger):
+    def __init__(self):
+        super().__init__()
+        self.async_hook_started: float | None = None
+        self.async_hook_finished: float | None = None
+
+    async def _record(self):
+        self.async_hook_started = time.monotonic()
+        await asyncio.sleep(0.2)
+        self.async_hook_finished = time.monotonic()
+
+    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+        await self._record()
+
+    async def async_log_stream_event(self, kwargs, response_obj, start_time, end_time):
+        await self._record()
+
+
+class RecordingExecutor:
+    def __init__(self, inner):
+        self._inner = inner
+        self.submits: list = []
+
+    def submit(self, fn, *args, **kwargs):
+        self.submits.append((time.monotonic(), fn))
+        return self._inner.submit(fn, *args, **kwargs)
+
+    def submit_times_for(self, logging_obj) -> list:
+        return [t for t, fn in self.submits if getattr(fn, "__self__", None) is logging_obj]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_callbacks():
+    saved = (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    )
+    yield
+    (
+        litellm.callbacks,
+        litellm.success_callback,
+        litellm._async_success_callback,
+        litellm.failure_callback,
+        litellm._async_failure_callback,
+    ) = saved
+
+
+@pytest.fixture
+def recording_executor(monkeypatch):
+    recording = RecordingExecutor(thread_pool_executor_module.executor)
+    monkeypatch.setattr(thread_pool_executor_module, "executor", recording)
+    monkeypatch.setattr(responses_streaming_iterator_module, "executor", recording)
+    return recording
+
+
+def _make_logging_obj() -> LitellmLogging:
+    logging_obj = LitellmLogging(
+        model="gpt-5.4-nano",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        call_type="aresponses",
+        start_time=time.time(),
+        litellm_call_id="lit-4210-test",
+        function_id="lit-4210-test",
+    )
+    logging_obj.model_call_details["litellm_params"] = {"aresponses": True}
+    return logging_obj
+
+
+def _make_iterator(logging_obj: LitellmLogging) -> ResponsesAPIStreamingIterator:
+    iterator = ResponsesAPIStreamingIterator(
+        response=httpx.Response(200),
+        model="gpt-5.4-nano",
+        responses_api_provider_config=None,
+        logging_obj=logging_obj,
+    )
+    iterator.completed_response = ResponsesAPIResponse(
+        id="resp_lit4210",
+        created_at=1700000000.0,
+        model="gpt-5.4-nano",
+        object="response",
+        output=[],
+        parallel_tool_calls=True,
+        tool_choice="auto",
+        tools=[],
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        temperature=1.0,
+        top_p=1.0,
+    )
+    return iterator
+
+
+@pytest.mark.asyncio
+async def test_custom_logger_only_never_submits_sync_success_handler(recording_executor):
+    recorder = RecordingCustomLogger()
+    litellm.success_callback = [recorder]
+    litellm._async_success_callback = [recorder]
+
+    logging_obj = _make_logging_obj()
+    iterator = _make_iterator(logging_obj)
+
+    iterator._log_completed_response(is_async=True)
+    await asyncio.sleep(0.6)
+
+    assert recorder.async_hook_started is not None
+    assert recording_executor.submit_times_for(logging_obj) == []
+
+
+@pytest.mark.asyncio
+async def test_sync_callbacks_run_only_after_async_handler_completes(recording_executor):
+    recorder = RecordingCustomLogger()
+    sync_events: list = []
+
+    def sync_callback(kwargs, response_obj, start_time, end_time):
+        sync_events.append(time.monotonic())
+
+    litellm.success_callback = [recorder, sync_callback]
+    litellm._async_success_callback = [recorder]
+
+    logging_obj = _make_logging_obj()
+    iterator = _make_iterator(logging_obj)
+
+    iterator._log_completed_response(is_async=True)
+    await asyncio.sleep(0.8)
+
+    assert recorder.async_hook_finished is not None
+    submit_times = recording_executor.submit_times_for(logging_obj)
+    assert len(submit_times) == 1
+    assert submit_times[0] >= recorder.async_hook_finished

--- a/tests/test_litellm/responses/test_responses_websocket_all_providers.py
+++ b/tests/test_litellm/responses/test_responses_websocket_all_providers.py
@@ -1122,7 +1122,7 @@ class TestNativeWebSocketGuardrails:
         client_ws = MagicMock()
         client_ws.send_text = AsyncMock()
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         delta_event = json.dumps(
             {"type": "response.output_text.delta", "delta": "alice@example.com"}
@@ -1196,7 +1196,7 @@ class TestNativeWebSocketGuardrails:
         client_ws = MagicMock()
         client_ws.send_text = AsyncMock()
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         done_events = [
             json.dumps(
@@ -1895,7 +1895,7 @@ class TestNativeWebSocketGuardrailMasking:
             ]
         )
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         handler = _make_streaming(
             websocket=websocket,
@@ -1951,7 +1951,7 @@ class TestNativeWebSocketGuardrailMasking:
             ]
         )
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         handler = _make_streaming(
             websocket=websocket,
@@ -2014,7 +2014,7 @@ class TestNativeWebSocketGuardrailMasking:
             ]
         )
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         handler = _make_streaming(
             websocket=websocket,
@@ -2077,7 +2077,7 @@ class TestNativeWebSocketGuardrailMasking:
             ]
         )
         logging_obj = MagicMock()
-        logging_obj.async_success_handler = AsyncMock()
+        logging_obj.dispatch_success_handlers = AsyncMock()
 
         handler = _make_streaming(
             websocket=websocket,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4210

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A customer's proxy pods were segfaulting (exit 139) roughly 18 times a day. They isolated it to callback registration: a bare no-op `CustomLogger()` with zero overrides crashed pods within 30 to 90 minutes, while a config with only `prometheus` ran 19 hours clean. Their faulthandler dumps from 9 crashed pods all show the main thread inside pydantic `__setattr__` / `_check_frozen` while thread-pool workers run litellm's sync `success_handler`

The root cause is that several streaming iterators fire both success handlers at end of stream, unconditionally and with the same response object

```python
asyncio.create_task(self.logging_obj.async_success_handler(result=logging_response, ...))
executor.submit(self.logging_obj.success_handler, result=logging_response, ...)
```

The asyncio task and the executor thread then both run the full logging pipeline (helper mutations, cost calculation, hidden-params merge, redaction, standard logging payload) against one pydantic model and one shared `model_call_details` dict. Concurrent mutation of a pydantic-core model from two threads is unsound in the Rust core and eventually segfaults with no Python traceback. Chat completions streaming had this exact pair until v1.88.0 routed it through `dispatch_success_handlers` (#29089); the responses API, interactions API, and A2A iterators kept the old pattern. Note the executor-side submit does no useful CustomLogger work on async calls anyway, since `success_handler` gates `log_success_event` on `_is_sync_litellm_request`

Live proxy repro on this branch's base, run with a user callback module identical to the customer's no-op handler, except it also logs which executor worker threads exist at the moment the async success hook runs:

```
$ cat custom_callbacks.py
class NoopHandler(CustomLogger):
    async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
        pool_threads = sorted(t.name for t in threading.enumerate() if t.name.startswith("ThreadPoolExecutor"))
        logger.info("NOOP_CALLBACK success. executor_threads=%s", pool_threads)

$ python litellm/proxy/proxy_cli.py --config config.yaml --port 14210
$ curl -s http://127.0.0.1:14210/v1/responses \
    -H "Authorization: Bearer sk-lit4210" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-nano","input":"Say hello in one word","stream":true}'
data: {"type":"response.completed","response":{"id":"resp_ATrXFkqJ...","model":"gpt-5.4-nano-2026-03-17","usage":{"input_tokens":11,"output_tokens":5,"total_tokens":16},...}}
data: [DONE]
```

Before (base): the litellm logging executor spawns a worker to run the sync `success_handler` concurrently with the async hook that is mid-flight on the event loop

```
INFO:noop_handler:NOOP_CALLBACK success. executor_threads=['ThreadPoolExecutor-0_0', 'ThreadPoolExecutor-4_0']
```

After (this branch, same command repeated 3 times): no worker is ever submitted for the sync handler; the only pool thread is the unrelated one created during proxy startup

```
req1: 200
req2: 200
req3: 200
INFO:noop_handler:NOOP_CALLBACK success. executor_threads=['ThreadPoolExecutor-4_0']
INFO:noop_handler:NOOP_CALLBACK success. executor_threads=['ThreadPoolExecutor-4_0']
INFO:noop_handler:NOOP_CALLBACK success. executor_threads=['ThreadPoolExecutor-4_0']
```

The customer's production faulthandler dumps are the evidence for the segfault itself; a 10 minute local stress run (300k streamed responses through `litellm.aresponses` with the no-op logger) exercised the race continuously but did not reproduce the crash on this machine, which is expected for a pydantic-core memory-safety bug that needs their exact interpreter and payload profile to trigger. The fix removes the cross-thread concurrency outright, so the unsound interleaving can no longer occur

A screen recording of the same before and after reproduction is included below. The run exercises the native responses iterator through an outer proxy configured as `openai/gpt-5.4-nano` whose upstream is a second local proxy, with the CustomLogger-only config attached, so it drives the exact end-of-stream path this PR changes. The recording shows the proxy starting, the streaming `/v1/responses` output, the before and after `NOOP_CALLBACK` executor thread lines, and the four regression test files passing with 105 tests

![litellm PR 32239 end to end demo](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvODUwNGVjMDYtMmViYi00MjhlLTllODAtNDFjMDA5NGZkYTU5IiwiaWF0IjoxNzgzMzM1NTA1LCJleHAiOjE3ODM5NDAzMDUsImZpbGVuYW1lIjoicHItMzIyMzktZGVtby53ZWJwIn0.oQn4b9L1-49C9EiZAES-zmvP5w-nhWqODexDXwMJfgk)

Before, on the base branch, the litellm logging executor `ThreadPoolExecutor-0` has a live worker running the sync `success_handler` during the in-flight async hook

![Before, base branch reproduces the race](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNDE1ZDI5NWUtY2U5OS00ZDhlLWI4MGUtZjBmMmE4M2UzNjhlIiwiaWF0IjoxNzgzMzM1NTA1LCJleHAiOjE3ODM5NDAzMDUsImZpbGVuYW1lIjoic3NfMjc5NDBiMTMucG5nIn0.Kcvrobg4XnkByLc3dvJEzW7ujKkMq7n9Hr6RcVXp2Os)

After, on this branch head, the logging executor has no live worker across three streamed requests and the regression suite passes

![After, this branch has no logging executor worker and tests pass](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMmIxOGY5NDQtYzI3Ny00MGY3LWJlNmItYzExY2FiMzNiMWQxIiwiaWF0IjoxNzgzMzM1NTA2LCJleHAiOjE3ODM5NDAzMDYsImZpbGVuYW1lIjoic3NfYzk1MWE2M2YucG5nIn0.Hm19JKA_xJ9nHEMCrkgvf2ORYcjJKIetUkb1askqmOM)

## Type

🐛 Bug Fix

## Changes

The async completion paths of `litellm/responses/streaming_iterator.py` (including the responses websocket bridge), `litellm/interactions/streaming_iterator.py`, `litellm/a2a_protocol/streaming_iterator.py`, and `litellm/litellm_core_utils/realtime_streaming.py` now route end-of-stream logging through the existing `dispatch_success_handlers(prefer_async_handlers=True)` helper instead of firing `async_success_handler` and `executor.submit(success_handler)` side by side. The helper awaits the async handler first and then submits the sync handler only when `_should_run_sync_callbacks_for_async_calls()` finds a genuine sync-only callback such as `langfuse` or `s3`, so a CustomLogger-only config never touches the thread pool at all. Sync SDK paths keep their existing behavior. The realtime bridge's old submit also had a latent bug where success_handler ran inline and its return value was submitted to the pool; routing through the dispatch helper removes that too

Regression tests in `tests/test_litellm/responses/test_responses_streaming_iterator.py`, `tests/test_litellm/interactions/test_interactions_streaming_iterator.py`, and `tests/test_litellm/a2a_protocol/test_a2a_streaming_iterator.py` drive each iterator's completion handler with a recording executor and assert that a CustomLogger-only config never submits the sync handler to the pool, and that when a sync callback is configured the submit happens only after the async handler has fully completed. All of them fail on the base branch and pass with this change


Link to Devin session: https://app.devin.ai/sessions/e5a77af3ab5c4e498f81b9e9f84db82e
