### PR TITLE
fix(logging): classify allm_passthrough_route as async to prevent duplicate success callbacks

### DIFF
--- a/litellm/litellm_core_utils/get_litellm_params.py
+++ b/litellm/litellm_core_utils/get_litellm_params.py
@@ -76,6 +76,7 @@ def get_litellm_params(
     proxy_server_request=None,
     acompletion=None,
     aembedding=None,
+    allm_passthrough_route=None,
     preset_cache_key=None,
     no_log=None,
     input_cost_per_second=None,
@@ -118,6 +119,7 @@ def get_litellm_params(
     # Build base dict with explicit parameters (always included)
     litellm_params = {
         "acompletion": acompletion,
+        "allm_passthrough_route": allm_passthrough_route,
         "api_key": api_key,
         "force_timeout": force_timeout,
         "logger_fn": logger_fn,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1530,6 +1530,7 @@ class Logging(LiteLLMLoggingBaseClass):
             and litellm_params.get(CallTypes.aembedding.value, False) is not True
             and litellm_params.get(CallTypes.aimage_generation.value, False) is not True
             and litellm_params.get(CallTypes.atranscription.value, False) is not True
+            and litellm_params.get(CallTypes.allm_passthrough_route.value, False) is not True
         )
 
     def _is_assembled_stream_success(self, result=None) -> bool:

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -171,7 +171,6 @@ def llm_passthrough_route(
     api_key: Optional[str] = None,
     request_query_params: Optional[dict] = None,
     request_headers: Optional[dict] = None,
-    allm_passthrough_route: bool = False,
     content: Optional[Any] = None,
     data: Optional[dict] = None,
     files: Optional[RequestFiles] = None,
@@ -198,7 +197,7 @@ def llm_passthrough_route(
     from litellm.types.utils import LlmProviders
     from litellm.utils import ProviderConfigManager
 
-    _is_async = allm_passthrough_route
+    _is_async = bool(kwargs.get("allm_passthrough_route", False))
 
     litellm_logging_obj = cast("LiteLLMLoggingObj", kwargs.get("litellm_logging_obj"))
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -704,7 +704,9 @@ async def test_logging_non_streaming_request():
         litellm.callbacks = original_callbacks
 
 
-@pytest.mark.parametrize("async_flag", ["acompletion", "aresponses"])
+@pytest.mark.parametrize(
+    "async_flag", ["acompletion", "aresponses", "allm_passthrough_route"]
+)
 def test_success_handler_skips_sync_callbacks_for_async_requests(
     logging_obj, async_flag
 ):
@@ -792,6 +794,21 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
 def test_is_sync_litellm_request():
     assert LitellmLogging._is_sync_litellm_request({}) is True
     assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
+    assert (
+        LitellmLogging._is_sync_litellm_request({"allm_passthrough_route": True})
+        is False
+    )
+
+
+def test_get_litellm_params_propagates_allm_passthrough_route():
+    """`allm_passthrough_route=True` set on kwargs by the async passthrough entrypoint
+    must land in `litellm_params` so `_is_sync_litellm_request` sees it and the
+    request is classified as async. Regression guard for LIT-4192."""
+    from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
+
+    params = get_litellm_params(allm_passthrough_route=True)
+    assert params.get("allm_passthrough_route") is True
+    assert LitellmLogging._is_sync_litellm_request(params) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/passthrough/test_passthrough_main.py
+++ b/tests/test_litellm/passthrough/test_passthrough_main.py
@@ -726,3 +726,78 @@ async def test_allm_passthrough_route_429_streaming_raises():
 
     assert exc_info.value.response.status_code == 429
     assert len(chunks) == 0, "No chunks should be yielded before the 429 raises"
+
+
+def test_llm_passthrough_route_propagates_allm_passthrough_route_to_logging_obj():
+    """
+    Regression guard for LIT-4192: `allm_passthrough_route` sets
+    `kwargs["allm_passthrough_route"] = True` on the async entrypoint, and the
+    inner `llm_passthrough_route` must let that flag flow through
+    `get_litellm_params(**kwargs)` and land in the logging object's
+    `litellm_params`. Without that, `_is_sync_litellm_request` misclassifies
+    the request as sync and fires duplicate success callbacks.
+    """
+    import asyncio
+
+    from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+
+    client = HTTPHandler()
+
+    mock_provider_config = MagicMock()
+    mock_provider_config.get_complete_url.return_value = (
+        httpx.URL("https://bedrock-runtime.us-east-1.amazonaws.com/model/foo/converse"),
+        "https://bedrock-runtime.us-east-1.amazonaws.com",
+    )
+    mock_provider_config.get_api_key.return_value = "fake-key"
+    mock_provider_config.validate_environment.return_value = {}
+    mock_provider_config.sign_request.return_value = ({}, None)
+    mock_provider_config.is_streaming_request.return_value = False
+
+    captured_litellm_params: dict = {}
+
+    def _capture_update_env(*args, **kwargs):
+        captured_litellm_params.clear()
+        captured_litellm_params.update(kwargs.get("litellm_params") or {})
+
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables.side_effect = _capture_update_env
+
+    with (
+        patch(
+            "litellm.utils.ProviderConfigManager.get_provider_passthrough_config",
+            return_value=mock_provider_config,
+        ),
+        patch(
+            "litellm.litellm_core_utils.get_llm_provider_logic.get_llm_provider",
+            return_value=(
+                "bedrock/foo",
+                "bedrock",
+                "fake-key",
+                "https://bedrock-runtime.us-east-1.amazonaws.com",
+            ),
+        ),
+        patch.object(
+            client.client,
+            "send",
+            return_value=MagicMock(status_code=200, json=lambda: {}),
+        ),
+        patch.object(client.client, "build_request"),
+    ):
+        result = llm_passthrough_route(
+            model="bedrock/foo",
+            endpoint="model/foo/converse",
+            method="POST",
+            custom_llm_provider="bedrock",
+            api_base="https://bedrock-runtime.us-east-1.amazonaws.com",
+            api_key="fake-key",
+            json={"messages": []},
+            client=client,
+            litellm_logging_obj=mock_logging_obj,
+            allm_passthrough_route=True,
+        )
+
+    if asyncio.iscoroutine(result):
+        result.close()
+
+    assert captured_litellm_params.get("allm_passthrough_route") is True
+    assert LitellmLogging._is_sync_litellm_request(captured_litellm_params) is False


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4192

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Repro environment: postgres on `127.0.0.1:5432`, litellm proxy on `:4000`, fake Bedrock on `:5091`, fake LangSmith capture on `:5092`, team-level LangSmith success callback registered via `POST /team/{team_id}/callback`, one plain sync callback in `litellm_settings.success_callback` (the required trigger; see LIT-4192 "Trigger condition"). The Bedrock request is a real boto3 `converse` against the proxy's `/bedrock/...` passthrough

Before (unfixed, on `origin/litellm_internal_staging` @ `29035c4a99`):

```
=== RUN 1: Bedrock passthrough ===
A tiny fox found a star and shared its light.
total langsmith runs captured: 3
litellm_call_id=5a5dc7cb-5218-4e79-81b7-e996b2f2b86e run_count=3
  response_ids = ['chatcmpl-8fec6f35-...', 'chatcmpl-8fec6f35-...', 'chatcmpl-d398d129-...']
  call_types   = ['allm_passthrough_route', 'allm_passthrough_route', 'allm_passthrough_route']
  outcome      = ['success', 'success', 'success']

=== RUN 2: Bedrock passthrough (same key/team, thread race gives variance) ===
A tiny fox found a star and shared its light.
total langsmith runs captured: 3
litellm_call_id=9a3381e4-1851-40ca-99ea-29023d15c77d run_count=3
  response_ids = ['chatcmpl-d3a0bf84-...', 'chatcmpl-d3a0bf84-...', 'chatcmpl-9872d602-...']
  call_types   = ['allm_passthrough_route', 'allm_passthrough_route', 'allm_passthrough_route']
  outcome      = ['success', 'success', 'success']

=== CONTROL: /chat/completions (unaffected, exactly 1 run) ===
A tiny fox found a star and shared its light.
total langsmith runs captured: 1
litellm_call_id=2dde1f1f-0c29-4c54-b835-13ef4459d3a1 run_count=1
  response_ids = ['chatcmpl-61d22f26-...']
  call_types   = ['acompletion']
  outcome      = ['success']
```

Matches the fingerprint on the ticket: same `litellm_call_id`, different `chatcmpl-` response ids, count varying with the thread race, `/chat/completions` unaffected

After (this branch):

```
=== RUN 1: Bedrock passthrough (expect exactly 1) ===
A tiny fox found a star and shared its light.
total langsmith runs captured: 1
litellm_call_id=c24640c4-9878-41e4-addb-313f4a09bc4f run_count=1
  response_ids = ['chatcmpl-fa4d4b6a-6398-4896-b82f-5f2752057da9']
  call_types   = ['allm_passthrough_route']
  outcome      = ['success']

=== RUN 2: Bedrock passthrough (expect exactly 1) ===
A tiny fox found a star and shared its light.
total langsmith runs captured: 1
litellm_call_id=fdf34cc2-6a91-4469-998b-f8ed27ebc19b run_count=1

=== RUN 3-7: 5 back-to-back requests, each should be 1 ===
run 1: total langsmith runs captured: 1
run 2: total langsmith runs captured: 1
run 3: total langsmith runs captured: 1
run 4: total langsmith runs captured: 1
run 5: total langsmith runs captured: 1

=== CONTROL: /chat/completions (regression check, still 1) ===
total langsmith runs captured: 1
litellm_call_id=30b0117a-3c31-4b06-9587-091d616b9d66 run_count=1
  call_types   = ['acompletion']
  outcome      = ['success']
```

Exactly one LangSmith run per Bedrock passthrough request across 7 consecutive requests, `/chat/completions` unchanged

## Type

Bug Fix

## Changes

`Logging._is_sync_litellm_request()` (`litellm/litellm_core_utils/litellm_logging.py`) decides sync vs async by inspecting `litellm_params` for `acompletion` / `aresponses` / `aembedding` / `aimage_generation` / `atranscription`. The async passthrough entrypoint in `litellm/passthrough/main.py` sets `kwargs["allm_passthrough_route"] = True`, but that flag was never propagated into `litellm_params`, so `_is_sync_litellm_request` returned `True` for every async passthrough request. That trips the CustomLogger branch inside the sync `success_handler` (`isinstance(callback, CustomLogger) and is_sync_request and call_type != CallTypes.pass_through.value`), which calls `LangsmithLogger.log_success_event()` on top of the async worker's `async_log_success_event()`, producing duplicate LangSmith runs

Fix at the classifier level so the whole request path treats async passthrough consistently as async:

- `get_litellm_params` now accepts `allm_passthrough_route` and writes it into the returned `litellm_params` dict, matching the pattern used for `acompletion` and `aembedding`
- `llm_passthrough_route` forwards its `allm_passthrough_route` argument through the `get_litellm_params(...)` call so the flag reaches `litellm_params`
- `_is_sync_litellm_request` recognizes `allm_passthrough_route=True` as async, using the same shape as the existing checks

Regression tests in `tests/test_litellm/litellm_core_utils/test_litellm_logging.py`:

- `test_is_sync_litellm_request` grows an assertion that `{"allm_passthrough_route": True}` classifies as async
- `test_get_litellm_params_propagates_allm_passthrough_route` locks in that `get_litellm_params(allm_passthrough_route=True)` produces params that `_is_sync_litellm_request` reads as async, so the flag survives the propagation step end to end
- `test_success_handler_skips_sync_callbacks_for_async_requests` gains `allm_passthrough_route` as a parametrize case, so a future regression that reintroduces the sync-callback branch for async passthrough fails immediately

Reverted against `litellm_internal_staging`, all three of these tests fail; with the fix all pass, and the full `tests/test_litellm/litellm_core_utils/test_litellm_logging.py` suite (109 tests) is green

## Regression audit

Full sweep for regressions and backwards-incompatible changes; every claim below is grounded in code evidence

**Callers of `_is_sync_litellm_request` (four total)**

| Location | Behavior change for passthrough | Behavior change for anything else |
|---|---|---|
| `litellm_logging.py:1577` (`dispatch_success_handlers`) | passthrough now enters async path instead of sync shortcut | none; other call types don't set the new flag |
| `litellm_logging.py:1971` (`success_handler`) | CustomLogger sync branch (line 2308) skipped for passthrough, stopping the duplicate | none |
| `litellm_logging.py:2759` (`failure_handler`) | CustomLogger failure branch (line 2842) skipped for passthrough, preventing a symmetric duplicate on failures | none |
| `streaming_handler.py:1671` (`CustomStreamWrapper.run_success_logging_and_cache_storage`) | no real impact; passthrough streaming uses `_sync_streaming`/`_async_streaming` in `passthrough/main.py`, not `CustomStreamWrapper` | none |

**Writers of `kwargs["allm_passthrough_route"] = True`**: exactly one site, `passthrough/main.py:63`. No other code, tests, or docs set this key, so no non-passthrough request can accidentally flip to async

**Callers of `get_litellm_params`**: 48 across `litellm/` and `tests/`. All use `**kwargs` or explicit keyword arguments; no positional callers, so adding `allm_passthrough_route=None` as a keyword-only parameter is safe

**Downstream consumers of the returned `litellm_params` dict**: none read `"allm_passthrough_route"` as a key outside `_is_sync_litellm_request`. Not serialized to `SpendLogsPayload`, `StandardLoggingPayload`, DB rows, or callback payloads. The new `None` value on non-passthrough requests is invisible in every observable path

**`@client` decorator and signature introspection**: `litellm/utils.py` `client`/`function_setup`/`wrapper_async` do not use `inspect.signature`/`__signature__`. Dropping `allm_passthrough_route: bool = False` from `llm_passthrough_route`'s signature is safe

**Callers of `llm_passthrough_route(...)`**: no external caller passes `allm_passthrough_route=True` as a keyword. The only writer is the internal `allm_passthrough_route` which sets `kwargs["allm_passthrough_route"] = True`; the flag now flows through `**kwargs` naturally

**Orthogonality with the old `pass_through_endpoint` guard**: `CallTypes.pass_through.value == "pass_through_endpoint"` and `CallTypes.allm_passthrough_route.value == "allm_passthrough_route"` are distinct strings for distinct code paths; no redundancy, no contradiction

**Empirical test-diff (baseline `origin/litellm_internal_staging` vs `HEAD`)**

Suite: `tests/test_litellm/litellm_core_utils/` + `tests/test_litellm/passthrough/` + `tests/test_litellm/proxy/pass_through_endpoints/` + `tests/test_litellm/proxy/guardrails/test_deferred_guardrail_logging.py` + `tests/pass_through_unit_tests/test_unit_test_streaming.py`

Regressions introduced by this PR: **0**

Newly passing on this branch: 4 — exactly the LIT-4192 tests added or extended here (`test_is_sync_litellm_request` new assertion, `test_get_litellm_params_propagates_allm_passthrough_route`, `test_success_handler_skips_sync_callbacks_for_async_requests[allm_passthrough_route]`, `test_llm_passthrough_route_propagates_allm_passthrough_route_to_logging_obj`); on `origin/litellm_internal_staging` they fail because the source fix is absent, which serves as the mutation check for this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes logging callback routing for passthrough requests; scoped fix with tests but affects observability integrations on a hot path.
> 
> **Overview**
> Fixes **duplicate success callbacks** (e.g. LangSmith runs) on async LLM passthrough by treating `allm_passthrough_route` like other async entrypoints.
> 
> **`get_litellm_params`** now accepts and stores `allm_passthrough_route` in `litellm_params`. **`Logging._is_sync_litellm_request`** treats `allm_passthrough_route=True` as async so the sync `success_handler` does not also fire `CustomLogger.log_success_event` on top of the async path.
> 
> **`llm_passthrough_route`** no longer takes `allm_passthrough_route` as a dedicated parameter; it reads `kwargs["allm_passthrough_route"]` for async detection while the flag still flows through `get_litellm_params(**kwargs)` into the logging object.
> 
> Regression tests cover param propagation, sync/async classification, and skipping sync callbacks for `allm_passthrough_route`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335f99ea3537e194954b3948e3c117bc15131746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
