### PR TITLE
fix(caching): valkey-semantic async cache silently does not cache

### DIFF
--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -279,7 +279,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 print_verbose("No prompt provided for semantic caching")
                 return
 
-            embedding = await self._get_async_embedding(prompt, **kwargs)
+            embedding = await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
             await self._ensure_index_async(len(embedding))
 
             doc_key = self._doc_key(key)
@@ -298,7 +298,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
                 return None
 
-            embedding = await self._get_async_embedding(prompt, **kwargs)
+            embedding = await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
             await self._ensure_index_async(len(embedding))
 
             search_result = await self.async_client.ft(self.index_name).search(

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -317,6 +317,60 @@ async def test_async_get_cache_misses_below_threshold():
     assert metadata["semantic-similarity"] == pytest.approx(0.6)
 
 
+@pytest.mark.asyncio
+async def test_async_embedding_called_with_metadata_only():
+    """
+    Regression test: async_set_cache / async_get_cache must call
+    _get_async_embedding(prompt, metadata=...) and NOT forward the full
+    request kwargs (messages, model, etc.).
+
+    The inherited _get_async_embedding signature only accepts (prompt, metadata),
+    so passing **kwargs raised TypeError, which the broad except swallowed --
+    silently caching nothing on every async request. The existing tests missed
+    this because they replaced _get_async_embedding with a permissive AsyncMock
+    that accepts any kwargs. This stub mirrors the real signature so a
+    regression fails loudly instead of silently.
+    """
+    captured = {}
+
+    async def strict_embedding(prompt, metadata=None):
+        captured["prompt"] = prompt
+        captured["metadata"] = metadata
+        return [0.1, 0.2, 0.3]
+
+    # --- set path ---
+    set_client = AsyncMock()
+    set_client.ft = _async_ft(0.05)
+    set_cache = _make_cache(async_client=set_client, similarity_threshold=0.8)
+    set_cache._get_async_embedding = strict_embedding
+
+    await set_cache.async_set_cache(
+        key="cache-key",
+        value={"content": "Paris"},
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        metadata={"user_api_key": "sk-123"},
+    )
+    # If the full kwargs leaked in, strict_embedding would TypeError, the except
+    # would swallow it, and hset would never run.
+    set_client.hset.assert_awaited_once()
+    assert captured["prompt"] == "What is the capital of France?"
+    assert captured["metadata"] == {"user_api_key": "sk-123"}
+
+    # --- get path ---
+    get_client = AsyncMock()
+    get_client.ft = _async_ft(0.05)
+    get_cache = _make_cache(async_client=get_client, similarity_threshold=0.8)
+    get_cache._get_async_embedding = strict_embedding
+
+    result = await get_cache.async_get_cache(
+        key="cache-key",
+        messages=[{"role": "user", "content": "capital city of France"}],
+        metadata={},
+    )
+    get_client.ft.return_value.search.assert_awaited_once()
+    assert result == {"content": "Paris"}
+
+
 def test_ensure_index_swallows_already_exists():
     sync_client = MagicMock()
     sync_client.ft.return_value.create_index.side_effect = Exception(


### PR DESCRIPTION
## What

`ValkeySemanticCache.async_set_cache` / `async_get_cache` calls `self._get_async_embedding(prompt, **kwargs)`, but the inherited signature is `_get_async_embedding(self, prompt, metadata=None)`. Forwarding the full request
kwargs (`messages`, ...) raises `TypeError`, which the surrounding `except Exception` swallows.

Result: on the async path, `valkey-semantic` silently writes nothing and never hits and every request falls through to the LLM. 

## Fix

Match the parent `RedisSemanticCache` (in both async methods):

```diff
- embedding = await self._get_async_embedding(prompt, **kwargs)
+ embedding = await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
```
## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix


## Changes
