### PR TITLE
fix(mcp_semantic_filter): keep tool names whole in filter response header

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -24,6 +24,18 @@ if TYPE_CHECKING:
     from litellm.router import Router
 
 
+def _truncate_csv_at_tool_name_boundary(tool_names_csv: str, max_length: int) -> str:
+    """Cap a CSV of tool names to max_length, dropping any name that does not fit whole."""
+    if len(tool_names_csv) <= max_length:
+        return tool_names_csv
+
+    head = tool_names_csv[: max_length + 1]
+    if "," not in head:
+        return ""
+
+    return head.rsplit(",", 1)[0]
+
+
 class SemanticToolFilterHook(CustomLogger):
     """
     Pre-call hook that filters MCP tools semantically.
@@ -327,11 +339,12 @@ class SemanticToolFilterHook(CustomLogger):
 
         # Add CSV of filtered tool names (nginx-safe length)
         tool_names_csv = metadata.get("litellm_semantic_filter_tools", "")
-        if tool_names_csv:
-            if len(tool_names_csv) > MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH:
-                tool_names_csv = tool_names_csv[: MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH - 3] + "..."
-
-            headers["x-litellm-semantic-filter-tools"] = tool_names_csv
+        header_safe_csv = _truncate_csv_at_tool_name_boundary(
+            tool_names_csv=tool_names_csv,
+            max_length=MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH,
+        )
+        if header_safe_csv:
+            headers["x-litellm-semantic-filter-tools"] = header_safe_csv
 
         return headers
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -1050,3 +1050,64 @@ class TestGetToolsByNames:
         )
 
         assert matched == []
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_headers_hook_emits_only_complete_tool_names():
+    """
+    Regression test for LIT-4215.
+
+    The x-litellm-semantic-filter-tools header used to be sliced mid-name at
+    MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH with a "..." suffix, so the UI
+    rendered a chopped tool name as the last entry. The header must only ever
+    contain complete tool names, in their original order, within the cap.
+    """
+    from litellm.constants import MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=10,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+    hook = SemanticToolFilterHook(filter_instance)
+
+    tool_names = [f"metrics_mcp-very_long_tool_name_for_header_{i:02d}" for i in range(8)]
+    data = {
+        "metadata": {
+            "litellm_semantic_filter_stats": "40->8",
+            "litellm_semantic_filter_tools": ",".join(tool_names),
+        }
+    }
+
+    headers = await hook.async_post_call_response_headers_hook(
+        data=data,
+        user_api_key_dict=Mock(),
+        response=None,
+    )
+
+    assert headers is not None
+    assert headers["x-litellm-semantic-filter"] == "40->8"
+
+    tools_header = headers["x-litellm-semantic-filter-tools"]
+    assert len(tools_header) <= MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH
+    emitted_names = tools_header.split(",")
+    assert emitted_names == tool_names[: len(emitted_names)]
+    assert 0 < len(emitted_names) < len(tool_names)
+
+
+def test_truncate_csv_at_tool_name_boundary_edges():
+    from litellm.proxy.hooks.mcp_semantic_filter.hook import (
+        _truncate_csv_at_tool_name_boundary,
+    )
+
+    assert _truncate_csv_at_tool_name_boundary(tool_names_csv="a,b,c", max_length=150) == "a,b,c"
+    assert _truncate_csv_at_tool_name_boundary(tool_names_csv="abc,def", max_length=3) == "abc"
+    assert _truncate_csv_at_tool_name_boundary(tool_names_csv="ab,cd,ef", max_length=5) == "ab,cd"
+    assert _truncate_csv_at_tool_name_boundary(tool_names_csv="ab,cd,ef", max_length=4) == "ab"
+    assert _truncate_csv_at_tool_name_boundary(tool_names_csv="single_name_longer_than_cap", max_length=10) == ""

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.test.tsx
@@ -103,6 +103,18 @@ describe("MCPSemanticFilterTestPanel", () => {
     expect(screen.getByText("wiki-fetch")).toBeInTheDocument();
     expect(screen.getByText("github-search")).toBeInTheDocument();
     expect(screen.getByText("slack-post")).toBeInTheDocument();
+    expect(screen.queryByText(/more selected tools not shown/i)).not.toBeInTheDocument();
+  });
+
+  it("should note how many selected tools are missing when the header list is incomplete", () => {
+    const testResult: TestResult = {
+      totalTools: 40,
+      selectedTools: 8,
+      tools: ["metrics_mcp-node_query_by_id", "metrics_mcp-latency_query_api", "inventory_mcp-site_lookup"],
+    };
+    render(<MCPSemanticFilterTestPanel {...buildProps({ testResult })} />);
+
+    expect(screen.getByText("+5 more selected tools not shown")).toBeInTheDocument();
   });
 
   it("should not render the results section when testResult is null", () => {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.tsx
@@ -103,6 +103,11 @@ export default function MCPSemanticFilterTestPanel({
                           </li>
                         ))}
                       </ul>
+                      {testResult.selectedTools > testResult.tools.length && (
+                        <Typography.Text type="secondary" style={{ display: "block", marginTop: 8 }}>
+                          +{testResult.selectedTools - testResult.tools.length} more selected tools not shown
+                        </Typography.Text>
+                      )}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4215

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The `x-litellm-semantic-filter-tools` response header is capped at `MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH` (default 150) characters. Before this change the cap sliced the CSV mid-name and appended `...`, so the semantic filter test panel in the admin UI rendered the last Selected Tools entry as a chopped name such as `SP...`. After this change the header only carries complete tool names and the panel says how many selected names did not fit

Reproduced and verified on a live proxy on localhost:4000 backed by Postgres, hitting the real Bedrock and OpenAI APIs (Claude Haiku 4.5 for the completion, text-embedding-3-small for the semantic router). Proxy config: `mcp_semantic_tool_filter` enabled with `top_k: 8`, `similarity_threshold: 0.05`, and two MCP servers with long aliases (`network_metrics_query_mcp`, `site_inventory_lookup_mcp`, both pointing at `https://mcp.deepwiki.com/mcp`) so the selected tool name CSV exceeds 150 chars

1. Start the proxy: `python litellm/proxy/proxy_cli.py --config lit4215_repro_config.yaml --detailed_debug`
2. Send a chat completion whose tools carry the MCP registry names and inspect the response headers:

```bash
curl -sD - -o /tmp/body.json http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock-invoke-haiku-4-5",
    "max_tokens": 64,
    "messages": [{"role": "user", "content": "Read the wiki structure and contents of the repo, ask a question about it, and look up the site inventory. Reply in one short sentence."}],
    "tools": [
      {"name": "network_metrics_query_mcp-read_wiki_structure", "description": "Get a list of documentation topics for a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}}, "required": ["repoName"]}},
      {"name": "network_metrics_query_mcp-read_wiki_contents", "description": "View documentation about a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}}, "required": ["repoName"]}},
      {"name": "network_metrics_query_mcp-ask_question", "description": "Ask any question about a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}, "question": {"type": "string"}}, "required": ["repoName", "question"]}},
      {"name": "site_inventory_lookup_mcp-read_wiki_structure", "description": "Get a list of documentation topics for a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}}, "required": ["repoName"]}},
      {"name": "site_inventory_lookup_mcp-read_wiki_contents", "description": "View documentation about a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}}, "required": ["repoName"]}},
      {"name": "site_inventory_lookup_mcp-ask_question", "description": "Ask any question about a GitHub repository", "input_schema": {"type": "object", "properties": {"repoName": {"type": "string"}, "question": {"type": "string"}}, "required": ["repoName", "question"]}}
    ]
  }' | grep -iE "^HTTP|x-litellm-semantic-filter"
```

Before (unfixed `litellm_internal_staging`, header is exactly 150 chars and the 4th name is chopped to `network_metrics_query_mc...`):

```
HTTP/1.1 200 OK
x-litellm-semantic-filter: 6->5
x-litellm-semantic-filter-tools: network_metrics_query_mcp-ask_question,site_inventory_lookup_mcp-ask_question,site_inventory_lookup_mcp-read_wiki_contents,network_metrics_query_mc...
```

After (this branch, same request; header is 122 chars, every name complete, the two names that do not fit are dropped whole):

```
HTTP/1.1 200 OK
x-litellm-semantic-filter: 6->5
x-litellm-semantic-filter-tools: network_metrics_query_mcp-ask_question,site_inventory_lookup_mcp-ask_question,site_inventory_lookup_mcp-read_wiki_contents
```

Both runs returned a real completion from Bedrock (`"model":"bedrock-invoke-haiku-4-5"`, finish_reason stop)

UI check for the admin panel (Settings, Admin Settings, MCP Semantic Filter, Test tab): the Selected Tools list renders each header entry verbatim. The two screenshots below drive the real `MCPSemanticFilterTestPanel` with the before/after header from the curl run above (`x-litellm-semantic-filter: 6->5` plus the tools CSV), since the live panel test flow emits these headers through the responses MCP path that LIT-4214 restores. Before the fix the list ends in the chopped entry `network_metrics_query_mc...` with no explanation; after the fix every listed name is complete and a "+2 more selected tools not shown" note accounts for the two names the capped header dropped

Before (chopped final tool name, no explanation):

![semantic filter test panel before the fix, showing a chopped final tool name](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNmRkZDg3MmMtNGM3Ni00YzhhLTk0YWYtNTdmNzE2NjBmNjFkIiwiaWF0IjoxNzgzMzc3MDEyLCJleHAiOjE3ODM5ODE4MTIsImZpbGVuYW1lIjoicG9mX2JlZm9yZS5wbmcifQ.mlZ5MZ9TaQsLEbU7WBcXPqQsRibAioG_VYbmyITvmRI)

After (whole tool names plus a note for the ones that did not fit):

![semantic filter test panel after the fix, showing whole tool names and a plus 2 more selected tools not shown note](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZmJhZWVlNGUtNTk5MS00ZTZmLTg5OGEtYzI0NzlhZDY4ODM0IiwiaWF0IjoxNzgzMzc3MDEyLCJleHAiOjE3ODM5ODE4MTIsImZpbGVuYW1lIjoicG9mX2FmdGVyLnBuZyJ9.dDaAlbWrCjjVfddZshegqJycLJPI9tCNQW4kVCYjGto)

## Type

🐛 Bug Fix

## Changes

`SemanticToolFilterHook.async_post_call_response_headers_hook` used to enforce the nginx safe header cap by slicing the tool names CSV mid-name and appending `...`. The new module level helper `_truncate_csv_at_tool_name_boundary` drops any name that does not fit whole, so the header always carries complete names in their original order; when not even one name fits the header is omitted rather than emitting a partial name

`MCPSemanticFilterTestPanel` now renders a secondary "+N more selected tools not shown" note when the parsed header carries fewer names than the selected tool count from `x-litellm-semantic-filter`, so the shortened list reads as intentional instead of looking truncated

Regression tests: `test_semantic_filter_headers_hook_emits_only_complete_tool_names` fails on the old slicing behavior (the last emitted entry was a chopped name) and passes with the fix; `test_truncate_csv_at_tool_name_boundary_edges` pins the boundary cases (exact fit at a comma, mid-name cut, single name longer than the cap). The panel test asserts the note appears when names are missing and stays hidden when the list is complete

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102