### PR TITLE
feat(providers): add GonkaRouter as OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -176,5 +176,12 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "gonkarouter": {
+    "base_url": "https://api.gonkarouter.io/v1",
+    "api_key_env": "GONKAROUTER_API_KEY",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1141,6 +1141,24 @@
         "interactions": true
       }
     },
+    "gonkarouter": {
+      "display_name": "GonkaRouter (`gonkarouter`)",
+      "url": "https://docs.litellm.ai/docs/providers/gonkarouter",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "vertex_ai": {
       "display_name": "Google - Vertex AI (`vertex_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/vertex",


### PR DESCRIPTION
## Title
Add GonkaRouter as OpenAI-compatible provider

## Relevant issues
N/A — new provider registration.

## What does this PR do?
Registers **GonkaRouter** as an OpenAI-compatible provider through the JSON-only `openai_like` path — no Python transformation class and no new code paths (same pattern as `scaleway`, `aihubmix`, `gonkabroker`).

GonkaRouter is an OpenAI-compatible AI model router that provides unified access to open-source models (MiniMax, Kimi, Qwen, and more) running on the decentralized [Gonka](https://gonka.ai) network. See https://gonkarouter.io.

### Changes
- **`litellm/llms/openai_like/providers.json`** — new `gonkarouter` entry:
  - `base_url`: `https://api.gonkarouter.io/v1`
  - `api_key_env`: `GONKAROUTER_API_KEY`
  - `param_mappings`: `max_completion_tokens → max_tokens`
- **`provider_endpoints_support.json`** — capability/metadata entry marking `chat_completions` as supported (satisfies the `check_provider_folders_documented` CI check).

A companion documentation PR will be opened against `BerriAI/litellm-docs`.

## Integration details
| | |
|---|---|
| API base URL | `https://api.gonkarouter.io/v1` |
| Authentication | API key via `GONKAROUTER_API_KEY` (`Authorization: Bearer sk-…`) |
| Model naming | `gonkarouter/<model-id>` |
| Model catalog | `GET https://api.gonkarouter.io/v1/models` |

### Example config
```yaml
model_list:
  - model_name: gonkarouter-model
    litellm_params:
      model: gonkarouter/MiniMaxAI/MiniMax-M2.7
      api_key: os.environ/GONKAROUTER_API_KEY
```

## Type
🆕 New Feature

## Testing
- `python3 tests/code_coverage_tests/check_provider_folders_documented.py` → all checks pass.
- Both JSON files validated.
- Verified the live endpoints exist and enforce auth:
  - `GET https://api.gonkarouter.io/v1/models` → `401` without a key
  - `POST https://api.gonkarouter.io/v1/chat/completions` → `401 {"error":{"code":"unauthorized","message":"missing Authorization or x-api-key header"}}` without a key