### PR TITLE
test(e2e): probe the full spend read surface including schema-hidden routes

### DIFF
--- a/tests/e2e/e2e_gateway.py
+++ b/tests/e2e/e2e_gateway.py
@@ -9,6 +9,7 @@ Gateway's key/customer methods for cleanup. Read-backs are eventually consistent
 from __future__ import annotations
 
 import time
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -18,6 +19,7 @@ from e2e_http import (
     Result,
     StreamingResponse,
     Success,
+    is_ok,
     unwrap,
 )
 from models import (
@@ -32,8 +34,14 @@ from models import (
     KeyInfo,
     KeyInfoParams,
     KeyInfoResponse,
+    LiteLLMParamsBody,
+    ModelDeleteBody,
+    ModelInfoBody,
     ModelInfoEntry,
     ModelInfoResponse,
+    ModelMode,
+    ModelNewBody,
+    ModelNewResponse,
     OcrBody,
     OcrResponse,
     SpendLogRow,
@@ -110,6 +118,38 @@ class Gateway:
                 response_type=ModelInfoResponse,
             )
         ).data
+
+    def create_model(
+        self,
+        model_name: str,
+        litellm_params: LiteLLMParamsBody,
+        mode: ModelMode | None = None,
+    ) -> str:
+        """Register a deployment under `model_name` (id == model_name) and return the
+        model_id. add_deployment runs synchronously in /model/new, so the model is
+        callable as soon as this returns."""
+        return unwrap(
+            self.transport.post(
+                "/model/new",
+                headers=self.transport.master,
+                json=ModelNewBody(
+                    model_name=model_name,
+                    litellm_params=litellm_params,
+                    model_info=ModelInfoBody(id=model_name, mode=mode),
+                ),
+                response_type=ModelNewResponse,
+            )
+        ).model_id
+
+    def delete_model(self, model_id: str) -> None:
+        result = self.transport.post(
+            "/model/delete",
+            headers=self.transport.master,
+            json=ModelDeleteBody(id=model_id),
+            response_type=NoBody,
+        )
+        if not is_ok(result):
+            warnings.warn(f"delete_model({model_id!r}) failed: {result}", stacklevel=2)
 
     # ---- LLM calls ------------------------------------------------------
 

--- a/tests/e2e/llm_translation/endpoints_client.py
+++ b/tests/e2e/llm_translation/endpoints_client.py
@@ -14,15 +14,8 @@ from dataclasses import dataclass
 from pydantic import BaseModel
 
 from e2e_gateway import Gateway, build_gateway
-from e2e_http import NoBody, StreamingResponse, is_ok, unwrap
-from models import (
-    ChatMessage,
-    LiteLLMParamsBody,
-    ModelDeleteBody,
-    ModelInfoBody,
-    ModelNewBody,
-    ModelNewResponse,
-)
+from e2e_http import StreamingResponse
+from models import ChatMessage, LiteLLMParamsBody
 
 
 class ResponsesRequest(BaseModel):
@@ -136,32 +129,10 @@ class EndpointsClient:
     gateway: Gateway
 
     def create_model(self, model_name: str, litellm_params: LiteLLMParamsBody) -> str:
-        """Register a deployment under `model_name` (id == model_name) and return the
-        model_id. add_deployment runs synchronously in /model/new, so the model is
-        callable as soon as this returns."""
-        return unwrap(
-            self.gateway.transport.post(
-                "/model/new",
-                headers=self.gateway.transport.master,
-                json=ModelNewBody(
-                    model_name=model_name,
-                    litellm_params=litellm_params,
-                    model_info=ModelInfoBody(id=model_name),
-                ),
-                response_type=ModelNewResponse,
-            )
-        ).model_id
+        return self.gateway.create_model(model_name, litellm_params)
 
     def delete_model(self, model_id: str) -> None:
