### PR TITLE
fix(mcp): stamp oauth2_flow=authorization_code when persisting a DCR client registration

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -772,6 +772,7 @@ async def _persist_dcr_client_registration(
             data=UpdateMCPServerRequest(
                 server_id=mcp_server.server_id,
                 credentials=credentials,
+                oauth2_flow="authorization_code",
                 **({"token_url": mcp_server.token_url} if mcp_server.token_url else {}),
             ),
             touched_by="mcp_oauth_dcr",

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -519,7 +519,12 @@ async def test_register_client_persists_dcr_client_identity():
     """A dynamic client registration (RFC 7591) must persist the issued client_id /
     client_secret / token_endpoint_auth_method and the token_url onto the server row so
     autonomous refresh can authenticate as the registered client. Without persistence the
-    minted client_id is discarded and the refresh_token grant has no client identity."""
+    minted client_id is discarded and the refresh_token grant has no client identity.
+
+    The persist must also stamp oauth2_flow="authorization_code": only the interactive
+    flow reaches this persist, and without the stamp the row (client creds + token_url,
+    no persisted authorization_url) matches the legacy M2M inference whenever endpoint
+    discovery fails at registry build, flipping the server to client_credentials."""
     try:
         from fastapi import Request
 
@@ -597,6 +602,7 @@ async def test_register_client_persists_dcr_client_identity():
     assert update_data.credentials["client_id"] == "generated-client"
     assert update_data.credentials["client_secret"] == "generated-secret"
     assert update_data.credentials["token_endpoint_auth_method"] == "client_secret_basic"
+    assert update_data.oauth2_flow == "authorization_code"
 
     mock_update_server.assert_called_once()
 


### PR DESCRIPTION
## Relevant issues

First of a short sequence that persists oauth2_flow at every write site so the legacy field-shape inference in _resolve_oauth2_flow can eventually be deleted. Follow-ups: write-side persistence for UI/REST creates and edits, an app-level backfill for legacy null rows plus resolved-flow reads for the dashboard, then deletion of the inference

## Behavior

When an admin completes the interactive OAuth/DCR flow for a server, the row is permanently marked oauth2_flow=authorization_code alongside the registered client_id, so a DCR-registered interactive server can no longer be mistaken for M2M when endpoint discovery fails at registry load

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduction on a live proxy backed by Postgres (master key `sk-1234`)

1. Start the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Go to http://localhost:4000/ui/?page=mcp-servers, add an interactive OAuth server that supports dynamic client registration (a Linear MCP works: url `https://mcp.linear.app/mcp`, transport Streamable HTTP, auth type OAuth, leave client id/secret blank so the gateway runs DCR), then open the server's tools tab and complete the Authorize browser flow as a proxy admin

3. Read the row back and confirm the flow was stamped alongside the registered client

```
curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" \
  | jq '.[] | select(.alias=="linear") | {auth_type, oauth2_flow, token_url}'
```

Before this change `oauth2_flow` stays null after the authorize flow; after it the read-back shows `"oauth2_flow": "authorization_code"`

## Type

🐛 Bug Fix

## Changes

Only the gateway-managed interactive flow reaches _persist_dcr_client_registration (the public /register routes never pass persist_credentials, so client-driven and delegate registrations never persist), which means every row that persist writes is an authorization_code server by definition. The flow was not recorded, leaving the row as client credentials + token_url with no persisted authorization_url and a null oauth2_flow: exactly the shape the legacy M2M inference in _resolve_oauth2_flow matches. The row normally classifies correctly anyway because endpoint discovery backfills authorization_url in memory before the inference runs, but on any transient discovery failure at registry build the server flips to client_credentials for that load and per-user traffic routes to the M2M path

This stamps oauth2_flow="authorization_code" in the same partial update that persists the registered client_id, so a DCR-registered interactive server classifies correctly without depending on discovery succeeding. Rows persisted before this change stay null until the follow-up backfill; they keep today's discovery-dependent behavior, no worse

The existing regression test for the DCR persist now also asserts the stamp, so removing it fails the test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth persistence and flow classification; wrong values could misroute token/egress behavior, but the change is a single explicit field on an already-interactive-only code path with test coverage.
> 
> **Overview**
> When the gateway persists a **dynamic client registration (RFC 7591)** result for an interactive MCP OAuth server, it now also sets **`oauth2_flow="authorization_code"`** on the same `UpdateMCPServerRequest` as the registered `client_id` / secret / `token_url`.
> 
> Previously that persist left **`oauth2_flow` null** while the row looked like legacy M2M (credentials + `token_url`, no stored `authorization_url`). **`_resolve_oauth2_flow`** could then infer **`client_credentials`** if endpoint discovery failed during registry build, sending per-user traffic down the wrong OAuth path.
> 
> The DCR persist regression test now asserts **`oauth2_flow == "authorization_code"`** alongside the existing credential checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15a840e1e0a4e08abd4cd3526f80d7fff2ee5c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
