### PR TITLE
fix(e2e): route model management to the control plane 

### DIFF
--- a/tests/e2e/e2e_gateway.py
+++ b/tests/e2e/e2e_gateway.py
@@ -9,6 +9,7 @@ Gateway's key/customer methods for cleanup. Read-backs are eventually consistent
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -18,6 +19,7 @@ from e2e_http import (
     Result,
     StreamingResponse,
     Success,
+    is_ok,
     unwrap,
 )
 from models import (
@@ -32,8 +34,14 @@ from models import (
     KeyInfo,
     KeyInfoParams,
     KeyInfoResponse,
+    LiteLLMParamsBody,
+    ModelDeleteBody,
+    ModelInfoBody,
     ModelInfoEntry,
     ModelInfoResponse,
+    ModelMode,
+    ModelNewBody,
+    ModelNewResponse,
     OcrBody,
     OcrResponse,
     SpendLogRow,
@@ -110,6 +118,38 @@ class Gateway:
                 response_type=ModelInfoResponse,
             )
         ).data
+
+    def create_model(
+        self,
+        model_name: str,
+        litellm_params: LiteLLMParamsBody,
+        mode: ModelMode | None = None,
+    ) -> str:
+        """Register a deployment under `model_name` (id == model_name) and return the
+        model_id. add_deployment runs synchronously in /model/new, so the model is
+        callable as soon as this returns."""
+        return unwrap(
+            self.transport.post(
+                "/model/new",
+                headers=self.transport.master,
+                json=ModelNewBody(
+                    model_name=model_name,
+                    litellm_params=litellm_params,
+                    model_info=ModelInfoBody(id=model_name, mode=mode),
+                ),
+                response_type=ModelNewResponse,
+            )
+        ).model_id
+
+    def delete_model(self, model_id: str) -> None:
+        result = self.transport.post(
+            "/model/delete",
+            headers=self.transport.master,
+            json=ModelDeleteBody(id=model_id),
+            response_type=NoBody,
+        )
+        if not is_ok(result):
+            warnings.warn(f"delete_model({model_id!r}) failed: {result}", stacklevel=2)
 
     # ---- LLM calls ------------------------------------------------------
 

--- a/tests/e2e/llm_translation/endpoints_client.py
+++ b/tests/e2e/llm_translation/endpoints_client.py
@@ -14,15 +14,8 @@ from dataclasses import dataclass
 from pydantic import BaseModel
 
 from e2e_gateway import Gateway, build_gateway
-from e2e_http import NoBody, StreamingResponse, is_ok, unwrap
-from models import (
-    ChatMessage,
-    LiteLLMParamsBody,
-    ModelDeleteBody,
-    ModelInfoBody,
-    ModelNewBody,
-    ModelNewResponse,
-)
+from e2e_http import StreamingResponse
+from models import ChatMessage, LiteLLMParamsBody
 
 
 class ResponsesRequest(BaseModel):
@@ -136,32 +129,10 @@ class EndpointsClient:
     gateway: Gateway
 
     def create_model(self, model_name: str, litellm_params: LiteLLMParamsBody) -> str:
-        """Register a deployment under `model_name` (id == model_name) and return the
-        model_id. add_deployment runs synchronously in /model/new, so the model is
-        callable as soon as this returns."""
-        return unwrap(
-            self.gateway.transport.post(
-                "/model/new",
-                headers=self.gateway.transport.master,
-                json=ModelNewBody(
-                    model_name=model_name,
-                    litellm_params=litellm_params,
-                    model_info=ModelInfoBody(id=model_name),
-                ),
-                response_type=ModelNewResponse,
-            )
-        ).model_id
+        return self.gateway.create_model(model_name, litellm_params)
 
     def delete_model(self, model_id: str) -> None:
