### PR TITLE
fix(responses_id_security): decrypt response ids for input_items follow-ups

### DIFF
--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -44,6 +44,7 @@ class ResponsesIDSecurity(CustomLogger):
             "aget_responses",
             "adelete_responses",
             "acancel_responses",
+            "alist_input_items",
         }
         if call_type not in responses_api_call_types:
             return None
@@ -54,7 +55,7 @@ class ResponsesIDSecurity(CustomLogger):
                 original_response_id, user_id, team_id = self._decrypt_response_id(previous_response_id)
                 self.check_user_access_to_response_id(user_id, team_id, user_api_key_dict)
                 data["previous_response_id"] = original_response_id
-        elif call_type in {"aget_responses", "adelete_responses", "acancel_responses"}:
+        elif call_type in {"aget_responses", "adelete_responses", "acancel_responses", "alist_input_items"}:
             response_id = data.get("response_id")
 
             if response_id and self._is_encrypted_response_id(response_id):

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -519,6 +519,62 @@ class TestAsyncPreCallHook:
                     assert "team" in exc_info.value.detail.lower()
 
 
+    @pytest.mark.asyncio
+    async def test_async_pre_call_hook_alist_input_items_decrypts_response_id(
+        self, responses_id_security, mock_user_api_key_dict, mock_cache
+    ):
+        data = {"response_id": "resp_encrypted_789"}
+
+        with patch.object(
+            responses_id_security, "_is_encrypted_response_id", return_value=True
+        ):
+            with patch.object(
+                responses_id_security,
+                "_decrypt_response_id",
+                return_value=("resp_original_789", "test-user-123", "test-team-123"),
+            ):
+                result = await responses_id_security.async_pre_call_hook(
+                    user_api_key_dict=mock_user_api_key_dict,
+                    cache=mock_cache,
+                    data=data,
+                    call_type="alist_input_items",
+                )
+
+                assert result is not None
+                assert result["response_id"] == "resp_original_789"
+
+    @pytest.mark.asyncio
+    async def test_async_pre_call_hook_alist_input_items_team_security(
+        self, responses_id_security, mock_cache
+    ):
+        mock_auth_team_a = MagicMock()
+        mock_auth_team_a.user_id = None
+        mock_auth_team_a.team_id = "team-a"
+        mock_auth_team_a.user_role = None
+
+        data = {"response_id": "resp_encrypted_team_b"}
+
+        with patch.object(
+            responses_id_security, "_is_encrypted_response_id", return_value=True
+        ):
+            with patch.object(
+                responses_id_security,
+                "_decrypt_response_id",
+                return_value=("resp_original_team_b", None, "team-b"),
+            ):
+                with patch("litellm.proxy.proxy_server.general_settings", {}):
+                    with pytest.raises(HTTPException) as exc_info:
+                        await responses_id_security.async_pre_call_hook(
+                            user_api_key_dict=mock_auth_team_a,
+                            cache=mock_cache,
+                            data=data,
+                            call_type="alist_input_items",
+                        )
+
+                    assert exc_info.value.status_code == 403
+                    assert "team" in exc_info.value.detail.lower()
+
+
 class TestAsyncPostCallSuccessHook:
     """Test async_post_call_success_hook function"""
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Part of LIT-4111

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy against the real OpenAI API (`openai/gpt-4o-mini`), DB-less, responses id security on by default:

```yaml
model_list:
  - model_name: openai-responses-test
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

Before (proxy on `litellm_internal_staging` at `f628b41400`, port 53798): create a response, then list its input items with the encrypted id the proxy returned

```
$ curl -s http://127.0.0.1:53798/v1/responses -H "Authorization: Bearer sk-****" -H "Content-Type: application/json" \
    -d '{"model":"openai-responses-test","input":"Say hello in five words"}'
{"id":"resp_ffXLBRNh5TbUew3Z4BzpUdWDX9JSFTHyhg5aSuezhmpe1n5EOqQwHFW...","created_at":1783369547,...,"output":[{...,"text":"Hello! How are you today?",...}],...}

$ curl -s -w '\nHTTP %{http_code}\n' "http://127.0.0.1:53798/v1/responses/resp_ffXLBRNh5TbUew3Z4BzpUdWDX9JSFTHyhg5aSuezhmpe1n5EOqQwHFW.../input_items" \
    -H "Authorization: Bearer sk-****"
{"error":{"message":"litellm.BadRequestError: You passed in model=None. There are no healthy deployments for this model","type":null,"param":null,"code":"400"}}
HTTP 400
```

For contrast, `GET /v1/responses/{id}` on the same encrypted id returns HTTP 200 on the same unpatched proxy, since `aget_responses` is already in the hook's decrypt list

After (proxy on this branch, same config and port): identical commands, and input_items now returns the real item list from OpenAI

```
$ curl -s http://127.0.0.1:53798/v1/responses -H "Authorization: Bearer sk-****" -H "Content-Type: application/json" \
    -d '{"model":"openai-responses-test","input":"Say hello in five words"}'
{"id":"resp_JzWHWd230cj_Ebm7DMjhM3sBpOoWFVdMnEOCGNSqVsXJ8_RyJgCwkR1...",...}

$ curl -s -w '\nHTTP %{http_code}\n' "http://127.0.0.1:53798/v1/responses/resp_JzWHWd230cj_Ebm7DMjhM3sBpOoWFVdMnEOCGNSqVsXJ8_RyJgCwkR1.../input_items" \
    -H "Authorization: Bearer sk-****"
{"object":"list","data":[{"id":"msg_0935ac0038198c91006a4c101feb98819983674218e12a92d6","type":"message","status":"completed","content":[{"type":"input_text","text":"Say hello in five words"}],"role":"user"}],"first_id":"msg_0935ac0038198c91006a4c101feb98819983674218e12a92d6","has_more":false,"last_id":"msg_0935ac0038198c91006a4c101feb98819983674218e12a92d6"}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

The `ResponsesIDSecurity` hook (on by default) encrypts the `id` returned by `POST /v1/responses` and decrypts it again in `async_pre_call_hook`, but only for the call types listed in its `responses_api_call_types` set. `alist_input_items` was missing from that set, so `GET /v1/responses/{response_id}/input_items` forwarded the still-encrypted id to the router; the router could not decode the provider and model from it and failed with a 400 "You passed in model=None. There are no healthy deployments for this model". Every follow-up route that got its call type added to the set works (get, delete, cancel), which made input_items the odd one out. Reported by a customer; reproduced against both `openai/gpt-4o-mini` and `azure/gpt-4o`, so it is provider-agnostic

The fix adds `alist_input_items` to the set and to the branch that decrypts `data["response_id"]`, which is exactly the key `get_response_input_items` in `litellm/proxy/response_api_endpoints/endpoints.py` populates from the path parameter. This also means the hook's user/team access check now runs for input_items follow-ups, closing the gap where the route skipped `check_user_access_to_response_id` entirely

Two regression tests were added to the existing `tests/test_litellm/test_responses_id_security.py`: one asserts `async_pre_call_hook` with `call_type="alist_input_items"` decrypts `response_id`, the other asserts a key from team A gets a 403 when listing input items of a response owned by team B. Both fail on the unpatched hook

Note: there is a separate Azure-specific bug in how the upstream input_items URL is built (path segment appended after the query string), being fixed in another PR. On Azure deployments, input_items needs both fixes to work end to end
