### PR TITLE
fix(bedrock): honor AWS auth params in realtime handler

### DIFF
--- a/litellm/llms/bedrock/realtime/handler.py
+++ b/litellm/llms/bedrock/realtime/handler.py
@@ -13,6 +13,7 @@ from litellm._logging import _redact_string, verbose_proxy_logger
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 
 from ..base_aws_llm import BaseAWSLLM
+from ..common_utils import BedrockError
 from .transformation import BedrockRealtimeConfig
 
 
@@ -80,7 +81,7 @@ class BedrockRealtime(BaseAWSLLM):
 
         verbose_proxy_logger.debug(f"Bedrock Realtime: Connecting to {endpoint_uri} with model {model}")
 
-        frozen_credentials = self.get_credentials(
+        credentials = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
@@ -91,7 +92,16 @@ class BedrockRealtime(BaseAWSLLM):
             aws_web_identity_token=aws_web_identity_token,
             aws_sts_endpoint=aws_sts_endpoint,
             aws_external_id=aws_external_id,
-        ).get_frozen_credentials()
+        )
+        if credentials is None:
+            raise BedrockError(
+                status_code=401,
+                message=(
+                    "No AWS credentials found for Bedrock realtime. Set aws_* params in litellm_params "
+                    "or configure credentials in the environment"
+                ),
+            )
+        frozen_credentials = credentials.get_frozen_credentials()
 
         # Initialize Bedrock client with aws_sdk_bedrock_runtime
         config = Config(

--- a/litellm/llms/bedrock/realtime/handler.py
+++ b/litellm/llms/bedrock/realtime/handler.py
@@ -59,9 +59,7 @@ class BedrockRealtime(BaseAWSLLM):
                 InvokeModelWithBidirectionalStreamOperationInput,
             )
             from aws_sdk_bedrock_runtime.config import Config
-            from smithy_aws_core.identity.environment import (
-                EnvironmentCredentialsResolver,
-            )
+            from smithy_aws_core.identity import StaticCredentialsResolver
         except ImportError:
             raise ImportError("Missing aws_sdk_bedrock_runtime. Install with: pip install aws-sdk-bedrock-runtime")
 
@@ -82,11 +80,27 @@ class BedrockRealtime(BaseAWSLLM):
 
         verbose_proxy_logger.debug(f"Bedrock Realtime: Connecting to {endpoint_uri} with model {model}")
 
+        frozen_credentials = self.get_credentials(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            aws_region_name=aws_region_name,
+            aws_session_name=aws_session_name,
+            aws_profile_name=aws_profile_name,
+            aws_role_name=aws_role_name,
+            aws_web_identity_token=aws_web_identity_token,
+            aws_sts_endpoint=aws_sts_endpoint,
+            aws_external_id=aws_external_id,
+        ).get_frozen_credentials()
+
         # Initialize Bedrock client with aws_sdk_bedrock_runtime
         config = Config(
             endpoint_uri=endpoint_uri,
             region=aws_region_name,
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+            aws_access_key_id=frozen_credentials.access_key,
+            aws_secret_access_key=frozen_credentials.secret_key,
+            aws_session_token=frozen_credentials.token,
+            aws_credentials_identity_resolver=StaticCredentialsResolver(),
         )
         bedrock_client = BedrockRuntimeClient(config=config)
 

--- a/tests/test_litellm/llms/bedrock/realtime/test_bedrock_realtime_handler.py
+++ b/tests/test_litellm/llms/bedrock/realtime/test_bedrock_realtime_handler.py
@@ -9,6 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.llms.bedrock.realtime.handler import BedrockRealtime
 from litellm.llms.bedrock.realtime.transformation import BedrockRealtimeConfig
 
@@ -102,6 +103,11 @@ class ImmediatelyEndingBedrockStream:
 
 class FakeStaticCredentialsResolver:
     pass
+
+
+class NoCredentialsBedrockRealtime(BedrockRealtime):
+    def get_credentials(self, **kwargs):
+        return None
 
 
 class StubCredentialsBedrockRealtime(BedrockRealtime):
@@ -336,6 +342,20 @@ class TestBedrockRealtimeAwsAuth:
         assert config_kwargs["aws_secret_access_key"] == "assumed-secret-key"
         assert config_kwargs["aws_session_token"] == "assumed-session-token"
         assert isinstance(config_kwargs["aws_credentials_identity_resolver"], FakeStaticCredentialsResolver)
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_credentials_raise_clear_auth_error(self, stub_aws_sdk_client):
+        handler = NoCredentialsBedrockRealtime()
+
+        with pytest.raises(BedrockError, match="No AWS credentials found for Bedrock realtime"):
+            await handler.async_realtime(
+                model="amazon.nova-sonic-v1:0",
+                websocket=RealtimeClientWS(),
+                logging_obj=MagicMock(),
+                aws_region_name="us-east-1",
+            )
+
+        assert "config_kwargs" not in stub_aws_sdk_client
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/llms/bedrock/realtime/test_bedrock_realtime_handler.py
+++ b/tests/test_litellm/llms/bedrock/realtime/test_bedrock_realtime_handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import types
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -78,6 +79,106 @@ class EndedBedrockReceiver:
 class EndedBedrockStream:
     async def await_output(self):
         return (None, EndedBedrockReceiver())
