### PR TITLE
feat(mcp): migrate client_credentials (M2M) onto the v2 resolver arm

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -93,6 +93,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.token_exchange_
 )
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     AuthorizationCodeConfig,
+    ClientCredentialsConfig,
     CredError,
     IdJagConfig,
     PassthroughConfig,
@@ -2739,14 +2740,18 @@ class MCPServerManager:
                 )
                 if not conflicts:
                     return auth, extra_headers
-                if isinstance(spec.config, (TokenExchangeConfig, AuthorizationCodeConfig, IdJagConfig)):
-                    # The resolver owns the per-user credential here (token_exchange's exchanged
-                    # token, authorization_code's stored token, id_jag's minted assertion). It is
-                    # authoritative: a guardrail such
-                    # as MCPJWTSigner, static_headers, or any other injected Authorization must NOT
-                    # shadow it (otherwise the upstream gets e.g. the signer's JWT instead of the
-                    # exchanged token and rejects it). Drop the conflicting header so the resolved
-                    # token reaches upstream.
+                if isinstance(
+                    spec.config,
+                    (TokenExchangeConfig, AuthorizationCodeConfig, IdJagConfig, ClientCredentialsConfig),
+                ):
+                    # The resolver owns the credential here (token_exchange's exchanged token,
+                    # authorization_code's stored token, id_jag's minted assertion,
+                    # client_credentials' gateway-minted M2M token). It is authoritative: a
+                    # guardrail such as MCPJWTSigner, static_headers, or any other injected
+                    # Authorization must NOT shadow it (otherwise the upstream gets e.g. the
+                    # signer's JWT instead of the minted token and rejects it, and for M2M the
+                    # one-shot 401 refetch is lost with it). Drop the conflicting header so the
+                    # resolved token reaches upstream.
                     return auth, _without_authorization(extra_headers)
                 # Other modes: an Authorization already supplied via extra_headers (a forwarded caller
                 # header or static_headers) is intentional and wins; v1 applies those last.

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -21,8 +21,12 @@ from typing_extensions import assert_never
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     ApiKeyConfig,
     AuthorizationCodeConfig,
+<<<<<<< HEAD
     ClientAuth,
     ClientSecretAuth,
+=======
+    ClientCredentialsConfig,
+>>>>>>> 73df37ca23 (feat(mcp): migrate client_credentials (M2M) onto the v2 resolver arm)
     CredError,
     IdJagConfig,
     NoneConfig,
