### PR TITLE
fix(proxy): sanitize passthrough auth headers

### DIFF
--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -7,6 +7,7 @@ from litellm._logging import verbose_logger
 from litellm.constants import PASS_THROUGH_HEADER_PREFIX
 
 # Headers that must never be forwarded from the raw client request.
+# A configured general_settings.litellm_key_header_name is added at runtime.
 _RAW_FORWARD_EXCLUDED_HEADERS: frozenset = frozenset(
     {
         "api-key",
@@ -26,6 +27,22 @@ _PASS_THROUGH_BLOCKED_HEADERS: frozenset = frozenset({"host", "content-length"})
 
 # Header name prefix used to block AWS SigV4 signing headers from being overridden.
 _PASS_THROUGH_PROTECTED_HEADER_PREFIXES: tuple = ("x-amz-",)
+
+
+def _configured_litellm_key_header_names() -> frozenset[str]:
+    try:
+        from litellm.proxy import proxy_server
+    except ImportError:
+        return frozenset()
+
+    general_settings = getattr(proxy_server, "general_settings", None)
+    if not isinstance(general_settings, dict):
+        return frozenset()
+
+    name = general_settings.get("litellm_key_header_name")
+    if not isinstance(name, str) or not name:
+        return frozenset()
+    return frozenset({name.lower()})
 
 
 class BasePassthroughUtils:
@@ -82,12 +99,13 @@ class BasePassthroughUtils:
                 x_pass_header_names.add(actual_header_name)
 
         if forward_headers is True:
+            raw_forward_excluded_headers = _RAW_FORWARD_EXCLUDED_HEADERS | _configured_litellm_key_header_names()
             forwardable_request_headers = {}
             for header_name, header_value in request_headers.items():
                 normalized_header_name = header_name.lower()
                 if (
                     (
-                        normalized_header_name in _RAW_FORWARD_EXCLUDED_HEADERS
+                        normalized_header_name in raw_forward_excluded_headers
                         and not (normalized_header_name == "authorization" and forward_raw_authorization is True)
                     )
                     or normalized_header_name.startswith(PASS_THROUGH_HEADER_PREFIX)

--- a/litellm/passthrough/utils.py
+++ b/litellm/passthrough/utils.py
@@ -6,19 +6,23 @@ import httpx
 from litellm._logging import verbose_logger
 from litellm.constants import PASS_THROUGH_HEADER_PREFIX
 
-# Headers that must not be overwritten via the x-pass- forwarding mechanism.
-# Includes standard credential/auth headers and protocol-level headers that
-# affect routing or message framing.
-_PASS_THROUGH_PROTECTED_HEADERS: frozenset = frozenset(
+# Headers that must never be forwarded from the raw client request.
+_RAW_FORWARD_EXCLUDED_HEADERS: frozenset = frozenset(
     {
-        "authorization",
         "api-key",
+        "authorization",
+        "content-length",
+        "host",
+        "ocp-apim-subscription-key",
         "x-api-key",
         "x-goog-api-key",
-        "host",
-        "content-length",
+        "x-litellm-api-key",
     }
 )
+
+# Headers that must never be injected via the x-pass- forwarding mechanism
+# because they affect routing or message framing.
+_PASS_THROUGH_BLOCKED_HEADERS: frozenset = frozenset({"host", "content-length"})
 
 # Header name prefix used to block AWS SigV4 signing headers from being overridden.
 _PASS_THROUGH_PROTECTED_HEADER_PREFIXES: tuple = ("x-amz-",)
@@ -56,6 +60,7 @@ class BasePassthroughUtils:
         request_headers: dict,
         headers: dict,
         forward_headers: Optional[bool] = False,
+        forward_raw_authorization: Optional[bool] = False,
     ):
         """
         Helper to forward headers from original request.
@@ -64,34 +69,55 @@ class BasePassthroughUtils:
         with the prefix stripped, regardless of forward_headers setting.
         e.g., 'x-pass-anthropic-beta: value' becomes 'anthropic-beta: value'
         """
-        if forward_headers is True:
-            # Header We Should NOT forward
-            request_headers.pop("content-length", None)
-            request_headers.pop("host", None)
+        configured_header_names = {header_name.lower() for header_name in headers}
+        x_pass_header_names = set()
+        for header_name in request_headers:
+            normalized_header_name = header_name.lower()
+            if normalized_header_name.startswith(PASS_THROUGH_HEADER_PREFIX):
+                actual_header_name = normalized_header_name[len(PASS_THROUGH_HEADER_PREFIX) :]
+                if actual_header_name in _PASS_THROUGH_BLOCKED_HEADERS or any(
+                    actual_header_name.startswith(p) for p in _PASS_THROUGH_PROTECTED_HEADER_PREFIXES
+                ):
+                    continue
+                x_pass_header_names.add(actual_header_name)
 
-            custom_header_names = {header_name.lower() for header_name in headers}
-            for header_name in list(request_headers.keys()):
-                if header_name.lower() in custom_header_names:
-                    request_headers.pop(header_name, None)
+        if forward_headers is True:
+            forwardable_request_headers = {}
+            for header_name, header_value in request_headers.items():
+                normalized_header_name = header_name.lower()
+                if (
+                    (
+                        normalized_header_name in _RAW_FORWARD_EXCLUDED_HEADERS
+                        and not (normalized_header_name == "authorization" and forward_raw_authorization is True)
+                    )
+                    or normalized_header_name.startswith(PASS_THROUGH_HEADER_PREFIX)
+                    or normalized_header_name in configured_header_names
+                    or normalized_header_name in x_pass_header_names
+                ):
+                    continue
+                forwardable_request_headers[header_name] = header_value
 
             # Combine request headers with custom headers
-            headers = {**request_headers, **headers}
+            headers = {**forwardable_request_headers, **headers}
 
         # Process x-pass- prefixed headers (strip prefix and forward)
-        # Credential and protocol-level headers are excluded from this mechanism.
+        existing_header_names = set(configured_header_names)
         for header_name, header_value in request_headers.items():
             if header_name.lower().startswith(PASS_THROUGH_HEADER_PREFIX):
                 # Strip the 'x-pass-' prefix and normalize to lowercase
                 actual_header_name = header_name[len(PASS_THROUGH_HEADER_PREFIX) :].lower()
-                if actual_header_name in _PASS_THROUGH_PROTECTED_HEADERS or any(
-                    actual_header_name.startswith(p) for p in _PASS_THROUGH_PROTECTED_HEADER_PREFIXES
+                if (
+                    actual_header_name in _PASS_THROUGH_BLOCKED_HEADERS
+                    or actual_header_name in existing_header_names
+                    or any(actual_header_name.startswith(p) for p in _PASS_THROUGH_PROTECTED_HEADER_PREFIXES)
                 ):
                     verbose_logger.debug(
-                        "x-pass- header %s maps to a protected header name; skipping",
+                        "x-pass- header %s maps to a blocked or existing header name; skipping",
                         header_name,
                     )
                     continue
                 headers[actual_header_name] = header_value
+                existing_header_names.add(actual_header_name)
 
         return headers
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1998,6 +1998,10 @@ class PassThroughGenericEndpoint(LiteLLMPydanticObjectBase):
         default=False,
         description="If True, requests to subpaths of the path will be forwarded to the target endpoint. For example, if the path is /bria and include_subpath is True, requests to /bria/v1/text-to-image/base/2.3 will be forwarded to the target endpoint.",
     )
+    forward_raw_authorization: bool = Field(
+        default=False,
+        description="If True, allows raw client Authorization forwarding when forward_headers is also enabled. Defaults to False to avoid forwarding the LiteLLM proxy key upstream; prefer x-pass-authorization for provider credentials.",
+    )
     cost_per_request: float = Field(
         default=0.0,
         description="The USD cost per request to the target endpoint. This is used to calculate the cost of the request to the target endpoint.",

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -698,6 +698,7 @@ async def pass_through_request(
     custom_llm_provider: Optional[str] = None,
     guardrails_config: Optional[dict] = None,
     timeout: Optional[float] = None,
+    forward_raw_authorization: Optional[bool] = False,
 ):
     """
     Pass through endpoint handler, makes the httpx request for pass-through endpoints and ensures logging hooks are called
@@ -709,6 +710,7 @@ async def pass_through_request(
         user_api_key_dict: The user API key dictionary
         custom_body: The custom body
         forward_headers: Whether to forward headers
+        forward_raw_authorization: Whether to allow raw Authorization forwarding
         merge_query_params: Whether to merge query params
         query_params: The query params
         default_query_params: The default query params to be applied if not overridden by client
@@ -749,6 +751,7 @@ async def pass_through_request(
             request_headers=_safe_get_request_headers(request).copy(),
             headers=headers,
             forward_headers=forward_headers,
+            forward_raw_authorization=forward_raw_authorization,
         )
 
         # Apply default query parameters if provided, regardless of merge_query_params setting
@@ -1497,6 +1500,7 @@ def create_pass_through_route(
     guardrails: Optional[Dict[str, Any]] = None,
     config_file_path: Optional[str] = None,
     timeout: Optional[float] = None,
+    _forward_raw_authorization: Optional[bool] = False,
 ):
     # check if target is an adapter.py or a url
     from litellm._uuid import uuid
@@ -1570,6 +1574,7 @@ def create_pass_through_route(
                 "target": target,
                 "custom_headers": custom_headers,
                 "forward_headers": _forward_headers,
+                "forward_raw_authorization": _forward_raw_authorization,
                 "merge_query_params": _merge_query_params,
                 "cost_per_request": cost_per_request,
                 "guardrails": None,
@@ -1583,6 +1588,10 @@ def create_pass_through_route(
             param_target = target_params.get("target") or target
             param_custom_headers = target_params.get("custom_headers", custom_headers)
             param_forward_headers = target_params.get("forward_headers", _forward_headers)
+            param_forward_raw_authorization = target_params.get(
+                "forward_raw_authorization",
+                _forward_raw_authorization,
+            )
             param_merge_query_params = target_params.get("merge_query_params", _merge_query_params)
             param_cost_per_request = target_params.get("cost_per_request", cost_per_request)
             param_guardrails = target_params.get("guardrails", None)
@@ -1624,6 +1633,10 @@ def create_pass_through_route(
                     custom_headers=headers_dict,
                     user_api_key_dict=user_api_key_dict,
                     forward_headers=cast(Optional[bool], param_forward_headers),
+                    forward_raw_authorization=cast(
+                        Optional[bool],
+                        param_forward_raw_authorization,
+                    ),
                     merge_query_params=cast(Optional[bool], param_merge_query_params),
                     query_params=final_query_params,
                     default_query_params=cast(Optional[dict], param_default_query_params),
@@ -2242,6 +2255,7 @@ class InitPassThroughEndpointHelpers:
         config_file_path: Optional[str] = None,
         auth: bool = False,
         timeout: Optional[float] = None,
+        forward_raw_authorization: Optional[bool] = False,
     ):
         """Add exact path route for pass-through endpoint"""
         # Default to all methods if none specified (backward compatibility)
@@ -2283,6 +2297,7 @@ class InitPassThroughEndpointHelpers:
                 guardrails=guardrails,
                 config_file_path=config_file_path,
                 timeout=timeout,
+                _forward_raw_authorization=forward_raw_authorization,
             ),
             methods=methods,
             dependencies=dependencies,
@@ -2299,6 +2314,7 @@ class InitPassThroughEndpointHelpers:
                 "target": target,
                 "custom_headers": custom_headers,
                 "forward_headers": forward_headers,
+                "forward_raw_authorization": forward_raw_authorization,
                 "merge_query_params": merge_query_params,
                 "default_query_params": default_query_params,
                 "dependencies": dependencies,
@@ -2325,6 +2341,7 @@ class InitPassThroughEndpointHelpers:
         config_file_path: Optional[str] = None,
         auth: bool = False,
         timeout: Optional[float] = None,
+        forward_raw_authorization: Optional[bool] = False,
     ):
         """Add wildcard route for sub-paths"""
         # Default to all methods if none specified (backward compatibility)
@@ -2367,6 +2384,7 @@ class InitPassThroughEndpointHelpers:
                 guardrails=guardrails,
                 config_file_path=config_file_path,
                 timeout=timeout,
+                _forward_raw_authorization=forward_raw_authorization,
             ),
             methods=methods,
             dependencies=dependencies,
@@ -2383,6 +2401,7 @@ class InitPassThroughEndpointHelpers:
                 "target": target,
                 "custom_headers": custom_headers,
                 "forward_headers": forward_headers,
+                "forward_raw_authorization": forward_raw_authorization,
                 "merge_query_params": merge_query_params,
                 "default_query_params": default_query_params,
                 "dependencies": dependencies,
@@ -2541,6 +2560,7 @@ async def _register_pass_through_endpoint(
 
     custom_headers = await set_env_variables_in_header(custom_headers=endpoint_data.get("headers"))
     forward_headers = endpoint_data.get("forward_headers")
+    forward_raw_authorization = endpoint_data.get("forward_raw_authorization", False)
     merge_query_params = endpoint_data.get("merge_query_params")
     default_query_params = endpoint_data.get("default_query_params")
     auth = endpoint_data.get("auth")
@@ -2581,6 +2601,7 @@ async def _register_pass_through_endpoint(
         config_file_path=config_file_path,
         auth=auth_enforced,
         timeout=timeout,
+        forward_raw_authorization=forward_raw_authorization,
     )
 
     methods_for_key = methods if methods else ["GET", "POST", "PUT", "DELETE", "PATCH"]
@@ -2608,6 +2629,7 @@ async def _register_pass_through_endpoint(
             config_file_path=config_file_path,
             auth=auth_enforced,
             timeout=timeout,
+            forward_raw_authorization=forward_raw_authorization,
         )
         visited_endpoints.add(f"{endpoint_id}:subpath:{path}:{methods_str}")
 

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1751,16 +1751,16 @@ async def websocket_passthrough_request(
     upstream_headers = custom_headers.copy()
 
     if forward_headers:
-        # Forward relevant headers from the incoming request
-        incoming_headers = dict(websocket.headers)
-        for header_name, header_value in incoming_headers.items():
-            # Only forward certain headers to avoid conflicts
-            if header_name.lower() in [
-                "authorization",
-                "x-api-key",
-                "x-goog-user-project",
-            ]:
-                upstream_headers[header_name] = header_value
+        incoming_headers = {
+            header_name: header_value
+            for header_name, header_value in dict(websocket.headers).items()
+            if header_name.lower() == "x-goog-user-project"
+        }
+        upstream_headers = HttpPassThroughEndpointHelpers.forward_headers_from_request(
+            request_headers=incoming_headers,
+            headers=upstream_headers,
+            forward_headers=True,
+        )
 
     # Initialize logging object similar to HTTP passthrough
     logging_obj = Logging(

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1853,6 +1853,98 @@ class TestForwardHeaders:
     """
 
     @pytest.mark.asyncio
+    async def test_websocket_forward_headers_strips_proxy_credentials(self):
+        from contextlib import asynccontextmanager
+
+        from starlette.websockets import WebSocketState
+
+        import litellm.proxy.proxy_server as proxy_server
+        from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
+            websocket_passthrough_request,
+        )
+
+        original_general_settings = proxy_server.general_settings
+        proxy_server.general_settings = {
+            "litellm_key_header_name": "X-My-Tenant-Key",
+        }
+
+        mock_websocket = MagicMock()
+        mock_websocket.headers = {
+            "authorization": "Bearer proxy-token",
+            "x-api-key": "proxy-api-key",
+            "X-My-Tenant-Key": "tenant-proxy-key",
+            "x-goog-user-project": "billing-project",
+        }
+        mock_websocket.accept = AsyncMock()
+        mock_websocket.close = AsyncMock()
+        mock_websocket.receive = AsyncMock(
+            return_value={"type": "websocket.disconnect"}
+        )
+        mock_websocket.send_text = AsyncMock()
+        mock_websocket.client_state = WebSocketState.CONNECTED
+
+        mock_logging_obj = MagicMock()
+        mock_logging_obj.model_call_details = {}
+
+        mock_proxy_logging_obj = MagicMock()
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
+        mock_proxy_logging_obj.post_call_success_hook = AsyncMock(return_value=None)
+        mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+        mock_upstream_ws = MagicMock()
+        mock_upstream_ws.send = AsyncMock()
+        mock_upstream_ws.recv = AsyncMock(return_value=b"{}")
+        mock_upstream_ws.close = AsyncMock()
+        mock_upstream_ws.__aiter__.return_value = []
+
+        @asynccontextmanager
+        async def mock_connect_context(*args, **kwargs):
+            yield mock_upstream_ws
+
+        try:
+            with (
+                patch(
+                    "litellm.litellm_core_utils.litellm_logging.Logging",
+                    return_value=mock_logging_obj,
+                ),
+                patch(
+                    "litellm.proxy.proxy_server.proxy_logging_obj",
+                    mock_proxy_logging_obj,
+                ),
+                patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.connect",
+                    side_effect=mock_connect_context,
+                ) as mock_connect,
+                patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.pass_through_endpoint_logging."
+                    "pass_through_async_success_handler",
+                    new=Mock(return_value=None),
+                ),
+                patch(
+                    "litellm.proxy.pass_through_endpoints.pass_through_endpoints.GLOBAL_LOGGING_WORKER."
+                    "ensure_initialized_and_enqueue",
+                ),
+            ):
+                await websocket_passthrough_request(
+                    websocket=mock_websocket,
+                    target="wss://example.com/live",
+                    custom_headers={"Authorization": "Bearer provider-token"},
+                    user_api_key_dict=UserAPIKeyAuth(api_key="hashed-proxy-key"),
+                    forward_headers=True,
+                    accept_websocket=False,
+                )
+        finally:
+            proxy_server.general_settings = original_general_settings
+
+        sent_headers = mock_connect.call_args.kwargs["additional_headers"]
+        assert sent_headers["Authorization"] == "Bearer provider-token"
+        assert sent_headers["x-goog-user-project"] == "billing-project"
+        assert "authorization" not in sent_headers
+        assert "x-api-key" not in sent_headers
+        assert "X-My-Tenant-Key" not in sent_headers
+        mock_proxy_logging_obj.post_call_failure_hook.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_pass_through_request_with_forward_headers_true(self):
         """
         Test that when forward_headers=True, user headers from the main request

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -1874,8 +1874,10 @@ class TestForwardHeaders:
         # User headers that should be forwarded
         user_headers = {
             "x-custom-header": "custom-value",
-            "x-api-key": "user-api-key",
-            "authorization": "Bearer user-token",
+            "x-api-key": "proxy-api-key",
+            "authorization": "Bearer sk-litellm-proxy-token",
+            "x-pass-authorization": "Bearer provider-token",
+            "x-pass-x-api-key": "provider-api-key",
             "user-agent": "test-client/1.0",
             "content-type": "application/json",
             # These should NOT be forwarded
@@ -1950,8 +1952,10 @@ class TestForwardHeaders:
 
             # Verify user headers were forwarded (except content-length and host)
             assert sent_headers["x-custom-header"] == "custom-value"
-            assert sent_headers["x-api-key"] == "user-api-key"
-            assert sent_headers["authorization"] == "Bearer user-token"
+            assert sent_headers["x-api-key"] == "provider-api-key"
+            assert sent_headers["authorization"] == "Bearer provider-token"
+            assert "x-pass-authorization" not in sent_headers
+            assert "x-pass-x-api-key" not in sent_headers
             assert sent_headers["user-agent"] == "test-client/1.0"
             assert sent_headers["content-type"] == "application/json"
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -582,6 +582,33 @@ def test_forward_headers_strips_proxy_credentials_and_uses_x_pass_auth():
     assert result.get("x-api-key") != "proxy-x-api-key"
 
 
+def test_forward_headers_strips_configured_custom_proxy_key_header():
+    """
+    A custom general_settings.litellm_key_header_name is also a proxy credential
+    header and must not be raw-forwarded upstream.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+    from litellm.proxy import proxy_server
+
+    original_general_settings = getattr(proxy_server, "general_settings", None)
+    proxy_server.general_settings = {"litellm_key_header_name": "X-My-Tenant-Key"}
+    try:
+        result = BasePassthroughUtils.forward_headers_from_request(
+            request_headers={
+                "X-My-Tenant-Key": "sk-litellm-custom",
+                "x-custom-header": "custom-value",
+            },
+            headers={},
+            forward_headers=True,
+        )
+    finally:
+        proxy_server.general_settings = original_general_settings
+
+    assert "X-My-Tenant-Key" not in result
+    assert "x-my-tenant-key" not in result
+    assert result["x-custom-header"] == "custom-value"
+
+
 def test_forward_headers_can_forward_raw_authorization_with_explicit_opt_in():
     """
     Operators who intentionally used forward_headers=True to pass caller

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py
@@ -486,9 +486,8 @@ def test_forward_headers_from_request_x_pass_prefix():
 
 def test_forward_headers_from_request_protected_headers_not_overwritten():
     """
-    Test that x-pass- headers whose stripped names resolve to credential or
-    protocol-level header names are silently dropped and do not overwrite
-    values already present in the outbound headers dict.
+    Test that x-pass- credential headers do not overwrite configured upstream
+    credential headers, while protocol-level headers are still blocked.
     """
     from litellm.passthrough.utils import BasePassthroughUtils
 
@@ -518,7 +517,7 @@ def test_forward_headers_from_request_protected_headers_not_overwritten():
         forward_headers=False,
     )
 
-    # Protected headers must retain the proxy-configured values
+    # Configured credential headers must retain their upstream values
     assert result["authorization"] == "Bearer proxy-upstream-key"
     assert result["api-key"] == "proxy-azure-key"
     assert result["x-api-key"] == "proxy-anthropic-key"
@@ -536,6 +535,100 @@ def test_forward_headers_from_request_protected_headers_not_overwritten():
 
     # Header name must be normalized to lowercase in output
     assert "Anthropic-Beta" not in result
+
+
+def test_forward_headers_strips_proxy_credentials_and_uses_x_pass_auth():
+    """
+    Generic passthrough routes authenticate the caller with proxy credential
+    headers; x-pass-* is the explicit way to send provider auth upstream.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    request_headers = {
+        "authorization": "Bearer sk-litellm-master",
+        "api-key": "proxy-api-key",
+        "x-api-key": "proxy-x-api-key",
+        "x-goog-api-key": "proxy-google-api-key",
+        "ocp-apim-subscription-key": "proxy-apim-key",
+        "x-litellm-api-key": "proxy-litellm-key",
+        "x-pass-authorization": "Bearer provider-oauth-token",
+        "x-pass-x-api-key": "provider-api-key",
+        "x-pass-anthropic-beta": "context-1m-2025-08-07",
+        "x-custom-header": "custom-value",
+        "content-length": "123",
+        "host": "proxy.example.com",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers={},
+        forward_headers=True,
+    )
+
+    assert result["authorization"] == "Bearer provider-oauth-token"
+    assert result["x-api-key"] == "provider-api-key"
+    assert result["anthropic-beta"] == "context-1m-2025-08-07"
+    assert result["x-custom-header"] == "custom-value"
+    assert "x-pass-authorization" not in result
+    assert "x-pass-x-api-key" not in result
+    assert "x-pass-anthropic-beta" not in result
+    assert "api-key" not in result
+    assert "x-goog-api-key" not in result
+    assert "ocp-apim-subscription-key" not in result
+    assert "x-litellm-api-key" not in result
+    assert "content-length" not in result
+    assert "host" not in result
+    assert result.get("authorization") != "Bearer sk-litellm-master"
+    assert result.get("x-api-key") != "proxy-x-api-key"
+
+
+def test_forward_headers_can_forward_raw_authorization_with_explicit_opt_in():
+    """
+    Operators who intentionally used forward_headers=True to pass caller
+    Authorization upstream can restore that legacy behavior per endpoint.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    request_headers = {
+        "authorization": "Bearer upstream-caller-token",
+        "x-api-key": "proxy-x-api-key",
+        "x-custom-header": "custom-value",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers={},
+        forward_headers=True,
+        forward_raw_authorization=True,
+    )
+
+    assert result["authorization"] == "Bearer upstream-caller-token"
+    assert "x-api-key" not in result
+    assert result["x-custom-header"] == "custom-value"
+
+
+def test_forward_headers_x_pass_overrides_same_request_raw_header():
+    """
+    x-pass-* is the explicit override path for upstream headers from the same
+    client request. It should only lose to configured/signed upstream headers.
+    """
+    from litellm.passthrough.utils import BasePassthroughUtils
+
+    request_headers = {
+        "Anthropic-Beta": "raw-beta",
+        "x-pass-anthropic-beta": "explicit-beta",
+        "x-request-id": "req-123",
+    }
+
+    result = BasePassthroughUtils.forward_headers_from_request(
+        request_headers=request_headers,
+        headers={},
+        forward_headers=True,
+    )
+
+    assert result["anthropic-beta"] == "explicit-beta"
+    assert "Anthropic-Beta" not in result
+    assert result["x-request-id"] == "req-123"
 
 
 def test_forward_headers_custom_wins_case_insensitive_over_request_authorization():

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -28318,6 +28318,12 @@ export interface components {
                 [key: string]: unknown;
             };
             /**
+             * Forward Raw Authorization
+             * @description If True, allows raw client Authorization forwarding when forward_headers is also enabled. Defaults to False to avoid forwarding the LiteLLM proxy key upstream; prefer x-pass-authorization for provider credentials.
+             * @default false
+             */
+            forward_raw_authorization: boolean;
+            /**
              * Guardrails
              * @description Guardrails configuration for this passthrough endpoint. Dict keys are guardrail names, values are optional settings for field targeting. When set, all org/team/key level guardrails will also execute. Defaults to None (no guardrails execute).
              */


### PR DESCRIPTION
﻿## Relevant issues

Fixes #32202

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Local reproduction with a LiteLLM proxy configured with `pass_through_endpoints.forward_headers: true` and a mock upstream that echoes received headers.

Request sent to LiteLLM:

```bash
curl http://127.0.0.1:4001/anthropic/v1/messages \
  -H "Authorization: Bearer sk-litellm-master" \
  -H "x-pass-authorization: Bearer PROVIDER_OAUTH_123" \
  -H "x-pass-anthropic-beta: context-1m-2025-08-07" \
  -H "content-type: application/json" \
  --data-binary @tmp_32202_body.json
```

Mock upstream received:

```json
{
  "received_headers": {
    "anthropic-beta": "context-1m-2025-08-07",
    "authorization": "Bearer PROVIDER_OAUTH_123",
    "content-type": "application/json",
    "host": "127.0.0.1:8899"
  }
}
```

The upstream received the provider credential from `x-pass-authorization` with the prefix stripped. It did not receive the LiteLLM proxy key (`sk-litellm-master`) and did not receive raw `x-pass-*` headers.

## Type

Bug Fix
Test

## Changes

- Separates raw `forward_headers` merging from explicit `x-pass-*` forwarding.
- Blocks raw forwarding of LiteLLM proxy credential headers by default: `Authorization`, `api-key`, `x-api-key`, `x-goog-api-key`, `Ocp-Apim-Subscription-Key`, and `x-litellm-api-key`.
- Continues blocking protocol/framing headers (`host`, `content-length`) and raw `x-pass-*` header names.
- Allows provider credentials to be sent explicitly through `x-pass-*`, including `x-pass-authorization` and `x-pass-x-api-key`, while stripping the prefix before forwarding upstream.
- Preserves configured/signed upstream header precedence case-insensitively.
- Lets explicit `x-pass-*` headers win over same-request raw headers while still losing to configured provider headers.
- Adds an endpoint-level compatibility escape hatch, `forward_raw_authorization: true`, for operators who intentionally relied on raw caller `Authorization` forwarding with `forward_headers: true`.
- Updates the generated dashboard OpenAPI TypeScript schema for the new pass-through endpoint field.

## Tests

```bash
D:\miniconda\Scripts\pytest.exe tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py::test_forward_headers_strips_proxy_credentials_and_uses_x_pass_auth tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py::test_forward_headers_can_forward_raw_authorization_with_explicit_opt_in tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py::test_forward_headers_x_pass_overrides_same_request_raw_header -q
# 3 passed

D:\miniconda\Scripts\pytest.exe tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py::TestForwardHeaders::test_pass_through_request_with_forward_headers_true -q
# 1 passed

D:\miniconda\Scripts\pytest.exe tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py -q
# 14 passed

D:\miniconda\Scripts\pytest.exe tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py::TestForwardHeaders -q
# 3 passed, 1 warning

D:\miniconda\Scripts\ruff.exe format --check litellm/passthrough/utils.py litellm/proxy/pass_through_endpoints/pass_through_endpoints.py litellm/proxy/_types.py
# 3 files already formatted

D:\miniconda\Scripts\ruff.exe check litellm/passthrough/utils.py litellm/proxy/pass_through_endpoints/pass_through_endpoints.py litellm/proxy/_types.py
# All checks passed!

git diff --check -- litellm/passthrough/utils.py litellm/proxy/_types.py litellm/proxy/pass_through_endpoints/pass_through_endpoints.py tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py tests/test_litellm/proxy/pass_through_endpoints/test_vertex_passthrough_load_balancing.py ui/litellm-dashboard/src/lib/http/schema.d.ts
# passed
```

