### PR TITLE
fix(batches): price anthropic passthrough message batches correctly in batch cost job

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -99,7 +99,7 @@
     "limit": 0
   },
   "reportUnknownArgumentType": {
-    "limit": 45895
+    "limit": 45894
   },
   "reportUnknownLambdaType": {
     "limit": 113

--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from litellm.proxy._types import LiteLLM_ManagedObjectTable
     from litellm.proxy.utils import PrismaClient, ProxyLogging
     from litellm.router import Router
+    from litellm.types.utils import LiteLLMBatch
 
 
 CHECK_BATCH_COST_USER_AGENT = "LiteLLM Proxy/CheckBatchCost"
@@ -277,13 +278,20 @@ class CheckBatchCost:
         except Exception:
             return None
 
-    async def check_batch_cost(self):
+    async def _track_completed_batch_cost(
+        self,
+        job: "LiteLLM_ManagedObjectTable",
+        response: "LiteLLMBatch",
+        model_id: str,
+        batch_id: str,
+        prom_logger: Optional["PrometheusLogger"],
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
         """
-        Check if the batch JOB has been tracked.
-        - get all status="validating" and file_purpose="batch" jobs
-        - check if batch is now complete
-        - if not, return False
-        - if so, return True
+        Fetch a completed batch's results, compute cost/usage, and emit the
+        aretrieve_batch spend log. Returns (model_name, llm_provider) on
+        success, None when the job can't be routed to a deployment. Raises on
+        results-fetch or cost-computation failures so the caller can leave the
+        job unprocessed and retry it on a later poll.
         """
         from litellm.batches.batch_utils import (
             _get_file_content_as_dictionary,
@@ -296,6 +304,184 @@ class CheckBatchCost:
             _is_base64_encoded_unified_file_id,
         )
 
+        verbose_proxy_logger.info(
+            f"Batch ID: {batch_id} is complete, tracking cost and usage"
+        )
+
+        # aretrieve_batch is called with the raw provider batch ID, so response.id
+        # is the raw provider value (e.g. "batch_20260223-0518.234"). We need the
+        # unified base64 ID in the S3 log so downstream consumers can correlate it
+        # back to the batch they submitted via the proxy.
+        #
+        # CheckBatchCost builds its own LiteLLMLogging object (logging_obj below) and
+        # calls async_success_handler(result=response) directly. That handler calls
+        # _build_standard_logging_payload(response, ...) which reads response.id at
+        # that point — so setting response.id here is sufficient.
+        #
+        # The HTTP endpoint does this substitution via the managed files hook
+        # (async_post_call_success_hook). CheckBatchCost bypasses that hook entirely,
+        # so we do it explicitly here.
+        response.id = job.unified_object_id
+
+        # This background job runs as default_user_id, so going through the HTTP endpoint
+        # would trigger check_managed_file_id_access and get 403. Instead, extract the raw
+        # provider file ID and call afile_content directly with deployment credentials.
+        raw_output_file_id = response.output_file_id
+        decoded = _is_base64_encoded_unified_file_id(raw_output_file_id)
+        if decoded:
+            try:
+                raw_output_file_id = decoded.split("llm_output_file_id,")[1].split(";")[0]
+            except (IndexError, AttributeError):
+                pass
+
+        credentials = self.llm_router.get_deployment_credentials_with_provider(model_id) or {}
+        _file_content = await afile_content(
+            file_id=raw_output_file_id,
+            **credentials,
+        )
+
+        # Access content - handle both direct attribute and method call
+        if hasattr(_file_content, 'content'):
+            content_bytes = _file_content.content  # type: ignore[union-attr]
+        elif hasattr(_file_content, 'read'):
+            content_bytes = await _file_content.read()  # type: ignore[misc]
+        else:
+            content_bytes = _file_content  # type: ignore[assignment]
+
+        file_content_as_dict = _get_file_content_as_dictionary(
+            content_bytes  # type: ignore[arg-type]
+        )
+
+        # Record output file size
+        if prom_logger and content_bytes:
+            try:
+                prom_logger.record_managed_file_size(
+                    size_bytes=len(content_bytes),  # type: ignore
+                    purpose="batch",
+                    file_type="output",
+                    model=model_id,
+                )
+            except Exception:
+                pass
+
+        deployment_info = self.llm_router.get_deployment(model_id=model_id)
+        if deployment_info is None:
+            verbose_proxy_logger.info(
+                f"Skipping job {job.unified_object_id} because it is not a valid deployment info"
+            )
+            self._record_error(prom_logger, "deployment_not_found")
+            return None
+        custom_llm_provider = deployment_info.litellm_params.custom_llm_provider
+        litellm_model_name = deployment_info.litellm_params.model
+
+        model_name, llm_provider, _, _ = get_llm_provider(
+            model=litellm_model_name,
+            custom_llm_provider=custom_llm_provider,
+        )
+
+        # CheckBatchCost bypasses async_post_call_success_hook, so convert raw
+        # output/error file IDs to managed base64 IDs before the DB write here.
+        managed_files_hook = self.proxy_logging_obj.get_proxy_hook("managed_files")
+        if managed_files_hook is not None:
+            from litellm.proxy._types import UserAPIKeyAuth
+            _minimal_auth = UserAPIKeyAuth(
+                user_id=job.created_by or "default-user-id",
+                team_id=getattr(job, "team_id", None),
+            )
+            for _file_attr in ["output_file_id", "error_file_id"]:
+                _raw_file_id = getattr(response, _file_attr, None)
+                if _raw_file_id and not _is_base64_encoded_unified_file_id(_raw_file_id):
+                    try:
+                        _unified_file_id = managed_files_hook.get_unified_output_file_id(
+                            output_file_id=_raw_file_id,
+                            model_id=model_id,
+                            model_name=str(model_name) if model_name else deployment_info.model_name or None,
+                        )
+                        await managed_files_hook.store_unified_file_id(
+                            file_id=_unified_file_id,
+                            file_object=None,
+                            litellm_parent_otel_span=None,
+                            model_mappings={model_id: _raw_file_id},
+                            user_api_key_dict=_minimal_auth,
+                        )
+                        setattr(response, _file_attr, _unified_file_id)
+                        verbose_proxy_logger.info(
+                            f"CheckBatchCost: converted {_file_attr} "
+                            f"{_raw_file_id!r} -> managed ID for batch {batch_id}"
+                        )
+                    except Exception as _e:
+                        verbose_proxy_logger.warning(
+                            f"CheckBatchCost: failed to create managed file ID for "
+                            f"{_file_attr}={_raw_file_id!r}: {_e}"
+                        )
+
+        # Pass deployment model_info so custom batch pricing
+        # (input_cost_per_token_batches etc.) is used for cost calc
+        deployment_model_info = deployment_info.model_info.model_dump() if deployment_info.model_info else {}
+        batch_cost, batch_usage, batch_models = (
+            await calculate_batch_cost_and_usage(
+                file_content_dictionary=file_content_as_dict,
+                custom_llm_provider=llm_provider,  # type: ignore
+                model_name=model_name,
+                model_info=deployment_model_info,  # type: ignore[arg-type]
+            )
+        )
+        logging_obj = LiteLLMLogging(
+            model=batch_models[0],
+            messages=[{"role": "user", "content": "<retrieve_batch>"}],
+            stream=False,
+            call_type="aretrieve_batch",
+            start_time=datetime.now(),
+            litellm_call_id=str(uuid.uuid4()),
+            function_id=str(uuid.uuid4()),
+        )
+
+        creator_user_id = job.created_by
+        user_info = await self._get_user_info(batch_id, job.created_by)
+
+        logging_obj.update_environment_variables(
+            litellm_params={
+                # set the user-agent header so that S3 callback consumers can easily identify CheckBatchCost callbacks
+                "proxy_server_request": {
+                    "headers": {
+                        "user-agent": CHECK_BATCH_COST_USER_AGENT,
+                    }
+                },
+                "metadata": {
+                    "user_api_key_user_id": creator_user_id,
+                    **user_info,
+                },
+            },
+            optional_params={},
+        )
+
+        await logging_obj.async_success_handler(
+            result=response,
+            batch_cost=batch_cost,
+            batch_usage=batch_usage,
+            batch_models=batch_models,
+        )
+
+        # Record batch duration (completed_at - created_at)
+        if prom_logger and response.completed_at and response.created_at:
+            duration_seconds = float(response.completed_at - response.created_at)
+            if duration_seconds >= 0:
+                prom_logger.record_managed_batch_duration(
+                    duration_seconds=duration_seconds,
+                    model=model_name,
+                    api_provider=str(llm_provider) if llm_provider else None,
+                )
+
+        return model_name, str(llm_provider) if llm_provider else None
+
+    async def check_batch_cost(self):
+        """
+        Check if the batch JOB has been tracked.
+        - get all status="validating" and file_purpose="batch" jobs
+        - check if batch is now complete
+        - if not, return False
+        - if so, return True
+        """
         try:
             from litellm.integrations.prometheus import PrometheusLogger
             prom_logger = PrometheusLogger.get_instance()
@@ -381,177 +567,26 @@ class CheckBatchCost:
                 response.status == "completed"
                 and response.output_file_id is not None
             ):
-                verbose_proxy_logger.info(
-                    f"Batch ID: {batch_id} is complete, tracking cost and usage"
-                )
-
-                # aretrieve_batch is called with the raw provider batch ID, so response.id
-                # is the raw provider value (e.g. "batch_20260223-0518.234"). We need the
-                # unified base64 ID in the S3 log so downstream consumers can correlate it
-                # back to the batch they submitted via the proxy.
-                #
-                # CheckBatchCost builds its own LiteLLMLogging object (logging_obj below) and
-                # calls async_success_handler(result=response) directly. That handler calls
-                # _build_standard_logging_payload(response, ...) which reads response.id at
-                # that point — so setting response.id here is sufficient.
-                #
-                # The HTTP endpoint does this substitution via the managed files hook
-                # (async_post_call_success_hook). CheckBatchCost bypasses that hook entirely,
-                # so we do it explicitly here.
-                response.id = job.unified_object_id
-
-                # This background job runs as default_user_id, so going through the HTTP endpoint
-                # would trigger check_managed_file_id_access and get 403. Instead, extract the raw
-                # provider file ID and call afile_content directly with deployment credentials.
-                raw_output_file_id = response.output_file_id
-                decoded = _is_base64_encoded_unified_file_id(raw_output_file_id)
-                if decoded:
-                    try:
-                        raw_output_file_id = decoded.split("llm_output_file_id,")[1].split(";")[0]
-                    except (IndexError, AttributeError):
-                        pass
-
-                credentials = self.llm_router.get_deployment_credentials_with_provider(model_id) or {}
-                _file_content = await afile_content(
-                    file_id=raw_output_file_id,
-                    **credentials,
-                )
-
-                # Access content - handle both direct attribute and method call
-                if hasattr(_file_content, 'content'):
-                    content_bytes = _file_content.content  # type: ignore[union-attr]
-                elif hasattr(_file_content, 'read'):
-                    content_bytes = await _file_content.read()  # type: ignore[misc]
-                else:
-                    content_bytes = _file_content  # type: ignore[assignment]
-
-                file_content_as_dict = _get_file_content_as_dictionary(
-                    content_bytes  # type: ignore[arg-type]
-                )
-
-                # Record output file size
-                if prom_logger and content_bytes:
-                    try:
-                        prom_logger.record_managed_file_size(
-                            size_bytes=len(content_bytes),  # type: ignore
-                            purpose="batch",
-                            file_type="output",
-                            model=model_id,
-                        )
-                    except Exception:
-                        pass
-
-                deployment_info = self.llm_router.get_deployment(model_id=model_id)
-                if deployment_info is None:
-                    verbose_proxy_logger.info(
-                        f"Skipping job {job.unified_object_id} because it is not a valid deployment info"
+                try:
+                    tracked = await self._track_completed_batch_cost(
+                        job=job,
+                        response=response,
+                        model_id=model_id,
+                        batch_id=batch_id,
+                        prom_logger=prom_logger,
                     )
-                    if prom_logger:
-                        prom_logger.record_check_batch_cost_error("deployment_not_found")
+                except Exception as tracking_err:
+                    verbose_proxy_logger.error(
+                        f"CheckBatchCost: failed to track cost for batch {batch_id} "
+                        f"(job {job.id}); leaving it unprocessed so the next poll retries: {tracking_err}"
+                    )
+                    self._record_error(prom_logger, "cost_tracking_error")
                     continue
-                custom_llm_provider = deployment_info.litellm_params.custom_llm_provider
-                litellm_model_name = deployment_info.litellm_params.model
-
-                model_name, llm_provider, _, _ = get_llm_provider(
-                    model=litellm_model_name,
-                    custom_llm_provider=custom_llm_provider,
-                )
-
-                # CheckBatchCost bypasses async_post_call_success_hook, so convert raw
-                # output/error file IDs to managed base64 IDs before the DB write here.
-                managed_files_hook = self.proxy_logging_obj.get_proxy_hook("managed_files")
-                if managed_files_hook is not None:
-                    from litellm.proxy._types import UserAPIKeyAuth
-                    _minimal_auth = UserAPIKeyAuth(
-                        user_id=job.created_by or "default-user-id",
-                        team_id=getattr(job, "team_id", None),
-                    )
-                    for _file_attr in ["output_file_id", "error_file_id"]:
-                        _raw_file_id = getattr(response, _file_attr, None)
-                        if _raw_file_id and not _is_base64_encoded_unified_file_id(_raw_file_id):
-                            try:
-                                _unified_file_id = managed_files_hook.get_unified_output_file_id(
-                                    output_file_id=_raw_file_id,
-                                    model_id=model_id,
-                                    model_name=str(model_name) if model_name else deployment_info.model_name or None,
-                                )
-                                await managed_files_hook.store_unified_file_id(
-                                    file_id=_unified_file_id,
-                                    file_object=None,
-                                    litellm_parent_otel_span=None,
-                                    model_mappings={model_id: _raw_file_id},
-                                    user_api_key_dict=_minimal_auth,
-                                )
-                                setattr(response, _file_attr, _unified_file_id)
-                                verbose_proxy_logger.info(
-                                    f"CheckBatchCost: converted {_file_attr} "
-                                    f"{_raw_file_id!r} -> managed ID for batch {batch_id}"
-                                )
-                            except Exception as _e:
-                                verbose_proxy_logger.warning(
-                                    f"CheckBatchCost: failed to create managed file ID for "
-                                    f"{_file_attr}={_raw_file_id!r}: {_e}"
-                                )
-
-                # Pass deployment model_info so custom batch pricing
-                # (input_cost_per_token_batches etc.) is used for cost calc
-                deployment_model_info = deployment_info.model_info.model_dump() if deployment_info.model_info else {}
-                batch_cost, batch_usage, batch_models = (
-                    await calculate_batch_cost_and_usage(
-                        file_content_dictionary=file_content_as_dict,
-                        custom_llm_provider=llm_provider,  # type: ignore
-                        model_name=model_name,
-                        model_info=deployment_model_info,  # type: ignore[arg-type]
-                    )
-                )
-                logging_obj = LiteLLMLogging(
-                    model=batch_models[0],
-                    messages=[{"role": "user", "content": "<retrieve_batch>"}],
-                    stream=False,
-                    call_type="aretrieve_batch",
-                    start_time=datetime.now(),
-                    litellm_call_id=str(uuid.uuid4()),
-                    function_id=str(uuid.uuid4()),
-                )
-
-                creator_user_id = job.created_by
-                user_info = await self._get_user_info(batch_id, job.created_by)
-
-                logging_obj.update_environment_variables(
-                    litellm_params={
-                        # set the user-agent header so that S3 callback consumers can easily identify CheckBatchCost callbacks
-                        "proxy_server_request": {
-                            "headers": {
-                                "user-agent": CHECK_BATCH_COST_USER_AGENT,
-                            }
-                        },
-                        "metadata": {
-                            "user_api_key_user_id": creator_user_id,
-                            **user_info,
-                        },
-                    },
-                    optional_params={},
-                )
-
-                await logging_obj.async_success_handler(
-                    result=response,
-                    batch_cost=batch_cost,
-                    batch_usage=batch_usage,
-                    batch_models=batch_models,
-                )
-
-                # Record batch duration (completed_at - created_at)
-                if prom_logger and response.completed_at and response.created_at:
-                    duration_seconds = float(response.completed_at - response.created_at)
-                    if duration_seconds >= 0:
-                        prom_logger.record_managed_batch_duration(
-                            duration_seconds=duration_seconds,
-                            model=model_name,
-                            api_provider=str(llm_provider) if llm_provider else None,
-                        )
+                if tracked is None:
+                    continue
 
                 # Track this job for the final metrics summary
-                processed_models.append((model_name, str(llm_provider) if llm_provider else None))
+                processed_models.append(tracked)
 
                 # mark the job as complete
                 try:

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -34,7 +34,7 @@ async def calculate_batch_cost_and_usage(
         custom_llm_provider=custom_llm_provider,
         model_name=model_name,
     )
-    batch_models = _get_batch_models_from_file_content(file_content_dictionary, model_name)
+    batch_models = _get_batch_models_from_file_content(file_content_dictionary, model_name, custom_llm_provider)
 
     return batch_cost, batch_usage, batch_models
 
@@ -70,7 +70,7 @@ async def _handle_completed_batch(
         model_name=model_name,
     )
 
-    batch_models = _get_batch_models_from_file_content(file_content_dictionary, model_name)
+    batch_models = _get_batch_models_from_file_content(file_content_dictionary, model_name, custom_llm_provider)
 
     return batch_cost, batch_usage, batch_models
 
@@ -78,6 +78,7 @@ async def _handle_completed_batch(
 def _get_batch_models_from_file_content(
     file_content_dictionary: List[dict],
     model_name: Optional[str] = None,
+    custom_llm_provider: str = "openai",
 ) -> List[str]:
     """
     Get the models from the file content
@@ -86,8 +87,8 @@ def _get_batch_models_from_file_content(
         return [model_name]
     batch_models = []
     for _item in file_content_dictionary:
-        if _batch_response_was_successful(_item):
-            _response_body = _get_response_from_batch_job_output_file(_item)
+        if _batch_response_was_successful(_item, custom_llm_provider):
+            _response_body = _get_response_from_batch_job_output_file(_item, custom_llm_provider)
             _model = _response_body.get("model")
             if _model:
                 batch_models.append(_model)
@@ -373,10 +374,10 @@ def _get_batch_job_cost_from_file_content(
         # parse the file content as json
         verbose_logger.debug("file_content_dictionary=%s", json.dumps(file_content_dictionary, indent=4))
         for _item in file_content_dictionary:
-            if _batch_response_was_successful(_item):
-                _response_body = _get_response_from_batch_job_output_file(_item)
-                if model_info is not None:
-                    usage = _get_batch_job_usage_from_response_body(_response_body)
+            if _batch_response_was_successful(_item, custom_llm_provider):
+                _response_body = _get_response_from_batch_job_output_file(_item, custom_llm_provider)
+                if model_info is not None or custom_llm_provider == "anthropic":
+                    usage = _get_batch_job_usage_from_response_body(_response_body, custom_llm_provider)
                     model = _response_body.get("model", "")
                     prompt_cost, completion_cost = batch_cost_calculator(
                         usage=usage,
@@ -419,9 +420,9 @@ def _get_batch_job_total_usage_from_file_content(
     prompt_tokens: int = 0
     completion_tokens: int = 0
     for _item in file_content_dictionary:
-        if _batch_response_was_successful(_item):
-            _response_body = _get_response_from_batch_job_output_file(_item)
-            usage: Usage = _get_batch_job_usage_from_response_body(_response_body)
+        if _batch_response_was_successful(_item, custom_llm_provider):
+            _response_body = _get_response_from_batch_job_output_file(_item, custom_llm_provider)
+            usage: Usage = _get_batch_job_usage_from_response_body(_response_body, custom_llm_provider)
             total_tokens += usage.total_tokens
             prompt_tokens += usage.prompt_tokens
             completion_tokens += usage.completion_tokens
@@ -465,27 +466,51 @@ def _count_prompt_or_input_tokens(model: str, value: Any) -> int:
     return 0
 
 
-def _get_batch_job_usage_from_response_body(response_body: dict) -> Usage:
+def _get_batch_job_usage_from_response_body(response_body: dict, custom_llm_provider: str = "openai") -> Usage:
     """
     Get the tokens of a batch job from the response body
     """
+    if custom_llm_provider == "anthropic":
+        from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+        return AnthropicConfig().calculate_usage(
+            usage_object=response_body.get("usage", None) or {},
+            reasoning_content=None,
+        )
     _usage_dict = response_body.get("usage", None) or {}
     usage: Usage = Usage(**_usage_dict)
     return usage
 
 
-def _get_response_from_batch_job_output_file(batch_job_output_file: dict) -> Any:
+def _get_anthropic_result_from_batch_results_line(batch_results_line: dict) -> dict:
+    """
+    Get the ``result`` object from a line of an Anthropic message batch results JSONL file.
+
+    Anthropic batch results lines look like:
+    ``{"custom_id": ..., "result": {"type": "succeeded", "message": {..., "usage": {...}}}}``
+    """
+    return batch_results_line.get("result", None) or {}
+
+
+def _get_response_from_batch_job_output_file(batch_job_output_file: dict, custom_llm_provider: str = "openai") -> Any:
     """
     Get the response from the batch job output file
     """
+    if custom_llm_provider == "anthropic":
+        return _get_anthropic_result_from_batch_results_line(batch_job_output_file).get("message", None) or {}
     _response: dict = batch_job_output_file.get("response", None) or {}
     _response_body = _response.get("body", None) or {}
     return _response_body
 
 
-def _batch_response_was_successful(batch_job_output_file: dict) -> bool:
+def _batch_response_was_successful(batch_job_output_file: dict, custom_llm_provider: str = "openai") -> bool:
     """
-    Check if the batch job response status == 200
+    Check if the batch job response was successful
+
+    OpenAI-shaped output rows report ``response.status_code == 200``; Anthropic
+    message batch results lines report ``result.type == "succeeded"``.
     """
+    if custom_llm_provider == "anthropic":
+        return _get_anthropic_result_from_batch_results_line(batch_job_output_file).get("type") == "succeeded"
     _response: dict = batch_job_output_file.get("response", None) or {}
     return _response.get("status_code", None) == 200

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -3,6 +3,7 @@ from typing import Any, Iterator, List, Literal, Optional, Tuple
 
 import litellm
 from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.llm_cost_calc.utils import _parse_prompt_tokens_details
 from litellm.types.llms.openai import Batch
 from litellm.types.utils import CallTypes, ModelInfo, Usage
 from litellm.utils import token_counter
@@ -419,6 +420,8 @@ def _get_batch_job_total_usage_from_file_content(
     total_tokens: int = 0
     prompt_tokens: int = 0
     completion_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
     for _item in file_content_dictionary:
         if _batch_response_was_successful(_item, custom_llm_provider):
             _response_body = _get_response_from_batch_job_output_file(_item, custom_llm_provider)
@@ -426,10 +429,22 @@ def _get_batch_job_total_usage_from_file_content(
             total_tokens += usage.total_tokens
             prompt_tokens += usage.prompt_tokens
             completion_tokens += usage.completion_tokens
+            prompt_details = _parse_prompt_tokens_details(usage)
+            cache_read_tokens += prompt_details["cache_hit_tokens"]
+            cache_creation_tokens += prompt_details["cache_creation_tokens"]
+    cache_token_params = {
+        key: tokens
+        for key, tokens in (
+            ("cache_read_input_tokens", cache_read_tokens),
+            ("cache_creation_input_tokens", cache_creation_tokens),
+        )
+        if tokens > 0
+    }
     return Usage(
         total_tokens=total_tokens,
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
+        **cache_token_params,
     )
 
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -2155,17 +2155,23 @@ def batch_cost_calculator(
     if input_cost_per_token_batches:
         total_prompt_cost = usage.prompt_tokens * input_cost_per_token_batches
     elif input_cost_per_token:
+        details = _parse_prompt_tokens_details(usage)
+        cache_read_tokens = details["cache_hit_tokens"]
+        cache_creation_tokens = details["cache_creation_tokens"]
+
         # Subtract cached tokens from prompt_tokens before calculating cost
         # Fixes issue where cached tokens are being charged again
+        base_input_tokens = get_billable_input_tokens(usage) - cache_creation_tokens
         total_prompt_cost = (
-            get_billable_input_tokens(usage) * (input_cost_per_token) / 2
+            base_input_tokens * (input_cost_per_token) / 2
         )  # batch cost is usually half of the regular token cost
 
         # Add cache read cost if applicable
-        details = _parse_prompt_tokens_details(usage)
-        cache_read_tokens = details["cache_hit_tokens"]
         cache_read_cost_key = _get_service_tier_cost_key("cache_read_input_token_cost", None)
         total_prompt_cost += calculate_cost_component(model_info, cache_read_cost_key, cache_read_tokens) / 2
+
+        cache_creation_cost = model_info.get("cache_creation_input_token_cost") or input_cost_per_token
+        total_prompt_cost += cache_creation_tokens * cache_creation_cost / 2
     if output_cost_per_token_batches:
         total_completion_cost = usage.completion_tokens * output_cost_per_token_batches
     elif output_cost_per_token:

--- a/litellm/llms/anthropic/files/transformation.py
+++ b/litellm/llms/anthropic/files/transformation.py
@@ -39,6 +39,7 @@ from ..common_utils import AnthropicError, AnthropicModelInfo
 
 ANTHROPIC_FILES_API_BASE = "https://api.anthropic.com"
 ANTHROPIC_FILES_BETA_HEADER = "files-api-2025-04-14"
+ANTHROPIC_MESSAGE_BATCH_ID_PREFIX = "msgbatch_"
 
 
 class AnthropicFilesConfig(BaseFilesConfig):
@@ -258,6 +259,8 @@ class AnthropicFilesConfig(BaseFilesConfig):
         file_id = file_content_request.get("file_id")
         api_base = AnthropicModelInfo.get_api_base(litellm_params.get("api_base")) or ANTHROPIC_FILES_API_BASE
         encoded_file_id = encode_url_path_segment(file_id, field_name="file_id")
+        if file_id.startswith(ANTHROPIC_MESSAGE_BATCH_ID_PREFIX):
+            return f"{api_base.rstrip('/')}/v1/messages/batches/{encoded_file_id}/results", {}
         return f"{api_base.rstrip('/')}/v1/files/{encoded_file_id}/content", {}
 
     def transform_file_content_response(

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -4735,6 +4735,13 @@ class BaseLLMHTTPHandler:
         except Exception as e:
             raise self._handle_error(e=e, provider_config=provider_config)
 
+        if response.status_code >= 400:
+            raise provider_config.get_error_class(
+                error_message=response.text,
+                status_code=response.status_code,
+                headers=response.headers,
+            )
+
         return provider_config.transform_file_content_response(
             raw_response=response,
             logging_obj=logging_obj,
@@ -4790,6 +4797,13 @@ class BaseLLMHTTPHandler:
             response = await async_httpx_client.get(url=url, headers=headers, params=params)
         except Exception as e:
             raise self._handle_error(e=e, provider_config=provider_config)
+
+        if response.status_code >= 400:
+            raise provider_config.get_error_class(
+                error_message=response.text,
+                status_code=response.status_code,
+                headers=response.headers,
+            )
 
         return provider_config.transform_file_content_response(
             raw_response=response,

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -398,6 +398,72 @@ class TestCheckBatchCost:
         assert update_data["status"] == "complete"
 
     @pytest.mark.asyncio
+    async def test_cost_tracking_failure_leaves_job_unprocessed(
+        self, check_batch_cost_instance, mock_prisma_client, mock_llm_router
+    ):
+        """LIT-4008 regression: when fetching a completed batch's results fails
+        (e.g. Anthropic rejecting a msgbatch_ id on the Files API), the job must
+        NOT be marked complete/batch_processed. Pre-fix the $0 spend row was
+        written and batch_processed=True made it permanent; the failure must
+        instead leave the row untouched so the next poll retries, without
+        aborting the poll cycle.
+        """
+        from unittest.mock import patch
+
+        mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
+            return_value=0
+        )
+        mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=None
+        )
+
+        mock_job = MagicMock()
+        mock_job.id = "job-anthropic-1"
+        mock_job.unified_object_id = "dW5pZmllZF9iYXRjaF9pZA=="
+        mock_job.created_by = "user-1"
+
+        mock_prisma_client.db.litellm_managedobjecttable.find_many = AsyncMock(
+            return_value=[mock_job]
+        )
+
+        mock_response = MagicMock()
+        mock_response.status = "completed"
+        mock_response.output_file_id = "msgbatch_01WA5hdsa2Xx8w4zyPjV1frs"
+
+        mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
+        mock_llm_router.get_deployment_credentials_with_provider = MagicMock(
+            return_value={"api_key": "sk-test", "custom_llm_provider": "anthropic"}
+        )
+
+        decoded_id = "llm_model_id,model-123;llm_batch_id,msgbatch_01WA5hdsa2Xx8w4zyPjV1frs;"
+
+        with (
+            patch(
+                "litellm.proxy.openai_files_endpoints.common_utils._is_base64_encoded_unified_file_id",
+                side_effect=[decoded_id, None],
+            ),
+            patch(
+                "litellm.proxy.openai_files_endpoints.common_utils.get_model_id_from_unified_batch_id",
+                return_value="model-123",
+            ),
+            patch(
+                "litellm.proxy.openai_files_endpoints.common_utils.get_batch_id_from_unified_batch_id",
+                return_value="msgbatch_01WA5hdsa2Xx8w4zyPjV1frs",
+            ),
+            patch(
+                "litellm.files.main.afile_content",
+                new_callable=AsyncMock,
+                side_effect=Exception("File id must have `file_` prefix."),
+            ),
+        ):
+            await check_batch_cost_instance.check_batch_cost()
+
+        assert (
+            mock_prisma_client.db.litellm_managedobjecttable.update.call_count == 0
+        ), "a failed cost tracking attempt must not mark the job processed"
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("terminal_status", ["failed", "expired", "cancelled"])
     async def test_terminal_status_marks_job_processed(
         self,

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -733,3 +733,167 @@ def test_total_usage_vertex_disable_transform_path(monkeypatch):
 
     usage = bu._get_batch_job_total_usage_from_file_content([], custom_llm_provider="vertex_ai", model_name="gemini-x")
     assert usage.total_tokens == 3
+
+
+def _anthropic_usage(input_tokens, output_tokens, cache_creation=0, cache_read=0):
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+    }
+
+
+def _anthropic_succeeded_row(model="claude-sonnet-4-5-20250929", usage=None):
+    return {
+        "custom_id": "req-1",
+        "result": {
+            "type": "succeeded",
+            "message": {
+                "id": "msg_1",
+                "type": "message",
+                "role": "assistant",
+                "model": model,
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": usage or _anthropic_usage(10, 5),
+            },
+        },
+    }
+
+
+def _anthropic_errored_row():
+    return {
+        "custom_id": "req-2",
+        "result": {
+            "type": "errored",
+            "error": {"type": "invalid_request_error", "message": "bad request"},
+        },
+    }
+
+
+_ANTHROPIC_MODEL_INFO = {
+    "input_cost_per_token": 3e-6,
+    "output_cost_per_token": 15e-6,
+    "cache_read_input_token_cost": 3e-7,
+    "cache_creation_input_token_cost": 3.75e-6,
+}
+
+
+@pytest.mark.parametrize(
+    "row,expected",
+    [
+        (_anthropic_succeeded_row(), True),
+        (_anthropic_errored_row(), False),
+        ({"custom_id": "x", "result": {"type": "canceled"}}, False),
+        ({"custom_id": "x", "result": {"type": "expired"}}, False),
+        ({"custom_id": "x"}, False),
+        ({"custom_id": "x", "result": None}, False),
+    ],
+)
+def test_anthropic_result_line_success_check(row, expected):
+    """
+    LIT-4008 regression: anthropic batch results JSONL lines are not
+    OpenAI-shaped; success is result.type == "succeeded", not
+    response.status_code == 200. Pre-fix every anthropic line parsed as
+    unsuccessful, so completed batches were billed $0 forever.
+    """
+    assert bu._batch_response_was_successful(row, custom_llm_provider="anthropic") is expected
+
+
+def test_anthropic_response_body_is_result_message():
+    row = _anthropic_succeeded_row(model="claude-sonnet-4-5-20250929")
+    body = bu._get_response_from_batch_job_output_file(row, custom_llm_provider="anthropic")
+    assert body["model"] == "claude-sonnet-4-5-20250929"
+    assert body["usage"] == _anthropic_usage(10, 5)
+
+
+def test_anthropic_usage_conversion_includes_cache_tokens():
+    body = {"model": "claude-sonnet-4-5-20250929", "usage": _anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000)}
+    usage = bu._get_batch_job_usage_from_response_body(body, custom_llm_provider="anthropic")
+    assert usage.prompt_tokens == 11000
+    assert usage.completion_tokens == 200
+    assert usage.total_tokens == 11200
+    assert usage.prompt_tokens_details.cached_tokens == 8000
+    assert usage.prompt_tokens_details.cache_creation_tokens == 2000
+
+
+def test_anthropic_total_usage_sums_succeeded_only():
+    rows = [
+        _anthropic_succeeded_row(usage=_anthropic_usage(10, 5)),
+        _anthropic_errored_row(),
+        _anthropic_succeeded_row(usage=_anthropic_usage(20, 10, cache_read=100)),
+    ]
+    usage = bu._get_batch_job_total_usage_from_file_content(rows, custom_llm_provider="anthropic")
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (130, 15, 145)
+
+
+def test_anthropic_cost_applies_batch_discount_and_cache_pricing():
+    """Anthropic batches bill at 50% of the regular rate for base input,
+    cache reads, cache writes, and output tokens alike."""
+    rows = [
+        _anthropic_succeeded_row(usage=_anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000)),
+        _anthropic_errored_row(),
+    ]
+
+    total = bu._get_batch_job_cost_from_file_content(
+        rows,
+        custom_llm_provider="anthropic",
+        model_info=_ANTHROPIC_MODEL_INFO,  # type: ignore[arg-type]
+    )
+
+    expected_half_price = (1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3.75e-6 + 200 * 15e-6) / 2
+    assert total == pytest.approx(expected_half_price)
+
+
+def test_anthropic_cost_without_model_info_uses_batch_cost_calculator(monkeypatch):
+    import litellm.cost_calculator as cc
+
+    seen = []
+
+    def _fake_batch_cost_calculator(**kw):
+        seen.append(kw)
+        return (0.1, 0.2)
+
+    monkeypatch.setattr(cc, "batch_cost_calculator", _fake_batch_cost_calculator)
+    monkeypatch.setattr(
+        litellm,
+        "completion_cost",
+        lambda **kw: pytest.fail("anthropic rows must not go through completion_cost"),
+    )
+
+    total = bu._get_batch_job_cost_from_file_content(
+        [_anthropic_succeeded_row()], custom_llm_provider="anthropic"
+    )
+
+    assert total == pytest.approx(0.3)
+    assert seen[0]["model"] == "claude-sonnet-4-5-20250929"
+    assert seen[0]["custom_llm_provider"] == "anthropic"
+    assert seen[0]["usage"].prompt_tokens == 10
+
+
+def test_anthropic_batch_models_collected_from_succeeded_rows():
+    rows = [
+        _anthropic_succeeded_row(model="claude-sonnet-4-5-20250929"),
+        _anthropic_errored_row(),
+    ]
+    assert bu._get_batch_models_from_file_content(rows, None, "anthropic") == ["claude-sonnet-4-5-20250929"]
+
+
+@pytest.mark.asyncio
+async def test_calculate_batch_cost_and_usage_anthropic_end_to_end():
+    rows = [
+        _anthropic_succeeded_row(usage=_anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000)),
+        _anthropic_errored_row(),
+    ]
+
+    cost, usage, models = await bu.calculate_batch_cost_and_usage(
+        file_content_dictionary=rows,
+        custom_llm_provider="anthropic",
+        model_name="claude-sonnet-4-5",
+        model_info=_ANTHROPIC_MODEL_INFO,  # type: ignore[arg-type]
+    )
+
+    assert cost == pytest.approx(1000 * 3e-6 / 2 + 8000 * 3e-7 / 2 + 2000 * 3.75e-6 / 2 + 200 * 15e-6 / 2)
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (11000, 200, 11200)
+    assert models == ["claude-sonnet-4-5"]

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -828,6 +828,31 @@ def test_anthropic_total_usage_sums_succeeded_only():
     assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (130, 15, 145)
 
 
+def test_anthropic_total_usage_aggregates_cache_token_details():
+    rows = [
+        _anthropic_succeeded_row(usage=_anthropic_usage(1000, 200, cache_creation=2000, cache_read=8000)),
+        _anthropic_errored_row(),
+        _anthropic_succeeded_row(usage=_anthropic_usage(50, 20, cache_creation=300, cache_read=700)),
+    ]
+    usage = bu._get_batch_job_total_usage_from_file_content(rows, custom_llm_provider="anthropic")
+    assert usage.prompt_tokens_details.cached_tokens == 8700
+    assert usage.prompt_tokens_details.cache_creation_tokens == 2300
+    assert usage.cache_read_input_tokens == 8700
+    assert usage.cache_creation_input_tokens == 2300
+
+
+def test_total_usage_without_cache_tokens_has_no_prompt_details():
+    rows = [
+        {
+            "custom_id": "req-1",
+            "response": {"status_code": 200, "body": {"model": "gpt-5.2", "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}},
+        }
+    ]
+    usage = bu._get_batch_job_total_usage_from_file_content(rows, custom_llm_provider="openai")
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (10, 5, 15)
+    assert usage.prompt_tokens_details is None
+
+
 def test_anthropic_cost_applies_batch_discount_and_cache_pricing():
     """Anthropic batches bill at 50% of the regular rate for base input,
     cache reads, cache writes, and output tokens alike."""

--- a/tests/test_litellm/llms/anthropic/files/test_anthropic_files_transformation.py
+++ b/tests/test_litellm/llms/anthropic/files/test_anthropic_files_transformation.py
@@ -309,6 +309,31 @@ class TestAnthropicFilesConfig:
         assert url == f"{ANTHROPIC_FILES_API_BASE}/v1/files/file-abc123/content"
         assert params == {}
 
+    def test_transform_file_content_request_routes_message_batch_id_to_batch_results(self):
+        """
+        Regression test for anthropic passthrough batch cost tracking (LIT-4008).
+
+        Anthropic batch results are exposed via output_file_id=<msgbatch_...>.
+        The Files API rejects those ids ("File id must have `file_` prefix"),
+        so file content for a msgbatch_ id must be fetched from the message
+        batches results endpoint instead.
+        """
+        url, params = self.config.transform_file_content_request(
+            file_content_request={"file_id": "msgbatch_01WA5hdsa2Xx8w4zyPjV1frs"},
+            optional_params={},
+            litellm_params={},
+        )
+        assert url == f"{ANTHROPIC_FILES_API_BASE}/v1/messages/batches/msgbatch_01WA5hdsa2Xx8w4zyPjV1frs/results"
+        assert params == {}
+
+    def test_transform_file_content_request_message_batch_id_custom_api_base(self):
+        url, _ = self.config.transform_file_content_request(
+            file_content_request={"file_id": "msgbatch_abc"},
+            optional_params={},
+            litellm_params={"api_base": "https://custom.example.com/"},
+        )
+        assert url == "https://custom.example.com/v1/messages/batches/msgbatch_abc/results"
+
     def test_transform_file_content_request_rejects_dot_segment(self):
         with pytest.raises(ValueError, match="file_id cannot be a dot path segment"):
             self.config.transform_file_content_request(

--- a/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
+++ b/tests/test_litellm/llms/custom_httpx/test_llm_http_handler.py
@@ -1685,3 +1685,63 @@ async def test_async_audio_transcriptions_sends_dict_data_as_json_body():
     assert captured["content_type"] == "application/json"
     assert captured["body"] == {"config": {"model": "test-model"}, "content": "YXVkaW8="}
     assert response.text == "transcribed"
+
+
+@pytest.mark.asyncio
+async def test_async_retrieve_file_content_raises_on_http_error():
+    """
+    LIT-4008 regression: a provider error response (e.g. Anthropic's 400
+    "File id must have `file_` prefix") must raise instead of being wrapped
+    as file content, which downstream batch cost tracking would parse as an
+    empty results file and bill $0.
+    """
+    from litellm.llms.anthropic.common_utils import AnthropicError
+    from litellm.llms.anthropic.files.transformation import AnthropicFilesConfig
+
+    handler = BaseLLMHTTPHandler()
+    client = Mock(spec=AsyncHTTPHandler)
+    client.get = AsyncMock(
+        return_value=httpx.Response(
+            status_code=400,
+            content=b'{"type":"error","error":{"type":"invalid_request_error","message":"File id must have `file_` prefix."}}',
+        )
+    )
+
+    with pytest.raises(AnthropicError) as exc_info:
+        await handler.async_retrieve_file_content(
+            file_content_request={"file_id": "msgbatch_123"},
+            provider_config=AnthropicFilesConfig(),
+            litellm_params={"api_key": "sk-test"},
+            headers={},
+            logging_obj=Mock(),
+            client=client,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "file_" in str(exc_info.value)
+
+
+def test_sync_retrieve_file_content_raises_on_http_error():
+    from litellm.llms.anthropic.common_utils import AnthropicError
+    from litellm.llms.anthropic.files.transformation import AnthropicFilesConfig
+
+    handler = BaseLLMHTTPHandler()
+    client = Mock(spec=HTTPHandler)
+    client.get = Mock(
+        return_value=httpx.Response(
+            status_code=404,
+            content=b'{"type":"error","error":{"type":"not_found_error","message":"not found"}}',
+        )
+    )
+
+    with pytest.raises(AnthropicError) as exc_info:
+        handler.retrieve_file_content(
+            file_content_request={"file_id": "file-abc"},
+            provider_config=AnthropicFilesConfig(),
+            litellm_params={"api_key": "sk-test"},
+            headers={},
+            logging_obj=Mock(),
+            client=client,
+        )
+
+    assert exc_info.value.status_code == 404

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -3318,3 +3318,60 @@ def test_cost_per_token_per_second_pricing(monkeypatch):
 
     assert prompt_cost == pytest.approx(0.02 * 1.5)
     assert completion_cost_value == pytest.approx(0.04 * 1.5)
+
+
+def _batch_cache_usage() -> Usage:
+    return Usage(
+        prompt_tokens=11000,
+        completion_tokens=200,
+        total_tokens=11200,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=8000,
+            cache_creation_tokens=2000,
+            text_tokens=1000,
+        ),
+        cache_creation_input_tokens=2000,
+        cache_read_input_tokens=8000,
+    )
+
+
+def test_batch_cost_calculator_prices_cache_creation_tokens_at_cache_write_rate():
+    """
+    LIT-4008 regression: anthropic batch usage is dominated by cache tokens.
+    Cache creation tokens must be priced at cache_creation_input_token_cost / 2,
+    not folded into the base input rate, and must not also be billed as base
+    input tokens.
+    """
+    from litellm.cost_calculator import batch_cost_calculator
+
+    prompt_cost, completion_cost_value = batch_cost_calculator(
+        usage=_batch_cache_usage(),
+        model="claude-sonnet-4-5-20250929",
+        custom_llm_provider="anthropic",
+        model_info={  # type: ignore[arg-type]
+            "input_cost_per_token": 3e-6,
+            "output_cost_per_token": 15e-6,
+            "cache_read_input_token_cost": 3e-7,
+            "cache_creation_input_token_cost": 3.75e-6,
+        },
+    )
+
+    assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3.75e-6) / 2)
+    assert completion_cost_value == pytest.approx(200 * 15e-6 / 2)
+
+
+def test_batch_cost_calculator_cache_creation_falls_back_to_input_rate():
+    from litellm.cost_calculator import batch_cost_calculator
+
+    prompt_cost, _ = batch_cost_calculator(
+        usage=_batch_cache_usage(),
+        model="claude-sonnet-4-5-20250929",
+        custom_llm_provider="anthropic",
+        model_info={  # type: ignore[arg-type]
+            "input_cost_per_token": 3e-6,
+            "output_cost_per_token": 15e-6,
+            "cache_read_input_token_cost": 3e-7,
+        },
+    )
+
+    assert prompt_cost == pytest.approx((1000 * 3e-6 + 8000 * 3e-7 + 2000 * 3e-6) / 2)


### PR DESCRIPTION
## Relevant issues

Related: #24204, #11364

## Linear ticket

Resolves LIT-4008

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live e2e before/after against the real Anthropic API through a local proxy, real batches billed by Anthropic, no mocks. Config is one model_list entry (`model_name: claude-opus-4-6`, `model: anthropic/claude-opus-4-6`) with `PROXY_BATCH_POLLING_INTERVAL=60` so the CheckBatchCost job runs every minute. Same commands in both runs, each against a fresh database; only the checked-out commit differs

### Before (commit 76eeaf2381)

Create a message batch through the passthrough:

```bash
curl -s http://localhost:61304/anthropic/v1/messages/batches \
  -H "Authorization: Bearer sk-...xxxx" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"requests":[{"custom_id":"qa-before-1","params":{"model":"claude-opus-4-6","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}]}},{"custom_id":"qa-before-2","params":{"model":"claude-opus-4-6","max_tokens":32,"messages":[{"role":"user","content":"Say bye"}]}}]}'
```

```json
{"id":"msgbatch_01TQuNX53hJWH8GY9Dvk8CaZ","type":"message_batch","processing_status":"in_progress","request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}, ...}
```

Poll until it ends, then fetch the results to show both requests really completed:

```bash
curl -s http://localhost:61304/anthropic/v1/messages/batches/msgbatch_01TQuNX53hJWH8GY9Dvk8CaZ \
  -H "Authorization: Bearer sk-...xxxx" -H "anthropic-version: 2023-06-01"
# ... "processing_status":"ended","request_counts":{"processing":0,"succeeded":2, ...}

curl -s http://localhost:61304/anthropic/v1/messages/batches/msgbatch_01TQuNX53hJWH8GY9Dvk8CaZ/results \
  -H "Authorization: Bearer sk-...xxxx" -H "anthropic-version: 2023-06-01"
```

```json
{"custom_id":"qa-before-1","result":{"type":"succeeded","message":{"model":"claude-opus-4-6", ..., "content":[{"type":"text","text":"Hi there! ..."}],"usage":{"input_tokens":9, ..., "output_tokens":25,"service_tier":"batch"}}}}
{"custom_id":"qa-before-2","result":{"type":"succeeded","message":{"model":"claude-opus-4-6", ..., "content":[{"type":"text","text":"Bye! ..."}],"usage":{"input_tokens":9, ..., "output_tokens":16,"service_tier":"batch"}}}}
```

The next CheckBatchCost cycle fetches the results from the OpenAI-shaped files endpoint; Anthropic rejects it and the error body is swallowed as file content (proxy log):

```
POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/files/msgbatch_01TQuNX53hJWH8GY9Dvk8CaZ/content \
-H 'x-api-key: sk-ant-...xxxx' -H 'anthropic-version: 2023-06-01' -H 'anthropic-beta: files-api-2025-04-14' \
-d '{}'

batch_utils.py:291 - json_objects=[
    {
        "type": "error",
        "error": {
            "type": "invalid_request_error",
            "message": "File id must have `file_` prefix."
        },
        "request_id": "req_011CcmvZkS7vsYTbAztg4dVZ"
    }
]
```

The job records $0 and permanently marks the batch processed:

```
$ psql litellm_qa_lit4008_before -c 'SELECT call_type, model, spend, total_tokens, prompt_tokens, completion_tokens FROM "LiteLLM_SpendLogs" WHERE call_type = '"'"'aretrieve_batch'"'"';'
    call_type    |      model      | spend | total_tokens | prompt_tokens | completion_tokens
-----------------+-----------------+-------+--------------+---------------+-------------------
 aretrieve_batch | claude-opus-4-6 |     0 |            0 |             0 |                 0

$ psql litellm_qa_lit4008_before -c 'SELECT model_object_id, status, batch_processed FROM "LiteLLM_ManagedObjectTable";'
          model_object_id          |  status  | batch_processed
-----------------------------------+----------+-----------------
 msgbatch_01TQuNX53hJWH8GY9Dvk8CaZ | complete | t
```

18 real input tokens and 41 real output tokens billed by Anthropic, tracked as $0 forever

### After (commit 65a34a03ec)

Same commands, fresh database:

```bash
curl -s http://localhost:64900/anthropic/v1/messages/batches \
  -H "Authorization: Bearer sk-...xxxx" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"requests":[{"custom_id":"qa-after-1","params":{"model":"claude-opus-4-6","max_tokens":32,"messages":[{"role":"user","content":"Say hi"}]}},{"custom_id":"qa-after-2","params":{"model":"claude-opus-4-6","max_tokens":32,"messages":[{"role":"user","content":"Say bye"}]}}]}'
```

```json
{"id":"msgbatch_011RLULF5pVTevaJP7k9dyCJ","type":"message_batch","processing_status":"in_progress","request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0}, ...}
```

```bash
curl -s http://localhost:64900/anthropic/v1/messages/batches/msgbatch_011RLULF5pVTevaJP7k9dyCJ \
  -H "Authorization: Bearer sk-...xxxx" -H "anthropic-version: 2023-06-01"
# ... "processing_status":"ended","request_counts":{"processing":0,"succeeded":2, ...}

curl -s http://localhost:64900/anthropic/v1/messages/batches/msgbatch_011RLULF5pVTevaJP7k9dyCJ/results \
  -H "Authorization: Bearer sk-...xxxx" -H "anthropic-version: 2023-06-01"
```

```json
{"custom_id":"qa-after-1","result":{"type":"succeeded","message":{"model":"claude-opus-4-6", ..., "content":[{"type":"text","text":"Hi there! ..."}],"usage":{"input_tokens":9, ..., "output_tokens":25,"service_tier":"batch"}}}}
{"custom_id":"qa-after-2","result":{"type":"succeeded","message":{"model":"claude-opus-4-6", ..., "content":[{"type":"text","text":"Bye! ..."}],"usage":{"input_tokens":9, ..., "output_tokens":18,"service_tier":"batch"}}}}
```

The next CheckBatchCost cycle now fetches from the message batches results endpoint (proxy log; the pre-call debug template always prints "curl -X POST" but the handler issues a GET):

```
check_batch_cost.py:307 - Batch ID: msgbatch_011RLULF5pVTevaJP7k9dyCJ is complete, tracking cost and usage

POST Request Sent from LiteLLM:
curl -X POST \
https://api.anthropic.com/v1/messages/batches/msgbatch_011RLULF5pVTevaJP7k9dyCJ/results \
-H 'x-api-key: sk-ant-...xxxx' -H 'anthropic-version: 2023-06-01' -H 'anthropic-beta: files-api-2025-04-14' \
-d '{}'

spend_tracking_utils.py:443 - SpendTable: created payload - request_id: 02d0208138b1bbe065782bb99c59f745, model: claude-opus-4-6, spend: 0.0005825
```

and the spend row carries the real cost and token counts:

```
$ psql litellm_qa_lit4008_after2 -c 'SELECT call_type, model, spend, total_tokens, prompt_tokens, completion_tokens FROM "LiteLLM_SpendLogs" WHERE call_type = '"'"'aretrieve_batch'"'"';'
    call_type    |      model      |   spend   | total_tokens | prompt_tokens | completion_tokens
-----------------+-----------------+-----------+--------------+---------------+-------------------
 aretrieve_batch | claude-opus-4-6 | 0.0005825 |           61 |            18 |                43

$ psql litellm_qa_lit4008_after2 -c 'SELECT model_object_id, status, batch_processed FROM "LiteLLM_ManagedObjectTable";'
          model_object_id          |  status  | batch_processed
-----------------------------------+----------+-----------------
 msgbatch_011RLULF5pVTevaJP7k9dyCJ | complete | t
```

The dollar amount is exact: (18 input tokens x $5/M + 43 output tokens x $25/M) x 50% batch discount = $0.0005825. This batch uses no prompt caching, so the cache-detail aggregation added at this commit leaves `prompt_tokens_details` unset in the spend log's usage object and the token totals are unchanged

## Type

🐛 Bug Fix

## Changes

Anthropic Message Batches created through the proxy's `/anthropic/v1/messages/batches` passthrough never got cost attributed. When the CheckBatchCost background job saw a completed anthropic batch, it fetched the results with an OpenAI-shaped files call (`POST /v1/files/msgbatch_.../content`), which Anthropic rejects with "File id must have `file_` prefix". The error body was silently wrapped as file content, parsed as a results file with zero successful rows, and the job wrote a $0 `aretrieve_batch` spend row and set `batch_processed=true`, making the $0 permanent

The fix lands at four layers. `AnthropicFilesConfig.transform_file_content_request` now routes `msgbatch_` file ids to `GET /v1/messages/batches/{id}/results`, the endpoint where Anthropic actually serves batch results, so `afile_content` works for anthropic batch output files without any poller-side branching. `BaseLLMHTTPHandler.retrieve_file_content` (sync and async) now raises the provider error class on a non-2xx response instead of returning the error body as binary file content. `litellm/batches/batch_utils.py` now understands Anthropic's results JSONL shape: success is `result.type == "succeeded"` rather than `response.status_code == 200`, the response body is `result.message`, and usage is converted through the existing `AnthropicConfig.calculate_usage` helper so `cache_creation_input_tokens` and `cache_read_input_tokens` are counted. `batch_cost_calculator` now prices cache creation tokens at `cache_creation_input_token_cost / 2` instead of folding them into the base input rate, keeping the 50% anthropic batch discount correct for base input, cache reads, cache writes, and output alike

CheckBatchCost also no longer treats a cost tracking failure as terminal. The completed-batch handling moved into `_track_completed_batch_cost`, and any results-fetch or cost-computation error now logs, records a `cost_tracking_error` metric, and leaves the row with `batch_processed=false` so the next poll retries, instead of the previous behavior where the swallowed error produced a permanently recorded $0

No `*_batches` pricing keys were added to the cost map on purpose: `batch_cost_calculator`'s fallback already bills at half the regular token rate, which is exactly Anthropic's 50% batch discount, while the `*_batches` fast path ignores cache tokens entirely, so adding those keys would have priced cache-heavy batches worse

A follow-up commit also aggregates cache token details into the batch-level `Usage`: `_get_batch_job_total_usage_from_file_content` now sums per-row cache read and cache creation tokens and carries them on the aggregated usage (`prompt_tokens_details.cached_tokens` / `cache_creation_tokens`), so the `aretrieve_batch` spend log row exposes the cache split instead of a single prompt-token lump. Purely OpenAI-shaped batches without cache data keep `prompt_tokens_details` unset

Regression tests cover the msgbatch_ results-endpoint routing, the raise-on-HTTP-error behavior in `retrieve_file_content`, the anthropic JSONL success/usage/cost parsing (including exact 50% cache-aware pricing math), the cache-creation pricing in `batch_cost_calculator`, and that a failed cost tracking attempt leaves the managed object row unprocessed, and that the aggregated batch usage carries the summed cache read and cache creation token details