@@ -70,10 +74,10 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
     an ``assert_never`` tail, so a newly added auth mode fails the type gate here until it is
     explicitly mapped or explicitly deferred, rather than silently falling through to v1. Live
     modes: ``none``, the static-header family (``api_key`` plus the Authorization schemes,
-    all shared-key), ``oauth2`` per-user tokens (``authorization_code``), ``oauth2_token_exchange``
-    (OBO), and the client-forwarded token modes ``true_passthrough`` / ``oauth_delegate``
-    (``PassthroughConfig``); client_credentials (M2M), delegated/passthrough oauth2, and SigV4
-    return None and stay on v1.
+    all shared-key), ``oauth2`` per-user tokens (``authorization_code``), ``oauth2`` M2M
+    (``client_credentials``), ``oauth2_token_exchange`` (OBO), and the client-forwarded token
+    modes ``true_passthrough`` / ``oauth_delegate`` (``PassthroughConfig``); delegated/passthrough
+    oauth2 and SigV4 return None and stay on v1.
     """
     if server.is_byok:
         return None  # per-user BYOK source not migrated yet -> defer to v1 (any auth_type)
@@ -95,13 +99,15 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
         case MCPAuth.basic:
             return _shared_key_spec(server, resource, "Authorization", "Basic", encode=True)
         case MCPAuth.oauth2:
+            if server.has_client_credentials:
+                return _client_credentials_spec(server, resource)
             if server.needs_user_oauth_token and not server.delegate_auth_to_upstream:
                 return ServerSpec(
                     server_id=server.server_id,
                     resource=resource,
                     config=AuthorizationCodeConfig(),
                 )
-            # client_credentials (M2M) and delegate/passthrough oauth2 stay on v1
+            # delegate/passthrough oauth2 stay on v1
             return None
         case MCPAuth.oauth2_id_jag:
             return _id_jag_spec(server, resource)
@@ -112,6 +118,29 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
         case MCPAuth.aws_sigv4:
             return None  # SigV4 is not migrated yet -> defer to v1
     assert_never(auth_type)
+
+
+def _client_credentials_spec(server: MCPServer, resource: str) -> ServerSpec:
+    """Build a client_credentials (M2M) spec; the explicit ``oauth2_flow`` opt-in owns the server.
+
+    Missing grant fields (``client_id``/``client_secret``/``token_url``) are NOT a reason to defer:
+    v1 would connect unauthenticated and the upstream's 401 gets absorbed into an empty tool list,
+    so the arm fails closed with ``misconfigured`` instead, naming the missing fields (mirrors the
+    OBO ownership rule). ``audience`` is forwarded only when the operator set it; a missing one is
+    omitted, not derived, since a fabricated value risks the IdP rejecting the grant.
+    """
+    return ServerSpec(
+        server_id=server.server_id,
+        resource=resource,
+        config=ClientCredentialsConfig(
+            client_id=server.client_id,
+            client_secret=SecretStr(server.client_secret) if server.client_secret else None,
+            token_url=server.token_url,
+            scopes=tuple(server.scopes or ()),
+            audience=server.audience,
+            token_endpoint_auth_method=server.token_endpoint_auth_method,
+        ),
+    )
 
 
 def _token_exchange_spec(server: MCPServer, resource: str) -> Optional[ServerSpec]:

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -96,16 +96,7 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
         case MCPAuth.basic:
             return _shared_key_spec(server, resource, "Authorization", "Basic", encode=True)
         case MCPAuth.oauth2:
-            if server.has_client_credentials:
-                return _client_credentials_spec(server, resource)
-            if server.needs_user_oauth_token and not server.delegate_auth_to_upstream:
-                return ServerSpec(
-                    server_id=server.server_id,
-                    resource=resource,
-                    config=AuthorizationCodeConfig(),
-                )
-            # delegate/passthrough oauth2 stay on v1
-            return None
+            return _oauth2_spec(server, resource)
         case MCPAuth.oauth2_id_jag:
             return _id_jag_spec(server, resource)
         case MCPAuth.true_passthrough | MCPAuth.oauth_delegate:
@@ -115,6 +106,24 @@ def to_server_spec(server: MCPServer) -> Optional[ServerSpec]:
         case MCPAuth.aws_sigv4:
             return None  # SigV4 is not migrated yet -> defer to v1
     assert_never(auth_type)
+
+
+def _oauth2_spec(server: MCPServer, resource: str) -> ServerSpec | None:
+    """Dispatch the oauth2 auth_type across its sub-modes: M2M, gateway-managed interactive, or v1.
+
+    ``client_credentials`` (the explicit ``oauth2_flow`` opt-in) builds the M2M spec, per-user
+    ``authorization_code`` without upstream delegation builds the interactive spec, and the
+    delegate/passthrough shapes defer to v1 (None).
+    """
+    if server.has_client_credentials:
+        return _client_credentials_spec(server, resource)
+    if server.needs_user_oauth_token and not server.delegate_auth_to_upstream:
+        return ServerSpec(
+            server_id=server.server_id,
+            resource=resource,
+            config=AuthorizationCodeConfig(),
+        )
+    return None
 
 
 def _client_credentials_spec(server: MCPServer, resource: str) -> ServerSpec:

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/adapter.py
@@ -21,12 +21,9 @@ from typing_extensions import assert_never
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     ApiKeyConfig,
     AuthorizationCodeConfig,
-<<<<<<< HEAD
     ClientAuth,
-    ClientSecretAuth,
-=======
     ClientCredentialsConfig,
->>>>>>> 73df37ca23 (feat(mcp): migrate client_credentials (M2M) onto the v2 resolver arm)
+    ClientSecretAuth,
     CredError,
     IdJagConfig,
     NoneConfig,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
@@ -168,6 +168,7 @@ class ClientCredentialsTokenSource:
         default_ttl_seconds: float = 300.0,
         expiry_skew_seconds: float = 60.0,
         min_cache_seconds: float = 10.0,
+        max_locks: int = 1024,
         clock: Callable[[], float] = time.time,
     ) -> None:
         self._post = post
@@ -175,10 +176,18 @@ class ClientCredentialsTokenSource:
         self._default_ttl_seconds = default_ttl_seconds
         self._expiry_skew_seconds = expiry_skew_seconds
         self._min_cache_seconds = min_cache_seconds
+        self._max_locks = max_locks
         self._clock = clock
         self._locks: dict[str, asyncio.Lock] = {}
 
     def _lock(self, server_id: str) -> asyncio.Lock:
+        """Per-server single-flight lock, bounded so ephemeral server ids (e.g. the REST tools
+        preview mints a fresh id per call) cannot grow the dict for the life of the process.
+        Evicting the oldest entry while a task still holds it only means a concurrent caller for
+        that server may run its own grant — single-flight is an optimization, not correctness.
+        """
+        if server_id not in self._locks and len(self._locks) >= self._max_locks:
+            self._locks.pop(next(iter(self._locks)), None)
         return self._locks.setdefault(server_id, asyncio.Lock())
 
     async def get(self, server_id: str, config: ClientCredentialsConfig) -> Result[OAuthToken, CredError]:
@@ -243,8 +252,11 @@ class ClientCredentialsTokenSource:
             expires_at=self._clock() + expires_in if expires_in is not None else None,
             scopes=_parse_granted_scopes(body.get("scope")) or (),
         )
+        # The min-cache floor is itself capped at the token's real lifetime, so a token whose
+        # expires_in is below the skew is never served past its actual expiry; a non-positive
+        # expires_in caches nothing (every request re-fetches, serialized by the per-server lock).
         ttl = (
-            max(expires_in - self._expiry_skew_seconds, self._min_cache_seconds)
+            max(expires_in - self._expiry_skew_seconds, min(float(expires_in), self._min_cache_seconds), 0.0)
             if expires_in is not None
             else self._default_ttl_seconds
         )

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
@@ -340,6 +340,7 @@ class ClientCredentialsBearerAuth(httpx.Auth):
         fresh = await self._refetch(token)
         if fresh is None:
             return
+        self._access_token = SecretStr(fresh)
         request.headers[self.header_name] = f"Bearer {fresh}"
         yield request
 

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
@@ -1,0 +1,334 @@
+"""The ``client_credentials`` (M2M) arm's token source and retrying bearer auth.
+
+Implements the client-credentials behavior contract for the v2 resolver:
+
+- **Acquisition**: POST ``grant_type=client_credentials`` to the configured token endpoint with
+  the configured scopes and (when set) the IdP's ``audience`` parameter, authenticating the
+  client per ``token_endpoint_auth_method`` (RFC 6749 section 2.3.1, shared helper).
+- **Caching**: tokens are cached per ``(client identity, server)`` where the identity key hashes
+  ``token_url`` / ``client_id`` / ``client_secret`` / auth method / scopes / audience — rotating
+  or re-scoping the credentials changes the key, so a stale token can never be served for the
+  new identity (the contract's rotation-invalidation clause).
+- **Expiry**: the cache TTL respects ``expires_in`` minus a skew so an entry lapses before the
+  real token does; a response with no ``expires_in`` is cached briefly
+  (``default_ttl_seconds``), not assumed long-lived. No refresh_token is ever expected.
+- **401 recovery**: ``ClientCredentialsBearerAuth`` retries an upstream request exactly once
+  after a 401 — discard the cached token, mint a fresh one, resend; a second failure surfaces
+  the upstream's own auth error unchanged.
+- **No user context**: nothing here reads a ``Subject``; every caller shares the one client
+  identity.
+
+The token-endpoint POST is injected (``M2MTokenEndpointPost``) so the grant orchestration is
+testable without a live IdP; ``post_client_credentials_grant`` is the httpx edge and the one
+place the untyped response boundary is contained. Failures are values: the source returns
+``Result[OAuthToken, CredError]``; only the httpx edge touches exceptions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import time
+from collections.abc import AsyncGenerator, Awaitable, Callable, Generator
+from dataclasses import dataclass
+from typing import Annotated, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, TypeAdapter, ValidationError
+from typing_extensions import assert_never
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
+    InMemoryTokenCacheBackend,
+    OAuthToken,
+    TokenCacheBackend,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.result import (
+    Error,
+    Ok,
+    Result,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
+    ClientCredentialsConfig,
+    CredError,
+)
+
+
+class TokenEndpointSuccess(BaseModel):
+    """The endpoint returned a JSON object; field validation is the caller's job."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["success"] = "success"
+    body: dict[str, object]
+
+
+class TokenEndpointDenied(BaseModel):
+    """The endpoint answered but did not grant a token (an HTTP error or a non-JSON body)."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["denied"] = "denied"
+    status_code: int
+    detail: str
+
+
+class TokenEndpointUnreachable(BaseModel):
+    """The endpoint could not be reached (DNS, TLS, connect/read failure)."""
+
+    model_config = ConfigDict(frozen=True)
+    tag: Literal["unreachable"] = "unreachable"
+    detail: str
+
+
+TokenEndpointOutcome = Annotated[
+    TokenEndpointSuccess | TokenEndpointDenied | TokenEndpointUnreachable,
+    Field(discriminator="tag"),
+]
+
+M2MTokenEndpointPost = Callable[[str, "dict[str, str]", "dict[str, str]"], Awaitable[TokenEndpointOutcome]]
+
+
+_TOKEN_BODY_ADAPTER: TypeAdapter[dict[str, object]] = TypeAdapter(dict[str, object])
+
+
+async def post_client_credentials_grant(
+    url: str, form: dict[str, str], headers: dict[str, str]
+) -> TokenEndpointOutcome:
+    """POST the grant to the token endpoint and classify the transport outcome.
+
+    The httpx edge: litellm's handler is partially typed (and raises ``HTTPStatusError`` itself on
+    a 4xx/5xx), so the untyped boundary is contained here and every field the caller reads comes
+    out of a validated ``TokenEndpointOutcome``.
+    """
+    from litellm.llms.custom_httpx.http_handler import (  # noqa: PLC0415
+        get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]  # handler is partially typed
+    )
+    from litellm.types.llms.custom_http import httpxSpecialProvider  # noqa: PLC0415
+
+    try:
+        client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
+        response = await client.post(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]  # handler is partially typed
+            url, headers={"Accept": "application/json", **headers}, data=form
+        )
+    except httpx.HTTPStatusError as status_err:
+        status_code = status_err.response.status_code
+        return TokenEndpointDenied(status_code=status_code, detail=f"token endpoint returned HTTP {status_code}")
+    except Exception as exc:  # noqa: BLE001  # any transport failure is the same outcome: unreachable
+        return TokenEndpointUnreachable(detail=str(exc))
+    if not isinstance(response, httpx.Response):
+        return TokenEndpointUnreachable(detail="token endpoint returned no response")
+    try:
+        body = _TOKEN_BODY_ADAPTER.validate_json(response.content)
+    except ValidationError:
+        return TokenEndpointDenied(
+            status_code=response.status_code, detail="token endpoint returned a non-JSON-object body"
+        )
+    return TokenEndpointSuccess(body=body)
+
+
+def _parse_expires_in(raw: object) -> int | None:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_granted_scopes(raw: object) -> tuple[str, ...] | None:
+    return tuple(raw.split()) if isinstance(raw, str) and raw else None
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedGrant:
+    """A validated, ready-to-POST grant plus the identity key its token caches under."""
+
+    token_url: str
+    form: dict[str, str]
+    headers: dict[str, str]
+    identity_key: str
+
+
+class ClientCredentialsTokenSource:
+    """Cached M2M access tokens, one per ``(client identity, server)``.
+
+    ``get`` serves from the cache while the entry's TTL (derived from ``expires_in`` minus
+    ``expiry_skew_seconds``) holds, fetching under a per-server lock so concurrent misses
+    produce one grant. ``refetch`` is the 401-recovery path: it drops the failed token and
+    mints a fresh one, unless a concurrent caller already replaced it.
+    """
+
+    def __init__(
+        self,
+        post: M2MTokenEndpointPost = post_client_credentials_grant,
+        *,
+        backend: TokenCacheBackend | None = None,
+        default_ttl_seconds: float = 300.0,
+        expiry_skew_seconds: float = 60.0,
+        min_cache_seconds: float = 10.0,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._post = post
+        self._backend: TokenCacheBackend = backend or InMemoryTokenCacheBackend(clock=clock)
+        self._default_ttl_seconds = default_ttl_seconds
+        self._expiry_skew_seconds = expiry_skew_seconds
+        self._min_cache_seconds = min_cache_seconds
+        self._clock = clock
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _lock(self, server_id: str) -> asyncio.Lock:
+        return self._locks.setdefault(server_id, asyncio.Lock())
+
+    async def get(self, server_id: str, config: ClientCredentialsConfig) -> Result[OAuthToken, CredError]:
+        match _prepare_grant(config):
+            case Error(err):
+                return Error(err)
+            case Ok(grant):
+                cached = await self._backend.get(grant.identity_key, server_id)
+                if cached is not None:
+                    return Ok(cached)
+                async with self._lock(server_id):
+                    cached = await self._backend.get(grant.identity_key, server_id)
+                    if cached is not None:
+                        return Ok(cached)
+                    return await self._fetch_and_cache(server_id, grant)
+
+    async def refetch(self, server_id: str, config: ClientCredentialsConfig, failed_access_token: str) -> str | None:
+        """Replace a token the upstream just 401'd; returns the fresh bearer value or ``None``.
+
+        Runs under the same per-server lock as ``get``: if a concurrent caller already replaced
+        the failed token, that replacement is returned without another grant, so a burst of 401s
+        yields one fetch. A failed refetch returns ``None`` and the caller surfaces the
+        upstream's original auth error (the contract's retry-once-then-give-up clause).
+        """
+        match _prepare_grant(config):
+            case Error(_):
+                return None
+            case Ok(grant):
+                async with self._lock(server_id):
+                    cached = await self._backend.get(grant.identity_key, server_id)
+                    if cached is not None and cached.access_token != failed_access_token:
+                        return cached.access_token
+                    await self._backend.delete(grant.identity_key, server_id)
+                    match await self._fetch_and_cache(server_id, grant):
+                        case Ok(token):
+                            return token.access_token
+                        case Error(_):
+                            return None
+
+    async def _fetch_and_cache(self, server_id: str, grant: _PreparedGrant) -> Result[OAuthToken, CredError]:
+        outcome = await self._post(grant.token_url, grant.form, grant.headers)
+        match outcome:
+            case TokenEndpointUnreachable():
+                return Error(CredError.of_upstream_unavailable(f"OAuth2 token endpoint unreachable: {outcome.detail}"))
+            case TokenEndpointDenied():
+                if outcome.status_code >= 500:
+                    return Error(CredError.of_upstream_unavailable(f"OAuth2 token endpoint failed: {outcome.detail}"))
+                return Error(CredError.of_misconfigured(f"OAuth2 client_credentials grant rejected: {outcome.detail}"))
+            case TokenEndpointSuccess():
+                return await self._cache_token(server_id, grant, outcome.body)
+        assert_never(outcome)
+
+    async def _cache_token(
+        self, server_id: str, grant: _PreparedGrant, body: dict[str, object]
+    ) -> Result[OAuthToken, CredError]:
+        access_token = body.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return Error(CredError.of_misconfigured("OAuth2 token response is missing 'access_token'"))
+        expires_in = _parse_expires_in(body.get("expires_in"))
+        token = OAuthToken(
+            access_token=access_token,
+            expires_at=self._clock() + expires_in if expires_in is not None else None,
+            scopes=_parse_granted_scopes(body.get("scope")) or (),
+        )
+        ttl = (
+            max(expires_in - self._expiry_skew_seconds, self._min_cache_seconds)
+            if expires_in is not None
+            else self._default_ttl_seconds
+        )
+        await self._backend.set(grant.identity_key, server_id, token, ttl)
+        return Ok(token)
+
+
+def _prepare_grant(config: ClientCredentialsConfig) -> Result[_PreparedGrant, CredError]:
+    if not config.client_id or not config.client_secret or not config.token_url:
+        missing = ", ".join(
+            name
+            for name, present in (
+                ("client_id", bool(config.client_id)),
+                ("client_secret", bool(config.client_secret)),
+                ("token_url", bool(config.token_url)),
+            )
+            if not present
+        )
+        return Error(CredError.of_misconfigured(f"client_credentials config is missing: {missing}"))
+
+    from litellm.proxy._experimental.mcp_server.auth.token_endpoint_auth import (  # noqa: PLC0415
+        build_token_endpoint_client_auth,
+    )
+
+    client_auth = build_token_endpoint_client_auth(
+        auth_method=config.token_endpoint_auth_method,
+        client_id=config.client_id,
+        client_secret=config.client_secret.get_secret_value(),
+    )
+    form = {
+        "grant_type": "client_credentials",
+        **client_auth.body,
+        **({"scope": " ".join(config.scopes)} if config.scopes else {}),
+        **({"audience": config.audience} if config.audience else {}),
+    }
+    return Ok(
+        _PreparedGrant(
+            token_url=config.token_url,
+            form=form,
+            headers=client_auth.headers,
+            identity_key=_identity_key(config),
+        )
+    )
+
+
+def _identity_key(config: ClientCredentialsConfig) -> str:
+    """Hash of everything that names the client identity; any rotation yields a new key."""
+    material = "\n".join(
+        (
+            config.token_url or "",
+            config.client_id or "",
+            config.client_secret.get_secret_value() if config.client_secret else "",
+            config.token_endpoint_auth_method or "",
+            " ".join(config.scopes),
+            config.audience or "",
+        )
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+class ClientCredentialsBearerAuth(httpx.Auth):
+    """Bearer auth that retries an upstream 401 exactly once with a freshly minted token.
+
+    The initial token was already resolved (so config/IdP failures surfaced as typed errors
+    before any upstream request); ``refetch`` is the source's 401-recovery callback. If the
+    refetch fails, or the retried request 401s again, the upstream's response stands.
+    """
+
+    def __init__(self, access_token: str, refetch: Callable[[str], Awaitable[str | None]]) -> None:
+        self.header_name = "Authorization"
+        self._access_token = SecretStr(access_token)
+        self._refetch = refetch
+
+    async def async_auth_flow(self, request: httpx.Request) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        token = self._access_token.get_secret_value()
+        request.headers[self.header_name] = f"Bearer {token}"
+        response = yield request
+        if response.status_code != 401:
+            return
+        fresh = await self._refetch(token)
+        if fresh is None:
+            return
+        request.headers[self.header_name] = f"Bearer {fresh}"
+        yield request
+
+    def sync_auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, httpx.Response, None]:
+        raise RuntimeError("ClientCredentialsBearerAuth only supports async httpx clients")

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
@@ -260,7 +260,8 @@ class ClientCredentialsTokenSource:
             if expires_in is not None
             else self._default_ttl_seconds
         )