-        result = self.gateway.transport.post(
-            "/model/delete",
-            headers=self.gateway.transport.master,
-            json=ModelDeleteBody(id=model_id),
-            response_type=NoBody,
-        )
-        if not is_ok(result):
-            import warnings
-            warnings.warn(f"delete_model({model_id!r}) failed: {result}", stacklevel=2)
+        self.gateway.delete_model(model_id)
 
     def _send(self, path: str, key: str, body: BaseModel) -> StreamingResponse:
         return self.gateway.transport.send(

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -367,9 +367,12 @@ class LiteLLMParamsBody(BaseModel):
     output_cost_per_token: float | None = None
 
 
+ModelMode = Literal["batch", "realtime", "image_generation"]
+
+
 class ModelInfoBody(BaseModel):
     id: str
-    mode: Literal["batch", "realtime", "image_generation"] | None = None
+    mode: ModelMode | None = None
 
 
 class ModelNewBody(BaseModel):

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -216,6 +216,25 @@ class SpendLogsParams(BaseModel):
     api_key: str | None = None
 
 
+class SpendLogsPageParams(BaseModel):
+    """Query for /spend/logs/v2, which requires an explicit date window and
+    serves pages of at most 100 rows."""
+
+    start_date: str
+    end_date: str
+    page: int
+    page_size: int
+    api_key: str | None = None
+
+
+class SpendLogsPage(BaseModel):
+    data: list[SpendLogRow] = []
+    total: int
+    page: int
+    page_size: int
+    total_pages: int
+
+
 # ---------- spend calculate ----------
 
 

--- a/tests/e2e/spend_tracking/SPEND_TRACKING_COVERAGE_MATRIX.md
+++ b/tests/e2e/spend_tracking/SPEND_TRACKING_COVERAGE_MATRIX.md
@@ -43,6 +43,7 @@ proxy + SpendLogs rows. Status: `covered` / `partial` / `gap`.
 | Tag | `test_update_daily_tag_spend.py` | partial | yes (`test_tag_spend_matches_sum_of_tagged_logs`) |
 | End-user | `test_proxy_update_spend.py` | covered | yes |
 | Spend == sum(logs) consistency | none | gap | yes (key + tag aggregate == sum of rows) |
+| Concurrent increments (one key, parallel writers) | `tests/spend_tracking_tests/test_spend_accuracy_tests.py` (burst) | partial | yes (`test_burst_of_concurrent_calls_loses_no_spend`) |
 
 ## Spend read endpoints (verification surface)
 
@@ -51,6 +52,7 @@ proxy + SpendLogs rows. Status: `covered` / `partial` / `gap`.
 | `/spend/logs` (request_id / api_key) | `test_spend_management_endpoints.py` | covered | yes (primary read path; `test_spend_logs_endpoint_returns_spend` asserts 200 + spend, never 5xx) |
 | `/spend/calculate` | `local_testing/test_spend_calculate_endpoint.py` | covered | yes (`test_spend_calculate_returns_nonzero_cost`) |
 | `/spend/tags` | `test_spend_management_endpoints.py` | partial | yes (tag accuracy test) |
+| `/spend/logs/v2` pagination (total/total_pages/out-of-range) | `test_spend_query_optimization.py` | covered | yes (`test_spend_logs_v2_pagination_caps_pages_and_keeps_total`; filter takes the hashed token, not the raw key) |
 | whole spend GET surface (22 routes) | unit per-handler | partial | yes (`test_spend_routes.py` probes each for 404/5xx) |
 
 ## What this suite pins
@@ -69,6 +71,8 @@ proxy + SpendLogs rows. Status: `covered` / `partial` / `gap`.
 | `test_failure_call_writes_failure_status_row` | failed call -> `status=failure`, `spend=0` |
 | `test_spend_calculate_returns_nonzero_cost` | cost-map smoke (no batch wait) |
 | `test_spend_logs_endpoint_returns_spend` | `/spend/logs` returns 200 + the key's spend, never a 5xx (intermittent-500 regression) |
+| `test_burst_of_concurrent_calls_loses_no_spend` | N parallel calls on one key: N distinct costed rows, key aggregate == sum (no lost increments) |
+| `test_spend_logs_v2_pagination_caps_pages_and_keeps_total` | `/spend/logs/v2` page cap, stable total on out-of-range page, zero total on no-match filter |
 | `test_spend_routes.py` (23) | no spend route 404s or 5xxs |
 
 ## Design + timing

--- a/tests/e2e/spend_tracking/conftest.py
+++ b/tests/e2e/spend_tracking/conftest.py
@@ -1,16 +1,55 @@
-"""Spend-tracking suite's `client` fixture.
+"""Spend-tracking suite's `client` fixture and driver-model registration.
 
 The shared lifecycle (resources/scoped_key), proxy liveness skip, and e2e marker
 live in the parent tests/e2e/conftest.py. SpendClient exposes the shared Gateway
 (GatewayProvider), so the `resources` fixture cleans up keys and customers this
 suite creates.
+
+The suite drives real calls through three deployments. On the stage gateway they
+are baked into the proxy config; on a local dev proxy they usually are not, so
+`driver_models` registers whichever are missing via /model/new and deletes only
+the ones it created, never a config-baked deployment. Each registration carries
+the provider key from the test runner's env when set (so a local proxy whose
+container env lacks the key still works); otherwise it falls back to an
+os.environ reference resolved from the proxy's own env, the stage convention.
 """
+
+import os
+from typing import Iterator
 
 import pytest
 
+from models import LiteLLMParamsBody
 from spend_e2e_client import SpendClient, build_client
+
+
+def _driver_params(provider_model: str, env_var: str) -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=provider_model,
+        api_key=os.environ.get(env_var) or f"os.environ/{env_var}",
+    )
+
+
+DRIVER_MODELS: tuple[tuple[str, str, str], ...] = (
+    ("gemini-2.5-flash", "gemini/gemini-2.5-flash", "GEMINI_API_KEY"),
+    ("claude-haiku-4-5", "anthropic/claude-haiku-4-5", "ANTHROPIC_API_KEY"),
+    ("openai-text-embedding-3-small", "openai/text-embedding-3-small", "OPENAI_API_KEY"),
+)
 
 
 @pytest.fixture(scope="session")
 def client() -> SpendClient:
     return build_client()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def driver_models(client: SpendClient) -> Iterator[None]:
+    existing = frozenset(entry.model_name for entry in client.gateway.model_info())
+    created = tuple(
+        client.gateway.create_model(name, _driver_params(provider_model, env_var))
+        for name, provider_model, env_var in DRIVER_MODELS
+        if name not in existing
+    )
+    yield
+    for model_id in created:
+        client.gateway.delete_model(model_id)

--- a/tests/e2e/spend_tracking/spend_e2e_client.py
+++ b/tests/e2e/spend_tracking/spend_e2e_client.py
@@ -15,6 +15,7 @@ import os
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 
 from e2e_config import unique_marker
 from e2e_http import (
@@ -39,6 +40,8 @@ from models import (
     SpendCalculateBody,
     SpendCalculateResponse,
     SpendLogRow,
+    SpendLogsPage,
+    SpendLogsPageParams,
     SpendTagsResponse,
     TagSpend,
 )
@@ -179,6 +182,28 @@ class SpendClient:
                 return spend
             time.sleep(self.gateway.poll_interval)
         return spend
+
+    def spend_logs_page(
+        self, *, api_key: str | None, page: int, page_size: int
+    ) -> SpendLogsPage:
+        """One page of /spend/logs/v2 over a window wide enough to contain every
+        row this test run wrote (the endpoint requires explicit dates)."""
+        now = datetime.now(timezone.utc)
+        fmt = "%Y-%m-%d %H:%M:%S"
+        return unwrap(
+            self.gateway.transport.get(
+                "/spend/logs/v2",
+                headers=self.gateway.transport.master,
+                params=SpendLogsPageParams(
+                    start_date=(now - timedelta(days=1)).strftime(fmt),
+                    end_date=(now + timedelta(days=1)).strftime(fmt),
+                    page=page,
+                    page_size=page_size,
+                    api_key=api_key,
+                ),
+                response_type=SpendLogsPage,
+            )
+        )
 
     def probe(self, path: str, *, params: DateRangeParams) -> ProbeResult:
         return self.gateway.transport.probe(path, params=params)

--- a/tests/e2e/spend_tracking/test_spend_routes.py
+++ b/tests/e2e/spend_tracking/test_spend_routes.py
@@ -27,13 +27,21 @@ pytestmark = pytest.mark.e2e
 
 # Verified present and responsive on a live proxy. One per row of the spend
 # surface: key / user / team / org / customer aggregation, model-cost, tags,
-# activity.
+# activity. Most are include_in_schema=False, so keep this list exhaustive by
+# hand; the schema test below only auto-catches the visible minority. Excluded
+# by design: path-param routes (/spend/logs/ui/{request_id}), POST readers
+# (/spend/calculate has its own test, /global/spend/end_users), mutating
+# POSTs (/global/spend/reset, /global/spend/refresh), and /provider/budgets,
+# which 500s whenever router_settings.provider_budget_config is absent, so it
+# is only probeable on a proxy configured with provider budget routing.
 SPEND_ROUTES = (
     "/spend/keys",
     "/spend/users",
     "/spend/tags",
     "/spend/logs",
     "/spend/logs/ui",
+    "/spend/logs/v2",
+    "/spend/logs/session/ui",
     "/global/spend",
     "/global/spend/keys",
     "/global/spend/teams",
@@ -43,9 +51,18 @@ SPEND_ROUTES = (
     "/global/spend/tags",
     "/global/spend/logs",
     "/global/spend/all_tag_names",
+    "/global/all_end_users",
     "/global/activity",
     "/global/activity/model",
     "/global/activity/exceptions",
+    "/global/activity/exceptions/deployment",
+    "/user/daily/activity",
+    "/user/daily/activity/aggregated",
+    "/team/daily/activity",
+    "/organization/daily/activity",
+    "/customer/daily/activity",
+    "/end_user/daily/activity",
+    "/tag/daily/activity",
     "/key/list",
     "/user/list",
     "/team/list",

--- a/tests/e2e/spend_tracking/test_spend_tracking_e2e.py
+++ b/tests/e2e/spend_tracking/test_spend_tracking_e2e.py
@@ -21,9 +21,9 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from e2e_http import Success
+from e2e_http import Result, Success
 from lifecycle import ResourceManager
-from models import SpendLogs, SpendLogsParams
+from models import ChatResponse, SpendLogs, SpendLogsParams
 from spend_e2e_client import SpendClient, SpendLogRow, is_ok, unique_marker, unwrap
 
 pytestmark = pytest.mark.e2e
@@ -212,18 +212,17 @@ def test_burst_of_concurrent_calls_loses_no_spend(
     the concurrent increment path (parallel writers racing on one key's counter),
     where a lost update can never be reproduced by sequential calls."""
     burst = 6
