### PR TITLE
fix(openrouter): migrate image generation to dedicated /v1/images endpoint

### DIFF
--- a/litellm/llms/openrouter/image_generation/transformation.py
+++ b/litellm/llms/openrouter/image_generation/transformation.py
@@ -1,28 +1,26 @@
 """
 OpenRouter Image Generation Support
 
-OpenRouter provides image generation through chat completion endpoints.
-Models like google/gemini-2.5-flash-image return images in the message content.
+OpenRouter provides a dedicated image generation endpoint at /api/v1/images.
+
+Request format:
+{
+    "model": "bytedance-seed/seedream-4.5",
+    "prompt": "A beautiful sunset over mountains",
+    "n": 1,
+    "size": "1024x1024",
+    "quality": "auto"
+}
 
 Response format:
 {
-    "choices": [{
-        "message": {
-            "content": "Here is a beautiful sunset for you! ",
-            "role": "assistant",
-            "images": [{
-                "image_url": {"url": "data:image/png;base64,..."},
-                "index": 0,
-                "type": "image_url"
-            }]
-        }
-    }],
+    "created": 1748372400,
+    "data": [{"b64_json": "<base64>", "media_type": "image/png"}],
     "usage": {
-        "completion_tokens": 1299,
-        "prompt_tokens": 6,
-        "total_tokens": 1305,
-        "completion_tokens_details": {"image_tokens": 1290},
-        "cost": 0.0387243
+        "prompt_tokens": 0,
+        "completion_tokens": 4175,
+        "total_tokens": 4175,
+        "cost": 0.04
     }
 }
 """
@@ -36,10 +34,11 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.image_generation.transformation import (
     BaseImageGenerationConfig,
 )
+from litellm.llms.openrouter.common_utils import OpenRouterException
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
-    OpenAIImageGenerationOptionalParams,
     AllMessageValues,
