### PR TITLE
feat(vertex_ai): add Google Cloud Speech-to-Text Chirp 3 transcription support

### DIFF
--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -123,6 +123,34 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
     return ProcessedAudioFile(file_content=file_content, filename=filename, content_type=content_type)
 
 
+BARE_ISO_639_1_TO_BCP47 = {
+    "en": "en-US",
+    "es": "es-ES",
+    "de": "de-DE",
+    "fr": "fr-FR",
+    "it": "it-IT",
+    "pt": "pt-BR",
+    "ja": "ja-JP",
+    "ko": "ko-KR",
+    "zh": "zh-CN",
+    "ru": "ru-RU",
+    "hi": "hi-IN",
+    "ar": "ar-SA",
+}
+
+
+def normalize_transcription_language_to_bcp47(language: str) -> str:
+    """
+    OpenAI's transcription `language` param accepts bare ISO-639-1 codes like
+    ``en``; speech APIs such as Google Speech-to-Text and NVIDIA Riva require
+    BCP-47 like ``en-US``. Map the most common bare codes and pass through
+    anything already region-qualified (or unknown, for a clear provider error).
+    """
+    if "-" in language:
+        return language
+    return BARE_ISO_639_1_TO_BCP47.get(language.lower(), language)
+
+
 def get_audio_file_name(file_obj: FileTypes) -> str:
     """
     Safely get the name of a file-like object or return its string representation.

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -1300,16 +1300,15 @@ class BaseLLMHTTPHandler:
         if client is None or not isinstance(client, HTTPHandler):
             client = _get_httpx_client()
 
+        json_data = data if files is None and isinstance(data, dict) else None
+
         try:
-            # Make the POST request - clean and simple, always use data and files
             response = client.post(
                 url=complete_url,
                 headers=headers,
-                data=data,
+                data=data if json_data is None else None,
                 files=files,
-                json=(
-                    data if files is None and isinstance(data, dict) else None
-                ),  # Use json param only when no files and data is dict
+                json=json_data,
                 timeout=timeout,
             )
         except Exception as e:
@@ -1373,16 +1372,15 @@ class BaseLLMHTTPHandler:
         else:
             async_httpx_client = client
 
+        json_data = data if files is None and isinstance(data, dict) else None
+
         try:
-            # Make the async POST request - clean and simple, always use data and files
             response = await async_httpx_client.post(
                 url=complete_url,
                 headers=headers,
-                data=data,
+                data=data if json_data is None else None,
                 files=files,
-                json=(
-                    data if files is None and isinstance(data, dict) else None
-                ),  # Use json param only when no files and data is dict
+                json=json_data,
                 timeout=timeout,
             )
         except Exception as e:

--- a/litellm/llms/vertex_ai/audio_transcription/transformation.py
+++ b/litellm/llms/vertex_ai/audio_transcription/transformation.py
@@ -1,0 +1,157 @@
+import base64
+
+from httpx import Headers, Response
+
+from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
+from litellm.llms.base_llm.audio_transcription.transformation import (
+    AudioTranscriptionRequestData,
+    BaseAudioTranscriptionConfig,
+)
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
+from litellm.llms.vertex_ai.common_utils import VertexAIError
+from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+from litellm.types.llms.openai import (
+    AllMessageValues,
+    OpenAIAudioTranscriptionOptionalParams,
+)
+from litellm.types.llms.vertex_ai_speech_to_text import (
+    VertexSpeechToTextAutoDecodingConfig,
+    VertexSpeechToTextRecognitionConfig,
+    VertexSpeechToTextRecognitionFeatures,
+    VertexSpeechToTextRecognizeRequest,
+    VertexSpeechToTextRecognizeResponse,
+)
+from litellm.types.utils import FileTypes, TranscriptionResponse
+
+DEFAULT_SPEECH_TO_TEXT_LOCATION = "us"
+AUTO_LANGUAGE_CODE = "auto"
+
+
+class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase):
+    def __init__(self) -> None:
+        BaseAudioTranscriptionConfig.__init__(self)
+        VertexBase.__init__(self)
+
+    def get_supported_openai_params(self, model: str) -> list[OpenAIAudioTranscriptionOptionalParams]:
+        return ["language", "response_format"]
+
+    def map_openai_params(
+        self,
+        non_default_params: dict,
+        optional_params: dict,
+        model: str,
+        drop_params: bool,
+    ) -> dict:
+        supported_params = self.get_supported_openai_params(model)
+        return {
+            **optional_params,
+            **{k: v for k, v in non_default_params.items() if k in supported_params},
+        }
+
+    def get_error_class(self, error_message: str, status_code: int, headers: dict | Headers) -> BaseLLMException:
+        return VertexAIError(status_code=status_code, message=error_message, headers=headers)
+
+    def validate_environment(
+        self,
+        headers: dict,
+        model: str,
+        messages: list[AllMessageValues],
+        optional_params: dict,
+        litellm_params: dict,
+        api_key: str | None = None,
+        api_base: str | None = None,
+    ) -> dict:
+        access_token, project_id = self._ensure_access_token(
+            credentials=self.safe_get_vertex_ai_credentials(litellm_params),
+            project_id=self.safe_get_vertex_ai_project(litellm_params),
+            custom_llm_provider="vertex_ai",
+        )
+        return {
+            **headers,
+            "Authorization": f"Bearer {access_token}",
+            "x-goog-user-project": project_id,
+            "Content-Type": "application/json",
+        }
+
+    def get_complete_url(
+        self,
+        api_base: str | None,
+        api_key: str | None,
+        model: str,
+        optional_params: dict,
+        litellm_params: dict,
+        stream: bool | None = None,
+    ) -> str:
+        location = self.safe_get_vertex_ai_location(litellm_params) or DEFAULT_SPEECH_TO_TEXT_LOCATION
+        project_id = self.safe_get_vertex_ai_project(litellm_params) or self._resolve_project_id_from_credentials(
+            litellm_params
+        )
+        host = "speech.googleapis.com" if location == "global" else f"{location}-speech.googleapis.com"
+        base_url = (api_base or f"https://{host}").rstrip("/")
+        return f"{base_url}/v2/projects/{project_id}/locations/{location}/recognizers/_:recognize"
+
+    def _resolve_project_id_from_credentials(self, litellm_params: dict) -> str:
+        _, project_id = self._ensure_access_token(
+            credentials=self.safe_get_vertex_ai_credentials(litellm_params),
+            project_id=None,
+            custom_llm_provider="vertex_ai",
+        )
+        return project_id
+
+    def transform_audio_transcription_request(
+        self,
+        model: str,
+        audio_file: FileTypes,
+        optional_params: dict,
+        litellm_params: dict,
+    ) -> AudioTranscriptionRequestData:
+        processed_audio = process_audio_file(audio_file)
+        language = optional_params.get("language")
+        language_codes = [language] if isinstance(language, str) and language else [AUTO_LANGUAGE_CODE]
+        request_body = VertexSpeechToTextRecognizeRequest(
+            config=VertexSpeechToTextRecognitionConfig(
+                model=model.removeprefix("vertex_ai/"),
+                languageCodes=language_codes,
+                features=VertexSpeechToTextRecognitionFeatures(enableAutomaticPunctuation=True),
+                autoDecodingConfig=VertexSpeechToTextAutoDecodingConfig(),
+            ),
+            content=base64.b64encode(processed_audio.file_content).decode("utf-8"),
+        )
+        return AudioTranscriptionRequestData(data=dict(request_body))
+
+    def transform_audio_transcription_response(
+        self,
+        raw_response: Response,
+    ) -> TranscriptionResponse:
+        try:
+            response_json = raw_response.json()
+        except Exception:
+            raise VertexAIError(
+                status_code=raw_response.status_code,
+                message=f"Received non-JSON response from Google Speech-to-Text: {raw_response.text}",
+            )
+        parsed = VertexSpeechToTextRecognizeResponse.model_validate(response_json)
+        transcripts = tuple(
+            result.alternatives[0].transcript
+            for result in parsed.results
+            if result.alternatives and result.alternatives[0].transcript
+        )
+        response = TranscriptionResponse(text=" ".join(transcripts))
+        response["task"] = "transcribe"
+        detected_language = next((result.languageCode for result in parsed.results if result.languageCode), None)
+        if detected_language is not None:
+            response["language"] = detected_language
+        billed_duration = _parse_duration_seconds(parsed.metadata.totalBilledDuration if parsed.metadata else None)
+        if billed_duration is not None:
+            response["duration"] = billed_duration
+        response._hidden_params = response_json
+        return response
+
+
+def _parse_duration_seconds(duration: str | None) -> float | None:
+    if duration is None or not duration.endswith("s"):
+        return None
+    try:
+        return float(duration[:-1])
+    except ValueError:
+        return None

--- a/litellm/llms/vertex_ai/audio_transcription/transformation.py
+++ b/litellm/llms/vertex_ai/audio_transcription/transformation.py
@@ -2,7 +2,10 @@ import base64
 
 from httpx import Headers, Response
 
-from litellm.litellm_core_utils.audio_utils.utils import process_audio_file
+from litellm.litellm_core_utils.audio_utils.utils import (
+    normalize_transcription_language_to_bcp47,
+    process_audio_file,
+)
 from litellm.llms.base_llm.audio_transcription.transformation import (
     AudioTranscriptionRequestData,
     BaseAudioTranscriptionConfig,
@@ -107,7 +110,11 @@ class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase)
     ) -> AudioTranscriptionRequestData:
         processed_audio = process_audio_file(audio_file)
         language = optional_params.get("language")
-        language_codes = [language] if isinstance(language, str) and language else [AUTO_LANGUAGE_CODE]
+        language_codes = (
+            [normalize_transcription_language_to_bcp47(language)]
+            if isinstance(language, str) and language
+            else [AUTO_LANGUAGE_CODE]
+        )
         request_body = VertexSpeechToTextRecognizeRequest(
             config=VertexSpeechToTextRecognitionConfig(
                 model=model.removeprefix("vertex_ai/"),
@@ -125,7 +132,7 @@ class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase)
     ) -> TranscriptionResponse:
         try:
             response_json = raw_response.json()
-        except Exception:
+        except ValueError:
             raise VertexAIError(
                 status_code=raw_response.status_code,
                 message=f"Received non-JSON response from Google Speech-to-Text: {raw_response.text}",

--- a/litellm/llms/vertex_ai/audio_transcription/transformation.py
+++ b/litellm/llms/vertex_ai/audio_transcription/transformation.py
@@ -11,7 +11,7 @@ from litellm.llms.base_llm.audio_transcription.transformation import (
     BaseAudioTranscriptionConfig,
 )
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
-from litellm.llms.vertex_ai.common_utils import VertexAIError
+from litellm.llms.vertex_ai.common_utils import VertexAIError, validate_vertex_location
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -28,6 +28,7 @@ from litellm.types.utils import FileTypes, TranscriptionResponse
 
 DEFAULT_SPEECH_TO_TEXT_LOCATION = "us"
 AUTO_LANGUAGE_CODE = "auto"
+_URL_UNSAFE_PROJECT_CHARS = ("/", "?", "#", "\\", ":", " ", "\t", "\n", "\r")
 
 
 class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase):
@@ -85,13 +86,26 @@ class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase)
         litellm_params: dict,
         stream: bool | None = None,
     ) -> str:
-        location = self.safe_get_vertex_ai_location(litellm_params) or DEFAULT_SPEECH_TO_TEXT_LOCATION
-        project_id = self.safe_get_vertex_ai_project(litellm_params) or self._resolve_project_id_from_credentials(
-            litellm_params
+        location = self._validate_location(self.safe_get_vertex_ai_location(litellm_params))
+        project_id = self._validate_project_id(
+            self.safe_get_vertex_ai_project(litellm_params) or self._resolve_project_id_from_credentials(litellm_params)
         )
         host = "speech.googleapis.com" if location == "global" else f"{location}-speech.googleapis.com"
         base_url = (api_base or f"https://{host}").rstrip("/")
         return f"{base_url}/v2/projects/{project_id}/locations/{location}/recognizers/_:recognize"
+
+    @staticmethod
+    def _validate_location(location: str | None) -> str:
+        try:
+            return validate_vertex_location(location or DEFAULT_SPEECH_TO_TEXT_LOCATION)
+        except ValueError as e:
+            raise VertexAIError(status_code=400, message=str(e)) from e
+
+    @staticmethod
+    def _validate_project_id(project_id: str) -> str:
+        if not project_id or ".." in project_id or any(c in project_id for c in _URL_UNSAFE_PROJECT_CHARS):
+            raise VertexAIError(status_code=400, message=f"Invalid vertex_project format: {project_id!r}")
+        return project_id
 
     def _resolve_project_id_from_credentials(self, litellm_params: dict) -> str:
         _, project_id = self._ensure_access_token(

--- a/litellm/llms/vertex_ai/audio_transcription/transformation.py
+++ b/litellm/llms/vertex_ai/audio_transcription/transformation.py
@@ -2,6 +2,8 @@ import base64
 
 from httpx import Headers, Response
 
+import litellm
+from litellm.exceptions import UnsupportedParamsError
 from litellm.litellm_core_utils.audio_utils.utils import (
     normalize_transcription_language_to_bcp47,
     process_audio_file,
@@ -28,6 +30,7 @@ from litellm.types.utils import FileTypes, TranscriptionResponse
 
 DEFAULT_SPEECH_TO_TEXT_LOCATION = "us"
 AUTO_LANGUAGE_CODE = "auto"
+SUPPORTED_RESPONSE_FORMATS = ("json", "text")
 _URL_UNSAFE_PROJECT_CHARS = ("/", "?", "#", "\\", ":", " ", "\t", "\n", "\r")
 
 
@@ -47,10 +50,23 @@ class VertexAIAudioTranscriptionConfig(BaseAudioTranscriptionConfig, VertexBase)
         drop_params: bool,
     ) -> dict:
         supported_params = self.get_supported_openai_params(model)
-        return {
+        mapped = {
             **optional_params,
             **{k: v for k, v in non_default_params.items() if k in supported_params},
         }
+        response_format = mapped.get("response_format")
+        if response_format is None or response_format in SUPPORTED_RESPONSE_FORMATS:
+            return mapped
+        if drop_params or litellm.drop_params:
+            return {k: v for k, v in mapped.items() if k != "response_format"}
+        raise UnsupportedParamsError(
+            status_code=400,
+            message=(
+                f"Google Speech-to-Text does not support response_format={response_format!r}. "
+                f"Supported values: {', '.join(SUPPORTED_RESPONSE_FORMATS)}. "
+                "To drop unsupported openai params from the call, set `litellm.drop_params = True`"
+            ),
+        )
 
     def get_error_class(self, error_message: str, status_code: int, headers: dict | Headers) -> BaseLLMException:
         return VertexAIError(status_code=status_code, message=error_message, headers=headers)

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -311,6 +311,28 @@ def get_vertex_base_model_name(model: str) -> str:
     return model
 
 
+def validate_vertex_location(vertex_location: Optional[str]) -> str:
+    """
+    Validate a Vertex AI location before interpolating it into a request host or
+    URL path.
+
+    ``vertex_location`` is client-controllable on the proxy (it flows in from the
+    request body), so it must never be trusted verbatim in a URL or an attacker
+    could point the host at their own server and exfiltrate the admin's Google
+    access token. Allow the special ``global`` control plane and otherwise require
+    a lowercase alphanumeric-plus-hyphen token (e.g. ``us``, ``us-central1``,
+    ``eu``), which rejects host injection like ``attacker.example/`` or
+    ``evil.com#``.
+    """
+    if vertex_location == "global":
+        return vertex_location
+    if vertex_location is None:
+        raise ValueError("vertex_location is required")
+    if not re.match(r"^[a-z][a-z0-9-]*$", vertex_location):
+        raise ValueError("Invalid vertex_location format")
+    return vertex_location
+
+
 def get_vertex_base_url(
     vertex_location: Optional[str],
 ) -> str:
@@ -321,15 +343,12 @@ def get_vertex_base_url(
     - Multi-region geographies (e.g. ``us``, ``eu``) use ``aiplatform.{geo}.rep.googleapis.com``.
     - Regional locations (e.g. ``us-central1``) use ``{region}-aiplatform.googleapis.com``.
     """