-    with ThreadPoolExecutor(max_workers=burst) as pool:
-        results = tuple(
-            pool.map(
-                lambda idx: client.chat(
-                    scoped_key,
-                    "gemini-2.5-flash",
-                    f"burst call {idx} {unique_marker()}",
-                    max_tokens=16,
-                ),
-                range(burst),
-            )
+
+    def call(idx: int) -> Result[ChatResponse]:
+        return client.chat(
+            scoped_key,
+            "gemini-2.5-flash",
+            f"burst call {idx} {unique_marker()}",
+            max_tokens=16,
         )
+
+    with ThreadPoolExecutor(max_workers=burst) as pool:
+        results = tuple(pool.map(call, range(burst)))
     failed = [r for r in results if not is_ok(r)]
     assert not failed, f"{len(failed)}/{burst} burst calls failed; first: {failed[0]}"
 

--- a/tests/e2e/spend_tracking/test_spend_tracking_e2e.py
+++ b/tests/e2e/spend_tracking/test_spend_tracking_e2e.py
@@ -17,6 +17,7 @@ fails the test; a pricing or token-count drift does not.
 
 import time
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -200,6 +201,105 @@ def test_key_spend_equals_sum_of_logs(client: SpendClient, scoped_key: str) -> N
     assert _approx_equal(
         key_spend, logs_total
     ), f"key aggregate {key_spend} != sum of logs {logs_total}; rows: {_summarize(rows)}"
+
+
+def test_burst_of_concurrent_calls_loses_no_spend(
+    client: SpendClient, scoped_key: str
+) -> None:
+    """Six concurrent calls on one key: every call lands its own spend row under a
+    distinct request_id and the key aggregate equals the sum of the rows.
+    Sequential accuracy is covered by test_key_spend_equals_sum_of_logs; this pins
+    the concurrent increment path (parallel writers racing on one key's counter),
+    where a lost update can never be reproduced by sequential calls."""
+    burst = 6
+    with ThreadPoolExecutor(max_workers=burst) as pool:
+        results = tuple(
+            pool.map(
+                lambda idx: client.chat(
+                    scoped_key,
+                    "gemini-2.5-flash",
+                    f"burst call {idx} {unique_marker()}",
+                    max_tokens=16,
+                ),
+                range(burst),
+            )
+        )
+    failed = [r for r in results if not is_ok(r)]
+    assert not failed, f"{len(failed)}/{burst} burst calls failed; first: {failed[0]}"
+
+    rows = client.poll_logs_for_key(
+        scoped_key,
+        min_rows=burst,
+        predicate=lambda rs: len([r for r in rs if (r.spend or 0) > 0]) >= burst,
+    )
+    costed = [r for r in rows if (r.spend or 0) > 0]
+    assert len(costed) >= burst, (
+        f"only {len(costed)}/{burst} burst calls produced a costed row - "
+        f"rows lost under concurrency: {_summarize(rows)}"
+    )
+    request_ids = [r.request_id for r in costed]
+    assert len(set(request_ids)) == len(request_ids), (
+        f"concurrent rows collapsed onto shared request_ids: {_summarize(rows)}"
+    )
+
+    logs_total = sum((r.spend or 0) for r in rows)
+    key_spend = client.poll_key_spend(scoped_key, minimum=logs_total * 0.999)
+    assert _approx_equal(key_spend, logs_total), (
+        f"key aggregate {key_spend} != sum of {len(rows)} rows {logs_total} - "
+        f"spend increments lost under concurrency: {_summarize(rows)}"
+    )
+
+
+def test_spend_logs_v2_pagination_caps_pages_and_keeps_total(
+    client: SpendClient, scoped_key: str
+) -> None:
+    """/spend/logs/v2 pagination contract for the key filter: page_size caps the
+    rows returned, total counts every row for the filter (so with page_size=1,
+    total_pages == total), a page past the end returns no rows while reporting
+    the same total (an out-of-range page must not reset the count the UI
+    paginates by), and a filter matching nothing reports zero without erroring.
+
+    Unlike /spend/logs, the v2 filter matches the hashed token exactly as stored
+    on the row (the form the UI passes), not the raw sk- key, so the filter value
+    is read off the rows the poll returned."""
+    for _ in range(2):
+        _ = unwrap(
+            client.chat(
+                scoped_key,
+                "gemini-2.5-flash",
+                f"page fodder {unique_marker()}",
+                max_tokens=16,
+            )
+        )
+    rows = client.poll_logs_for_key(
+        scoped_key, min_rows=2, predicate=lambda rs: sum((r.spend or 0) for r in rs) > 0
+    )
+    hashed_key = rows[0].api_key
+    assert hashed_key, f"polled rows carry no api_key: {_summarize(rows)}"
+
+    first = client.spend_logs_page(api_key=hashed_key, page=1, page_size=1)
+    assert first.total >= 2, f"expected >=2 rows for the key, got total={first.total}"
+    assert len(first.data) == 1, f"page_size=1 returned {len(first.data)} rows"
+    assert first.total_pages == first.total, (
+        f"page_size=1 must give one page per row: "
+        f"total={first.total} total_pages={first.total_pages}"
+    )
+
+    beyond = client.spend_logs_page(
+        api_key=hashed_key, page=first.total_pages + 7, page_size=1
+    )
+    assert beyond.data == [], f"out-of-range page returned rows: {beyond.data}"
+    assert beyond.total == first.total, (
+        f"out-of-range page changed the total: {beyond.total} != {first.total}"
+    )
+
+    nomatch = client.spend_logs_page(
+        api_key=f"sk-no-such-key-{unique_marker()}", page=1, page_size=1
+    )
+    assert nomatch.total == 0 and nomatch.data == [], (
+        f"filter matching nothing must report zero: "
+        f"total={nomatch.total} rows={len(nomatch.data)}"
+    )
 
 
 def test_request_tags_round_trip(client: SpendClient, scoped_key: str) -> None:

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -1,0 +1,140 @@
+"""Unit coverage for the Gateway model-management surface (create_model /
+delete_model).
+
+The batches conftest and several llm_translation tests register deployments at
+runtime through gateway.create_model; when that method went missing, every batch
+test errored at fixture setup (AttributeError) before a single request reached
+the proxy. This pins the surface with a typed fake Transport so a rename or
+signature drift fails here instead of in a live stage run.
+"""
+
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel
+
+from batches.batch_client import BatchClient
+from e2e_gateway import Gateway
+from e2e_http import (
+    AuthHeaders,
+    FileUploadForm,
+    ProbeResult,
+    Result,
+    StreamingResponse,
+    Success,
+)
+from models import LiteLLMParamsBody, ModelDeleteBody, ModelNewBody
+
+
+@dataclass
+class _RecordingTransport:
+    """Typed fake fulfilling the Transport protocol; records every post and
+    answers with a canned success so the test asserts on what was sent."""
+
+    posts: list[tuple[str, BaseModel]] = field(default_factory=list)
+
+    def post[R: BaseModel](
+        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+    ) -> Result[R]:
+        self.posts.append((path, json))
+        return Success(data=response_type.model_validate({"model_id": "registered-id"}))
+
+    def stream(
+        self, path: str, *, headers: BaseModel, json: BaseModel
+    ) -> StreamingResponse:
+        raise AssertionError("stream is not part of model management")
+
+    def send(
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        json: BaseModel,
+        params: BaseModel | None = None,
+        stream: bool = False,
+    ) -> StreamingResponse:
+        raise AssertionError("send is not part of model management")
+
+    def get[R: BaseModel](
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        params: BaseModel,
+        response_type: type[R],
+    ) -> Result[R]:
+        raise AssertionError("get is not part of model management")
+
+    def delete[R: BaseModel](
+        self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
+    ) -> Result[R]:
+        raise AssertionError("delete is not part of model management")
+
+    def probe(self, path: str, *, params: BaseModel) -> ProbeResult:
+        raise AssertionError("probe is not part of model management")
+
+    def upload[R: BaseModel](
+        self,
+        path: str,
+        *,
+        headers: BaseModel,
+        form: FileUploadForm,
+        filename: str,
+        content: bytes,
+        params: BaseModel | None = None,
+        response_type: type[R],
+    ) -> Result[R]:
+        raise AssertionError("upload is not part of model management")
+
+    def download(self, path: str, *, headers: BaseModel) -> StreamingResponse:
+        raise AssertionError("download is not part of model management")
+
+    def bearer(self, key: str) -> AuthHeaders:
+        return AuthHeaders(authorization=f"Bearer {key}")
+
+    @property
+    def master(self) -> AuthHeaders:
+        return self.bearer("sk-test-master")
+
+
+def test_gateway_create_model_registers_deployment_and_returns_model_id() -> None:
+    transport = _RecordingTransport()
+    gateway = Gateway(transport=transport)
+
+    model_id = gateway.create_model(
+        "e2e-test-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")
+    )
+
+    assert model_id == "registered-id"
+    path, body = transport.posts[0]
+    assert path == "/model/new"
+    assert isinstance(body, ModelNewBody)
+    assert body.model_name == "e2e-test-model"
+    assert body.model_info.id == "e2e-test-model"
+    assert body.model_info.mode is None
+
+
+def test_batch_client_create_model_registers_a_batch_mode_deployment() -> None:
+    transport = _RecordingTransport()
+    client = BatchClient(gateway=Gateway(transport=transport))
+
+    model_id = client.create_model(
+        "e2e-batch-model", LiteLLMParamsBody(model="openai/gpt-4o-mini")
+    )
+
+    assert model_id == "registered-id"
+    path, body = transport.posts[0]
+    assert path == "/model/new"
+    assert isinstance(body, ModelNewBody)
+    assert body.model_info.mode == "batch"
+
+
+def test_gateway_delete_model_posts_the_model_id() -> None:
+    transport = _RecordingTransport()
+    gateway = Gateway(transport=transport)
+
+    gateway.delete_model("registered-id")
+
+    path, body = transport.posts[0]
+    assert path == "/model/delete"
+    assert isinstance(body, ModelDeleteBody)
+    assert body.id == "registered-id"

