### PR TITLE
fix(main): forward verbosity param to chat completion providers

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -582,6 +582,7 @@ async def acompletion(
         "api_key": api_key,
         "model_list": model_list,
         "reasoning_effort": reasoning_effort,
+        "verbosity": verbosity,
         "safety_identifier": safety_identifier,
         "service_tier": service_tier,
         "extra_headers": extra_headers,
@@ -5193,6 +5194,7 @@ def completion(  # type: ignore
             "parallel_tool_calls": parallel_tool_calls,
             "messages": messages,
             "reasoning_effort": reasoning_effort,
+            "verbosity": verbosity,
             "thinking": thinking,
             "web_search_options": web_search_options,
             "include_server_side_tool_invocations": (

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -638,6 +638,93 @@ def test_bedrock_llama():
     )
 
 
+def _mocked_openai_chat_response(model: str) -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json={
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "created": 1677652288,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello from mocked response!",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 9,
+                "completion_tokens": 12,
+                "total_tokens": 21,
+            },
+        },
+    )
+
+
+def test_completion_forwards_verbosity_in_raw_request(respx_mock: respx.MockRouter):
+    """Regression test: completion() must forward the verbosity param to the provider request body."""
+    from litellm.types.utils import CallTypes
+    from litellm.utils import return_raw_request
+
+    model = "gpt-5.2"
+    messages = [{"role": "user", "content": "hi"}]
+    respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
+        return_value=_mocked_openai_chat_response(model)
+    )
+
+    request = return_raw_request(
+        endpoint=CallTypes.completion,
+        kwargs={
+            "model": model,
+            "messages": messages,
+            "verbosity": "high",
+        },
+    )
+
+    assert request["raw_request_body"]["verbosity"] == "high"
+    assert request["raw_request_body"]["model"] == model
+    assert request["raw_request_body"]["messages"] == messages
+
+
+@pytest.mark.asyncio
+async def test_acompletion_forwards_verbosity_to_provider_request(
+    respx_mock: respx.MockRouter, monkeypatch
+):
+    """Regression test: acompletion() must forward the verbosity param to the provider request body."""
+    original_disable_aiohttp = litellm.disable_aiohttp_transport
+    try:
+        litellm.disable_aiohttp_transport = True
+        monkeypatch.setenv("DISABLE_AIOHTTP_TRANSPORT", "True")
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+        model = "gpt-5.2"
+        messages = [{"role": "user", "content": "hi"}]
+        mock_route = respx_mock.post("https://api.openai.com/v1/chat/completions").mock(
+            return_value=_mocked_openai_chat_response(model)
+        )
+
+        response = await litellm.acompletion(
+            model=model,
+            messages=messages,
+            verbosity="low",
+            api_key="fake-openai-api-key",
+        )
+
+        assert response.choices[0].message.content == "Hello from mocked response!"
+        assert mock_route.called
+        request_body = json.loads(respx_mock.calls[0].request.read())
+        assert request_body["verbosity"] == "low"
+        assert request_body["model"] == model
+        assert request_body["messages"] == messages
+    finally:
+        litellm.disable_aiohttp_transport = original_disable_aiohttp
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+
 def test_responses_api_bridge_check_strips_responses_prefix():
     """Test that responses_api_bridge_check strips 'responses/' prefix and sets mode."""
     from litellm.main import responses_api_bridge_check


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4124

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a live proxy twice from an isolated git worktree with its own venv: once at the merge-base commit (before) and once at this PR's head (after). DB-free config with just the gpt-5.2 model entry and `master_key: sk-1234`, served on a random unused port (59053), hitting the real OpenAI API with gpt-5.2, no mocks. Proxy started with `.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 59053` in both phases

### Before (commit 6cecb6e9756df19d8ab41475b59b1c4a21a871c1)

`/utils/transform_request` shows the exact body LiteLLM would send to OpenAI; `verbosity` is silently dropped

```bash
curl -s http://localhost:59053/utils/transform_request -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"call_type": "completion", "request_body": {"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}], "verbosity": "high"}}' | jq '.raw_request_body'
```

