### PR TITLE
fix(mcp): apply semantic filter to expanded litellm_proxy tools and show filtered-out count

### DIFF
--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -193,6 +193,32 @@ class SemanticToolFilterHook(CustomLogger):
                 f"Semantic tool filter: all {len(native_tools)} tools are native, no MCP filtering applied"
             )
 
+    def _emit_filter_metadata_safe(
+        self,
+        data: dict,
+        mcp_tools: list[object],
+        filtered_mcp_tools: list[object],
+        native_tools: list[object],
+        filtered_tools: list[object],
+    ) -> None:
+        """
+        Emit filter metadata without letting an emission failure abort the
+        already-filtered request.
+        """
+        try:
+            self._emit_filter_metadata(
+                data=data,
+                mcp_tools=mcp_tools,
+                filtered_mcp_tools=filtered_mcp_tools,
+                native_tools=native_tools,
+                filtered_tools=filtered_tools,
+            )
+        except Exception as e:
+            verbose_proxy_logger.warning(
+                f"Failed to emit semantic filter metadata: {e}",
+                exc_info=True,
+            )
+
     async def async_pre_call_hook(
         self,
         user_api_key_dict: "UserAPIKeyAuth",
@@ -233,11 +259,16 @@ class SemanticToolFilterHook(CustomLogger):
                     verbose_proxy_logger.warning("No tools expanded from MCP references")
                     return None
 
+                if not self.filter.enabled:
+                    data["tools"] = native_tools_before_expand + expanded_tools
+                    verbose_proxy_logger.debug("Semantic filter disabled, forwarding expanded MCP tools unfiltered")
+                    return data
+
                 filtered_expanded_tools = await self._filter_expanded_tools(data=data, expanded_tools=expanded_tools)
 
                 combined_tools = native_tools_before_expand + filtered_expanded_tools
                 data["tools"] = combined_tools
-                self._emit_filter_metadata(
+                self._emit_filter_metadata_safe(
                     data=data,
                     mcp_tools=expanded_tools,
                     filtered_mcp_tools=filtered_expanded_tools,
@@ -313,19 +344,13 @@ class SemanticToolFilterHook(CustomLogger):
 
             data["tools"] = filtered_tools
 
-            try:
-                self._emit_filter_metadata(
-                    data=data,
-                    mcp_tools=mcp_tools,
-                    filtered_mcp_tools=filtered_mcp_tools,
-                    native_tools=native_tools,
-                    filtered_tools=filtered_tools,
-                )
-            except Exception as e:
-                verbose_proxy_logger.warning(
-                    f"Failed to emit semantic filter metadata: {e}",
-                    exc_info=True,
-                )
+            self._emit_filter_metadata_safe(
+                data=data,
+                mcp_tools=mcp_tools,
+                filtered_mcp_tools=filtered_mcp_tools,
+                native_tools=native_tools,
+                filtered_tools=filtered_tools,
+            )
 
             return data
 

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -117,6 +117,27 @@ class SemanticToolFilterHook(CustomLogger):
 
         return openai_tools_as_dicts
 
+    async def _filter_expanded_tools(
+        self,
+        data: dict,
+        expanded_tools: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """
+        Apply the semantic filter to expanded MCP tool definitions.
+
+        Expanded tools are flat OpenAI function dicts with a top-level
+        "name" (see transform_mcp_tool_to_openai_responses_api_tool), so
+        filter_tools can name-match them against the semantic router.
+        """
+        raw_messages = data.get("messages") or data.get("input") or []
+        messages = [{"role": "user", "content": raw_messages}] if isinstance(raw_messages, str) else raw_messages
+        user_query = self.filter.extract_user_query(messages)
+        if not user_query:
+            verbose_proxy_logger.debug("No user query found, skipping semantic filter on expanded MCP tools")
+            return expanded_tools
+
+        return await self.filter.filter_tools(query=user_query, available_tools=expanded_tools)
+
     def _is_mcp_tool(self, tool: object) -> bool:
         """
         Check whether *tool* is registered in the MCP semantic router.
@@ -194,9 +215,6 @@ class SemanticToolFilterHook(CustomLogger):
             verbose_proxy_logger.debug("No tools in request, skipping semantic filter")
             return None
 
-        # Expanded MCP tools are in OpenAI nested format which
-        # filter_tools/_extract_tool_info cannot name-match, so we skip
-        # semantic filtering and return early.
         if self._should_expand_mcp_tools(tools):
             verbose_proxy_logger.debug("Detected litellm_proxy MCP references, expanding before semantic filtering")
 
@@ -215,11 +233,21 @@ class SemanticToolFilterHook(CustomLogger):
                     verbose_proxy_logger.warning("No tools expanded from MCP references")
                     return None
 
-                data["tools"] = native_tools_before_expand + expanded_tools
+                filtered_expanded_tools = await self._filter_expanded_tools(data=data, expanded_tools=expanded_tools)
+
+                combined_tools = native_tools_before_expand + filtered_expanded_tools
+                data["tools"] = combined_tools
+                self._emit_filter_metadata(
+                    data=data,
+                    mcp_tools=expanded_tools,
+                    filtered_mcp_tools=filtered_expanded_tools,
+                    native_tools=native_tools_before_expand,
+                    filtered_tools=combined_tools,
+                )
                 verbose_proxy_logger.info(
                     f"Expanded MCP references to {len(expanded_tools)} tools "
                     f"({len(native_tools_before_expand)} native preserved), "
-                    f"skipping semantic filter (OpenAI nested format)"
+                    f"semantic filter selected {len(filtered_expanded_tools)}"
                 )
                 return data
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -774,6 +774,187 @@ async def test_semantic_filter_hook_responses_api_name_collision():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_filters_expanded_litellm_proxy_tools():
+    """
+    Regression test (LIT-4214): litellm_proxy MCP references must be
+    semantically filtered after expansion, with real filter stats.
+
+    Given: A /v1/responses-style request whose tools are a single
+           {"type": "mcp", "server_url": "litellm_proxy"} reference that
+           expands to 5 flat OpenAI function dicts
+    When:  The hook processes the request
+    Then:  The expanded tools go through the semantic filter (top_k=2)
+           and litellm_semantic_filter_stats reports pre/post counts, so
+           the x-litellm-semantic-filter header shows how many tools
+           were filtered out instead of silently forwarding all tools
+           with no stats.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=2,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    registry_tools = [
+        MCPTool(
+            name=f"srv-tool_{i}",
+            description=f"Registry tool {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(5)
+    ]
+    filter_instance._build_router(registry_tools)
+
+    expanded_tools = [
+        {
+            "type": "function",
+            "name": f"srv-tool_{i}",
+            "description": f"Registry tool {i}",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for i in range(5)
+    ]
+
+    hook = SemanticToolFilterHook(filter_instance)
+    hook._expand_mcp_tools = AsyncMock(  # type: ignore[method-assign]
+        return_value=expanded_tools
+    )
+
+    data = {
+        "model": "gpt-4",
+        "input": [{"role": "user", "content": "Send an email", "type": "message"}],
+        "tools": [
+            {
+                "type": "mcp",
+                "server_url": "litellm_proxy",
+                "require_approval": "never",
+            }
+        ],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="aresponses",
+    )
+
+    assert result is not None, "Hook should return modified data"
+    filtered = result["tools"]
+
+    assert len(filtered) <= 2, f"Expanded tools should be filtered to top_k=2, got {len(filtered)}"
+    assert len(filtered) < len(expanded_tools), (
+        f"Hook must not forward all {len(expanded_tools)} expanded tools unfiltered, got {len(filtered)}"
+    )
+    for tool in filtered:
+        assert tool in expanded_tools, "Filtered tools must be the original expanded tool dicts"
+
+    assert (
+        "litellm_semantic_filter_stats" in result["metadata"]
+    ), "Filter stats must be emitted for the litellm_proxy expansion path"
+    stats = result["metadata"]["litellm_semantic_filter_stats"]
+    total, selected = stats.split("->")
+    assert int(total) == 5, f"Stats 'from' should be pre-filter expanded count (5), got {total}"
+    assert int(selected) == len(filtered), f"Stats 'to' should match post-filter count, got {selected}"
+
+    print(f"✅ Expanded litellm_proxy tools filtered: {len(expanded_tools)} -> {len(filtered)}, stats={stats}")
+
+
+@pytest.mark.asyncio
+async def test_semantic_filter_hook_filters_expanded_tools_with_string_input():
+    """
+    Responses API requests may pass ``input`` as a plain string; the
+    expanded-tool filtering must treat it as the user query instead of
+    crashing (which would silently disable MCP expansion).
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+    from litellm.types.utils import Embedding, EmbeddingResponse
+
+    mock_router = Mock()
+
+    def mock_embedding_sync(*args, **kwargs):
+        return EmbeddingResponse(
+            data=[Embedding(embedding=[0.1] * 1536, index=0, object="embedding")],
+            model="text-embedding-3-small",
+            object="list",
+            usage={"prompt_tokens": 10, "total_tokens": 10},
+        )
+
+    async def mock_embedding_async(*args, **kwargs):
+        return mock_embedding_sync()
+
+    mock_router.embedding = mock_embedding_sync
+    mock_router.aembedding = mock_embedding_async
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=mock_router,
+        top_k=2,
+        similarity_threshold=0.3,
+        enabled=True,
+    )
+
+    registry_tools = [
+        MCPTool(
+            name=f"srv-tool_{i}",
+            description=f"Registry tool {i}",
+            inputSchema={"type": "object"},
+        )
+        for i in range(5)
+    ]
+    filter_instance._build_router(registry_tools)
+
+    expanded_tools = [
+        {
+            "type": "function",
+            "name": f"srv-tool_{i}",
+            "description": f"Registry tool {i}",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for i in range(5)
+    ]
+
+    hook = SemanticToolFilterHook(filter_instance)
+
+    filtered = await hook._filter_expanded_tools(
+        data={"input": "Send an email"},
+        expanded_tools=expanded_tools,
+    )
+
+    assert len(filtered) <= 2, f"String input must still drive semantic filtering, got {len(filtered)} tools"
+
+    print(f"✅ String input filtered expanded tools: {len(expanded_tools)} -> {len(filtered)}")
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_hook_preserves_tool_order():
     """
     Regression test: tool ordering preservation.

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_semantic_tool_filter.py
@@ -955,6 +955,70 @@ async def test_semantic_filter_hook_filters_expanded_tools_with_string_input():
 
 
 @pytest.mark.asyncio
+async def test_semantic_filter_hook_expansion_skips_filter_when_disabled():
+    """
+    When the filter is disabled at runtime (e.g. via the UI toggle), the
+    expansion path must forward all expanded tools and emit NO filter
+    stats, mirroring the generic path's enabled guard.
+    """
+    from litellm.proxy._experimental.mcp_server.semantic_tool_filter import (
+        SemanticMCPToolFilter,
+    )
+    from litellm.proxy.hooks.mcp_semantic_filter import SemanticToolFilterHook
+
+    filter_instance = SemanticMCPToolFilter(
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=Mock(),
+        top_k=2,
+        similarity_threshold=0.3,
+        enabled=False,
+    )
+
+    expanded_tools = [
+        {
+            "type": "function",
+            "name": f"srv-tool_{i}",
+            "description": f"Registry tool {i}",
+            "parameters": {"type": "object", "properties": {}},
+        }
+        for i in range(5)
+    ]
+
+    hook = SemanticToolFilterHook(filter_instance)
+    hook._expand_mcp_tools = AsyncMock(  # type: ignore[method-assign]
+        return_value=expanded_tools
+    )
+
+    data = {
+        "model": "gpt-4",
+        "input": [{"role": "user", "content": "Send an email", "type": "message"}],
+        "tools": [
+            {
+                "type": "mcp",
+                "server_url": "litellm_proxy",
+                "require_approval": "never",
+            }
+        ],
+        "metadata": {},
+    }
+
+    result = await hook.async_pre_call_hook(
+        user_api_key_dict=Mock(),
+        cache=Mock(),
+        data=data,
+        call_type="aresponses",
+    )
+
+    assert result is not None, "Hook should still expand MCP references when the filter is disabled"
+    assert len(result["tools"]) == 5, f"All expanded tools must be forwarded when disabled, got {len(result['tools'])}"
+    assert (
+        "litellm_semantic_filter_stats" not in result["metadata"]
+    ), "No filter stats may be emitted when the filter is disabled"
+
+    print("✅ Disabled filter: expansion preserved, no spurious stats")
+
+
+@pytest.mark.asyncio
 async def test_semantic_filter_hook_preserves_tool_order():
     """
     Regression test: tool ordering preservation.

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.test.tsx
@@ -90,7 +90,7 @@ describe("MCPSemanticFilterTestPanel", () => {
     expect(screen.queryByText("Semantic filtering is disabled")).not.toBeInTheDocument();
   });
 
-  it("should display test results when testResult is provided", () => {
+  it("should display selected and filtered-out counts when testResult is provided", () => {
     const testResult: TestResult = {
       totalTools: 10,
       selectedTools: 3,
@@ -98,11 +98,23 @@ describe("MCPSemanticFilterTestPanel", () => {
     };
     render(<MCPSemanticFilterTestPanel {...buildProps({ testResult })} />);
 
-    expect(screen.getByText("3 tools selected")).toBeInTheDocument();
-    expect(screen.getByText("Filtered from 10 available tools")).toBeInTheDocument();
+    expect(screen.getByText("3 of 10 tools selected")).toBeInTheDocument();
+    expect(screen.getByText("7 tools filtered out")).toBeInTheDocument();
     expect(screen.getByText("wiki-fetch")).toBeInTheDocument();
     expect(screen.getByText("github-search")).toBeInTheDocument();
     expect(screen.getByText("slack-post")).toBeInTheDocument();
+  });
+
+  it("should surface a zero filtered-out count when the filter selected every tool", () => {
+    const testResult: TestResult = {
+      totalTools: 207,
+      selectedTools: 207,
+      tools: ["tool-a", "tool-b"],
+    };
+    render(<MCPSemanticFilterTestPanel {...buildProps({ testResult })} />);
+
+    expect(screen.getByText("207 of 207 tools selected")).toBeInTheDocument();
+    expect(screen.getByText("0 tools filtered out")).toBeInTheDocument();
   });
 
   it("should not render the results section when testResult is null", () => {

--- a/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.tsx
+++ b/ui/litellm-dashboard/src/components/Settings/AdminSettings/MCPSemanticFilterSettings/MCPSemanticFilterTestPanel.tsx
@@ -86,9 +86,9 @@ export default function MCPSemanticFilterTestPanel({
                   <div>
                     <Typography.Title level={5}>Results</Typography.Title>
                     <Alert
-                      type="success"
-                      message={`${testResult.selectedTools} tools selected`}
-                      description={`Filtered from ${testResult.totalTools} available tools`}
+                      type={testResult.totalTools - testResult.selectedTools > 0 ? "success" : "warning"}
+                      message={`${testResult.selectedTools} of ${testResult.totalTools} tools selected`}
+                      description={`${testResult.totalTools - testResult.selectedTools} tools filtered out`}
                       showIcon
                       style={{ marginBottom: 16 }}
                     />


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4214

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on localhost:4000 backed by Postgres, hitting real OpenAI APIs (`gpt-4o-mini` plus `text-embedding-3-small` for the semantic router). Config: two public MCP servers (`deepwiki`, `microsoft_learn`, 6 tools total) and `litellm_settings.mcp_semantic_tool_filter: {enabled: true, top_k: 2, similarity_threshold: 0.3, embedding_model: text-embedding-3-small}`

Request used throughout (identical to what the admin UI test panel and its documented curl send):

```bash
curl -sD - http://localhost:4000/v1/responses \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{
    "model": "gpt-4o-mini",
    "input": [{"role": "user", "content": "Look up the deepwiki docs structure for the fastapi/fastapi repo", "type": "message"}],
    "tools": [{"type": "mcp", "server_url": "litellm_proxy", "require_approval": "never"}],
    "tool_choice": "required"
  }'
```

Before (unfixed hook, at `origin/litellm_internal_staging`): HTTP 200 but no semantic filter headers at all, and the outbound OpenAI payload carried all 6 tools

```
HTTP/1.1 200 OK
(no x-litellm-semantic-filter header present)

litellm.log:
14:55:32 - LiteLLM Proxy:INFO: hook.py:219 - Expanded MCP references to 6 tools (0 native preserved), skipping semantic filter (OpenAI nested format)

tools in outbound request payload (6 = everything):
deepwiki-ask_question, deepwiki-read_wiki_contents, deepwiki-read_wiki_structure,
microsoft_learn-microsoft_code_sample_search, microsoft_learn-microsoft_docs_fetch, microsoft_learn-microsoft_docs_search
```

After (this PR): same curl returns real counts and only the selected tools reach the model

```
HTTP/1.1 200 OK
x-litellm-semantic-filter: 6->2
x-litellm-semantic-filter-tools: deepwiki-read_wiki_structure,deepwiki-read_wiki_contents

litellm.log:
14:56:26 - LiteLLM Proxy:INFO: hook.py:247 - Expanded MCP references to 6 tools (0 native preserved), semantic filter selected 2
```

Selection is query dependent; an Azure flavored prompt ("Find official Azure docs on configuring Entra ID app registrations") over the same 6 tools selects the other server's tools

```
HTTP/1.1 200 OK
x-litellm-semantic-filter: 6->2
x-litellm-semantic-filter-tools: microsoft_learn-microsoft_docs_search,microsoft_learn-microsoft_code_sample_search
```

UI verification: the Results alert now reads "X of Z tools selected" with "Y tools filtered out" underneath, and turns into a yellow warning when nothing was filtered out so a no-op filter is obvious at a glance. The screenshots below drive the real `MCPSemanticFilterTestPanel` with the header-derived counts from the runs above (in the proxy this is at http://localhost:4000/ui -> Settings -> Admin Settings -> MCP Semantic Filter, enter a query, select `gpt-4o-mini`, click Test Filter)

Filtered case (matches the `6->2` curl above)

Before: a bare green "2 tools selected" over "Filtered from 6 available tools" that never states how many were dropped

![before, filtered case, green success with no filtered-out count](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvODM0NmQwYWYtMDM3Zi00N2U2LWFhNTEtMzJlYjkzNDMzYTA4IiwiaWF0IjoxNzgzMzg0Nzk4LCJleHAiOjE3ODM5ODk1OTgsImZpbGVuYW1lIjoicG9mODVfYmVmb3JlX2ZpbHRlcmVkLnBuZyJ9.dQXNkUgluiGJvt7xXLzrDWuovEflMgkvyr68sPM15pg)

After: green "2 of 6 tools selected" over "4 tools filtered out"

![after, filtered case, green success showing 4 tools filtered out](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZjVmMTBkYzMtNGY5Ny00OTZiLWJmYjAtM2VjNTUwNThiN2Q4IiwiaWF0IjoxNzgzMzg0Nzk4LCJleHAiOjE3ODM5ODk1OTgsImZpbGVuYW1lIjoicG9mODVfYWZ0ZXJfZmlsdGVyZWQucG5nIn0.3nW2B5keQFay41Y0oVDljmFl4eLqQpi6EsIbcSLOJp0)

No-op case (filter selects everything, the same shape as the customer's 207/207 report)

Before: still a green success "6 tools selected" over "Filtered from 6 available tools", so a filter that pruned nothing reads as a win

![before, no-op case, misleading green success](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZjBmOWY1ODMtYTg2Yy00ZmM4LTg3ZDMtY2Y5M2JjNzM3ODU3IiwiaWF0IjoxNzgzMzg0Nzk4LCJleHAiOjE3ODM5ODk1OTgsImZpbGVuYW1lIjoicG9mODVfYmVmb3JlX25vb3AucG5nIn0.-wjeIEbdinCMlK0P4fKJHuK7fB-omdJ7NRyt8cDu0PY)

After: a yellow warning "6 of 6 tools selected" over "0 tools filtered out", so the no-op is called out

![after, no-op case, yellow warning showing 0 tools filtered out](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNjg0ZmJkZjctMjRiZC00YjY1LWE2ZDMtNTQ2MGUwNzMwOGZhIiwiaWF0IjoxNzgzMzg0Nzk4LCJleHAiOjE3ODM5ODk1OTgsImZpbGVuYW1lIjoicG9mODVfYWZ0ZXJfbm9vcC5wbmcifQ.0vzkqACuzAj0XOmPRSljAEsHdgBYaQW7-ZIZwTkZgS4)

## Type

🐛 Bug Fix

## Changes

The MCP semantic filter test panel showed results like "207 tools selected / Filtered from 207 available tools", which never states how many tools were filtered out and makes a filter no-op read as success. A customer hit exactly that: the panel reported 207/207 while their real traffic forwarded every MCP tool to the model unfiltered, blowing past provider tool count limits

Backend: `SemanticToolFilterHook.async_pre_call_hook` has a dedicated branch for requests whose tools are `{"type": "mcp", "server_url": "litellm_proxy"}` references, which is the exact request the test panel and its documented curl send. That branch expanded the references and returned early, skipping semantic filtering and emitting no `x-litellm-semantic-filter` header at all. Its stated reason ("expanded tools are in OpenAI nested format which cannot name-match") does not hold on this path: expansion goes through `transform_mcp_tool_to_openai_responses_api_tool`, which produces flat function dicts whose top-level `name` `_extract_tool_info` reads fine. The branch now runs the expanded tools through `filter_tools` and emits the same stats metadata as the generic path, so the header carries real pre/post counts and the filter actually prunes the tool list before it reaches the model. A plain string `input` (valid on `/v1/responses`) is wrapped into a message list before query extraction so it cannot break the branch. The branch mirrors the generic path's other guards too: when the filter is disabled at runtime the expanded tools pass through with no stats, and metadata emission goes through a shared `_emit_filter_metadata_safe` helper so an emission failure drops the header instead of aborting the expansion

UI: the results alert now reads "X of Z tools selected" with "Y tools filtered out" underneath, and renders as a warning instead of a success when nothing was filtered out, so a no-op filter is visible at a glance

Tests: `test_semantic_filter_hook_filters_expanded_litellm_proxy_tools` fails on the old hook (all 5 expanded tools forwarded, no stats emitted) and passes with the fix (top_k respected, stats `5->N`); `test_semantic_filter_hook_filters_expanded_tools_with_string_input` covers the string input arm; `test_semantic_filter_hook_expansion_skips_filter_when_disabled` covers the disabled toggle; the panel specs assert the new copy including the zero filtered warning case

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-LLM tool lists on a high-traffic proxy hook path; behavior is guarded by tests and mirrors the existing generic filter path, but wrong filtering could still affect provider tool limits.
> 
> **Overview**
> Fixes **LIT-4214**: `/v1/responses` requests that pass `litellm_proxy` MCP tool references no longer skip semantic filtering after expansion.
> 
> **Proxy hook:** The `litellm_proxy` expansion branch used to attach every expanded tool and return without filtering or `x-litellm-semantic-filter` stats. It now runs expanded flat function dicts through `filter_tools` (with string `input` coerced for query extraction), honors `filter.enabled` (pass-through with no stats when off), and emits the same metadata via `_emit_filter_metadata_safe` so a metadata failure cannot abort the request.
> 
> **Admin UI:** The MCP semantic filter test panel shows **“X of Z tools selected”** and **“Y tools filtered out”**, and uses a **warning** alert when nothing was filtered so no-op runs are obvious.
> 
> **Tests:** Regression coverage for the expansion path (filtering, stats, disabled filter, string input) and updated panel copy expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ff2972a5de298415f5355a54147da1efe7a878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->