-    if vertex_location == "global":
+    validated_location = validate_vertex_location(vertex_location)
+    if validated_location == "global":
         return "https://aiplatform.googleapis.com"
-    if vertex_location is None:
-        raise ValueError("vertex_location is required")
-    if not re.match(r"^[a-z][a-z0-9-]*$", vertex_location):
-        raise ValueError("Invalid vertex_location format")
-    if "-" not in vertex_location:
-        return f"https://aiplatform.{vertex_location}.rep.googleapis.com"
-    return f"https://{vertex_location}-aiplatform.googleapis.com"
+    if "-" not in validated_location:
+        return f"https://aiplatform.{validated_location}.rep.googleapis.com"
+    return f"https://{validated_location}-aiplatform.googleapis.com"
 
 
 def _get_embedding_url(

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -34655,6 +34655,20 @@
             "/v1/audio/speech"
         ]
     },
+    "vertex_ai/chirp_3": {
+        "input_cost_per_second": 0.00026667,
+        "litellm_provider": "vertex_ai",
+        "metadata": {
+            "calculation": "$0.016/60 seconds = $0.00026667 per second",
+            "original_pricing_per_minute": 0.016
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://cloud.google.com/speech-to-text/pricing",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
     "vertex_ai/claude-3-5-haiku": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-anthropic_models",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -34663,7 +34663,6 @@
             "original_pricing_per_minute": 0.016
         },
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0,
         "source": "https://cloud.google.com/speech-to-text/pricing",
         "supported_endpoints": [
             "/v1/audio/transcriptions"

--- a/litellm/types/llms/vertex_ai_speech_to_text.py
+++ b/litellm/types/llms/vertex_ai_speech_to_text.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+
+class VertexSpeechToTextAutoDecodingConfig(TypedDict):
+    pass
+
+
+class VertexSpeechToTextRecognitionFeatures(TypedDict):
+    enableAutomaticPunctuation: bool
+
+
+class VertexSpeechToTextRecognitionConfig(TypedDict):
+    model: str
+    languageCodes: list[str]
+    features: VertexSpeechToTextRecognitionFeatures
+    autoDecodingConfig: VertexSpeechToTextAutoDecodingConfig
+
+
+class VertexSpeechToTextRecognizeRequest(TypedDict):
+    config: VertexSpeechToTextRecognitionConfig
+    content: str
+
+
+class VertexSpeechToTextAlternative(BaseModel):
+    transcript: str | None = None
+
+
+class VertexSpeechToTextResult(BaseModel):
+    alternatives: list[VertexSpeechToTextAlternative] = []
+    languageCode: str | None = None
+
+
+class VertexSpeechToTextResponseMetadata(BaseModel):
+    totalBilledDuration: str | None = None
+
+
+class VertexSpeechToTextRecognizeResponse(BaseModel):
+    results: list[VertexSpeechToTextResult] = []
+    metadata: VertexSpeechToTextResponseMetadata | None = None

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8097,6 +8097,12 @@ class ProviderConfigManager:
             )
 
             return SonioxAudioTranscriptionConfig()
+        elif litellm.LlmProviders.VERTEX_AI == provider:
+            from litellm.llms.vertex_ai.audio_transcription.transformation import (
+                VertexAIAudioTranscriptionConfig,
+            )
+
+            return VertexAIAudioTranscriptionConfig()
         return None
 
     @staticmethod

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -34837,7 +34837,6 @@
             "original_pricing_per_minute": 0.016
         },
         "mode": "audio_transcription",
