### PR TITLE
fix(proxy): avoid auth cache rewrite during spend updates

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2779,21 +2779,6 @@ async def update_cache(
             )
             # set cooldown on alert
 
-        if existing_spend_obj is not None and getattr(existing_spend_obj, "team_spend", None) is not None:
-            existing_team_spend = existing_spend_obj.team_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_spend = existing_team_spend + response_cost
-
-        if existing_spend_obj is not None and getattr(existing_spend_obj, "team_member_spend", None) is not None:
-            existing_team_member_spend = existing_spend_obj.team_member_spend or 0
-            # Calculate the new cost by adding the existing cost and response_cost
-            existing_spend_obj.team_member_spend = existing_team_member_spend + response_cost
-
-        # Existing spend_obj is mutated; UserApiKeyCache.async_set_cache_pipeline turns
-        # BaseModel values into dicts for Redis (same Codec path as async_set_cache).
-        existing_spend_obj.spend = new_spend
-        values_to_update_in_cache.append((hashed_token, existing_spend_obj))
-
     ### UPDATE USER SPEND ###
     async def _update_user_cache():
         ## UPDATE CACHE FOR USER ID + GLOBAL PROXY

--- a/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
+++ b/tests/test_litellm/proxy/proxy_server/test_spend_counters.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import litellm.proxy.proxy_server as ps
+from litellm.proxy._types import UserAPIKeyAuth
 
 from .conftest import normalize
 
@@ -1247,6 +1248,48 @@ async def test_update_cache_no_cached_entities_schedules_pipeline_flush(monkeypa
         "lookups": 4,
         "got_user": True,
         "got_team": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_update_cache_does_not_rewrite_cached_key_auth_object(monkeypatch):
+    cached_key = UserAPIKeyAuth(
+        token="hashed-token",
+        models=["old-model"],
+        spend=10.0,
+        team_spend=20.0,
+        team_member_spend=30.0,
+    )
+    fake_user_cache = _make_user_api_key_cache(get_value=cached_key)
+    monkeypatch.setattr(ps, "user_api_key_cache", fake_user_cache)
+
+    await ps.update_cache(
+        token="hashed-token",
+        user_id=None,
+        end_user_id=None,
+        team_id=None,
+        response_cost=1.0,
+        parent_otel_span=None,
+        tags=None,
+    )
+    await asyncio.sleep(0.1)
+
+    cache_list = fake_user_cache.async_set_cache_pipeline.call_args.kwargs[
+        "cache_list"
+    ]
+    observed = {
+        "cache_list": cache_list,
+        "spend": cached_key.spend,
+        "team_spend": cached_key.team_spend,
+        "team_member_spend": cached_key.team_member_spend,
+        "models": cached_key.models,
+    }
+    assert normalize(observed) == {
+        "cache_list": [],
+        "spend": 10.0,
+        "team_spend": 20.0,
+        "team_member_spend": 30.0,
+        "models": ["old-model"],
     }
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #32247

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## CI (LiteLLM team)

- [ ] Branch creation CI run
       Link:

- [ ] CI run for the last commit
       Link:

- [ ] Merge / cherry-pick CI run
       Links:

## Screenshots / Proof of Fix

This change prevents `update_cache` from mutating and writing the cached virtual-key auth object back into `user_api_key_cache`. The regression test verifies that a cached `UserAPIKeyAuth` object with stale `models` is not mutated and is not queued into the spend-update cache pipeline.

Local validation run:

```bash
python3 -m py_compile litellm/proxy/proxy_server.py tests/test_litellm/proxy/proxy_server/test_spend_counters.py
uvx ruff==0.15.3 check litellm/proxy/proxy_server.py tests/test_litellm/proxy/proxy_server/test_spend_counters.py
```

Both passed.

Focused unit test command attempted:

```bash
uv run pytest tests/test_litellm/proxy/proxy_server/test_spend_counters.py::test_update_cache_does_not_rewrite_cached_key_auth_object
```

It did not reach test execution locally because the editable package build requires Rust. This machine does not have Rust installed, and `maturin` failed while downloading `rustup-init` due local certificate verification failure.

## Type

Bug Fix
Test

## Changes

`update_cache` still reads the cached key object for key soft-budget alerting, but no longer mutates `spend`, `team_spend`, or `team_member_spend` on the `UserAPIKeyAuth` object and no longer writes the full key object back through `user_api_key_cache.async_set_cache_pipeline`. Key spend accounting remains in the spend-counter path, while auth cache contents remain owned by auth and key-management code.
