### PR TITLE
fix(caching): pass only metadata to valkey semantic async embedding

### DIFF
--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -279,7 +279,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 print_verbose("No prompt provided for semantic caching")
                 return
 
-            embedding = await self._get_async_embedding(prompt, **kwargs)
+            embedding = await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
             await self._ensure_index_async(len(embedding))
 
             doc_key = self._doc_key(key)
@@ -298,7 +298,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
                 return None
 
-            embedding = await self._get_async_embedding(prompt, **kwargs)
+            embedding = await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
             await self._ensure_index_async(len(embedding))
 
             search_result = await self.async_client.ft(self.index_name).search(

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -301,6 +301,33 @@ async def test_async_set_and_get_roundtrip():
 
 
 @pytest.mark.asyncio
+async def test_async_set_cache_passes_only_metadata_to_get_async_embedding():
+    async_client = AsyncMock()
+    async_client.ft = _async_ft(0.05)
+    cache = _make_cache(async_client=async_client)
+    captured: dict[str, object] = {}
+
+    async def spy_embedding(prompt: str, metadata: dict | None = None) -> list[float]:
+        captured["prompt"] = prompt
+        captured["metadata"] = metadata
+        return [0.1, 0.2, 0.3]
+
+    cache._get_async_embedding = spy_embedding
+
+    await cache.async_set_cache(
+        key="cache-key",
+        value={"content": "Paris"},
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        metadata={"user_api_key": "sk-test"},
+        cache_key="abc123",
+        custom_llm_provider="openai",
+    )
+
+    assert captured["metadata"] == {"user_api_key": "sk-test"}
+    async_client.hset.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_async_get_cache_misses_below_threshold():
     async_client = AsyncMock()
     async_client.ft = _async_ft(0.4)

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -328,6 +328,32 @@ async def test_async_set_cache_passes_only_metadata_to_get_async_embedding():
 
 
 @pytest.mark.asyncio
+async def test_async_get_cache_passes_only_metadata_to_get_async_embedding():
+    async_client = AsyncMock()
+    async_client.ft = _async_ft(0.05)
+    cache = _make_cache(async_client=async_client)
+    captured: dict[str, object] = {}
+
+    async def spy_embedding(prompt: str, metadata: dict | None = None) -> list[float]:
+        captured["prompt"] = prompt
+        captured["metadata"] = dict(metadata) if metadata is not None else None
+        return [0.1, 0.2, 0.3]
+
+    cache._get_async_embedding = spy_embedding
+
+    result = await cache.async_get_cache(
+        key="cache-key",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        metadata={"user_api_key": "sk-test"},
+        cache_key="abc123",
+        custom_llm_provider="openai",
+    )
+
+    assert result == {"content": "Paris"}
+    assert captured["metadata"] == {"user_api_key": "sk-test"}
+
+
+@pytest.mark.asyncio
 async def test_async_get_cache_misses_below_threshold():
     async_client = AsyncMock()
     async_client.ft = _async_ft(0.4)


### PR DESCRIPTION
Resolves LIT-4237

Issue
valkey-semantic caching never worked through the LiteLLM proxy async path. Every request returned x-litellm-semantic-similarity: 0.0, always hit the upstream LLM (cost + llm_provider-* headers), and Valkey's semantic index stayed empty (num_docs: 0) even for identical prompts.

This affected all embedding models configured for semantic cache, not just WatsonX. The bug was present since valkey-semantic was introduced in #30675

Cause
ValkeySemanticCache.async_set_cache and async_get_cache called:

await self._get_async_embedding(prompt, **kwargs)
The parent RedisSemanticCache._get_async_embedding() only accepts (prompt, metadata=None). Passing the full kwargs dict (e.g. cache_key, custom_llm_provider, messages) raised a TypeError before any embedding was generated. That exception was caught and logged at verbose level only, so cache writes and reads silently no-op'd

The existing unit tests masked this because they replace _get_async_embedding with AsyncMock, which accepts arbitrary kwargs. The sync path was unaffected since it calls _get_embedding(prompt) without extra kwargs; the proxy uses the async path exclusively

Fix
Match redis-semantic and pass only metadata:

await self._get_async_embedding(prompt, metadata=kwargs.get("metadata"))
Added a regression test (test_async_set_cache_passes_only_metadata_to_get_async_embedding) that uses a real spy function with the correct signature instead of AsyncMock, so extra kwargs would fail the test

Proof:

Before:
<img width="809" height="216" alt="Screenshot 2026-07-06 at 5 46 01 PM" src="https://github.com/user-attachments/assets/25d5e9ed-c63a-41b1-8292-6ce8f81add2e" />

After:
<img width="793" height="172" alt="Screenshot 2026-07-06 at 5 48 51 PM" src="https://github.com/user-attachments/assets/168b3c0c-3101-47d3-b331-5d6db465cc42" />