+    OpenAIImageGenerationOptionalParams,
 )
 from litellm.types.utils import (
     ImageObject,
@@ -47,7 +46,6 @@ from litellm.types.utils import (
     ImageUsage,
     ImageUsageInputTokensDetails,
 )
-from litellm.llms.openrouter.common_utils import OpenRouterException
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -55,26 +53,21 @@ else:
     LiteLLMLoggingObj = Any
 
 
+QUALITY_ALIASES: dict[str, str] = {
+    "standard": "low",
+    "hd": "high",
+}
+
+
 class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
-    """
-    Configuration for OpenRouter image generation via chat completions.
-
-    OpenRouter uses chat completion endpoints for image generation,
-    so we need to transform image generation requests to chat format
-    and extract images from chat responses.
-    """
-
     def get_supported_openai_params(self, model: str) -> List[OpenAIImageGenerationOptionalParams]:
-        """
-        Get supported OpenAI parameters for OpenRouter image generation.
-
-        Since OpenRouter uses chat completions for image generation,
-        we support standard image generation params.
-        """
         return [
-            "size",
-            "quality",
             "n",
+            "quality",
+            "size",
+            "background",
+            "output_compression",
+            "output_format",
         ]
 
     def map_openai_params(
@@ -84,105 +77,18 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
-        """
-        Map image generation params to OpenRouter chat completion format.
-
-        Maps OpenAI parameters to OpenRouter's image_config format:
-        - size -> image_config.aspect_ratio
-        - quality -> image_config.image_size
-        """
         supported_params = self.get_supported_openai_params(model)
 
         for key, value in non_default_params.items():
             if key in supported_params:
-                if key == "size":
-                    # Map OpenAI size to OpenRouter aspect_ratio
-                    aspect_ratio = self._map_size_to_aspect_ratio(value)
-                    if "image_config" not in optional_params:
-                        optional_params["image_config"] = {}
-                    optional_params["image_config"]["aspect_ratio"] = aspect_ratio
-                elif key == "quality":
-                    # Map OpenAI quality to OpenRouter image_size
-                    image_size = self._map_quality_to_image_size(value)
-                    if image_size:
-                        if "image_config" not in optional_params:
-                            optional_params["image_config"] = {}
-                        optional_params["image_config"]["image_size"] = image_size
+                if key == "quality":
+                    optional_params["quality"] = QUALITY_ALIASES.get(value, value)
                 else:
-                    # Pass through other supported params (like n)
                     optional_params[key] = value
             elif not drop_params:
-                # If not supported and drop_params is False, pass through
                 optional_params[key] = value
 
         return optional_params
-
-    def _map_size_to_aspect_ratio(self, size: str) -> str:
-        """
-        Map OpenAI size format to OpenRouter aspect_ratio format.
-
-        OpenAI sizes:
-        - 1024x1024 (square)
-        - 1536x1024 (landscape)
-        - 1024x1536 (portrait)
-        - 1792x1024 (wide landscape, dall-e-3)
-        - 1024x1792 (tall portrait, dall-e-3)
-        - 256x256, 512x512 (dall-e-2)
-        - auto (default)
-
-        OpenRouter aspect_ratios:
-        - 1:1 → 1024×1024 (default)
-        - 2:3 → 832×1248
-        - 3:2 → 1248×832
-        - 3:4 → 864×1184
-        - 4:3 → 1184×864
-        - 4:5 → 896×1152
-        - 5:4 → 1152×896
-        - 9:16 → 768×1344
-        - 16:9 → 1344×768
-        - 21:9 → 1536×672
-        """
-        size_to_aspect_ratio = {
-            # Square formats
-            "256x256": "1:1",
-            "512x512": "1:1",
-            "1024x1024": "1:1",
-            # Landscape formats
-            "1536x1024": "3:2",  # 1.5:1 ratio, closest to 3:2
-            "1792x1024": "16:9",  # 1.75:1 ratio, closest to 16:9
-            # Portrait formats
-            "1024x1536": "2:3",  # 0.67:1 ratio, closest to 2:3
-            "1024x1792": "9:16",  # 0.57:1 ratio, closest to 9:16
-            # Default
-            "auto": "1:1",
-        }
-        return size_to_aspect_ratio.get(size, "1:1")
-
-    def _map_quality_to_image_size(self, quality: str) -> Optional[str]:
-        """
-        Map OpenAI quality to OpenRouter image_size format.
-
-        OpenAI quality values:
-        - auto (default) - automatically select best quality
-        - high, medium, low - for GPT image models
-        - hd, standard - for dall-e-3
-
-        OpenRouter image_size values (Gemini only):
-        - 1K → Standard resolution (default)
-        - 2K → Higher resolution
-        - 4K → Highest resolution
-        """
-        quality_to_image_size = {
-            # OpenAI quality mappings
-            "low": "1K",
-            "standard": "1K",
-            "medium": "2K",
-            "high": "4K",
-            "hd": "4K",
-            # Auto defaults to standard
-            "auto": "1K",
-        }
-        return quality_to_image_size.get(quality)
 
     def _set_usage_and_cost(
         self,
@@ -190,29 +96,19 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         response_json: dict,
         model: str,
     ) -> None:
-        """
-        Extract and set usage and cost information from OpenRouter response.
-
-        Args:
-            model_response: ImageResponse object to populate
-            response_json: Parsed JSON response from OpenRouter
-            model: The model name
-        """
         usage_data = response_json.get("usage", {})
         if usage_data:
             prompt_tokens = usage_data.get("prompt_tokens", 0)
+            completion_tokens = usage_data.get("completion_tokens", 0)
             total_tokens = usage_data.get("total_tokens", 0)
-
-            completion_tokens_details = usage_data.get("completion_tokens_details", {})
-            image_tokens = completion_tokens_details.get("image_tokens", 0)
 
             model_response.usage = ImageUsage(
                 input_tokens=prompt_tokens,
                 input_tokens_details=ImageUsageInputTokensDetails(
-                    image_tokens=0,  # Input doesn't contain images for generation
+                    image_tokens=0,
                     text_tokens=prompt_tokens,
                 ),
-                output_tokens=image_tokens,
+                output_tokens=completion_tokens,
                 total_tokens=total_tokens,
             )
 
@@ -243,19 +139,13 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
-        """
-        Get the complete URL for OpenRouter image generation.
-
-        OpenRouter uses chat completions endpoint for image generation.
-        Default: https://openrouter.ai/api/v1/chat/completions
-        """
         if api_base:
-            if not api_base.endswith("/chat/completions"):
-                api_base = api_base.rstrip("/")
-                return f"{api_base}/chat/completions"
-            return api_base
+            base = api_base.rstrip("/")
+            if base.endswith("/images"):
+                return base
+            return f"{base}/images"
 
-        return "https://openrouter.ai/api/v1/chat/completions"
+        return "https://openrouter.ai/api/v1/images"
 
     def validate_environment(
         self,
@@ -283,27 +173,13 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
-        """
-        Transform image generation request to OpenRouter chat completion format.
-
-        Args:
-            model: The model name
-            prompt: The image generation prompt
-            optional_params: Optional parameters (including image_config)
-            litellm_params: LiteLLM parameters
-            headers: Request headers
-
-        Returns:
-            dict: Request body in chat completion format with image_config
-        """
-        request_body = {
+        request_body: dict[str, object] = {
             "model": model,
-            "messages": [{"role": "user", "content": prompt}],
+            "prompt": prompt,
         }
 
-        # These will be passed through to OpenRouter
         for key, value in optional_params.items():
-            if key not in ["model", "messages", "modalities"]:
+            if key not in ("model", "prompt"):
                 request_body[key] = value
 
         return request_body
@@ -321,26 +197,6 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
     ) -> ImageResponse:
-        """
-        Transform OpenRouter chat completion response to ImageResponse format.
-
-        Extracts images from the message content and maps usage/cost information.
-
-        Args:
-            model: The model name
-            raw_response: Raw HTTP response from OpenRouter
-            model_response: ImageResponse object to populate
-            logging_obj: Logging object
-            request_data: Original request data
-            optional_params: Optional parameters
-            litellm_params: LiteLLM parameters
-            encoding: Encoding
-            api_key: API key
-            json_mode: JSON mode flag
-
-        Returns:
-            ImageResponse: Populated image response
-        """
         try:
             response_json = raw_response.json()
         except Exception as e:
@@ -354,42 +210,18 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
             model_response.data = []
 
         try:
-            choices = response_json.get("choices", [])
+            for item in response_json.get("data", []):
+                b64 = item.get("b64_json")
+                url = item.get("url")
+                model_response.data.append(
+                    ImageObject(
+                        b64_json=b64,
+                        url=url,
+                        revised_prompt=None,
+                    )
+                )
 
-            for choice in choices:
-                message = choice.get("message", {})
-                images = message.get("images", [])
-
-                for image_data in images:
-                    image_url_obj = image_data.get("image_url", {})
-                    image_url = image_url_obj.get("url")
-
-                    if image_url:
-                        if image_url.startswith("data:"):
-                            # Extract base64 data
-                            # Format: data:image/png;base64,<base64_data>
-                            parts = image_url.split(",", 1)
-                            b64_data = parts[1] if len(parts) > 1 else None
-
-                            model_response.data.append(
-                                ImageObject(
-                                    b64_json=b64_data,
-                                    url=None,
-                                    revised_prompt=None,
-                                )
-                            )
-                        else:
-                            model_response.data.append(
-                                ImageObject(
-                                    b64_json=None,
-                                    url=image_url,
-                                    revised_prompt=None,
-                                )
-                            )
-
-            # Extract and set usage and cost information
             self._set_usage_and_cost(model_response, response_json, model)
-
             return model_response
 
         except Exception as e:
@@ -402,7 +234,6 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
     ) -> BaseLLMException:
-        """Get the appropriate error class for OpenRouter errors."""
         return OpenRouterException(
             message=error_message,
             status_code=status_code,

--- a/litellm/llms/openrouter/image_generation/transformation.py
+++ b/litellm/llms/openrouter/image_generation/transformation.py
@@ -143,6 +143,11 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
             base = api_base.rstrip("/")
             if base.endswith("/images"):
                 return base
+            if base.endswith("/chat/completions"):
+                # Backwards compatibility: image generation previously routed
+                # through /chat/completions, so older configs may still point
+                # api_base at that path.
+                base = base[: -len("/chat/completions")]
             return f"{base}/images"
 
         return "https://openrouter.ai/api/v1/images"

--- a/litellm/llms/openrouter/image_generation/transformation.py
+++ b/litellm/llms/openrouter/image_generation/transformation.py
@@ -34,11 +34,10 @@ from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.base_llm.image_generation.transformation import (
     BaseImageGenerationConfig,
 )
-from litellm.llms.openrouter.common_utils import OpenRouterException
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
-    AllMessageValues,
     OpenAIImageGenerationOptionalParams,
+    AllMessageValues,
 )
 from litellm.types.utils import (
     ImageObject,
@@ -46,6 +45,7 @@ from litellm.types.utils import (
     ImageUsage,
     ImageUsageInputTokensDetails,
 )
+from litellm.llms.openrouter.common_utils import OpenRouterException
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -60,7 +60,21 @@ QUALITY_ALIASES: dict[str, str] = {
 
 
 class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
+    """
+    Configuration for OpenRouter image generation.
+
+    OpenRouter exposes a dedicated, OpenAI-Images-compatible endpoint at
+    /api/v1/images, so requests and responses only need light translation
+    to and from litellm's image generation types.
+    """
+
     def get_supported_openai_params(self, model: str) -> List[OpenAIImageGenerationOptionalParams]:
+        """
+        Get supported OpenAI parameters for OpenRouter image generation.
+
+        OpenRouter's /api/v1/images endpoint accepts the standard OpenAI
+        image generation params.
+        """
         return [
             "n",
             "quality",
@@ -77,6 +91,13 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         model: str,
         drop_params: bool,
     ) -> dict:
+        """
+        Map image generation params to OpenRouter's /api/v1/images format.
+
+        Supported params pass through unchanged, except `quality`, where the
+        dall-e-3 aliases are mapped to OpenRouter values
+        (standard -> low, hd -> high).
+        """
         supported_params = self.get_supported_openai_params(model)
 
         for key, value in non_default_params.items():
@@ -96,6 +117,18 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         response_json: dict,
         model: str,
     ) -> None:
+        """
+        Extract and set usage and cost information from OpenRouter response.
+
+        The `usage.cost` field is surfaced via the
+        `llm_provider-x-litellm-response-cost` hidden header so litellm
+        reports OpenRouter's actual response cost.
+
+        Args:
+            model_response: ImageResponse object to populate
+            response_json: Parsed JSON response from OpenRouter
+            model: The model name
+        """
         usage_data = response_json.get("usage", {})
         if usage_data:
             prompt_tokens = usage_data.get("prompt_tokens", 0)
@@ -139,6 +172,13 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         stream: Optional[bool] = None,
     ) -> str:
+        """
+        Get the complete URL for OpenRouter image generation.
+
+        Default: https://openrouter.ai/api/v1/images
+        Legacy api_base values ending in /chat/completions (from the old
+        chat-completions workaround) are rewritten to /images.
+        """
         if api_base:
             base = api_base.rstrip("/")
             if base.endswith("/images"):
@@ -178,6 +218,19 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         litellm_params: dict,
         headers: dict,
     ) -> dict:
+        """
+        Transform image generation request to OpenRouter's /api/v1/images format.
+
+        Args:
+            model: The model name
+            prompt: The image generation prompt
+            optional_params: Optional parameters (size, quality, n, ...)
+            litellm_params: LiteLLM parameters
+            headers: Request headers
+
+        Returns:
+            dict: OpenAI-Images-compatible request body
+        """
         request_body: dict[str, object] = {
             "model": model,
             "prompt": prompt,
@@ -202,6 +255,26 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
         api_key: Optional[str] = None,
         json_mode: Optional[bool] = None,
     ) -> ImageResponse:
+        """
+        Transform OpenRouter /api/v1/images response to ImageResponse format.
+
+        Maps each `data` item's b64_json/url and sets usage/cost information.
+
+        Args:
+            model: The model name
+            raw_response: Raw HTTP response from OpenRouter
+            model_response: ImageResponse object to populate
+            logging_obj: Logging object
+            request_data: Original request data
+            optional_params: Optional parameters
+            litellm_params: LiteLLM parameters
+            encoding: Encoding
+            api_key: API key
+            json_mode: JSON mode flag
+
+        Returns:
+            ImageResponse: Populated image response
+        """
         try:
             response_json = raw_response.json()
         except Exception as e:
@@ -239,6 +312,7 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
     def get_error_class(
         self, error_message: str, status_code: int, headers: Union[dict, httpx.Headers]
     ) -> BaseLLMException:
+        """Get the appropriate error class for OpenRouter errors."""
         return OpenRouterException(
             message=error_message,
             status_code=status_code,

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1885,7 +1885,7 @@
         "messages": true,
         "responses": true,
         "embeddings": true,
-        "image_generations": false,
+        "image_generations": true,
         "audio_transcriptions": false,
         "audio_speech": false,
         "moderations": false,

--- a/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
+++ b/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
@@ -3,14 +3,12 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
 
 from litellm.llms.openrouter.image_generation.transformation import (
+    QUALITY_ALIASES,
     OpenRouterImageGenerationConfig,
 )
 from litellm.llms.openrouter.common_utils import OpenRouterException
@@ -19,157 +17,86 @@ from litellm.types.utils import ImageResponse
 
 class TestOpenRouterImageGenerationTransformation:
     def setup_method(self):
-        """Set up test fixtures before each test method."""
         self.config = OpenRouterImageGenerationConfig()
-        self.model = "google/gemini-2.5-flash-image"
+        self.model = "bytedance-seed/seedream-4.5"
         self.logging_obj = MagicMock()
 
     def test_get_supported_openai_params(self):
-        """Test that get_supported_openai_params returns correct parameters."""
         supported_params = self.config.get_supported_openai_params(self.model)
 
-        assert "size" in supported_params
-        assert "quality" in supported_params
         assert "n" in supported_params
-        assert len(supported_params) == 3
+        assert "quality" in supported_params
+        assert "size" in supported_params
+        assert "background" in supported_params
+        assert "output_compression" in supported_params
+        assert "output_format" in supported_params
+        assert len(supported_params) == 6
 
-    def test_map_size_to_aspect_ratio_square(self):
-        """Test mapping square sizes to aspect ratio."""
-        assert self.config._map_size_to_aspect_ratio("256x256") == "1:1"
-        assert self.config._map_size_to_aspect_ratio("512x512") == "1:1"
-        assert self.config._map_size_to_aspect_ratio("1024x1024") == "1:1"
-
-    def test_map_size_to_aspect_ratio_landscape(self):
-        """Test mapping landscape sizes to aspect ratio."""
-        assert self.config._map_size_to_aspect_ratio("1536x1024") == "3:2"
-        assert self.config._map_size_to_aspect_ratio("1792x1024") == "16:9"
-
-    def test_map_size_to_aspect_ratio_portrait(self):
-        """Test mapping portrait sizes to aspect ratio."""
-        assert self.config._map_size_to_aspect_ratio("1024x1536") == "2:3"
-        assert self.config._map_size_to_aspect_ratio("1024x1792") == "9:16"
-
-    def test_map_size_to_aspect_ratio_auto(self):
-        """Test mapping auto size to default aspect ratio."""
-        assert self.config._map_size_to_aspect_ratio("auto") == "1:1"
-
-    def test_map_size_to_aspect_ratio_unknown(self):
-        """Test mapping unknown size defaults to 1:1."""
-        assert self.config._map_size_to_aspect_ratio("999x999") == "1:1"
-
-    def test_map_quality_to_image_size_low(self):
-        """Test mapping low quality values to 1K."""
-        assert self.config._map_quality_to_image_size("low") == "1K"
-        assert self.config._map_quality_to_image_size("standard") == "1K"
-        assert self.config._map_quality_to_image_size("auto") == "1K"
-
-    def test_map_quality_to_image_size_medium(self):
-        """Test mapping medium quality to 2K."""
-        assert self.config._map_quality_to_image_size("medium") == "2K"
-
-    def test_map_quality_to_image_size_high(self):
-        """Test mapping high quality values to 4K."""
-        assert self.config._map_quality_to_image_size("high") == "4K"
-        assert self.config._map_quality_to_image_size("hd") == "4K"
-
-    def test_map_quality_to_image_size_unknown(self):
-        """Test mapping unknown quality returns None."""
-        assert self.config._map_quality_to_image_size("unknown") is None
-
-    def test_map_openai_params_size_only(self):
-        """Test that map_openai_params correctly maps size parameter."""
-        non_default_params = {"size": "1024x1024"}
-        optional_params = {}
-
+    def test_map_openai_params_size_passed_directly(self):
         result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
+            non_default_params={"size": "1024x1024"},
+            optional_params={},
             model=self.model,
             drop_params=False,
         )
 
-        assert "image_config" in result
-        assert result["image_config"]["aspect_ratio"] == "1:1"
+        assert result["size"] == "1024x1024"
+        assert "image_config" not in result
 
-    def test_map_openai_params_quality_only(self):
-        """Test that map_openai_params correctly maps quality parameter."""
-        non_default_params = {"quality": "high"}
-        optional_params = {}
-
+    def test_map_openai_params_quality_passed_directly(self):
         result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
+            non_default_params={"quality": "high"},
+            optional_params={},
             model=self.model,
             drop_params=False,
         )
 
