### PR TITLE
fix(ollama_chat): ignore empty tool calls in streaming responses

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -429,6 +429,7 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    saw_tool_calls: bool = False
 
     def _is_function_call_complete(self, function_args: Union[str, dict]) -> bool:
         if isinstance(function_args, dict):
@@ -473,7 +474,8 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             # process tool calls - if complete function arg - add id to tool call
             tool_calls = chunk["message"].get("tool_calls")
-            if tool_calls is not None:
+            if tool_calls:
+                self.saw_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
@@ -516,7 +518,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
                 finish_reason = chunk.get("done_reason") or "stop"
                 # Override finish_reason when tool_calls are present
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                if tool_calls or self.saw_tool_calls:
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -468,7 +468,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             # process tool calls - if complete function arg - add id to tool call
             tool_calls: Final = chunk["message"].get("tool_calls")
-            if tool_calls is not None:
+            if tool_calls:
                 self.seen_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -480,6 +480,71 @@ class TestOllamaToolCalling:
         assert result.choices[0].finish_reason == "stop"
         assert result.choices[0].message.tool_calls is None
 
+    def test_tool_calls_streaming(self):
+        """Streaming: native Ollama tool_calls must surface with string arguments, and the
+        terminal chunk must report finish_reason='tool_calls'.
+
+        Ollama /api/chat streams the tool call in a non-final chunk (done=False) and then
+        sends a SEPARATE terminal chunk (done=True, done_reason='stop') that carries no
+        tool_calls. finish_reason must still be upgraded to 'tool_calls' on that terminal
+        chunk so clients execute the tool. Regression guard for
+        https://github.com/BerriAI/litellm/issues/24091 on the streaming path; the
+        non-streaming path is covered by test_finish_reason_tool_calls_non_streaming.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:4b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "Beijing", "date": "tomorrow"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        tool_result = iterator.chunk_parser(tool_call_chunk)
+
+        assert tool_result.choices[0].finish_reason is None
+
+        tool_calls = tool_result.choices[0].delta.tool_calls
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+
+        tool_call = tool_calls[0]
+        assert tool_call.index == 0
+        assert tool_call.id is not None and tool_call.id != ""
+        assert tool_call.type == "function"
+        assert tool_call.function.name == "get_weather"
+        assert isinstance(tool_call.function.arguments, str)
+        assert json.loads(tool_call.function.arguments) == {
+            "location": "Beijing",
+            "date": "tomorrow",
+        }
+
+        done_chunk = {
+            "model": "qwen3:4b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        }
+
+        done_result = iterator.chunk_parser(done_chunk)
+
+        assert done_result.choices[0].finish_reason == "tool_calls"
+
 
 class TestOllamaFinishReasonLength:
     """Tests for done_reason 'length' → finish_reason 'length' mapping.

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -1,7 +1,7 @@
 import inspect
 import os
 import sys
-from typing import cast
+from typing import Final, cast
 
 import pytest
 from pydantic import BaseModel
@@ -477,6 +477,105 @@ class TestOllamaToolCalling:
         # finish_reason should be "stop" (default behavior)
         assert result.choices[0].finish_reason == "stop"
         assert result.choices[0].message.tool_calls is None
