### PR TITLE
feat(complexity_router): add custom_technical_keywords config

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -32,6 +32,14 @@ else:
     PreRoutingHookResponse = Any
 
 
+def _append_custom_keywords(base_keywords: list[str], custom_keywords: Optional[list[str]]) -> list[str]:
+    if not custom_keywords:
+        return base_keywords
+    base_lowered = frozenset(keyword.lower() for keyword in base_keywords)
+    deduped_custom = {keyword.lower(): keyword for keyword in custom_keywords if keyword.lower() not in base_lowered}
+    return [*base_keywords, *deduped_custom.values()]
+
+
 class DimensionScore:
     """Represents a score for a single dimension with optional signal."""
 
@@ -90,7 +98,10 @@ class ComplexityRouter(CustomLogger):
         # Build effective keyword lists (use config overrides or defaults)
         self.code_keywords = self.config.code_keywords or DEFAULT_CODE_KEYWORDS
         self.reasoning_keywords = self.config.reasoning_keywords or DEFAULT_REASONING_KEYWORDS
-        self.technical_keywords = self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS
+        self.technical_keywords = _append_custom_keywords(
+            self.config.technical_keywords or DEFAULT_TECHNICAL_KEYWORDS,
+            self.config.custom_technical_keywords,
+        )
         self.simple_keywords = self.config.simple_keywords or DEFAULT_SIMPLE_KEYWORDS
 
         # Pre-compile regex patterns for efficiency

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -237,6 +237,15 @@ class ComplexityRouterConfig(BaseModel):
         default=None,
         description="Keywords indicating technical content",
     )
