### PR TITLE
feat(mcp): startup backfill stamping oauth2_flow on legacy null rows

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
@@ -8,9 +8,11 @@ never had, and persists the result so the read path never has to infer again.
 
 Signal order, strongest first:
 
-1. Per-user token rows exist for the server (``LiteLLM_MCPUserCredentials``): only the
-   interactive flow mints per-user tokens, so this is definitive and immune to the
-   discovery trap.
+1. Per-user OAuth token rows exist for the server: only the interactive flow mints
+   per-user tokens, so this is definitive and immune to the discovery trap. BYOK API
+   keys share the same table (``LiteLLM_MCPUserCredentials``), so only rows whose
+   payload decodes as a ``type: oauth2`` token count as proof; bare keys and
+   undecodable rows prove nothing about the flow.
 2. ``authorization_url`` persisted: interactive needs a user-facing authorization
    endpoint; M2M (RFC 6749 section 4.4) never has one.
 3. ``registration_url`` persisted: dynamic client registration (RFC 7591) exists to mint
@@ -37,7 +39,7 @@ from collections import Counter
 from typing import Any, Literal, Optional
 
 from litellm._logging import verbose_proxy_logger
-from litellm.proxy._experimental.mcp_server.db import decrypt_credentials
+from litellm.proxy._experimental.mcp_server.db import _decode_oauth_payload, decrypt_credentials
 from litellm.proxy.utils import PrismaClient
 from litellm.types.mcp import MCPCredentials
 
