### PR TITLE
fix(azure): build responses input_items url with path before query string

### DIFF
--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -205,7 +205,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
     #########################################################
     ########## DELETE RESPONSE API TRANSFORMATION ##############
     #########################################################
-    def _construct_url_for_response_id_in_path(self, api_base: str, response_id: str) -> str:
+    def _construct_url_for_response_id_in_path(self, api_base: str, response_id: str, path_suffix: str = "") -> str:
         """
         Constructs a URL for the API request with the response_id in the path.
         """
@@ -218,7 +218,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         # Remove trailing slash if present to avoid double slashes
         path = parsed_url.path.rstrip("/")
         encoded_response_id = encode_url_path_segment(response_id, field_name="response_id")
-        new_path = f"{path}/{encoded_response_id}"
+        new_path = f"{path}/{encoded_response_id}{path_suffix}"
 
         # Reconstruct the URL with all original components but with the modified path
         constructed_url = urlunparse(
@@ -288,7 +288,9 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         limit: int = 20,
         order: Literal["asc", "desc"] = "desc",
     ) -> Tuple[str, Dict]:
-        url = self._construct_url_for_response_id_in_path(api_base=api_base, response_id=response_id) + "/input_items"
+        url = self._construct_url_for_response_id_in_path(
+            api_base=api_base, response_id=response_id, path_suffix="/input_items"
+        )
         params: Dict[str, Any] = {}
         if after is not None:
             params["after"] = after
@@ -322,27 +324,8 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
         This function handles URLs with query parameters by inserting the response_id
         at the correct location (before any query parameters).
         """
-        from urllib.parse import urlparse, urlunparse
-
-        # Parse the URL to separate its components
-        parsed_url = urlparse(api_base)
-
-        # Insert the response_id and /cancel at the end of the path component
-        # Remove trailing slash if present to avoid double slashes
-        path = parsed_url.path.rstrip("/")
-        encoded_response_id = encode_url_path_segment(response_id, field_name="response_id")
-        new_path = f"{path}/{encoded_response_id}/cancel"
-
-        # Reconstruct the URL with all original components but with the modified path
-        cancel_url = urlunparse(
-            (
-                parsed_url.scheme,  # http, https
-                parsed_url.netloc,  # domain name, port
-                new_path,  # path with response_id and /cancel added
-                parsed_url.params,  # parameters
-                parsed_url.query,  # query string
-                parsed_url.fragment,  # fragment
-            )
+        cancel_url = self._construct_url_for_response_id_in_path(
+            api_base=api_base, response_id=response_id, path_suffix="/cancel"
         )
 
         data: Dict = {}

--- a/litellm/llms/azure/responses/transformation.py
+++ b/litellm/llms/azure/responses/transformation.py
@@ -225,7 +225,7 @@ class AzureOpenAIResponsesAPIConfig(OpenAIResponsesAPIConfig):
             (
                 parsed_url.scheme,  # http, https
                 parsed_url.netloc,  # domain name, port
-                new_path,  # path with response_id added
+                new_path,
                 parsed_url.params,  # parameters
                 parsed_url.query,  # query string
                 parsed_url.fragment,  # fragment

--- a/tests/test_litellm/llms/azure/response/test_azure_transformation.py
+++ b/tests/test_litellm/llms/azure/response/test_azure_transformation.py
@@ -337,6 +337,24 @@ class TestAzureResponsesAPIConfig:
         assert url == expected_url
         assert data == {}
 
+    def test_azure_list_input_items_request_url_path_before_query(self):
+        from litellm.types.router import GenericLiteLLMParams
+
+        api_base = "https://test.openai.azure.com/openai/responses?api-version=2025-03-01-preview"
+
+        url, params = self.config.transform_list_input_items_request(
+            response_id="resp_test123",
+            api_base=api_base,
+            litellm_params=GenericLiteLLMParams(api_version="2025-03-01-preview"),
+            headers={},
+        )
+
+        assert (
+            url
+            == "https://test.openai.azure.com/openai/responses/resp_test123/input_items?api-version=2025-03-01-preview"
+        )
+        assert params == {"limit": 20, "order": "desc"}
+
     def test_azure_cancel_response_api_response(self):
         """Test Azure cancel response API response transformation"""
         from unittest.mock import Mock


### PR DESCRIPTION
## Relevant issues

Found while investigating a customer report on Responses API follow-up calls failing for Azure deployments

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy (dbless, `disable_responses_id_security: true`) with a real Azure OpenAI deployment (`azure/gpt-4o`, api_version `2025-03-01-preview`)

```bash
curl -s -X POST http://127.0.0.1:53834/v1/responses \
  -H "Authorization: Bearer sk-fix2-local" -H "Content-Type: application/json" \
  -d '{"model":"azure-responses-test","input":"Say hello in five words"}'
# -> {"id":"resp_bGl0ZWxsbT...","status":"completed",...}

curl -s -w "\nHTTP_STATUS:%{http_code}\n" \
  "http://127.0.0.1:53834/v1/responses/<id>/input_items" \
  -H "Authorization: Bearer sk-fix2-local"
```

Before (staging f628b41400), the proxy called a malformed upstream URL where `/input_items` was appended after the query string, per the proxy debug log

```
13:26:52 - LiteLLM:DEBUG: transformation.py:303 - list input items url=https://mateo-resource.openai.azure.com/openai/responses/resp_0beef846...?api-version=2025-03-01-preview/input_items
```

and the client saw Azure's 404 body wrapped in an HTTP 200

```
{"error":{"code":"404","message":"Resource not found"}}
HTTP_STATUS:200
```

After the fix, the same two curls hit the correct upstream URL

```
13:36:10 - LiteLLM:DEBUG: transformation.py:305 - list input items url=https://mateo-resource.openai.azure.com/openai/responses/resp_0301ee69.../input_items?api-version=2025-03-01-preview
```

and return the real item list

```
{"object":"list","data":[{"id":"msg_0301ee69...","type":"message","status":"completed","content":[{"type":"input_text","text":"Say hello in five words"}],"role":"user"}],"first_id":"msg_0301ee69...","has_more":false,"last_id":"msg_0301ee69..."}
HTTP_STATUS:200
```

As a side observation: the upstream 404 body was being passed through as an HTTP 200 to the client, masking the failure. That masking disappears here because the URL is now correct, but the response-status handling for list input items may deserve its own look

## Type

🐛 Bug Fix

## Changes

`GET /v1/responses/{id}/input_items` for `azure/` models built the upstream URL by string-concatenating `"/input_items"` onto the output of `_construct_url_for_response_id_in_path`, which already contains the `?api-version=...` query string. Azure therefore received `.../responses/{id}?api-version=.../input_items` and returned 404 Resource not found

`AzureOpenAIResponsesAPIConfig._construct_url_for_response_id_in_path` now takes a `path_suffix` parameter that is inserted into the URL path before the query string is reattached. `transform_list_input_items_request` passes `"/input_items"` through it, and `transform_cancel_response_api_request` (which had duplicated the same parse/unparse logic inline for `/cancel`) now reuses the shared helper. Get and delete URL building already used the helper and are unchanged. The OpenAI config builds its input_items URL from a query-less api_base, so other providers are unaffected

Regression test added in `tests/test_litellm/llms/azure/response/test_azure_transformation.py` asserting the exact input_items URL with the path segment before the query string; it fails on the previous concatenation behavior