+    custom_technical_keywords: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Domain-specific technical keywords appended to the effective base list "
+            "(technical_keywords if set, otherwise DEFAULT_TECHNICAL_KEYWORDS). "
+            "Order is preserved; duplicates are removed case-insensitively against "
+            "the base list and within this list."
+        ),
+    )
     simple_keywords: Optional[List[str]] = Field(
         default=None,
         description="Keywords indicating simple/basic queries",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -22,6 +22,7 @@ from litellm.router_strategy.complexity_router.complexity_router import (
 )
 from litellm.router_strategy.complexity_router.config import (
     DEFAULT_COMPLEXITY_CONFIG,
+    DEFAULT_TECHNICAL_KEYWORDS,
     ComplexityRouterConfig,
     ComplexityTier,
 )
@@ -466,6 +467,89 @@ class TestConfigOverrides:
         assert any(
             "long" in s.lower() if s else False for s in signals
         ), f"Expected 'long' signal, got {signals}"
+
+
+class TestCustomTechnicalKeywords:
+    """Test the custom_technical_keywords config option."""
+
+    def test_custom_keywords_appended_to_defaults(self, mock_router_instance):
+        """Custom keywords should be appended to the default technical keywords."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"custom_technical_keywords": ["udp", "kafka"]},
+        )
+        assert router.technical_keywords == DEFAULT_TECHNICAL_KEYWORDS + ["udp", "kafka"]
+
+    def test_custom_keywords_appended_to_technical_keywords_override(
+        self, mock_router_instance
+    ):
+        """Custom keywords should be appended to a technical_keywords override."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "technical_keywords": ["quantum", "photonics"],
+                "custom_technical_keywords": ["udp"],
+            },
+        )
+        assert router.technical_keywords == ["quantum", "photonics", "udp"]
+
+    def test_custom_keywords_deduplicated_case_insensitively(self, mock_router_instance):
+        """Duplicates against the base list and within the custom list should be dropped."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "custom_technical_keywords": ["TCP", "udp", "UDP", "kafka"]
+            },
+        )
+        lowered = [kw.lower() for kw in router.technical_keywords]
+        assert lowered == [kw.lower() for kw in DEFAULT_TECHNICAL_KEYWORDS] + [
+            "udp",
+            "kafka",
+        ]
+
+    def test_no_custom_keywords_leaves_defaults_unchanged(self, mock_router_instance):
+        """Absent or None custom_technical_keywords should leave the keyword list identical."""
+        router_absent = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": {"MEDIUM": "gpt-4o"}},
+        )
+        router_none = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"custom_technical_keywords": None},
+        )
+        assert router_absent.technical_keywords == DEFAULT_TECHNICAL_KEYWORDS
+        assert router_none.technical_keywords == DEFAULT_TECHNICAL_KEYWORDS
+
+    def test_prompt_with_only_custom_keywords_scores_technical(
+        self, mock_router_instance, basic_config
+    ):
+        """A prompt matching only custom keywords should score higher on technicalTerms."""
+        prompt = "Configure udp multicast between kafka brokers"
+        baseline_router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=basic_config,
+        )
+        custom_router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **basic_config,
+                "custom_technical_keywords": ["UDP", "Kafka"],
+            },
+        )
+        _, baseline_score, baseline_signals = baseline_router.classify(prompt)
+        _, custom_score, custom_signals = custom_router.classify(prompt)
+        assert not any("technical" in s.lower() for s in baseline_signals)
+        assert any(
+            "technical" in s.lower() for s in custom_signals
+        ), f"Expected technical signal, got {custom_signals}"
+        assert custom_score > baseline_score
 
 
 class TestAsyncPreRoutingHookEdgeCases:

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -1,4 +1,5 @@
-import { renderWithProviders, screen } from "../../../tests/test-utils";
+import { renderWithProviders, screen, within } from "../../../tests/test-utils";
+import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import ComplexityRouterConfig from "./ComplexityRouterConfig";
 
@@ -48,5 +49,42 @@ describe("ComplexityRouterConfig", () => {
     expect(screen.getByText(/Score 0.15 - 0.35/)).toBeInTheDocument();
     expect(screen.getByText(/Score 0.35 - 0.60/)).toBeInTheDocument();
     expect(screen.getByText(/Score > 0.60/)).toBeInTheDocument();
+  });
+
+  it("should render the custom technical keywords field", () => {
+    renderWithProviders(<ComplexityRouterConfig modelInfo={mockModelInfo} value={defaultTiers} onChange={vi.fn()} />);
+    expect(screen.getByText("Custom Technical Keywords")).toBeInTheDocument();
+  });
+
+  it("should display existing custom technical keywords as tags", () => {
+    renderWithProviders(
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={defaultTiers}
+        onChange={vi.fn()}
+        customTechnicalKeywords={["udp", "kafka"]}
+        onCustomTechnicalKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("udp")).toBeInTheDocument();
+    expect(screen.getByText("kafka")).toBeInTheDocument();
+  });
+
+  it("should call onCustomTechnicalKeywordsChange when a keyword is entered", async () => {
+    const user = userEvent.setup();
+    const onCustomTechnicalKeywordsChange = vi.fn();
+    renderWithProviders(
+      <ComplexityRouterConfig
+        modelInfo={mockModelInfo}
+        value={defaultTiers}
+        onChange={vi.fn()}
+        customTechnicalKeywords={[]}
+        onCustomTechnicalKeywordsChange={onCustomTechnicalKeywordsChange}
+      />,
+    );
+    const keywordsCard = screen.getByText("Custom Technical Keywords").closest(".ant-card") as HTMLElement;
+    const input = within(keywordsCard).getByRole("combobox");
+    await user.type(input, "udp,");
+    expect(onCustomTechnicalKeywordsChange).toHaveBeenCalledWith(["udp"]);
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -16,6 +16,8 @@ interface ComplexityRouterConfigProps {
   modelInfo: ModelGroup[];
   value: ComplexityTiers;
   onChange: (tiers: ComplexityTiers) => void;
+  customTechnicalKeywords?: string[];
+  onCustomTechnicalKeywordsChange?: (keywords: string[]) => void;
 }
 
 const TIER_DESCRIPTIONS: Record<keyof ComplexityTiers, { label: string; description: string; examples: string }> = {
@@ -41,7 +43,13 @@ const TIER_DESCRIPTIONS: Record<keyof ComplexityTiers, { label: string; descript
   },
 };
 
-const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({ modelInfo, value, onChange }) => {
+const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
+  modelInfo,
+  value,
+  onChange,
+  customTechnicalKeywords,
+  onCustomTechnicalKeywordsChange,
+}) => {
   // Prepare model options for dropdowns
   const modelOptions = modelInfo.map((model) => ({
     value: model.model_group,
@@ -101,6 +109,33 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({ modelIn
             </div>
           );
         })}
+      </Card>
+
+      <Divider />
+
+      <Card>
+        <div className="flex items-center gap-2 mb-2">
+          <Text strong style={{ fontSize: 16 }}>
+            Custom Technical Keywords
+          </Text>
+          <Tooltip title="Domain-specific terms appended to the built-in technical keyword list. Prompts containing these terms score higher on the technical dimension and route to more capable models.">
+            <InfoCircleOutlined className="text-gray-400" />
+          </Tooltip>
+        </div>
+        <Text type="secondary" style={{ display: "block", marginBottom: 8, fontSize: 12 }}>
+          Optional: add terms the built-in list misses (e.g., udp, kafka, terraform)
+        </Text>
+        <AntdSelect
+          mode="tags"
+          value={customTechnicalKeywords ?? []}
+          onChange={(keywords: string[]) => onCustomTechnicalKeywordsChange?.(keywords)}
+          placeholder="Type a keyword and press Enter, or paste a comma-separated list"
+          tokenSeparators={[","]}
+          open={false}
+          suffixIcon={null}
+          style={{ width: "100%" }}
+          allowClear
+        />
       </Card>
 
       <Divider />

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -55,6 +55,8 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
     REASONING: "",
   });
 
+  const [customTechnicalKeywords, setCustomTechnicalKeywords] = useState<string[]>([]);
+
   useEffect(() => {
     const fetchModelAccessGroups = async () => {
       const response = await modelAvailableCall(accessToken, "", "", false, null, true, true);
@@ -127,6 +129,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
             model_type: "complexity_router",
             complexity_router_config: {
               tiers: complexityTiers,
+              ...(customTechnicalKeywords.length > 0 && { custom_technical_keywords: customTechnicalKeywords }),
             },
             model_access_group: currentFormValues.model_access_group,
           };
@@ -280,6 +283,8 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({ form, handleOk, acc
                 onChange={(tiers) => {
                   setComplexityTiers(tiers);
                 }}
+                customTechnicalKeywords={customTechnicalKeywords}
+                onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
               />
             </div>
           ) : (


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3237

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified end to end against a live DB-less proxy hitting the real OpenAI API: fresh Python 3.13 venv with `pip install -e ".[proxy]"` in a detached worktree, random port 41624, identical config and identical prompt for both runs, so the only variable is the checked out code (base `29035c4a99` vs PR head `c5813586`). The config maps SIMPLE and MEDIUM to `gpt-5.4-mini` and COMPLEX and REASONING to `gpt-5.5`, and sets `custom_technical_keywords`. The test prompt contains eight custom keywords (kafka, redis, postgresql, mongodb, dns, udp, ssl, ssh) and exactly one built-in keyword ("api"), so it scores 0.150 (MEDIUM, weak model) when the custom list is ignored and 0.400 (COMPLEX, strong model) when it is applied

```yaml
# qa_config.yaml (identical for both runs)
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.5
    litellm_params:
      model: openai/gpt-5.5
      api_key: os.environ/OPENAI_API_KEY
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: gpt-5.4-mini
          MEDIUM: gpt-5.4-mini
          COMPLEX: gpt-5.5
          REASONING: gpt-5.5
        custom_technical_keywords:
          - udp
          - dns
          - ssl
          - tls
          - ssh
          - rest
          - graphql
          - kafka
          - redis
          - postgresql
          - mongodb

general_settings:
  master_key: sk-qa-lit3237
```

The served deployment is identified by the `x-litellm-model-id` response header; `/v1/model/info` on the running proxy maps the ids (same mapping on both SHAs since the hash is derived from litellm_params)

```
$ curl -s http://localhost:41624/v1/model/info -H "Authorization: Bearer sk-qa-lit3237" | jq -r '.data[] | .model_info.id + " => " + .model_name'
d6a6a3a93b891c90b9b55b0cc0c1131ed3f6f5360df766d5ce701e2ba72ae351 => gpt-5.4-mini
2f96736ffaabf705873de51f7ea8dae984209d6899667a040f612bbf55e2d9cb => gpt-5.5
6e275cdca0dacb085f061e48b7a0ed825735277207aaa9dfee27a9b24adb4da5 => smart-router
```

Before (base `29035c4a`): the prompt full of custom keywords routes to the weak model because `custom_technical_keywords` is silently ignored

```
$ git checkout --detach 29035c4a99d595321035def4ca5029786d29838e && git rev-parse --short HEAD
29035c4a99
$ .venv-qa/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 41624 > proxy_before.log 2>&1 &

$ curl -sS -D - -o before_body.json http://localhost:41624/v1/chat/completions \
    -H "Authorization: Bearer sk-qa-lit3237" -H "Content-Type: application/json" \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "Our team runs kafka alongside redis and postgresql, plus mongodb for document storage. Lately the dns lookups over udp appear slow, and ssl handshakes to the ssh bastion behind our internal api gateway keep stalling. Suggest a hardening plan for this stack and recommend tuning for each service so everything stays reliable under heavy load."}]}'
HTTP/1.1 200 OK
x-litellm-model-id: d6a6a3a93b891c90b9b55b0cc0c1131ed3f6f5360df766d5ce701e2ba72ae351
x-litellm-model-group: smart-router
x-litellm-model-api-base: https://api.openai.com
x-litellm-response-cost: 0.0101175

$ jq -r '.choices[0].message.content' before_body.json | head -c 200
Here’s a pragmatic hardening and tuning plan for a mixed Kafka + Redis + PostgreSQL + MongoDB stack when you’re seeing **slow UDP DNS lookups** and **TLS/SSH handshake stalls** through an internal API
```

Ran the same curl a second time on the base SHA: same `x-litellm-model-id` `d6a6a3a9...` (gpt-5.4-mini) since the router is deterministic

After (PR head `c5813586`): proxy killed, `git checkout --detach c5813586334944dcbf1f39da864fc06ed17e2471`, proxy restarted with the same config and port, same curl now routes to the strong model

```
$ git rev-parse --short HEAD
c581358633

$ curl -sS -D - -o after_body.json http://localhost:41624/v1/chat/completions \
    -H "Authorization: Bearer sk-qa-lit3237" -H "Content-Type: application/json" \
    -d @same_payload_as_above
HTTP/1.1 200 OK
x-litellm-model-id: 2f96736ffaabf705873de51f7ea8dae984209d6899667a040f612bbf55e2d9cb
x-litellm-model-group: smart-router
x-litellm-response-cost: 0.16249000000000002

$ jq -r '.choices[0].message.content' after_body.json | head -c 200
Below is a practical hardening and tuning plan for Kafka, Redis, PostgreSQL, and MongoDB, with specific attention to slow UDP DNS lookups and stalled TLS/SSH handshakes through an internal gateway.
```

Ran the main prompt three times total on the PR head (including across a proxy restart): all three returned `x-litellm-model-id` `2f96736f...` (gpt-5.5). A control prompt with no technical keywords ("Hello, please share a fun fact about the Eiffel Tower.") routed to `d6a6a3a9...` (gpt-5.4-mini) on both SHAs, confirming the flip is attributable to `custom_technical_keywords` and not a general routing change

## Type

🆕 New Feature

## Changes

Adds a `custom_technical_keywords` option to the complexity router. Unlike `technical_keywords`, which replaces the built-in list entirely, the new field appends domain-specific terms to the effective base list (`technical_keywords` if set, otherwise `DEFAULT_TECHNICAL_KEYWORDS`), preserving order and deduplicating case-insensitively against the base list and within itself. Custom keywords go through the same case-insensitive word boundary matching as the built-ins. This came out of a report from a customer whose technical prompts routed to weaker models because the default list misses common terms; it contains "tcp" but not "udp", for example

On the backend, `ComplexityRouterConfig` gains the new field and `ComplexityRouter.__init__` resolves the merged list through a small pure helper. On the Admin UI, the complexity router form in the Add Auto Router flow gets a tags input for custom technical keywords, and the entered terms are submitted as `custom_technical_keywords: string[]` inside `complexity_router_config` when non-empty

Unit tests cover appending to the defaults, appending to a `technical_keywords` override, case-insensitive dedup, unchanged behavior when the option is absent or null, and a scoring-level check that a prompt matching only custom keywords scores higher on the technicalTerms dimension. UI tests cover rendering the new field, displaying existing keywords as tags, and firing the change callback when a keyword is entered
