### PR TITLE
fix(dynamic_rate_limiter): make test_priority_reservation deterministic across minute rollover

### DIFF
--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -4,7 +4,8 @@
 
 import asyncio
 import os
-from typing import List, Optional, Tuple, Union
+from datetime import datetime
+from typing import Callable, List, Optional, Tuple, Union
 
 import litellm
 from litellm import ModelResponse, Router
@@ -30,12 +31,13 @@ class DynamicRateLimiterCache:
     Track number of active projects calling a model.
     """
 
-    def __init__(self, cache: DualCache) -> None:
+    def __init__(self, cache: DualCache, time_fn: Callable[[], datetime] = get_utc_datetime) -> None:
         self.cache = cache
         self.ttl = 60  # 1 min ttl
+        self.time_fn = time_fn
 
     async def async_get_cache(self, model: str) -> Optional[int]:
-        dt = get_utc_datetime()
+        dt = self.time_fn()
         current_minute = dt.strftime("%H-%M")
         key_name = "{}:{}".format(current_minute, model)
         _response = await self.cache.async_get_cache(key=key_name)
@@ -59,7 +61,7 @@ class DynamicRateLimiterCache:
         - Exception, if unable to connect to cache client (if redis caching enabled)
         """
         try:
-            dt = get_utc_datetime()
+            dt = self.time_fn()
             current_minute = dt.strftime("%H-%M")
 
             key_name = "{}:{}".format(current_minute, model)
@@ -75,8 +77,8 @@ class DynamicRateLimiterCache:
 
 class _PROXY_DynamicRateLimitHandler(CustomLogger):
     # Class variables or attributes
-    def __init__(self, internal_usage_cache: DualCache):
-        self.internal_usage_cache = DynamicRateLimiterCache(cache=internal_usage_cache)
+    def __init__(self, internal_usage_cache: DualCache, time_fn: Callable[[], datetime] = get_utc_datetime):
+        self.internal_usage_cache = DynamicRateLimiterCache(cache=internal_usage_cache, time_fn=time_fn)
 
     def update_variables(self, llm_router: Router):
         self.llm_router = llm_router

--- a/tests/local_testing/test_dynamic_rate_limit_handler.py
+++ b/tests/local_testing/test_dynamic_rate_limit_handler.py
@@ -7,7 +7,7 @@ import sys
 import time
 import traceback
 from litellm._uuid import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Tuple
 
 from dotenv import load_dotenv
@@ -38,7 +38,8 @@ Basic test cases:
 @pytest.fixture
 def dynamic_rate_limit_handler() -> DynamicRateLimitHandler:
     internal_cache = DualCache()