```json
{
  "model": "gpt-5.2",
  "messages": [
    {
      "role": "user",
      "content": "hi"
    }
  ]
}
```

Live call with `verbosity: low`

```bash
curl -s http://localhost:59053/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.2", "messages": [{"role": "user", "content": "Explain about quantum computing"}], "verbosity": "low"}' | jq '{model, completion_tokens: .usage.completion_tokens, content_chars: (.choices[0].message.content | length)}'
```

```json
{
  "model": "gpt-5.2",
  "completion_tokens": 751,
  "content_chars": 3573
}
```

Live call with `verbosity: high`

```bash
curl -s http://localhost:59053/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.2", "messages": [{"role": "user", "content": "Explain about quantum computing"}], "verbosity": "high"}' | jq '{model, completion_tokens: .usage.completion_tokens, content_chars: (.choices[0].message.content | length)}'
```

```json
{
  "model": "gpt-5.2",
  "completion_tokens": 709,
  "content_chars": 3345
}
```

low vs high is 751 vs 709 completion tokens (high is even slightly shorter), confirming the param never reached OpenAI

### After (commit fd2e2eec70)

Same worktree and venv, `git checkout fd2e2eec70`, same config and port. The transform now forwards `verbosity`

```bash
curl -s http://localhost:59053/utils/transform_request -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"call_type": "completion", "request_body": {"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}], "verbosity": "high"}}' | jq '.raw_request_body'
```

```json
{
  "model": "gpt-5.2",
  "messages": [
    {
      "role": "user",
      "content": "hi"
    }
  ],
  "verbosity": "high"
}
```

Live call with `verbosity: low`

```bash
curl -s http://localhost:59053/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.2", "messages": [{"role": "user", "content": "Explain about quantum computing"}], "verbosity": "low"}' | jq '{model, completion_tokens: .usage.completion_tokens, content_chars: (.choices[0].message.content | length)}'
```

```json
{
  "model": "gpt-5.2",
  "completion_tokens": 627,
  "content_chars": 2956
}
```

Live call with `verbosity: high`

```bash
curl -s http://localhost:59053/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model": "gpt-5.2", "messages": [{"role": "user", "content": "Explain about quantum computing"}], "verbosity": "high"}' | jq '{model, completion_tokens: .usage.completion_tokens, content_chars: (.choices[0].message.content | length)}'
```

```json
{
  "model": "gpt-5.2",
  "completion_tokens": 1451,
  "content_chars": 6537
}
```

low vs high is now 627 vs 1451 completion tokens, a 2.3x divergence, matching the roughly 3x spread seen when calling OpenAI directly. Before the fix the spread was within 6%

## Type

🐛 Bug Fix

## Changes

`verbosity` ("low"/"medium"/"high") passed to `litellm.completion()`/`acompletion()`, and therefore to the proxy's `/chat/completions`, was silently dropped and never forwarded to the provider. A customer noticed that verbosity low vs high through the proxy produced near-identical gpt-5.2 outputs while calling OpenAI directly diverged about 3x in length

Root cause: `completion()` accepts `verbosity` as a named parameter, but the `optional_param_args` dict it passes to `get_optional_params()` omitted it. Because it is a named parameter it never landed in `**kwargs`/`non_default_params` either, so `get_optional_params()` (which already has a `verbosity` parameter and correct GPT-5 handling via `litellm/llms/openai/chat/gpt_5_transformation.py`) never received it. The async path had the same gap: `acompletion()` also omitted `verbosity` from the `completion_kwargs` it builds for `completion()`

The fix adds `verbosity` to both dicts, right next to `reasoning_effort` which follows the identical plumbing. Downstream behavior now matches `reasoning_effort` semantics: GPT-5 family models forward it, non-supporting models (e.g. gpt-4o) raise `UnsupportedParamsError` unless `drop_params` is set, and `pre_process_non_default_params` keeps it since it is already in `DEFAULT_CHAT_COMPLETION_PARAM_VALUES`

Regression tests in `tests/test_litellm/test_main.py` assert the provider request body contains `verbosity` for both the sync (`return_raw_request`) and async (`acompletion` via respx) paths; both fail on the base branch and pass with the fix