--- a/tests/e2e/test_e2e_gateway.py
+++ b/tests/e2e/test_e2e_gateway.py
@@ -22,7 +22,12 @@ from e2e_http import (
     StreamingResponse,
     Success,
 )
-from models import LiteLLMParamsBody, ModelDeleteBody, ModelNewBody
+from models import (
+    LiteLLMParamsBody,
+    ModelDeleteBody,
+    ModelNewBody,
+    ModelNewResponse,
+)
 
 
 @dataclass
@@ -36,7 +41,10 @@ class _RecordingTransport:
         self, path: str, *, headers: BaseModel, json: BaseModel, response_type: type[R]
     ) -> Result[R]:
         self.posts.append((path, json))
-        return Success(data=response_type.model_validate({"model_id": "registered-id"}))
+        payload = (
+            {"model_id": "registered-id"} if response_type is ModelNewResponse else {}
+        )
+        return Success(data=response_type.model_validate(payload))
 
     def stream(
         self, path: str, *, headers: BaseModel, json: BaseModel

--- a/tests/e2e/test_transport.py
+++ b/tests/e2e/test_transport.py
@@ -1,0 +1,48 @@
+"""Unit coverage for SplitTransport path routing (is_control_plane_path).
+
+Model-management calls (/model/new, /model/delete, /model/info) must go to the
+control plane: the data-plane gateway does not serve management routes, so a
+misrouted /model/new 404s and takes down every suite that registers deployments
+at runtime (llm_translation, batches, access_control). /models must stay on the
+data plane; it is the OpenAI-compatible list-models route, not a management
+route.
+"""
+
+import pytest
+
+from transport import is_control_plane_path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/model/new",
+        "/model/delete",
+        "/model/update",
+        "/model/info",
+        "/key/generate",
+        "/budget/new",
+        "/spend/logs",
+    ],
+)
+def test_management_routes_go_to_the_control_plane(path: str) -> None:
+    assert is_control_plane_path(path), (
+        f"{path} is a management route; sending it to the data plane 404s"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/models",
+        "/v1/models",
+        "/chat/completions",
+        "/v1/messages",
+        "/embeddings",
+        "/anthropic/v1/messages",
+    ],
+)
+def test_llm_routes_stay_on_the_data_plane(path: str) -> None:
+    assert not is_control_plane_path(path), (
+        f"{path} is an LLM route; it must go to the data plane"
+    )

