### PR TITLE
fix: preserve per-user OAuth Authorization over MCP signer JWT on tools/calls

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3352,27 +3352,31 @@ class MCPServerManager:
         if hook_extra_headers:
             if extra_headers is None:
                 extra_headers = {}
-            if "Authorization" in hook_extra_headers:
-                if "Authorization" in extra_headers:
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers 'Authorization' will overwrite "
-                        "the existing Authorization header from static_headers. "
-                        "The hook JWT will take precedence."
-                    )
-                elif server_auth_header is not None:
-                    # server_auth_header is passed separately to _create_mcp_client as
-                    # auth_value.  Both will reach the upstream server — warn so admins
-                    # know two Authorization credentials are being sent.
-                    verbose_logger.warning(
-                        "MCPServerManager: hook_extra_headers injects 'Authorization' while "
-                        "server '%s' already has a configured authentication_token. "
-                        "Both credentials will be sent; the hook header is in extra_headers "
-                        "and the server token is in auth_value — the upstream server decides "
-                        "which one wins.  Consider unsetting authentication_token if you want "
-                        "the hook JWT to be the sole credential.",
-                        mcp_server.server_name or mcp_server.name,
-                    )
-            extra_headers.update(hook_extra_headers)
+            # Per-user OAuth and admin-configured static Authorization must take
+            # precedence over the signer's JWT (matches the tools/list guard) — skip the
+            # hook Authorization when extra_headers already carries one so the signed JWT
+            # doesn't clobber the resolved per-user token.
+            has_existing_authorization = any(
+                isinstance(k, str) and k.lower() == "authorization" for k in extra_headers.keys()
+            )
+            for header, value in hook_extra_headers.items():
+                if isinstance(header, str) and header.lower() == "authorization":
+                    if has_existing_authorization:
+                        continue
+                    if server_auth_header is not None:
+                        # server_auth_header is passed separately to _create_mcp_client as
+                        # auth_value.  Both will reach the upstream server — warn so admins
+                        # know two Authorization credentials are being sent.
+                        verbose_logger.warning(
+                            "MCPServerManager: hook_extra_headers injects 'Authorization' while "
+                            "server '%s' already has a configured authentication_token. "
+                            "Both credentials will be sent; the hook header is in extra_headers "
+                            "and the server token is in auth_value — the upstream server decides "
+                            "which one wins.  Consider unsetting authentication_token if you want "
+                            "the hook JWT to be the sole credential.",
+                            mcp_server.server_name or mcp_server.name,
+                        )
+                extra_headers[header] = value
 
         # Reset to None if no headers were actually added
         if extra_headers is not None and len(extra_headers) == 0:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -536,14 +536,15 @@ class TestHookHeaderMergePriority:
         )
 
     @pytest.mark.asyncio
-    async def test_hook_headers_override_static_headers(self):
-        """Hook headers should take precedence over static_headers."""
+    async def test_hook_non_auth_headers_merge_but_static_authorization_wins(self):
+        """Hook non-Authorization headers merge in, but an existing static
+        Authorization must survive the hook (JWT) merge (matches tools/list)."""
         manager = MCPServerManager()
         server = self._make_server(
             static_headers={"Authorization": "Bearer static-token", "X-Static": "yes"}
         )
 
-        hook_headers = {"Authorization": "Bearer hook-signed-jwt"}
+        hook_headers = {"Authorization": "Bearer hook-signed-jwt", "X-Trace-Id": "t1"}
 
         captured_extra_headers: Dict[str, Any] = {}
 
@@ -576,8 +577,9 @@ class TestHookHeaderMergePriority:
                     pass
 
         headers = captured_extra_headers.get("value", {})
-        assert headers["Authorization"] == "Bearer hook-signed-jwt"
+        assert headers["Authorization"] == "Bearer static-token"
         assert headers["X-Static"] == "yes"
+        assert headers["X-Trace-Id"] == "t1"
 
     @pytest.mark.asyncio
     async def test_no_hook_headers_preserves_existing_behavior(self):
@@ -619,8 +621,18 @@ class TestHookHeaderMergePriority:
         assert headers == {"X-Static": "static-value"}
 
     @pytest.mark.asyncio
-    async def test_hook_headers_merge_with_oauth2(self):
-        """Hook headers merge on top of OAuth2 headers."""
+    async def test_hook_headers_do_not_overwrite_per_user_oauth_authorization(self):
+        """Regression for #31977: a per-user OAuth Authorization already resolved
+        into extra_headers must survive the MCP JWT signer (hook) merge on the
+        tools/call path, matching the precedence enforced on tools/list. The
+        hook's non-Authorization headers still merge in.
+
+        Uses delegate_auth_to_upstream so the server stays on the v1 path
+        (to_server_spec is None) where the caller's OAuth token is NOT stripped
+        and therefore legitimately lives in extra_headers at the hook-merge
+        point — the exact scenario the reporter hits (tools/list works because
+        that guard already skips the signer when Authorization exists; tools/call
+        was clobbering it)."""
         manager = MCPServerManager()
         server = MCPServer(
             server_id="test-id",
@@ -629,6 +641,7 @@ class TestHookHeaderMergePriority:
             url="https://example.com",
             transport=MCPTransport.http,
             auth_type=MCPAuth.oauth2,
+            delegate_auth_to_upstream=True,
         )
 
         captured_extra_headers: Dict[str, Any] = {}
@@ -668,7 +681,7 @@ class TestHookHeaderMergePriority:
                     pass
 
         headers = captured_extra_headers.get("value", {})
-        assert headers["Authorization"] == "Bearer hook-jwt"
+        assert headers["Authorization"] == "Bearer oauth2-token"
         assert headers["X-OAuth"] == "yes"
         assert headers["X-Trace-Id"] == "trace-123"
 


### PR DESCRIPTION

## Relevant issues
Fixes #31977

## Linear ticket

<!-- if you are an internal contributor (e.g., your username is postfixed with -berri or -berriai), add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to magically link the Linear ticket to the GitHub PR -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ x My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
`pytest tests/.../test_mcp_hook_extra_headers.py` → 29 passed. Added a
regression test on the v1 `delegate_auth_to_upstream` oauth2 path (the scenario
#31977 reports) asserting the resolved OAuth Authorization survives the signer
merge. Mutation-checked: reverting the fix re-fails the test.

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->
     
   ### Screenshot of error in the code: 
<img width="1908" height="1420" alt="image" src="https://github.com/user-attachments/assets/5030095a-2e61-4952-9aa9-f344c54d7b24" />

### Screenshot after the fix 
<img width="1230" height="1058" alt="image" src="https://github.com/user-attachments/assets/85594ce1-e99c-4384-bf12-a0971d363fba" />


## Type
🐛 Bug Fix

## Changes
On the MCP `tools/call` path, the signer's JWT unconditionally overwrote the
Authorization header via `extra_headers.update(hook_extra_headers)`, even when a
per-user OAuth token had already been resolved into `extra_headers`. The
`tools/list` path already guards against this; this applies the same guard to
`tools/call` — the hook's non-Authorization headers still merge in.

