### PR TITLE
fix(proxy): wire general_settings SSRF allowlist to litellm globals

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2322,6 +2322,28 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "is active as a reminder that hard enforcement is relaxed."
         ),
     )
+    user_url_validation: Optional[bool] = Field(
+        None,
+        description=(
+            "Master switch for the SSRF guard applied to user-supplied URLs "
+            "(image_url, file_url, MCP/OpenAPI spec URLs, etc). Defaults to True. "
+            "Set to False to disable DNS/IP validation entirely (not recommended)."
+        ),
+    )
+    user_url_allowed_hosts: Optional[List[str]] = Field(
+        None,
+        description=(
+            "SSRF allowlist for user-supplied URLs. Entries are `hostname` or "
+            "`hostname:port` (bracketed for IPv6, e.g. `[::1]:8080`). Allowlisted "
+            "hosts skip the blocked-network check in validate_url() but still "
+            "resolve DNS. Use this to permit legitimate internal targets, e.g. "
+            "an internal OpenAPI/MCP server."
+        ),
+    )
+    provider_url_destination_allowed_hosts: Optional[List[str]] = Field(
+        None,
+        description="Allowlist of hosts a request may redirect a provider call's destination URL to.",
+    )
 
 
 class ConfigYAML(LiteLLMPydanticObjectBase):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2330,7 +2330,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "Set to False to disable DNS/IP validation entirely (not recommended)."
         ),
     )
