### PR TITLE
fix(streaming): stamp completion_start_time on first chunk for /v1/messages and /v1/responses

### DIFF
--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -26,6 +26,11 @@ from .success_handler import PassThroughEndpointLogging
 
 class PassThroughStreamingHandler:
     @staticmethod
+    def _stamp_first_chunk_if_needed(litellm_logging_obj: LiteLLMLoggingObj) -> None:
+        if litellm_logging_obj.completion_start_time is None:
+            litellm_logging_obj._update_completion_start_time(completion_start_time=datetime.now())
+
+    @staticmethod
     async def chunk_processor(
         response: httpx.Response,
         request_body: Optional[dict],
@@ -58,6 +63,7 @@ class PassThroughStreamingHandler:
                 # Hot path: just buffer for end-of-stream logging and forward.
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
+                    PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
                     yield chunk
             else:
                 # ``cost_injection_active`` already requires ``model_name`` to
@@ -67,6 +73,7 @@ class PassThroughStreamingHandler:
                 resolved_model_name: str = model_name
                 async for chunk in response.aiter_bytes():
                     raw_bytes.append(chunk)
+                    PassThroughStreamingHandler._stamp_first_chunk_if_needed(litellm_logging_obj)
                     if endpoint_type == EndpointType.VERTEX_AI:
                         if "streamRawPredict" in url_route or "rawPredict" in url_route:
                             modified_chunk = ProxyBaseLLMRequestProcessing._process_chunk_with_cost_injection(

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -128,6 +128,9 @@ class BaseResponsesAPIStreamingIterator:
             self.finished = True
             return None
 
+        if self.logging_obj.completion_start_time is None:
+            self.logging_obj._update_completion_start_time(completion_start_time=datetime.now())
+
         try:
             # Parse the JSON chunk
             parsed_chunk = json.loads(chunk)

--- a/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
+++ b/tests/llm_responses_api_testing/test_base_responses_api_streaming_iterator.py
@@ -67,6 +67,7 @@ class TestBaseResponsesAPIStreamingIterator:
 
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         mock_responses_api_response = Mock(spec=ResponsesAPIResponse)
@@ -107,6 +108,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.headers = {}
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         # Create a mock ResponsesAPIResponse for the completed event
@@ -179,6 +181,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.headers = {}
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         # Create a mock OutputTextDeltaEvent (not a completed event)
@@ -239,6 +242,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.headers = {}
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         # Create the iterator instance
@@ -265,6 +269,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.headers = {}
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         # Create the iterator instance
@@ -291,6 +296,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.headers = {}
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_config = Mock(spec=BaseResponsesAPIConfig)
 
         # Create the iterator instance
@@ -329,6 +335,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.aiter_bytes = Mock()
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_logging_obj.async_success_handler = Mock()
         mock_logging_obj.success_handler = Mock()
         mock_config = Mock(spec=BaseResponsesAPIConfig)
@@ -397,6 +404,7 @@ class TestBaseResponsesAPIStreamingIterator:
 
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_logging_obj.async_failure_handler = Mock()
         mock_logging_obj.failure_handler = Mock()
 
@@ -457,6 +465,7 @@ class TestBaseResponsesAPIStreamingIterator:
 
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_logging_obj.async_failure_handler = Mock()
         mock_logging_obj.failure_handler = Mock()
 
@@ -505,6 +514,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.aiter_bytes = Mock()
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_logging_obj.async_failure_handler = Mock()
         mock_logging_obj.failure_handler = Mock()
         mock_logging_obj.async_success_handler = Mock()
@@ -587,6 +597,7 @@ class TestBaseResponsesAPIStreamingIterator:
         mock_response.aiter_bytes = Mock()
         mock_logging_obj = Mock(spec=LiteLLMLoggingObj)
         mock_logging_obj.model_call_details = {"litellm_params": {}}
+        mock_logging_obj.completion_start_time = None
         mock_logging_obj.async_failure_handler = Mock()
         mock_logging_obj.failure_handler = Mock()
         mock_logging_obj.async_success_handler = Mock()

--- a/tests/llm_responses_api_testing/test_responses_hooks.py
+++ b/tests/llm_responses_api_testing/test_responses_hooks.py
@@ -34,6 +34,7 @@ class _FakeLoggingObj:
         self.last_success_kwargs = None
         self.last_async_success_kwargs = None
         self.start_time = datetime.now()
+        self.completion_start_time = None
         self.model_call_details = {"litellm_params": {}}
 
     # Signature alignment with Logging handlers
@@ -50,6 +51,10 @@ class _FakeLoggingObj:
 
     async def async_failure_handler(self, *args, **kwargs):
         self.async_failure_calls += 1
+
+    def _update_completion_start_time(self, completion_start_time):
+        self.completion_start_time = completion_start_time
+        self.model_call_details["completion_start_time"] = completion_start_time
 
 
 def _make_completed_response(response_id: str = "resp_test") -> ResponseCompletedEvent:

--- a/tests/pass_through_unit_tests/test_vertex_ai_anthropic_streaming_cost_injection.py
+++ b/tests/pass_through_unit_tests/test_vertex_ai_anthropic_streaming_cost_injection.py
@@ -57,6 +57,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_enabled():
         # Setup logging object with model info
         litellm_logging_obj = MagicMock(spec=LiteLLMLoggingObj)
         litellm_logging_obj.model_call_details = {"model": "claude-sonnet-4@20250514"}
+        litellm_logging_obj.completion_start_time = None
         litellm_logging_obj.async_success_handler = AsyncMock()
 
         request_body = {"model": "claude-sonnet-4@20250514"}
@@ -135,6 +136,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_disabled():
 
         litellm_logging_obj = MagicMock(spec=LiteLLMLoggingObj)
         litellm_logging_obj.model_call_details = {"model": "claude-sonnet-4@20250514"}
+        litellm_logging_obj.completion_start_time = None
         litellm_logging_obj.async_success_handler = AsyncMock()
 
         request_body = {"model": "claude-sonnet-4@20250514"}
@@ -196,6 +198,7 @@ async def test_vertex_ai_anthropic_streaming_cost_injection_no_usage_chunk():
 
         litellm_logging_obj = MagicMock(spec=LiteLLMLoggingObj)
         litellm_logging_obj.model_call_details = {"model": "claude-sonnet-4@20250514"}
+        litellm_logging_obj.completion_start_time = None
         litellm_logging_obj.async_success_handler = AsyncMock()
 
         request_body = {"model": "claude-sonnet-4@20250514"}
@@ -250,6 +253,7 @@ async def test_vertex_ai_anthropic_streaming_model_extraction():
 
         litellm_logging_obj = MagicMock(spec=LiteLLMLoggingObj)
         litellm_logging_obj.model_call_details = {}
+        litellm_logging_obj.completion_start_time = None
         litellm_logging_obj.async_success_handler = AsyncMock()
 
         # Test model extraction from request body

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_streaming_handler_interrupt.py
@@ -241,6 +241,126 @@ async def test_chunk_processor_routes_logging_through_logging_worker_on_disconne
     assert asyncio.iscoroutine(enqueued[0])
 
 
+def _logging_obj_with_write_once_cst():
+    """Build a MagicMock that mirrors the real Logging behavior: _update_completion_start_time
+    latches self.completion_start_time so the write-once guard actually latches."""
+    obj = MagicMock()
+    obj.completion_start_time = None
+
+    def _update(*, completion_start_time):
+        obj.completion_start_time = completion_start_time
+
+    obj._update_completion_start_time.side_effect = _update
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_stamps_completion_start_time_on_first_chunk():
+    """Regression: LIT-4185 — streaming pass-through must stamp completion_start_time on
+    the first upstream chunk. Otherwise _success_handler_helper_fn falls back to
+    completion_start_time = end_time, and Prometheus/OTEL/SpendLogs TTFT reads as
+    total request duration (0 speedup)."""
+    chunks = [b"chunk-1", b"chunk-2", b"chunk-3"]
+    response = _make_streaming_response(chunks)
+
+    mock_logging_obj = _logging_obj_with_write_once_cst()
+    mock_passthrough_handler = MagicMock()
+
+    with patch.object(
+        PassThroughStreamingHandler,
+        "_route_streaming_logging_to_handler",
+        new=AsyncMock(),
+    ):
+        received = []
+        async for chunk in PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "claude-haiku-4-5"},
+            litellm_logging_obj=mock_logging_obj,
+            endpoint_type=EndpointType.ANTHROPIC,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=mock_passthrough_handler,
+            url_route="/v1/messages",
+        ):
+            received.append(chunk)
+
+        await asyncio.sleep(0)
+
+    assert received == chunks
+    mock_logging_obj._update_completion_start_time.assert_called_once()
+    stamped = mock_logging_obj._update_completion_start_time.call_args.kwargs["completion_start_time"]
+    assert isinstance(stamped, datetime)
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_does_not_reset_completion_start_time_on_later_chunks():
+    """The stamp must be write-once: reading it on chunk 2/3 must not overwrite a real TTFT
+    from chunk 1 (which would collapse TTFT to time-to-last-chunk)."""
+    chunks = [b"chunk-1", b"chunk-2", b"chunk-3"]
+    response = _make_streaming_response(chunks)
+
+    real_first = datetime(2020, 1, 1, 0, 0, 0)
+    mock_logging_obj = MagicMock()
+    # Simulate first-chunk stamp having already landed (e.g. under contention or a
+    # prior wrapper that already set it): later chunks must be no-ops.
+    mock_logging_obj.completion_start_time = real_first
+    mock_passthrough_handler = MagicMock()
+
+    with patch.object(
+        PassThroughStreamingHandler,
+        "_route_streaming_logging_to_handler",
+        new=AsyncMock(),
+    ):
+        async for _ in PassThroughStreamingHandler.chunk_processor(
+            response=response,
+            request_body={"model": "claude-haiku-4-5"},
+            litellm_logging_obj=mock_logging_obj,
+            endpoint_type=EndpointType.ANTHROPIC,
+            start_time=datetime.now(),
+            passthrough_success_handler_obj=mock_passthrough_handler,
+            url_route="/v1/messages",
+        ):
+            pass
+
+    mock_logging_obj._update_completion_start_time.assert_not_called()
+    assert mock_logging_obj.completion_start_time == real_first
+
+
+@pytest.mark.asyncio
+async def test_chunk_processor_stamps_completion_start_time_on_cost_injection_path():
+    """The cost-injection branch runs alongside a hot path; both must stamp TTFT."""
+    import litellm as litellm_mod
+
+    chunks = [b"event: message_start\ndata: {}\n\n"]
+    response = _make_streaming_response(chunks)
+
+    mock_logging_obj = _logging_obj_with_write_once_cst()
+    mock_logging_obj.model_call_details = {"model": "claude-haiku-4-5"}
+    mock_passthrough_handler = MagicMock()
+
+    original = getattr(litellm_mod, "include_cost_in_streaming_usage", False)
+    litellm_mod.include_cost_in_streaming_usage = True
+    try:
+        with patch.object(
+            PassThroughStreamingHandler,
+            "_route_streaming_logging_to_handler",
+            new=AsyncMock(),
+        ):
+            async for _ in PassThroughStreamingHandler.chunk_processor(
+                response=response,
+                request_body={"model": "claude-haiku-4-5"},
+                litellm_logging_obj=mock_logging_obj,
+                endpoint_type=EndpointType.ANTHROPIC,
+                start_time=datetime.now(),
+                passthrough_success_handler_obj=mock_passthrough_handler,
+                url_route="/v1/messages",
+            ):
+                pass
+    finally:
+        litellm_mod.include_cost_in_streaming_usage = original
+
+    mock_logging_obj._update_completion_start_time.assert_called_once()
+
+
 def test_convert_raw_bytes_survives_truncated_multibyte_sequence():
     """A stream cut mid-multibyte-sequence (client disconnect) must still decode
     via errors="replace" so the usage events already received are logged, instead

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -1,0 +1,124 @@
+"""Regression tests for LIT-4185 — /v1/responses streaming must stamp
+completion_start_time on the first chunk so downstream TTFT consumers
+(Prometheus, OTEL, SpendLogs completionStartTime) do not fall back to
+completion_start_time = end_time."""
+
+import json
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.types.llms.openai import (
+    ResponseCompletedEvent,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
+)
+
+
+def _sse_event(payload: dict) -> bytes:
+    return f"data: {json.dumps(payload)}\n\n".encode("utf-8")
+
+
+def _make_iterator(
+    *,
+    sse_events: list[bytes],
+    logging_obj: LiteLLMLoggingObj,
+) -> ResponsesAPIStreamingIterator:
+    async def aiter_bytes():
+        for evt in sse_events:
+            yield evt
+
+    mock_response = Mock()
+    mock_response.headers = {}
+    mock_response.aiter_bytes = aiter_bytes
+
+    mock_config = Mock(spec=BaseResponsesAPIConfig)
+    mock_responses_api_response = Mock(spec=ResponsesAPIResponse)
+    mock_responses_api_response.id = "resp_ttft"
+
+    def _transform(model, parsed_chunk, logging_obj):
+        evt_type = parsed_chunk.get("type")
+        if evt_type == "response.completed":
+            completed = Mock(spec=ResponseCompletedEvent)
+            completed.type = ResponsesAPIStreamEvents.RESPONSE_COMPLETED
+            completed.response = mock_responses_api_response
+            return completed
+        stub = Mock()
+        stub.type = evt_type
+        return stub
+
+    mock_config.transform_streaming_response.side_effect = _transform
+
+    return ResponsesAPIStreamingIterator(
+        response=mock_response,
+        model="gpt-4o-mini",
+        responses_api_provider_config=mock_config,
+        logging_obj=logging_obj,
+        litellm_metadata={},
+        custom_llm_provider="openai",
+    )
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_stamps_completion_start_time_on_first_chunk():
+    """Without the fix, `logging_obj.completion_start_time` stays None across the
+    entire stream and _success_handler_helper_fn falls back to end_time — collapsing
+    the reported TTFT to full generation time."""
+    logging_obj = Mock(spec=LiteLLMLoggingObj)
+    logging_obj.completion_start_time = None
+    logging_obj.model_call_details = {"litellm_params": {}}
+    stamped: list[datetime] = []
+
+    def _update(*, completion_start_time):
+        stamped.append(completion_start_time)
+        logging_obj.completion_start_time = completion_start_time
+        logging_obj.model_call_details["completion_start_time"] = completion_start_time
+
+    logging_obj._update_completion_start_time.side_effect = _update
+
+    iterator = _make_iterator(
+        sse_events=[
+            _sse_event({"type": "response.created"}),
+            _sse_event({"type": "response.output_text.delta", "delta": "hi"}),
+            _sse_event({"type": "response.completed"}),
+        ],
+        logging_obj=logging_obj,
+    )
+
+    async for _ in iterator:
+        pass
+
+    assert len(stamped) == 1, (
+        f"Expected exactly one first-chunk stamp; got {len(stamped)}. "
+        "Later chunks must not re-stamp completion_start_time."
+    )
+    assert isinstance(stamped[0], datetime)
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_does_not_reset_prior_completion_start_time():
+    """If `completion_start_time` is already set (e.g. by an outer wrapper), the
+    iterator must not overwrite it — otherwise TTFT would collapse to
+    time-to-last-chunk under contention."""
+    prior = datetime(2020, 1, 1, 0, 0, 0)
+    logging_obj = Mock(spec=LiteLLMLoggingObj)
+    logging_obj.completion_start_time = prior
+    logging_obj.model_call_details = {"litellm_params": {}}
+
+    iterator = _make_iterator(
+        sse_events=[
+            _sse_event({"type": "response.created"}),
+            _sse_event({"type": "response.completed"}),
+        ],
+        logging_obj=logging_obj,
+    )
+
+    async for _ in iterator:
+        pass
+
+    logging_obj._update_completion_start_time.assert_not_called()
+    assert logging_obj.completion_start_time == prior


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4185

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy + Postgres, hitting real provider APIs. Config declares a native Anthropic model, an OpenAI model, and a custom callback that prints what `async_log_success_event` receives (`completion_start_time - start_time` vs `end_time - start_time`).

Same three streaming curls on unfixed and fixed code; SpendLogs is the persisted signal Prometheus/OTEL/UI read.

### Before (unfixed code)

```
$ curl -sS -N http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"claude-haiku","max_tokens":800,"stream":true,"messages":[{"role":"user","content":"Write a 500-word essay about latency."}]}' \
    -o /dev/null -w "%{time_starttransfer}s ttfb / %{time_total}s total\n"
0.624481s ttfb / 8.921292s total

$ curl -sS -N http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-mini","stream":true,"messages":[{"role":"user","content":"Write a 500-word essay about latency."}]}' \
    -o /dev/null -w "%{time_starttransfer}s ttfb / %{time_total}s total\n"
0.830721s ttfb / 13.920983s total

$ curl -sS -N http://localhost:4000/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"gpt-mini","stream":true,"input":"Write a 500-word essay about latency."}' \
    -o /dev/null -w "%{time_starttransfer}s ttfb / %{time_total}s total\n"
0.340454s ttfb / 8.417053s total
```

Callback (only `acompletion` reports honest TTFT; the other two hit the bug):

```
LIT4185 call_type=anthropic_messages stream=True ttft=8.302s total=8.302s cst_equals_end=True
LIT4185 call_type=acompletion       stream=True ttft=0.813s total=13.909s cst_equals_end=False
```

SpendLogs (Prometheus / OTEL / Admin UI all read `completionStartTime` from this row):

```
     call_type      |           model            | cst_equals_end | ttft_s | total_s
--------------------+----------------------------+----------------+--------+---------
 aresponses         | openai/gpt-4.1-mini        | f              |  8.397 |   8.398
 acompletion        | openai/gpt-4.1-mini        | f              |  0.813 |  13.909
 anthropic_messages | anthropic/claude-haiku-4-5 | t              |  8.302 |   8.302
```

`anthropic_messages` collapses to `cst_equals_end=t` explicitly. `aresponses` shows `ttft = total - 1ms` (the fallback in `_success_handler_helper_fn` sets `completion_start_time = end_time`). `acompletion` is the control and stays honest.

### After (fixed code)

```
$ curl -sS -N http://localhost:4000/v1/messages ...
0.905877s ttfb / 8.328649s total

$ curl -sS -N http://localhost:4000/v1/chat/completions ...
1.167069s ttfb / 7.222803s total

$ curl -sS -N http://localhost:4000/v1/responses ...
0.553045s ttfb / 10.005348s total
```

Callback:

```
LIT4185 call_type=anthropic_messages stream=True ttft=0.004s total=7.428s cst_equals_end=False
LIT4185 call_type=acompletion       stream=True ttft=1.148s total=7.212s cst_equals_end=False
```

SpendLogs (top three rows are the fixed run, bottom three are the unfixed run for direct comparison):

```
     call_type      |           model            | cst_equals_end | ttft_s | total_s
--------------------+----------------------------+----------------+--------+---------
 aresponses         | openai/gpt-4.1-mini        | f              |  0.520 |   9.970
 acompletion        | openai/gpt-4.1-mini        | f              |  1.148 |   7.212
 anthropic_messages | anthropic/claude-haiku-4-5 | f              |  0.004 |   7.428
 aresponses         | openai/gpt-4.1-mini        | f              |  8.397 |   8.398
 acompletion        | openai/gpt-4.1-mini        | f              |  0.813 |  13.909
 anthropic_messages | anthropic/claude-haiku-4-5 | t              |  8.302 |   8.302
```

TTFT is a real fraction of total for both previously-broken paths; the control keeps working; nothing collapses to `cst_equals_end`

## Type

🐛 Bug Fix

## Changes

Streaming pass-through for native Anthropic `/v1/messages` (`PassThroughStreamingHandler.chunk_processor`) and the `/v1/responses` streaming iterator (`BaseResponsesAPIStreamingIterator._process_chunk`) never set `logging_obj.completion_start_time`. `Logging._success_handler_helper_fn` then fell back to `completion_start_time = end_time`, so every downstream TTFT consumer (Prometheus, OTEL, Langfuse, Admin UI, spend logs `completionStartTime`, custom callbacks) reported time-to-first-token equal to total request duration. `/v1/chat/completions` streaming was unaffected because `CustomStreamWrapper` already stamps the first chunk

The fix stamps `completion_start_time` on the first upstream byte in each of those two spots via `logging_obj._update_completion_start_time(...)`, guarded on `is None` so it's write-once and never overwrites a real value if something upstream already stamped

The agentic-hook path for `/v1/messages` (`AgenticAnthropicStreamingIterator`) wraps the same `chunk_processor` stream, so fixing the underlying `chunk_processor` covers it transitively; no separate change is needed in the agentic iterator

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow observability fix on streaming hot paths with write-once guards; no auth, billing, or API contract changes beyond more accurate TTFT timestamps.
> 
> **Overview**
> Fixes **LIT-4185**: streaming on native Anthropic `/v1/messages` (pass-through) and `/v1/responses` never set `logging_obj.completion_start_time`, so success logging fell back to `completion_start_time = end_time` and **TTFT looked like full request duration** in SpendLogs, Prometheus, OTEL, and callbacks. Chat completions streaming was already correct via `CustomStreamWrapper`.
> 
> **Pass-through** (`PassThroughStreamingHandler`): new `_stamp_first_chunk_if_needed` runs on every upstream byte chunk (normal and cost-injection paths) and calls `_update_completion_start_time` only when `completion_start_time is None`.
> 
> **Responses API** (`BaseResponsesAPIStreamingIterator._process_chunk`): same write-once stamp on the first non-empty SSE payload (after `[DONE]` handling, before JSON parse).
> 
> Tests add LIT-4185 regressions (first-chunk stamp, no overwrite on later chunks, cost-injection path) and align mocks with `completion_start_time = None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fff0039d7bf28821dd40bdc593ee537123ec20d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->