+
+
+class RealtimeClientWS:
+    def __init__(self):
+        self.closed = False
+
+    async def receive_text(self):
+        raise RuntimeError("client disconnected")
+
+    async def close(self, code=None, reason=None):
+        self.closed = True
+
+
+class ImmediatelyEndingBedrockStream:
+    def __init__(self):
+        self.input_stream = FakeInputStream()
+
+    async def await_output(self):
+        return (None, EndedBedrockReceiver())
+
+
+class FakeStaticCredentialsResolver:
+    pass
+
+
+class StubCredentialsBedrockRealtime(BedrockRealtime):
+    def __init__(self, frozen_credentials):
+        super().__init__()
+        self.frozen_credentials = frozen_credentials
+        self.get_credentials_kwargs = None
+
+    def get_credentials(self, **kwargs):
+        self.get_credentials_kwargs = kwargs
+        return SimpleNamespace(get_frozen_credentials=lambda: self.frozen_credentials)
+
+
+@pytest.fixture
+def stub_aws_sdk_client(monkeypatch):
+    captured = {}
+
+    class CapturingConfig:
+        def __init__(self, **kwargs):
+            captured["config_kwargs"] = kwargs
+            self.kwargs = kwargs
+
+    class FakeOperationInput:
+        def __init__(self, model_id):
+            self.model_id = model_id
+
+    class FakeBedrockRuntimeClient:
+        def __init__(self, config):
+            captured["client_config"] = config
+
+        async def invoke_model_with_bidirectional_stream(self, operation_input):
+            captured["operation_input"] = operation_input
+            return ImmediatelyEndingBedrockStream()
+
+    package = types.ModuleType("aws_sdk_bedrock_runtime")
+    client_module = types.ModuleType("aws_sdk_bedrock_runtime.client")
+    client_module.BedrockRuntimeClient = FakeBedrockRuntimeClient
+    client_module.InvokeModelWithBidirectionalStreamOperationInput = FakeOperationInput
+    config_module = types.ModuleType("aws_sdk_bedrock_runtime.config")
+    config_module.Config = CapturingConfig
+    models_module = types.ModuleType("aws_sdk_bedrock_runtime.models")
+    models_module.BidirectionalInputPayloadPart = FakePayloadPart
+    models_module.InvokeModelWithBidirectionalStreamInputChunk = FakeInputChunk
+    package.client = client_module
+    package.config = config_module
+    package.models = models_module
+    smithy_package = types.ModuleType("smithy_aws_core")
+    identity_module = types.ModuleType("smithy_aws_core.identity")
+    identity_module.StaticCredentialsResolver = FakeStaticCredentialsResolver
+    smithy_package.identity = identity_module
+
+    stubbed_modules = {
+        "aws_sdk_bedrock_runtime": package,
+        "aws_sdk_bedrock_runtime.client": client_module,
+        "aws_sdk_bedrock_runtime.config": config_module,
+        "aws_sdk_bedrock_runtime.models": models_module,
+        "smithy_aws_core": smithy_package,
+        "smithy_aws_core.identity": identity_module,
+    }
+    for module_name, module in stubbed_modules.items():
+        monkeypatch.setitem(sys.modules, module_name, module)
+
+    for env_var in (
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AWS_REGION_NAME",
+        "AWS_SESSION_NAME",
+        "AWS_PROFILE_NAME",
+        "AWS_ROLE_NAME",
+        "AWS_WEB_IDENTITY_TOKEN",
+        "AWS_STS_ENDPOINT",
+        "AWS_EXTERNAL_ID",
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
+    return captured
 
 
 @pytest.fixture
@@ -168,6 +269,73 @@ class TestBedrockRealtimeHandler:
         )
 
         assert client_ws.closed