@@ -100,13 +102,15 @@ async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[Backfi
     token_rows: list[Any] = await prisma_client.db.litellm_mcpusercredentials.find_many(
         where={"server_id": {"in": server_ids}},
     )
-    server_ids_with_tokens: set[str] = {token_row.server_id for token_row in token_rows}
+    server_ids_with_oauth_tokens: set[str] = {
+        token_row.server_id for token_row in token_rows if _decode_oauth_payload(token_row.credential_b64) is not None
+    }
 
     classified = tuple(
         (
             row,
             classify_null_flow_row(
-                has_per_user_tokens=row.server_id in server_ids_with_tokens,
+                has_per_user_tokens=row.server_id in server_ids_with_oauth_tokens,
                 authorization_url=row.authorization_url,
                 registration_url=row.registration_url,
                 token_url=row.token_url,
@@ -138,7 +142,7 @@ async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[Backfi
     for stamped_flow in stamped_flows:
         server_ids_for_flow = [row.server_id for row, (row_flow, _) in classified if row_flow == stamped_flow]
         await prisma_client.db.litellm_mcpservertable.update_many(
-            where={"server_id": {"in": server_ids_for_flow}},
+            where={"server_id": {"in": server_ids_for_flow}, "oauth2_flow": None},
             data={"oauth2_flow": stamped_flow, "updated_by": _BACKFILL_AUDIT_ACTOR},
         )
 

--- a/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
@@ -1,0 +1,128 @@
+"""Startup backfill for oauth2 MCP server rows persisted before oauth2_flow was written.
+
+Rows created before the write-side stamps (DCR persist, UI create, REST create) carry a
+null ``oauth2_flow`` and rely on read-time field-shape inference, which cannot tell a
+DCR-registered interactive server from an M2M server unless endpoint discovery succeeds
+first. This backfill classifies each null row once, at rest, using signals inference
+never had, and persists the result so the read path never has to infer again.
+
+Signal order, strongest first:
+
+1. Per-user token rows exist for the server (``LiteLLM_MCPUserCredentials``): only the
+   interactive flow mints per-user tokens, so this is definitive and immune to the
+   discovery trap.
+2. ``authorization_url`` persisted: interactive needs a user-facing authorization
+   endpoint; M2M (RFC 6749 section 4.4) never has one.
+3. ``registration_url`` persisted: dynamic client registration (RFC 7591) exists to mint
+   clients for the interactive flow; M2M servers are configured with static credentials.
+4. ``token_url`` plus decryptable ``client_id`` and ``client_secret``: the M2M credential
+   shape, mirroring the legacy inference in ``MCPServerManager._resolve_oauth2_flow``.
+5. Anything else is interactive: matching how ``needs_user_oauth_token`` treats a null
+   flow, so the stamp never changes runtime routing for rows no rule recognizes.
+
+Runs before the first registry load on every boot and is idempotent: a healed fleet has
+no null rows and the backfill exits after one query.
+"""
+
+import json
+from collections import Counter
+from typing import Any, Literal, Optional
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy._experimental.mcp_server.db import decrypt_credentials
+from litellm.proxy.utils import PrismaClient
+from litellm.types.mcp import MCPCredentials
+
+OAuth2Flow = Literal["client_credentials", "authorization_code"]
+BackfillRule = Literal[
+    "per_user_tokens",
+    "authorization_url",
+    "registration_url",
+    "m2m_credential_shape",
+    "interactive_default",
+]
+
+_BACKFILL_AUDIT_ACTOR = "oauth2_flow_backfill"
+
+
+def _decrypted_credentials(raw_credentials: Any) -> Optional[MCPCredentials]:
+    if raw_credentials is None:
+        return None
+    if isinstance(raw_credentials, str):
+        try:
+            parsed = json.loads(raw_credentials)
+        except (ValueError, TypeError):
+            return None
+    else:
+        parsed = raw_credentials
+    if not isinstance(parsed, dict):
+        return None
+    return decrypt_credentials(credentials=dict(parsed))
+
+
+def classify_null_flow_row(
+    *,
+    has_per_user_tokens: bool,
+    authorization_url: Optional[str],
+    registration_url: Optional[str],
+    token_url: Optional[str],
+    credentials: Optional[MCPCredentials],
+) -> tuple[OAuth2Flow, BackfillRule]:
+    if has_per_user_tokens:
+        return "authorization_code", "per_user_tokens"
+    if authorization_url:
+        return "authorization_code", "authorization_url"
+    if registration_url:
+        return "authorization_code", "registration_url"
+    if token_url and credentials and credentials.get("client_id") and credentials.get("client_secret"):
+        return "client_credentials", "m2m_credential_shape"
+    return "authorization_code", "interactive_default"
+
+
+async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[BackfillRule, int]:
+    """Stamp every ``auth_type=oauth2`` row whose ``oauth2_flow`` is null; returns counts per rule."""
+    null_rows: list[Any] = await prisma_client.db.litellm_mcpservertable.find_many(
+        where={"auth_type": "oauth2", "oauth2_flow": None},
+    )
+    if not null_rows:
+        return {}
+
+    server_ids = [row.server_id for row in null_rows]
+    token_rows: list[Any] = await prisma_client.db.litellm_mcpusercredentials.find_many(
+        where={"server_id": {"in": server_ids}},
+    )
+    server_ids_with_tokens: set[str] = {token_row.server_id for token_row in token_rows}
+
+    classified = tuple(
+        (
+            row,
+            classify_null_flow_row(
+                has_per_user_tokens=row.server_id in server_ids_with_tokens,
+                authorization_url=row.authorization_url,
+                registration_url=row.registration_url,
+                token_url=row.token_url,
+                credentials=_decrypted_credentials(row.credentials),
+            ),
+        )
+        for row in null_rows
+    )
+
+    for row, (flow, rule) in classified:
+        await prisma_client.db.litellm_mcpservertable.update(
+            where={"server_id": row.server_id},
+            data={"oauth2_flow": flow, "updated_by": _BACKFILL_AUDIT_ACTOR},
+        )
+        verbose_proxy_logger.info(
+            "oauth2_flow backfill: server_id=%s stamped %s (rule=%s)",
+            row.server_id,
+            flow,
+            rule,
+        )
+
+    counts: dict[BackfillRule, int] = dict(Counter(rule for _, (_, rule) in classified))
+    verbose_proxy_logger.info(
+        "oauth2_flow backfill: stamped %d oauth2 server row(s): %s",
+        len(null_rows),
+        counts,
+    )
+    return counts

--- a/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
@@ -88,7 +88,8 @@ def classify_null_flow_row(
 
 
 async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[BackfillRule, int]:
-    """Stamp every ``auth_type=oauth2`` row whose ``oauth2_flow`` is null; returns counts per rule."""
+    """Classify every ``auth_type=oauth2`` row whose ``oauth2_flow`` is null; stamp the provable
+    ones, warn on the ambiguous ones, and return counts per rule."""
     null_rows: list[Any] = await prisma_client.db.litellm_mcpservertable.find_many(
         where={"auth_type": "oauth2", "oauth2_flow": None},
     )
@@ -125,16 +126,20 @@ async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[Backfi
                 "next boot.",
                 row.server_id,
             )
-            continue
-        await prisma_client.db.litellm_mcpservertable.update(
-            where={"server_id": row.server_id},
-            data={"oauth2_flow": flow, "updated_by": _BACKFILL_AUDIT_ACTOR},
-        )
-        verbose_proxy_logger.info(
-            "oauth2_flow backfill: server_id=%s stamped %s (rule=%s)",
-            row.server_id,
-            flow,
-            rule,
+        else:
+            verbose_proxy_logger.info(
+                "oauth2_flow backfill: server_id=%s stamped %s (rule=%s)",
+                row.server_id,
+                flow,
+                rule,
+            )
+
+    stamped_flows = {flow for _, (flow, _) in classified if flow is not None}
+    for stamped_flow in stamped_flows:
+        server_ids_for_flow = [row.server_id for row, (row_flow, _) in classified if row_flow == stamped_flow]
+        await prisma_client.db.litellm_mcpservertable.update_many(
+            where={"server_id": {"in": server_ids_for_flow}},
+            data={"oauth2_flow": stamped_flow, "updated_by": _BACKFILL_AUDIT_ACTOR},
         )
 
     counts: dict[BackfillRule, int] = dict(Counter(rule for _, (_, rule) in classified))

--- a/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth2_flow_backfill.py
@@ -15,13 +15,21 @@ Signal order, strongest first:
    endpoint; M2M (RFC 6749 section 4.4) never has one.
 3. ``registration_url`` persisted: dynamic client registration (RFC 7591) exists to mint
    clients for the interactive flow; M2M servers are configured with static credentials.
-4. ``token_url`` plus decryptable ``client_id`` and ``client_secret``: the M2M credential
-   shape, mirroring the legacy inference in ``MCPServerManager._resolve_oauth2_flow``.
+4. ``token_url`` plus decryptable ``client_id`` and ``client_secret``: ambiguous, left
+   unstamped. The shape is shared by M2M servers and DCR-registered interactive servers
+   whose authorization endpoint lives only in discovery (registered but never signed
+   in), so stamping client_credentials here could permanently route per-user traffic
+   through the proxy's stored client credential. The row keeps working through the
+   request-time backstop and a warning names it with the one-line fix (set oauth2_flow
+   via the dashboard or ``PUT /v1/mcp/server``); a completed interactive sign-in also
+   heals it via rule 1 at the next boot.
 5. Anything else is interactive: matching how ``needs_user_oauth_token`` treats a null
    flow, so the stamp never changes runtime routing for rows no rule recognizes.
 
-Runs before the first registry load on every boot and is idempotent: a healed fleet has
-no null rows and the backfill exits after one query.
+The backfill never stamps client_credentials: M2M is asserted by a human (config
+requires it, the API accepts it, the dashboard sets it), mirroring the config-level
+validation error. Runs before the first registry load on every boot and is idempotent:
+a healed fleet has no null rows and the backfill exits after one query.
 """
 
 import json
@@ -38,7 +46,7 @@ BackfillRule = Literal[
     "per_user_tokens",
     "authorization_url",
     "registration_url",
-    "m2m_credential_shape",
+    "ambiguous_m2m_shape",
     "interactive_default",
 ]
 
@@ -67,7 +75,7 @@ def classify_null_flow_row(
     registration_url: Optional[str],
     token_url: Optional[str],
     credentials: Optional[MCPCredentials],
-) -> tuple[OAuth2Flow, BackfillRule]:
+) -> tuple[Optional[OAuth2Flow], BackfillRule]:
     if has_per_user_tokens:
         return "authorization_code", "per_user_tokens"
     if authorization_url:
@@ -75,7 +83,7 @@ def classify_null_flow_row(
     if registration_url:
         return "authorization_code", "registration_url"
     if token_url and credentials and credentials.get("client_id") and credentials.get("client_secret"):
-        return "client_credentials", "m2m_credential_shape"
+        return None, "ambiguous_m2m_shape"
     return "authorization_code", "interactive_default"
 
 
@@ -108,6 +116,16 @@ async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[Backfi
     )
 
     for row, (flow, rule) in classified:
+        if flow is None:
+            verbose_proxy_logger.warning(
+                "oauth2_flow backfill: server_id=%s is ambiguous (client credentials + token_url, "
+                "no interactive signal); left unstamped. Set oauth2_flow explicitly via the "
+                "dashboard or PUT /v1/mcp/server: client_credentials if this server is M2M, or "
+                "complete an interactive sign-in and it will be stamped authorization_code at the "
+                "next boot.",
+                row.server_id,
+            )
+            continue
         await prisma_client.db.litellm_mcpservertable.update(
             where={"server_id": row.server_id},
             data={"oauth2_flow": flow, "updated_by": _BACKFILL_AUDIT_ACTOR},
@@ -121,7 +139,7 @@ async def backfill_null_oauth2_flows(prisma_client: PrismaClient) -> dict[Backfi
 
     counts: dict[BackfillRule, int] = dict(Counter(rule for _, (_, rule) in classified))
     verbose_proxy_logger.info(
-        "oauth2_flow backfill: stamped %d oauth2 server row(s): %s",
+        "oauth2_flow backfill: processed %d oauth2 server row(s): %s",
         len(null_rows),
         counts,
     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6366,6 +6366,17 @@ class ProxyConfig:
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
+        from litellm.proxy._experimental.mcp_server.oauth2_flow_backfill import (
+            backfill_null_oauth2_flows,
+        )
+
+        try:
+            if prisma_client is not None:
+                await backfill_null_oauth2_flows(prisma_client)
+        except Exception as e:  # noqa: BLE001
+            verbose_proxy_logger.exception(
+                "litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db backfill - {}".format(str(e))
+            )
 
         try:
             await global_mcp_server_manager.reload_servers_from_database()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
@@ -115,7 +115,7 @@ def _row(server_id, *, authorization_url=None, registration_url=None, token_url=
 def _mock_prisma(null_rows, token_rows):
     mock_prisma = MagicMock()
     mock_prisma.db.litellm_mcpservertable.find_many = AsyncMock(return_value=null_rows)
-    mock_prisma.db.litellm_mcpservertable.update = AsyncMock(return_value=MagicMock())
+    mock_prisma.db.litellm_mcpservertable.update_many = AsyncMock(return_value=MagicMock())
     mock_prisma.db.litellm_mcpusercredentials.find_many = AsyncMock(return_value=token_rows)
     return mock_prisma
 
@@ -132,7 +132,7 @@ async def test_backfill_only_targets_null_flow_oauth2_rows():
         where={"auth_type": "oauth2", "oauth2_flow": None},
     )
     mock_prisma.db.litellm_mcpusercredentials.find_many.assert_not_awaited()
-    mock_prisma.db.litellm_mcpservertable.update.assert_not_awaited()
+    mock_prisma.db.litellm_mcpservertable.update_many.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -158,15 +158,10 @@ async def test_backfill_stamps_rows_and_reports_rule_counts():
 
     assert counts == {"per_user_tokens": 1, "ambiguous_m2m_shape": 1, "authorization_url": 1}
 
-    stamped = {
-        call.kwargs["where"]["server_id"]: call.kwargs["data"]
-        for call in mock_prisma.db.litellm_mcpservertable.update.await_args_list
-    }
-    assert stamped["signed_in_dcr"]["oauth2_flow"] == "authorization_code"
-    assert stamped["legacy_interactive"]["oauth2_flow"] == "authorization_code"
-    assert "legacy_m2m" not in stamped
-    assert mock_prisma.db.litellm_mcpservertable.update.await_count == 2
-    assert all(data["updated_by"] == "oauth2_flow_backfill" for data in stamped.values())
+    mock_prisma.db.litellm_mcpservertable.update_many.assert_awaited_once()
+    call = mock_prisma.db.litellm_mcpservertable.update_many.await_args
+    assert sorted(call.kwargs["where"]["server_id"]["in"]) == ["legacy_interactive", "signed_in_dcr"]
+    assert call.kwargs["data"] == {"oauth2_flow": "authorization_code", "updated_by": "oauth2_flow_backfill"}
 
 
 @pytest.mark.asyncio
@@ -183,7 +178,7 @@ async def test_backfill_handles_json_string_credentials():
     counts = await backfill_null_oauth2_flows(mock_prisma)
 
     assert counts == {"ambiguous_m2m_shape": 1}
-    mock_prisma.db.litellm_mcpservertable.update.assert_not_awaited()
+    mock_prisma.db.litellm_mcpservertable.update_many.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
@@ -1,0 +1,190 @@
+"""
+Tests for the startup oauth2_flow backfill.
+
+Legacy oauth2 rows with a null oauth2_flow are classified once, at rest, using
+signals read-time inference never had (per-user token rows first), and the
+result is persisted so the read path never infers again. The signal order is
+the spec: a wrong order re-introduces the DCR trap where an interactive server
+with client creds + token_url and no persisted authorization_url is stamped M2M.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from litellm.proxy._experimental.mcp_server.oauth2_flow_backfill import (
+    backfill_null_oauth2_flows,
+    classify_null_flow_row,
+)
+
+
+def test_classify_per_user_tokens_beat_m2m_shape():
+    """The DCR trap row: creds + token_url, no authorization_url, but a user has
+    signed in. Tokens are definitive; the M2M shape must not win."""
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=True,
+        authorization_url=None,
+        registration_url=None,
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    assert flow == "authorization_code"
+    assert rule == "per_user_tokens"
+
+
+def test_classify_authorization_url_beats_m2m_shape():
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=False,
+        authorization_url="https://idp.example.com/authorize",
+        registration_url=None,
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    assert flow == "authorization_code"
+    assert rule == "authorization_url"
+
+
+def test_classify_registration_url_beats_m2m_shape():
+    """A registration endpoint means DCR, and DCR exists to mint interactive
+    clients; an abandoned-DCR row (no sign-in yet) must not be stamped M2M."""
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=False,
+        authorization_url=None,
+        registration_url="https://idp.example.com/register",
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    assert flow == "authorization_code"
+    assert rule == "registration_url"
+
+
+def test_classify_m2m_credential_shape():
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=False,
+        authorization_url=None,
+        registration_url=None,
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    assert flow == "client_credentials"
+    assert rule == "m2m_credential_shape"
+
+
+def test_classify_partial_credentials_default_interactive():
+    """token_url without a full credential pair is not the M2M shape."""
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=False,
+        authorization_url=None,
+        registration_url=None,
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid"},
+    )
+    assert flow == "authorization_code"
+    assert rule == "interactive_default"
+
+
+def test_classify_bare_row_default_interactive():
+    flow, rule = classify_null_flow_row(
+        has_per_user_tokens=False,
+        authorization_url=None,
+        registration_url=None,
+        token_url=None,
+        credentials=None,
+    )
+    assert flow == "authorization_code"
+    assert rule == "interactive_default"
+
+
+def _row(server_id, *, authorization_url=None, registration_url=None, token_url=None, credentials=None):
+    return SimpleNamespace(
+        server_id=server_id,
+        authorization_url=authorization_url,
+        registration_url=registration_url,
+        token_url=token_url,
+        credentials=credentials,
+    )
+
+
+def _mock_prisma(null_rows, token_rows):
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_mcpservertable.find_many = AsyncMock(return_value=null_rows)
+    mock_prisma.db.litellm_mcpservertable.update = AsyncMock(return_value=MagicMock())
+    mock_prisma.db.litellm_mcpusercredentials.find_many = AsyncMock(return_value=token_rows)
+    return mock_prisma
+
+
+@pytest.mark.asyncio
+async def test_backfill_only_targets_null_flow_oauth2_rows():
+    """The where clause is the guard that explicit and non-oauth2 rows are never touched."""
+    mock_prisma = _mock_prisma([], [])
+
+    counts = await backfill_null_oauth2_flows(mock_prisma)
+
+    assert counts == {}
+    mock_prisma.db.litellm_mcpservertable.find_many.assert_awaited_once_with(
+        where={"auth_type": "oauth2", "oauth2_flow": None},
+    )
+    mock_prisma.db.litellm_mcpusercredentials.find_many.assert_not_awaited()
+    mock_prisma.db.litellm_mcpservertable.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backfill_stamps_rows_and_reports_rule_counts():
+    dcr_trap_row = _row(
+        "signed_in_dcr",
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    m2m_row = _row(
+        "legacy_m2m",
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    interactive_row = _row("legacy_interactive", authorization_url="https://idp.example.com/authorize")
+
+    mock_prisma = _mock_prisma(
+        [dcr_trap_row, m2m_row, interactive_row],
+        [SimpleNamespace(server_id="signed_in_dcr", user_id="u1")],
+    )
+
+    counts = await backfill_null_oauth2_flows(mock_prisma)
+
+    assert counts == {"per_user_tokens": 1, "m2m_credential_shape": 1, "authorization_url": 1}
+
+    stamped = {
+        call.kwargs["where"]["server_id"]: call.kwargs["data"]
+        for call in mock_prisma.db.litellm_mcpservertable.update.await_args_list
+    }
+    assert stamped["signed_in_dcr"]["oauth2_flow"] == "authorization_code"
+    assert stamped["legacy_m2m"]["oauth2_flow"] == "client_credentials"
+    assert stamped["legacy_interactive"]["oauth2_flow"] == "authorization_code"
+    assert all(data["updated_by"] == "oauth2_flow_backfill" for data in stamped.values())
+
+
+@pytest.mark.asyncio
+async def test_backfill_handles_json_string_credentials():
+    m2m_row = _row(
+        "json_creds_m2m",
+        token_url="https://idp.example.com/token",
+        credentials='{"client_id": "cid", "client_secret": "csecret"}',
+    )
+    mock_prisma = _mock_prisma([m2m_row], [])
+
+    counts = await backfill_null_oauth2_flows(mock_prisma)
+
+    assert counts == {"m2m_credential_shape": 1}
+
+
+@pytest.mark.asyncio
+async def test_backfill_treats_undecodable_credentials_as_absent():
+    row = _row(
+        "corrupt_creds",
+        token_url="https://idp.example.com/token",
+        credentials="not-json",
+    )
+    mock_prisma = _mock_prisma([row], [])
+
+    counts = await backfill_null_oauth2_flows(mock_prisma)
+
+    assert counts == {"interactive_default": 1}

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
@@ -4,8 +4,10 @@ Tests for the startup oauth2_flow backfill.
 Legacy oauth2 rows with a null oauth2_flow are classified once, at rest, using
 signals read-time inference never had (per-user token rows first), and the
 result is persisted so the read path never infers again. The signal order is
-the spec: a wrong order re-introduces the DCR trap where an interactive server
-with client creds + token_url and no persisted authorization_url is stamped M2M.
+the spec, and so is the refusal to stamp client_credentials: the M2M credential
+shape is shared by DCR-registered interactive servers whose authorization
+endpoint lives only in discovery, so ambiguous rows are left unstamped for a
+human to assert rather than being permanently mislabeled M2M.
 """
 
 from types import SimpleNamespace
@@ -59,7 +61,11 @@ def test_classify_registration_url_beats_m2m_shape():
     assert rule == "registration_url"
 
 
-def test_classify_m2m_credential_shape():
+def test_classify_m2m_shape_is_ambiguous_and_unstamped():
+    """The M2M shape alone must never stamp client_credentials: a DCR-registered
+    interactive server that nobody signed into yet has the identical shape, and a
+    wrong M2M stamp would permanently route its per-user traffic through the
+    proxy's stored client credential."""
     flow, rule = classify_null_flow_row(
         has_per_user_tokens=False,
         authorization_url=None,
@@ -67,8 +73,8 @@ def test_classify_m2m_credential_shape():
         token_url="https://idp.example.com/token",
         credentials={"client_id": "cid", "client_secret": "csecret"},
     )
-    assert flow == "client_credentials"
-    assert rule == "m2m_credential_shape"
+    assert flow is None
+    assert rule == "ambiguous_m2m_shape"
 
 
 def test_classify_partial_credentials_default_interactive():
@@ -150,20 +156,23 @@ async def test_backfill_stamps_rows_and_reports_rule_counts():
 
     counts = await backfill_null_oauth2_flows(mock_prisma)
 
-    assert counts == {"per_user_tokens": 1, "m2m_credential_shape": 1, "authorization_url": 1}
+    assert counts == {"per_user_tokens": 1, "ambiguous_m2m_shape": 1, "authorization_url": 1}
 
     stamped = {
         call.kwargs["where"]["server_id"]: call.kwargs["data"]
         for call in mock_prisma.db.litellm_mcpservertable.update.await_args_list
     }
     assert stamped["signed_in_dcr"]["oauth2_flow"] == "authorization_code"
-    assert stamped["legacy_m2m"]["oauth2_flow"] == "client_credentials"
     assert stamped["legacy_interactive"]["oauth2_flow"] == "authorization_code"
+    assert "legacy_m2m" not in stamped
+    assert mock_prisma.db.litellm_mcpservertable.update.await_count == 2
     assert all(data["updated_by"] == "oauth2_flow_backfill" for data in stamped.values())
 
 
 @pytest.mark.asyncio
 async def test_backfill_handles_json_string_credentials():
+    """JSON-string credential blobs must decode: the M2M shape is recognized (and
+    therefore deliberately left unstamped) rather than misread as credential-less."""
     m2m_row = _row(
         "json_creds_m2m",
         token_url="https://idp.example.com/token",
@@ -173,7 +182,8 @@ async def test_backfill_handles_json_string_credentials():
 
     counts = await backfill_null_oauth2_flows(mock_prisma)
 
-    assert counts == {"m2m_credential_shape": 1}
+    assert counts == {"ambiguous_m2m_shape": 1}
+    mock_prisma.db.litellm_mcpservertable.update.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_oauth2_flow_backfill.py
@@ -10,6 +10,8 @@ endpoint lives only in discovery, so ambiguous rows are left unstamped for a
 human to assert rather than being permanently mislabeled M2M.
 """
 
+import base64
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -112,6 +114,23 @@ def _row(server_id, *, authorization_url=None, registration_url=None, token_url=
     )
 
 
+def _oauth_token_row(server_id):
+    payload = json.dumps({"type": "oauth2", "access_token": "tok", "connected_at": "2026-07-01T00:00:00Z"})
+    return SimpleNamespace(
+        server_id=server_id,
+        user_id="u1",
+        credential_b64=base64.urlsafe_b64encode(payload.encode()).decode(),
+    )
+
+
+def _byok_key_row(server_id):
+    return SimpleNamespace(
+        server_id=server_id,
+        user_id="u1",
+        credential_b64=base64.urlsafe_b64encode(b"sk-user-supplied-upstream-key").decode(),
+    )
+
+
 def _mock_prisma(null_rows, token_rows):
     mock_prisma = MagicMock()
     mock_prisma.db.litellm_mcpservertable.find_many = AsyncMock(return_value=null_rows)
@@ -151,7 +170,7 @@ async def test_backfill_stamps_rows_and_reports_rule_counts():
 
     mock_prisma = _mock_prisma(
         [dcr_trap_row, m2m_row, interactive_row],
-        [SimpleNamespace(server_id="signed_in_dcr", user_id="u1")],
+        [_oauth_token_row("signed_in_dcr")],
     )
 
     counts = await backfill_null_oauth2_flows(mock_prisma)
@@ -161,6 +180,7 @@ async def test_backfill_stamps_rows_and_reports_rule_counts():
     mock_prisma.db.litellm_mcpservertable.update_many.assert_awaited_once()
     call = mock_prisma.db.litellm_mcpservertable.update_many.await_args
     assert sorted(call.kwargs["where"]["server_id"]["in"]) == ["legacy_interactive", "signed_in_dcr"]
+    assert "oauth2_flow" in call.kwargs["where"] and call.kwargs["where"]["oauth2_flow"] is None
     assert call.kwargs["data"] == {"oauth2_flow": "authorization_code", "updated_by": "oauth2_flow_backfill"}
 
 
@@ -193,3 +213,22 @@ async def test_backfill_treats_undecodable_credentials_as_absent():
     counts = await backfill_null_oauth2_flows(mock_prisma)
 
     assert counts == {"interactive_default": 1}
+
+
+@pytest.mark.asyncio
+async def test_backfill_byok_key_rows_are_not_sign_in_proof():
+    """BYOK API keys live in the same table as per-user OAuth tokens; a bare key row
+    must not satisfy the per_user_tokens rule, or a BYOK-flavored M2M-shaped server
+    would be permanently stamped authorization_code. Only rows whose payload decodes
+    as a type oauth2 token count."""
+    byok_shaped_row = _row(
+        "byok_m2m_shape",
+        token_url="https://idp.example.com/token",
+        credentials={"client_id": "cid", "client_secret": "csecret"},
+    )
+    mock_prisma = _mock_prisma([byok_shaped_row], [_byok_key_row("byok_m2m_shape")])
+
+    counts = await backfill_null_oauth2_flows(mock_prisma)
+
+    assert counts == {"ambiguous_m2m_shape": 1}
+    mock_prisma.db.litellm_mcpservertable.update_many.assert_not_awaited()


### PR DESCRIPTION
## Relevant issues

Third of the sequence that persists oauth2_flow at every write site so the legacy field-shape inference in _resolve_oauth2_flow can be deleted. Follows #32283 (DCR-persist stamp) and #32288 (create-time stamps); the follow-up stacked on this branch removes the read-time inference for DB rows. Once deployments upgrade past this PR, the null-flow population that produces the masked misclassification family (including the legacy-M2M display gap flagged on #31772) no longer exists

## Behavior

On every boot, legacy null-flow oauth2 rows are classified once from proof rather than shape: per-user tokens, a stored authorization_url, or a stored registration_url stamp authorization_code; the ambiguous M2M-looking shape is left null with a warning naming the server and the fix; client_credentials is never stamped. Writes are batched into one update_many per flow value. Net effect: after the first boot every row is either provably classified or explicitly flagged for a human decision, and nothing is guessed into permanence

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduction on a live proxy backed by Postgres (master key `sk-1234`)

1. Seed legacy-shaped rows by creating two oauth2 servers, then nulling their flow directly in the DB to simulate pre-stamp rows

```
curl -s -X POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_name":"legacy_m2m","url":"https://upstream.example.com/mcp","transport":"http","auth_type":"oauth2","token_url":"https://idp.example.com/token","credentials":{"client_id":"cid","client_secret":"csecret"}}' > /dev/null
curl -s -X POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"server_name":"legacy_interactive","url":"https://upstream2.example.com/mcp","transport":"http","auth_type":"oauth2","authorization_url":"https://idp.example.com/authorize"}' > /dev/null
psql $DATABASE_URL -c "UPDATE \"LiteLLM_MCPServerTable\" SET oauth2_flow = NULL WHERE server_name IN ('legacy_m2m','legacy_interactive');"
```

2. Restart the proxy

```
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

The startup log shows one line per row: stamped rows carry the rule that fired, e.g. `oauth2_flow backfill: server_id=... stamped authorization_code (rule=authorization_url)`, ambiguous rows carry a warning naming the one-line fix, plus a summary count

3. Read the rows back

```
curl -s http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" \
  | jq '.[] | select(.server_name | startswith("legacy_")) | {server_name, oauth2_flow, updated_by}'
```

legacy_interactive shows authorization_code with updated_by oauth2_flow_backfill. legacy_m2m stays null with a startup warning telling the admin to set oauth2_flow explicitly (dashboard or PUT /v1/mcp/server); setting it stops the warning. A second restart logs only the remaining ambiguous row

### Live run (stack tip, Postgres-backed proxy on localhost:4000)

Both rows nulled via psql (UPDATE 2), proxy restarted. Startup log:

```
oauth2_flow backfill: server_id=770d7b86-... stamped authorization_code (rule=authorization_url)
oauth2_flow backfill: server_id=ad8e1592-... is ambiguous (client credentials + token_url, no interactive signal); left unstamped. Set oauth2_flow explicitly via the dashboard or PUT /v1/mcp/server: client_credentials if this server is M2M, or complete an interactive sign-in and it will be stamped authorization_code at the next boot.
oauth2_flow backfill: processed 2 oauth2 server row(s): {'authorization_url': 1, 'ambiguous_m2m_shape': 1}
```

After remediating the ambiguous row per the warning (PUT oauth2_flow=client_credentials), psql ground truth:

```
 legacy_interactive | authorization_code | oauth2_flow_backfill
 legacy_m2m         | client_credentials | default_user_id
```

A further restart logs zero backfill lines: the fleet is healed and the run is idempotent

## Type

🆕 New Feature

## Changes

Rows created before the write-side stamps carry a null oauth2_flow and rely on read-time field-shape inference at registry build. That inference cannot tell a DCR-registered interactive server (client creds + token_url, no persisted authorization_url) from an M2M server unless endpoint discovery succeeds first, so on a transient discovery failure those servers flip to client_credentials for that load and per-user traffic routes to the M2M path

The backfill classifies each null oauth2 row once, at rest, using signals the read path never had, ordered by strength. Per-user token rows in LiteLLM_MCPUserCredentials come first: only the interactive flow mints per-user tokens, so this is definitive and immune to the discovery trap. A persisted authorization_url means interactive (M2M under RFC 6749 section 4.4 has no authorization endpoint). A persisted registration_url means interactive too, since dynamic client registration exists to mint interactive clients; this covers rows that registered a DCR client but where no user has signed in yet. The M2M credential shape (token_url plus decryptable client_id and client_secret) is deliberately left unstamped: the same shape belongs to a DCR-registered interactive server whose authorization endpoint lives only in discovery (registered but never signed in), and a wrong client_credentials stamp would be permanent and would route per-user traffic through the proxy's stored client credential. Ambiguous rows get an actionable warning (set oauth2_flow via the dashboard or PUT /v1/mcp/server), keep working per-request through the request-time security backstop, and self-heal via the per-user-token rule the moment someone completes a sign-in. The backfill never stamps client_credentials; M2M is asserted by a human, mirroring the config-level validation. Everything else defaults to authorization_code, which matches how needs_user_oauth_token already treats a null flow, so the default stamp never changes runtime routing

The backfill runs in _init_mcp_servers_in_db before the registry load, so the first build of each boot classifies from the column. It is isolated (a failure cannot block server loading), idempotent (a healed fleet exits after one indexed query), and auditable (each stamp is logged with its rule and written with updated_by=oauth2_flow_backfill). Because it runs on every boot, rows created by an older writer during a mixed-version rollout are healed at the next restart

Tests pin the signal ordering (per-user tokens and authorization_url and registration_url each beat the M2M shape, which is the DCR trap), the where-clause guard that explicit and non-oauth2 rows are never touched, JSON-string and undecodable credential handling, and the per-rule counts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes OAuth routing metadata at startup for MCP servers; misclassification could affect per-user vs M2M token routing, though the design deliberately avoids stamping `client_credentials` on ambiguous rows.
> 
> **Overview**
> Adds a **startup backfill** that runs in `_init_mcp_servers_in_db` before MCP registry load, classifying legacy `auth_type=oauth2` rows with null `oauth2_flow` and persisting `authorization_code` when provable.
> 
> Classification uses ordered signals: per-user OAuth tokens (excluding BYOK keys), stored `authorization_url`, stored `registration_url`, then defaults to interactive; **token_url + client credentials alone stays unstamped** with a warning (never auto-stamps `client_credentials`). Updates are batched via `update_many` with `updated_by=oauth2_flow_backfill`; backfill failures are logged but do not block server loading.
> 
> Unit tests cover rule ordering, DB query guards, credential decoding edge cases, and integration-style backfill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a281949b182a8e3e7d16674f0669fdcbfce51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

