### PR TITLE
fix(github_copilot): route gpt-5.4+ tool calls with reasoning_effort to /v1/responses

### DIFF
--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -44,14 +44,21 @@ def github_copilot_supports_responses_api(model: str) -> bool:
     """
     Gate native /v1/responses dispatch per github_copilot model.
 
-    Resolution (first match wins): mode "responses" -> True; mode "chat" ->
-    False (opt-out wins for dual-endpoint models); "/v1/responses" in
-    supported_endpoints -> True; else False. Unknown model -> False (the bridge
-    always works since every Copilot model supports /chat/completions).
+    Resolution (first match wins): gpt-5.4+ -> True (responses-capable even
+    though the map default mode is "chat", so tools + reasoning_effort can be
+    bridged); mode "responses" -> True; mode "chat" -> False (opt-out wins for
+    dual-endpoint models); "/v1/responses" in supported_endpoints -> True; else
+    False. Unknown model -> False (the bridge always works since every Copilot
+    model supports /chat/completions).
 
     Reads merged model info (per-deployment model_info applied via the router's
     register_model, which also clears the cache used here).
     """
+    from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+
+    if OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model):
+        return True
+
     try:
         info = _cached_get_model_info_helper(model=model, custom_llm_provider="github_copilot")
     except Exception as e:

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -43,14 +43,21 @@ def github_copilot_supports_responses_api(model: str) -> bool:
     """
     Gate native /v1/responses dispatch per github_copilot model.
 
-    Resolution (first match wins): mode "responses" -> True; mode "chat" ->
-    False (opt-out wins for dual-endpoint models); "/v1/responses" in
-    supported_endpoints -> True; else False. Unknown model -> False (the bridge
-    always works since every Copilot model supports /chat/completions).
+    Resolution (first match wins): gpt-5.4+ -> True (responses-capable even
+    though the map default mode is "chat", so tools + reasoning_effort can be
+    bridged); mode "responses" -> True; mode "chat" -> False (opt-out wins for
+    dual-endpoint models); "/v1/responses" in supported_endpoints -> True; else
+    False. Unknown model -> False (the bridge always works since every Copilot
+    model supports /chat/completions).
 
     Reads merged model info (per-deployment model_info applied via the router's
     register_model, which also clears the cache used here).
     """
