### PR TITLE
fix(responses): surface upstream error status on get instead of 500

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1944,7 +1944,7 @@ def _map_azure_exception(
             response=getattr(original_exception, "response", None),
             body=getattr(original_exception, "body", None),
         )
-    elif "invalid_request_error" in error_str:
+    elif "invalid_request_error" in error_str and getattr(original_exception, "status_code", None) in (None, 400):
         raise BadRequestError(
             message=f"AzureException BadRequestError - {message}",
             llm_provider="azure",
@@ -1981,6 +1981,14 @@ def _map_azure_exception(
         elif original_exception.status_code == 401:
             raise AuthenticationError(
                 message=f"AzureException AuthenticationError - {message}",
+                llm_provider="azure",
+                model=model,
+                litellm_debug_info=extra_information,
+                response=getattr(original_exception, "response", None),
+            )
+        elif original_exception.status_code == 404:
+            raise NotFoundError(
+                message=f"AzureException NotFoundError - {message}",
                 llm_provider="azure",
                 model=model,
                 litellm_debug_info=extra_information,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2912,6 +2912,7 @@ class BaseLLMHTTPHandler:
 
         try:
             response = sync_httpx_client.get(url=url, headers=headers, params=data)
+            response.raise_for_status()
         except Exception as e:
             raise self._handle_error(
                 e=e,
@@ -2983,7 +2984,7 @@ class BaseLLMHTTPHandler:
 
         try:
             response = await async_httpx_client.get(url=url, headers=headers, params=data)
-
+            response.raise_for_status()
         except Exception as e:
             verbose_logger.exception(f"Error retrieving response: {e}")
             raise self._handle_error(
@@ -3076,6 +3077,7 @@ class BaseLLMHTTPHandler:
 
         try:
             response = sync_httpx_client.get(url=url, headers=headers, params=params)
+            response.raise_for_status()
         except Exception as e:
             raise self._handle_error(e=e, provider_config=responses_api_provider_config)
 
@@ -3149,6 +3151,7 @@ class BaseLLMHTTPHandler:
 
         try:
             response = await async_httpx_client.get(url=url, headers=headers, params=params)
+            response.raise_for_status()
         except Exception as e:
             raise self._handle_error(e=e, provider_config=responses_api_provider_config)
 

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -2986,7 +2986,7 @@ class BaseLLMHTTPHandler:
             response = await async_httpx_client.get(url=url, headers=headers, params=data)
             response.raise_for_status()
         except Exception as e:
-            verbose_logger.exception(f"Error retrieving response: {e}")
+            verbose_logger.debug(f"Error retrieving response: {e}")
             raise self._handle_error(
                 e=e,
                 provider_config=responses_api_provider_config,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -649,3 +649,22 @@ def test_upstream_4xx_without_model_maps_to_bad_request():
 
     assert excinfo.value.status_code == 400
     assert "Cannot cancel a synchronous response." in excinfo.value.message
+
+
+def test_azure_404_with_invalid_request_error_type_maps_to_not_found():
+    from litellm.llms.base_llm.chat.transformation import BaseLLMException
+
+    original_exception = BaseLLMException(
+        status_code=404,
+        message='{"error": {"message": "Response with id \'resp_abc\' not found.", "type": "invalid_request_error"}}',
+    )
+
+    with pytest.raises(litellm.NotFoundError) as excinfo:
+        exception_type(
+            model=None,
+            original_exception=original_exception,
+            custom_llm_provider="azure",
+        )
+
+    assert excinfo.value.status_code == 404
+    assert "Response with id 'resp_abc' not found." in excinfo.value.message

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1745,3 +1745,79 @@ def test_sync_retrieve_file_content_raises_on_http_error():
         )
 
     assert exc_info.value.status_code == 404
+
+
+_UPSTREAM_NOT_FOUND_BODY = {
+    "error": {
+        "message": "Response with id 'resp_abc' not found.",
+        "type": "invalid_request_error",
+        "param": None,
+        "code": None,
+    }
+}
+
+
+def _async_handler_returning(status_code: int, body: dict) -> AsyncHTTPHandler:
+    handler = AsyncHTTPHandler()
+    handler.client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(status_code, json=body))
+    )
+    return handler
+
+
+def _sync_handler_returning(status_code: int, body: dict) -> HTTPHandler:
+    handler = HTTPHandler()
+    handler.client = httpx.Client(transport=httpx.MockTransport(lambda request: httpx.Response(status_code, json=body)))
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_aget_responses_surfaces_upstream_error_status_instead_of_500():
+    client = _async_handler_returning(404, _UPSTREAM_NOT_FOUND_BODY)
+
+    with pytest.raises(litellm.NotFoundError) as excinfo:
+        await litellm.aget_responses(
+            response_id="resp_abc",
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-03-01-preview",
+            client=client,
+        )
+
+    assert excinfo.value.status_code == 404
+    assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+def test_get_responses_surfaces_upstream_error_status_instead_of_500():
+    client = _sync_handler_returning(404, _UPSTREAM_NOT_FOUND_BODY)
+
+    with pytest.raises(litellm.NotFoundError) as excinfo:
+        litellm.get_responses(
+            response_id="resp_abc",
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-03-01-preview",
+            client=client,
+        )
+
+    assert excinfo.value.status_code == 404
+    assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+@pytest.mark.asyncio
+async def test_alist_input_items_surfaces_upstream_error_status():
+    client = _async_handler_returning(404, _UPSTREAM_NOT_FOUND_BODY)
+
+    with pytest.raises(litellm.NotFoundError) as excinfo:
+        await litellm.alist_input_items(
+            response_id="resp_abc",
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-03-01-preview",
+            client=client,
+        )
+
+    assert excinfo.value.status_code == 404

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1806,6 +1806,22 @@ def test_get_responses_surfaces_upstream_error_status_instead_of_500():
     assert "Response with id 'resp_abc' not found." in excinfo.value.message
 
 
+def test_list_input_items_surfaces_upstream_error_status():
+    client = _sync_handler_returning(404, _UPSTREAM_NOT_FOUND_BODY)
+
+    with pytest.raises(litellm.NotFoundError) as excinfo:
+        litellm.list_input_items(
+            response_id="resp_abc",
+            custom_llm_provider="azure",
+            api_base="https://test.openai.azure.com",
+            api_key="test-key",
+            api_version="2025-03-01-preview",
+            client=client,
+        )
+
+    assert excinfo.value.status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_alist_input_items_surfaces_upstream_error_status():
     client = _async_handler_returning(404, _UPSTREAM_NOT_FOUND_BODY)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against a real Azure OpenAI deployment (`azure/gpt-4o`, api_version 2025-03-01-preview), run with `.venv/bin/python litellm/proxy/proxy_cli.py --config config.yaml --port 29764 --detailed_debug`

Before, on `litellm_internal_staging` @ `7f991481cc069d7a069a8a50c140bcfaec9a4e6c`. Create a non-retrievable response, then GET it

```bash
curl -s http://localhost:29764/v1/responses \
  -H "Authorization: Bearer sk-fix4-local" -H "Content-Type: application/json" \
  -d '{"model":"azure-responses-test","input":"ping","store":false}'
# 200, id resp_LOQEeaPx46R3...

curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://localhost:29764/v1/responses/resp_LOQEeaPx46R3... \
  -H "Authorization: Bearer sk-fix4-local"
```

```
{"error":{"message":"litellm.APIConnectionError: AzureException APIConnectionError - 3 validation errors for ResponsesAPIResponse\nid\n  Field required [type=missing, input_value={'error': {'message': \"Re...m': None, 'code': None}}, input_type=dict]\n ...","type":null,"param":null,"code":"500"}}
HTTP_STATUS:500
```

Same on a deleted id: POST with `"store": true`, DELETE it (200 `response.deleted`), then GET the deleted id returns the identical 500 pydantic ValidationError. Control: POST stored + GET returns 200

After, on `fd9d0cf3f6ff9e718a5e172c17ad485f536a1fa2`. Same two error curls now surface the real upstream status and message

```bash
curl -s -w "\nHTTP_STATUS:%{http_code}\n" http://localhost:29764/v1/responses/resp_04fd61c97344... \
  -H "Authorization: Bearer sk-fix4-local"
```

```
{"error":{"message":"litellm.NotFoundError: AzureException NotFoundError - {\n  \"error\": {\n    \"message\": \"Response with id 'resp_04fd61c97344f4f8016a4c26fa6fcc819391ced2af096216ae' not found.\",\n    \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\": null\n  }\n} ...","type":null,"param":null,"code":"404"}}
HTTP_STATUS:404
```

GET on a deleted id likewise returns 404 with Azure's "Response with id ... not found." message. The stored control still returns 200 with the full response, and DELETE still returns 200

## Type

🐛 Bug Fix

## Changes

`GET /v1/responses/{id}` returned a 500 `APIConnectionError` whenever the upstream provider returned an error (response created with `"store": false`, or id already deleted). Root cause: `HTTPHandler.get` / `AsyncHTTPHandler.get` never call `raise_for_status()` (unlike `post` and `delete`), so the upstream error JSON flowed into `transform_get_response_api_response`, which force-parsed it into the `ResponsesAPIResponse` pydantic model and blew up with `ValidationError: 3 validation errors ... id/created_at/output Field required`

`llm_http_handler.py`: the four responses GET call sites (`get_responses`, `async_get_responses`, `list_responses_input_items`, `async_list_responses_input_items`) now call `response.raise_for_status()` inside the existing try, so upstream errors route through `_handle_error` and the provider error class with their real status and body, matching what create/cancel (POST) and delete already do

`exception_mapping_utils.py`: the azure mapper had no 404 branch in its status ladder, and its `"invalid_request_error" in error_str` string match ran before any status check, downgrading Azure's 404 (which carries `"type": "invalid_request_error"`) to a 400. Added the 404 branch raising `NotFoundError` and gated the string match to status 400 or no status, so real statuses survive the mapping

Regression tests in the mapped test files: `tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py` covers async GET, sync GET, and input items surfacing a 404 `NotFoundError` (dependency-injected client backed by `httpx.MockTransport`), and `tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py` pins azure 404 + `invalid_request_error` mapping to `NotFoundError`. All four tests fail on the pre-fix code and pass with the fix
