### PR TITLE
fix(anthropic /v1/messages): route bedrock_mantle Responses-API models to the Responses API

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -50,7 +50,9 @@ from .utils import AnthropicMessagesRequestUtils, mock_response
 _RESPONSES_API_PROVIDERS = frozenset({"openai"})
 
 
-def _should_route_to_responses_api(custom_llm_provider: Optional[str]) -> bool:
+def _should_route_to_responses_api(
+    custom_llm_provider: Optional[str], model: Optional[str] = None
+) -> bool:
     """Return True when the provider should use the Responses API path.
 
     Set ``litellm.use_chat_completions_url_for_anthropic_messages = True`` to
@@ -58,7 +60,19 @@ def _should_route_to_responses_api(custom_llm_provider: Optional[str]) -> bool:
     """
     if litellm.use_chat_completions_url_for_anthropic_messages:
         return False
-    return custom_llm_provider in _RESPONSES_API_PROVIDERS
+    if custom_llm_provider in _RESPONSES_API_PROVIDERS:
+        return True
+    # bedrock_mantle serves only its frontier models (gpt-5.x) on the Responses
+    # API; gpt-oss and non-OpenAI Mantle models are chat/completions only, so
+    # gate per-model on whether a Responses config resolves for this model.
+    if custom_llm_provider == "bedrock_mantle":
+        return (
+            ProviderConfigManager.get_provider_responses_api_config(
+                provider=litellm.LlmProviders.BEDROCK_MANTLE, model=model
+            )
+            is not None
+        )
+    return False
 
 
 def _deployment_passes_through_anthropic_messages(model_info: object) -> bool:
@@ -515,7 +529,7 @@ def anthropic_messages_handler(
             custom_llm_provider=custom_llm_provider,
             **kwargs,
         )
-        if _should_route_to_responses_api(custom_llm_provider):
+        if _should_route_to_responses_api(custom_llm_provider, model):
             return LiteLLMMessagesToResponsesAPIHandler.anthropic_messages_handler(**_shared_kwargs)
 
         # The in-gateway context_management polyfill runs inside

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -821,3 +821,50 @@ def test_gate_passthrough_skipped_when_only_chat_completions_supported(monkeypat
     assert result == "translated"
     assert translation_calls["count"] == 1
     assert "config" not in captured
+
+
+def _route(provider, model=None):
+    from litellm.llms.anthropic.experimental_pass_through.messages.handler import (
+        _should_route_to_responses_api,
+    )
+
+    return _should_route_to_responses_api(provider, model)
+
+
+def test_should_route_to_responses_api_openai_unchanged():
+    assert _route("openai") is True
+
+
+@pytest.mark.parametrize("model", ["openai.gpt-5.4", "openai.gpt-5.5"])
+def test_should_route_bedrock_mantle_responses_models_to_responses(model):
+    assert _route("bedrock_mantle", model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["openai.gpt-oss-safeguard-120b", "openai.gpt-oss-safeguard-20b"],
+)
+def test_bedrock_mantle_chat_only_models_stay_on_chat_completions(model):
+    # Regression guard: chat-only Mantle models (mode=chat) must NOT be forced
+    # onto the Responses API just because the provider is bedrock_mantle.
+    assert _route("bedrock_mantle", model) is False
+
+
+def test_should_route_bedrock_mantle_requires_model():
+    assert _route("bedrock_mantle", None) is False
+
+
+def test_should_route_to_responses_api_other_provider_false():
+    assert _route("anthropic", "claude-sonnet-4-5") is False
+
+
+def test_use_chat_completions_url_opt_out_overrides_bedrock_mantle():
+    import litellm
+
+    original = litellm.use_chat_completions_url_for_anthropic_messages
+    litellm.use_chat_completions_url_for_anthropic_messages = True
+    try:
+        assert _route("bedrock_mantle", "openai.gpt-5.4") is False
+        assert _route("openai") is False
+    finally:
+        litellm.use_chat_completions_url_for_anthropic_messages = original


### PR DESCRIPTION
## Relevant issues

Relates to #30941 (Bedrock Mantle Responses-only models over the Anthropic surface). Companion to the OpenAI-only messages -> Responses routing; a scoped subset of the capability-driven direction in #26088.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Problem

`bedrock_mantle` serves its frontier models (the `openai.gpt-5.x` family) only on the Responses API; `gpt-oss` and the other Mantle models are chat/completions only. On the Anthropic `/v1/messages` surface, `_should_route_to_responses_api` only routed the `openai` provider to the Responses API, so a `bedrock_mantle` Responses-only model fell through to the chat/completions path and the backend rejected it with `Bedrock_mantleException ... The model 'openai.gpt-5.x' does not exist`. The two-layer messages -> chat/completions bridge also silently drops `reasoning_effort` and `thinking` even when it does not hard-fail.

## Changes

`_should_route_to_responses_api` now also routes `bedrock_mantle` to the Responses API, gated per model on whether a Responses config actually resolves for that model (`ProviderConfigManager.get_provider_responses_api_config(...) is not None`), which delegates to the existing `mantle_supports_responses` price-map signal. Responses-capable Mantle models (gpt-5.x) reach the Responses adapter; chat-only Mantle models (gpt-oss and friends) keep their existing chat/completions path with no change. `openai` behaviour is untouched, and the `use_chat_completions_url_for_anthropic_messages` opt-out still wins.

The messages -> Responses adapter already exists and is exercised by the `openai` path, so this is purely a routing-gate change.

## Proof of Fix

Verified end to end against a live `bedrock_mantle` deployment (real calls, no mocks). Endpoint and key redacted.

Before this change, `/v1/messages` for a Responses-only Mantle model routed to chat/completions and returned `Bedrock_mantleException ... does not exist` (the symptom in #30941).

After, a non-streaming call routes to the Responses API (note the `resp_`-derived id):

```
$ curl -s $PROXY/v1/messages -H "Authorization: Bearer $KEY" -H 'anthropic-version: 2023-06-01' \
    -d '{"model":"bedrock_mantle/openai.gpt-5.5","max_tokens":40,"messages":[{"role":"user","content":"say pong"}]}'
{"id":"resp_...(base64 encodes custom_llm_provider:bedrock_mantle;response_id:resp_...)","type":"message","role":"assistant",
 "model":"bedrock_mantle/openai.gpt-5.5","content":[{"type":"text","text":"pong"}],"stop_reason":"end_turn",
 "usage":{"input_tokens":8,"output_tokens":5,"total_tokens":13}}
```

Streaming returns clean Anthropic SSE (no AWS event-stream decode issues, since this path uses the Responses adapter's plain SSE, not the native bedrock messages decoder):

```
$ curl -sN $PROXY/v1/messages ... -d '{"model":"bedrock_mantle/openai.gpt-5.5","stream":true,...}'
event: message_start
data: {"type":"message_start","message":{"id":"msg_...","role":"assistant","model":"openai.gpt-5.5",...}}
event: content_block_start
data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
...
```

Tool calling round-trips:

```
$ curl -s $PROXY/v1/messages ... -d '{"model":"bedrock_mantle/openai.gpt-5.5","tools":[{"name":"get_weather",...}],"messages":[{"role":"user","content":"Use the get_weather tool to check Tokyo."}]}'
stop_reason: tool_use
content blocks: ['tool_use']
tool_use: {"id":"call_0","name":"get_weather","input":{"city":"Tokyo"}}
```

A chat-only Mantle model (e.g. `gpt-oss-safeguard-*`) and non-Mantle providers are unaffected; regression tests cover both.

## Type

Bug Fix
