### PR TITLE
fix(gemini): disable penalty params for Gemini 2.5 models

### DIFF
--- a/litellm/llms/gemini/chat/transformation.py
+++ b/litellm/llms/gemini/chat/transformation.py
@@ -74,6 +74,32 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
     def is_model_gemini_audio_model(self, model: str) -> bool:
         return "tts" in model
 
+    @staticmethod
+    def _is_gemini_2_5_model(model: str) -> bool:
+        """
+        Check if the model belongs to the Gemini 2.5 family.
+
+        Gemini 2.5 models include:
+        - gemini-2.5-flash
+        - gemini-2.5-flash-lite
+        - gemini-2.5-pro
+        - gemini-2.5-pro-preview-06-05
+        - Any future Gemini 2.5 models
+        """
+        return "gemini-2.5" in model
+
+    def _supports_penalty_parameters(self, model: str) -> bool:
+        """
+        Gemini 2.5 models do not support frequency_penalty and presence_penalty.
+        """
+        if not super()._supports_penalty_parameters(model):
+            return False
+
+        if self._is_gemini_2_5_model(model):
+            return False
+
+        return True
+
     def get_supported_openai_params(self, model: str) -> List[str]:
         supported_params = [
             "temperature",
@@ -88,19 +114,28 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
             "n",
             "stop",
             "logprobs",
-            "frequency_penalty",
-            "presence_penalty",
             "modalities",
             "parallel_tool_calls",
             "web_search_options",
             "include_server_side_tool_invocations",
             "service_tier",
         ]
+
+        if self._supports_penalty_parameters(model):
+            supported_params.extend(
+                [
+                    "frequency_penalty",
+                    "presence_penalty",
+                ]
+            )
+
         if supports_reasoning(model, custom_llm_provider="gemini"):
             supported_params.append("reasoning_effort")
             supported_params.append("thinking")
+
         if self.is_model_gemini_audio_model(model):
             supported_params.append("audio")
+
         return supported_params
 
     def _transform_messages(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2881,6 +2881,45 @@ def test_google_ai_studio_presence_penalty_supported():
 
     assert "presence_penalty" in supported_params
 
+def test_google_ai_studio_penalty_params_not_supported_for_gemini_2_5():
+    """
+    Test that Gemini 2.5 models do not advertise penalty parameters.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/26108
+    """
+    config = GoogleAIStudioGeminiConfig()
+
+    supported_params = config.get_supported_openai_params(
+        model="gemini-2.5-flash"
+    )
+
+    assert "frequency_penalty" not in supported_params
+    assert "presence_penalty" not in supported_params
+
+def test_google_ai_studio_gemini_3_penalty_not_supported():
+    """
+    Test that penalty parameters are not supported for Gemini 3 models.
+    """
+    config = GoogleAIStudioGeminiConfig()
+    supported_params = config.get_supported_openai_params(model="gemini-3-flash")
+
+    assert "frequency_penalty" not in supported_params
+    assert "presence_penalty" not in supported_params
+
+
+def test_google_ai_studio_penalty_params_supported_for_gemini_2_0():
+    """
+    Test that Gemini 2.0 models continue to support penalty parameters.
+    """
+    config = GoogleAIStudioGeminiConfig()
+
+    supported_params = config.get_supported_openai_params(
+        model="gemini-2.0-flash"
+    )
+
+    assert "frequency_penalty" in supported_params
+    assert "presence_penalty" in supported_params
+
 
 # ==================== Tool Type Separation Tests ====================
 # These tests verify that each Tool object contains exactly one type per Vertex AI API spec


### PR DESCRIPTION
## Relevant issues

Fixes #26108

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`GoogleAIStudioGeminiConfig.get_supported_openai_params()` currently advertises `frequency_penalty` and `presence_penalty` as supported for Gemini 2.5 models. Since LiteLLM considers these parameters supported, `drop_params=True` does not remove them before sending the request to the Gemini API.

Gemini 2.5 models reject these parameters with:

```
Penalty is not enabled for models/gemini-2.5-flash
```

### Before (`litellm_internal_staging`)

```python
import litellm

params = litellm.get_supported_openai_params(
    model="gemini/gemini-2.5-flash"
)

print("frequency_penalty" in params)
# True

litellm.drop_params = True

await litellm.acompletion(
    model="gemini/gemini-2.5-flash",
    messages=[{"role": "user", "content": "Hello"}],
    frequency_penalty=0.4,
)
```

Result:

```
400 Bad Request

Penalty is not enabled for models/gemini-2.5-flash
```

### After (this PR)

```python
import litellm

params = litellm.get_supported_openai_params(
    model="gemini/gemini-2.5-flash"
)

print("frequency_penalty" in params)
# False

print("presence_penalty" in params)
# False
```

Regression tests verify:

- Gemini 2.5 models no longer advertise `frequency_penalty` and `presence_penalty`.
- Gemini 2.0 models continue to advertise both parameters.

## Type

🐛 Bug Fix

## Changes

- Implemented model-specific capability detection for Gemini 2.5, consistent with the existing `VertexGeminiConfig` implementation..
- Excluded `frequency_penalty` and `presence_penalty` from `get_supported_openai_params()` for Gemini 2.5 models.
- Added regression tests to verify unsupported behavior for Gemini 2.5 and preserve existing behavior for Gemini 2.0.