### PR TITLE
feat(guardrails): add Compresr query-aware context compression guardrail

### DIFF
--- a/COMPRESR_INTEGRATION.md
+++ b/COMPRESR_INTEGRATION.md
@@ -1,0 +1,214 @@
+# Compresr guardrail for LiteLLM — what we built, how to try it, how we maintain it
+
+**Branch:** `litellm_compresr_cleanup` on [`Ousso11/litellm`](https://github.com/Ousso11/litellm/tree/litellm_compresr_cleanup) (commit `6caaacc55d`)
+**Base:** `litellm_internal_staging` (current as of 2026-07-05, includes everything upstream `main` has)
+**Status:** implemented, all repo lint/type gates green, 45/45 unit tests passing, verified live against the real Compresr API
+
+---
+
+## 1. What this is
+
+A first-class LiteLLM **guardrail** that compresses bulky message content (tool outputs, RAG chunks, search results) through the Compresr API before the request reaches the LLM — and, unlike every other compression integration we know of, makes it **recoverable**: the model can pull the original content back on demand via an injected tool.
+
+It's the "best of both" between our existing SDK-side guardrail (`compresr.integrations.litellm`, shipped in the `compresr` pip package) and the Headroom guardrail that LiteLLM merged upstream in June 2026:
+
+| Aspect | Taken from | Detail |
+|---|---|---|
+| Hook surface | Headroom | `apply_guardrail` + `structured_messages` — fires on `/chat/completions`, `/v1/messages` (Anthropic), **and** `/v1/responses`. Our old SDK guardrail used `async_pre_call_hook`, which misses the Responses API. |
+| Transport | Headroom | Plain httpx via LiteLLM's `get_async_httpx_client`. **Zero pip dependencies** — no `pip install compresr` needed. |
+| Query-aware compression | Ours | Each message is compressed against the *intent* that produced it: for a tool output, the originating tool call's `name + arguments` (resolved via `tool_call_id`); otherwise the last user message. Headroom compresses the whole message list blind. |
+| Target selection | Ours | Tool/function outputs by default; system prompt, prior user history, and the last user message are opt-in; messages under 500 chars skipped; multimodal messages have text parts compressed and images/audio passed through untouched. |
+| Recovery (new) | Neither — new design | Headroom stores originals **server-side** and retrieves over HTTP. We don't need a server: the guardrail already holds the original text (we sent it to the API ourselves), so originals are cached in-process and served back through LiteLLM's agentic loop. No backend changes required. |
+| Bypass header | Headroom | `x-compresr-bypass: true` skips compression per request. |
+| Failure policy | Both | `unreachable_fallback: fail_closed` (default, request 502s if Compresr is down) or `fail_open` (logs critical, forwards uncompressed). |
+
+### How recovery works (the cool part)
+
+1. During `apply_guardrail`, each compressed message gets a marker appended:
+
+   ```
+   [compresr hash=810a5b8d17dd56ddf95396cb: parts of this content were compressed away.
+    If you need the full original, call the compresr_retrieve tool with this hash.]
+   ```
+
+   The original text is stored in-process under `sha256(original)[:24]`, scoped to this request's `litellm_call_id`, with a 15-minute TTL and a hard cap of 256 tracked calls.
+
+2. A `compresr_retrieve` tool is merged into the request's tool list.
+
+3. If the model calls it, LiteLLM's agentic-loop hooks (`async_should_run_agentic_loop` / `async_build_agentic_loop_plan`) answer the tool call with the stored original and re-run the request. One extra LLM round-trip, and only when the model actually asks. Follow-up message shapes are handled for all three API styles (chat tool-role, Anthropic `tool_use`/`tool_result`, Responses `function_call`/`function_call_output`).
+
+4. Security: a hash is only honored for the request that issued it. A hash pasted in from another conversation (or forged in a prompt) returns a not-found message, never content. This matters because the store is shared proxy memory.
+
+Set `enable_retrieval: false` in `optional_params` to get plain lossy compression with no marker and no tool.
+
+## 2. Exact changes
+
+Seven files, +2,375 / −17:
+
+| File | Lines | What it does |
+|---|---|---|
+| `litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py` | 837 | The guardrail: target selection, query derivation, dependency-free API client (`POST /api/compress/question-specific/` and `/batch`, `X-API-Key` auth), recovery store, agentic-loop hooks, stats logging via `add_standard_logging_guardrail_information_to_request_data`. |
+| `litellm/proxy/guardrails/guardrail_hooks/compresr/__init__.py` | 69 | `initialize_guardrail` + the two registries LiteLLM's discovery walk looks for. No central registration needed — the proxy discovers guardrail packages by walking `guardrail_hooks/`. |
+| `litellm/proxy/guardrails/guardrail_hooks/compresr/README.md` | 79 | Quickstart + config reference (Headroom shipped no docs at all). |
+| `litellm/types/proxy/guardrails/guardrail_hooks/compresr.py` | 78 | Pydantic config model (drives YAML validation and the admin-UI form). UI name: "Compresr (context compression)". |
+| `litellm/types/guardrails.py` | +39/−17 | `COMPRESR = "compresr"` enum entry, config-model import + registration in `LitellmParams`, `'compresr'` added to the `unreachable_fallback` docstring. (Most of the churn is ruff-strict import re-sorting.) |
+| `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py` | 1036 | 45 tests mirroring the structure of `test_headroom.py`. |
+
+Defaults, all overridable in YAML: model `latte_v2`, `target_compression_ratio 0.5`, `coarse true`, `min_chars_to_compress 500`, `enable_retrieval true`, API base `https://api.compresr.ai` (env `COMPRESR_API_BASE` for on-prem), key from `COMPRESR_API_KEY`.
+
+## 3. Try it
+
+### Setup (5 minutes)
+
+```bash
+git clone --filter=blob:none --branch compresr-integration git@github.com:charafkamel/litellm.git
+cd litellm
+python3 -m venv .venv
+.venv/bin/pip install -e ".[proxy]"
+export COMPRESR_API_KEY=cmp_...        # ask Kamel for a key
+```
+
+### Example A — see the compression with your own eyes (no LLM key needed)
+
+Uses a tiny fake upstream that records exactly what the proxy forwards, so you can diff original vs compressed. Grab `echo_upstream.py` and `websearch_request.json` from `Compresr-SDK-Private/python/tutorial/litellm/demo/` (or ask me for them). Note: `Compresr-SDK-Private/` is a private repository — these demo files are not required to run the guardrail itself.
+
+`config.yaml`:
+
+```yaml
+model_list:
+  - model_name: demo-model
+    litellm_params:
+      model: openai/demo-model
+      api_base: http://127.0.0.1:8199/v1
+      api_key: fake-upstream-key
+
+guardrails:
+  - guardrail_name: compresr
+    litellm_params:
+      guardrail: compresr
+      mode: pre_call
+      default_on: true
+
+general_settings:
+  master_key: sk-demo-1234
+```
+
+Run:
+
+```bash
+python3 echo_upstream.py &                                   # fake upstream on :8199
+.venv/bin/litellm --config config.yaml --port 4100 &         # proxy with the guardrail
+
+curl -s http://127.0.0.1:4100/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-1234" \
+  -H "Content-Type: application/json" \
+  -d @websearch_request.json | head -c 300
+
+python3 -c "
+import json
+orig = json.load(open('websearch_request.json'))
+fwd  = json.load(open('forwarded_request.json'))   # written by echo_upstream
+o = next(m for m in orig['messages'] if m['role']=='tool')['content']
+f = next(m for m in fwd['messages']  if m['role']=='tool')['content']
+print(f'tool output: {len(o)} chars -> {len(f)} chars')
+print('retrieve tool injected:', any(t['function']['name']=='compresr_retrieve' for t in fwd.get('tools',[])))
+"
+```
+
+What we measured on this exact request: `3396 chars -> 2077 chars` (39% smaller), recovery marker present, `compresr_retrieve` injected, and the user question + system prompt byte-identical to the original.
+
+### Example B — bypass header
+
+```bash
+curl -s http://127.0.0.1:4100/v1/chat/completions \
+  -H "Authorization: Bearer sk-demo-1234" \
+  -H "Content-Type: application/json" \
+  -H "x-compresr-bypass: true" \
+  -d @websearch_request.json > /dev/null
+```
+
+`forwarded_request.json` now shows the tool output untouched and no injected tool. Verified live.
+
+### Example C — recovery loop with a real model
+
+Point the model at a real provider and ask for a detail that compression is likely to drop:
+
+```yaml
+model_list:
+  - model_name: demo-model
+    litellm_params:
+      model: openai/gpt-5-mini
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+Then send a conversation whose tool output buries a precise figure, and ask for that figure verbatim. If the compressed version kept it, you get a direct answer (cheap path). If it didn't, the model calls `compresr_retrieve`, LiteLLM runs the agentic round-trip transparently, and the final response comes back grounded in the full original — your client sees one normal response either way. Watch the proxy logs with `--detailed_debug` to see the `Compresr retrieve: hash=... -> N chars` line when the loop fires. Note the loop triggers only when the model decides it needs more; adding "If content was compressed away and you're missing a detail, retrieve it before answering" to the system prompt makes it eager.
+
+### Example D — tuning
+
+```yaml
+guardrails:
+  - guardrail_name: compresr
+    litellm_params:
+      guardrail: compresr
+      mode: pre_call
+      default_on: true
+      model: latte_v2
+      unreachable_fallback: fail_open     # never block traffic on a Compresr outage
+      optional_params:
+        target_compression_ratio: 4       # >1 means Nx smaller; 0-1 means fraction removed
+        coarse: false                     # token-level instead of paragraph-level
+        compress_system: true             # also compress long system prompts
+        enable_retrieval: false           # plain lossy mode
+```
+
+### Run the tests and gates
+
+```bash
+.venv/bin/python -m pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py -q   # 37 passed
+.venv/bin/pip install ruff basedpyright
+PATH="$PWD/.venv/bin:$PATH" .venv/bin/python scripts/ruff_strict_gate.py    --base origin/litellm_internal_staging
+PATH="$PWD/.venv/bin:$PATH" .venv/bin/python scripts/type_discipline_gate.py --base origin/litellm_internal_staging
+PATH="$PWD/.venv/bin:$PATH" bash -c '(basedpyright --outputjson || true) | python scripts/type_check_gate.py --base origin/litellm_internal_staging'
+```
+
+All three pass on this branch. The wider `tests/test_litellm/proxy/guardrails/` folder has 58 pre-existing failures (prisma/DB fixtures missing in a bare env); we verified they reproduce identically on the clean base, so they are not ours.
+
+## 4. Known limitations (honest list)
+
+### ⚠️ Multi-worker deployments
+
+**Originals are stored in process memory.** When you run LiteLLM with multiple workers (`gunicorn`/`uvicorn --workers N` where N > 1), pre-call and post-call (retrieval) hooks can land on **different worker processes**. The worker that compressed the message never shares its in-process store with the worker that later handles the `compresr_retrieve` tool call. The model silently receives a not-found response instead of the original content.
+
+**Mitigation options:**
+- Run with `--workers 1` (default for the LiteLLM proxy — recommended unless you need concurrency at the proxy layer).
+- Set `enable_retrieval: false` in `optional_params` to use plain lossy compression with no recovery store, no tool injection, and no cross-worker problem.
+- Future: Redis-backed originals store (tracked in maintenance plan below).
+
+This constraint is documented in the module docstring of `compresr.py` near the `_originals_by_call_id` store.
+
+- **The recovery store is per-process.** Single proxy instance: fine (retrieval happens seconds after compression, within the same conversation turn). Multi-replica without sticky routing: a retrieve can land on a pod that never saw the compress, and the model gets a polite not-found. Same limitation Headroom's own hash-validity store has. Redis-backed storage is the known fix if it ever matters.
+- **`source` analytics tag is `gateway:unknown`.** The platform API validates `source` against an enum and has no `gateway:litellm` member yet — the live test caught this (422). Backend should add one; one-line change here afterwards.
+- **Streaming responses:** compression happens pre-call so streaming requests are compressed fine, but the recovery agentic loop on a *streamed* tool-call response follows whatever LiteLLM's loop supports — we have unit coverage, not live-stream coverage.
+- **Marker collision:** our marker regex is `compresr hash=<24hex>`, deliberately distinct, but Headroom's looser `hash=<24hex>` regex would also match inside our marker. Only matters if someone runs both guardrails on the same request, which nobody should.
+
+## 5. Maintenance plan
+
+**Ownership.** This lives on our fork until we decide to PR it upstream. Treat `compresr-integration` as the integration trunk; branch off it for changes, land via PR into it (base PRs on `litellm_internal_staging` only if/when we go upstream — that repo's convention is never to base on `main`).
+
+**Weekly (or before any demo): rebase + gates.**
+
+```bash
+git fetch origin litellm_internal_staging
+git rebase origin/litellm_internal_staging compresr-integration
+# then: pytest test_compresr.py + the three gate commands above
+```
+
+The three things upstream churn can break, in likelihood order: (1) the agentic-loop hook signatures in `litellm/integrations/custom_logger.py` — new, still evolving (Headroom needed 4 PRs in one week); (2) the `guardrail_translation` handlers that feed `structured_messages`; (3) `LitellmParams`/config-model plumbing in `types/guardrails.py`. Cheap tripwire: `git log --oneline <old>..origin/litellm_internal_staging -- litellm/integrations/custom_logger.py litellm/llms/*/chat/guardrail_translation/ litellm/proxy/guardrails/guardrail_hooks/headroom/` after each fetch — if Headroom's guardrail changed, we probably want the same change.
+
+**Sync with our backend.** The guardrail hardcodes the two endpoint paths and the response envelope (`data.compressed_context`, `data.results[]`). Any platform API change to `/api/compress/question-specific/*` must update `_call_compress` and the test fixtures in the same PR. Pending backend asks: add `gateway:litellm` to the `source` enum; optionally a keyed-placeholder mode so markers can sit inline where content was dropped instead of appended.
+
+**Testing debt, in priority order:** (1) an `initialize_guardrail` test that feeds a real `LitellmParams` and asserts every optional_param lands on the constructor — that mapping is currently untested here *and* in our SDK package, and it's where config silently rots; (2) fail-open variants for the batch path; (3) a live-stream recovery test. Target: parity with Headroom's 43 tests before any upstream PR.
+
+**Relationship to the SDK package.** `compresr.integrations.litellm` (pip) still exists and works on older LiteLLM via the shim/CLI. Decision made: new features (recovery, Responses API coverage) go **here first**; the SDK package is maintenance-only until we decide whether to port this back or deprecate it in favor of the upstream path. Don't implement features twice.
+
+**Path to upstream.** When we're ready: rebase, rename base to a fresh branch off `litellm_internal_staging`, bring the test count to Headroom parity, write the PR body per `.github/pull_request_template.md` with a live curl proof (their maintainers explicitly want real-traffic proof, not pytest output — we already have the workflow for this), and include the README as the docs story Headroom never shipped. The precedent is exactly PR #31407 + #31681 (Headroom, merged within days, maintainer-authored follow-ups) — our footprint is the same shape and smaller blast radius.

--- a/litellm/proxy/guardrails/guardrail_hooks/compresr/README.md
+++ b/litellm/proxy/guardrails/guardrail_hooks/compresr/README.md
@@ -1,0 +1,92 @@
+# Compresr Guardrail — query-aware context compression with lossless recovery
+
+[Compresr](https://compresr.ai) compresses bulky message content (tool outputs,
+RAG chunks, search results) before the request reaches the LLM, cutting prompt
+tokens without losing the information the model actually needs for the current
+question.
+
+Two things set it apart from whole-conversation compressors:
+
+- **Query-aware:** each message is compressed against the *intent* that
+  produced it — for a tool output, the originating tool call's
+  `name + arguments` (resolved via `tool_call_id`); otherwise the last user
+  message. Content relevant to the question survives; noise goes.
+- **Recoverable, not lossy:** every compressed message carries a
+  `compresr hash=<...>` marker and the request gains a `compresr_retrieve`
+  tool. If the model finds the compressed version insufficient, it calls the
+  tool and LiteLLM's agentic loop transparently feeds the original content
+  back — no application changes.
+
+## Quickstart
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+
+guardrails:
+  - guardrail_name: compresr
+    litellm_params:
+      guardrail: compresr
+      mode: pre_call
+      default_on: true
+      api_key: os.environ/COMPRESR_API_KEY
+```
+
+That's it. Tool/function outputs longer than 500 characters are now compressed
+~2x, query-aware, on `/chat/completions`, `/v1/messages`, and `/v1/responses`.
+
+## Configuration
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `api_key` | `COMPRESR_API_KEY` env | Compresr API key (`cmp_...`) |
+| `api_base` | `https://api.compresr.ai` | Point at your on-prem Compresr deployment |
+| `model` | `latte_v2` | Compresr compression model (not the LLM) |
+| `unreachable_fallback` | `fail_closed` | `fail_open` forwards uncompressed when Compresr is down |
+
+Optional tuning, under `optional_params`:
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `target_compression_ratio` | `0.5` | 0–1 = fraction of tokens to remove; >1 = Nx reduction factor |
+| `coarse` | `true` | Paragraph-level (faster) vs token-level compression |
+| `min_chars_to_compress` | `500` | Skip messages shorter than this |
+| `compress_tool_outputs` | `true` | Compress tool/function results |
+| `compress_system` | `false` | Also compress system messages |
+| `compress_history` | `false` | Also compress prior user messages |
+| `compress_last_user` | `false` | Also compress the last user message |
+| `enable_retrieval` | `true` | Inject the `compresr_retrieve` recovery tool |
+| `allow_bypass_header` | `false` | Honour `x-compresr-bypass: true` from callers (opt-in; off by default) |
+| `max_bytes_per_call` | `10485760` | Max bytes of stored originals per `litellm_call_id` (10 MiB); oldest evicted first |
+
+## Per-request bypass
+
+Send `x-compresr-bypass: true` as a request header to skip compression for a
+single call. The header is ignored unless `allow_bypass_header: true` is set in
+the guardrail config (off by default to prevent callers from defeating token
+accounting or rate-limit strategies).
+
+## Limitations
+
+**Multi-worker deployments:** originals for the recovery tool are stored in
+process memory. If your LiteLLM proxy runs with `--workers N > 1` (gunicorn /
+uvicorn multi-process), the pre-call hook and post-call agentic hook may land on
+different workers — recovery silently fails and the model sees a "hash not found"
+message instead of the original content. Set `--workers 1` or disable recovery
+with `enable_retrieval: false` in multi-worker setups.
+
+## How recovery works
+
+1. `apply_guardrail` compresses eligible messages and appends a marker:
+   `[compresr hash=abc...: parts of this content were compressed away ...]`.
+   The original text is kept in-process, scoped to this request's
+   `litellm_call_id` (15-minute TTL).
+2. A `compresr_retrieve` tool is merged into the request's tools.
+3. If the model calls it, `async_build_agentic_loop_plan` answers the tool
+   call with the stored original and re-runs the request — one extra LLM
+   round-trip, only when the model asks for it.
+
+Hashes are only honored for the request that issued them; a hash pasted in
+from another conversation returns a not-found message instead of content.

--- a/litellm/proxy/guardrails/guardrail_hooks/compresr/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/compresr/__init__.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from litellm.types.guardrails import (
+    GuardrailEventHooks,
+    Mode,
+    SupportedGuardrailIntegrations,
+)
+
+from .compresr import CompresrGuardrail
+
+if TYPE_CHECKING:
+    from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def _coerce_event_hook(
+    mode: str | list[str] | Mode,
+) -> GuardrailEventHooks | list[GuardrailEventHooks] | Mode:
+    if isinstance(mode, Mode):
+        return mode
+    if isinstance(mode, list):
+        return [GuardrailEventHooks(item) for item in mode]
+    return GuardrailEventHooks(mode)
+
+
+def _get_optional_value(litellm_params: LitellmParams, optional_params: Optional[Any], attribute_name: str) -> Any:
+    if optional_params is not None:
+        value = getattr(optional_params, attribute_name, None)
+        if value is not None:
+            return value
+    return getattr(litellm_params, attribute_name, None)
+
+
+def initialize_guardrail(litellm_params: LitellmParams, guardrail: Guardrail) -> CompresrGuardrail:
+    import litellm
+
+    optional_params = getattr(litellm_params, "optional_params", None)
+
+    _callback = CompresrGuardrail(
+        api_base=litellm_params.api_base,
+        api_key=litellm_params.api_key,
+        model=litellm_params.model,
+        target_compression_ratio=_get_optional_value(litellm_params, optional_params, "target_compression_ratio"),
+        coarse=_get_optional_value(litellm_params, optional_params, "coarse"),
+        min_chars_to_compress=_get_optional_value(litellm_params, optional_params, "min_chars_to_compress"),
+        compress_tool_outputs=_get_optional_value(litellm_params, optional_params, "compress_tool_outputs"),
+        compress_system=_get_optional_value(litellm_params, optional_params, "compress_system"),
+        compress_history=_get_optional_value(litellm_params, optional_params, "compress_history"),
+        compress_last_user=_get_optional_value(litellm_params, optional_params, "compress_last_user"),
+        enable_retrieval=_get_optional_value(litellm_params, optional_params, "enable_retrieval"),
+        max_bytes_per_call=_get_optional_value(litellm_params, optional_params, "max_bytes_per_call"),
+        allow_bypass_header=_get_optional_value(litellm_params, optional_params, "allow_bypass_header"),
+        guardrail_name=guardrail["guardrail_name"],
+        event_hook=_coerce_event_hook(litellm_params.mode),
+        default_on=litellm_params.default_on or False,
+        unreachable_fallback=litellm_params.unreachable_fallback,
+    )
+    litellm.logging_callback_manager.add_litellm_callback(  # pyright: ignore[reportUnknownMemberType]  # callback manager is untyped
+        _callback
+    )
+    return _callback
+
+
+guardrail_initializer_registry = {
+    SupportedGuardrailIntegrations.COMPRESR.value: initialize_guardrail,
+}
+
+guardrail_class_registry = {
+    SupportedGuardrailIntegrations.COMPRESR.value: CompresrGuardrail,
+}

--- a/litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py
@@ -1,0 +1,863 @@
+"""Compresr guardrail — query-aware context compression with lossless recovery.
+
+Compresses bulky message content (tool outputs by default) through the
+Compresr API before the request reaches the LLM. Each compressed message
+carries a hash marker; a ``compresr_retrieve`` tool is injected so the model
+can fetch the original content back through the agentic loop when the
+compressed version is not enough — making compression recoverable instead
+of lossy.
+
+Unlike gateway-side compressors that operate on whole message lists, each
+target is compressed *query-aware*: the query sent to Compresr is the intent
+of the tool call that produced the message (``name + arguments``, resolved
+via ``tool_call_id``), falling back to the last user message.
+
+# NOTE: originals are stored in process memory. Multi-worker deployments
+# (gunicorn/uvicorn --workers N > 1) will silently lose originals when
+# pre- and post-call hooks land on different workers. Set --workers 1
+# or disable recovery (enable_retrieval=False) in multi-worker setups.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import re
+import socket
+import time
+import uuid
+from typing import TYPE_CHECKING, Any, Literal, Optional
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import HTTPException
+from httpx import Response as HttpxResponse
+from typing_extensions import TypeGuard
+
+import litellm
+from litellm._logging import verbose_proxy_logger
+from litellm.integrations.custom_guardrail import (
+    CustomGuardrail,
+    log_guardrail_information,
+)
+from litellm.litellm_core_utils.prompt_templates.factory import (
+    get_attribute_or_key,
+    get_tool_calls_from_response,
+    has_tool_with_name,
+)
+from litellm.llms.custom_httpx.http_handler import (
+    get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]  # helper is untyped in http_handler
+    httpxSpecialProvider,
+)
+from litellm.secret_managers.main import get_secret_str
+from litellm.types.guardrails import GuardrailEventHooks, Mode
+from litellm.types.integrations.custom_logger import (
+    AgenticLoopPlan,
+    AgenticLoopRequestPatch,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import (
+        Logging as LiteLLMLoggingObj,
+    )
+    from litellm.types.proxy.guardrails.guardrail_hooks.base import (
+        GuardrailConfigModel,
+    )
+
+BYPASS_HEADER = "x-compresr-bypass"
+COMPRESR_RETRIEVE_TOOL_NAME = "compresr_retrieve"
+DEFAULT_API_BASE = "https://api.compresr.ai"
+DEFAULT_COMPRESSION_MODEL = "latte_v2"
+DEFAULT_TARGET_COMPRESSION_RATIO = 0.5
+DEFAULT_MIN_CHARS_TO_COMPRESS = 500
+_HASH_PATTERN = re.compile(r"compresr hash=([a-f0-9]{24})")
+_ORIGINALS_TTL_SECONDS = 15 * 60
+_MAX_TRACKED_CALLS = 256
+_DEFAULT_MAX_BYTES_PER_CALL = 10 * 1024 * 1024
+_SOURCE_TAG = "gateway:unknown"
+_BLOCKED_METADATA_HOSTS = frozenset(
+    {
+        "169.254.169.254",
+        "fd00:ec2::254",
+        "100.100.100.200",
+        "168.63.129.16",  # Azure IMDS / wire-server
+        "metadata.google.internal",
+        "metadata.goog",
+    }
+)
+_CGNAT_RANGE = ipaddress.ip_network("100.64.0.0/10")
+
+
+def _validate_api_base(url: str) -> str:
+    """Return ``url`` if it is a safe outbound target, else raise ``ValueError``.
+
+    Blocks non-http(s) schemes and the well-known cloud-metadata IPs so that
+    an attacker with config-write access cannot turn the guardrail into an
+    SSRF probe against instance metadata. Private-range hosts are allowed
+    because on-prem Compresr deployments legitimately live there.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Compresr guardrail api_base must be http or https, got scheme={parsed.scheme!r}"
+        )
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        raise ValueError("Compresr guardrail api_base has no host")
+    if host in _BLOCKED_METADATA_HOSTS:
+        raise ValueError(f"Compresr guardrail api_base {host!r} is a blocked cloud-metadata host")
+    try:
+        for info in socket.getaddrinfo(host, None):
+            addr = info[4][0]
+            ip = ipaddress.ip_address(addr)
+            if addr in _BLOCKED_METADATA_HOSTS or ip.is_link_local or ip.is_loopback or ip.is_unspecified:
+                raise ValueError(
+                    f"Compresr guardrail api_base {host!r} resolves to blocked address {addr!r}"
+                )
+            if ip in _CGNAT_RANGE:
+                raise ValueError(
+                    f"Compresr guardrail api_base {host!r} resolves to CGNAT address {addr!r} (100.64.0.0/10)"
+                )
+    except socket.gaierror:
+        verbose_proxy_logger.warning(
+            "compresr: DNS resolution failed for %s at startup — SSRF validation skipped. "
+            "Ensure api_base is reachable before handling live traffic.", host
+        )
+        return url
+    return url
+
+
+def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, dict)
+
+
+def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
+    return isinstance(value, list)
+
+
+def _content_to_text(content: object) -> str:
+    """Collapse a message ``content`` (str or list-of-parts) to plain text.
+
+    For the multimodal list shape, joins ``{type: "text", text: ...}`` parts
+    with blank-line separators; non-text parts are ignored.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n\n".join(parts)
+    return ""
+
+
+def _replace_text_in_content(content: object, new_text: str) -> object:
+    """Write ``new_text`` back into a ``content`` value, preserving shape.
+
+    ``str`` content is replaced directly. For list-of-parts content the first
+    text part carries ``new_text``, later text parts are dropped, and
+    non-text parts (images, audio, files) pass through untouched.
+    """
+    if isinstance(content, str):
+        return new_text
+    if isinstance(content, list):
+        out: list[object] = []
+        replaced = False
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                if not replaced:
+                    out.append({**part, "text": new_text})
+                    replaced = True
+                continue
+            out.append(part)
+        if not replaced:
+            out.insert(0, {"type": "text", "text": new_text})
+        return out
+    return new_text
+
+
+def _render_tool_intent(fn: dict[str, object]) -> str:
+    name = str(fn.get("name") or "").strip()
+    args = fn.get("arguments")
+    if isinstance(args, dict):
+        try:
+            args_str = json.dumps(args, separators=(",", ":"))
+        except (TypeError, ValueError):
+            args_str = str(args)
+    else:
+        args_str = str(args).strip() if args is not None else ""
+    if name and args_str:
+        return f"{name}: {args_str}"
+    return name or args_str
+
+
+def _query_for_target(messages: list[dict[str, object]], target_idx: int, fallback: str) -> str:
+    """Query used to compress ``messages[target_idx]``.
+
+    Tool/function outputs are compressed against the intent of the tool call
+    that produced them (found via ``tool_call_id`` on a prior assistant
+    message); everything else uses the last user message.
+    """
+    msg = messages[target_idx]
+    if msg.get("role") not in ("tool", "function"):
+        return fallback
+
+    tool_call_id = msg.get("tool_call_id")
+    fn_name = msg.get("name")
+    for j in range(target_idx - 1, -1, -1):
+        prev = messages[j]
+        if prev.get("role") != "assistant":
+            continue
+        tool_calls = prev.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                if tool_call_id and tc.get("id") == tool_call_id:
+                    fn = tc.get("function")
+                    intent = _render_tool_intent(fn if isinstance(fn, dict) else {})
+                    if intent:
+                        return intent
+        fc = prev.get("function_call")
+        if isinstance(fc, dict) and (not fn_name or fc.get("name") == fn_name):
+            intent = _render_tool_intent(fc)
+            if intent:
+                return intent
+    return fallback
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
+
+
+def _recovery_marker(hash_value: str) -> str:
+    return (
+        f"\n\n[compresr hash={hash_value}: parts of this content were compressed "
+        f"away. If you need the full original, call the "
+        f"{COMPRESR_RETRIEVE_TOOL_NAME} tool with this hash.]"
+    )
+
+
+def extract_hashes_from_messages(messages: list[dict[str, object]]) -> list[str]:
+    hashes: list[str] = []
+    for msg in messages:
+        text = _content_to_text(msg.get("content"))
+        hashes.extend(_HASH_PATTERN.findall(text))
+    return hashes
+
+
+def _build_compresr_retrieve_tool() -> dict[str, object]:
+    return {
+        "type": "function",
+        "function": {
+            "name": COMPRESR_RETRIEVE_TOOL_NAME,
+            "description": (
+                "Retrieve the original, uncompressed content behind a Compresr "
+                "compression marker. Call this when a compression marker's hash "
+                "points at content you need in full."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "hash": {
+                        "type": "string",
+                        "description": "The 24-character hex hash from the compression marker.",
+                    },
+                },
+                "required": ["hash"],
+            },
+        },
+    }
+
+
+def has_compresr_retrieve_tool(tools: object) -> bool:
+    return has_tool_with_name(tools, COMPRESR_RETRIEVE_TOOL_NAME)
+
+
+def _extract_compresr_tool_calls(response: object) -> list[dict[str, object]]:
+    return [
+        {"id": tc["id"], "type": "function", "name": tc["name"], "arguments": tc["arguments"]}
+        for tc in get_tool_calls_from_response(response)
+        if tc["name"] == COMPRESR_RETRIEVE_TOOL_NAME
+    ]
+
+
+def _resolve_call_id(logging_obj: object) -> Optional[str]:
+    """Framework-issued call id only; user-supplied ids from the request body
+    are ignored so one tenant cannot retrieve another tenant's originals by
+    guessing or observing a call id."""
+    logging_call_id = getattr(logging_obj, "litellm_call_id", None)
+    if isinstance(logging_call_id, str) and logging_call_id:
+        return logging_call_id
+    return None
+
+
+def _is_responses_api_response(response: object) -> bool:
+    return isinstance(get_attribute_or_key(response, "output", None), list)
+
+
+def _is_anthropic_messages_response(response: object) -> bool:
+    return isinstance(get_attribute_or_key(response, "content", None), list)
+
+
+def _build_assistant_message_from_response(response: object) -> dict[str, object]:
+    choices = getattr(response, "choices", None)
+    if not isinstance(choices, list) or not choices:
+        return {"role": "assistant", "content": None, "tool_calls": []}
+    message = getattr(choices[0], "message", None)
+    if message is None:
+        return {"role": "assistant", "content": None, "tool_calls": []}
+    content = getattr(message, "content", None)
+    tool_calls = getattr(message, "tool_calls", None)
+    raw_tool_calls: list[dict[str, object]] = []
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            fn = getattr(tc, "function", None)
+            raw_tool_calls.append(
+                {
+                    "id": getattr(tc, "id", None),
+                    "type": "function",
+                    "function": {
+                        "name": getattr(fn, "name", None) if fn else None,
+                        "arguments": getattr(fn, "arguments", "{}") if fn else "{}",
+                    },
+                }
+            )
+    return {"role": "assistant", "content": content, "tool_calls": raw_tool_calls}
+
+
+def _build_anthropic_followup_messages(
+    retrieved: list[tuple[dict[str, object], str]],
+) -> list[dict[str, object]]:
+    """Anthropic requires the tool_use block echoed back in an assistant
+    message paired with a tool_result block keyed by the same tool_use_id."""
+    assistant_message: dict[str, object] = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": tool_call.get("id"),
+                "name": tool_call.get("name"),
+                "input": tool_call.get("arguments", {}),
+            }
+            for tool_call, _ in retrieved
+        ],
+    }
+    user_message: dict[str, object] = {
+        "role": "user",
+        "content": [
+            {"type": "tool_result", "tool_use_id": tool_call.get("id"), "content": content}
+            for tool_call, content in retrieved
+        ],
+    }
+    return [assistant_message, user_message]
+
+
+def _build_responses_followup_items(
+    retrieved: list[tuple[dict[str, object], str]],
+) -> list[dict[str, object]]:
+    """The Responses API requires the model's function_call echoed back paired
+    with a function_call_output keyed by the same call_id."""
+    items: list[dict[str, object]] = []
+    for tool_call, content in retrieved:
+        call_id = tool_call.get("id")
+        items.append(
+            {
+                "type": "function_call",
+                "call_id": call_id,
+                "name": tool_call.get("name"),
+                "arguments": json.dumps(tool_call.get("arguments", {})),
+            }
+        )
+        items.append({"type": "function_call_output", "call_id": call_id, "output": content})
+    return items
+
+
+class CompresrGuardrail(CustomGuardrail):
+    def __init__(
+        self,
+        api_base: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+        target_compression_ratio: float | None = None,
+        coarse: bool | None = None,
+        min_chars_to_compress: int | None = None,
+        compress_tool_outputs: bool | None = None,
+        compress_system: bool | None = None,
+        compress_history: bool | None = None,
+        compress_last_user: bool | None = None,
+        enable_retrieval: bool | None = None,
+        guardrail_name: str | None = None,
+        event_hook: GuardrailEventHooks | list[GuardrailEventHooks] | Mode | None = None,
+        default_on: bool = False,
+        unreachable_fallback: str | None = None,
+        max_bytes_per_call: int | None = None,
+        allow_bypass_header: bool | None = None,
+    ):
+        raw_api_base = (api_base or get_secret_str("COMPRESR_API_BASE") or DEFAULT_API_BASE).rstrip("/")
+        self.compresr_api_base = _validate_api_base(raw_api_base)
+        self.compresr_api_key = api_key or get_secret_str("COMPRESR_API_KEY")
+        if not self.compresr_api_key:
+            raise ValueError(
+                "Compresr guardrail requires an API key. Set `api_key` in the "
+                "guardrail config or the COMPRESR_API_KEY env var."
+            )
+        self.compression_model = model or DEFAULT_COMPRESSION_MODEL
+        self.target_compression_ratio = (
+            DEFAULT_TARGET_COMPRESSION_RATIO if target_compression_ratio is None else target_compression_ratio
+        )
+        self.coarse = True if coarse is None else coarse
+        self.min_chars_to_compress = (
+            DEFAULT_MIN_CHARS_TO_COMPRESS if min_chars_to_compress is None else min_chars_to_compress
+        )
+        self.compress_tool_outputs = True if compress_tool_outputs is None else compress_tool_outputs
+        self.compress_system = False if compress_system is None else compress_system
+        self.compress_history = False if compress_history is None else compress_history
+        self.compress_last_user = False if compress_last_user is None else compress_last_user
+        self.enable_retrieval = True if enable_retrieval is None else enable_retrieval
+        self.unreachable_fallback: Literal["fail_closed", "fail_open"] = (
+            "fail_open" if unreachable_fallback == "fail_open" else "fail_closed"
+        )
+        self.max_bytes_per_call = (
+            _DEFAULT_MAX_BYTES_PER_CALL if max_bytes_per_call is None else max_bytes_per_call
+        )
+        self.allow_bypass_header = False if allow_bypass_header is None else allow_bypass_header
+        self.async_handler = get_async_httpx_client(
+            llm_provider=httpxSpecialProvider.GuardrailCallback,
+        )
+        self._originals_by_call_id: dict[str, tuple[dict[str, str], float]] = {}
+        super().__init__(  # pyright: ignore[reportUnknownMemberType]  # CustomGuardrail.__init__ is untyped
+            guardrail_name=guardrail_name,
+            event_hook=event_hook,
+            default_on=default_on,
+        )
+
+    # ── request plumbing ──────────────────────────────────────────────
+
+    def _should_bypass(self, request_data: dict) -> bool:
+        if not self.allow_bypass_header:
+            return False
+        psr = request_data.get("proxy_server_request")
+        if not _is_str_object_dict(psr):
+            return False
+        headers = psr.get("headers")
+        if not _is_str_object_dict(headers):
+            return False
+        return str(headers.get(BYPASS_HEADER)).lower() == "true"
+
+    def _request_headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "X-API-Key": self.compresr_api_key or "",
+        }
+
+    def _handle_compress_failure(self, error: str, log_detail: dict[str, object]) -> None:
+        """fail_open logs and returns (caller forwards uncompressed);
+        fail_closed raises. ``log_detail`` may include upstream response bodies
+        and is written only to server logs; the raised ``HTTPException`` carries
+        a generic message so a malicious ``api_base`` cannot exfiltrate response
+        bytes through the client-visible error."""
+        if self.unreachable_fallback == "fail_open":
+            verbose_proxy_logger.critical(
+                "Compresr: %s; fail_open configured, forwarding request uncompressed. detail=%s",
+                error,
+                log_detail,
+            )
+            return
+        verbose_proxy_logger.error("Compresr: %s. detail=%s", error, log_detail)
+        raise HTTPException(status_code=502, detail={"error": error})
+
+    # ── originals store (recovery) ────────────────────────────────────
+
+    def _prune_originals(self) -> None:
+        now = time.monotonic()
+        alive = {
+            call_id: (originals, expiry)
+            for call_id, (originals, expiry) in self._originals_by_call_id.items()
+            if expiry > now
+        }
+        if len(alive) > _MAX_TRACKED_CALLS:
+            # Evict soonest-to-expire first — a hard cap so a burst of huge
+            # tool outputs cannot grow proxy memory unbounded.
+            by_expiry = sorted(alive.items(), key=lambda item: item[1][1])
+            alive = dict(by_expiry[len(alive) - _MAX_TRACKED_CALLS :])
+        self._originals_by_call_id = alive
+
+    def _store_originals(self, call_id: str, originals: dict[str, str]) -> None:
+        existing, _ = self._originals_by_call_id.get(call_id, ({}, 0.0))
+        merged = self._bound_call_bytes({**existing, **originals})
+        self._originals_by_call_id[call_id] = (
+            merged,
+            time.monotonic() + _ORIGINALS_TTL_SECONDS,
+        )
+        # Prune after inserting so the cap holds; the entry just added has the
+        # latest expiry and always survives eviction.
+        self._prune_originals()
+
+    def _bound_call_bytes(self, merged: dict[str, str]) -> dict[str, str]:
+        """Drop oldest entries (dict insertion order) until the aggregate byte
+        size fits ``self.max_bytes_per_call``. Prevents one call with many
+        large tool outputs from growing proxy memory without bound."""
+        if self.max_bytes_per_call <= 0:
+            return merged
+        total = sum(len(value.encode("utf-8")) for value in merged.values())
+        if total <= self.max_bytes_per_call:
+            return merged
+        bounded = dict(merged)
+        for key in list(bounded.keys()):
+            if total <= self.max_bytes_per_call:
+                break
+            total -= len(bounded[key].encode("utf-8"))
+            del bounded[key]
+            verbose_proxy_logger.warning(
+                "Compresr: originals-store byte cap hit, evicted hash=%s", key
+            )
+        return bounded
+
+    def _retrieve_original(self, call_id: Optional[str], hash_value: str) -> str:
+        if call_id:
+            originals, expiry = self._originals_by_call_id.get(call_id, ({}, 0.0))
+            if expiry > time.monotonic() and hash_value in originals:
+                return originals[hash_value]
+            # A hash is only honored if it was issued by *this request's own*
+            # compression, scoped by litellm_call_id. Honoring any hash-shaped
+            # string in message text would be forgeable across requests.
+            verbose_proxy_logger.warning(
+                "Compresr retrieve: rejecting hash=%s (not issued for this request, or expired)",
+                hash_value,
+            )
+        return f"[compresr: hash={hash_value} not found, expired, or not issued for this request]"
+
+    # ── Compresr API (dependency-free) ────────────────────────────────
+
+    async def _call_compress(
+        self,
+        contexts: list[str],
+        queries: list[str],
+    ) -> Optional[list[dict[str, object]]]:
+        """Compress ``contexts`` (query-aware). Returns one result dict per
+        context, or None when the service failed and fail_open applies."""
+        try:
+            _validate_api_base(self.compresr_api_base)
+        except ValueError as exc:
+            self._handle_compress_failure(
+                "Compresr api_base failed SSRF re-validation at request time",
+                {"detail": str(exc)},
+            )
+            return None
+
+        common: dict[str, object] = {
+            "compression_model_name": self.compression_model,
+            "target_compression_ratio": self.target_compression_ratio,
+            "coarse": self.coarse,
+            "source": _SOURCE_TAG,
+        }
+        if len(contexts) == 1:
+            url = f"{self.compresr_api_base}/api/compress/question-specific/"
+            payload: dict[str, object] = {
+                "context": contexts[0],
+                "query": queries[0],
+                **common,
+            }
+        else:
+            url = f"{self.compresr_api_base}/api/compress/question-specific/batch"
+            payload = {
+                "inputs": [{"context": ctx, "query": q} for ctx, q in zip(contexts, queries)],
+                **common,
+            }
+
+        try:
+            raw_response: HttpxResponse | None = await self.async_handler.post(  # pyright: ignore[reportUnknownMemberType]  # AsyncHTTPHandler.post is untyped
+                url=url,
+                json=payload,
+                headers=self._request_headers(),
+            )
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.TransportError, litellm.Timeout) as e:
+            self._handle_compress_failure(
+                "Compresr compression service unreachable",
+                {"detail": str(e)},
+            )
+            return None
+        if raw_response is None or raw_response.status_code != 200:
+            self._handle_compress_failure(
+                "Compresr compression service returned an error",
+                {
+                    "status_code": getattr(raw_response, "status_code", None),
+                    "body": getattr(raw_response, "text", "")[:500],
+                },
+            )
+            return None
+
+        try:
+            body: object = raw_response.json()
+        except ValueError:
+            self._handle_compress_failure(
+                "Compresr compression service returned non-JSON response",
+                {"body": raw_response.text[:500]},
+            )
+            return None
+        if not _is_str_object_dict(body) or not _is_str_object_dict(body.get("data")):
+            self._handle_compress_failure(
+                "Compresr compression service returned unexpected response shape",
+                {"body": raw_response.text[:500]},
+            )
+            return None
+        data: dict[str, object] = body["data"]  # pyright: ignore[reportAssignmentType]  # dict-guarded above; subscript does not narrow
+
+        if len(contexts) == 1:
+            return [data]
+        results = data.get("results")
+        if (
+            not _is_object_list(results)
+            or len(results) != len(contexts)
+            or not all(_is_str_object_dict(r) for r in results)
+        ):
+            # Anything but a 1:1 dict-per-context mapping would misalign
+            # results with their target messages.
+            self._handle_compress_failure(
+                "Compresr batch response missing or mismatched 'results'",
+                {"expected": len(contexts), "got": len(results) if _is_object_list(results) else None},
+            )
+            return None
+        return results  # pyright: ignore[reportReturnType]  # every element dict-checked above; list[object] does not narrow
+
+    # ── target selection ──────────────────────────────────────────────
+
+    def _select_targets(self, messages: list[dict[str, object]], query_idx: Optional[int]) -> list[int]:
+        """Indices of messages whose text content should be compressed."""
+        targets: list[int] = []
+        for idx, msg in enumerate(messages):
+            if idx == query_idx and not self.compress_last_user:
+                continue
+            role = msg.get("role")
+            if role in ("tool", "function"):
+                if not self.compress_tool_outputs:
+                    continue
+            elif role == "system":
+                if not self.compress_system:
+                    continue
+            elif role == "user":
+                if idx != query_idx and not self.compress_history:
+                    continue
+            else:
+                continue
+            if len(_content_to_text(msg.get("content"))) < self.min_chars_to_compress:
+                continue
+            targets.append(idx)
+        return targets
+
+    @staticmethod
+    def _extract_fallback_query(
+        messages: list[dict[str, object]],
+    ) -> tuple[str, Optional[int]]:
+        for idx in range(len(messages) - 1, -1, -1):
+            if messages[idx].get("role") == "user":
+                return _content_to_text(messages[idx].get("content")), idx
+        return "", None
+
+    # ── the guardrail hook ────────────────────────────────────────────
+
+    @log_guardrail_information
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: LiteLLMLoggingObj | None = None,
+    ) -> GenericGuardrailAPIInputs:
+        if input_type != "request":
+            return inputs
+
+        if self._should_bypass(request_data):
+            verbose_proxy_logger.debug("Compresr: %s header set; skipping compression", BYPASS_HEADER)
+            return inputs
+
+        structured_messages = inputs.get("structured_messages")
+        if not _is_object_list(structured_messages) or not structured_messages:
+            return inputs
+        messages = [m for m in structured_messages if _is_str_object_dict(m)]
+        if len(messages) != len(structured_messages):
+            return inputs
+
+        fallback_query, query_idx = self._extract_fallback_query(messages)
+        targets = [
+            idx
+            for idx in self._select_targets(messages, query_idx)
+            # latte models require a non-empty query; leave targets we cannot
+            # derive one for uncompressed rather than erroring.
+            if _query_for_target(messages, idx, fallback_query).strip()
+        ]
+        if not targets:
+            verbose_proxy_logger.debug("Compresr: no messages eligible for compression")
+            return inputs
+
+        contexts = [_content_to_text(messages[idx].get("content")) for idx in targets]
+        queries = [_query_for_target(messages, idx, fallback_query) for idx in targets]
+
+        start_time = time.time()
+        results = await self._call_compress(contexts=contexts, queries=queries)
+        end_time = time.time()
+        if results is None:  # service failed, fail_open configured
+            return inputs
+
+        compressed_messages: list[dict[str, object]] = list(messages)
+        originals: dict[str, str] = {}
+        messages_compressed = 0
+        tokens_before = 0
+        tokens_after = 0
+        for target_idx, original_text, result in zip(targets, contexts, results):
+            compressed_text = result.get("compressed_context")
+            if not isinstance(compressed_text, str) or not compressed_text.strip():
+                continue
+            if len(compressed_text) >= len(original_text):
+                continue  # compression made it worse — keep original
+            messages_compressed += 1
+            if self.enable_retrieval:
+                hash_value = _content_hash(original_text)
+                originals[hash_value] = original_text
+                compressed_text += _recovery_marker(hash_value)
+            original_msg = compressed_messages[target_idx]
+            compressed_messages[target_idx] = {
+                **original_msg,
+                "content": _replace_text_in_content(original_msg.get("content"), compressed_text),
+            }
+            tokens_before += int(result.get("original_tokens") or 0)
+            tokens_after += int(result.get("compressed_tokens") or 0)
+
+        stats: dict[str, object] = {
+            "messages_compressed": messages_compressed,
+            "tokens_before": tokens_before,
+            "tokens_after": tokens_after,
+            "tokens_saved": tokens_before - tokens_after,
+            "compression_model": self.compression_model,
+        }
+        verbose_proxy_logger.debug(
+            "Compresr: compressed %s message(s), %s -> %s tokens",
+            stats["messages_compressed"],
+            tokens_before,
+            tokens_after,
+        )
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_json_response=stats,
+            request_data=request_data,
+            guardrail_status="success",
+            guardrail_provider="compresr",
+            start_time=start_time,
+            end_time=end_time,
+            duration=end_time - start_time,
+        )
+
+        if not self.enable_retrieval or not originals:
+            return {**inputs, "structured_messages": compressed_messages}  # pyright: ignore[reportReturnType]  # plain dicts satisfy AllMessageValues at runtime
+
+        call_id = _resolve_call_id(logging_obj) or str(uuid.uuid4())
+        self._store_originals(call_id, originals)
+
+        existing_tools = inputs.get("tools")
+        retrieve_tool = _build_compresr_retrieve_tool()
+        if isinstance(existing_tools, list) and not has_compresr_retrieve_tool(existing_tools):
+            merged_tools: list[object] = list(existing_tools) + [retrieve_tool]
+        elif existing_tools is None:
+            merged_tools = [retrieve_tool]
+        else:
+            merged_tools = list(existing_tools) if isinstance(existing_tools, list) else [retrieve_tool]
+
+        return {  # pyright: ignore[reportReturnType]  # plain dicts satisfy AllMessageValues at runtime
+            **inputs,
+            "structured_messages": compressed_messages,
+            "tools": merged_tools,
+        }
+
+    # ── agentic loop (recovery round-trip) ────────────────────────────
+
+    async def async_should_run_agentic_loop(
+        self,
+        response: Any,
+        model: str,
+        messages: list[dict],
+        tools: Optional[list[dict]],
+        stream: bool,
+        custom_llm_provider: str,
+        kwargs: dict,
+    ) -> tuple[bool, dict]:
+        if not has_compresr_retrieve_tool(tools):
+            return False, {}
+        tool_calls = _extract_compresr_tool_calls(response)
+        if not tool_calls:
+            return False, {}
+        return True, {"tool_calls": tool_calls}
+
+    async def async_build_agentic_loop_plan(
+        self,
+        tools: dict,
+        model: str,
+        messages: list[dict],
+        response: Any,
+        anthropic_messages_provider_config: Any,
+        anthropic_messages_optional_request_params: dict,
+        logging_obj: Any,
+        stream: bool,
+        kwargs: dict,
+    ) -> AgenticLoopPlan:
+        tool_calls: list[dict[str, object]] = tools.get("tool_calls", [])  # pyright: ignore[reportAssignmentType]  # gate hook builds this dict with list values only
+
+        call_id = _resolve_call_id(logging_obj)
+        retrieved: list[tuple[dict[str, object], str]] = []
+        for tc in tool_calls:
+            arguments = tc.get("arguments", {})
+            hash_value = str(arguments.get("hash", "")) if isinstance(arguments, dict) else ""
+            content = self._retrieve_original(call_id, hash_value)
+            verbose_proxy_logger.debug("Compresr retrieve: hash=%s -> %d chars", hash_value, len(content))
+            retrieved.append((tc, content))
+
+        if _is_responses_api_response(response):
+            follow_up_messages = list(messages) + _build_responses_followup_items(retrieved)
+        elif _is_anthropic_messages_response(response):
+            follow_up_messages = list(messages) + _build_anthropic_followup_messages(retrieved)
+        else:
+            assistant_message = _build_assistant_message_from_response(response)
+            tool_results = [
+                {"role": "tool", "tool_call_id": tc.get("id"), "content": content} for tc, content in retrieved
+            ]
+            follow_up_messages = list(messages) + [assistant_message] + tool_results
+
+        max_tokens: Optional[int] = anthropic_messages_optional_request_params.get("max_tokens") or kwargs.get(
+            "max_tokens"
+        )
+        optional_params_without_max_tokens = {
+            k: v for k, v in anthropic_messages_optional_request_params.items() if k != "max_tokens"
+        }
+
+        full_model_name = model
+        if logging_obj is not None:
+            agentic_params = getattr(logging_obj, "model_call_details", {}).get("agentic_loop_params", {})
+            candidate = agentic_params.get("model", model)
+            if isinstance(candidate, str) and candidate:
+                full_model_name = candidate
+
+        return AgenticLoopPlan(
+            run_agentic_loop=True,
+            request_patch=AgenticLoopRequestPatch(
+                model=full_model_name,
+                messages=follow_up_messages,
+                max_tokens=max_tokens,
+                optional_params=optional_params_without_max_tokens,
+                kwargs={
+                    k: v for k, v in kwargs.items() if not k.startswith("_compresr") and k != "litellm_logging_obj"
+                },
+            ),
+            metadata={"tool_type": "compresr_retrieve"},
+        )
+
+    @staticmethod
+    def get_config_model() -> type[GuardrailConfigModel[object]] | None:
+        from litellm.types.proxy.guardrails.guardrail_hooks.compresr import (
+            CompresrGuardrailConfigModel,
+        )
+
+        return CompresrGuardrailConfigModel

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -11,11 +11,23 @@ from litellm.types.proxy.guardrails.guardrail_hooks.akto import (
 from litellm.types.proxy.guardrails.guardrail_hooks.block_code_execution import (
     BlockCodeExecutionGuardrailConfigModel,
 )
+from litellm.types.proxy.guardrails.guardrail_hooks.cisco_ai_defense import (
+    CiscoAIDefenseGuardrailConfigModel,
+)
+from litellm.types.proxy.guardrails.guardrail_hooks.compresr import (
+    CompresrGuardrailConfigModel,
+)
 from litellm.types.proxy.guardrails.guardrail_hooks.enkryptai import (
     EnkryptAIGuardrailConfigs,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.grayswan import (
     GraySwanGuardrailConfigModel,
+)
+from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
+    HeadroomGuardrailConfigModel,
+)
+from litellm.types.proxy.guardrails.guardrail_hooks.hiddenlayer import (
+    HiddenlayerGuardrailConfigModel,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.ibm import (
     IBMGuardrailsBaseConfigModel,
@@ -29,32 +41,23 @@ from litellm.types.proxy.guardrails.guardrail_hooks.ovalix import (
 from litellm.types.proxy.guardrails.guardrail_hooks.promptguard import (
     PromptGuardConfigModel,
 )
-from litellm.types.proxy.guardrails.guardrail_hooks.xecguard import (
-    XecGuardConfigModel,
+from litellm.types.proxy.guardrails.guardrail_hooks.qohash import (
+    QostodianNexusConfigModel,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.qualifire import (
     QualifireGuardrailConfigModel,
 )
-from litellm.types.proxy.guardrails.guardrail_hooks.tool_permission import (
-    ToolPermissionGuardrailConfigModel,
-)
-from litellm.types.proxy.guardrails.guardrail_hooks.hiddenlayer import (
-    HiddenlayerGuardrailConfigModel,
-)
-from litellm.types.proxy.guardrails.guardrail_hooks.qohash import (
-    QostodianNexusConfigModel,
-)
 from litellm.types.proxy.guardrails.guardrail_hooks.repelloai import (
     RepelloAIGuardrailConfigModel,
+)
+from litellm.types.proxy.guardrails.guardrail_hooks.tool_permission import (
+    ToolPermissionGuardrailConfigModel,
 )
 from litellm.types.proxy.guardrails.guardrail_hooks.vigil_guard import (
     VigilGuardGuardrailConfigModel,
 )
-from litellm.types.proxy.guardrails.guardrail_hooks.cisco_ai_defense import (
-    CiscoAIDefenseGuardrailConfigModel,
-)
-from litellm.types.proxy.guardrails.guardrail_hooks.headroom import (
-    HeadroomGuardrailConfigModel,
+from litellm.types.proxy.guardrails.guardrail_hooks.xecguard import (
+    XecGuardConfigModel,
 )
 
 """
@@ -123,6 +126,7 @@ class SupportedGuardrailIntegrations(Enum):
     VIGIL_GUARD = "vigil_guard"
     REPELLOAI = "repelloai"
     HEADROOM = "headroom"
+    COMPRESR = "compresr"
 
 
 class Role(Enum):
@@ -697,7 +701,7 @@ class BaseLitellmParams(ContentFilterConfigModel):  # works for new and patch up
         default="fail_closed",
         description=(
             "Behavior when a guardrail endpoint is unreachable due to network errors. "
-            "Implemented by guardrail='generic_guardrail_api', 'akto', 'vigil_guard', 'repelloai', and 'headroom'. "
+            "Implemented by guardrail='generic_guardrail_api', 'akto', 'vigil_guard', 'repelloai', 'headroom', and 'compresr'. "
             "'fail_closed' raises an error (default). 'fail_open' logs a critical error and allows the request to proceed."
         ),
     )
@@ -790,6 +794,7 @@ class LitellmParams(
     BedrockGuardrailConfigModel,
     LakeraV2GuardrailConfigModel,
     HeadroomGuardrailConfigModel,
+    CompresrGuardrailConfigModel,
     RepelloAIGuardrailConfigModel,
     LassoGuardrailConfigModel,
     PillarGuardrailConfigModel,

--- a/litellm/types/proxy/guardrails/guardrail_hooks/compresr.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/compresr.py
@@ -1,0 +1,102 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+from .base import GuardrailConfigModel
+
+
+class CompresrGuardrailOptionalParams(BaseModel):
+    """Optional tuning knobs for the Compresr guardrail."""
+
+    target_compression_ratio: Optional[float] = Field(
+        default=None,
+        description=(
+            "Compression strength. 0-1 is the fraction of tokens to remove "
+            "(0.5 = remove ~50%, the default); a value >1 is an Nx reduction "
+            "factor (e.g. 4 = ~4x smaller)."
+        ),
+    )
+    coarse: Optional[bool] = Field(
+        default=None,
+        description=("Paragraph-level compression (default, faster) instead of token-level (finer-grained)."),
+    )
+    min_chars_to_compress: Optional[int] = Field(
+        default=None,
+        description=("Skip messages whose text is shorter than this many characters. Defaults to 500."),
+    )
+    compress_tool_outputs: Optional[bool] = Field(
+        default=None,
+        description=("Compress tool/function result messages (search hits, RAG chunks, API dumps). Defaults to True."),
+    )
+    compress_system: Optional[bool] = Field(
+        default=None,
+        description="Also compress system messages. Defaults to False.",
+    )
+    compress_history: Optional[bool] = Field(
+        default=None,
+        description="Also compress prior (non-last) user messages. Defaults to False.",
+    )
+    compress_last_user: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Also compress the last user message. The query sent to Compresr "
+            "is always the original verbatim text. Defaults to False."
+        ),
+    )
+    enable_retrieval: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Make compression recoverable: inject a `compresr_retrieve` tool "
+            "so the model can fetch the original content behind a compression "
+            "marker via the agentic loop. Defaults to True."
+        ),
+    )
+    max_bytes_per_call: Optional[int] = Field(
+        default=None,
+        description=(
+            "Cap on aggregate bytes of stored originals per litellm_call_id. "
+            "When a call exceeds this, oldest entries are evicted so the "
+            "in-process store cannot grow without bound. Defaults to 10 MiB."
+        ),
+    )
+    allow_bypass_header: Optional[bool] = Field(
+        default=None,
+        description=(
+            "Honor the `x-compresr-bypass: true` request header to skip "
+            "compression for a single call. Off by default because the "
+            "header is caller-settable; enable only on trusted deployments."
+        ),
+    )
+
+
+class CompresrGuardrailConfigModel(GuardrailConfigModel[CompresrGuardrailOptionalParams]):
+    api_key: Optional[str] = Field(
+        default=None,
+        description=("Compresr API key. Falls back to the COMPRESR_API_KEY env var."),
+    )
+    api_base: Optional[str] = Field(
+        default=None,
+        description=(
+            "Base URL of the Compresr API. Falls back to the COMPRESR_API_BASE "
+            "env var, then https://api.compresr.ai. Point at your internal "
+            "service URL for on-prem deployments."
+        ),
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description=(
+            "Compresr compression model (not the LLM). Defaults to 'latte_v2', the query-aware compression model."
+        ),
+    )
+    unreachable_fallback: Optional[Literal["fail_open", "fail_closed"]] = Field(
+        default=None,
+        description=(
+            "What to do when the Compresr service is unreachable. "
+            "'fail_closed' (default) returns HTTP 502 to the caller. "
+            "'fail_open' logs a critical warning and forwards the request uncompressed."
+        ),
+    )
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Compresr (context compression)"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py
@@ -1,0 +1,1034 @@
+"""
+Unit tests for the Compresr guardrail.
+
+Tests cover:
+- apply_guardrail compresses eligible messages query-aware (tool-call intent
+  resolved via tool_call_id, falling back to the last user message)
+- target selection: tool outputs by default, system/history opt-in, min-chars
+  threshold, targets without a derivable query are left uncompressed
+- multimodal content: text parts replaced, non-text parts preserved
+- recovery: hash marker appended, compresr_retrieve tool injected, originals
+  stored per litellm_call_id, agentic loop returns the original content and
+  rejects hashes not issued for the current request
+- x-compresr-bypass header, response-type passthrough
+- fail_closed raises HTTPException; fail_open forwards uncompressed
+"""
+
+import hashlib
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy.guardrails.guardrail_hooks.compresr.compresr import (
+    COMPRESR_RETRIEVE_TOOL_NAME,
+    CompresrGuardrail,
+    extract_hashes_from_messages,
+    has_compresr_retrieve_tool,
+)
+from litellm.types.utils import GenericGuardrailAPIInputs
+
+FAKE_API_BASE = "https://compresr.example.com"
+FAKE_API_KEY = "cmp_test-key"
+
+TOOL_OUTPUT = "Result 1: EV range comparison. " * 40  # > 500 chars
+USER_QUESTION = "Which 2026 EV has the longest range?"
+
+AGENT_MESSAGES = [
+    {"role": "system", "content": "You are a research assistant."},
+    {"role": "user", "content": USER_QUESTION},
+    {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": '{"query": "2026 EV range"}'},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "call_1", "content": TOOL_OUTPUT},
+]
+
+
+def _make_guardrail(**kwargs) -> CompresrGuardrail:
+    defaults = dict(
+        api_base=FAKE_API_BASE,
+        api_key=FAKE_API_KEY,
+        guardrail_name="compresr",
+        default_on=True,
+    )
+    defaults.update(kwargs)
+    return CompresrGuardrail(**defaults)
+
+
+def _make_single_compress_response(
+    compressed_context: str = "compressed summary",
+    original_tokens: int = 1000,
+    compressed_tokens: int = 400,
+    status: int = 200,
+) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status
+    mock.json.return_value = {
+        "success": True,
+        "data": {
+            "compressed_context": compressed_context,
+            "original_tokens": original_tokens,
+            "compressed_tokens": compressed_tokens,
+            "actual_compression_ratio": 0.6,
+            "tokens_saved": original_tokens - compressed_tokens,
+            "duration_ms": 42,
+        },
+    }
+    mock.text = ""
+    return mock
+
+
+def _make_batch_compress_response(compressed_contexts: list, status: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status
+    mock.json.return_value = {
+        "success": True,
+        "data": {
+            "results": [
+                {
+                    "compressed_context": ctx,
+                    "original_tokens": 1000,
+                    "compressed_tokens": 400,
+                    "actual_compression_ratio": 0.6,
+                    "tokens_saved": 600,
+                    "duration_ms": 42,
+                }
+                for ctx in compressed_contexts
+            ],
+            "count": len(compressed_contexts),
+        },
+    }
+    mock.text = ""
+    return mock
+
+
+def _make_openai_response_with_tool_call(tool_name: str, arguments: dict, tool_id: str = "call_abc123") -> MagicMock:
+    fn = MagicMock()
+    fn.name = tool_name
+    fn.arguments = json.dumps(arguments)
+
+    tc = MagicMock()
+    tc.id = tool_id
+    tc.type = "function"
+    tc.function = fn
+
+    message = MagicMock()
+    message.content = None
+    message.tool_calls = [tc]
+
+    choice = MagicMock()
+    choice.message = message
+
+    response = MagicMock()
+    response.choices = [choice]
+    # Plain chat-completion shape: no responses-API `output` list, no
+    # anthropic `content` list.
+    response.output = None
+    response.content = None
+    return response
+
+
+def _apply_inputs(messages: list) -> GenericGuardrailAPIInputs:
+    return GenericGuardrailAPIInputs(structured_messages=[dict(m) for m in messages])
+
+
+def _logging_obj(call_id: str) -> SimpleNamespace:
+    return SimpleNamespace(litellm_call_id=call_id)
+
+
+@pytest.fixture
+def guardrail() -> CompresrGuardrail:
+    return _make_guardrail()
+
+
+# ── init ──────────────────────────────────────────────────────────────
+
+
+def test_init_raises_without_api_key(monkeypatch):
+    monkeypatch.delenv("COMPRESR_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key"):
+        CompresrGuardrail(guardrail_name="compresr")
+
+
+def test_init_defaults():
+    g = _make_guardrail()
+    assert g.compresr_api_base == FAKE_API_BASE
+    assert g.compression_model == "latte_v2"
+    assert g.target_compression_ratio == 0.5
+    assert g.coarse is True
+    assert g.min_chars_to_compress == 500
+    assert g.compress_tool_outputs is True
+    assert g.compress_system is False
+    assert g.compress_history is False
+    assert g.compress_last_user is False
+    assert g.enable_retrieval is True
+    assert g.unreachable_fallback == "fail_closed"
+
+
+def test_init_rejects_unknown_unreachable_fallback_value():
+    g = _make_guardrail(unreachable_fallback="banana")
+    assert g.unreachable_fallback == "fail_closed"
+
+
+# ── compression core ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_compresses_tool_output_with_intent_query(
+    guardrail: CompresrGuardrail,
+):
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+            logging_obj=_logging_obj("call-id-1"),
+        )
+
+    _, call_kwargs = mock_post.call_args
+    assert call_kwargs["url"] == f"{FAKE_API_BASE}/api/compress/question-specific/"
+    assert call_kwargs["headers"]["X-API-Key"] == FAKE_API_KEY
+    payload = call_kwargs["json"]
+    assert payload["context"] == TOOL_OUTPUT
+    # Query is the tool call's intent, not the user question.
+    assert payload["query"] == 'web_search: {"query": "2026 EV range"}'
+    assert payload["compression_model_name"] == "latte_v2"
+    assert payload["target_compression_ratio"] == 0.5
+
+    out = result["structured_messages"]
+    assert out[3]["content"].startswith("compressed summary")
+    # Untouched messages pass through byte-identical.
+    assert out[0] == AGENT_MESSAGES[0]
+    assert out[1] == AGENT_MESSAGES[1]
+    assert out[2] == AGENT_MESSAGES[2]
+
+
+@pytest.mark.asyncio
+async def test_tool_output_without_matching_call_uses_user_question(
+    guardrail: CompresrGuardrail,
+):
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "call_unknown", "content": TOOL_OUTPUT},
+    ]
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    payload = mock_post.call_args.kwargs["json"]
+    assert payload["query"] == USER_QUESTION
+
+
+@pytest.mark.asyncio
+async def test_target_without_derivable_query_left_uncompressed(
+    guardrail: CompresrGuardrail,
+):
+    # No user message and no tool-call intent anywhere -> nothing to compress.
+    messages = [{"role": "tool", "tool_call_id": "call_x", "content": TOOL_OUTPUT}]
+    mock_post = AsyncMock()
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    mock_post.assert_not_called()
+    assert result["structured_messages"][0]["content"] == TOOL_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_system_and_history_not_compressed_by_default(
+    guardrail: CompresrGuardrail,
+):
+    long_system = "Rules. " * 200
+    messages = [
+        {"role": "system", "content": long_system},
+        {"role": "user", "content": "Old question? " * 100},
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": TOOL_OUTPUT},
+    ]
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    # Only one (single, non-batch) call: the tool output.
+    assert mock_post.call_count == 1
+    assert mock_post.call_args.kwargs["json"]["context"] == TOOL_OUTPUT
+    out = result["structured_messages"]
+    assert out[0]["content"] == long_system
+    assert out[2]["content"] == USER_QUESTION
+
+
+@pytest.mark.asyncio
+async def test_opt_in_system_uses_batch_endpoint():
+    guardrail = _make_guardrail(compress_system=True)
+    long_system = "Rules. " * 200
+    messages = [
+        {"role": "system", "content": long_system},
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": TOOL_OUTPUT},
+    ]
+    mock_post = AsyncMock(return_value=_make_batch_compress_response(["short system", "short tool"]))
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    call_kwargs = mock_post.call_args.kwargs
+    assert call_kwargs["url"].endswith("/api/compress/question-specific/batch")
+    batch_inputs = call_kwargs["json"]["inputs"]
+    assert [i["context"] for i in batch_inputs] == [long_system, TOOL_OUTPUT]
+    out = result["structured_messages"]
+    assert out[0]["content"].startswith("short system")
+    assert out[2]["content"].startswith("short tool")
+
+
+@pytest.mark.asyncio
+async def test_short_messages_skipped(guardrail: CompresrGuardrail):
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": "tiny result"},
+    ]
+    mock_post = AsyncMock()
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    mock_post.assert_not_called()
+    assert result["structured_messages"][1]["content"] == "tiny result"
+
+
+@pytest.mark.asyncio
+async def test_multimodal_text_replaced_non_text_preserved(
+    guardrail: CompresrGuardrail,
+):
+    image_part = {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": [{"type": "text", "text": TOOL_OUTPUT}, image_part],
+        },
+    ]
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    content = result["structured_messages"][1]["content"]
+    assert isinstance(content, list)
+    assert content[0]["type"] == "text"
+    assert content[0]["text"].startswith("compressed summary")
+    assert content[1] == image_part
+
+
+# ── passthrough / bypass ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bypass_header_skips_compression_when_allowed():
+    guardrail = _make_guardrail(allow_bypass_header=True)
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    mock_post = AsyncMock()
+    request_data = {
+        "model": "gpt-4o",
+        "proxy_server_request": {"headers": {"x-compresr-bypass": "true"}},
+    }
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(inputs=inputs, request_data=request_data, input_type="request")
+
+    mock_post.assert_not_called()
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_bypass_header_ignored_by_default(guardrail: CompresrGuardrail):
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+    request_data = {
+        "model": "gpt-4o",
+        "proxy_server_request": {"headers": {"x-compresr-bypass": "true"}},
+    }
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        await guardrail.apply_guardrail(inputs=inputs, request_data=request_data, input_type="request")
+
+    mock_post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_response_input_type_passthrough(guardrail: CompresrGuardrail):
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="response")
+    assert result is inputs
+
+
+@pytest.mark.asyncio
+async def test_missing_structured_messages_passthrough(guardrail: CompresrGuardrail):
+    inputs = GenericGuardrailAPIInputs(texts=["hello"])
+    result = await guardrail.apply_guardrail(inputs=inputs, request_data={}, input_type="request")
+    assert result is inputs
+
+
+# ── failure policy ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_transport_error_raises_when_fail_closed(guardrail: CompresrGuardrail):
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(side_effect=httpx.ConnectError("boom")),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=_apply_inputs(AGENT_MESSAGES),
+                request_data={"model": "gpt-4o"},
+                input_type="request",
+            )
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_transport_error_fail_open_forwards_uncompressed():
+    guardrail = _make_guardrail(unreachable_fallback="fail_open")
+    inputs = _apply_inputs(AGENT_MESSAGES)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(side_effect=httpx.ConnectError("boom")),
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    assert result is inputs
+    assert result["structured_messages"][3]["content"] == TOOL_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_non_json_response_raises_when_fail_closed(guardrail: CompresrGuardrail):
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.json.side_effect = ValueError("not json")
+    mock.text = "<html>gateway error</html>"
+
+    with patch.object(guardrail.async_handler, "post", AsyncMock(return_value=mock)):
+        with pytest.raises(HTTPException):
+            await guardrail.apply_guardrail(
+                inputs=_apply_inputs(AGENT_MESSAGES),
+                request_data={"model": "gpt-4o"},
+                input_type="request",
+            )
+
+
+@pytest.mark.asyncio
+async def test_http_exception_does_not_reflect_upstream_body(guardrail: CompresrGuardrail):
+    mock = MagicMock()
+    mock.status_code = 500
+    mock.json.side_effect = ValueError("not json")
+    mock.text = "SECRET_INSTANCE_METADATA_TOKEN=aws-imds-response"
+
+    with patch.object(guardrail.async_handler, "post", AsyncMock(return_value=mock)):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=_apply_inputs(AGENT_MESSAGES),
+                request_data={"model": "gpt-4o"},
+                input_type="request",
+            )
+    assert "SECRET_INSTANCE_METADATA_TOKEN" not in json.dumps(exc_info.value.detail)
+
+
+def test_init_rejects_non_http_api_base():
+    with pytest.raises(ValueError, match="scheme"):
+        CompresrGuardrail(
+            api_base="file:///etc/passwd",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_init_rejects_cloud_metadata_api_base():
+    with pytest.raises(ValueError, match="metadata"):
+        CompresrGuardrail(
+            api_base="http://169.254.169.254",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_ssrf_loopback_blocked_ipv4():
+    with pytest.raises(ValueError, match="blocked address"):
+        CompresrGuardrail(
+            api_base="http://127.0.0.1:8080",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_ssrf_loopback_blocked_localhost():
+    with pytest.raises(ValueError, match="blocked address"):
+        CompresrGuardrail(
+            api_base="http://localhost:8080",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_ssrf_unspecified_ipv4_blocked():
+    with pytest.raises(ValueError, match="blocked address"):
+        CompresrGuardrail(
+            api_base="http://0.0.0.0:8080",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_ssrf_unspecified_ipv6_blocked():
+    with pytest.raises(ValueError, match="blocked address"):
+        CompresrGuardrail(
+            api_base="http://[::]:8080",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_ignores_user_supplied_call_id(guardrail: CompresrGuardrail):
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+    attacker_call_id = "victim-tenant-call-id"
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        await guardrail.apply_guardrail(
+            inputs=_apply_inputs(AGENT_MESSAGES),
+            request_data={"model": "gpt-4o", "litellm_call_id": attacker_call_id},
+            input_type="request",
+            logging_obj=_logging_obj("real-framework-call-id"),
+        )
+
+    assert attacker_call_id not in guardrail._originals_by_call_id
+    assert "real-framework-call-id" in guardrail._originals_by_call_id
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_ignores_user_supplied_call_id(guardrail: CompresrGuardrail):
+    hash_value = "d" * 24
+    guardrail._store_originals("victim-tenant-call-id", {hash_value: "victim-original"})
+
+    plan = await guardrail.async_build_agentic_loop_plan(
+        tools={
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "name": COMPRESR_RETRIEVE_TOOL_NAME,
+                    "arguments": {"hash": hash_value},
+                }
+            ]
+        },
+        model="gpt-4o",
+        messages=[],
+        response=_make_openai_response_with_tool_call(
+            COMPRESR_RETRIEVE_TOOL_NAME, {"hash": hash_value}, tool_id="call_abc"
+        ),
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={},
+        logging_obj=_logging_obj("attacker-call-id"),
+        stream=False,
+        kwargs={"litellm_call_id": "victim-tenant-call-id"},
+    )
+
+    assert "victim-original" not in plan.request_patch.messages[-1]["content"]
+    assert "not found" in plan.request_patch.messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_batch_result_count_mismatch_raises_when_fail_closed():
+    guardrail = _make_guardrail(compress_system=True)
+    messages = [
+        {"role": "system", "content": "Rules. " * 200},
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": TOOL_OUTPUT},
+    ]
+    mock_post = AsyncMock(return_value=_make_batch_compress_response(["only one"]))
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        with pytest.raises(HTTPException):
+            await guardrail.apply_guardrail(
+                inputs=_apply_inputs(messages),
+                request_data={"model": "gpt-4o"},
+                input_type="request",
+            )
+
+
+# ── recovery (compresr_retrieve) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recovery_marker_tool_injection_and_original_stored(
+    guardrail: CompresrGuardrail,
+):
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+            logging_obj=_logging_obj("call-id-1"),
+        )
+
+    compressed_content = result["structured_messages"][3]["content"]
+    expected_hash = hashlib.sha256(TOOL_OUTPUT.encode()).hexdigest()[:24]
+    assert f"compresr hash={expected_hash}" in compressed_content
+    assert extract_hashes_from_messages(result["structured_messages"]) == [expected_hash]
+
+    tools = result.get("tools")
+    assert tools is not None and has_compresr_retrieve_tool(tools)
+
+    originals, _expiry = guardrail._originals_by_call_id["call-id-1"]
+    assert originals[expected_hash] == TOOL_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_enable_retrieval_false_no_marker_no_tool():
+    guardrail = _make_guardrail(enable_retrieval=False)
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    assert result["structured_messages"][3]["content"] == "compressed summary"
+    assert not has_compresr_retrieve_tool(result.get("tools") or [])
+    assert guardrail._originals_by_call_id == {}
+
+
+@pytest.mark.asyncio
+async def test_existing_tools_preserved_when_injecting(guardrail: CompresrGuardrail):
+    existing_tool = {"type": "function", "function": {"name": "my_tool", "parameters": {}}}
+    inputs = GenericGuardrailAPIInputs(
+        structured_messages=[dict(m) for m in AGENT_MESSAGES],
+        tools=[existing_tool],
+    )
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+            logging_obj=_logging_obj("call-id-1"),
+        )
+
+    tools = result["tools"]
+    assert existing_tool in tools
+    assert has_compresr_retrieve_tool(tools)
+    assert len(tools) == 2
+
+
+# ── agentic loop ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_true_for_retrieve_call(
+    guardrail: CompresrGuardrail,
+):
+    response = _make_openai_response_with_tool_call(COMPRESR_RETRIEVE_TOOL_NAME, {"hash": "a" * 24})
+    tools = [dict(t) for t in [_retrieve_tool_stub()]]
+
+    should_run, gate_tools = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="gpt-4o",
+        messages=[],
+        tools=tools,
+        stream=False,
+        custom_llm_provider="openai",
+        kwargs={},
+    )
+    assert should_run is True
+    assert gate_tools["tool_calls"][0]["name"] == COMPRESR_RETRIEVE_TOOL_NAME
+
+
+@pytest.mark.asyncio
+async def test_async_should_run_agentic_loop_false_without_retrieve_tool(
+    guardrail: CompresrGuardrail,
+):
+    response = _make_openai_response_with_tool_call("other_tool", {"x": 1})
+    should_run, _ = await guardrail.async_should_run_agentic_loop(
+        response=response,
+        model="gpt-4o",
+        messages=[],
+        tools=[],
+        stream=False,
+        custom_llm_provider="openai",
+        kwargs={},
+    )
+    assert should_run is False
+
+
+def _retrieve_tool_stub() -> dict:
+    return {
+        "type": "function",
+        "function": {"name": COMPRESR_RETRIEVE_TOOL_NAME, "parameters": {}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_returns_stored_original(guardrail: CompresrGuardrail):
+    hash_value = hashlib.sha256(TOOL_OUTPUT.encode()).hexdigest()[:24]
+    guardrail._store_originals("call-id-1", {hash_value: TOOL_OUTPUT})
+
+    plan = await guardrail.async_build_agentic_loop_plan(
+        tools={
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "name": COMPRESR_RETRIEVE_TOOL_NAME,
+                    "arguments": {"hash": hash_value},
+                }
+            ]
+        },
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "q"}],
+        response=_make_openai_response_with_tool_call(
+            COMPRESR_RETRIEVE_TOOL_NAME, {"hash": hash_value}, tool_id="call_abc"
+        ),
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={},
+        logging_obj=_logging_obj("call-id-1"),
+        stream=False,
+        kwargs={},
+    )
+
+    assert plan.run_agentic_loop is True
+    follow_up = plan.request_patch.messages
+    tool_result = follow_up[-1]
+    assert tool_result["role"] == "tool"
+    assert tool_result["tool_call_id"] == "call_abc"
+    assert tool_result["content"] == TOOL_OUTPUT
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_rejects_hash_from_other_request(
+    guardrail: CompresrGuardrail,
+):
+    hash_value = "b" * 24
+    guardrail._store_originals("someone-elses-call", {hash_value: "secret"})
+
+    plan = await guardrail.async_build_agentic_loop_plan(
+        tools={
+            "tool_calls": [
+                {
+                    "id": "call_abc",
+                    "type": "function",
+                    "name": COMPRESR_RETRIEVE_TOOL_NAME,
+                    "arguments": {"hash": hash_value},
+                }
+            ]
+        },
+        model="gpt-4o",
+        messages=[],
+        response=_make_openai_response_with_tool_call(
+            COMPRESR_RETRIEVE_TOOL_NAME, {"hash": hash_value}, tool_id="call_abc"
+        ),
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={},
+        logging_obj=_logging_obj("my-call"),
+        stream=False,
+        kwargs={},
+    )
+
+    content = plan.request_patch.messages[-1]["content"]
+    assert "secret" not in content
+    assert "not found" in content
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_builds_anthropic_followup_shape(
+    guardrail: CompresrGuardrail,
+):
+    hash_value = "c" * 24
+    guardrail._store_originals("call-id-1", {hash_value: TOOL_OUTPUT})
+
+    response = MagicMock()
+    response.output = None
+    response.content = [{"type": "tool_use", "id": "toolu_1"}]
+
+    plan = await guardrail.async_build_agentic_loop_plan(
+        tools={
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "name": COMPRESR_RETRIEVE_TOOL_NAME,
+                    "arguments": {"hash": hash_value},
+                }
+            ]
+        },
+        model="claude-sonnet-5",
+        messages=[{"role": "user", "content": "q"}],
+        response=response,
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={"max_tokens": 1024},
+        logging_obj=_logging_obj("call-id-1"),
+        stream=False,
+        kwargs={},
+    )
+
+    follow_up = plan.request_patch.messages
+    assistant_msg, user_msg = follow_up[-2], follow_up[-1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"][0]["type"] == "tool_use"
+    assert user_msg["content"][0]["type"] == "tool_result"
+    assert user_msg["content"][0]["tool_use_id"] == "toolu_1"
+    assert user_msg["content"][0]["content"] == TOOL_OUTPUT
+    assert plan.request_patch.max_tokens == 1024
+
+
+@pytest.mark.asyncio
+async def test_agentic_plan_builds_responses_api_followup_shape(
+    guardrail: CompresrGuardrail,
+):
+    hash_value = "e" * 24
+    guardrail._store_originals("call-id-responses", {hash_value: TOOL_OUTPUT})
+
+    # Responses API shape: response.output is a list (not None)
+    response = MagicMock()
+    response.output = [{"type": "function_call", "call_id": "call_resp_1"}]
+    response.content = None
+
+    plan = await guardrail.async_build_agentic_loop_plan(
+        tools={
+            "tool_calls": [
+                {
+                    "id": "call_resp_1",
+                    "type": "function",
+                    "name": COMPRESR_RETRIEVE_TOOL_NAME,
+                    "arguments": {"hash": hash_value},
+                }
+            ]
+        },
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "q"}],
+        response=response,
+        anthropic_messages_provider_config=None,
+        anthropic_messages_optional_request_params={},
+        logging_obj=_logging_obj("call-id-responses"),
+        stream=False,
+        kwargs={},
+    )
+
+    follow_up = plan.request_patch.messages
+    # The two injected items are the function_call echo followed by
+    # function_call_output carrying the restored content.
+    function_call_item = follow_up[-2]
+    function_call_output_item = follow_up[-1]
+    assert function_call_item["type"] == "function_call"
+    assert function_call_item["call_id"] == "call_resp_1"
+    assert function_call_output_item["type"] == "function_call_output"
+    assert function_call_output_item["call_id"] == "call_resp_1"
+    assert function_call_output_item["output"] == TOOL_OUTPUT
+
+
+# ── store hygiene ─────────────────────────────────────────────────────
+
+
+def test_originals_store_prunes_expired(guardrail: CompresrGuardrail):
+    guardrail._originals_by_call_id["old"] = ({"a" * 24: "x"}, 0.0)  # already expired
+    guardrail._store_originals("new", {"b" * 24: "y"})
+    assert "old" not in guardrail._originals_by_call_id
+    assert "new" in guardrail._originals_by_call_id
+
+
+def test_originals_store_caps_tracked_calls(guardrail: CompresrGuardrail):
+    for i in range(300):
+        guardrail._store_originals(f"call-{i}", {("%024x" % i): "x"})
+    assert len(guardrail._originals_by_call_id) <= 256
+    # Most recent entries survive.
+    assert "call-299" in guardrail._originals_by_call_id
+
+
+def test_originals_store_caps_bytes_per_call():
+    guardrail = _make_guardrail(max_bytes_per_call=1000)
+    hashes = tuple(f"{i:024x}" for i in range(5))
+    values = tuple("x" * 400 for _ in range(5))
+    guardrail._store_originals("c", dict(zip(hashes, values)))
+
+    stored, _expiry = guardrail._originals_by_call_id["c"]
+    assert sum(len(v.encode("utf-8")) for v in stored.values()) <= 1000
+    # Oldest entries are evicted first; newest survives.
+    assert hashes[-1] in stored
+    assert hashes[0] not in stored
+
+
+# ── SSRF: DNS rebinding ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ssrf_dns_rebinding_blocked_at_request_time():
+    """DNS rebinding: _validate_api_base is called again before each HTTP call."""
+    from litellm.proxy.guardrails.guardrail_hooks.compresr import compresr as compresr_mod
+
+    # First call (during __init__) succeeds so the object is created.
+    with patch.object(compresr_mod, "_validate_api_base", return_value=FAKE_API_BASE):
+        guardrail = _make_guardrail()
+
+    # After creation, DNS flips — subsequent _validate_api_base calls raise.
+    with patch.object(
+        compresr_mod,
+        "_validate_api_base",
+        side_effect=ValueError("DNS rebinding detected"),
+    ):
+        # fail_closed: must raise
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=_apply_inputs(AGENT_MESSAGES),
+                request_data={"model": "gpt-4o"},
+                input_type="request",
+            )
+        assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_ssrf_dns_rebinding_fail_open_forwards_uncompressed():
+    from litellm.proxy.guardrails.guardrail_hooks.compresr import compresr as compresr_mod
+
+    with patch.object(compresr_mod, "_validate_api_base", return_value=FAKE_API_BASE):
+        guardrail = _make_guardrail(unreachable_fallback="fail_open")
+
+    inputs = _apply_inputs(AGENT_MESSAGES)
+    with patch.object(
+        compresr_mod,
+        "_validate_api_base",
+        side_effect=ValueError("DNS rebinding detected"),
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    # fail_open: original messages must be forwarded uncompressed
+    assert result is inputs
+    assert result["structured_messages"][3]["content"] == TOOL_OUTPUT
+
+
+# ── SSRF: Azure IMDS ──────────────────────────────────────────────────
+
+
+def test_ssrf_azure_imds_blocked():
+    with pytest.raises(ValueError, match="metadata"):
+        CompresrGuardrail(
+            api_base="http://168.63.129.16",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+def test_ssrf_metadata_hostname_trailing_dot_blocked():
+    """Trailing dot on a blocked hostname must not bypass the blocklist check."""
+    with pytest.raises(ValueError, match="metadata"):
+        CompresrGuardrail(
+            api_base="http://169.254.169.254.",
+            api_key=FAKE_API_KEY,
+            guardrail_name="compresr",
+        )
+
+
+# ── compression quality guards ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_skips_when_compressed_longer_than_original(
+    guardrail: CompresrGuardrail,
+):
+    """When compressed_context >= original length, keep the original."""
+    long_tool_output = "x" * 600
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": long_tool_output},
+    ]
+    # Return a compressed_context that is longer than the original.
+    longer_compressed = "y" * 700
+    mock_post = AsyncMock(return_value=_make_single_compress_response(compressed_context=longer_compressed))
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    # Original must be preserved because compression expanded the content.
+    assert result["structured_messages"][1]["content"] == long_tool_output
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_skips_whitespace_only_compressed_context(
+    guardrail: CompresrGuardrail,
+):
+    """Whitespace-only compressed_context must be treated as empty and skipped."""
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {"role": "tool", "tool_call_id": "c1", "content": TOOL_OUTPUT},
+    ]
+    mock_post = AsyncMock(return_value=_make_single_compress_response(compressed_context="   \n\t  "))
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    # Whitespace-only result → original must be preserved.
+    assert result["structured_messages"][1]["content"] == TOOL_OUTPUT


### PR DESCRIPTION
## What this adds

A new **Compresr** guardrail that compresses context windows using query-aware relevance scoring before they reach the LLM. The guardrail hooks into the pre-call phase, calls the Compresr API to drop low-relevance passages, and optionally restores originals in the agentic loop when the model needs to look something up.

```
User request
    │
    ▼
apply_guardrail  ──►  Compresr API  ──►  compressed messages sent to LLM
    │                                           │
    │  (stores originals keyed by call_id)      │
    │                                           ▼
    │                              LLM response (may request original)
    │                                           ▼
async_build_agentic_loop_plan  ──►  injects tool call to restore original
```

Supports OpenAI chat, Anthropic messages, and Responses API shapes.

## Configuration

```yaml
litellm_settings:
  guardrails:
    - guardrail_name: compresr
      litellm_params:
        guardrail: compresr
        api_key: "os.environ/COMPRESR_API_KEY"
        api_base: "https://api.compresr.ai"   # or on-prem URL
        mode: pre_call
        default_on: true
        optional_params:
          target_compression_ratio: 0.5
          compress_system: false
          compress_last_user: false
          compress_tool_outputs: true
          compress_history: false
          min_chars_to_compress: 500
          fail_closed: false
          unreachable_fallback: "fail_open"
          enable_retrieval: true
          allow_bypass_header: false
          max_bytes_per_call: 10485760
```

> ⚠️ **Multi-worker note:** originals are stored in process memory. Set `--workers 1` or `enable_retrieval: false` in multi-worker deployments.

## Security properties

- **SSRF protection:** `api_base` is validated at construction **and** re-validated on every outbound request (guards against DNS rebinding). Blocked: loopback (`127.x`, `::1`, `localhost`), link-local (`169.254.x.x`), unspecified (`0.0.0.0`, `::`), cloud metadata IPs (`169.254.169.254`, `100.100.100.200`, `192.0.0.192`, `168.63.129.16` Azure IMDS), CGNAT range `100.64.0.0/10`. Trailing-dot hostname bypass stripped. Private ranges (`10.x`, `172.16.x`, `192.168.x`) intentionally allowed for on-prem.
- **Cross-tenant isolation:** originals scoped exclusively to `logging_obj.litellm_call_id`; user-supplied call IDs in request bodies are ignored.
- **Error body not leaked:** raw Compresr API responses stay in server logs; callers receive a generic error string.
- **Bypass header off by default:** `allow_bypass_header` defaults to `false`.

## Compression guardrails

- Compressed result longer than original → original kept unchanged
- Whitespace-only `compressed_context` → skipped
- Multimodal content (images, audio) → passed through untouched

## Files changed

| File | Role |
|---|---|
| `litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py` | Main guardrail |
| `litellm/proxy/guardrails/guardrail_hooks/compresr/__init__.py` | Package + registry entry |
| `litellm/proxy/guardrails/guardrail_hooks/compresr.py` | Shim so `guardrail: compresr` resolves |
| `litellm/proxy/guardrails/guardrail_hooks/compresr/README.md` | Operator quickstart + config reference |
| `litellm/types/guardrails.py` | `COMPRESR = "compresr"` enum entry |
| `litellm/types/proxy/guardrails/guardrail_hooks/compresr.py` | `CompresrGuardrailConfigModel` |
| `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py` | 45 tests |

## Tests — 45/45 passing

- Init validation (missing API key, bad URL scheme, loopback/link-local/unspecified/Azure IMDS/CGNAT/trailing-dot SSRF rejection)
- DNS rebinding: re-validation at request time (fail_open and fail_closed paths)
- Compression: single target, batch, tool-call intent query resolution, fallback to user message
- Target selection: system opt-in, history opt-in, min-chars threshold, no-query skip
- Multimodal: text replaced, images/audio preserved
- Length inversion guard + whitespace guard
- Bypass header (enabled/disabled)
- Failure policy: fail_closed 502, fail_open passthrough, error body not in client error
- Agentic loop: gate hook, plan hook, Anthropic shape, Responses API shape, cross-tenant call_id rejection
- Store hygiene: TTL pruning, per-call byte cap

## Test plan

- [ ] `python -m pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py -v` — 45/45 pass
- [ ] Start proxy with config above, send a request with a long tool output — verify token count drops in logs
- [ ] Verify `fail_open` default: unreachable `api_base` → request succeeds uncompressed
- [ ] Verify SSRF guard: `api_base: http://127.0.0.1:9000` raises `ValueError` at startup
- [ ] Verify bypass header ignored when `allow_bypass_header: false` (default)