-        await self._backend.set(grant.identity_key, server_id, token, ttl)
+        if ttl > 0:
+            await self._backend.set(grant.identity_key, server_id, token, ttl)
         return Ok(token)
 
 

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/client_credentials.py
@@ -98,10 +98,10 @@ async def post_client_credentials_grant(
     a 4xx/5xx), so the untyped boundary is contained here and every field the caller reads comes
     out of a validated ``TokenEndpointOutcome``.
     """
-    from litellm.llms.custom_httpx.http_handler import (  # noqa: PLC0415
+    from litellm.llms.custom_httpx.http_handler import (  # noqa: PLC0415  # defer heavy handler import to call time
         get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]  # handler is partially typed
     )
-    from litellm.types.llms.custom_http import httpxSpecialProvider  # noqa: PLC0415
+    from litellm.types.llms.custom_http import httpxSpecialProvider  # noqa: PLC0415  # deferred with the handler import
 
     try:
         client = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
@@ -277,7 +277,7 @@ def _prepare_grant(config: ClientCredentialsConfig) -> Result[_PreparedGrant, Cr
         )
         return Error(CredError.of_misconfigured(f"client_credentials config is missing: {missing}"))
 
-    from litellm.proxy._experimental.mcp_server.auth.token_endpoint_auth import (  # noqa: PLC0415
+    from litellm.proxy._experimental.mcp_server.auth.token_endpoint_auth import (  # noqa: PLC0415  # keep package v1-free at import time
         build_token_endpoint_client_auth,
     )
 

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/resolver.py
@@ -9,18 +9,24 @@ at runtime instead of returning `None`.
 
 `none`, `api_key` (shared-key source), and `passthrough` (forwards the caller's own inbound token)
 are live, as is `authorization_code`, which reads the user's token from the injected
-`OAuthTokenStore`, and `token_exchange`, which swaps the caller's inbound token through the
-injected `TokenExchanger`. The remaining arms are `not_implemented` stubs that each land in a
-follow-up PR with their seam. Pure v2: no imports from v1.
+`OAuthTokenStore`, `token_exchange`, which swaps the caller's inbound token through the injected
+`TokenExchanger`, and `client_credentials`, which mints and caches the gateway's M2M token through
+the injected `ClientCredentialsTokenSource`. The remaining arms are `not_implemented` stubs that
+each land in a follow-up PR with their seam. Pure v2: no imports from v1.
 """
 
 from __future__ import annotations
 
 import hashlib
+from functools import partial
 
 import httpx
 from typing_extensions import assert_never
 
+from litellm.proxy._experimental.mcp_server.outbound_credentials.client_credentials import (
+    ClientCredentialsBearerAuth,
+    ClientCredentialsTokenSource,
+)
 from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
     NoOpAuth,
     StaticHeaderAuth,
