### PR TITLE
fix(router): apply weighted-failover exclusion before deployment-affinity callback

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10297,6 +10297,15 @@ class Router:
 
         healthy_deployments = self._filter_blocked_deployments(healthy_deployments)
 
+        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
+        ## this request via weighted-failover. Always honored, regardless of the
+        ## router-level flag, so a stale exclusion key on kwargs cannot escape.
+        _excluded_deployment_ids = (request_kwargs or {}).pop("_excluded_deployment_ids", None)
+        healthy_deployments = litellm.utils._get_excluded_filtered_deployments(
+            cast(List[Dict], healthy_deployments),
+            excluded_deployment_ids=_excluded_deployment_ids,
+        )
+
         healthy_deployments = await self.async_callback_filter_deployments(
             model=model,
             healthy_deployments=healthy_deployments,
@@ -10325,15 +10334,6 @@ class Router:
         _target_order = (request_kwargs or {}).pop("_target_order", None)
         healthy_deployments = litellm.utils._get_order_filtered_deployments(
             cast(List[Dict], healthy_deployments), target_order=_target_order
-        )
-
-        ## WEIGHTED FAILOVER EXCLUSION ## -> drop deployments already tried in
-        ## this request via weighted-failover. Always honored, regardless of the
-        ## router-level flag, so a stale exclusion key on kwargs cannot escape.
-        _excluded_deployment_ids = (request_kwargs or {}).pop("_excluded_deployment_ids", None)
-        healthy_deployments = litellm.utils._get_excluded_filtered_deployments(
-            cast(List[Dict], healthy_deployments),
-            excluded_deployment_ids=_excluded_deployment_ids,
         )
 
         if len(healthy_deployments) == 0:

--- a/tests/test_litellm/test_router_weighted_failover.py
+++ b/tests/test_litellm/test_router_weighted_failover.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import litellm
 from litellm import Router
+from litellm.router_utils.pre_call_checks.deployment_affinity_check import (
+    DeploymentAffinityCheck,
+)
 from litellm.utils import _get_excluded_filtered_deployments
 
 
@@ -769,3 +773,64 @@ async def test_failover_falls_through_to_external_fallback_when_remaining_in_coo
         )
 
     assert response._hidden_params["model_id"] == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_weighted_failover_exclusion_runs_before_affinity_callback():
+    """Regression: the weighted-failover exclusion must be applied before the
+    deployment-affinity callback in async_get_healthy_deployments. Otherwise a
+    session pinned to the just-failed deployment collapses the candidate set to
+    that one deployment, the exclusion then empties it, and the request escapes
+    to cross-group fallback even though a healthy sibling in the same group is
+    available."""
+    callbacks_snapshot = list(litellm.callbacks)
+    try:
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-4o", "api_key": "key"},
+                    "model_info": {"id": "dep-a"},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-4o", "api_key": "key"},
+                    "model_info": {"id": "dep-b"},
+                },
+            ],
+            routing_strategy="simple-shuffle",
+            enable_weighted_failover=True,
+            optional_pre_call_checks=["session_affinity"],
+        )
+
+        affinity_check = next(
+            c
+            for c in (router.optional_callbacks or [])
+            if isinstance(c, DeploymentAffinityCheck)
+        )
+        session_id = "sess-abc"
+        await affinity_check.cache.async_set_cache(
+            DeploymentAffinityCheck.get_session_affinity_cache_key(
+                model_group="test-model", session_id=session_id
+            ),
+            {"model_id": "dep-a"},
+        )
+
+        pinned = await router.async_get_healthy_deployments(
+            model="test-model",
+            request_kwargs={"metadata": {"session_id": session_id}},
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert {d["model_info"]["id"] for d in pinned} == {"dep-a"}
+
+        rerouted = await router.async_get_healthy_deployments(
+            model="test-model",
+            request_kwargs={
+                "metadata": {"session_id": session_id},
+                "_excluded_deployment_ids": ["dep-a"],
+            },
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert {d["model_info"]["id"] for d in rerouted} == {"dep-b"}
+    finally:
+        litellm.callbacks[:] = callbacks_snapshot


### PR DESCRIPTION
## Relevant issues

Fixes #32308

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

A model group with both weighted failover and deployment affinity (session_affinity or similar) enabled can silently lose same-group failover. When a request fails over, weighted failover excludes the failed deployment for the retry, but async_get_healthy_deployments runs the affinity callback before applying that exclusion. If the affinity cache still points at the just-failed deployment, the callback narrows the candidate list down to that one deployment before the exclusion filter gets a chance to remove it, the list ends up empty, and the retry falls through to cross-group fallback even though a healthy same-group sibling exists. This is the same shape as #29760 and the /v1/messages fix in #31679: an exclusion computed for a retry is applied after another filter has already collapsed the candidate set.

The fix moves the weighted-failover exclusion filter in async_get_healthy_deployments to run immediately after the existing blocked-deployment filter, ahead of the affinity callback, instead of at the end of the filter pipeline. This treats a weighted-failover exclusion the same as a cooldown or blocked deployment: a hard pre-filter that every later stage already sees, not something applied as an afterthought. The affinity check already verifies its pinned deployment is still in the candidate set and falls back to the full set when it is not, so removing the excluded deployment first is exactly what makes it stop re-pinning to the dead one. Only the async path is touched; the sync get_available_deployment path has no callback-filter step and is unaffected.

One regression test was added to tests/test_litellm/test_router_weighted_failover.py. It pins a session to deployment A, then asserts two things: with nothing excluded the affinity pin still returns A (affinity unchanged), and with A excluded async_get_healthy_deployments now returns the healthy sibling B instead of emptying out and raising RouterRateLimitError. The test fails if the exclusion filter is moved back after the affinity callback.

## Screenshots / Proof of Fix

Live proxy on localhost:4000, no real keys needed because the failing deployment is forced with mock_response. The affinity pin is written when a deployment is selected (pre-call), so a single request reproduces it: the request is picked on the failing A, which pins the session to A, then fails, and the weighted-failover retry has to get past the stale A pin to reach B.

config.yaml:

```yaml
model_list:
  - model_name: claude-group
    litellm_params:
      model: gpt-4o
      mock_response: "litellm.RateLimitError"
      api_key: sk-fake
      weight: 100
    model_info:
      id: dep-a
  - model_name: claude-group
    litellm_params:
      model: gpt-4o
      mock_response: "served by B, the healthy sibling"
      api_key: sk-fake
    model_info:
      id: dep-b
  - model_name: gpt-fallback
    litellm_params:
      model: gpt-4o
      mock_response: "served by the cross-group fallback"
      api_key: sk-fake

router_settings:
  routing_strategy: simple-shuffle
  enable_weighted_failover: true
  optional_pre_call_checks: ["session_affinity"]
  fallbacks: [{"claude-group": ["gpt-fallback"]}]
```

```bash
litellm --config config.yaml

curl -s http://localhost:4000/chat/completions \
  -H "content-type: application/json" \
  -H "x-litellm-session-id: sess-1" \
  -d '{"model": "claude-group", "messages": [{"role": "user", "content": "hi"}]}'
```

Before the fix (commit a1873d8): the reply comes from the cross-group fallback, because the stale pin to A collapses the retry and weighted failover gives up. After the fix (commit 9912e4b): the reply comes from B, the healthy sibling in the same group.