-        result = self.gateway.transport.post(
-            "/model/delete",
-            headers=self.gateway.transport.master,
-            json=ModelDeleteBody(id=model_id),
-            response_type=NoBody,
-        )
-        if not is_ok(result):
-            import warnings
-            warnings.warn(f"delete_model({model_id!r}) failed: {result}", stacklevel=2)
+        self.gateway.delete_model(model_id)
 
     def _send(self, path: str, key: str, body: BaseModel) -> StreamingResponse:
         return self.gateway.transport.send(

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -367,9 +367,12 @@ class LiteLLMParamsBody(BaseModel):
     output_cost_per_token: float | None = None
 
 
+ModelMode = Literal["batch", "realtime", "image_generation"]
+
+
 class ModelInfoBody(BaseModel):
     id: str
-    mode: Literal["batch", "realtime", "image_generation"] | None = None
+    mode: ModelMode | None = None
 
 
 class ModelNewBody(BaseModel):

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -1,0 +1,140 @@
+"""Unit coverage for the Gateway model-management surface (create_model /
+delete_model).
+
+The batches conftest and several llm_translation tests register deployments at
+runtime through gateway.create_model; when that method went missing, every batch
+test errored at fixture setup (AttributeError) before a single request reached
+the proxy. This pins the surface with a typed fake Transport so a rename or
+signature drift fails here instead of in a live stage run.
+"""
+
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel
+
+from batches.batch_client import BatchClient
+from e2e_gateway import Gateway
+from e2e_http import (
+    AuthHeaders,
+    FileUploadForm,
+    ProbeResult,
+    Result,
+    StreamingResponse,
+    Success,
+)
+from models import LiteLLMParamsBody, ModelDeleteBody, ModelNewBody
+
+
+@dataclass
+class _RecordingTransport:
+    """Typed fake fulfilling the Transport protocol; records every post and
+    answers with a canned success so the test asserts on what was sent."""
+
+    posts: list[tuple[str, BaseModel]] = field(default_factory=list)
+
+    def post[R: BaseModel](
+        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+    ) -> Result[R]:
+        self.posts.append((path, json))
+        return Success(data=response_type.model_validate({"model_id": "registered-id"}))
+
+    def stream(
+        self, path: str, *, headers: BaseModel, json: BaseModel
+    ) -> StreamingResponse:
+        raise AssertionError("stream is not part of model management")
+
+    def send(
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        json: BaseModel,
+        params: BaseModel | None = None,
+        stream: bool = False,
+    ) -> StreamingResponse:
+        raise AssertionError("send is not part of model management")
+
+    def get[R: BaseModel](
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        params: BaseModel,
+        response_type: type[R],
+    ) -> Result[R]:
+        raise AssertionError("get is not part of model management")
+
+    def delete[R: BaseModel](
+        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+    ) -> Result[R]:
+        raise AssertionError("delete is not part of model management")
+
+    def probe(self, path: str, *, params: BaseModel) -> ProbeResult:
+        raise AssertionError("probe is not part of model management")
+
+    def upload[R: BaseModel](
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        form: FileUploadForm,
+        filename: str,
+        content: bytes,
+        params: BaseModel | None = None,
+        response_type: type[R],
+    ) -> Result[R]:
+        raise AssertionError("upload is not part of model management")
+
+    def download(self, path: str, *, headers: BaseModel) -> StreamingResponse:
+        raise AssertionError("download is not part of model management")
+
+    def bearer(self, key: str) -> AuthHeaders:
+        return AuthHeaders(authorization=f"Bearer {key}")
+
+    @property
+    def master(self) -> AuthHeaders:
+        return self.bearer("sk-test-master")
+
+
+def test_gateway_create_model_registers_deployment_and_returns_model_id() -> None:
+    transport = _RecordingTransport()
+    gateway = Gateway(transport=transport)
+
+    model_id = gateway.create_model(
+        "e2e-test-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")
+    )
+
+    assert model_id == "registered-id"
+    path, body = transport.posts[0]
+    assert path == "/model/new"
+    assert isinstance(body, ModelNewBody)
+    assert body.model_name == "e2e-test-model"
+    assert body.model_info.id == "e2e-test-model"
+    assert body.model_info.mode is None
+
+
+def test_batch_client_create_model_registers_a_batch_mode_deployment() -> None:
+    transport = _RecordingTransport()
+    client = BatchClient(gateway=Gateway(transport=transport))
+
+    model_id = client.create_model(
+        "e2e-batch-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")
+    )
+
+    assert model_id == "registered-id"
+    path, body = transport.posts[0]
+    assert path == "/model/new"
+    assert isinstance(body, ModelNewBody)
+    assert body.model_info.mode == "batch"
+
+
+def test_gateway_delete_model_posts_the_model_id() -> None:
+    transport = _RecordingTransport()
+    gateway = Gateway(transport=transport)
+
+    gateway.delete_model("registered-id")
+
+    path, body = transport.posts[0]
+    assert path == "/model/delete"
+    assert isinstance(body, ModelDeleteBody)
+    assert body.id == "registered-id"

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -22,7 +22,12 @@ from e2e_http import (
     StreamingResponse,
     Success,
 )
-from models import LiteLLMParamsBody, ModelDeleteBody, ModelNewBody
+from models import (
+    LiteLLMParamsBody,
+    ModelDeleteBody,
+    ModelNewBody,
+    ModelNewResponse,
+)
 
 
 @dataclass
@@ -36,7 +41,10 @@ class _RecordingTransport:
         self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
     ) -> Result[R]:
         self.posts.append((path, json))