-        assert "image_config" in result
-        assert result["image_config"]["image_size"] == "4K"
+        assert result["quality"] == "high"
+        assert "image_config" not in result
 
-    def test_map_openai_params_size_and_quality(self):
-        """Test that map_openai_params correctly maps both size and quality."""
-        non_default_params = {"size": "1792x1024", "quality": "hd"}
-        optional_params = {}
+    def test_map_openai_params_quality_aliases(self):
+        for alias, mapped in QUALITY_ALIASES.items():
+            result = self.config.map_openai_params(
+                non_default_params={"quality": alias},
+                optional_params={},
+                model=self.model,
+                drop_params=False,
+            )
+            assert result["quality"] == mapped
 
+    def test_map_openai_params_multiple(self):
         result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
+            non_default_params={"size": "1792x1024", "quality": "hd", "n": 2},
+            optional_params={},
             model=self.model,
             drop_params=False,
         )
 
-        assert "image_config" in result
-        assert result["image_config"]["aspect_ratio"] == "16:9"
-        assert result["image_config"]["image_size"] == "4K"
-
-    def test_map_openai_params_with_n_parameter(self):
-        """Test that map_openai_params correctly passes through n parameter."""
-        non_default_params = {"size": "1024x1024", "n": 2}
-        optional_params = {}
-
-        result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
-            model=self.model,
-            drop_params=False,
-        )
-
-        assert "image_config" in result
-        assert result["image_config"]["aspect_ratio"] == "1:1"
+        assert result["size"] == "1792x1024"
+        assert result["quality"] == "high"
         assert result["n"] == 2
 
