### PR TITLE
fix(chatgpt): map gpt-5.4-mini to responses

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -19571,6 +19571,21 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "chatgpt/gpt-5.4-mini": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4-pro": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -19729,6 +19729,21 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "chatgpt/gpt-5.4-mini": {
+        "litellm_provider": "chatgpt",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "responses",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true
+    },
     "chatgpt/gpt-5.4-pro": {
         "litellm_provider": "chatgpt",
         "max_input_tokens": 1050000,

--- a/tests/test_litellm/test_chatgpt_model_config.py
+++ b/tests/test_litellm/test_chatgpt_model_config.py
@@ -1,0 +1,62 @@
+import json
+import os
+from typing import TypeAlias, cast
+
+import pytest
+
+from litellm.main import responses_api_bridge_check
+
+JsonObject: TypeAlias = dict[str, object]
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "../..")
+MODEL_NAME = "chatgpt/gpt-5.4-mini"
+
+
+def _load_cost_map(path: str) -> dict[str, JsonObject]:
+    with open(path) as f:
+        return cast(dict[str, JsonObject], json.load(f))
+
+
+def _load_root_cost_map() -> dict[str, JsonObject]:
+    return _load_cost_map(os.path.join(REPO_ROOT, "model_prices_and_context_window.json"))
+
+
+def _load_backup_cost_map() -> dict[str, JsonObject]:
+    return _load_cost_map(os.path.join(REPO_ROOT, "litellm/model_prices_and_context_window_backup.json"))
+
+
+@pytest.mark.parametrize(
+    "cost_map",
+    [_load_root_cost_map(), _load_backup_cost_map()],
+    ids=["root", "bundled_backup"],
+)
+def test_chatgpt_gpt_5_4_mini_is_responses_model(cost_map: dict[str, JsonObject]) -> None:
+    info = cost_map[MODEL_NAME]
+
+    assert info["litellm_provider"] == "chatgpt"
+    assert info["mode"] == "responses"
+    assert info["max_input_tokens"] == 272000
+    assert info["max_output_tokens"] == 128000
+    assert info["max_tokens"] == 128000
+    assert info["supported_endpoints"] == ["/v1/chat/completions", "/v1/responses"]
+    assert info["supports_function_calling"] is True
+    assert info["supports_parallel_function_calling"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_vision"] is True
+
+
+def test_chatgpt_gpt_5_4_mini_bridges_chat_completions_to_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get_model_info_helper(model: str, custom_llm_provider: str) -> JsonObject:
+        assert model == MODEL_NAME
+        assert custom_llm_provider == "chatgpt"
+        return _load_backup_cost_map()[MODEL_NAME]
+
+    monkeypatch.setattr("litellm.main._get_model_info_helper", fake_get_model_info_helper)
+
+    model_info, model = cast(
+        tuple[JsonObject, str],
+        responses_api_bridge_check(model=MODEL_NAME, custom_llm_provider="chatgpt"),
+    )
+
+    assert model == MODEL_NAME
+    assert model_info["mode"] == "responses"


### PR DESCRIPTION
## Relevant issues

Partially addresses #25954

Related but separate: #28044 covers DB-registered ChatGPT response-mode models skipping the ChatGPT Responses config path

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks run locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review)

## Screenshots / Proof of Fix

Reproduction before this model map entry, using current LiteLLM with ChatGPT OAuth:

```bash
python - <<'PY'
import litellm
litellm.completion(
    model="chatgpt/gpt-5.4-mini",
    messages=[{"role":"user","content":"Reply exactly: ok"}],
    stream=True,
    max_tokens=20,
)
PY
```

LiteLLM routes the unmapped model through `/backend-api/codex/chat/completions`, which returns a Cloudflare HTML challenge instead of the Codex Responses API SSE stream

The same account and token succeeds when calling the Codex Responses API directly with `model: gpt-5.4-mini`; the model catalog endpoint lists `gpt-5.4-mini` with `supported_in_api: true`, `context_window: 272000`, and `max_context_window: 272000`

Local verification from this branch:

```bash
LITELLM_LOCAL_MODEL_COST_MAP=True uv run --extra proxy python - <<'PY'
import litellm
print(litellm.model_cost["chatgpt/gpt-5.4-mini"]["mode"])
r = litellm.completion(
    model="chatgpt/gpt-5.4-mini",
    messages=[{"role":"user","content":"Reply exactly: ok"}],
    stream=True,
    max_tokens=20,
)
print("".join(chunk.choices[0].delta.content or "" for chunk in r))
PY
```

Output:

```text
responses
ok
```

Also validated JSON syntax, added cost-map and bridge regression coverage for root and bundled backup maps, ran `uv run --with pytest python -m pytest tests/test_litellm/test_chatgpt_model_config.py -q`, and ran `make pre-commit`

## Type

Bug Fix
Test

## Changes

Adds the missing `chatgpt/gpt-5.4-mini` model-cost entry and marks it as a Responses API model for the ChatGPT provider, matching the existing ChatGPT provider routing pattern while using the Codex model catalog's 272k input context value

Adds the same entry to the bundled backup map so local fallback mode resolves the model consistently

Adds focused regression coverage that checks the root and bundled backup entries stay in sync for provider, mode, limits, endpoints, and capabilities, plus a bridge-path assertion that chat completions for the model are treated as Responses API calls