-        return Success(data=response_type.model_validate({"model_id": "registered-id"}))
+        payload = (
+            {"model_id": "registered-id"} if response_type is ModelNewResponse else {}
+        )
+        return Success(data=response_type.model_validate(payload))
 
     def stream(
         self, path: str, *, headers: BaseModel, json: BaseModel

--- a/tests/e2e/test_transport.py
+++ b/tests/e2e/test_transport.py
@@ -1,0 +1,48 @@
+"""Unit coverage for SplitTransport path routing (is_control_plane_path).
+
+Model-management calls (/model/new, /model/delete, /model/info) must go to the
+control plane: the data-plane gateway does not serve management routes, so a
+misrouted /model/new 404s and takes down every suite that registers deployments
+at runtime (llm_translation, batches, access_control). /models must stay on the
+data plane; it is the OpenAI-compatible list-models route, not a management
+route.
+"""
+
+import pytest
+
+from transport import is_control_plane_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/model/new",
+        "/model/delete",
+        "/model/update",
+        "/model/info",
+        "/key/generate",
+        "/budget/new",
+        "/spend/logs",
+    ],
+)
+def test_management_routes_go_to_the_control_plane(path: str) -> None:
+    assert is_control_plane_path(path), (
+        f"{path} is a management route; sending it to the data plane 404s"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/models",
+        "/v1/models",
+        "/chat/completions",
+        "/v1/messages",
+        "/embeddings",
+        "/anthropic/v1/messages",
+    ],
+)
+def test_llm_routes_stay_on_the_data_plane(path: str) -> None:
+    assert not is_control_plane_path(path), (
+        f"{path} is an LLM route; it must go to the data plane"
+    )

--- a/tests/e2e/transport.py
+++ b/tests/e2e/transport.py
@@ -204,7 +204,7 @@ CONTROL_PLANE_PREFIXES: tuple[str, ...] = (
     "/customer",
     "/tag",
     "/budget",
-    "/model/info",
+    "/model/",
     "/spend",
     "/global",
     "/openapi.json",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The 2026-07-06 00:59 UTC stage run failed 46 tests and errored 17 more. Every test that registers a deployment at runtime died on one of the two bugs this PR fixes

Proof against the live split deployment on berrie-litellm-stage, with `kubectl port-forward svc/litellm-gateway 14000:4000` (data plane) and `kubectl port-forward svc/litellm-backend 14001:4001` (control plane). First `/model/new` against the data plane, which is where the old routing table sent it:

```
$ curl -s -w "\nhttp_code: %{http_code}\n" -X POST http://localhost:14000/model/new \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model_name": "e2e-routing-proof", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "os.environ/OPENAI_API_KEY"}, "model_info": {"id": "e2e-routing-proof"}}'
{"detail":"Not Found"}
http_code: 404
```

The identical request against the control plane, which is where this PR routes it, registers the deployment:

```
$ curl -s -X POST http://localhost:14001/model/new \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model_name": "e2e-routing-proof", "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "os.environ/OPENAI_API_KEY"}, "model_info": {"id": "e2e-routing-proof"}}'
{"model_id":"e2e-routing-proof","model_name":"e2e-routing-proof","litellm_params":{...},"mode...
```

Same split for the teardown route:

```
$ curl -s -w "\nhttp_code: %{http_code}\n" -X POST http://localhost:14000/model/delete \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"id": "e2e-routing-proof"}'
{"detail":"Not Found"}
http_code: 404

$ curl -s -w "\nhttp_code: %{http_code}\n" -X POST http://localhost:14001/model/delete \
    -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"id": "e2e-routing-proof"}'
{"message":"Model: e2e-routing-proof deleted successfully"}
http_code: 200
```

The new regression tests fail on the previous code (6 failed) and pass with the fix

## Type

Bug Fix

## Changes

Two harness bugs, one routing and one API surface, together account for 33 of the 63 failures in the stage run (the rest are exhausted Anthropic credits plus a handful still under investigation)

`SplitTransport` routes each path to the data plane or the control plane by prefix, but `CONTROL_PLANE_PREFIXES` listed only `/model/info`. `POST /model/new` and `POST /model/delete` therefore fell through to the data-plane gateway, which serves no management routes and answers 404. Every llm_translation test that registers its deployment at runtime failed at setup, and the access_control 403 test failed because its probe of `/model/new` never reached the control plane's auth check. The prefix is now `/model/`, which covers all model-management routes while `/models`, the OpenAI-compatible list-models route, stays on the data plane

`batch_client.py`, `test_provider_features_e2e.py`, and `test_deepseek_reasoning_e2e.py` call `gateway.create_model`, but `Gateway` never had that method, so all 17 batch tests errored at fixture setup with AttributeError before a single request was sent. `Gateway` now owns `create_model` (with the optional `mode` the batches suite passes) and `delete_model`, and `EndpointsClient` delegates to them instead of carrying its own copy, per the harness convention that shared routes live on `Gateway`

Regression coverage: `test_transport.py` pins the management-vs-LLM routing predicate, and `test_e2e_gateway.py` pins the `Gateway` model-management surface through a typed fake `Transport`, including the batch-mode delegation that was the exact failing call chain


A follow-up commit also excludes the master key from HttpTransport's repr: pytest prints fixture values verbatim into failure output, so every failed e2e test was embedding the proxy master key in CI logs and any aggregator they ship to (the 2026-07-06 stage run's Loki export contains it verbatim; rotating the stage master key is recommended). A canary test pins the fixture repr chain