-    user_url_allowed_hosts: Optional[List[str]] = Field(
+    user_url_allowed_hosts: Optional[list[str]] = Field(
         None,
         description=(
             "SSRF allowlist for user-supplied URLs. Entries are `hostname` or "
@@ -2340,7 +2340,7 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "an internal OpenAPI/MCP server."
         ),
     )
-    provider_url_destination_allowed_hosts: Optional[List[str]] = Field(
+    provider_url_destination_allowed_hosts: Optional[list[str]] = Field(
         None,
         description="Allowlist of hosts a request may redirect a provider call's destination URL to.",
     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4541,6 +4541,16 @@ class ProxyConfig:
                     RoleBasedPermissions(**role_permission) for role_permission in rbac_role_permissions
                 ]
 
+            ### SSRF URL VALIDATION SETTINGS ###
+            if "user_url_allowed_hosts" in general_settings:
+                litellm.user_url_allowed_hosts = general_settings["user_url_allowed_hosts"]
+            if "user_url_validation" in general_settings:
+                litellm.user_url_validation = general_settings["user_url_validation"]
+            if "provider_url_destination_allowed_hosts" in general_settings:
+                litellm.provider_url_destination_allowed_hosts = general_settings[
+                    "provider_url_destination_allowed_hosts"
+                ]
+
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
                 raise ValueError("Trying to use `enforced_params`" + CommonProxyErrors.not_premium_user.value)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3554,6 +3554,28 @@ def _scrub_db_overlay_remote_module_loads(section: str, db_value: Any) -> Any:
     return sanitized
 
 
+def _normalize_user_url_validation(value: object) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return str_to_bool(value)
+    return bool(value)
+
+
+def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
+    user_url_allowed_hosts = settings.get("user_url_allowed_hosts")
+    if user_url_allowed_hosts is not None:
+        litellm.user_url_allowed_hosts = cast(list[str], user_url_allowed_hosts)
+
+    user_url_validation = _normalize_user_url_validation(settings.get("user_url_validation"))
+    if user_url_validation is not None:
+        litellm.user_url_validation = user_url_validation
+
+    provider_url_destination_allowed_hosts = settings.get("provider_url_destination_allowed_hosts")
+    if provider_url_destination_allowed_hosts is not None:
+        litellm.provider_url_destination_allowed_hosts = cast(list[str], provider_url_destination_allowed_hosts)
+
+
 class ProxyConfig:
     """
     Abstraction class on top of config loading/updating logic. Gives us one place to control all config updating logic.
@@ -4542,14 +4564,7 @@ class ProxyConfig:
                 ]
 
             ### SSRF URL VALIDATION SETTINGS ###
-            if "user_url_allowed_hosts" in general_settings:
-                litellm.user_url_allowed_hosts = general_settings["user_url_allowed_hosts"]
-            if "user_url_validation" in general_settings:
-                litellm.user_url_validation = general_settings["user_url_validation"]
-            if "provider_url_destination_allowed_hosts" in general_settings:
-                litellm.provider_url_destination_allowed_hosts = general_settings[
-                    "provider_url_destination_allowed_hosts"
-                ]
+            _apply_ssrf_general_settings(general_settings)
 
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
@@ -5587,6 +5602,15 @@ class ProxyConfig:
             # Reschedule cleanup job if value changed (including when set to None)
             if old_value != new_value:
                 await self._reschedule_spend_log_cleanup_job()
+
+        for key in (
+            "user_url_allowed_hosts",
+            "user_url_validation",
+            "provider_url_destination_allowed_hosts",
+        ):
+            if key in _general_settings:
+                general_settings[key] = _general_settings[key]
+        _apply_ssrf_general_settings(_general_settings)
 
     def _update_config_fields(
         self,
@@ -14296,6 +14320,7 @@ async def update_config_general_settings(
 
     if data.field_name == "plugins":
         register_plugins_from_config(general_settings)
+    _apply_ssrf_general_settings(general_settings)
 
     return response
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3563,17 +3563,17 @@ def _normalize_user_url_validation(value: object) -> Optional[bool]:
 
 
 def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
-    user_url_allowed_hosts = settings.get("user_url_allowed_hosts")
-    if user_url_allowed_hosts is not None:
-        litellm.user_url_allowed_hosts = cast(list[str], user_url_allowed_hosts)
+    if "user_url_allowed_hosts" in settings:
+        litellm.user_url_allowed_hosts = cast(list[str], settings["user_url_allowed_hosts"])
 
     user_url_validation = _normalize_user_url_validation(settings.get("user_url_validation"))
     if user_url_validation is not None:
         litellm.user_url_validation = user_url_validation
 
-    provider_url_destination_allowed_hosts = settings.get("provider_url_destination_allowed_hosts")
-    if provider_url_destination_allowed_hosts is not None:
-        litellm.provider_url_destination_allowed_hosts = cast(list[str], provider_url_destination_allowed_hosts)
+    if "provider_url_destination_allowed_hosts" in settings:
+        litellm.provider_url_destination_allowed_hosts = cast(
+            list[str], settings["provider_url_destination_allowed_hosts"]
+        )
 
 
 class ProxyConfig:

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -721,6 +721,37 @@ async def test_ProxyConfig_load_config_minimal_yaml(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ProxyConfig_load_config_wires_general_settings_url_validation(tmp_path, monkeypatch):
+    """Regression for #26599: SSRF settings in general_settings must reach litellm globals."""
+    f = tmp_path / "c.yaml"
+    f.write_text(
+        "model_list: []\n"
+        "general_settings:\n"
+        "  user_url_validation: false\n"
+        "  user_url_allowed_hosts:\n"
+        "    - internal.corp\n"
+        "  provider_url_destination_allowed_hosts:\n"
+        "    - api.example.com\n"
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)
+    monkeypatch.delenv("LITELLM_CONFIG_BUCKET_NAME", raising=False)
+
+    original_validation = litellm.user_url_validation
+    original_hosts = list(litellm.user_url_allowed_hosts)
+    original_provider_hosts = list(litellm.provider_url_destination_allowed_hosts)
+    try:
+        await ProxyConfig().load_config(router=None, config_file_path=str(f))
+        assert litellm.user_url_validation is False
+        assert litellm.user_url_allowed_hosts == ["internal.corp"]
+        assert litellm.provider_url_destination_allowed_hosts == ["api.example.com"]
+    finally:
+        litellm.user_url_validation = original_validation
+        litellm.user_url_allowed_hosts = original_hosts
+        litellm.provider_url_destination_allowed_hosts = original_provider_hosts
+
+
+@pytest.mark.asyncio
 async def test_ProxyConfig_load_config_missing_file_raises(monkeypatch):
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
     monkeypatch.setattr("litellm.proxy.proxy_server.store_model_in_db", False)

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2584,6 +2584,42 @@ async def test_load_config_max_budget_env_var_coerced_to_float(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_load_config_user_url_validation_handles_null_and_string_false(tmp_path, monkeypatch):
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    null_config_file = tmp_path / "null_config.yaml"
+    null_config_file.write_text(
+        yaml.dump(
+            {
+                "model_list": [],
+                "general_settings": {"user_url_validation": None},
+            }
+        )
+    )
+
+    await ProxyConfig().load_config(
+        router=MagicMock(), config_file_path=str(null_config_file)
+    )
+    assert litellm.user_url_validation is True
+
+    false_config_file = tmp_path / "false_config.yaml"
+    false_config_file.write_text(
+        yaml.dump(
+            {
+                "model_list": [],
+                "general_settings": {"user_url_validation": "false"},
+            }
+        )
+    )
+
+    await ProxyConfig().load_config(
+        router=MagicMock(), config_file_path=str(false_config_file)
+    )
+    assert litellm.user_url_validation is False
+
+
+@pytest.mark.asyncio
 async def test_load_environment_variables_direct_and_os_environ():
     """
     Test _load_environment_variables method with direct values and os.environ/ prefixed values
@@ -8869,6 +8905,55 @@ async def test_update_config_general_settings_emits_audit_log(monkeypatch):
     assert "sk-stored-secret" not in written["before_value"]
     assert "sk-stored-secret" not in written["updated_values"]
     assert before["some_api_key"] != "sk-stored-secret"
+
+
+@pytest.mark.asyncio
+async def test_update_config_general_settings_applies_ssrf_globals(monkeypatch):
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import ConfigFieldUpdate
+    from litellm.proxy.proxy_server import update_config_general_settings
+
+    fake = _fake_prisma_with_config({})
+    monkeypatch.setattr(proxy_server_module, "prisma_client", fake)
+    monkeypatch.setattr(litellm, "store_audit_logs", False)
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", [])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", [])
+
+    admin = UserAPIKeyAuth(
+        api_key="hashed-admin",
+        user_id="admin-1",
+        user_role=LitellmUserRoles.PROXY_ADMIN,
+    )
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="user_url_validation",
+            field_value="false",
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="user_url_allowed_hosts",
+            field_value=["internal.example"],
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="provider_url_destination_allowed_hosts",
+            field_value=["provider.example"],
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+    await asyncio.sleep(0)
+
+    assert litellm.user_url_validation is False
+    assert litellm.user_url_allowed_hosts == ["internal.example"]
+    assert litellm.provider_url_destination_allowed_hosts == ["provider.example"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2588,12 +2588,18 @@ async def test_load_config_user_url_validation_handles_null_and_string_false(tmp
     from litellm.proxy.proxy_server import ProxyConfig
 
     monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", ["internal.example"])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", ["provider.example"])
     null_config_file = tmp_path / "null_config.yaml"
     null_config_file.write_text(
         yaml.dump(
             {
                 "model_list": [],
-                "general_settings": {"user_url_validation": None},
+                "general_settings": {
+                    "user_url_allowed_hosts": None,
+                    "user_url_validation": None,
+                    "provider_url_destination_allowed_hosts": None,
+                },
             }
         )
     )
@@ -2602,6 +2608,8 @@ async def test_load_config_user_url_validation_handles_null_and_string_false(tmp
         router=MagicMock(), config_file_path=str(null_config_file)
     )
     assert litellm.user_url_validation is True
+    assert litellm.user_url_allowed_hosts is None
+    assert litellm.provider_url_destination_allowed_hosts is None
 
     false_config_file = tmp_path / "false_config.yaml"
     false_config_file.write_text(
@@ -8954,6 +8962,27 @@ async def test_update_config_general_settings_applies_ssrf_globals(monkeypatch):
     assert litellm.user_url_validation is False
     assert litellm.user_url_allowed_hosts == ["internal.example"]
     assert litellm.provider_url_destination_allowed_hosts == ["provider.example"]
+
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="user_url_allowed_hosts",
+            field_value=None,
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+    await update_config_general_settings(
+        data=ConfigFieldUpdate(
+            field_name="provider_url_destination_allowed_hosts",
+            field_value=None,
+            config_type="general_settings",
+        ),
+        user_api_key_dict=admin,
+    )
+    await asyncio.sleep(0)
+
+    assert litellm.user_url_allowed_hosts is None
+    assert litellm.provider_url_destination_allowed_hosts is None
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22509,6 +22509,11 @@ export interface components {
              */
             plugins?: components["schemas"]["PluginConfig"][] | null;
             /**
+             * Provider Url Destination Allowed Hosts
+             * @description Allowlist of hosts a request may redirect a provider call's destination URL to.
+             */
+            provider_url_destination_allowed_hosts?: string[] | null;
+            /**
              * Reject Clientside Metadata Tags
              * @description When set to True, rejects requests that contain client-side 'metadata.tags' to prevent users from influencing budgets by sending different tags. Tags can only be inherited from the API key metadata.
              */
@@ -22566,6 +22571,16 @@ export interface components {
              * @description Controls how non-admin users interact with MCP servers in the dashboard. 'restricted' shows only accessible servers, 'view_all' lists every server in read-only mode.
              */
             user_mcp_management_mode?: ("restricted" | "view_all") | null;
+            /**
+             * User Url Allowed Hosts
+             * @description SSRF allowlist for user-supplied URLs. Entries are `hostname` or `hostname:port` (bracketed for IPv6, e.g. `[::1]:8080`). Allowlisted hosts skip the blocked-network check in validate_url() but still resolve DNS. Use this to permit legitimate internal targets, e.g. an internal OpenAPI/MCP server.
+             */
+            user_url_allowed_hosts?: string[] | null;
+            /**
+             * User Url Validation
+             * @description Master switch for the SSRF guard applied to user-supplied URLs (image_url, file_url, MCP/OpenAPI spec URLs, etc). Defaults to True. Set to False to disable DNS/IP validation entirely (not recommended).
+             */
+            user_url_validation?: boolean | null;
         };
         /** ConfigList */
         ConfigList: {


### PR DESCRIPTION
## Summary
- Wire `user_url_validation`, `user_url_allowed_hosts`, and `provider_url_destination_allowed_hosts` from `general_settings` into `litellm.*` globals during proxy startup
- Document the three fields on `ConfigGeneralSettings` so they are recognized as valid `general_settings` keys
- Fixes #26599 — the SSRF error message already pointed admins at `general_settings`, but only `litellm_settings` was ever wired

**Before**
<img width="979" height="195" alt="image" src="https://github.com/user-attachments/assets/d51d3d86-3667-404d-99f2-daf9be36fa25" />

**After**
<img width="979" height="195" alt="image" src="https://github.com/user-attachments/assets/717ccf47-f1a6-446c-b9b3-545caa5c71d6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSRF enforcement configuration and runtime globals; incorrect wiring could leave stale allowlists or unexpected validation behavior, though the change is intended to make documented admin settings effective.
> 
> **Overview**
> Fixes **#26599** by making proxy `general_settings` actually drive the SSRF globals that `validate_url()` / `safe_get` already read (`litellm.user_url_validation`, `user_url_allowed_hosts`, `provider_url_destination_allowed_hosts`).
> 
> Adds **`_apply_ssrf_general_settings`** (with string/`"false"` handling for `user_url_validation` and explicit updates when keys are present, including `null` to clear allowlists) and calls it on **initial config load**, **merged general_settings updates**, and **`update_config_general_settings`** so YAML and dashboard changes take effect without restart. Documents the three fields on **`ConfigGeneralSettings`** and extends the dashboard OpenAPI schema; regression tests cover load and live config updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92722db59165e97f36b16cf174d8d6e13d949763. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->