@@ -104,11 +110,13 @@ class UpstreamCredentialProvider:
         token_exchanger: TokenExchanger | None = None,
         token_endpoint: TokenEndpointClient | None = None,
         exchanged_tokens: ExchangedTokenCache | None = None,
+        client_credentials_source: ClientCredentialsTokenSource | None = None,
     ) -> None:
         self._oauth_token_store: OAuthTokenStore = oauth_token_store or _NullOAuthTokenStore()
         self._token_exchanger: TokenExchanger = token_exchanger or _NullTokenExchanger()
         self._token_endpoint: TokenEndpointClient = token_endpoint or TokenEndpointClient()
         self._exchanged_tokens: ExchangedTokenCache = exchanged_tokens or ExchangedTokenCache()
+        self._client_credentials_source = client_credentials_source or ClientCredentialsTokenSource()
 
     async def resolve_credentials(self, subject: Subject, server: ServerSpec) -> Result[httpx.Auth, CredError]:
         match server.config:
@@ -118,8 +126,8 @@ class UpstreamCredentialProvider:
                 return self._api_key(config)
             case PassthroughConfig():
                 return self._passthrough(subject)
-            case ClientCredentialsConfig():
-                return _not_implemented(AuthSpecKind.client_credentials)
+            case ClientCredentialsConfig() as config:
+                return await self._client_credentials(server.server_id, config)
             case TokenExchangeConfig() as config:
                 return await self._token_exchange(subject, server, config)
             case IdJagConfig() as config:
@@ -215,6 +223,23 @@ class UpstreamCredentialProvider:
             return Error(CredError.of_unauthorized("Authorization required: complete the OAuth flow for this server."))
         return Ok(StaticHeaderAuth(f"Bearer {token.access_token}", header_name="Authorization"))
 
+    async def _client_credentials(
+        self, server_id: str, config: ClientCredentialsConfig
+    ) -> Result[httpx.Auth, CredError]:
+        """The M2M arm: resolve a cached (or freshly minted) gateway token; no user context.
+
+        The token is resolved here, before any upstream request, so a misconfigured grant or an
+        unreachable IdP surfaces as a typed ``CredError``. The returned auth carries the source's
+        ``refetch``, so an upstream 401 is retried exactly once with a freshly minted token (the
+        contract's invalid-token recovery); a second 401 surfaces the upstream's own error.
+        """
+        match await self._client_credentials_source.get(server_id, config):
+            case Ok(token):
+                refetch = partial(self._client_credentials_source.refetch, server_id, config)
+                return Ok(ClientCredentialsBearerAuth(token.access_token, refetch))
+            case Error(err):
+                return Error(err)
+
     async def _token_exchange(
         self, subject: Subject, server: ServerSpec, config: TokenExchangeConfig
     ) -> Result[StaticHeaderAuth, CredError]:
@@ -245,7 +270,9 @@ class UpstreamCredentialProvider:
 
         Used after an upstream rejects the injected credential, so the next resolve re-mints rather
         than serving the same rejected token until TTL. `token_exchange` and `id_jag` hold a