+    from litellm.llms.openai.chat.gpt_5_transformation import OpenAIGPT5Config
+
+    if OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model):
+        return True
+
     try:
         info: Final = _cached_get_model_info_helper(model=model, custom_llm_provider="github_copilot")
     except Exception as e:

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -115,6 +115,37 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
+    def is_gpt5_responses_bridge_case(
+        cls,
+        model: str,
+        custom_llm_provider: str,
+        current_mode: Optional[str],
+        has_tools: bool,
+        has_reasoning_effort: bool,
+        has_reasoning_summary: bool,
+    ) -> bool:
+        """Whether a GPT-5 chat/completions request must be bridged to the Responses API.
+
+        Chat Completions rejects Responses-only fields (e.g. ``reasoningSummary``) and,
+        for gpt-5.4+, rejects function tools combined with ``reasoning_effort``; those
+        combinations are transparently upgraded to /v1/responses instead. Applies to the
+        OpenAI-family chat providers (openai, azure, github_copilot). The reasoning-summary
+        alias path stays openai/azure-only; github_copilot bridges only the gpt-5.4+ tools
+        path.
+        """
+        if custom_llm_provider not in ("openai", "azure", "github_copilot"):
+            return False
+        if current_mode == "responses":
+            return False
+        if not cls.is_model_gpt_5_model(model) or cls.is_model_gpt_5_search_model(model):
+            return False
+        if not has_reasoning_effort:
+            return False
+        if has_reasoning_summary and custom_llm_provider in ("openai", "azure"):
+            return True
+        return cls.is_model_gpt_5_4_plus_model(model) and has_tools
+
+    @classmethod
     def _supports_reasoning_effort_level(cls, model: str, level: str) -> bool:
         """Check if the model supports a specific reasoning_effort level.
 

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -128,6 +128,37 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
+    def is_gpt5_responses_bridge_case(
+        cls,
+        model: str,
+        custom_llm_provider: str,
+        is_responses_mode: bool,
+        has_function_tool: bool,
+        has_reasoning_effort: bool,
+        has_reasoning_summary: bool,
+        reasoning_active: bool,
+        on_constraint_enforcing_endpoint: bool,
+    ) -> bool:
+        """Whether a GPT-5 chat request needs the Responses API for its tools or reasoning."""
+        if custom_llm_provider not in ("openai", "azure", "github_copilot"):
+            return False
+        if is_responses_mode:
+            return False
+        if not cls.is_model_gpt_5_model(model) or cls.is_model_gpt_5_search_model(model):
+            return False
+        if has_reasoning_effort and has_reasoning_summary and custom_llm_provider in ("openai", "azure"):
+            return True
+        return (
+            cls.is_model_gpt_5_4_plus_model(model)
+            and has_function_tool
+            and reasoning_active
+            and (
+                has_reasoning_effort
+                or (custom_llm_provider in ("openai", "azure") and on_constraint_enforcing_endpoint)
+            )
+        )
+
+    @classmethod
     def _model_map_lookup_name(cls, model: str) -> str:
         """The name this model is looked up by in the cost map.
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1010,12 +1010,15 @@ def responses_api_bridge_check(
     # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
     #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).
     if (
-        custom_llm_provider in ("openai", "azure")
+        custom_llm_provider in ("openai", "azure", "github_copilot")
         and model_info.get("mode") != "responses"
         and OpenAIGPT5Config.is_model_gpt_5_model(model)
         and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
         and reasoning_effort is not None
-        and (reasoning_summary is not None or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools))
+        and (
+            (reasoning_summary is not None and custom_llm_provider in ("openai", "azure"))
+            or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools)
+        )
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1002,23 +1002,13 @@ def responses_api_bridge_check(
             mode = "responses"
             model_info["mode"] = mode
 
-    # OpenAI/Azure GPT-5 chat-completions that need Responses-only fields (e.g.
-    # ``reasoningSummary`` in ``extra_body``) must be bridged; Chat Completions rejects
-    # those keys.
-    #
-    # - gpt-5.4+: tools + reasoning_effort (original) or any reasoning-summary alias.
-    # - Older GPT-5 names (e.g. ``gpt-5``, ``gpt-5.1``): bridge only when a reasoning
-    #   summary alias is present with ``reasoning_effort`` (tools alone stay on chat).
-    if (
-        custom_llm_provider in ("openai", "azure", "github_copilot")
-        and model_info.get("mode") != "responses"
-        and OpenAIGPT5Config.is_model_gpt_5_model(model)
-        and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
-        and reasoning_effort is not None
-        and (
-            (reasoning_summary is not None and custom_llm_provider in ("openai", "azure"))
-            or (OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model) and tools)
-        )
+    if OpenAIGPT5Config.is_gpt5_responses_bridge_case(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        current_mode=model_info.get("mode"),
+        has_tools=bool(tools),
+        has_reasoning_effort=reasoning_effort is not None,
+        has_reasoning_summary=reasoning_summary is not None,
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1087,17 +1087,24 @@ def responses_api_bridge_check(
         custom_llm_provider == "azure" or resolved_api_base == "" or _is_openai_backed_api_base(resolved_api_base)
     )
     if (
-        custom_llm_provider in ("openai", "azure")
+        custom_llm_provider in ("openai", "azure", "github_copilot")
         and model_info.get("mode") != "responses"
         and OpenAIGPT5Config.is_model_gpt_5_model(model)
         and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
         and (
-            (reasoning_effort is not None and reasoning_summary is not None)
+            (
+                reasoning_effort is not None
+                and reasoning_summary is not None
+                and custom_llm_provider in ("openai", "azure")
+            )
             or (
                 OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
                 and has_function_tool
                 and reasoning_active
-                and (reasoning_effort is not None or on_constraint_enforcing_endpoint)
+                and (
+                    reasoning_effort is not None
+                    or (custom_llm_provider in ("openai", "azure") and on_constraint_enforcing_endpoint)
+                )
             )
         )
     ):

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -1086,27 +1086,15 @@ def responses_api_bridge_check(
     on_constraint_enforcing_endpoint: Final = (
         custom_llm_provider == "azure" or resolved_api_base == "" or _is_openai_backed_api_base(resolved_api_base)
     )
-    if (
-        custom_llm_provider in ("openai", "azure", "github_copilot")
-        and model_info.get("mode") != "responses"
-        and OpenAIGPT5Config.is_model_gpt_5_model(model)
-        and not OpenAIGPT5Config.is_model_gpt_5_search_model(model)
-        and (
-            (
-                reasoning_effort is not None
-                and reasoning_summary is not None
-                and custom_llm_provider in ("openai", "azure")
-            )
-            or (
-                OpenAIGPT5Config.is_model_gpt_5_4_plus_model(model)
-                and has_function_tool
-                and reasoning_active
-                and (
-                    reasoning_effort is not None
-                    or (custom_llm_provider in ("openai", "azure") and on_constraint_enforcing_endpoint)
-                )
-            )
-        )
+    if OpenAIGPT5Config.is_gpt5_responses_bridge_case(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        is_responses_mode=model_info.get("mode") == "responses",
+        has_function_tool=has_function_tool,
+        has_reasoning_effort=reasoning_effort is not None,
+        has_reasoning_summary=reasoning_summary is not None,
+        reasoning_active=reasoning_active,
+        on_constraint_enforcing_endpoint=on_constraint_enforcing_endpoint,
     ):
         model_info["mode"] = "responses"
         model = model.replace("responses/", "")

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -586,6 +586,34 @@ class TestGithubCopilotResponsesAPIRouting:
         )
         assert isinstance(config, GithubCopilotResponsesAPIConfig)
 
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._cached_get_model_info_helper"
+    )
+    def test_gpt_5_4_returns_config_even_when_mode_is_chat(self, mock_get_info):
+        """gpt-5.4+ is responses-capable and overrides the ``mode=chat`` opt-out.
+
+        Regression for https://github.com/BerriAI/litellm/issues/23156. The catalog
+        default for gpt-5.4 is ``mode=chat``, but tools + reasoning_effort must be
+        bridgeable to /v1/responses; without this the completion() responses bridge
+        would receive a None config and bounce the request back to /v1/chat/completions."""
+        mock_get_info.return_value = {"mode": "chat"}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/gpt-5.4",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    def test_gpt_5_4_returns_native_config_without_catalog_entry(self):
+        """github_copilot/gpt-5.4 has no catalog entry, yet must still resolve to the
+        native responses config via the name-based gpt-5.4+ capability check so the
+        bridge can route tools + reasoning_effort. Exercises the real
+        ``_cached_get_model_info_helper`` plumbing (no mock)."""
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/gpt-5.4",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
 
 class TestGithubCopilotReasoningStreamItemIdNormalization:
     """GitHub Copilot's native /responses stream tags every reasoning-summary

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -582,17 +582,24 @@ class TestGithubCopilotResponsesAPIRouting:
         )
         assert isinstance(config, GithubCopilotResponsesAPIConfig)
 
-    @patch(
-        "litellm.llms.github_copilot.responses.transformation._cached_get_model_info_helper"
-    )
-    def test_gpt_5_4_returns_config_even_when_mode_is_chat(self, mock_get_info):
+    def test_gpt_5_4_returns_config_even_when_mode_is_chat(self) -> None:
         """gpt-5.4+ is responses-capable and overrides the ``mode=chat`` opt-out.
 
         Regression for https://github.com/BerriAI/litellm/issues/23156. The catalog
         default for gpt-5.4 is ``mode=chat``, but tools + reasoning_effort must be
         bridgeable to /v1/responses; without this the completion() responses bridge
         would receive a None config and bounce the request back to /v1/chat/completions."""
-        mock_get_info.return_value = {"mode": "chat"}
+        litellm.register_model(
+            {
+                "github_copilot/gpt-5.4": {
+                    "litellm_provider": "github_copilot",
+                    "max_tokens": 128000,
+                    "input_cost_per_token": 0,
+                    "output_cost_per_token": 0,
+                    "mode": "chat",
+                }
+            }
+        )
         config = ProviderConfigManager.get_provider_responses_api_config(
             model="github_copilot/gpt-5.4",
             provider=LlmProviders.GITHUB_COPILOT,

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -582,6 +582,34 @@ class TestGithubCopilotResponsesAPIRouting:
         )
         assert isinstance(config, GithubCopilotResponsesAPIConfig)
 
+    @patch(
+        "litellm.llms.github_copilot.responses.transformation._cached_get_model_info_helper"
+    )
+    def test_gpt_5_4_returns_config_even_when_mode_is_chat(self, mock_get_info):
+        """gpt-5.4+ is responses-capable and overrides the ``mode=chat`` opt-out.
+
+        Regression for https://github.com/BerriAI/litellm/issues/23156. The catalog
+        default for gpt-5.4 is ``mode=chat``, but tools + reasoning_effort must be
+        bridgeable to /v1/responses; without this the completion() responses bridge
+        would receive a None config and bounce the request back to /v1/chat/completions."""
+        mock_get_info.return_value = {"mode": "chat"}
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/gpt-5.4",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
+    def test_gpt_5_4_returns_native_config_without_catalog_entry(self):
+        """github_copilot/gpt-5.4 has no catalog entry, yet must still resolve to the
+        native responses config via the name-based gpt-5.4+ capability check so the
+        bridge can route tools + reasoning_effort. Exercises the real
+        ``_cached_get_model_info_helper`` plumbing (no mock)."""
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            model="github_copilot/gpt-5.4",
+            provider=LlmProviders.GITHUB_COPILOT,
+        )
+        assert isinstance(config, GithubCopilotResponsesAPIConfig)
+
 
 class TestGithubCopilotReasoningStreamItemIdNormalization:
     """GitHub Copilot's native /responses stream tags every reasoning-summary

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -898,6 +898,63 @@ def test_responses_api_bridge_check_gpt_5_tools_without_summary_stays_chat():
     assert model_info.get("mode") != "responses"
 
 
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_plus_reasoning_routes_to_responses():
+    """github_copilot/gpt-5.4 with tools + reasoning_effort should route to Responses API.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23156 - the copilot
+    variant that /v1/chat/completions rejects with "Function tools with reasoning_effort
+    are not supported for gpt-5.4 ... Please use /v1/responses instead".
+    """
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.4",
+            custom_llm_provider="github_copilot",
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            reasoning_effort="low",
+        )
+
+    assert model == "github_copilot/gpt-5.4"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_without_reasoning_stays_chat():
+    """github_copilot/gpt-5.4 with tools but no reasoning_effort should stay on chat."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.4",
+            custom_llm_provider="github_copilot",
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            reasoning_effort=None,
+        )
+
+    assert model_info.get("mode") != "responses"
+
+
+def test_responses_api_bridge_check_github_copilot_gpt_5_1_reasoning_summary_stays_chat():
+    """The reasoning_summary bridge path stays openai/azure-only: a copilot gpt-5.1
+    (pre-5.4) request with reasoning_effort + reasoning_summary but no tools must NOT
+    bridge, so copilot is not lumped into the untested summary path."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.1",
+            custom_llm_provider="github_copilot",
+            tools=None,
+            reasoning_effort="medium",
+            reasoning_summary="auto",
+        )
+
+    assert model_info.get("mode") != "responses"
+
+
 @patch("litellm.completion_extras.responses_api_bridge.completion")
 def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
     mock_responses_completion,

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1330,6 +1330,63 @@ def test_responses_api_bridge_check_gpt_5_tools_without_summary_stays_chat():
     assert model_info.get("mode") != "responses"
 
 
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_plus_reasoning_routes_to_responses():
+    """github_copilot/gpt-5.4 with tools + reasoning_effort should route to Responses API.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/23156 - the copilot
+    variant that /v1/chat/completions rejects with "Function tools with reasoning_effort
+    are not supported for gpt-5.4 ... Please use /v1/responses instead".
+    """
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.4",
+            custom_llm_provider="github_copilot",
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            reasoning_effort="low",
+        )
+
+    assert model == "github_copilot/gpt-5.4"
+    assert model_info.get("mode") == "responses"
+
+
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_without_reasoning_stays_chat():
+    """github_copilot/gpt-5.4 with tools but no reasoning_effort should stay on chat."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.4",
+            custom_llm_provider="github_copilot",
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            reasoning_effort=None,
+        )
+
+    assert model_info.get("mode") != "responses"
+
+
+def test_responses_api_bridge_check_github_copilot_gpt_5_1_reasoning_summary_stays_chat():
+    """The reasoning_summary bridge path stays openai/azure-only: a copilot gpt-5.1
+    (pre-5.4) request with reasoning_effort + reasoning_summary but no tools must NOT
+    bridge, so copilot is not lumped into the untested summary path."""
+    from litellm.main import responses_api_bridge_check
+
+    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
+        mock_get_model_info.return_value = {"max_tokens": 128000}
+        model_info, model = responses_api_bridge_check(
+            model="github_copilot/gpt-5.1",
+            custom_llm_provider="github_copilot",
+            tools=None,
+            reasoning_effort="medium",
+            reasoning_summary="auto",
+        )
+
+    assert model_info.get("mode") != "responses"
+
+
 @patch("litellm.completion_extras.responses_api_bridge.completion")
 def test_gpt_5_4_responses_bridge_preserves_reasoning_summary_dict(
     mock_responses_completion,

--- a/tests/test_litellm/test_main.py
+++ b/tests/test_litellm/test_main.py
@@ -1330,7 +1330,25 @@ def test_responses_api_bridge_check_gpt_5_tools_without_summary_stays_chat():
     assert model_info.get("mode") != "responses"
 
 
-def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_plus_reasoning_routes_to_responses():
+@pytest.fixture
+def github_copilot_chat_catalog(local_model_cost_map: None) -> None:
+    litellm.register_model(
+        {
+            f"github_copilot/{model}": {
+                "litellm_provider": "github_copilot",
+                "max_tokens": 128000,
+                "input_cost_per_token": 0,
+                "output_cost_per_token": 0,
+                "mode": "chat",
+            }
+            for model in ("gpt-5.4", "gpt-5.1")
+        }
+    )
+
+
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_plus_reasoning_routes_to_responses(
+    github_copilot_chat_catalog: None,
+) -> None:
     """github_copilot/gpt-5.4 with tools + reasoning_effort should route to Responses API.
 
     Regression test for https://github.com/BerriAI/litellm/issues/23156 - the copilot
