### PR TITLE
fix(e2e): exclude the master key from transport repr

### DIFF
--- a/tests/e2e/test_transport.py
+++ b/tests/e2e/test_transport.py
@@ -10,7 +10,7 @@ route.
 
 import pytest
 
-from transport import is_control_plane_path
+from transport import HttpTransport, SplitTransport, is_control_plane_path
 
 
 @pytest.mark.parametrize(
@@ -50,3 +50,14 @@ def test_llm_routes_stay_on_the_data_plane(path: str) -> None:
     assert not is_control_plane_path(path), (
         f"{path} is an LLM route; it must go to the data plane"
     )
+
+
+def test_transport_repr_never_leaks_the_master_key() -> None:
+    """pytest prints fixture values (Gateway -> SplitTransport -> HttpTransport)
+    verbatim into failure output, which ships to CI logs and log aggregators, so
+    the repr chain must never carry the master key."""
+    secret = "sk-e2e-repr-leak-canary"
+    transport = HttpTransport(base_url="http://localhost:4000", master_key=secret)
+    split = SplitTransport(data=transport, control=transport)
+    assert secret not in repr(transport)
+    assert secret not in repr(split)

--- a/tests/e2e/transport.py
+++ b/tests/e2e/transport.py
@@ -7,7 +7,7 @@ client touches requests.* or builds raw dicts; they pass pydantic models here.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
 from pydantic import BaseModel
@@ -79,8 +79,12 @@ class Transport(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class HttpTransport:
+    """`master_key` is excluded from repr: pytest prints fixture values verbatim
+    into failure output, so a repr carrying the key leaks it into CI logs and any
+    log aggregator they ship to."""
+
     base_url: str
-    master_key: str
+    master_key: str = field(repr=False)
     request_timeout: float = 60.0
 
     def _url(self, path: str) -> URL:


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

This commit was originally on the #32261 branch; that PR was closed after #32267 carried its other commits into staging, so this fix never landed. Cherry-picked onto a fresh branch

## Screenshots / Proof of Fix

Before the fix, any failed e2e test printed the fixture repr chain, master key included, into CI output; the 2026-07-06 stage run's Loki export contains the stage master key verbatim inside the pytest failure blocks (fixture line: `client = SpendClient(gateway=Gateway(transport=SplitTransport(data=HttpTransport(base_url=..., master_key='sk-640f...'`)

After the fix the canary test pins the repr chain:

```
$ uv run pytest tests/e2e/test_transport.py -q
18 passed in 0.08s
```

## Type

Bug Fix

## Changes

pytest prints fixture values verbatim into failure output, so every failed e2e test embedded the proxy master key in CI logs and whatever aggregator they ship to. Exclude master_key from HttpTransport's repr with field(repr=False) and add a canary test asserting the key never appears in the repr of HttpTransport or SplitTransport. Since past log exports already carry the stage master key, rotating it is recommended independently of this fix