+
+    def test_tool_calls_streaming(self):
+        """Streaming: native Ollama tool_calls must surface with string arguments, and the
+        terminal chunk must report finish_reason='tool_calls'.
+
+        Ollama /api/chat streams the tool call in a non-final chunk (done=False) and then
+        sends a SEPARATE terminal chunk (done=True, done_reason='stop') that carries no
+        tool_calls. finish_reason must still be upgraded to 'tool_calls' on that terminal
+        chunk so clients execute the tool. Regression guard for
+        https://github.com/BerriAI/litellm/issues/24091 on the streaming path; the
+        non-streaming path is covered by test_finish_reason_tool_calls_non_streaming.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:4b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "Beijing", "date": "tomorrow"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        tool_result = iterator.chunk_parser(tool_call_chunk)
+
+        assert tool_result.choices[0].finish_reason is None
+
+        tool_calls = tool_result.choices[0].delta.tool_calls
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+
+        tool_call = tool_calls[0]
+        assert tool_call.index == 0
+        assert tool_call.id is not None and tool_call.id != ""
+        assert tool_call.type == "function"
+        assert tool_call.function.name == "get_weather"
+        assert isinstance(tool_call.function.arguments, str)
+        assert json.loads(tool_call.function.arguments) == {
+            "location": "Beijing",
+            "date": "tomorrow",
+        }
+
+        done_chunk = {
+            "model": "qwen3:4b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        }
+
+        done_result = iterator.chunk_parser(done_chunk)
+
+        assert done_result.choices[0].finish_reason == "tool_calls"
+
+    @pytest.mark.parametrize("done_reason", ["stop", "length"])
+    @pytest.mark.parametrize("empty_calls_in_terminal_chunk", [False, True])
+    def test_empty_tool_calls_preserve_finish_reason(
+        self, done_reason: str, empty_calls_in_terminal_chunk: bool
+    ) -> None:
+        iterator: Final = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+        content_result: Final = iterator.chunk_parser(
+            {
+                "model": "qwen3:4b",
+                "message": {"role": "assistant", "content": "Hello", "tool_calls": []},
+                "done": False,
+            }
+        )
+        done_result: Final = iterator.chunk_parser(
+            {
+                "model": "qwen3:4b",
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    **({"tool_calls": []} if empty_calls_in_terminal_chunk else {}),
+                },
+                "done": True,
+                "done_reason": done_reason,
+            }
+        )
+
+        assert content_result.choices[0].finish_reason is None
+        assert not content_result.choices[0].delta.tool_calls
+        assert done_result.choices[0].finish_reason == done_reason
+        assert not done_result.choices[0].delta.tool_calls
 
 
 class TestOllamaFinishReasonLength:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Empty Ollama tool-call lists incorrectly produce `finish_reason: tool_calls`

How it solves it:

- Track tool calls only when the list is nonempty
- Preserve `stop` and `length` when no tools were called

Upstream #39010 now includes the original fix for tool calls arriving before the final chunk. Its `seen_tool_calls` flag serves the same purpose as this PR's original `saw_tool_calls`, so the rebase removes the duplicate flag and uses upstream's implementation. The flag is still set when any chunk contains tool calls and checked on the final chunk, even when that final chunk has no calls

The PR still fixes an empty-list case: upstream's `if tool_calls is not None` sets `seen_tool_calls` for `tool_calls: []`, incorrectly overriding `stop` or `length` with `tool_calls`. This revision uses `if tool_calls` so only nonempty lists set the flag, and retains regression coverage for tool-call serialization

## User Flow

Before: a streamed response can report a tool call when none exists

1. Send `POST http://localhost:4000/v1/chat/completions` with an `ollama_chat` model, messages, tool definitions, and `"stream": true`
2. Ollama returns text with an empty `tool_calls` list and finishes with `stop` or `length`
3. The final event incorrectly reports `finish_reason: tool_calls` without any tool to execute

After: the same response retains its actual finish reason

1. Send `POST http://localhost:4000/v1/chat/completions` with an `ollama_chat` model, messages, tool definitions, and `"stream": true`
2. Ollama returns text with an empty `tool_calls` list and finishes with `stop` or `length`
3. The final event correctly reports `finish_reason: stop` or `finish_reason: length`

## Relevant issues

Related to #24091 and #34692. Builds on #39010

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] The test files covering my change pass locally
- [ ] My PR passes all required CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 for this revision before requesting a maintainer review

## Validation

`make lint BASE_REF=origin/litellm_internal_staging` passed

The Ollama unit tests and Anthropic streaming stop-reason adapter tests passed: 79 tests

```bash
.venv/bin/pytest tests/test_litellm/llms/ollama tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_stop_reason.py -q
```

Cross-checked against upstream `1af7a403c6` in a separate checkout with unchanged production code and this PR's test file. The two real-tool-call streaming cases pass on both upstream and PR commit `f92ef4da3a`. All four empty-list cases fail on upstream because the final reason becomes `tool_calls`, and all four pass on this PR. The remaining fix is therefore still needed

Run the same selection on each checkout:

```bash
python -m pytest tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py -q -k 'test_tool_calls_streaming or test_finish_reason_tool_calls_streamed_before_done_chunk or test_empty_tool_calls_preserve_finish_reason' --tb=short
```

Upstream: `4 failed, 2 passed`. PR: `6 passed`

Greptile reviewed `f92ef4da3a` and returned a Confidence Score of 5/5

## Screenshots / Proof of Fix

Fresh live Ollama validation on this revision is pending; Ollama is not installed on this machine

## Type

Bug Fix

## Caveats

### Low

Local checks passed and Greptile returned 5/5. The provider and enterprise test jobs passed, but their coverage upload jobs failed at `Download coverage report` with `Failed to ListArtifacts` and HTTP `403 Forbidden`, before reaching Codecov: [provider upload](https://github.com/BerriAI/litellm/actions/runs/34248637774/job/102139317673), [enterprise upload](https://github.com/BerriAI/litellm/actions/runs/34248637774/job/102139371816)

Both saved coverage artifacts exist. Inspection of `coverage-llm-other-providers-34248637774-1` confirms that the changed production line, `transformation.py:471`, was executed by CI. This failure is in artifact retrieval rather than a coverage threshold

Maintainer action is needed: rerun the affected provider and enterprise test jobs with their dependent coverage uploads. Rerunning tests also regenerates artifacts with the new attempt number expected by the upload jobs. GitHub denied the author's rerun request with HTTP 403, `Must have admin rights to Repository`

## Final Attestation

- [x] Tests cover real streamed tool-call arguments and empty lists with both `stop` and `length` finish reasons