-        "output_cost_per_second": 0.0,
         "source": "https://cloud.google.com/speech-to-text/pricing",
         "supported_endpoints": [
             "/v1/audio/transcriptions"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -34829,6 +34829,20 @@
             "/v1/audio/speech"
         ]
     },
+    "vertex_ai/chirp_3": {
+        "input_cost_per_second": 0.00026667,
+        "litellm_provider": "vertex_ai",
+        "metadata": {
+            "calculation": "$0.016/60 seconds = $0.00026667 per second",
+            "original_pricing_per_minute": 0.016
+        },
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0,
+        "source": "https://cloud.google.com/speech-to-text/pricing",
+        "supported_endpoints": [
+            "/v1/audio/transcriptions"
+        ]
+    },
     "vertex_ai/claude-3-5-haiku": {
         "input_cost_per_token": 1e-06,
         "litellm_provider": "vertex_ai-anthropic_models",

--- a/tests/test_litellm/litellm_core_utils/test_audio_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_audio_utils.py
@@ -326,3 +326,24 @@ class TestGetAudioFileContentHash:
 
         assert isinstance(hash_result, str)
         assert len(hash_result) == 64, "Should return valid hash even on fallback"
+
+
+class TestNormalizeTranscriptionLanguageToBcp47:
+    @pytest.mark.parametrize(
+        "language,expected",
+        [
+            ("en", "en-US"),
+            ("EN", "en-US"),
+            ("ja", "ja-JP"),
+            ("en-US", "en-US"),
+            ("en-GB", "en-GB"),
+            ("auto", "auto"),
+            ("xx", "xx"),
+        ],
+    )
+    def test_normalization(self, language, expected):
+        from litellm.litellm_core_utils.audio_utils.utils import (
+            normalize_transcription_language_to_bcp47,
+        )
+
+        assert normalize_transcription_language_to_bcp47(language) == expected

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 import sys
 from unittest.mock import AsyncMock, Mock, patch
@@ -12,6 +13,11 @@ from litellm.integrations.code_interpreter_interception.handler import (
     CodeInterpreterInterceptionLogger,
     LITELLM_CODE_EXECUTION_TOOL_NAME,
 )
+from litellm.llms.base_llm.audio_transcription.transformation import (
+    AudioTranscriptionRequestData,
+    BaseAudioTranscriptionConfig,
+)
+from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import (
     BaseLLMHTTPHandler,
@@ -19,6 +25,7 @@ from litellm.llms.custom_httpx.llm_http_handler import (
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.router import GenericLiteLLMParams
+from litellm.types.utils import TranscriptionResponse
 
 _ACTIVE_KEY = "_code_interpreter_interception_active"
 _SANDBOX_KEY = "_code_interpreter_interception_sandbox_key"
@@ -1585,3 +1592,96 @@ async def test_realtime_backend_open_does_not_retry_auth_failure(rejection):
         await BaseLLMHTTPHandler._open_realtime_backend_ws(fake, "wss://backend.example/live", {}, None)
 
     assert fake.attempts == 1
+
+
+class _JSONBodyAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
+    def get_supported_openai_params(self, model):
+        return []
+
+    def map_openai_params(self, non_default_params, optional_params, model, drop_params):
+        return optional_params
+
+    def validate_environment(
+        self,
+        headers,
+        model,
+        messages,
+        optional_params,
+        litellm_params,
+        api_key=None,
+        api_base=None,
+    ):
+        return {**headers, "Authorization": "Bearer test-token"}
+
+    def get_complete_url(self, api_base, api_key, model, optional_params, litellm_params, stream=None):
+        return "https://transcription.example/recognize"
+
+    def transform_audio_transcription_request(self, model, audio_file, optional_params, litellm_params):
+        return AudioTranscriptionRequestData(data={"config": {"model": model}, "content": "YXVkaW8="})
+
+    def transform_audio_transcription_response(self, raw_response):
+        return TranscriptionResponse(text=raw_response.json()["text"])
+
+    def get_error_class(self, error_message, status_code, headers):
+        return BaseLLMException(message=error_message, status_code=status_code, headers=headers)
+
+
+def _json_transcription_call_kwargs(provider_config):
+    return {
+        "model": "test-model",
+        "audio_file": b"raw-audio",
+        "optional_params": {},
+        "litellm_params": {},
+        "model_response": TranscriptionResponse(),
+        "timeout": 10.0,
+        "max_retries": 0,
+        "logging_obj": Mock(),
+        "api_key": None,
+        "api_base": None,
+        "custom_llm_provider": "custom",
+        "headers": {},
+        "provider_config": provider_config,
+    }
+
+
+def _capture_json_transcription_request(captured):
+    def respond(request):
+        captured["content_type"] = request.headers.get("content-type")
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"text": "transcribed"})
+
+    return respond
+
+
+def test_audio_transcriptions_sends_dict_data_as_json_body():
+    """Regression: dict request data was passed to httpx's data= param, which
+    form-encodes it and silently ignores json=; JSON-body providers (e.g.
+    Google Speech-to-Text) need an application/json body."""
+    captured = {}
+    client = HTTPHandler(client=httpx.Client(transport=httpx.MockTransport(_capture_json_transcription_request(captured))))
+
+    response = BaseLLMHTTPHandler().audio_transcriptions(
+        client=client,
+        atranscription=False,
+        **_json_transcription_call_kwargs(_JSONBodyAudioTranscriptionConfig()),
+    )
+
+    assert captured["content_type"] == "application/json"
+    assert captured["body"] == {"config": {"model": "test-model"}, "content": "YXVkaW8="}
+    assert response.text == "transcribed"
+
+
+@pytest.mark.asyncio
+async def test_async_audio_transcriptions_sends_dict_data_as_json_body():
+    captured = {}
+    client = AsyncHTTPHandler()
+    client.client = httpx.AsyncClient(transport=httpx.MockTransport(_capture_json_transcription_request(captured)))
+
+    response = await BaseLLMHTTPHandler().async_audio_transcriptions(
+        client=client,
+        **_json_transcription_call_kwargs(_JSONBodyAudioTranscriptionConfig()),
+    )
+
+    assert captured["content_type"] == "application/json"
+    assert captured["body"] == {"config": {"model": "test-model"}, "content": "YXVkaW8="}
+    assert response.text == "transcribed"

--- a/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 import sys
+from urllib.parse import urlparse
 
 import httpx
 import pytest
@@ -12,6 +13,7 @@ import litellm
 from litellm.llms.vertex_ai.audio_transcription.transformation import (
     VertexAIAudioTranscriptionConfig,
 )
+from litellm.llms.vertex_ai.common_utils import VertexAIError
 from litellm.types.utils import LlmProviders
 from litellm.utils import ProviderConfigManager, get_optional_params_transcription
 
@@ -61,6 +63,75 @@ class TestGetCompleteUrl:
             litellm_params={"vertex_project": "test-project"},
         )
         assert url == "http://localhost:8080/v2/projects/test-project/locations/us/recognizers/_:recognize"