-    def test_map_openai_params_unsupported_param_drop_false(self):
-        """Test that unsupported params are passed through when drop_params=False."""
-        non_default_params = {"size": "1024x1024", "unsupported_param": "value"}
-        optional_params = {}
-
+    def test_map_openai_params_unsupported_drop_false(self):
         result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
+            non_default_params={"size": "1024x1024", "unsupported_param": "value"},
+            optional_params={},
             model=self.model,
             drop_params=False,
         )
 
-        assert "image_config" in result
         assert result["unsupported_param"] == "value"
 
-    def test_map_openai_params_unsupported_param_drop_true(self):
-        """Test that unsupported params are dropped when drop_params=True."""
-        non_default_params = {"size": "1024x1024", "unsupported_param": "value"}
-        optional_params = {}
-
+    def test_map_openai_params_unsupported_drop_true(self):
         result = self.config.map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
+            non_default_params={"size": "1024x1024", "unsupported_param": "value"},
+            optional_params={},
             model=self.model,
             drop_params=True,
         )
 
-        assert "image_config" in result
         assert "unsupported_param" not in result
 
     def test_get_complete_url_default(self):
-        """Test that get_complete_url returns default OpenRouter URL."""
         result = self.config.get_complete_url(
             api_base=None,
             api_key="test_key",
@@ -178,62 +105,50 @@ class TestOpenRouterImageGenerationTransformation:
             litellm_params={},
         )
 