--- a/tests/e2e/test_transport.py
+++ b/tests/e2e/test_transport.py
@@ -23,6 +23,10 @@ from transport import is_control_plane_path
         "/key/generate",
         "/budget/new",
         "/spend/logs",
+        "/end_user/daily/activity",
+        "/user/daily/activity",
+        "/team/daily/activity",
+        "/tag/daily/activity",
     ],
 )
 def test_management_routes_go_to_the_control_plane(path: str) -> None:

--- a/tests/e2e/transport.py
+++ b/tests/e2e/transport.py
@@ -204,7 +204,7 @@ CONTROL_PLANE_PREFIXES: tuple[str, ...] = (
     "/customer",
     "/tag",
     "/budget",
-    "/model/info",
+    "/model/",
     "/spend",
     "/global",
     "/openapi.json",

--- a/tests/e2e/transport.py
+++ b/tests/e2e/transport.py
@@ -202,6 +202,7 @@ CONTROL_PLANE_PREFIXES: tuple[str, ...] = (
     "/team",
     "/organization",
     "/customer",
+    "/end_user",
     "/tag",
     "/budget",
     "/model/",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

Stacked on #32261; the first two commits here are that PR and this one should merge after it

## Screenshots / Proof of Fix

Every added route probed against the live split stage deployment (kubectl port-forward of litellm-backend:4001 as 14001 for the control plane and litellm-gateway:4000 as 14000 for the data plane), with the master key and a one-day date range:

```
$ START=$(date -u -v-1d +%Y-%m-%d); END=$(date -u +%Y-%m-%d)
$ for route in /spend/logs/v2 /spend/logs/session/ui /global/all_end_users \
    /global/activity/exceptions/deployment /user/daily/activity \
    /user/daily/activity/aggregated /team/daily/activity /organization/daily/activity \
    /customer/daily/activity /end_user/daily/activity /tag/daily/activity; do
    code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $MASTER_KEY" \
      "http://localhost:14001${route}?start_date=${START}&end_date=${END}")
    dcode=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $MASTER_KEY" \
      "http://localhost:14000${route}?start_date=${START}&end_date=${END}")
    echo "$route -> control:$code data:$dcode"
  done
/spend/logs/v2 -> control:200 data:404
/spend/logs/session/ui -> control:422 data:404
/global/all_end_users -> control:200 data:404
/global/activity/exceptions/deployment -> control:422 data:404
/user/daily/activity -> control:200 data:404
/user/daily/activity/aggregated -> control:200 data:404
/team/daily/activity -> control:200 data:404
/organization/daily/activity -> control:200 data:404
/customer/daily/activity -> control:200 data:404
/end_user/daily/activity -> control:200 data:404
/tag/daily/activity -> control:200 data:404
```

The 422s are the two routes whose required params a bare probe intentionally omits (session_id and deployment grouping); per the suite's healthy definition that still proves the route is wired and the handler ran. The data-plane 404 column shows why the /end_user prefix addition matters: without it the probe of /end_user/daily/activity would have gone to the gateway and failed the way /model/new did before #32261

The full suite run against the same live deployment:

```
$ LITELLM_PROXY_URL=http://localhost:14000 LITELLM_CONTROL_PLANE_URL=http://localhost:14001 \
    uv run pytest tests/e2e/spend_tracking/test_spend_routes.py -q
34 passed in 9.17s
```

Follow-up commits on this branch, both live-verified against stage: the suite no longer assumes its driver deployments are baked into the proxy config; a session fixture registers any missing driver via /model/new (provider key from the runner's env when set, os.environ reference otherwise) and deletes only what it created. Two accuracy behaviors were ported from the CircleCI integration suites as true e2e tests: a six-way concurrent burst on one key must produce six distinct costed rows summing exactly to the key aggregate (the lost-increment contract), and /spend/logs/v2 pagination must cap rows by page_size, keep total stable for out-of-range pages, and report zero for a no-match filter. One live-contract note: the v2 api_key filter matches the hashed token as stored on rows, not the raw sk- key, so the test reads the filter value off the polled rows

## Type

Test

## Changes

The spend read surface is mostly served with `include_in_schema=False`, so the schema-discovery test misses roughly 70% of it and the curated `SPEND_ROUTES` list is the real coverage. That list was missing twelve read routes: `/spend/logs/v2`, `/spend/logs/session/ui`, `/global/all_end_users`, `/global/activity/exceptions/deployment`, and the seven per-entity daily activity routes (`/user/daily/activity`, `/user/daily/activity/aggregated`, `/team/daily/activity`, `/organization/daily/activity`, `/customer/daily/activity`, `/end_user/daily/activity`, `/tag/daily/activity`). All are now probed

`/end_user` is added to `CONTROL_PLANE_PREFIXES` because `/end_user/daily/activity` is a management route that the data-plane gateway 404s on the split deployment, and the transport routing test gains rows for it and the daily-activity family

Deliberately excluded, with the reasons documented next to the list: path-param routes, the POST readers (`/spend/calculate` already has a dedicated test), the mutating `/global/spend/reset` and `/global/spend/refresh`, and `/provider/budgets`, which raises a 500 whenever `router_settings.provider_budget_config` is not set, so it cannot be probed green on a proxy without provider budget routing. That 500 on an unconfigured feature arguably deserves a product fix to return an empty object instead; left out of scope here