+
+    @pytest.mark.parametrize(
+        "location,expected_netloc",
+        [
+            ("us", "us-speech.googleapis.com"),
+            ("us-central1", "us-central1-speech.googleapis.com"),
+            ("eu", "eu-speech.googleapis.com"),
+            ("global", "speech.googleapis.com"),
+        ],
+    )
+    def test_valid_location_netloc_always_google(self, config, location, expected_netloc):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="chirp_3",
+            optional_params={},
+            litellm_params={"vertex_project": "test-project", "vertex_location": location},
+        )
+        netloc = urlparse(url).netloc
+        assert netloc == expected_netloc
+        assert netloc.endswith("speech.googleapis.com")
+
+    @pytest.mark.parametrize(
+        "malicious_location",
+        [
+            "attacker.example/",
+            "evil.com#",
+            "us.attacker.example",
+            "us/../..",
+            "US",
+            "us_central1",
+            "us central1",
+            "attacker.example:443",
+            "-us",
+        ],
+    )
+    def test_malicious_location_is_rejected(self, config, malicious_location):
+        """SSRF/credential-exfil guard: vertex_location is client-controllable on
+        the proxy, so a host-injecting value must raise rather than steer the
+        request (and its admin-minted Google bearer token) at another host."""
+        with pytest.raises(VertexAIError):
+            config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="chirp_3",
+                optional_params={},
+                litellm_params={"vertex_project": "test-project", "vertex_location": malicious_location},
+            )
+
+    @pytest.mark.parametrize(
+        "malicious_project",
+        [
+            "proj/../../locations",
+            "proj/evil",
+            "proj#frag",
+            "proj?a=b",
+            "proj:evil",
+            "proj space",
+        ],
+    )
+    def test_malicious_project_is_rejected(self, config, malicious_project):
+        with pytest.raises(VertexAIError):
+            config.get_complete_url(
+                api_base=None,
+                api_key=None,
+                model="chirp_3",
+                optional_params={},
+                litellm_params={"vertex_project": malicious_project, "vertex_location": "us"},
+            )
 
 
 class TestTransformRequest:

--- a/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
@@ -286,6 +286,36 @@ class TestProviderRouting:
                 temperature=1,
             )
 
+    @pytest.mark.parametrize("response_format", ["json", "text"])
+    def test_supported_response_formats_pass_through(self, response_format):
+        optional_params = get_optional_params_transcription(
+            model="chirp_3",
+            custom_llm_provider="vertex_ai",
+            response_format=response_format,
+        )
+        assert optional_params["response_format"] == response_format
+
+    @pytest.mark.parametrize("response_format", ["verbose_json", "srt", "vtt"])
+    def test_unsupported_response_format_raises(self, response_format):
+        with pytest.raises(litellm.utils.UnsupportedParamsError, match="response_format"):
+            get_optional_params_transcription(
+                model="chirp_3",
+                custom_llm_provider="vertex_ai",
+                response_format=response_format,
+            )
+
+    @pytest.mark.parametrize("response_format", ["verbose_json", "srt", "vtt"])
+    def test_unsupported_response_format_dropped_with_drop_params(self, response_format):
+        optional_params = get_optional_params_transcription(
+            model="chirp_3",
+            custom_llm_provider="vertex_ai",
+            language="fr-FR",
+            response_format=response_format,
+            drop_params=True,
+        )
+        assert "response_format" not in optional_params
+        assert optional_params["language"] == "fr-FR"
+
 
 class TestModelCostEntry:
     REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))

--- a/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
@@ -83,14 +83,24 @@ class TestTransformRequest:
             "content": base64.b64encode(audio_bytes).decode("utf-8"),
         }
 
-    def test_language_param_maps_to_language_codes(self, config):
+    @pytest.mark.parametrize(
+        "language,expected_language_codes",
+        [
+            ("en", ["en-US"]),
+            ("en-US", ["en-US"]),
+            ("es-ES", ["es-ES"]),
+            ("fr", ["fr-FR"]),
+            (None, ["auto"]),
+        ],
+    )
+    def test_language_param_maps_to_language_codes(self, config, language, expected_language_codes):
         request_data = config.transform_audio_transcription_request(
             model="chirp_3",
             audio_file=b"fake-audio-bytes",
-            optional_params={"language": "es-ES"},
+            optional_params={"language": language} if language is not None else {},
             litellm_params={},
         )