+
+
+class TestBedrockRealtimeAwsAuth:
+    """AWS auth params passed via litellm_params must reach the Smithy client config (LIT-3923 regression)"""
+
+    @pytest.mark.asyncio
+    async def test_static_credentials_from_litellm_params_reach_smithy_config(self, stub_aws_sdk_client):
+        handler = BedrockRealtime()
+        websocket = RealtimeClientWS()
+
+        await handler.async_realtime(
+            model="amazon.nova-sonic-v1:0",
+            websocket=websocket,
+            logging_obj=MagicMock(),
+            aws_region_name="us-east-1",
+            aws_access_key_id="litellm-params-access-key",
+            aws_secret_access_key="litellm-params-secret-key",
+            aws_session_token="litellm-params-session-token",
+        )
+
+        config_kwargs = stub_aws_sdk_client["config_kwargs"]
+        assert config_kwargs["aws_access_key_id"] == "litellm-params-access-key"
+        assert config_kwargs["aws_secret_access_key"] == "litellm-params-secret-key"
+        assert config_kwargs["aws_session_token"] == "litellm-params-session-token"
+        assert isinstance(config_kwargs["aws_credentials_identity_resolver"], FakeStaticCredentialsResolver)
+        assert config_kwargs["region"] == "us-east-1"
+        assert stub_aws_sdk_client["client_config"].kwargs is config_kwargs
+        assert stub_aws_sdk_client["operation_input"].model_id == "amazon.nova-sonic-v1:0"
+        assert websocket.closed
+
+    @pytest.mark.asyncio
+    async def test_role_assumption_params_forwarded_to_get_credentials(self, stub_aws_sdk_client):
+        handler = StubCredentialsBedrockRealtime(
+            SimpleNamespace(
+                access_key="assumed-access-key",
+                secret_key="assumed-secret-key",
+                token="assumed-session-token",
+            )
+        )
+
+        await handler.async_realtime(
+            model="amazon.nova-sonic-v1:0",
+            websocket=RealtimeClientWS(),
+            logging_obj=MagicMock(),
+            aws_region_name="eu-west-1",
+            aws_role_name="arn:aws:iam::123456789012:role/nova-sonic",
+            aws_session_name="realtime-session",
+            aws_external_id="realtime-external-id",
+        )
+
+        assert handler.get_credentials_kwargs == {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+            "aws_region_name": "eu-west-1",
+            "aws_session_name": "realtime-session",
+            "aws_profile_name": None,
+            "aws_role_name": "arn:aws:iam::123456789012:role/nova-sonic",
+            "aws_web_identity_token": None,
+            "aws_sts_endpoint": None,
+            "aws_external_id": "realtime-external-id",
+        }
+        config_kwargs = stub_aws_sdk_client["config_kwargs"]
+        assert config_kwargs["aws_access_key_id"] == "assumed-access-key"
+        assert config_kwargs["aws_secret_access_key"] == "assumed-secret-key"
+        assert config_kwargs["aws_session_token"] == "assumed-session-token"
+        assert isinstance(config_kwargs["aws_credentials_identity_resolver"], FakeStaticCredentialsResolver)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3923

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs below hit a live proxy on localhost against the real Bedrock Nova Sonic model in us-east-1, with AWS credentials supplied only through litellm_params under non-standard env var names; every standard AWS_* credential variable was scrubbed from the proxy environment before launch. Before is the merge-base commit b4a10fb134, after is this branch at 489e94b92d. The config, launcher, and client are byte-identical across the two arms; only the checkout changes

Config (`qa_config.yaml`):

```yaml
model_list:
  - model_name: bedrock-sonic
    litellm_params:
      model: bedrock/amazon.nova-sonic-v1:0
      aws_region_name: us-east-1
      aws_access_key_id: os.environ/LIT3923_QA_KEY_ID
      aws_secret_access_key: os.environ/LIT3923_QA_SECRET
      aws_session_token: os.environ/LIT3923_QA_SESSION
    model_info:
      mode: realtime

general_settings:
  master_key: sk-qa-lit3923
```

Proxy launcher (`run_proxy_qa.sh`), which loads session credentials produced by `aws configure export-credentials --format env`, re-exports them under the non-standard names the config reads, and unsets every standard AWS variable before starting the proxy:

```sh
. ./qa_creds.env
export LIT3923_QA_KEY_ID="$AWS_ACCESS_KEY_ID"
export LIT3923_QA_SECRET="$AWS_SECRET_ACCESS_KEY"
export LIT3923_QA_SESSION="$AWS_SESSION_TOKEN"
unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
    AWS_CREDENTIAL_EXPIRATION AWS_PROFILE AWS_DEFAULT_PROFILE \
    AWS_BEARER_TOKEN_BEDROCK AWS_REGION AWS_DEFAULT_REGION
env | grep -oE '^(AWS|LIT3923)[A-Z0-9_]*' | sort
exec .venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 56759 --detailed_debug
```

Env check printed at proxy start, identical in both arms, confirming no standard AWS_* credential vars remain in the proxy environment:

```text
LIT3923_QA_KEY_ID
LIT3923_QA_SECRET
LIT3923_QA_SESSION
```

