### PR TITLE
fix(proxy): resolve os.environ/ refs for all AWS auth params in DB-sourced models

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1134,6 +1134,9 @@ _DB_LITELLM_PARAM_ENV_REF_KEYS = frozenset(
         "aws_sts_endpoint",
         "aws_external_id",
         "aws_bedrock_runtime_endpoint",
+        "aws_bedrock_project_id",
+        "aws_batch_role_arn",
+        "aws_workspace_id",
     }
 )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -1125,6 +1125,15 @@ _DB_LITELLM_PARAM_ENV_REF_KEYS = frozenset(
         "vertex_ai_credentials",
         "aws_access_key_id",
         "aws_secret_access_key",
+        "aws_session_token",
+        "aws_region_name",
+        "aws_session_name",
+        "aws_profile_name",
+        "aws_role_name",
+        "aws_web_identity_token",
+        "aws_sts_endpoint",
+        "aws_external_id",
+        "aws_bedrock_runtime_endpoint",
     }
 )
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1175,6 +1175,12 @@ def test_ProxyConfig__add_deployment_resolves_env_refs_for_aws_bedrock_auth_para
             "BEDROCK_RUNTIME_ENDPOINT",
             "https://bedrock-runtime.us-east-1.amazonaws.com",
         ),
+        "aws_bedrock_project_id": ("BEDROCK_PROJECT_ID", "resolved-project-id"),
+        "aws_batch_role_arn": (
+            "BEDROCK_BATCH_ROLE_ARN",
+            "arn:aws:iam::123456789012:role/batch",
+        ),
+        "aws_workspace_id": ("BEDROCK_WORKSPACE_ID", "resolved-workspace-id"),
     }
     for _, (env_name, env_value) in aws_env.items():
         monkeypatch.setenv(env_name, env_value)

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -1148,6 +1148,99 @@ def test_ProxyConfig__resolve_db_litellm_param_skips_non_string_values(monkeypat
     assert pc._resolve_db_litellm_param(key="tpm", value=100) == 100
 
 
+def test_ProxyConfig__add_deployment_resolves_env_refs_for_aws_bedrock_auth_params(
+    monkeypatch,
+):
+    """Regression: DB-stored Bedrock/SageMaker auth params like
+    ``aws_role_name: os.environ/BEDROCK_ASSUME_ROLE_ARN`` must resolve at
+    DB-load time. PR #30867 removed request-time expansion in
+    ``BaseAWSLLM.get_credentials``; without DB-load resolution the literal
+    string reaches STS and fails with ``ValidationError: ... is invalid``."""
+    aws_env = {
+        "aws_session_token": ("BEDROCK_SESSION_TOKEN", "resolved-session-token"),
+        "aws_region_name": ("BEDROCK_REGION", "us-east-1"),
+        "aws_session_name": ("BEDROCK_SESSION_NAME", "resolved-session"),
+        "aws_profile_name": ("BEDROCK_PROFILE", "resolved-profile"),
+        "aws_role_name": (
+            "BEDROCK_ASSUME_ROLE_ARN",
+            "arn:aws:iam::123456789012:role/resolved",
+        ),
+        "aws_web_identity_token": ("BEDROCK_WEB_IDENTITY_TOKEN", "resolved-token"),
+        "aws_sts_endpoint": (
+            "BEDROCK_STS_ENDPOINT",
+            "https://sts.us-east-1.amazonaws.com",
+        ),
+        "aws_external_id": ("BEDROCK_EXTERNAL_ID", "resolved-external-id"),
+        "aws_bedrock_runtime_endpoint": (
+            "BEDROCK_RUNTIME_ENDPOINT",
+            "https://bedrock-runtime.us-east-1.amazonaws.com",
+        ),
+    }
+    for _, (env_name, env_value) in aws_env.items():
+        monkeypatch.setenv(env_name, env_value)
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: value,
+    )
+    fake_router = MagicMock()
+    fake_router.upsert_deployment = MagicMock(return_value=True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", fake_router)
+    pc = ProxyConfig()
+    litellm_params: Dict[str, Any] = {"model": "bedrock/anthropic.claude-v2"}
+    for key, (env_name, _) in aws_env.items():
+        litellm_params[key] = f"os.environ/{env_name}"
+    db_model = SimpleNamespace(
+        model_id="model-1",
+        model_name="bedrock-model",
+        model_info={"id": "model-1"},
+        litellm_params=litellm_params,
+        blocked=False,
+    )
+
+    added = pc._add_deployment(db_models=[db_model])
+    deployment = fake_router.upsert_deployment.call_args.kwargs["deployment"]
+
+    assert added == 1
+    for key, (_, expected) in aws_env.items():
+        assert getattr(deployment.litellm_params, key) == expected, key
+
+
+def test_ProxyConfig__add_deployment_keeps_team_aws_env_refs_literal(monkeypatch):
+    """Team-scoped DB models must NOT resolve env refs even for AWS auth
+    params: this is the LIT-3831 defense-in-depth path where a team admin
+    could otherwise craft a DB entry that reads the process environment."""
+
+    def fail_on_call(secret_name, *args, **kwargs):
+        raise AssertionError("team DB models should not resolve env refs")
+
+    monkeypatch.setenv("BEDROCK_ASSUME_ROLE_ARN", "arn:aws:iam::123:role/should-not-leak")
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.decrypt_value_helper",
+        lambda value, key, return_original_value: value,
+    )
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_secret", fail_on_call)
+    fake_router = MagicMock()
+    fake_router.upsert_deployment = MagicMock(return_value=True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", fake_router)
+    pc = ProxyConfig()
+    db_model = SimpleNamespace(
+        model_id="model-1",
+        model_name="model_name_team-1_bedrock",
+        model_info={"id": "model-1", "team_id": "team-1"},
+        litellm_params={
+            "model": "bedrock/anthropic.claude-v2",
+            "aws_role_name": "os.environ/BEDROCK_ASSUME_ROLE_ARN",
+        },
+        blocked=False,
+    )
+
+    added = pc._add_deployment(db_models=[db_model])
+    deployment = fake_router.upsert_deployment.call_args.kwargs["deployment"]
+
+    assert added == 1
+    assert deployment.litellm_params.aws_role_name == "os.environ/BEDROCK_ASSUME_ROLE_ARN"
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig.decrypt_model_list_from_db
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The customer reported that after upgrading from 1.89.1 to 1.91.0, a model stored in the DB with `aws_role_name: os.environ/BEDROCK_ASSUME_ROLE_ARN` stopped working. STS returns `ValidationError: os.environ/BEDROCK_ASSUME_ROLE_ARN is invalid` because the literal string reaches AssumeRole instead of the resolved ARN.

The proof-of-fix curls a proxy connected to a real Postgres, with a DB row shaped like the customer's:

```
model_id        | bedrock-repro-1
model_name      | bedrock-claude
litellm_params  | {"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
                   "aws_role_name": "os.environ/BEDROCK_ASSUME_ROLE_ARN",
                   "aws_region_name": "us-east-1"}
BEDROCK_ASSUME_ROLE_ARN=arn:aws:iam::111111111111:role/some-bedrock-role
```

Before (unfixed 1.91.x): the router receives the literal `os.environ/...` string and forwards it to STS

```
$ curl -sS http://localhost:4000/model/info -H 'Authorization: Bearer sk-1234' | jq '.data[] | select(.model_name=="bedrock-claude") | .litellm_params'
{
  "aws_region_name": "us-east-1",
  "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
  "aws_role_name": "os.environ/BEDROCK_ASSUME_ROLE_ARN"
}

$ curl -sS -w "\nHTTP=%{http_code}\n" http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"bedrock-claude","messages":[{"role":"user","content":"hi"}]}'
```

The traceback shows `_auth_with_aws_role` was called with the literal string as `RoleArn`, so `sts_client.assume_role(RoleArn="os.environ/BEDROCK_ASSUME_ROLE_ARN", ...)` fires and STS rejects it. In this repro the fake AWS creds trip `InvalidClientTokenId` first, but the customer's real AWS creds get past that check and hit the exact `ValidationError: ... is invalid` they reported

After (with this PR): the router receives the resolved ARN, and STS receives a well-formed value

```
$ curl -sS http://localhost:4000/model/info -H 'Authorization: Bearer sk-1234' | jq '.data[] | select(.model_name=="bedrock-claude") | .litellm_params'
{
  "aws_region_name": "us-east-1",
  "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
  "aws_role_name": "arn:aws:iam::111111111111:role/some-bedrock-role"
}
```

LIT-3831 stays closed: an attacker sending `aws_role_name: os.environ/DATABASE_URL` in the HTTP request body is still refused by the existing `_BANNED_REQUEST_BODY_PARAMS` gate

```
$ curl -sS -w "\nHTTP=%{http_code}\n" http://localhost:4000/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"bedrock-claude","messages":[{"role":"user","content":"hi"}],"aws_role_name":"os.environ/DATABASE_URL"}'
{"error":{"message":"Authentication Error, Rejected Request: aws_role_name is not allowed in request body. ..."}}
HTTP=401
```

Team-scoped DB models still get `resolve_env_refs=False`, matching the LIT-3831 defense-in-depth contract for the team-scoped DB path (see the regression test `test_ProxyConfig__add_deployment_keeps_team_aws_env_refs_literal`)

## Type

🐛 Bug Fix

## Changes

Root cause: PR #30867 (LIT-3831) removed the per-request `os.environ/` expansion inside `BaseAWSLLM.get_credentials`. That is only safe if the config-load path pre-resolves `os.environ/` refs, so the value reaching `get_credentials` is already the real secret. The YAML config path has always done this. The DB-load path (`ProxyConfig._resolve_db_litellm_param` in `litellm/proxy/proxy_server.py`) only re-expands keys in `_DB_LITELLM_PARAM_ENV_REF_KEYS`, which covered `api_key`, `client_secret`, `vertex_credentials`, `vertex_ai_credentials`, `aws_access_key_id`, and `aws_secret_access_key`, but none of the other AWS auth fields. A model row like `aws_role_name: os.environ/BEDROCK_ASSUME_ROLE_ARN` lands on the router with the literal string, `get_credentials` no longer expands it, and STS rejects the AssumeRole call

Fix: extend `_DB_LITELLM_PARAM_ENV_REF_KEYS` to cover the remaining nine AWS auth params (`aws_session_token`, `aws_region_name`, `aws_session_name`, `aws_profile_name`, `aws_role_name`, `aws_web_identity_token`, `aws_sts_endpoint`, `aws_external_id`, `aws_bedrock_runtime_endpoint`). Now `os.environ/` refs resolve at DB-load time (trusted, server-owned), matching the YAML-config code path. Team-scoped DB rows still get `resolve_env_refs=False`, so the LIT-3831 team-scoped defense-in-depth path is unchanged and the request-body attack surface stays gated by `_BANNED_REQUEST_BODY_PARAMS`

Regression tests in `tests/test_litellm/proxy/proxy_server/test_proxy_config.py`:
- `test_ProxyConfig__add_deployment_resolves_env_refs_for_aws_bedrock_auth_params` pins every added field as an `os.environ/…` DB value and asserts each resolves on the router (mutation-checked; fails on unfixed code with the exact "literal string not resolved" symptom)
- `test_ProxyConfig__add_deployment_keeps_team_aws_env_refs_literal` pins that team-scoped DB rows do NOT resolve `aws_role_name`, guarding the LIT-3831 team path