-        assert request_data.data["config"]["languageCodes"] == ["es-ES"]
+        assert request_data.data["config"]["languageCodes"] == expected_language_codes
 
     def test_model_prefix_is_stripped(self, config):
         request_data = config.transform_audio_transcription_request(

--- a/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/audio_transcription/test_vertex_ai_audio_transcription_transformation.py
@@ -1,0 +1,225 @@
+import base64
+import json
+import os
+import sys
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../.."))
+
+import litellm
+from litellm.llms.vertex_ai.audio_transcription.transformation import (
+    VertexAIAudioTranscriptionConfig,
+)
+from litellm.types.utils import LlmProviders
+from litellm.utils import ProviderConfigManager, get_optional_params_transcription
+
+
+@pytest.fixture
+def config():
+    return VertexAIAudioTranscriptionConfig()
+
+
+class TestGetCompleteUrl:
+    def test_defaults_to_us_regional_host(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="chirp_3",
+            optional_params={},
+            litellm_params={"vertex_project": "test-project"},
+        )
+        assert url == "https://us-speech.googleapis.com/v2/projects/test-project/locations/us/recognizers/_:recognize"
+
+    def test_uses_vertex_location_for_regional_host(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="chirp_3",
+            optional_params={},
+            litellm_params={"vertex_project": "test-project", "vertex_location": "eu"},
+        )
+        assert url == "https://eu-speech.googleapis.com/v2/projects/test-project/locations/eu/recognizers/_:recognize"
+
+    def test_global_location_uses_unprefixed_host(self, config):
+        url = config.get_complete_url(
+            api_base=None,
+            api_key=None,
+            model="chirp_3",
+            optional_params={},
+            litellm_params={"vertex_project": "test-project", "vertex_location": "global"},
+        )
+        assert url == "https://speech.googleapis.com/v2/projects/test-project/locations/global/recognizers/_:recognize"
+
+    def test_api_base_override(self, config):
+        url = config.get_complete_url(
+            api_base="http://localhost:8080/",
+            api_key=None,
+            model="chirp_3",
+            optional_params={},
+            litellm_params={"vertex_project": "test-project"},
+        )
+        assert url == "http://localhost:8080/v2/projects/test-project/locations/us/recognizers/_:recognize"
+
+
+class TestTransformRequest:
+    def test_request_body_shape(self, config):
+        audio_bytes = b"fake-audio-bytes"
+        request_data = config.transform_audio_transcription_request(
+            model="chirp_3",
+            audio_file=audio_bytes,
+            optional_params={},
+            litellm_params={},
+        )
+        assert request_data.files is None
+        assert request_data.data == {
+            "config": {
+                "model": "chirp_3",
+                "languageCodes": ["auto"],
+                "features": {"enableAutomaticPunctuation": True},
+                "autoDecodingConfig": {},
+            },
+            "content": base64.b64encode(audio_bytes).decode("utf-8"),
+        }
+
+    def test_language_param_maps_to_language_codes(self, config):
+        request_data = config.transform_audio_transcription_request(
+            model="chirp_3",
+            audio_file=b"fake-audio-bytes",
+            optional_params={"language": "es-ES"},
+            litellm_params={},
+        )
+        assert request_data.data["config"]["languageCodes"] == ["es-ES"]
+
+    def test_model_prefix_is_stripped(self, config):
+        request_data = config.transform_audio_transcription_request(
+            model="vertex_ai/chirp_3",
+            audio_file=b"fake-audio-bytes",
+            optional_params={},
+            litellm_params={},
+        )
+        assert request_data.data["config"]["model"] == "chirp_3"
+
+    def test_body_is_json_serializable(self, config):
+        request_data = config.transform_audio_transcription_request(
+            model="chirp_3",
+            audio_file=b"fake-audio-bytes",
+            optional_params={},
+            litellm_params={},
+        )
+        json.dumps(request_data.data)
+
+
+class TestTransformResponse:
+    def test_multi_result_transcripts_are_joined(self, config):
+        raw_response = httpx.Response(
+            status_code=200,
+            json={
+                "results": [
+                    {"alternatives": [{"transcript": "Hello world.", "confidence": 0.98}], "languageCode": "en-US"},
+                    {"alternatives": [{"transcript": "How are you?", "confidence": 0.97}], "languageCode": "en-US"},
+                ],
+                "metadata": {"totalBilledDuration": "15s"},
+            },
+        )
+        response = config.transform_audio_transcription_response(raw_response)
+        assert response.text == "Hello world. How are you?"
+        assert response["task"] == "transcribe"
+        assert response["language"] == "en-US"
+        assert response["duration"] == 15.0
+
+    def test_results_without_alternatives_are_skipped(self, config):
+        raw_response = httpx.Response(
+            status_code=200,
+            json={
+                "results": [
+                    {"alternatives": [{"transcript": "First."}]},
+                    {"alternatives": []},
+                    {},
+                    {"alternatives": [{"transcript": "Last."}]},
+                ]
+            },
+        )
+        response = config.transform_audio_transcription_response(raw_response)
+        assert response.text == "First. Last."
+
+    def test_empty_results_returns_empty_text(self, config):
+        raw_response = httpx.Response(status_code=200, json={})
+        response = config.transform_audio_transcription_response(raw_response)
+        assert response.text == ""
+
+    def test_fractional_billed_duration(self, config):
+        raw_response = httpx.Response(
+            status_code=200,
+            json={
+                "results": [{"alternatives": [{"transcript": "Hi."}]}],
+                "metadata": {"totalBilledDuration": "3.5s"},
+            },
+        )
+        response = config.transform_audio_transcription_response(raw_response)
+        assert response["duration"] == 3.5
+
+
+class TestValidateEnvironment:
+    def test_sets_oauth_headers(self):
+        class StubbedConfig(VertexAIAudioTranscriptionConfig):
+            def _ensure_access_token(self, credentials, project_id, custom_llm_provider):
+                return "fake-token", "resolved-project"
+
+        headers = StubbedConfig().validate_environment(
+            headers={},
+            model="chirp_3",
+            messages=[],
+            optional_params={},
+            litellm_params={"vertex_project": "resolved-project"},
+        )
+        assert headers["Authorization"] == "Bearer fake-token"
+        assert headers["x-goog-user-project"] == "resolved-project"
+        assert headers["Content-Type"] == "application/json"
+
+
+class TestProviderRouting:
+    def test_provider_config_manager_returns_vertex_config(self):
+        provider_config = ProviderConfigManager.get_provider_audio_transcription_config(
+            model="chirp_3",
+            provider=LlmProviders.VERTEX_AI,
+        )
+        assert isinstance(provider_config, VertexAIAudioTranscriptionConfig)
+
+    def test_get_optional_params_transcription_maps_language(self):
+        optional_params = get_optional_params_transcription(
+            model="chirp_3",
+            custom_llm_provider="vertex_ai",
+            language="fr-FR",
+            response_format="json",
+        )
+        assert optional_params["language"] == "fr-FR"
+        assert optional_params["response_format"] == "json"
+
+    def test_get_optional_params_transcription_rejects_unsupported_param(self):
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            get_optional_params_transcription(
+                model="chirp_3",
+                custom_llm_provider="vertex_ai",
+                temperature=1,
+            )
+
+
+class TestModelCostEntry:
+    REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../.."))
+
+    @pytest.mark.parametrize(
+        "cost_map_path",
+        [
+            "model_prices_and_context_window.json",
+            "litellm/model_prices_and_context_window_backup.json",
+        ],
+    )
+    def test_chirp_3_registered_as_audio_transcription(self, cost_map_path):
+        with open(os.path.join(self.REPO_ROOT, cost_map_path)) as f:
+            entry = json.load(f)["vertex_ai/chirp_3"]
+        assert entry["mode"] == "audio_transcription"
+        assert entry["litellm_provider"] == "vertex_ai"
+        assert entry["input_cost_per_second"] == pytest.approx(0.016 / 60, rel=1e-3)
+        assert entry["supported_endpoints"] == ["/v1/audio/transcriptions"]

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -18,8 +18,23 @@ from litellm.llms.vertex_ai.common_utils import (
     pop_vertex_request_labels,
     set_schema_property_ordering,
     supports_response_json_schema,
+    validate_vertex_location,
     vertex_request_labels_from_litellm_params,
 )
+
+
+@pytest.mark.parametrize("location", ["us", "eu", "us-central1", "europe-west1", "global"])
+def test_validate_vertex_location_accepts_valid(location):
+    assert validate_vertex_location(location) == location
+
+
+@pytest.mark.parametrize(
+    "location",
+    ["attacker.example/", "evil.com#", "us.attacker.example", "us/../..", "US", "us_central1", "-us", "", None],
+)
+def test_validate_vertex_location_rejects_invalid(location):
+    with pytest.raises(ValueError):
+        validate_vertex_location(location)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -347,6 +347,30 @@ def test_transcription_cost_falls_back_to_duration():
     assert pytest.approx(cost, rel=1e-6) == expected_cost
 
 
+def test_vertex_chirp_3_transcription_cost_from_duration():
+    """Regression: the chirp_3 cost map entry shipped with output_cost_per_second 0.0,
+    and cost_per_second prefers output_cost_per_second whenever it is not None, so
+    every transcription priced to $0.00 instead of using input_cost_per_second."""
+    from litellm import completion_cost
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    response = TranscriptionResponse(text="demo text")
+    response.duration = 18.0
+
+    cost = completion_cost(
+        completion_response=response,
+        model="vertex_ai/chirp_3",
+        custom_llm_provider="vertex_ai",
+        call_type="atranscription",
+    )
+
+    expected_cost = 18.0 * 0.00026667
+    assert cost > 0
+    assert pytest.approx(cost, rel=1e-6) == expected_cost
+
+
 def test_handle_realtime_stream_cost_calculation():
     from litellm.cost_calculator import RealtimeAPITokenUsageProcessor
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3682

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live before/after demonstration on a local proxy hitting the real Google Speech-to-Text v2 API with application default credentials, `LITELLM_LOCAL_MODEL_COST_MAP=True`, and the 17.6 second `tests/gettysburg.wav` clip. The proxy config maps `chirp-3` to `vertex_ai/chirp_3` with only `vertex_project` set, so the `us` location default is what gets exercised

Before commit: `b4a10fb134ac0de14a642efc7a5a5adde95c7b6e` (merge base, feature absent). After commit: `2b8706776f4b25f5745e819232166b8baf04a3cf` (branch head). The transcription and security command outputs below were captured at `aaf8b1f0abaa36cde7afb511c2661aa7af9178fb`, the security-fix commit; the head commit only adds response_format validation on top and leaves these results unchanged

```yaml
model_list:
  - model_name: chirp-3
    litellm_params:
      model: vertex_ai/chirp_3
      vertex_project: os.environ/VERTEXAI_PROJECT
```

Before, on the merge base, the request fails with an unmapped provider error:

```
$ git rev-parse --short HEAD
b4a10fb134
$ .venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 61687 --detailed_debug
$ curl -sS http://localhost:61687/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-qa-1234" \
    -F model="chirp-3" \
    -F file=@tests/gettysburg.wav
{"error":{"message":"litellm.APIConnectionError: Unmapped provider passed in. Unable to get the response.\n[...traceback trimmed...]\nValueError: Unmapped provider passed in. Unable to get the response.\n. Received Model Group=chirp-3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
```

After, on this branch, the identical request returns HTTP 200 with the transcript in the OpenAI response shape:

```
$ git rev-parse --short HEAD
aaf8b1f0ab
$ .venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 61687 --detailed_debug
$ curl -sS http://localhost:61687/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-qa-1234" \
    -F model="chirp-3" \
    -F file=@tests/gettysburg.wav
{"text":"Four score and seven years ago our fathers brought forth on this continent a new nation, conceived in liberty, and dedicated to the proposition that all men are created equal. Now we are engaged in a great civil war, testing whether that nation, or any nation so conceived and so dedicated, can long endure.","usage":null,"task":"transcribe","language":"en","duration":18.0}
```

An explicit OpenAI style bare ISO-639-1 `language` also works and gets normalized to the BCP-47 code Google requires, so `language="en"` returns 200 with the language echoed back as `en-US`:

```
$ curl -sS http://localhost:61687/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-qa-1234" \
    -F model="chirp-3" \
    -F file=@tests/gettysburg.wav \
    -F language="en"
{"text":"Four score and seven years ago our fathers brought forth on this continent a new nation, [...] can long endure.","usage":null,"task":"transcribe","language":"en-US","duration":18.0}
```

Cost tracking prices the 18 billed seconds at Google's $0.016 per minute rate; both successful requests in the run logged the same figure:

```
$ grep -o "response_cost[': ]*[0-9.e-]*" proxy.log | sort | uniq -c
   2 response_cost: 0.00480006
```

### Security: client-controlled location is validated

`vertex_location` is client-controllable on the proxy and lands in the request host, so a crafted value could otherwise redirect the outbound call, along with the admin-minted Google bearer token, to an attacker host. On this branch every non-conforming location is rejected with a 400 before any request is built, and the token never leaves the proxy. Three malicious values, a hostname with a trailing slash, one with a fragment, and one pointing at a local listener, all return the same 400:

```
$ for loc in "attacker.example/" "evil.com#" "127.0.0.1:61688/"; do
    curl -sS -w " [HTTP %{http_code}]\n" http://localhost:61687/v1/audio/transcriptions \
      -H "Authorization: Bearer sk-qa-1234" \
      -F model="chirp-3" -F file=@tests/gettysburg.wav \
      -F vertex_location="$loc"
  done
{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - Invalid vertex_location format. Received Model Group=chirp-3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}} [HTTP 400]
{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - Invalid vertex_location format. Received Model Group=chirp-3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}} [HTTP 400]
{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - Invalid vertex_location format. Received Model Group=chirp-3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}} [HTTP 400]
```

To prove no egress, a throwaway listener ran on `127.0.0.1:61688` and its log was truncated to empty before firing the `127.0.0.1:61688/` case above. After the malicious requests the listener log is still empty, so the token never reached it:

```
$ python3 -m http.server 61688 --bind 127.0.0.1 > listener.log 2>&1 &   # started earlier, log truncated to empty
$ wc -l < listener.log
       0
```

The proxy debug log confirms the only outbound Speech-to-Text hosts were Google's own regional endpoints; the attacker strings appear solely as echoes of the rejected input, never in an outbound URL:

```
$ grep -oE "https://[a-z0-9.-]*speech.googleapis.com[^ \"']*" proxy.log | sort | uniq -c
   3 https://us-central1-speech.googleapis.com/v2/projects/<project>/locations/us-central1/recognizers/_:recognize
   2 https://us-speech.googleapis.com/v2/projects/<project>/locations/us/recognizers/_:recognize
```

A well-formed location is still honored: `vertex_location="us-central1"` builds a real `us-central1-speech.googleapis.com` request, which Google answers with a benign 400 because chirp_3 is not served from that region, not an SSRF:

```
$ curl -sS -w "\nHTTP_STATUS:%{http_code}\n" http://localhost:61687/v1/audio/transcriptions \
    -H "Authorization: Bearer sk-qa-1234" \
    -F model="chirp-3" -F file=@tests/gettysburg.wav \
    -F vertex_location="us-central1"
{"error":{"message":"litellm.BadRequestError: Vertex_aiException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"The model \\\"chirp_3\\\" does not exist in the location named \\\"us-central1\\\"..\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}\n. Received Model Group=chirp-3\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

## Type

🆕 New Feature

## Changes

Adds Google Cloud Speech-to-Text support for Chirp 3, so `vertex_ai/chirp_3` works on `/v1/audio/transcriptions` through both `litellm.transcription()` and `litellm.atranscription()` (the async path is what the proxy uses). The new `VertexAIAudioTranscriptionConfig` is wired through `ProviderConfigManager` and calls the Speech-to-Text v2 `recognize` endpoint. Authentication reuses the standard Vertex AI credential resolution (`vertex_project`, `vertex_location`, `vertex_credentials`, or application default credentials), so users configure it exactly like any other vertex_ai model

The location defaults to the `us` multi-region because Google serves chirp_3 only from the `us` and `eu` multi-regions, and non-global locations are routed to the regional `<location>-speech.googleapis.com` host. The OpenAI `language` param maps to `languageCodes`, defaulting to `auto` (Chirp 3's language-agnostic transcription). Because OpenAI clients send bare ISO-639-1 codes like `en` while Google rejects anything that is not region-qualified BCP-47, a shared `normalize_transcription_language_to_bcp47` helper in `litellm_core_utils/audio_utils` maps common bare codes (`en` becomes `en-US`) and passes region-qualified codes through unchanged; the NVIDIA Riva transcription config had already hand-rolled the same mapping privately, so the shared helper gives future providers one place to reuse. The response joins the top alternative of every result into the transcript, and `duration` comes from the `totalBilledDuration` Google returns, so cost tracking uses Google's own billing number

A `vertex_ai/chirp_3` cost map entry is added at Google's published $0.016 per minute for V2 standard recognition. The entry deliberately omits `output_cost_per_second`: the shared `cost_per_second` calculator prefers `output_cost_per_second` whenever it is not None, so a 0.0 there (the shape several existing STT entries use) silently prices every request at $0.00. A regression test computes the chirp_3 transcription cost from model info so that exact failure cannot recur

Because `vertex_location` is client-controllable on the proxy and lands in the request host, `get_complete_url` validates it before use so a caller cannot steer the request (and its admin-minted Google bearer token) at an attacker host. The `^[a-z][a-z0-9-]*$` plus `global` check that the rest of vertex_ai already applied through `get_vertex_base_url` is factored into a shared `validate_vertex_location` helper in `common_utils.py` and called from both the chat host builder and the new speech host builder, so there is one validation, not two copies. An invalid location raises a 400 `VertexAIError` rather than falling back silently, and `vertex_project` (which lands in the URL path) is likewise rejected if it carries path-structural characters. Tests assert on the parsed netloc so the security property is pinned, not just the string

Like every other vertex_ai flow, authentication needs `google-auth` at request time, which is not part of the base install; bare proxy installs should use the `google` extra (`pip install "litellm[google]"`), the same requirement vertex_ai chat and TTS models already have

Wiring this end to end surfaced a latent bug in the shared audio transcription HTTP handler: dict request bodies were passed to httpx's `data=` parameter, which form-encodes them and silently ignores the `json=` argument the handler also passed, so the JSON body path had never actually worked (no existing provider on the generic path returned dict data). The handler now sends JSON when a provider returns dict data without files, in both the sync and async paths; providers using multipart or raw bytes are unaffected. Regression tests pin the JSON body behavior at the handler level and the full request/response transformation (regional URL building, language mapping, transcript joining, billed duration parsing, provider routing) at the Vertex config level

Example usage:

```bash
curl http://localhost:4000/v1/audio/transcriptions \
  -H "Authorization: Bearer sk-1234" \
  -F model="vertex_ai/chirp_3" \
  -F file="@audio.wav"
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy-facing Vertex URL construction and OAuth-backed outbound calls, with deliberate SSRF guards; the shared transcription HTTP change affects all JSON-body providers but is covered by regression tests.
> 
> **Overview**
> Adds **`vertex_ai/chirp_3`** on `/v1/audio/transcriptions` via a new `VertexAIAudioTranscriptionConfig` that calls Google Speech-to-Text v2 `recognize` (base64 JSON body, OAuth headers, regional `*-speech.googleapis.com` URLs). OpenAI **`language`** maps to `languageCodes` (default `auto`); bare ISO codes are normalized through shared **`normalize_transcription_language_to_bcp47`**. Responses are shaped as OpenAI transcripts with optional **`language`** and billed **`duration`**.
> 
> **Security:** **`validate_vertex_location`** is centralized in `common_utils` (used by chat base URLs and speech URLs) so client-controlled **`vertex_location`** / **`vertex_project`** cannot inject hosts or path segments before outbound Google calls.
> 
> **HTTP fix:** Sync/async transcription handlers now send dict payloads with **`json=`** only (not **`data=`** alongside **`json=`**), fixing JSON-body providers.
> 
> **Pricing:** **`vertex_ai/chirp_3`** is registered with **`input_cost_per_second`** for transcription billing; tests cover cost from duration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b8706776f4b25f5745e819232166b8baf04a3cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->