-    return DynamicRateLimitHandler(internal_usage_cache=internal_cache)
+    frozen_now = datetime(2024, 1, 1, 10, 30, 0, tzinfo=timezone.utc)
+    return DynamicRateLimitHandler(internal_usage_cache=internal_cache, time_fn=lambda: frozen_now)
 
 
 @pytest.fixture

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.proxy.hooks.dynamic_rate_limiter import (
+    DynamicRateLimiterCache,
+    _PROXY_DynamicRateLimitHandler,
+)
+
+
+@pytest.mark.asyncio
+async def test_sadd_and_get_share_injected_clock_window():
+    dual_cache = DualCache()
+    cache = DynamicRateLimiterCache(
+        cache=dual_cache,
+        time_fn=lambda: datetime(2024, 1, 1, 10, 30, 0, tzinfo=timezone.utc),
+    )
+    await cache.async_set_cache_sadd(model="my-fake-model", value=["p1", "p2", "p3"])
+    assert await cache.async_get_cache(model="my-fake-model") == 3
+    assert await dual_cache.async_get_cache(key="10-30:my-fake-model") is not None
+
+
+@pytest.mark.asyncio
+async def test_minute_rollover_between_sadd_and_get_reads_empty_window():
+    ticks = iter(
+        (
+            datetime(2024, 1, 1, 10, 30, 59, 999999, tzinfo=timezone.utc),
+            datetime(2024, 1, 1, 10, 31, 0, 0, tzinfo=timezone.utc),
+        )
+    )
+    cache = DynamicRateLimiterCache(cache=DualCache(), time_fn=lambda: next(ticks))
+    await cache.async_set_cache_sadd(model="my-fake-model", value=["p1"])
+    assert await cache.async_get_cache(model="my-fake-model") is None
+
+
+@pytest.mark.asyncio
+async def test_handler_threads_time_fn_to_internal_cache():
+    handler = _PROXY_DynamicRateLimitHandler(
+        internal_usage_cache=DualCache(),
+        time_fn=lambda: datetime(2024, 1, 1, 10, 30, 0, tzinfo=timezone.utc),
+    )
+    await handler.internal_usage_cache.async_set_cache_sadd(model="my-fake-model", value=["p1", "p2"])
+    assert await handler.internal_usage_cache.async_get_cache(model="my-fake-model") == 2


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`test_priority_reservation[100]` failed on CircleCI job [2000264](https://circleci.com/gh/BerriAI/litellm/2000264) with `assert 90 == 0`. `DynamicRateLimiterCache` keys the active-project set by the current UTC minute (`"%H-%M:{model}"`), and the test's `async_set_cache_sadd` and the handler's read inside `check_available_usage` each call `get_utc_datetime()` independently. When the wall-clock minute rolls over between the two calls, the read targets the next minute's empty key, `active_projects` comes back `None`, the divide-by-projects step is skipped, and availability is `int(100 * 0.9) = 90` for every parametrization; only `[1]` survives that because its expected value happens to also be 90. The sibling `test_multiple_projects_e2e` was skipped back in June 2024 for this exact class of problem ("Unstable on ci/cd due to curr minute changes")

Deterministic reproduction of the mechanism on the parent commit, driving the two clock reads across a minute boundary:

```
$ python /tmp/repro_minute_rollover.py
sadd at 23:04:59.999, get at 23:05:00.001 -> availability: 90 | expected: 0
```

Plain rerunning cannot catch it because the race window is sub-millisecond (20 of 20 green before the fix on a quiet clock):

```
$ cd tests/local_testing && for i in $(seq 1 20); do LITELLM_LICENSE=... python -m pytest "test_dynamic_rate_limit_handler.py::test_priority_reservation" -q -p no:cacheprovider >/dev/null 2>&1 && echo "run $i: pass" || echo "run $i: FAIL"; done
run 1: pass ... run 20: pass   (pre-fix:  20 passed, 0 failed; flake needs a minute rollover)
run 1: pass ... run 20: pass   (post-fix: 20 passed, 0 failed; clock frozen, rollover impossible)
```

With the fix, the fixture pins the limiter's clock, so the sadd and the read can never straddle a minute boundary, and `tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py::test_minute_rollover_between_sadd_and_get_reads_empty_window` pins the rollover mechanism itself deterministically

## Type

🐛 Bug Fix
✅ Test

## Changes

`DynamicRateLimiterCache` and `_PROXY_DynamicRateLimitHandler` now take an injectable `time_fn` (defaulting to `get_utc_datetime`, so production behavior is unchanged) instead of hardcoding the clock; this follows the repo preference for dependency injection over monkeypatching. The flaky `tests/local_testing/test_dynamic_rate_limit_handler.py` fixture injects a frozen clock, which makes `test_priority_reservation` (and the other tests in that file that share the same write-then-read-within-one-window assumption, e.g. `test_update_cache`, whose 2s sleep gave it roughly a 1 in 30 chance of straddling a rollover per run) deterministic. New unit tests in `tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter.py` cover the injected-clock key window, the minute-rollover behavior that caused the flake, and the handler threading `time_fn` through to its cache
