### PR TITLE
fix(proxy): handle split UTF-8 MCP routing peeks

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3180,7 +3180,7 @@ if MCP_AVAILABLE:
         try:
             data = json.loads(body)
             return isinstance(data, dict) and data.get("method") == "initialize"
-        except (json.JSONDecodeError, TypeError):
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
             return False
 
     async def _read_request_body_for_routing(
@@ -3867,7 +3867,7 @@ if MCP_AVAILABLE:
                             "MCP: detected JSON-RPC response POST (id=%s), skipping session lock to avoid deadlock",
                             _peeked.get("id"),
                         )
-                except (json.JSONDecodeError, TypeError):
+                except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
                     # Peek cap truncated the body, so it can't be fully parsed.
                     # Scan the top-level keys (depth-aware) instead of a flat
                     # substring search: a response's result payload may nest a

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1546,6 +1546,103 @@ async def test_mcp_routing_caps_body_peek_for_oversized_chunked_body():
 
 
 @pytest.mark.asyncio
+async def test_mcp_routing_utf8_split_at_peek_boundary_reaches_stateless_handler():
+    """
+    A large non-initialize POST whose routing peek ends in a partial UTF-8
+    sequence should route as a normal stateless request instead of returning 500.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server import server as mcp_server
+        from litellm.proxy._experimental.mcp_server.server import (
+            handle_streamable_http_mcp,
+            session_manager_stateful,
+            session_manager_stateless,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    peek_cap = mcp_server._MCP_ROUTING_PEEK_MAX_BYTES
+    prefix = (
+        b'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":'
+        b'{"name":"render","arguments":{"html":"'
+    )
+    multibyte_char = "é".encode("utf-8")
+    filler = b"a" * (peek_cap - len(prefix) - 1)
+    suffix = b'"}}}'
+    request_body = prefix + filler + multibyte_char + suffix
+
+    assert request_body[:peek_cap][-1:] == multibyte_char[:1]
+    assert request_body[peek_cap : peek_cap + 1] == multibyte_char[1:]
+
+    messages = [
+        {
+            "type": "http.request",
+            "body": request_body[:peek_cap],
+            "more_body": True,
+        },
+        {
+            "type": "http.request",
+            "body": request_body[peek_cap:],
+            "more_body": False,
+        },
+    ]
+    receive_calls = {"count": 0}
+
+    async def receive():
+        idx = receive_calls["count"]
+        receive_calls["count"] += 1
+        return messages[idx]
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp/progress_test",
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"authorization", b"Bearer test-key"),
+        ],
+    }
+    send = AsyncMock()
+    stateless_received_chunks = []
+
+    async def stateless_handle(s, r, se):
+        while True:
+            msg = await r()
+            if msg.get("type") != "http.request":
+                break
+            stateless_received_chunks.append(msg.get("body", b"") or b"")
+            if not msg.get("more_body", False):
+                break
+
+    async def stateful_handle(s, r, se):
+        raise AssertionError("non-initialize POST should not reach stateful manager")
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.extract_mcp_auth_context",
+            new_callable=AsyncMock,
+            return_value=(MagicMock(), None, ["progress_test"], None, None, None),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.server.set_auth_context"),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._SESSION_MANAGERS_INITIALIZED",
+            True,
+        ),
+        patch.object(session_manager_stateless, "handle_request", side_effect=stateless_handle),
+        patch.object(session_manager_stateful, "handle_request", side_effect=stateful_handle),
+        patch.object(session_manager_stateless, "_server_instances", {}),
+        patch.object(session_manager_stateful, "_server_instances", {}),
+    ):
+        await handle_streamable_http_mcp(scope, receive, send)
+
+    assert b"".join(stateless_received_chunks) == request_body
+    response_starts = [
+        call.args[0] for call in send.await_args_list if call.args[0].get("type") == "http.response.start"
+    ]
+    assert response_starts == []
+
+
+@pytest.mark.asyncio
 async def test_enforce_stateful_session_cap_evicts_oldest_idle_then_rejects():
     """
     A caller at the per-owner session cap should have its own oldest *idle*


### PR DESCRIPTION
﻿## Relevant issues

Fixes #32226

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

I reproduced the failure locally before the fix with a request body whose 4096-byte routing peek ends inside a multibyte UTF-8 sequence. Before the change, the new regression test failed with `UnicodeDecodeError` from `_is_initialize_request(body)` and the request did not reach the stateless MCP handler

After the fix, the targeted MCP server test file passes locally:

```text
D:\miniconda\python.exe -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q
131 passed, 4 warnings in 25.82s
```

I also ran:

```text
D:\miniconda\python.exe -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -k utf8_split_at_peek_boundary -q
1 passed, 130 deselected in 30.68s

D:\miniconda\python.exe -m ruff check litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
All checks passed!

D:\miniconda\python.exe -m ruff format --check litellm/proxy/_experimental/mcp_server/server.py
1 file already formatted

git diff --cached --check -- litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
```

`make pre-commit` could not run in this Windows shell because `make` is not installed locally

## Type

Bug Fix
Test

## Changes

This updates the MCP streamable HTTP routing peek to treat `UnicodeDecodeError` like the existing JSON parse failures. A capped peek can end inside a UTF-8 character even when the full request body is valid, so partial peek data should be considered unparseable for routing instead of returning 500

The change keeps the current memory behavior: LiteLLM still peeks at most `_MCP_ROUTING_PEEK_MAX_BYTES`, does not drain or buffer the rest of a large payload for routing, and replays consumed ASGI messages to the downstream handler. The same decode handling is applied to the adjacent JSON-RPC response peek path

The regression test builds a non-initialize MCP request where `é` is split exactly across the 4096-byte peek boundary. It verifies the request routes to the stateless handler, no 500 response start is emitted, and the full original body is delivered downstream