### PR TITLE
fix(responses): map upstream 4xx on cancel to client error instead of 500

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -2173,7 +2173,7 @@ def exception_type(  # type: ignore
     litellm_response_headers = _get_response_headers(original_exception=original_exception)
     try:
         error_str = redact_string(str(original_exception)) if _ENABLE_SECRET_REDACTION else str(original_exception)
-        if model:
+        if model or custom_llm_provider:
             if hasattr(original_exception, "message"):
                 error_str = (
                     redact_string(str(original_exception.message))

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -626,3 +626,26 @@ def test_replicate_422_maps_to_unprocessable_entity():
         )
 
     assert excinfo.value.llm_provider == "replicate"
+
+
+def test_upstream_4xx_without_model_maps_to_bad_request():
+    """Responses API follow-ups (cancel/get/delete) call ``exception_type`` with
+    ``model=None``; the provider mapping used to be gated on ``if model:``, so an
+    upstream 400 like Azure's "Cannot cancel a synchronous response." fell through to
+    the generic 500 APIConnectionError instead of surfacing as a 400."""
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(
+        status_code=400,
+        message='{"error": {"message": "Cannot cancel a synchronous response.", "type": "invalid_request_error"}}',
+    )
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        exception_type(
+            model=None,
+            original_exception=original_exception,
+            custom_llm_provider="azure",
+        )
+
+    assert excinfo.value.status_code == 400
+    assert "Cannot cancel a synchronous response." in excinfo.value.message


### PR DESCRIPTION
## Relevant issues

Found while investigating a customer report on Responses API follow-up requests

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:33551 (`azure-responses-test` -> `azure/gpt-4o`, api_version 2025-03-01-preview), real Azure OpenAI calls

Before (unmodified staging): cancelling a synchronous response surfaces Azure's 400 as a 500 APIConnectionError

```
$ RID=$(curl -s -X POST http://localhost:33551/v1/responses \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"azure-responses-test","input":"Say hello in five words"}' | jq -r .id)
$ curl -s -w "\nHTTP %{http_code}\n" -X POST "http://localhost:33551/v1/responses/${RID}/cancel" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY"
{"error":{"message":"litellm.APIConnectionError: azure - {\n  \"error\": {\n    \"message\": \"Cannot cancel a synchronous response.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\": null\n  }\n}. Received Model Group=08b90bf8d58c60394752c30ca84489fb43ca4ca81fd3673c59ab778ba16a7dd1\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
HTTP 500
```

After (this branch): the upstream client error passes through with its real status and message

```
$ RID=$(curl -s -X POST http://localhost:33551/v1/responses \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"azure-responses-test","input":"Say hello in five words"}' | jq -r .id)
$ curl -s -w "\nHTTP %{http_code}\n" -X POST "http://localhost:33551/v1/responses/${RID}/cancel" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY"
{"error":{"message":"litellm.BadRequestError: AzureException BadRequestError - {\n  \"error\": {\n    \"message\": \"Cannot cancel a synchronous response.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\": null\n  }\n}. Received Model Group=08b90bf8d58c60394752c30ca84489fb43ca4ca81fd3673c59ab778ba16a7dd1\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP 400
```

Cancelling a `background: true` response still works (must not regress)

```
$ RID=$(curl -s -X POST http://localhost:33551/v1/responses \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"azure-responses-test","input":"Write a 2000 word essay about the history of lighthouses in great detail","background":true}' | jq -r .id)
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST "http://localhost:33551/v1/responses/${RID}/cancel" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY"
HTTP 200
```

with body `{"status":"cancelled","background":true,...}`

The same passthrough now applies to the other follow-ups; DELETE of an already deleted response returned a 500 before and now returns the upstream 404

```
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X DELETE "http://localhost:33551/v1/responses/${RID}" \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY"
HTTP 404
```

## Type

🐛 Bug Fix

## Changes

`POST /v1/responses/{id}/cancel` against an Azure synchronous (non background) response makes Azure reject with a 400 "Cannot cancel a synchronous response.", but litellm surfaced it as a 500 APIConnectionError. The responses follow-up endpoints (cancel/get/delete, and likewise evals, skills, vector stores, interactions, rag) call `litellm.exception_type(model=None, ...)`, and the whole provider mapping block in `exception_type` is gated on `if model:`, so every upstream error on those paths, whatever its real status code, fell through to the generic 500 APIConnectionError fallback

The gate now also enters the mapping when only `custom_llm_provider` is known, which is what the per-provider mappers actually dispatch on; none of them dereference `model` beyond message formatting. Upstream 4xx errors on follow-up requests now map to the proper litellm exception (BadRequestError for the sync cancel case) with the provider's original message, exactly like completion-style endpoints already do

Regression test in `tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py`: an upstream 400 wrapped in a `BaseLLMException` with `model=None` and `custom_llm_provider="azure"` must map to `litellm.BadRequestError` with status 400 and the upstream message preserved. It fails on the pre-fix code with APIConnectionError