-        re-mintable cached credential here; other modes are a no-op.
+        re-mintable cached credential here; `client_credentials` recovers inside its own auth flow
+        (`ClientCredentialsBearerAuth` retries the 401'd request once with a fresh token), and
+        other modes are a no-op.
         """
         if subject.inbound_token is None:
             return

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/types.py
@@ -184,7 +184,12 @@ class ClientCredentialsConfig(BaseModel):
 
     Fields are optional so the config can be built incomplete: a value may be supplied at
     runtime (`token_url` via RFC 8414 discovery, `client_id`/`secret` via DCR), and the
-    resolver arm raises `CredError.misconfigured` when a needed field is still absent.
+    resolver arm returns `CredError.misconfigured` when a needed field is still absent.
+
+    `audience` is the IdP-specific audience parameter some authorization servers require on
+    the client_credentials grant (sent as `audience` in the token request when set).
+    `token_endpoint_auth_method` selects how the client authenticates to the token endpoint
+    (RFC 6749 section 2.3.1); `None` defaults to `client_secret_post`.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -193,6 +198,8 @@ class ClientCredentialsConfig(BaseModel):
     client_secret: SecretStr | None = None
     token_url: str | None = None
     scopes: tuple[str, ...] = ()
+    audience: str | None = None
+    token_endpoint_auth_method: Literal["client_secret_post", "client_secret_basic"] | None = None
 
 
 class TokenExchangeConfig(BaseModel):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_adapter.py
@@ -21,6 +21,7 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.adapter import 
 from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
     ApiKeyConfig,
     AuthorizationCodeConfig,
+    ClientCredentialsConfig,
     ClientSecretAuth,
     CredError,
     IdJagConfig,
@@ -107,7 +108,6 @@ def test_oauth2_user_token_maps_to_authorization_code(oauth2_flow):
     [
         _server(auth_type=MCPAuth.api_key),  # no token configured
         _server(auth_type=MCPAuth.bearer_token),  # no token configured
-        _server(auth_type=MCPAuth.oauth2, oauth2_flow="client_credentials"),  # M2M -> v1
         _server(auth_type=MCPAuth.oauth2, delegate_auth_to_upstream=True),  # delegated upstream OAuth -> v1
         _server(auth_type=MCPAuth.oauth2_token_exchange),  # no endpoint/client creds -> incomplete -> v1
         _server(
@@ -122,6 +122,74 @@ def test_oauth2_user_token_maps_to_authorization_code(oauth2_flow):
 def test_unmigrated_modes_defer_to_v1(server):
     # A None spec is the defer signal; the caller falls back to v1.
     assert to_server_spec(server) is None
+
+
+def test_client_credentials_maps_full_config():
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="client_credentials",
+            url="https://up.example.com/mcp",
+            token_url="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+            scopes=["read", "write"],
+            audience="https://up.example.com",
+            token_endpoint_auth_method="client_secret_basic",
+        )
+    )
+    assert spec is not None
+    config = spec.config
+    assert isinstance(config, ClientCredentialsConfig)
+    assert config.client_id == "cid"
+    assert config.client_secret is not None
+    assert config.client_secret.get_secret_value() == "csec"
+    assert config.token_url == "https://idp.example.com/token"
+    assert config.scopes == ("read", "write")
+    assert config.audience == "https://up.example.com"
+    assert config.token_endpoint_auth_method == "client_secret_basic"
+
+
+def test_client_credentials_omits_audience_when_unset():
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="client_credentials",
+            token_url="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+    )
+    assert spec is not None
+    assert isinstance(spec.config, ClientCredentialsConfig)
+    assert spec.config.audience is None
+
+
+def test_client_credentials_with_incomplete_grant_fields_is_owned_for_fail_closed():
+    # An M2M server missing its grant fields is still owned by v2 (spec, not None) so it fails
+    # closed at the source (misconfigured, 500) rather than deferring to v1, which would connect
+    # unauthenticated and mask the upstream 401 as an empty tool list.
+    spec = to_server_spec(_server(auth_type=MCPAuth.oauth2, oauth2_flow="client_credentials", client_id="cid"))
+    assert spec is not None
+    assert isinstance(spec.config, ClientCredentialsConfig)
+    assert spec.config.token_url is None
+    assert spec.config.client_secret is None
+
+
+def test_client_credentials_wins_over_delegate_flag():
+    # v1 never delegates for M2M servers; the explicit oauth2_flow opt-in outranks the delegate flag.
+    spec = to_server_spec(
+        _server(
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="client_credentials",
+            delegate_auth_to_upstream=True,
+            token_url="https://idp.example.com/token",
+            client_id="cid",
+            client_secret="csec",
+        )
+    )
+    assert spec is not None
+    assert isinstance(spec.config, ClientCredentialsConfig)
 
 
 def test_token_exchange_maps_full_config():

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
@@ -152,6 +152,39 @@ async def test_short_lived_token_is_never_served_past_its_expiry():
     assert len(poster.calls) == 2
 
 
+class _RecordingBackend:
+    """A TokenCacheBackend spy: records every write so a test can assert none happened."""
+
+    def __init__(self) -> None:
+        self.set_ttls: list[float] = []
+
+    async def get(self, identity_key: str, server_id: str):
+        return None
+
+    async def set(self, identity_key: str, server_id: str, token, ttl_seconds: float) -> None:
+        self.set_ttls.append(ttl_seconds)
+
+    async def delete(self, identity_key: str, server_id: str) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expires_in", [0, -30])
+async def test_non_positive_expires_in_writes_no_cache_entry(expires_in):
+    # A dead-on-arrival entry (ttl 0) must not be written at all: it can never be served, but it
+    # would occupy a slot in the bounded backend and could evict a live token. The mint itself
+    # still succeeds for the current request, and the next get re-fetches.
+    backend = _RecordingBackend()
+    poster = _FakePoster([_success("t1", expires_in=expires_in), _success("t2", expires_in=expires_in)])
+    source = ClientCredentialsTokenSource(poster, backend=backend)
+    first = await source.get("s", _config())
+    assert isinstance(first, Ok) and first.ok.access_token == "t1"
+    again = await source.get("s", _config())
+    assert isinstance(again, Ok) and again.ok.access_token == "t2"
+    assert backend.set_ttls == []
+    assert len(poster.calls) == 2
+
+
 @pytest.mark.asyncio
 async def test_lock_dict_is_bounded_for_ephemeral_server_ids():
     poster = _FakePoster([_success()])

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
@@ -341,6 +341,27 @@ async def test_bearer_auth_retries_a_401_once_with_a_fresh_token():
 
 
 @pytest.mark.asyncio
+async def test_bearer_auth_remembers_the_rotated_token_for_later_requests():
+    # The auth object lives for the whole MCP session (it is the httpx client's auth), so after a
+    # 401 recovery it must send the fresh token first on subsequent requests; re-sending the
+    # rejected one would burn a 401 round trip and the single retry on every call.
+    transport, seen = _upstream([httpx.Response(401), httpx.Response(200), httpx.Response(200)])
+    refetched: "list[str]" = []
+
+    async def refetch(failed: str) -> "str | None":
+        refetched.append(failed)
+        return "fresh-token"
+
+    auth = ClientCredentialsBearerAuth("stale-token", refetch)
+    async with httpx.AsyncClient(transport=transport, auth=auth) as client:
+        first = await client.get("https://upstream.example.com/mcp")
+        second = await client.get("https://upstream.example.com/mcp")
+    assert first.status_code == 200 and second.status_code == 200
+    assert refetched == ["stale-token"]
+    assert seen == ["Bearer stale-token", "Bearer fresh-token", "Bearer fresh-token"]
+
+
+@pytest.mark.asyncio
 async def test_bearer_auth_surfaces_the_401_when_the_refetch_fails():
     transport, seen = _upstream([httpx.Response(401)])
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
@@ -1,0 +1,320 @@
+"""Tests for the client_credentials (M2M) token source and its retrying bearer auth.
+
+These are the behavior-contract spec: grant shape (scopes / audience / client auth method),
+rotation-aware cache keying, expires_in-driven expiry, error classification, and the
+401 -> discard -> refetch -> retry-once recovery in ``ClientCredentialsBearerAuth``.
+"""
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from litellm.proxy._experimental.mcp_server.outbound_credentials.client_credentials import (
+    ClientCredentialsBearerAuth,
+    ClientCredentialsTokenSource,
+    TokenEndpointDenied,
+    TokenEndpointOutcome,
+    TokenEndpointSuccess,
+    TokenEndpointUnreachable,
+)
+from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Error, Ok
+from litellm.proxy._experimental.mcp_server.outbound_credentials.types import (
+    ClientCredentialsConfig,
+)
+
+
+class _Clock:
+    def __init__(self, t: float = 1000.0) -> None:
+        self.t = t
+
+    def __call__(self) -> float:
+        return self.t
+
+
+class _FakePoster:
+    """Records every grant POST and returns canned outcomes (last one repeats)."""
+
+    def __init__(self, outcomes: "list[TokenEndpointOutcome]") -> None:
+        self._outcomes = outcomes
+        self.calls: "list[tuple[str, dict[str, str], dict[str, str]]]" = []
+
+    async def __call__(self, url: str, form: "dict[str, str]", headers: "dict[str, str]") -> TokenEndpointOutcome:
+        self.calls.append((url, dict(form), dict(headers)))
+        index = min(len(self.calls) - 1, len(self._outcomes) - 1)
+        return self._outcomes[index]
+
+
+def _success(access_token: str = "m2m-token", **extra: object) -> TokenEndpointSuccess:
+    return TokenEndpointSuccess(body={"access_token": access_token, **extra})
+
+
+def _config(**overrides: object) -> ClientCredentialsConfig:
+    fields: "dict[str, object]" = {
+        "client_id": "cid",
+        "client_secret": SecretStr("csec"),
+        "token_url": "https://idp.example.com/token",
+        **overrides,
+    }
+    return ClientCredentialsConfig.model_validate(fields)
+
+
+@pytest.mark.asyncio
+async def test_grant_posts_client_credentials_with_scopes_and_audience():
+    poster = _FakePoster([_success()])
+    source = ClientCredentialsTokenSource(poster)
+    result = await source.get("s", _config(scopes=("read", "write"), audience="https://api.example.com"))
+    assert isinstance(result, Ok)
+    assert result.ok.access_token == "m2m-token"
+    url, form, _headers = poster.calls[0]
+    assert url == "https://idp.example.com/token"
+    assert form["grant_type"] == "client_credentials"
+    assert form["scope"] == "read write"
+    assert form["audience"] == "https://api.example.com"
+    assert form["client_id"] == "cid"
+    assert form["client_secret"] == "csec"
+
+
+@pytest.mark.asyncio
+async def test_grant_omits_scope_and_audience_when_not_configured():
+    poster = _FakePoster([_success()])
+    await ClientCredentialsTokenSource(poster).get("s", _config())
+    _url, form, _headers = poster.calls[0]
+    assert "scope" not in form
+    assert "audience" not in form
+
+
+@pytest.mark.asyncio
+async def test_grant_honors_client_secret_basic():
+    poster = _FakePoster([_success()])
+    await ClientCredentialsTokenSource(poster).get("s", _config(token_endpoint_auth_method="client_secret_basic"))
+    _url, form, headers = poster.calls[0]
+    assert headers["Authorization"].startswith("Basic ")
+    assert "client_secret" not in form
+    assert "client_id" not in form
+
+
+@pytest.mark.asyncio
+async def test_missing_grant_fields_are_misconfigured_and_never_posted():
+    poster = _FakePoster([_success()])
+    result = await ClientCredentialsTokenSource(poster).get(
+        "s", ClientCredentialsConfig(client_id="cid", client_secret=SecretStr("csec"))
+    )
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+    assert "token_url" in result.error.summary
+    assert poster.calls == []
+
+
+@pytest.mark.asyncio
+async def test_token_is_cached_across_gets():
+    poster = _FakePoster([_success(expires_in=3600)])
+    source = ClientCredentialsTokenSource(poster)
+    first = await source.get("s", _config())
+    second = await source.get("s", _config())
+    assert isinstance(first, Ok) and isinstance(second, Ok)
+    assert second.ok.access_token == first.ok.access_token
+    assert len(poster.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_expires_in_bounds_the_cache_lifetime():
+    clock = _Clock(1000.0)
+    poster = _FakePoster([_success("t1", expires_in=120), _success("t2", expires_in=120)])
+    source = ClientCredentialsTokenSource(poster, expiry_skew_seconds=60.0, clock=clock)
+    first = await source.get("s", _config())
+    assert isinstance(first, Ok)
+    assert first.ok.expires_at == 1120.0
+    clock.t = 1059.0  # within expires_in - skew
+    assert len(poster.calls) == 1
+    within = await source.get("s", _config())
+    assert isinstance(within, Ok) and within.ok.access_token == "t1"
+    clock.t = 1061.0  # past expires_in - skew: the entry lapsed before the real token does
+    lapsed = await source.get("s", _config())
+    assert isinstance(lapsed, Ok) and lapsed.ok.access_token == "t2"
+    assert len(poster.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_expires_in_is_cached_briefly_not_an_hour():
+    clock = _Clock(1000.0)
+    poster = _FakePoster([_success("t1"), _success("t2")])
+    source = ClientCredentialsTokenSource(poster, default_ttl_seconds=300.0, clock=clock)
+    first = await source.get("s", _config())
+    assert isinstance(first, Ok)
+    assert first.ok.expires_at is None
+    clock.t = 1301.0  # past the default TTL; v1 would still be serving its 3600s-cached token
+    second = await source.get("s", _config())
+    assert isinstance(second, Ok) and second.ok.access_token == "t2"
+    assert len(poster.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rotation",
+    [
+        {"client_secret": SecretStr("rotated")},
+        {"client_id": "cid-2"},
+        {"scopes": ("admin",)},
+        {"audience": "https://other.example.com"},
+        {"token_url": "https://idp2.example.com/token"},
+    ],
+)
+async def test_credential_rotation_invalidates_the_cached_token(rotation):
+    poster = _FakePoster([_success("old", expires_in=3600), _success("new", expires_in=3600)])
+    source = ClientCredentialsTokenSource(poster)
+    before = await source.get("s", _config())
+    after = await source.get("s", _config(**rotation))
+    assert isinstance(before, Ok) and before.ok.access_token == "old"
+    assert isinstance(after, Ok) and after.ok.access_token == "new"
+    assert len(poster.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_idp_4xx_is_misconfigured_and_5xx_is_unavailable():
+    denied = await ClientCredentialsTokenSource(
+        _FakePoster([TokenEndpointDenied(status_code=401, detail="HTTP 401")])
+    ).get("s", _config())
+    assert isinstance(denied, Error) and denied.error.tag == "misconfigured"
+    down = await ClientCredentialsTokenSource(
+        _FakePoster([TokenEndpointDenied(status_code=503, detail="HTTP 503")])
+    ).get("s", _config())
+    assert isinstance(down, Error) and down.error.tag == "upstream_unavailable"
+    unreachable = await ClientCredentialsTokenSource(_FakePoster([TokenEndpointUnreachable(detail="dns")])).get(
+        "s", _config()
+    )
+    assert isinstance(unreachable, Error) and unreachable.error.tag == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_response_without_access_token_is_misconfigured():
+    poster = _FakePoster([TokenEndpointSuccess(body={"token_type": "Bearer"})])
+    result = await ClientCredentialsTokenSource(poster).get("s", _config())
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+
+
+@pytest.mark.asyncio
+async def test_error_results_are_not_cached():
+    poster = _FakePoster([TokenEndpointUnreachable(detail="down"), _success("recovered")])
+    source = ClientCredentialsTokenSource(poster)
+    first = await source.get("s", _config())
+    second = await source.get("s", _config())
+    assert isinstance(first, Error)
+    assert isinstance(second, Ok) and second.ok.access_token == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_refetch_discards_the_failed_token_and_mints_a_fresh_one():
+    poster = _FakePoster([_success("stale", expires_in=3600), _success("fresh", expires_in=3600)])
+    source = ClientCredentialsTokenSource(poster)
+    first = await source.get("s", _config())
+    assert isinstance(first, Ok)
+    fresh = await source.refetch("s", _config(), failed_access_token="stale")
+    assert fresh == "fresh"
+    assert len(poster.calls) == 2
+    after = await source.get("s", _config())
+    assert isinstance(after, Ok) and after.ok.access_token == "fresh"
+    assert len(poster.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_refetch_reuses_a_concurrent_replacement_without_a_second_grant():
+    poster = _FakePoster([_success("replacement", expires_in=3600)])
+    source = ClientCredentialsTokenSource(poster)
+    seeded = await source.get("s", _config())
+    assert isinstance(seeded, Ok)
+    result = await source.refetch("s", _config(), failed_access_token="some-older-token")
+    assert result == "replacement"
+    assert len(poster.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_refetch_returns_none_when_the_grant_fails():
+    poster = _FakePoster([_success("stale"), TokenEndpointUnreachable(detail="down")])
+    source = ClientCredentialsTokenSource(poster)
+    await source.get("s", _config())
+    assert await source.refetch("s", _config(), failed_access_token="stale") is None
+
+
+def _upstream(responses: "list[httpx.Response]") -> "tuple[httpx.MockTransport, list[str]]":
+    # The auth flow re-yields the same Request object on retry, so snapshot the Authorization
+    # value per send; holding the Request would show the post-retry mutation for both entries.
+    seen: "list[str]" = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers.get("Authorization", ""))
+        return responses[min(len(seen) - 1, len(responses) - 1)]
+
+    return httpx.MockTransport(handler), seen
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_sends_the_token_and_leaves_a_success_alone():
+    transport, seen = _upstream([httpx.Response(200)])
+
+    async def refetch(failed: str) -> "str | None":
+        raise AssertionError("must not refetch on success")
+
+    auth = ClientCredentialsBearerAuth("m2m-token", refetch)
+    async with httpx.AsyncClient(transport=transport, auth=auth) as client:
+        response = await client.get("https://upstream.example.com/mcp")
+    assert response.status_code == 200
+    assert seen == ["Bearer m2m-token"]
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_retries_a_401_once_with_a_fresh_token():
+    transport, seen = _upstream([httpx.Response(401), httpx.Response(200)])
+    refetched: "list[str]" = []
+
+    async def refetch(failed: str) -> "str | None":
+        refetched.append(failed)
+        return "fresh-token"
+
+    auth = ClientCredentialsBearerAuth("stale-token", refetch)
+    async with httpx.AsyncClient(transport=transport, auth=auth) as client:
+        response = await client.get("https://upstream.example.com/mcp")
+    assert response.status_code == 200
+    assert refetched == ["stale-token"]
+    assert seen == ["Bearer stale-token", "Bearer fresh-token"]
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_surfaces_the_401_when_the_refetch_fails():
+    transport, seen = _upstream([httpx.Response(401)])
+
+    async def refetch(failed: str) -> "str | None":
+        return None
+
+    auth = ClientCredentialsBearerAuth("stale-token", refetch)
+    async with httpx.AsyncClient(transport=transport, auth=auth) as client:
+        response = await client.get("https://upstream.example.com/mcp")
+    assert response.status_code == 401
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_bearer_auth_gives_up_after_a_second_401():
+    transport, seen = _upstream([httpx.Response(401), httpx.Response(401)])
+    refetched: "list[str]" = []
+
+    async def refetch(failed: str) -> "str | None":
+        refetched.append(failed)
+        return "fresh-token"
+
+    auth = ClientCredentialsBearerAuth("stale-token", refetch)
+    async with httpx.AsyncClient(transport=transport, auth=auth) as client:
+        response = await client.get("https://upstream.example.com/mcp")
+    assert response.status_code == 401
+    assert len(seen) == 2
+    assert refetched == ["stale-token"]
+
+
+def test_bearer_auth_rejects_sync_clients():
+    async def refetch(failed: str) -> "str | None":
+        return None
+
+    auth = ClientCredentialsBearerAuth("token", refetch)
+    with httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(200)), auth=auth) as client:
+        with pytest.raises(RuntimeError):
+            client.get("https://upstream.example.com/mcp")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_client_credentials.py
@@ -135,6 +135,34 @@ async def test_expires_in_bounds_the_cache_lifetime():
 
 
 @pytest.mark.asyncio
+async def test_short_lived_token_is_never_served_past_its_expiry():
+    # expires_in below the skew must not be floored into serving an expired token: the cache
+    # entry lapses with the token itself, and the next get re-fetches.
+    clock = _Clock(1000.0)
+    poster = _FakePoster([_success("t1", expires_in=5), _success("t2", expires_in=5)])
+    source = ClientCredentialsTokenSource(poster, expiry_skew_seconds=60.0, min_cache_seconds=10.0, clock=clock)
+    first = await source.get("s", _config())
+    assert isinstance(first, Ok) and first.ok.access_token == "t1"
+    clock.t = 1004.0  # still within the token's real lifetime
+    within = await source.get("s", _config())
+    assert isinstance(within, Ok) and within.ok.access_token == "t1"
+    clock.t = 1006.0  # past expires_at: the floor must not keep serving t1
+    lapsed = await source.get("s", _config())
+    assert isinstance(lapsed, Ok) and lapsed.ok.access_token == "t2"
+    assert len(poster.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_lock_dict_is_bounded_for_ephemeral_server_ids():
+    poster = _FakePoster([_success()])
+    source = ClientCredentialsTokenSource(poster, max_locks=8)
+    for index in range(20):
+        result = await source.get(f"ephemeral-{index}", _config())
+        assert isinstance(result, Ok)
+    assert len(source._locks) <= 8
+
+
+@pytest.mark.asyncio
 async def test_missing_expires_in_is_cached_briefly_not_an_hour():
     clock = _Clock(1000.0)
     poster = _FakePoster([_success("t1"), _success("t2")])

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_resolver.py
@@ -1,9 +1,10 @@
 """Tests for the resolver dispatch: live arms produce auth, stubbed arms fail closed.
 
-`none`, `api_key` (shared-key source), `passthrough`, `authorization_code`, and `token_exchange` are
-implemented; every other arm, plus the `api_key` BYOK source, returns a typed `not_implemented` error
-until its mode lands. Parametrizing the stubs over one config each also guards reachability: a dropped
-`case` would hit `assert_never` and raise instead of returning the stub.
+`none`, `api_key` (shared-key source), `passthrough`, `authorization_code`, `token_exchange`, and
+`client_credentials` are implemented; every other arm, plus the `api_key` BYOK source, returns a
+typed `not_implemented` error until its mode lands. Parametrizing the stubs over one config each
+also guards reachability: a dropped `case` would hit `assert_never` and raise instead of
+returning the stub.
 """
 
 import httpx
@@ -324,9 +325,106 @@ async def test_passthrough_without_inbound_token_is_a_no_op():
     assert isinstance(result.ok, NoOpAuth)
 
 
+class _FakeM2MSource:
+    """A ClientCredentialsTokenSource returning a canned result and recording refetches."""
+
+    def __init__(self, result) -> None:
+        self._result = result
+        self.gets: list[str] = []
+        self.refetches: list[tuple[str, str]] = []
+
+    async def get(self, server_id: str, config):
+        self.gets.append(server_id)
+        return self._result
+
+    async def refetch(self, server_id: str, config, failed_access_token: str):
+        self.refetches.append((server_id, failed_access_token))
+        return "fresh-m2m"
+
+
+_M2M = ClientCredentialsConfig(
+    client_id="cid",
+    client_secret=SecretStr("csec"),
+    token_url="https://idp.example.com/token",
+)
+
+
+async def _emitted_async(auth: httpx.Auth, respond=None) -> tuple[httpx.Headers, list[httpx.Request]]:
+    """Drive the async auth flow one request at a time, replying via ``respond`` when given."""
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return respond(request) if respond else httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler), auth=auth) as client:
+        await client.get("https://upstream.example.com/mcp")
+    return seen[-1].headers, seen
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_emits_the_minted_bearer():
+    source = _FakeM2MSource(Ok(OAuthToken(access_token="m2m-at")))
+    result = await UpstreamCredentialProvider(client_credentials_source=source).resolve_credentials(
+        _SUBJECT, _spec(_M2M)
+    )
+    assert isinstance(result, Ok)
+    headers, _ = await _emitted_async(result.ok)
+    assert headers["Authorization"] == "Bearer m2m-at"
+    assert source.gets == ["s"]
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_ignores_the_subject():
+    # The contract's no-user-context clause: every caller shares the one client identity.
+    source = _FakeM2MSource(Ok(OAuthToken(access_token="m2m-at")))
+    provider = UpstreamCredentialProvider(client_credentials_source=source)
+    alice = await provider.resolve_credentials(Subject(tenant_id="t1", subject_id="alice"), _spec(_M2M))
+    bob = await provider.resolve_credentials(Subject(tenant_id="t2", subject_id="bob"), _spec(_M2M))
+    assert isinstance(alice, Ok) and isinstance(bob, Ok)
+    alice_headers, _ = await _emitted_async(alice.ok)
+    bob_headers, _ = await _emitted_async(bob.ok)
+    assert alice_headers["Authorization"] == bob_headers["Authorization"] == "Bearer m2m-at"
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_auth_retries_a_401_through_the_source():
+    source = _FakeM2MSource(Ok(OAuthToken(access_token="stale-at")))
+    result = await UpstreamCredentialProvider(client_credentials_source=source).resolve_credentials(
+        _SUBJECT, _spec(_M2M)
+    )
+    assert isinstance(result, Ok)
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        is_stale = request.headers["Authorization"] == "Bearer stale-at"
+        return httpx.Response(401) if is_stale else httpx.Response(200)
+
+    headers, seen = await _emitted_async(result.ok, respond)
+    assert headers["Authorization"] == "Bearer fresh-m2m"
+    assert len(seen) == 2
+    assert source.refetches == [("s", "stale-at")]
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_propagates_the_source_error():
+    source = _FakeM2MSource(Error(CredError.of_upstream_unavailable("idp down")))
+    result = await UpstreamCredentialProvider(client_credentials_source=source).resolve_credentials(
+        _SUBJECT, _spec(_M2M)
+    )
+    assert isinstance(result, Error)
+    assert result.error.tag == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_with_no_source_wired_fails_closed_on_missing_config():
+    # The default source validates the grant fields before any network is touched.
+    result = await UpstreamCredentialProvider().resolve_credentials(_SUBJECT, _spec(ClientCredentialsConfig()))
+    assert isinstance(result, Error)
+    assert result.error.tag == "misconfigured"
+
+
 _STUBBED = [
     ("api_key_byok", ApiKeyConfig(key_source=Byok())),
-    ("client_credentials", ClientCredentialsConfig()),
     ("aws_sigv4", AwsSigV4Config(region="us-east-1")),
 ]
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -1760,6 +1760,42 @@ class TestMCPServerManager:
         assert "authorization" not in {k.lower() for k in (client.extra_headers or {})}
 
     @pytest.mark.asyncio
+    async def test_injected_authorization_does_not_shadow_m2m_minted_token(self):
+        """The M2M twin of the OBO shadow test: a guardrail/static Authorization must not displace
+        the gateway-minted client_credentials bearer. Dropping the resolved auth here would also
+        drop the one-shot 401 refetch that rides on it, so the resolver-owned credential is
+        authoritative exactly as for token_exchange and authorization_code."""
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.httpx_auth import (
+            StaticHeaderAuth,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+
+        class _FakeProvider:
+            async def resolve_credentials(self, subject, server):
+                return Ok(StaticHeaderAuth("Bearer MINTED-M2M", header_name="Authorization"))
+
+        manager = MCPServerManager(cred_provider=_FakeProvider())
+        server = MCPServer(
+            server_id="m2m-shadow",
+            name="m2m-shadow-server",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.oauth2,
+            oauth2_flow="client_credentials",
+            client_id="cid",
+            client_secret="csec",
+            token_url="https://idp.example.com/token",
+        )
+
+        client = await manager._create_mcp_client(
+            server,
+            extra_headers={"Authorization": "Bearer signer-jwt"},  # simulate the JWT signer
+        )
+
+        assert client._resolved_auth is not None
+        assert "authorization" not in {k.lower() for k in (client.extra_headers or {})}
+
+    @pytest.mark.asyncio
     async def test_preflight_token_exchange_challenges_on_rejected_subject(self):
         """A subject the IdP rejects must raise the RFC 9728 401 challenge from the preflight, so a
         single-server route fails observably at the transport edge instead of the old behavior of

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -7760,23 +7760,58 @@ class TestCreateMcpClientV2Graft:
         assert client._resolved_auth.header_name == "Authorization"
         assert client._resolved_auth._header_value.get_secret_value() == f"Basic {encoded}"
 
-    async def test_m2m_client_credentials_defers_to_v1(self):
-        # M2M (oauth2 client_credentials) is not migrated: to_server_spec returns
-        # None, so the graft sets no resolved auth and leaves v1 in charge (v1
-        # performs the client_credentials grant itself - the static
-        # authentication_token is never consumed for oauth2, so it does not flow
-        # to _mcp_auth_value). Per-user oauth2 (authorization_code) is migrated to
-        # v2 and is exercised separately.
+    async def test_m2m_client_credentials_resolves_via_v2(self):
+        # M2M (oauth2 client_credentials) is migrated: to_server_spec owns the server and the
+        # v2 arm mints the token through the injected source; nothing flows to v1's auth_value.
+        from litellm.proxy._experimental.mcp_server.outbound_credentials import (
+            UpstreamCredentialProvider,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.client_credentials import (
+            ClientCredentialsBearerAuth,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
+            OAuthToken,
+        )
+        from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
+
+        class _FakeM2MSource:
+            async def get(self, server_id, config):
+                return Ok(OAuthToken(access_token="m2m-at"))
+
+            async def refetch(self, server_id, config, failed_access_token):
+                return None
+
         client = await MCPServerManager()._create_mcp_client(
             self._http_server(
                 auth_type=MCPAuth.oauth2,
                 oauth2_flow="client_credentials",
-                authentication_token="legacy-token",
-            )
+                client_id="cid",
+                client_secret="csec",
+                token_url="https://idp.example.com/token",
+            ),
+            cred_provider=UpstreamCredentialProvider(client_credentials_source=_FakeM2MSource()),
         )
 
-        assert client._resolved_auth is None
+        assert isinstance(client._resolved_auth, ClientCredentialsBearerAuth)
+        assert client._resolved_auth._access_token.get_secret_value() == "m2m-at"
         assert client._mcp_auth_value is None
+
+    async def test_m2m_client_credentials_incomplete_config_fails_closed(self):
+        # An M2M server missing its grant fields is still owned by v2 and surfaces a 500
+        # misconfigured naming the missing fields, rather than deferring to v1 and connecting
+        # unauthenticated (which masked the upstream 401 as an empty tool list).
+        with pytest.raises(HTTPException) as exc_info:
+            await MCPServerManager()._create_mcp_client(
+                self._http_server(
+                    auth_type=MCPAuth.oauth2,
+                    oauth2_flow="client_credentials",
+                    authentication_token="legacy-token",
+                )
+            )
+
+        assert exc_info.value.status_code == 500
+        assert "misconfigured" in str(exc_info.value.detail)
+        assert "token_url" in str(exc_info.value.detail)
 
     async def test_static_token_missing_defers_to_v1(self):
         client = await MCPServerManager()._create_mcp_client(


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4263

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Evidence is a live proxy backed by real Postgres, pointed at a local stub IdP + MCP upstream that records every grant request it receives and can revoke issued tokens on demand. The stub records the grant forms on `GET /grants` (secrets redacted) so the exact request the gateway sends to the token endpoint is observable. Config for the server under test:

```yaml
mcp_servers:
  stub_m2m:
    url: http://127.0.0.1:9100/mcp
    transport: http
    auth_type: oauth2
    oauth2_flow: client_credentials
    client_id: gw-client
    client_secret: gw-secret
    token_url: http://127.0.0.1:9100/token
    scopes: ["mcp.read"]
    audience: https://stub-upstream/api
```

Before (branch base, v1 path). The grant never carries the configured audience, and after the IdP revokes the token the gateway keeps replaying it from cache; the upstream 401 comes back as HTTP 200 with an empty tool list and no re-fetch is ever attempted

```
$ curl -s -X POST http://localhost:4000/mcp/stub_m2m -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"stub_m2m-ping", ...}]}}

$ curl -s http://127.0.0.1:9100/grants
{"grants":[{"grant_type":"client_credentials","client_id":"gw-client","client_secret":"***"},
           {"grant_type":"client_credentials","client_id":"gw-client","client_secret":"***","scope":"mcp.read"},
           {"grant_type":"client_credentials","client_id":"gw-client","client_secret":"***","scope":"mcp.read"}]}
# no "audience" anywhere despite it being configured

$ curl -s -X POST http://127.0.0.1:9100/revoke
{"revoked":["tok-1","tok-2","tok-3"]}

$ curl -s -X POST http://localhost:4000/mcp/stub_m2m -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":3,"method":"tools/list","params":{}}'
data: {"jsonrpc":"2.0","id":3,"result":{"tools":[]}}
# HTTP 200, empty tools: the upstream 401 is masked as success

$ curl -s http://127.0.0.1:9100/grants | python3 -c "import json,sys; print('grants:', len(json.load(sys.stdin)['grants']))"
grants: 3
# no re-fetch attempted; this persists until the 1h cache TTL lapses
```

After (this branch, same commands, stub restarted with clean counters). One grant carrying scope and audience; after each revocation the next request recovers transparently with exactly one re-fetch

```
$ curl -s -X POST http://localhost:4000/mcp/stub_m2m -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"stub_m2m-ping", ...}]}}

$ curl -s http://127.0.0.1:9100/grants
{"grants":[{"grant_type":"client_credentials","client_id":"gw-client","client_secret":"***","scope":"mcp.read","audience":"https://stub-upstream/api"}]}

$ curl -s -X POST http://127.0.0.1:9100/revoke
{"revoked":["tok-1"]}

$ curl -s -X POST http://localhost:4000/mcp/stub_m2m -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
data: {"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"stub_m2m-ping", ...}]}}
# transparent recovery: discard, one re-fetch, retry once

$ curl -s -X POST http://127.0.0.1:9100/revoke > /dev/null
$ curl -s -X POST http://localhost:4000/mcp/stub_m2m -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"stub_m2m-ping","arguments":{}}}'
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"pong from stub upstream"}], ..., "isError":false}}
# tools/call recovers the same way (the retry lives in the httpx auth flow, so every request type gets it)

$ curl -s http://127.0.0.1:9100/grants | python3 -c "import json,sys; g=json.load(sys.stdin)['grants']; print('grants:', len(g))"
grants: 3
# 1 initial + exactly 1 per recovery, each with scope and audience
```

## Type

🆕 New Feature

## Changes

Migrates the OAuth2 client_credentials (M2M) MCP flow onto the v2 outbound-credentials resolver, replacing the `not_implemented` stub arm. `to_server_spec` now maps a server with the explicit `oauth2_flow: client_credentials` opt-in onto `ClientCredentialsConfig` (grant fields, scopes, audience, `token_endpoint_auth_method`), and the resolver arm mints the token through a new `ClientCredentialsTokenSource` before any upstream request, so a bad grant surfaces as a typed CredError (500/503) instead of an unauthenticated connect

The new source closes four behavior gaps the v1 `MCPOAuth2TokenCache` has. First, an upstream 401 now discards the cached token, re-fetches once, and retries the request once via `ClientCredentialsBearerAuth` (an `httpx.Auth` whose async flow sees the 401 before the MCP SDK does, so initialize, tools/list, and tools/call all get the recovery); v1 defines `invalidate()` but nothing calls it, so a revoked token keeps failing until TTL expiry and the aggregate listing masks the 401 as an empty tool list. Second, the cache key is a hash of token_url, client_id, client_secret, auth method, scopes, and audience, so rotating or re-scoping credentials can never serve the stale token; v1 keys by server_id alone and never invalidates on update. Third, the grant now sends the configured `audience` (the server row already had the field; v1 only used it for token exchange), which audience-required IdPs need for M2M. Fourth, a response without `expires_in` is cached for 300s rather than v1's assumed 3600s

Concurrency is a per-server asyncio lock (one grant per server across concurrent misses, matching v1), and the refetch path short-circuits when a concurrent caller already replaced the failed token, so a burst of 401s produces one grant. Client authentication reuses the shared `build_token_endpoint_client_auth` helper (`client_secret_post` default, `client_secret_basic` supported). The httpx edge validates the token response with a pydantic `TypeAdapter` so no `Any` escapes the boundary; errors are values (`Result[OAuthToken, CredError]`) end to end

One deliberate parity break, mirroring the OBO ownership rule: an M2M server with incomplete grant fields (missing client_id/client_secret/token_url) is still owned by v2 and fails closed with a misconfigured error naming the missing fields, where v1 silently connected unauthenticated and the resulting upstream 401 surfaced as "no tools". Per-request `x-mcp-*` auth overrides still defer to v1 and keep their existing precedence, delegate/passthrough oauth2 stays on v1, and caller Authorization headers remain stripped for M2M servers

Tests: `test_client_credentials.py` pins the grant shape, rotation keying, expires_in expiry, error classification, refetch semantics, and the retry-once auth flow against a mock transport; `test_resolver.py` covers the new arm (bearer emission, subject independence, error propagation, fail-closed default source) and drops client_credentials from the stubbed-arms list; `test_adapter.py` pins the new mapping including the fail-closed ownership and the M2M-over-delegate precedence; the `_create_mcp_client` graft tests in `test_mcp_server_manager.py` are updated from the pre-migration contract (M2M defers to v1) to the new one (resolves via v2, fails closed on incomplete grant config). All 9 new resolver/adapter tests fail on the base commit and pass with this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP upstream authentication and token caching for all M2M servers; behavior changes include fail-closed config, shorter default cache without expires_in, and authoritative gateway bearer over injected headers—important for security but scoped to explicit client_credentials flow.
> 
> **Overview**
> **OAuth2 `client_credentials` (M2M) for MCP upstreams moves from v1 to the v2 outbound-credentials path.** Servers with `oauth2_flow: client_credentials` map to `ClientCredentialsConfig` in `to_server_spec`; the resolver mints tokens via a new `ClientCredentialsTokenSource` and returns `ClientCredentialsBearerAuth` instead of deferring to v1.
> 
> The token source POSTs the client-credentials grant (scopes, optional **audience**, `token_endpoint_auth_method`), caches by a **rotation-aware identity hash**, and classifies IdP failures as typed `CredError`s. **Upstream 401** triggers discard-cache, one refetch, and **one retry** in httpx auth (so revoked tokens are not masked as empty tool lists). Incomplete grant config is **owned by v2** and fails with **misconfigured** rather than connecting unauthenticated.
> 
> `mcp_server_manager` treats M2M minted bearer like other resolver-owned modes: conflicting injected `Authorization` headers are dropped so guardrails do not shadow the gateway token or its retry behavior. `ClientCredentialsConfig` gains `audience` and `token_endpoint_auth_method` fields documented for the grant wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf04ba8d3e1d35055fabd4f961a62e321eb8f6ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Review-round hardening (post-rebase commits): a mint whose expires_in computes a ttl of 0 no longer writes a dead entry into the bounded cache; the session-long bearer auth remembers the rotated token after a 401 recovery instead of re-sending the rejected one on every later call; and the minted M2M bearer is authoritative over any injected Authorization (MCPJWTSigner, static_headers) in _resolve_v2_auth, matching token_exchange and authorization_code, so the injected header is dropped rather than the resolved auth. Each carries a regression test that fails on the commit before it