-        assert result == "https://openrouter.ai/api/v1/chat/completions"
+        assert result == "https://openrouter.ai/api/v1/images"
 
     def test_get_complete_url_with_custom_base(self):
-        """Test that get_complete_url uses custom api_base."""
-        custom_base = "https://custom.openrouter.ai/api/v1"
-
         result = self.config.get_complete_url(
-            api_base=custom_base,
+            api_base="https://custom.openrouter.ai/api/v1",
             api_key="test_key",
             model=self.model,
             optional_params={},
             litellm_params={},
         )
 
-        assert result == f"{custom_base}/chat/completions"
+        assert result == "https://custom.openrouter.ai/api/v1/images"
 
-    def test_get_complete_url_with_base_already_complete(self):
-        """Test that get_complete_url doesn't duplicate /chat/completions."""
-        custom_base = "https://custom.openrouter.ai/api/v1/chat/completions"
-
+    def test_get_complete_url_already_complete(self):
         result = self.config.get_complete_url(
-            api_base=custom_base,
+            api_base="https://custom.openrouter.ai/api/v1/images",
             api_key="test_key",
             model=self.model,
             optional_params={},
             litellm_params={},
         )
 
-        assert result == custom_base
+        assert result == "https://custom.openrouter.ai/api/v1/images"
 
     @patch("litellm.llms.openrouter.image_generation.transformation.get_secret_str")
     def test_validate_environment_with_api_key(self, mock_get_secret):
-        """Test that validate_environment correctly sets authorization header."""
-        headers = {}
-        api_key = "test_api_key"
-
         result = self.config.validate_environment(
-            headers=headers,
+            headers={},
             model=self.model,
             messages=[],
             optional_params={},
             litellm_params={},
-            api_key=api_key,
+            api_key="test_api_key",
         )
 
-        assert result["Authorization"] == f"Bearer {api_key}"
+        assert result["Authorization"] == "Bearer test_api_key"
         mock_get_secret.assert_not_called()
 
     @patch("litellm.llms.openrouter.image_generation.transformation.get_secret_str")
     def test_validate_environment_with_secret_key(self, mock_get_secret):
-        """Test that validate_environment uses secret API key when api_key is None."""
         mock_get_secret.return_value = "secret_api_key"
-        headers = {}
 
         result = self.config.validate_environment(
-            headers=headers,
+            headers={},
             model=self.model,
             messages=[],
             optional_params={},
@@ -244,73 +159,53 @@ class TestOpenRouterImageGenerationTransformation:
         assert result["Authorization"] == "Bearer secret_api_key"
         mock_get_secret.assert_called_once_with("OPENROUTER_API_KEY")
 
-    def test_transform_image_generation_request_basic(self):
-        """Test that transform_image_generation_request creates correct request body."""
-        prompt = "A beautiful sunset over mountains"
-        optional_params = {}
-
+    def test_transform_request_basic(self):
         result = self.config.transform_image_generation_request(
             model=self.model,
-            prompt=prompt,
-            optional_params=optional_params,
+            prompt="A beautiful sunset over mountains",
+            optional_params={},
             litellm_params={},
             headers={},
         )
 
         assert result["model"] == self.model
-        assert result["messages"] == [{"role": "user", "content": prompt}]
-        assert "modalities" not in result  # modalities should not be added by default
+        assert result["prompt"] == "A beautiful sunset over mountains"
+        assert "messages" not in result
 
-    def test_transform_image_generation_request_with_image_config(self):
-        """Test that transform_image_generation_request includes image_config."""
-        prompt = "A beautiful sunset"
-        optional_params = {
-            "image_config": {"aspect_ratio": "16:9", "image_size": "4K"},
-            "n": 2,
-        }
-
+    def test_transform_request_with_optional_params(self):
         result = self.config.transform_image_generation_request(
             model=self.model,
-            prompt=prompt,
-            optional_params=optional_params,
+            prompt="A sunset",
+            optional_params={
+                "size": "1024x1024",
+                "quality": "high",
+                "n": 2,
+                "background": "transparent",
+            },
             litellm_params={},
             headers={},
         )
 
         assert result["model"] == self.model
-        assert result["messages"] == [{"role": "user", "content": prompt}]
-        assert result["image_config"]["aspect_ratio"] == "16:9"
-        assert result["image_config"]["image_size"] == "4K"
+        assert result["prompt"] == "A sunset"
+        assert result["size"] == "1024x1024"
+        assert result["quality"] == "high"
         assert result["n"] == 2
+        assert result["background"] == "transparent"
 
-    def test_transform_image_generation_response_with_base64_images(self):
-        """Test that transform_image_generation_response correctly extracts base64 images."""
+    def test_transform_response_with_b64_images(self):
         response_data = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Here is your image!",
-                        "role": "assistant",
-                        "images": [
-                            {
-                                "image_url": {
-                                    "url": "data:image/png;base64,iVBORw0KGgoAAAANS"
-                                },
-                                "index": 0,
-                                "type": "image_url",
-                            }
-                        ],
-                    }
-                }
+            "created": 1748372400,
+            "data": [
+                {"b64_json": "iVBORw0KGgoAAAANS", "media_type": "image/png"},
             ],
             "usage": {
                 "prompt_tokens": 10,
-                "completion_tokens": 1300,
-                "total_tokens": 1310,
-                "completion_tokens_details": {"image_tokens": 1290},
-                "cost": 0.0387243,
+                "completion_tokens": 4175,
+                "total_tokens": 4185,
+                "cost": 0.04,
             },
-            "model": "google/gemini-2.5-flash-image",
+            "model": "bytedance-seed/seedream-4.5",
         }
 
         mock_response = MagicMock()
@@ -318,12 +213,10 @@ class TestOpenRouterImageGenerationTransformation:
         mock_response.status_code = 200
         mock_response.headers = {}
 
