### PR TITLE
fix(model_armor): scan MCP tool calls for pre_mcp_call / during_mcp_call modes

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -39,6 +39,7 @@ from litellm.proxy.guardrails.guardrail_hooks.model_armor.file_scanning import (
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.utils import (
+    CallTypes,
     CallTypesLiteral,
     Choices,
     GuardrailStatus,
@@ -477,6 +478,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         )
 
         event_type = GuardrailEventHooks.pre_call
+        if call_type == CallTypes.call_mcp_tool.value:
+            event_type = GuardrailEventHooks.pre_mcp_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
             return data
 
@@ -574,6 +577,8 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         )
 
         event_type = GuardrailEventHooks.during_call
+        if call_type == CallTypes.call_mcp_tool.value:
+            event_type = GuardrailEventHooks.during_mcp_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
             return data
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
@@ -2940,3 +2940,127 @@ def test_accumulated_responses_are_redactable_as_a_list():
     assert "secret-one" not in blob
     assert "secret-two" not in blob
     assert blob.count("[REDACTED]") == 2
+
+
+def _mcp_synthetic_data(tool_name: str = "send_email", arguments: dict = None):
+    """Mirror ProxyLogging._convert_mcp_to_llm_format: an MCP tool call rendered as a
+    synthetic user message so the existing prompt-scanning path can inspect it."""
+    if arguments is None:
+        arguments = {"to": "user@example.com", "body": "some content"}
+    return {
+        "model": "mcp-tool-call",
+        "messages": [
+            {
+                "role": "user",
+                "content": f"Tool: {tool_name}\nArguments: {arguments}",
+            }
+        ],
+        "metadata": {"guardrails": ["model-armor-test"]},
+        "mcp_tool_name": tool_name,
+        "mcp_arguments": arguments,
+    }
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_scans_mcp_tool_call_when_configured_for_pre_mcp_call():
+    """A guardrail configured with mode `pre_mcp_call` must scan MCP tool calls.
+
+    Regression: async_pre_call_hook hardcoded its event-type gate to `pre_call`, so a
+    `pre_mcp_call` guardrail's own inner should_run_guardrail check returned False for an
+    MCP call (call_type=call_mcp_tool) and the scan was skipped entirely -- letting
+    sensitive content in tool arguments through unscanned. The gate must remap
+    call_mcp_tool -> pre_mcp_call.
+    """
+    guardrail = _make_guardrail(event_hook="pre_mcp_call", mask_request_content=True)
+    data = _mcp_synthetic_data()
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(return_value=_armor_response(blocked=False)),
+    ) as mock_post:
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            cache=MagicMock(spec=DualCache),
+            data=data,
+            call_type="call_mcp_tool",
+        )
+
+    mock_post.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_pre_call_hook_skips_chat_traffic_when_configured_for_pre_mcp_call():
+    """A `pre_mcp_call` guardrail must NOT scan ordinary chat completions -- the remap is
+    scoped to MCP calls, so a `completion` call_type still fails the gate and is skipped."""
+    guardrail = _make_guardrail(event_hook="pre_mcp_call", mask_request_content=True)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hello there"}],
+        "metadata": {"guardrails": ["model-armor-test"]},
+    }
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(return_value=_armor_response(blocked=False)),
+    ) as mock_post:
+        result = await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            cache=MagicMock(spec=DualCache),
+            data=data,
+            call_type="completion",
+        )
+
+    assert result == data
+    mock_post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_moderation_hook_scans_mcp_tool_call_when_configured_for_during_mcp_call():
+    """A guardrail configured with mode `during_mcp_call` must scan MCP tool calls.
+
+    Regression: async_moderation_hook hardcoded its event-type gate to `during_call`, so a
+    `during_mcp_call` guardrail skipped MCP calls (call_type=call_mcp_tool). The gate must
+    remap call_mcp_tool -> during_mcp_call.
+    """
+    guardrail = _make_guardrail(event_hook="during_mcp_call", mask_request_content=True)
+    data = _mcp_synthetic_data()
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(return_value=_armor_response(blocked=False)),
+    ) as mock_post:
+        await guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            call_type="call_mcp_tool",
+        )
+
+    mock_post.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_moderation_hook_skips_chat_traffic_when_configured_for_during_mcp_call():
+    """A `during_mcp_call` guardrail must NOT scan ordinary chat completions."""
+    guardrail = _make_guardrail(event_hook="during_mcp_call", mask_request_content=True)
+    data = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hello there"}],
+        "metadata": {"guardrails": ["model-armor-test"]},
+    }
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        AsyncMock(return_value=_armor_response(blocked=False)),
+    ) as mock_post:
+        result = await guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(),
+            call_type="completion",
+        )
+
+    assert result == data
+    mock_post.assert_not_called()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a Confidence Score of at least 4/5

## Screenshots / Proof of Fix

Original author's proof of fix (from #32278): validated in a live dev deployment with a Model Armor guardrail configured for `pre_mcp_call` / `during_mcp_call`; MCP tool calls are now scanned instead of silently skipped.

```bash
pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py -k "mcp_tool_call or chat_traffic"
# 4 passed

pytest tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py
# 72 passed, 3 skipped
```

## Type

🐛 Bug Fix

## Changes

A Model Armor guardrail configured with mode `pre_mcp_call` (or `during_mcp_call`) does not scan MCP tool calls; the tool name and arguments pass through completely unscanned.

`ModelArmorGuardrail.async_pre_call_hook` and `async_moderation_hook` hardcode their inner `should_run_guardrail` event type to `pre_call` / `during_call`. The central dispatcher (`ProxyLogging._process_guardrail_callback` / `during_call_hook` in `litellm/proxy/utils.py`) already remaps `call_mcp_tool` to `pre_mcp_call` / `during_mcp_call` and passes the outer gate, but Model Armor's redundant inner gate then re-checks against the un-remapped `pre_call` / `during_call`, so a guardrail whose configured mode is `pre_mcp_call` fails its own inner check and the scan is skipped.

The fix remaps `call_mcp_tool` to `pre_mcp_call` / `during_mcp_call` in both hooks, matching the behavior already present in the unified guardrail path.

Scope: this scans the MCP tool name/arguments on the `pre_mcp_call` / `during_mcp_call` hooks. It does not scan MCP tool results; there is no `post_mcp_call` event and MCP output scanning is a separate, pre-existing framework gap, unchanged by this PR.

Adds 4 tests in `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_model_armor.py`: 2 regression tests proving a `pre_mcp_call` / `during_mcp_call` guardrail now scans an MCP tool call, and 2 scoping guards proving ordinary chat traffic is still skipped.

---

## Credit

Adopted from #32278 by @eugene-yao-zocdoc. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guardrail gating on MCP tool calls (security-sensitive); scope is narrow and covered by new tests, with no change to MCP result scanning.
> 
> **Overview**
> Fixes a security gap where **Model Armor** guardrails configured for **`pre_mcp_call`** or **`during_mcp_call`** never ran on MCP tool invocations, so tool names and arguments could bypass scanning.
> 
> In **`async_pre_call_hook`** and **`async_moderation_hook`**, when `call_type` is **`call_mcp_tool`**, the inner `should_run_guardrail` gate now uses **`pre_mcp_call`** / **`during_mcp_call`** instead of always **`pre_call`** / **`during_call`**, aligning with the proxy dispatcher. Ordinary chat **`completion`** traffic is unchanged for MCP-only modes.
> 
> Adds four regression tests covering MCP scans and chat skip behavior for both hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d037d1330a051399c5a57a4116da19434c640642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->