@@ -1339,50 +1357,49 @@ def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_plus_reasoning_
     """
     from litellm.main import responses_api_bridge_check
 
-    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
-        mock_get_model_info.return_value = {"max_tokens": 128000}
-        model_info, model = responses_api_bridge_check(
-            model="github_copilot/gpt-5.4",
-            custom_llm_provider="github_copilot",
-            tools=[{"type": "function", "function": {"name": "get_weather"}}],
-            reasoning_effort="low",
-        )
+    model_info, model = responses_api_bridge_check(
+        model="github_copilot/gpt-5.4",
+        custom_llm_provider="github_copilot",
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        reasoning_effort="low",
+    )
 
     assert model == "github_copilot/gpt-5.4"
     assert model_info.get("mode") == "responses"
 
 
-def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_without_reasoning_stays_chat():
-    """github_copilot/gpt-5.4 with tools but no reasoning_effort should stay on chat."""
+@pytest.mark.parametrize("reasoning_effort", [None, "none", {"effort": "none"}])
+def test_responses_api_bridge_check_github_copilot_gpt_5_4_tools_without_reasoning_stays_chat(
+    reasoning_effort: str | dict[str, str] | None,
+    github_copilot_chat_catalog: None,
+) -> None:
     from litellm.main import responses_api_bridge_check
 
-    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
-        mock_get_model_info.return_value = {"max_tokens": 128000}
-        model_info, model = responses_api_bridge_check(
-            model="github_copilot/gpt-5.4",
-            custom_llm_provider="github_copilot",
-            tools=[{"type": "function", "function": {"name": "get_weather"}}],
-            reasoning_effort=None,
-        )
+    model_info, model = responses_api_bridge_check(
+        model="github_copilot/gpt-5.4",
+        custom_llm_provider="github_copilot",
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        reasoning_effort=reasoning_effort,
+    )
 
     assert model_info.get("mode") != "responses"
 
 
-def test_responses_api_bridge_check_github_copilot_gpt_5_1_reasoning_summary_stays_chat():
+def test_responses_api_bridge_check_github_copilot_gpt_5_1_reasoning_summary_stays_chat(
+    github_copilot_chat_catalog: None,
+) -> None:
     """The reasoning_summary bridge path stays openai/azure-only: a copilot gpt-5.1
     (pre-5.4) request with reasoning_effort + reasoning_summary but no tools must NOT
     bridge, so copilot is not lumped into the untested summary path."""
     from litellm.main import responses_api_bridge_check
 
-    with patch("litellm.main._get_model_info_helper") as mock_get_model_info:
-        mock_get_model_info.return_value = {"max_tokens": 128000}
-        model_info, model = responses_api_bridge_check(
-            model="github_copilot/gpt-5.1",
-            custom_llm_provider="github_copilot",
-            tools=None,
-            reasoning_effort="medium",
-            reasoning_summary="auto",
-        )
+    model_info, model = responses_api_bridge_check(
+        model="github_copilot/gpt-5.1",
+        custom_llm_provider="github_copilot",
+        tools=None,
+        reasoning_effort="medium",
+        reasoning_summary="auto",
+    )
 
     assert model_info.get("mode") != "responses"
 


### PR DESCRIPTION
## Rebase validation

Rebased onto `litellm_internal_staging` at `1af7a403c6`. The updated bridge helper preserves upstream's function-tool detection, explicit `reasoning_effort="none"` opt-out, custom-tool handling, and endpoint checks for default reasoning. Copilot still bridges only function tools with explicitly supplied active reasoning; its reasoning-summary-only path stays unchanged

At `851c066e1b`, 442 tests passed across `tests/test_litellm/test_main.py`, the GitHub Copilot provider tests, and the GPT-5 transformation/model-detection tests. All lint checks pass; the test-quality gate was rerun successfully after replacing internal mocks with `litellm.register_model` and the existing isolated catalog fixture

All 80 completed CI checks pass, including Codecov patch coverage at 93.33%. Greptile reviewed `851c066e1b` and returned 5/5; ready for maintainer review

## Relevant issues

Resolves #23156

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Fresh live GitHub Copilot verification on the rebased revision is pending. The following is the manual verification procedure, not a newly captured run

Runs against a real GitHub Copilot backend, so it needs Copilot auth configured (device flow). Steps to reproduce and confirm:

1. Add a deployment to your config:
   ```yaml
   model_list:
     - model_name: github_copilot/gpt-5.4
       litellm_params:
         model: github_copilot/gpt-5.4
   ```
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config <config>.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
3. Send the exact failing combination (function tool + `reasoning_effort`):
   ```bash
   curl -sS http://localhost:4000/v1/chat/completions \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer sk-1234" \
     -d '{
       "model": "github_copilot/gpt-5.4",
       "messages": [{"role": "user", "content": "What is the weather in Tartu?"}],
       "tools": [{"type": "function", "function": {"name": "get_weather", "parameters": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}}],
       "tool_choice": "required",
       "reasoning_effort": "low"
     }'
   ```
4. Before this change the request returns `OpenAIException - Function tools with reasoning_effort are not supported for gpt-5.4 in /v1/chat/completions. Please use /v1/responses instead`. After this change it returns a normal tool call, and `litellm.log` shows the request dispatched through the responses bridge (`/v1/responses`) rather than `/v1/chat/completions`

## Type

🐛 Bug Fix

## Changes

`github_copilot/gpt-5.4` calls that combine function tools with `reasoning_effort` failed at the provider, since `/v1/chat/completions` rejects that combination and tells you to use `/v1/responses`. The OpenAI and Azure variants are already auto-bridged to the Responses API by `responses_api_bridge_check` in `litellm/main.py`, but that gate was scoped to `custom_llm_provider in ("openai", "azure")`, so github_copilot fell through to chat completions and hit the 400

Widening that gate alone is not enough. When the bridge flips a request to responses mode it calls `litellm.responses()`, which re-derives the provider config through `github_copilot_supports_responses_api`. That gate returns `False` for a `mode: chat` model (its documented opt-out for dual-endpoint models) and for an unmapped model, and `github_copilot/gpt-5.4` resolves to the openai `gpt-5.4` catalog entry whose mode is `chat`. With a `None` responses config, `litellm.responses()` falls back to chat completions and reissues the same rejected request, so the fix has to address both layers

This PR makes two coordinated changes. First, the chat-to-responses bridge decision now covers `github_copilot` on the gpt-5.4+ tools path (the `reasoning_summary` alias branch stays openai/azure-only, since copilot support for that alias is untested); that decision lives in a typed helper `OpenAIGPT5Config.is_gpt5_responses_bridge_case` that `responses_api_bridge_check` calls, so the provider allow-list and model checks sit under `llms/` rather than in `main.py`. Second, `github_copilot_supports_responses_api` now treats gpt-5.4 and newer as responses-capable ahead of the `mode` checks, so the native `GithubCopilotResponsesAPIConfig` is selected instead of bouncing back to chat. Both reuse the existing `OpenAIGPT5Config.is_model_gpt_5_4_plus_model` detector, which strips the provider prefix and so already matches `github_copilot/gpt-5.4`

The openai/gpt-5.4 case from the issue title is already fixed on current staging; that path predated the reporter's v1.82.0, so upgrading resolves it. This PR closes the remaining github_copilot gap

Tests cover both layers and were confirmed to fail before the change and pass after: bridge routing for `github_copilot/gpt-5.4` with tools and `reasoning_effort="low"` (the reporter's exact value) in `tests/test_litellm/test_main.py`, plus negative guards that keep the scope tight (no bridging without `reasoning_effort`, and no copilot bridging via the `reasoning_summary` path); and responses-config selection for gpt-5.4 in `tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py`, including the case where the catalog default is `mode: chat`