-        model_response = ImageResponse(data=[])
-
         result = self.config.transform_image_generation_response(
             model=self.model,
             raw_response=mock_response,
-            model_response=model_response,
+            model_response=ImageResponse(data=[]),
             logging_obj=self.logging_obj,
             request_data={},
             optional_params={},
@@ -335,30 +228,17 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[0].b64_json == "iVBORw0KGgoAAAANS"
         assert result.data[0].url is None
 
-    def test_transform_image_generation_response_with_url_images(self):
-        """Test that transform_image_generation_response correctly extracts URL images."""
+    def test_transform_response_with_url_images(self):
         response_data = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Here is your image!",
-                        "role": "assistant",
-                        "images": [
-                            {
-                                "image_url": {"url": "https://example.com/image.png"},
-                                "index": 0,
-                                "type": "image_url",
-                            }
-                        ],
-                    }
-                }
+            "created": 1748372400,
+            "data": [
+                {"url": "https://example.com/image.png"},
             ],
             "usage": {
                 "prompt_tokens": 10,
-                "completion_tokens": 1300,
-                "total_tokens": 1310,
+                "completion_tokens": 4175,
+                "total_tokens": 4185,
             },
-            "model": "google/gemini-2.5-flash-image",
         }
 
         mock_response = MagicMock()
@@ -366,12 +246,10 @@ class TestOpenRouterImageGenerationTransformation:
         mock_response.status_code = 200
         mock_response.headers = {}
 
-        model_response = ImageResponse(data=[])
-
         result = self.config.transform_image_generation_response(
             model=self.model,
             raw_response=mock_response,
-            model_response=model_response,
+            model_response=ImageResponse(data=[]),
             logging_obj=self.logging_obj,
             request_data={},
             optional_params={},
@@ -383,33 +261,18 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[0].url == "https://example.com/image.png"
         assert result.data[0].b64_json is None
 
-    def test_transform_image_generation_response_with_usage_and_cost(self):
-        """Test that transform_image_generation_response correctly extracts usage and cost."""
+    def test_transform_response_usage_and_cost(self):
         response_data = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Here is your image!",
-                        "role": "assistant",
-                        "images": [
-                            {
-                                "image_url": {"url": "data:image/png;base64,abc123"},
-                                "index": 0,
-                                "type": "image_url",
-                            }
-                        ],
-                    }
-                }
-            ],
+            "created": 1748372400,
+            "data": [{"b64_json": "abc123"}],
             "usage": {
                 "prompt_tokens": 10,
-                "completion_tokens": 1300,
-                "total_tokens": 1310,
-                "completion_tokens_details": {"image_tokens": 1290},
-                "cost": 0.0387243,
-                "cost_details": {"input_cost": 0.001, "output_cost": 0.037},
+                "completion_tokens": 4175,
+                "total_tokens": 4185,
+                "cost": 0.04,
+                "cost_details": {"input_cost": 0.001, "output_cost": 0.039},
             },
-            "model": "google/gemini-2.5-flash-image",
+            "model": "bytedance-seed/seedream-4.5",
         }
 
         mock_response = MagicMock()
@@ -417,12 +280,10 @@ class TestOpenRouterImageGenerationTransformation:
         mock_response.status_code = 200
         mock_response.headers = {}
 
-        model_response = ImageResponse(data=[])
-
         result = self.config.transform_image_generation_response(
             model=self.model,
             raw_response=mock_response,
-            model_response=model_response,
+            model_response=ImageResponse(data=[]),
             logging_obj=self.logging_obj,
             request_data={},
             optional_params={},
@@ -430,65 +291,30 @@ class TestOpenRouterImageGenerationTransformation:
             encoding=None,
         )
 
-        # Check usage
         assert result.usage is not None
         assert result.usage.input_tokens == 10
-        assert result.usage.output_tokens == 1290
-        assert result.usage.total_tokens == 1310
+        assert result.usage.output_tokens == 4175
+        assert result.usage.total_tokens == 4185
         assert result.usage.input_tokens_details.text_tokens == 10
         assert result.usage.input_tokens_details.image_tokens == 0
 
-        # Check cost
-        assert hasattr(result, "_hidden_params")
-        assert "additional_headers" in result._hidden_params
-        assert (
-            result._hidden_params["additional_headers"][
-                "llm_provider-x-litellm-response-cost"
-            ]
-            == 0.0387243
-        )
-
-        # Check cost details
-        assert "response_cost_details" in result._hidden_params
+        assert result._hidden_params["additional_headers"]["llm_provider-x-litellm-response-cost"] == 0.04
         assert result._hidden_params["response_cost_details"]["input_cost"] == 0.001
-        assert result._hidden_params["response_cost_details"]["output_cost"] == 0.037
+        assert result._hidden_params["response_cost_details"]["output_cost"] == 0.039
+        assert result._hidden_params["model"] == "bytedance-seed/seedream-4.5"
 
-        # Check model
-        assert result._hidden_params["model"] == "google/gemini-2.5-flash-image"
-
-    def test_transform_image_generation_response_multiple_images(self):
-        """Test that transform_image_generation_response handles multiple images."""
+    def test_transform_response_multiple_images(self):
         response_data = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Here are your images!",
-                        "role": "assistant",
-                        "images": [
-                            {
-                                "image_url": {
-                                    "url": "data:image/png;base64,image1data"
-                                },
-                                "index": 0,
-                                "type": "image_url",
-                            },
-                            {
-                                "image_url": {
-                                    "url": "data:image/png;base64,image2data"
-                                },
-                                "index": 1,
-                                "type": "image_url",
-                            },
-                        ],
-                    }
-                }
+            "created": 1748372400,
+            "data": [
+                {"b64_json": "image1data"},
+                {"b64_json": "image2data"},
             ],
             "usage": {
                 "prompt_tokens": 10,
-                "completion_tokens": 2600,
-                "total_tokens": 2610,
+                "completion_tokens": 8350,
+                "total_tokens": 8360,
             },
-            "model": "google/gemini-2.5-flash-image",
         }
 
         mock_response = MagicMock()
@@ -496,12 +322,10 @@ class TestOpenRouterImageGenerationTransformation:
         mock_response.status_code = 200
         mock_response.headers = {}
 
