### PR TITLE
docs(github): note greptile runs automatically and require commit hashes in proof of fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 - [ ] I have added meaningful tests
 - [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
 - [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
-- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review
+- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)
 
 ## Delays in PR merge?
 
@@ -24,6 +24,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
 <!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
      The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
      For bug fixes: show reproduction before the fix and passing behavior after
+     Include the commit hash each proof was captured at, for both the before and the after runs
      For new features: show the feature working end-to-end
      For UI changes: include before/after screenshots -->
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (not applicable, template-only change)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Template-only change; the rendered result is the proof: [pull_request_template.md on this branch](https://github.com/BerriAI/litellm/blob/litellm_pr_template_greptile_auto_proof_hashes/.github/pull_request_template.md)

## Type

📖 Documentation

## Changes

The pre-submission checklist told contributors to request a Greptile review by commenting `@greptileai`, which led agents and contributors to post that comment immediately on opening a PR even though Greptile already reviews every new PR automatically. The checklist item now keeps the 4/5 confidence score requirement and clarifies that commenting `@greptileai` is only for re-requesting a review after pushing changes

The Screenshots / Proof of Fix guidance now also requires including the commit hash each proof was captured at, for both the before and the after runs