### PR TITLE
fix(otel): use JSON-serializable span-dedupe key so metadata survives json.dumps

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1043,10 +1043,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         ``scope`` parts may include unhashable containers (list, dict, set);
         they are normalized into a hashable shape via ``_freeze_for_dedupe``
-        before keying the marker dict. The marker is stored in
+        and the whole key is ``repr``-ed to a string. The string form matters:
+        the marker is stored in
         ``kwargs["litellm_params"]["metadata"]["_otel_internal"]`` so it is
         request-local (kwargs is shared across the sync/async callbacks and
-        lifecycle hooks for one request).
+        lifecycle hooks for one request), and that metadata is serialized to
+        JSON downstream (e.g. spend logs). A tuple key would make ``metadata``
+        non-JSON-serializable and crash ``json.dumps``.
         """
         litellm_params = kwargs.get("litellm_params")
         if not isinstance(litellm_params, dict):
@@ -1068,10 +1071,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (
-            self.__class__.__name__,
-            id(self),
-            *(_freeze_for_dedupe(part) for part in scope),
+        dedupe_key = repr(
+            (
+                self.__class__.__name__,
+                id(self),
+                *(_freeze_for_dedupe(part) for part in scope),
+            )
         )
         if spans_logged.get(dedupe_key) is True:
             return False

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4748,6 +4748,43 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
         self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
 
+    def test_emit_once_keeps_metadata_json_serializable(self):
+        """Regression for the spend-logs crash + memory leak (issue #32250).
+
+        The dedupe markers ``_emit_once`` writes into
+        ``litellm_params["metadata"]["_otel_internal"]`` propagate into the
+        persisted request body, which is serialized with plain ``json.dumps``.
+        A tuple dedupe key makes that dict non-JSON-serializable, so
+        ``json.dumps`` raised ``TypeError: keys must be str, ... not tuple`` on
+        every request, dropping the spend-log write and growing the in-memory
+        transaction queue without bound.
+
+        The key must be a string so ``metadata`` stays JSON-serializable, and
+        the markers must survive serialization so dedup state is not silently
+        dropped."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+
+        otel._emit_once(kwargs, "success")
+        otel._emit_once(kwargs, "guardrail", "pii", 1.0, ["pre_call", "post_call"])
+        otel._emit_once(kwargs, "guardrail", "pii", 1.0, {"tags": ["pre", "post"]})
+
+        metadata = kwargs["litellm_params"]["metadata"]
+        spans_logged = metadata["_otel_internal"]["spans_logged"]
+        self.assertTrue(
+            all(isinstance(key, str) for key in spans_logged),
+            "Dedupe keys must be strings; a tuple key crashes json.dumps",
+        )
+
+        serialized = json.dumps(metadata)
+
+        self.assertEqual(
+            len(json.loads(serialized)["_otel_internal"]["spans_logged"]),
+            3,
+            "All three dedupe markers must survive JSON serialization; a "
+            "non-string key would be silently dropped, losing dedup state",
+        )
+
     def test_create_guardrail_span_does_not_raise_on_list_mode(self):
         """End-to-end regression for LIT-3428: ``_create_guardrail_span``
         must produce exactly one span (not raise ``TypeError``) when the


### PR DESCRIPTION
## Relevant issues

Refs #32250

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Run a proxy with the OpenTelemetry callback active and prompt storage on, so the span-dedupe markers are written into request metadata and then serialized into the persisted spend log

1. Minimal config `otel_repro.yaml`

   ```yaml
   model_list:
     - model_name: haiku
       litellm_params:
         model: anthropic/claude-haiku-4-5
         api_key: os.environ/ANTHROPIC_API_KEY
   litellm_settings:
     callbacks: ["otel"]
   general_settings:
     store_prompts_in_spend_logs: true
   ```

2. Start the proxy (console OTEL exporter needs no collector)

   ```bash
   OTEL_EXPORTER=console python litellm/proxy/proxy_cli.py --config otel_repro.yaml --detailed_debug --reload 2>&1 | tee litellm.log
   ```

3. Send a real chat completion (hits Anthropic, costs real money)

   ```bash
   curl -s http://localhost:4000/v1/chat/completions \
     -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
     -d '{"model":"haiku","messages":[{"role":"user","content":"say hi in 3 words"}]}' | jq .
   ```

4. Read the persisted spend log and pull the stored request body

   ```bash
   curl -s "http://localhost:4000/spend/logs" -H "Authorization: Bearer sk-1234" \
     | jq '.[-1].proxy_server_request | fromjson | .metadata._otel_internal.spans_logged'
   ```

   On this branch the dedupe markers survive as string keys, for example

   ```json
   {
     "('OpenTelemetry', 4400788816, 'success')": true
   }
   ```

   Before this change the same key was a Python tuple. `spend_tracking_utils` sanitizes the request body with `safe_dumps`, which silently drops every non-string key, so the persisted `spans_logged` came back as `{}` and the dedup state was lost; any code path that serializes request metadata with plain `json.dumps` (the request path did exactly this before #29515) raised `TypeError: keys must be str, int, float, bool or None, not tuple` on every OpenTelemetry request, dropping the spend-log write and letting the in-memory transaction queue grow without bound

## Type

🐛 Bug Fix

## Changes

`OpenTelemetry._emit_once` writes a per-request idempotency marker into `litellm_params["metadata"]["_otel_internal"]["spans_logged"]`, keyed by `(handler class, id(self), *frozen scope)`. That metadata propagates into the persisted request body, which spend logging serializes. A tuple dict key is not JSON-serializable, so this leaked a value into request metadata that plain `json.dumps` cannot encode

The originally reported crash site on the request path was already mitigated by #29515, which switched it to `safe_dumps`. That masks the symptom rather than fixing the cause; `safe_dumps` drops the non-string keys, so the persisted dedup markers are silently emptied, and any other current or future consumer that serializes request metadata with plain `json.dumps` still crashes. This change fixes the root cause so tuple keys never enter metadata in the first place

The fix `repr`s the composed key to a string. The dedup identity is unchanged, since the marker is only ever compared against itself within a single request, and `repr` over the already-frozen, hashable parts is stable within a process. `repr` is also the fallback this module already uses in `_freeze_for_dedupe`, so this stays in keeping with the existing design rather than introducing a new convention

Added a regression test in `TestOpenTelemetrySpanDedupe` that drives `_emit_once` with tuple, list, and dict scopes, then asserts the resulting metadata is encodable with plain `json.dumps` and that all dedup markers survive serialization. It fails on the previous tuple-key code (`TypeError` / dropped markers) and passes with the string key