The client (`qa_realtime_client.py`) opens `ws://localhost:56759/v1/realtime?model=bedrock-sonic` authenticated with the master key, sends `session.update` (text modalities), one `conversation.item.create` user message "Say hello in one sentence.", then `response.create`, and prints every received event type with a 60 second overall timeout

Before, at merge-base b4a10fb134: the session connects and then hangs silently, zero events in 60 seconds

```text
$ git checkout b4a10fb134
$ ./run_proxy_qa.sh 56759 > proxy_before.log 2>&1 &
$ .venv/bin/python qa_realtime_client.py 56759
CONNECTED
VERDICT: TIMED OUT after 60s partial_text=''
```

The before proxy log confirms the hang; this is the last Bedrock realtime line, the stream is never established and no error is surfaced:

```text
14:19:04 - LiteLLM Proxy:DEBUG: handler.py:83 - Bedrock Realtime: Connecting to https://bedrock-runtime.us-east-1.amazonaws.com with model amazon.nova-sonic-v1:0
```

After, on this branch at 489e94b92d, same config, same launcher, same client:

```text
$ git checkout 489e94b92d
$ ./run_proxy_qa.sh 56759 > proxy_after.log 2>&1 &
$ .venv/bin/python qa_realtime_client.py 56759
CONNECTED
EVENT: response.created
EVENT: response.output_item.added
EVENT: response.content_part.added
EVENT: response.text.delta
EVENT: response.text.done
EVENT: response.content_part.done
EVENT: response.output_item.done
EVENT: response.created
EVENT: response.output_item.added
EVENT: response.content_part.added
EVENT: response.audio.delta
[EVENT: response.audio.delta repeated 59 times total, trimmed]
EVENT: response.audio.done
EVENT: response.content_part.done
EVENT: response.output_item.done
EVENT: response.done
VERDICT: RESPONSE RECEIVED: "Hello there! I'm ready to chat. What's on your mind today?"
```

The after proxy log shows the stream opening with the litellm_params credentials:

```text
14:21:15 - LiteLLM Proxy:DEBUG: handler.py:81 - Bedrock Realtime: Connecting to https://bedrock-runtime.us-east-1.amazonaws.com with model amazon.nova-sonic-v1:0
14:21:15 - LiteLLM Proxy:DEBUG: handler.py:115 - Bedrock Realtime: Bidirectional stream established
```

## Type

🐛 Bug Fix

## Changes

The Bedrock Nova Sonic realtime handler (`litellm/llms/bedrock/realtime/handler.py`, backing `/v1/realtime`) accepted every standard AWS auth param in `async_realtime` (aws_access_key_id, aws_secret_access_key, aws_session_token, aws_role_name, aws_session_name, aws_profile_name, aws_web_identity_token, aws_sts_endpoint, aws_external_id) but ignored all of them: the Smithy client config was built with a hardcoded `aws_credentials_identity_resolver=EnvironmentCredentialsResolver()`, which only ever reads the ambient AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables. Credentials supplied via litellm_params were silently dropped and the session hung at stream open with zero events and no error

The fix resolves credentials with the same machinery every other Bedrock path uses: `BaseAWSLLM.get_credentials(...)`, which handles static keys, session tokens, role assumption via STS, web identity tokens (IRSA), named profiles, and falls back to the boto3 default chain when nothing is configured. The resolved credentials are frozen and fed to the Smithy `Config` as `aws_access_key_id`/`aws_secret_access_key`/`aws_session_token` alongside the SDK's own `StaticCredentialsResolver`; this is the smithy_aws_core static-credentials flow, where the SigV4 auth scheme builds identity properties from those config fields and the resolver returns them as the `AWSCredentialsIdentity` used for signing

This makes static keys stored under non-standard env names, role assumption (`aws_role_name`/`aws_session_name`/`aws_external_id`), web identity auth, profile auth, and STS endpoint overrides work for the realtime endpoint. When no aws params are given, behavior is now the boto3 default credential chain, consistent with bedrock chat/converse and strictly more capable than the previous env-only behavior. The optional-import error message for aws_sdk_bedrock_runtime is unchanged

Regression tests in `tests/test_litellm/llms/bedrock/realtime/test_bedrock_realtime_handler.py` stub the optional `aws_sdk_bedrock_runtime`/`smithy_aws_core` modules in sys.modules and assert that static credentials passed to `async_realtime` reach the captured Smithy config through the real `get_credentials` path, and that role-assumption params are forwarded to `get_credentials` with the resolved credentials landing on the config; both tests fail on the base branch and pass with the fix

Follow-up commit c89bffc: when `get_credentials` resolves nothing anywhere (returns None), the handler now raises a BedrockError with a clear message ("No AWS credentials found for Bedrock realtime") instead of an obscure AttributeError on `get_frozen_credentials`; covered by a regression test that fails on the previous commit