-        model_response = ImageResponse(data=[])
-
         result = self.config.transform_image_generation_response(
             model=self.model,
             raw_response=mock_response,
-            model_response=model_response,
+            model_response=ImageResponse(data=[]),
             logging_obj=self.logging_obj,
             request_data={},
             optional_params={},
@@ -513,20 +337,17 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[0].b64_json == "image1data"
         assert result.data[1].b64_json == "image2data"
 
-    def test_transform_image_generation_response_json_error(self):
-        """Test that transform_image_generation_response raises error on invalid JSON."""
+    def test_transform_response_json_parse_error(self):
         mock_response = MagicMock()
         mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
         mock_response.status_code = 500
         mock_response.headers = {}
 
-        model_response = ImageResponse(data=[])
-
         with pytest.raises(OpenRouterException) as exc_info:
             self.config.transform_image_generation_response(
                 model=self.model,
                 raw_response=mock_response,
-                model_response=model_response,
+                model_response=ImageResponse(data=[]),
                 logging_obj=self.logging_obj,
                 request_data={},
                 optional_params={},
@@ -537,45 +358,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert "Error parsing OpenRouter response" in str(exc_info.value)
         assert exc_info.value.status_code == 500
 
-    def test_transform_image_generation_response_transformation_error(self):
-        """Test that transform_image_generation_response handles transformation errors."""
-        response_data = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Here is your image!",
-                        "role": "assistant",
-                        "images": "invalid_format",  # Invalid format
-                    }
-                }
-            ]
-        }
-
-        mock_response = MagicMock()
-        mock_response.json.return_value = response_data
-        mock_response.status_code = 200
-        mock_response.headers = {}
-
-        model_response = ImageResponse(data=[])
-
-        with pytest.raises(OpenRouterException) as exc_info:
-            self.config.transform_image_generation_response(
-                model=self.model,
-                raw_response=mock_response,
-                model_response=model_response,
-                logging_obj=self.logging_obj,
-                request_data={},
-                optional_params={},
-                litellm_params={},
-                encoding=None,
-            )
-
-        assert "Error transforming OpenRouter image generation response" in str(
-            exc_info.value
-        )
-
     def test_get_error_class(self):
-        """Test that get_error_class returns OpenRouterException."""
         error = self.config.get_error_class(
             error_message="Test error",
             status_code=400,

--- a/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
+++ b/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
@@ -5,7 +5,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, os.path.abspath("../../../../.."))  # Adds the parent directory to the system path
+sys.path.insert(
+    0, os.path.abspath("../../../../..")
+)  # Adds the parent directory to the system path
 
 from litellm.llms.openrouter.image_generation.transformation import (
     QUALITY_ALIASES,
@@ -17,11 +19,13 @@ from litellm.types.utils import ImageResponse
 
 class TestOpenRouterImageGenerationTransformation:
     def setup_method(self):
+        """Set up test fixtures before each test method."""
         self.config = OpenRouterImageGenerationConfig()
         self.model = "bytedance-seed/seedream-4.5"
         self.logging_obj = MagicMock()
 
     def test_get_supported_openai_params(self):
+        """Test that get_supported_openai_params returns correct parameters."""
         supported_params = self.config.get_supported_openai_params(self.model)
 
         assert "n" in supported_params
@@ -33,6 +37,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert len(supported_params) == 6
 
     def test_map_openai_params_size_passed_directly(self):
+        """Test that map_openai_params passes size through unchanged."""
         result = self.config.map_openai_params(
             non_default_params={"size": "1024x1024"},
             optional_params={},
@@ -44,6 +49,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert "image_config" not in result
 
     def test_map_openai_params_quality_passed_directly(self):
+        """Test that map_openai_params passes quality through unchanged."""
         result = self.config.map_openai_params(
             non_default_params={"quality": "high"},
             optional_params={},
@@ -55,6 +61,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert "image_config" not in result
 
     def test_map_openai_params_quality_aliases(self):
+        """Test that dall-e-3 quality aliases are mapped (standard->low, hd->high)."""
         for alias, mapped in QUALITY_ALIASES.items():
             result = self.config.map_openai_params(
                 non_default_params={"quality": alias},
@@ -65,6 +72,7 @@ class TestOpenRouterImageGenerationTransformation:
             assert result["quality"] == mapped
 
     def test_map_openai_params_multiple(self):
+        """Test that map_openai_params correctly maps multiple parameters."""
         result = self.config.map_openai_params(
             non_default_params={"size": "1792x1024", "quality": "hd", "n": 2},
             optional_params={},
@@ -77,6 +85,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result["n"] == 2
 
     def test_map_openai_params_unsupported_drop_false(self):
+        """Test that unsupported params are passed through when drop_params=False."""
         result = self.config.map_openai_params(
             non_default_params={"size": "1024x1024", "unsupported_param": "value"},
             optional_params={},
@@ -87,6 +96,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result["unsupported_param"] == "value"
 
     def test_map_openai_params_unsupported_drop_true(self):
+        """Test that unsupported params are dropped when drop_params=True."""
         result = self.config.map_openai_params(
             non_default_params={"size": "1024x1024", "unsupported_param": "value"},
             optional_params={},
@@ -97,6 +107,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert "unsupported_param" not in result
 
     def test_get_complete_url_default(self):
+        """Test that get_complete_url returns the default OpenRouter /images URL."""
         result = self.config.get_complete_url(
             api_base=None,
             api_key="test_key",
@@ -108,6 +119,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result == "https://openrouter.ai/api/v1/images"
 
     def test_get_complete_url_with_custom_base(self):
+        """Test that get_complete_url appends /images to a custom api_base."""
         result = self.config.get_complete_url(
             api_base="https://custom.openrouter.ai/api/v1",
             api_key="test_key",
@@ -119,6 +131,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result == "https://custom.openrouter.ai/api/v1/images"
 
     def test_get_complete_url_already_complete(self):
+        """Test that get_complete_url doesn't duplicate /images."""
         result = self.config.get_complete_url(
             api_base="https://custom.openrouter.ai/api/v1/images",
             api_key="test_key",
@@ -143,6 +156,7 @@ class TestOpenRouterImageGenerationTransformation:
 
     @patch("litellm.llms.openrouter.image_generation.transformation.get_secret_str")
     def test_validate_environment_with_api_key(self, mock_get_secret):
+        """Test that validate_environment correctly sets authorization header."""
         result = self.config.validate_environment(
             headers={},
             model=self.model,
@@ -157,6 +171,7 @@ class TestOpenRouterImageGenerationTransformation:
 
     @patch("litellm.llms.openrouter.image_generation.transformation.get_secret_str")
     def test_validate_environment_with_secret_key(self, mock_get_secret):
+        """Test that validate_environment uses secret API key when api_key is None."""
         mock_get_secret.return_value = "secret_api_key"
 
         result = self.config.validate_environment(
@@ -172,6 +187,7 @@ class TestOpenRouterImageGenerationTransformation:
         mock_get_secret.assert_called_once_with("OPENROUTER_API_KEY")
 
     def test_transform_request_basic(self):
+        """Test that transform_image_generation_request creates correct request body."""
         result = self.config.transform_image_generation_request(
             model=self.model,
             prompt="A beautiful sunset over mountains",
@@ -185,6 +201,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert "messages" not in result
 
     def test_transform_request_with_optional_params(self):
+        """Test that transform_image_generation_request includes optional params."""
         result = self.config.transform_image_generation_request(
             model=self.model,
             prompt="A sunset",
@@ -206,6 +223,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result["background"] == "transparent"
 
     def test_transform_response_with_b64_images(self):
+        """Test that transform_image_generation_response correctly extracts base64 images."""
         response_data = {
             "created": 1748372400,
             "data": [
@@ -241,6 +259,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[0].url is None
 
     def test_transform_response_with_url_images(self):
+        """Test that transform_image_generation_response correctly extracts URL images."""
         response_data = {
             "created": 1748372400,
             "data": [
@@ -274,6 +293,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[0].b64_json is None
 
     def test_transform_response_usage_and_cost(self):
+        """Test that transform_image_generation_response correctly extracts usage and cost."""
         response_data = {
             "created": 1748372400,
             "data": [{"b64_json": "abc123"}],
@@ -316,6 +336,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result._hidden_params["model"] == "bytedance-seed/seedream-4.5"
 
     def test_transform_response_multiple_images(self):
+        """Test that transform_image_generation_response handles multiple images."""
         response_data = {
             "created": 1748372400,
             "data": [
@@ -350,6 +371,7 @@ class TestOpenRouterImageGenerationTransformation:
         assert result.data[1].b64_json == "image2data"
 
     def test_transform_response_json_parse_error(self):
+        """Test that transform_image_generation_response raises error on invalid JSON."""
         mock_response = MagicMock()
         mock_response.json.side_effect = json.JSONDecodeError("Invalid JSON", "", 0)
         mock_response.status_code = 500
@@ -370,7 +392,33 @@ class TestOpenRouterImageGenerationTransformation:
         assert "Error parsing OpenRouter response" in str(exc_info.value)
         assert exc_info.value.status_code == 500
 
+    def test_transform_response_transformation_error(self):
+        """Test that transform_image_generation_response handles transformation errors."""
+        response_data = {"data": "invalid_format"}  # Invalid format
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = response_data
+        mock_response.status_code = 200
+        mock_response.headers = {}
+
+        with pytest.raises(OpenRouterException) as exc_info:
+            self.config.transform_image_generation_response(
+                model=self.model,
+                raw_response=mock_response,
+                model_response=ImageResponse(data=[]),
+                logging_obj=self.logging_obj,
+                request_data={},
+                optional_params={},
+                litellm_params={},
+                encoding=None,
+            )
+
+        assert "Error transforming OpenRouter image generation response" in str(
+            exc_info.value
+        )
+
     def test_get_error_class(self):
+        """Test that get_error_class returns OpenRouterException."""
         error = self.config.get_error_class(
             error_message="Test error",
             status_code=400,

--- a/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
+++ b/tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py
@@ -129,6 +129,18 @@ class TestOpenRouterImageGenerationTransformation:
 
         assert result == "https://custom.openrouter.ai/api/v1/images"
 
+    def test_get_complete_url_legacy_chat_completions_base(self):
+        """api_base values from the old chat-completions workaround still resolve to /images."""
+        result = self.config.get_complete_url(
+            api_base="https://openrouter.ai/api/v1/chat/completions",
+            api_key="test_key",
+            model=self.model,
+            optional_params={},
+            litellm_params={},
+        )
+
+        assert result == "https://openrouter.ai/api/v1/images"
+
     @patch("litellm.llms.openrouter.image_generation.transformation.get_secret_str")
     def test_validate_environment_with_api_key(self, mock_get_secret):
         result = self.config.validate_environment(


### PR DESCRIPTION
## Relevant issues

N/A

## Type

🐛 Bug Fix / 🆕 New Feature

## Changes

OpenRouter now provides a dedicated, OpenAI-Images-compatible image generation endpoint: `POST https://openrouter.ai/api/v1/images` ([docs](https://openrouter.ai/docs)). This PR migrates the `openrouter` `image_generation` provider off the chat-completions workaround (where image requests were tunneled through `/chat/completions` with `modalities: ["image"]` and images extracted from assistant-message `images` fields) to the native endpoint.

- `get_complete_url()` now targets `/api/v1/images` (respects a custom `api_base`, appending `/images` if needed)
- Request transform emits the native payload: `{model, prompt, n, size, quality, ...}` — no more chat `messages` wrapping; OpenAI `quality` aliases (`standard`/`hd`) are mapped to OpenRouter's `low`/`high`
- Response transform parses the OpenAI-Images-shaped response `{created, data: [{b64_json | url}], usage}`, including OpenRouter's `usage.cost` passthrough into `x-litellm-response-cost`
- Flips `image_generations` to `true` for `openrouter` in `provider_endpoints_support.json`

## Testing

- **Live E2E confirmed:** ran `litellm.image_generation(model="openrouter/...", prompt=...)` on this branch against the real OpenRouter API — the request hit the new `/api/v1/images` endpoint and returned a valid image with usage/cost populated (including the `x-litellm-response-cost` passthrough).
- Rewrote `tests/test_litellm/llms/openrouter/image_generation/test_openrouter_image_gen_transformation.py` for the new endpoint contract — 22 tests covering URL construction, param mapping, request/response transforms, usage/cost handling, and error paths. All passing locally (`pytest tests/test_litellm/llms/openrouter/image_generation/ -x -q` → `22 passed`).
- `ruff format --check` and `ruff check` pass on the changed files.
