### PR TITLE
fix(gateway): keep the Prometheus /metrics Mount in the gateway route trim

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -25,17 +25,25 @@ DatabaseURLSettings.from_env().apply_to_env()
 
 from litellm.proxy.proxy_server import app
 
-from gateway.routes.allowlist import GATEWAY_EXACT_PATHS, GATEWAY_PATH_PREFIXES
+from gateway.routes.allowlist import (
+    GATEWAY_EXACT_PATHS,
+    GATEWAY_MOUNT_PATHS,
+    GATEWAY_PATH_PREFIXES,
+)
 
 
 def _is_gateway_route(route) -> bool:
-    """Keep the route on the gateway if its path is in the LLM data-plane surface."""
+    """Keep the route on the gateway if its path is in the LLM data-plane surface.
+
+    Prometheus registers /metrics as a Mount (``app.mount("/metrics", make_asgi_app())``),
+    so Mounts are matched against GATEWAY_MOUNT_PATHS instead of being dropped with
+    the UI static mounts.
+    """
     path = getattr(route, "path", None)
     if path is None:
         return False
     if isinstance(route, Mount):
-        # Gateway never serves the static UI or its asset bundles.
-        return False
+        return path in GATEWAY_MOUNT_PATHS
     if path in GATEWAY_EXACT_PATHS:
         return True
     return any(path.startswith(prefix) for prefix in GATEWAY_PATH_PREFIXES)

--- a/gateway/routes/allowlist.py
+++ b/gateway/routes/allowlist.py
@@ -106,7 +106,7 @@ GATEWAY_PATH_PREFIXES: tuple[str, ...] = (
     # Health & ops
     "/health",
     "/metrics",
-    "/watsonx"
+    "/watsonx",
 )
 
 GATEWAY_EXACT_PATHS: frozenset[str] = frozenset(
@@ -118,5 +118,11 @@ GATEWAY_EXACT_PATHS: frozenset[str] = frozenset(
         "/docs/oauth2-redirect",
         "/redoc",
         "/test",
+    }
+)
+
+GATEWAY_MOUNT_PATHS: frozenset[str] = frozenset(
+    {
+        "/metrics",
     }
 )

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -11,10 +11,16 @@ clients hitting that path on the corresponding pod get a 404. This test
 guarantees that the union of the two trimmed route sets equals the full set
 of routes on the proxy app — i.e. no endpoint is dropped on the floor.
 
-The test reproduces the same predicate that ``gateway/main.py`` and
-``backend/main.py`` use, without importing them. The component modules wrap
+The union-coverage test reproduces the same predicate that ``gateway/main.py``
+and ``backend/main.py`` use, without importing them. The component modules wrap
 the shared ``app.router.lifespan_context``; importing them in the test process
-would chain wrappers and corrupt the snapshot.
+would chain wrappers and corrupt the snapshot. The gateway Mount tests below
+import the real ``gateway.main._is_gateway_route`` instead, undoing both of the
+module's import-time side effects: the lifespan wrapper is restored right after
+the import, and the DATABASE_* env vars are popped for its duration because
+``gateway.main`` runs ``DatabaseURLSettings.from_env().apply_to_env()`` at
+import (which raises on a non-postgres ``DATABASE_URL`` scheme and can mint an
+RDS IAM token when ``IAM_TOKEN_DB_AUTH`` is set).
 """
 
 import os
@@ -36,6 +42,7 @@ for _key, _value in _THROWAWAY_ENV.items():
     os.environ.setdefault(_key, _value)
 
 from fastapi.routing import Mount
+from prometheus_client import make_asgi_app
 
 # gateway/ and backend/ live at the repo root, not inside litellm/.
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
@@ -47,13 +54,35 @@ from backend.routes.allowlist import (
     BACKEND_MOUNT_PATHS,
     BACKEND_PATH_PREFIXES,
 )
-from gateway.routes.allowlist import GATEWAY_EXACT_PATHS, GATEWAY_PATH_PREFIXES
+from gateway.routes.allowlist import (
+    GATEWAY_EXACT_PATHS,
+    GATEWAY_MOUNT_PATHS,
+    GATEWAY_PATH_PREFIXES,
+)
 from litellm.proxy.proxy_server import app
 
 for _key, _previous in _PRE_EXISTING_ENV.items():
     if _previous is None:
         os.environ.pop(_key, None)
     else:
+        os.environ[_key] = _previous
+
+_DB_ENV_KEYS = (
+    "DATABASE_URL",
+    "DIRECT_URL",
+    "DATABASE_URL_READ_REPLICA",
+    "DATABASE_HOST",
+    "DATABASE_HOST_READ_REPLICA",
+    "DATABASE_PASSWORD",
+    "IAM_TOKEN_DB_AUTH",
+)
+_PRE_DB_ENV = {_key: os.environ.pop(_key, None) for _key in _DB_ENV_KEYS}
+_PRE_COMPONENT_LIFESPAN = app.router.lifespan_context
+from gateway.main import _is_gateway_route
+
+app.router.lifespan_context = _PRE_COMPONENT_LIFESPAN
+for _key, _previous in _PRE_DB_ENV.items():
+    if _previous is not None:
         os.environ[_key] = _previous
 
 
@@ -133,3 +162,61 @@ def test_backend_drops_non_allowlisted_mounts():
     for mount_path in non_backend_mounts:
         assert mount_path not in BACKEND_MOUNT_PATHS, \
             f"Mount {mount_path} should not be in BACKEND_MOUNT_PATHS"
+
+
+def test_gateway_mount_paths_defined():
+    """GATEWAY_MOUNT_PATHS constant must exist and expose /metrics."""
+    assert isinstance(GATEWAY_MOUNT_PATHS, frozenset), \
+        f"GATEWAY_MOUNT_PATHS must be a frozenset, got {type(GATEWAY_MOUNT_PATHS)}"
+    assert "/metrics" in GATEWAY_MOUNT_PATHS, \
+        "/metrics Mount path must be in GATEWAY_MOUNT_PATHS"
+
+
+def test_gateway_trim_keeps_metrics_mount():
+    """The Prometheus /metrics Mount must survive the gateway route trim.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/30291:
+    ``_is_gateway_route`` used to reject every Mount before the allowlist
+    check, so the /metrics Mount registered by
+    ``PrometheusLogger._mount_metrics_endpoint()`` was dropped at startup and
+    the gateway returned 404 on /metrics.
+    """
+    metrics_mount = Mount("/metrics", app=make_asgi_app())
+    routes = [*app.router.routes, metrics_mount]
+    trimmed = [r for r in routes if _is_gateway_route(r)]
+    assert metrics_mount in trimmed, \
+        "/metrics Mount must survive the gateway route trim"
+
+
+def test_gateway_drops_ui_and_swagger_mounts():
+    """UI static and swagger Mounts must still be trimmed from the gateway."""
+    for path in ("/ui", "/_next", "/litellm-asset-prefix/_next", "/swagger"):
+        assert not _is_gateway_route(Mount(path, app=make_asgi_app())), \
+            f"Mount {path} must not be served by the gateway"
+
+
+def test_every_app_mount_is_assigned_to_a_component():
+    """Every Mount on the proxy app must be consciously assigned to a component.
+
+    A Mount must be kept by the gateway (GATEWAY_MOUNT_PATHS), kept by the
+    backend (BACKEND_MOUNT_PATHS), or be a static mount served by the
+    dedicated UI container. A Mount matching none of these is unreachable in
+    a componentized deployment, which is exactly how the /metrics Mount was
+    silently dropped.
+    """
+    ui_served_prefixes = ("/ui", "/_next", "/litellm-asset-prefix")
+    mounts = [*app.router.routes, Mount("/metrics", app=make_asgi_app())]
+    unassigned = {
+        path
+        for r in mounts
+        if isinstance(r, Mount)
+        and (path := getattr(r, "path", None)) is not None
+        and path not in GATEWAY_MOUNT_PATHS
+        and path not in BACKEND_MOUNT_PATHS
+        and not path.startswith(ui_served_prefixes)
+    }
+    assert not unassigned, (
+        f"{len(unassigned)} Mount(s) are not exposed on any component. "
+        f"Add them to GATEWAY_MOUNT_PATHS, BACKEND_MOUNT_PATHS, or serve them "
+        f"from the UI container:\n  " + "\n  ".join(sorted(unassigned))
+    )


### PR DESCRIPTION
## Relevant issues

Fixes #30291

## Linear ticket

Resolves LIT-4236

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use the componentized gateway entrypoint with the same config, no load balancer or ingress in the path (this is what a `kubectl port-forward` of the gateway service sees):

```yaml
model_list:
  - model_name: gpt-5.4-mini
    litellm_params:
      model: openai/gpt-5.4-mini
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  success_callback: ["prometheus"]
  require_auth_for_metrics_endpoint: false
```

```bash
uvicorn gateway.main:app --host 127.0.0.1 --port 4236
```

Before the fix (base `litellm_internal_staging`), `/metrics` 404s while `/health` works, which is the exact symptom from the issue:

```
$ curl -sL -w "\nHTTP %{http_code}\n" http://127.0.0.1:4236/metrics
{"detail":"Not Found"}
HTTP 404

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:4236/health/liveliness
HTTP 200
```

Control on the same base commit and config: the monolithic entrypoint (`uvicorn litellm.proxy.proxy_server:app`) serves `/metrics` with HTTP 200, confirming the regression is specific to the gateway trim

After the fix, on the same gateway entrypoint, `/metrics` serves the Prometheus exposition and the management/UI surfaces stay trimmed:

```
$ curl -sL -w "HTTP %{http_code}\n" http://127.0.0.1:4236/metrics | head -4
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 2465.0
HTTP 200

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://127.0.0.1:4236/ui
HTTP 404

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://127.0.0.1:4236/key/generate
HTTP 404
```

End to end with a real provider call through the fixed gateway, the per-user request metrics the endpoint exists for show up on the scrape:

```
$ curl -s http://127.0.0.1:4236/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"Say metrics-ok and nothing else"}]}'
-> "metrics-ok", usage: {"prompt_tokens": 12, "completion_tokens": 5}

$ curl -sL http://127.0.0.1:4236/metrics | grep -E "^litellm_" | head -3
litellm_spend_metric_total{api_provider="openai",model="gpt-5.4-mini",requested_model="gpt-5.4-mini",user="default_user_id",...} 3.15e-05
litellm_total_tokens_metric_total{api_provider="openai",model="gpt-5.4-mini",...} 17.0
litellm_requests_metric_total{api_provider="openai",model="gpt-5.4-mini",...} 1.0
```

### Independent e2e run

Reproduced independently on the componentized gateway entrypoint with the config and commands above. BEFORE is the merge-base of this branch with `litellm_internal_staging` (`git merge-base origin/litellm_internal_staging origin/litellm_gateway_metrics_mount`, commit `5b93ba0`), where `_is_gateway_route` drops every Mount; AFTER is this branch (`ad0a456`), where `GATEWAY_MOUNT_PATHS` keeps `/metrics`. Both ran `uvicorn gateway.main:app`, BEFORE on port 4000 and AFTER on port 4001

Before and after curl sequence against the running gateway:

![before and after curl sequence on the gateway](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZjhkMzRjZmYtYTA2MC00YmJhLTgzMDQtMzAwM2Y0MjEzN2NlIiwiaWF0IjoxNzgzNDA1NTQ0LCJleHAiOjE3ODQwMTAzNDQsImZpbGVuYW1lIjoid2Fsa3Rocm91Z2guZ2lmIn0.hNQ0EBcNTE_r2SzqOaHFzIP8jDb-HeuQSttycY5RDA4)

BEFORE, on the merge-base, `/metrics` is 404 on the gateway even though `/health/liveliness` is 200:

![before: gateway metrics 404 while liveliness is 200](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMGI1MDQ0MDQtYmNiMC00MWUwLTk3Y2QtMWU2NTU3YTg2NjZkIiwiaWF0IjoxNzgzNDA1NTQ0LCJleHAiOjE3ODQwMTAzNDQsImZpbGVuYW1lIjoiYmVmb3JlXzQwNC5wbmcifQ.H3aLnRDRh9w8sN4yTii7PGbf2VPn71FWP0YD_MAkI90)

AFTER, on this branch, `/metrics` returns 200 with the Prometheus exposition text (`# HELP python_gc_...`), and `/ui` plus `POST /key/generate` stay 404:

![after: gateway metrics 200 with prometheus exposition text](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvOTIxODU2MWUtYzc2YS00ZWVlLWIyZjktMjhhY2U2NGMwYWJkIiwiaWF0IjoxNzgzNDA1NTQ0LCJleHAiOjE3ODQwMTAzNDQsImZpbGVuYW1lIjoiYWZ0ZXJfMjAwLnBuZyJ9._3DhaYPnQEm7pgPoYozpoOYZk3dKCeyqpWSQgjlBbKI)

The regression tests in `tests/test_litellm/proxy/test_component_allowlists.py` pass on the branch, 9 passed:

![regression tests 9 passed](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZDZjODNjY2ItNzVjMC00OTlkLWFkMmMtZGVmNzRkNDBmOGIyIiwiaWF0IjoxNzgzNDA1NTQ0LCJleHAiOjE3ODQwMTAzNDQsImZpbGVuYW1lIjoicHl0ZXN0X3Bhc3MucG5nIn0.xXovHyg5kIaGcBhEZtqqn4Uk4DAbbtHSXzCZxPgR0gA)

One environment note for anyone reproducing this locally: FastAPI 0.137+ changed `app.include_router` to attach a lazy `_IncludedRouter` object that has no `.path`, so on those versions the lifespan trim drops the whole included-route surface (health, models, chat, everything), not just Mounts, and the fixed `/metrics` cannot even be observed because nothing else is served. This run pinned `fastapi==0.136.3`, the lower bound of the `fastapi>=0.136.3,<1.0` range in `pyproject.toml`, where `include_router` still flattens routes so the trim behaves as designed. A reasonable follow-up would be to make `_is_gateway_route` recurse into `_IncludedRouter` so the gateway keeps working on newer FastAPI, since the resolved lockfile currently picks 0.139.0

## Type

🐛 Bug Fix

## Changes

The componentized gateway entrypoint (`gateway/main.py`) trims the shared proxy route table at startup. Its `_is_gateway_route` predicate rejected every starlette `Mount` before consulting the allowlist, but Prometheus registers `/metrics` as a Mount via `app.mount("/metrics", make_asgi_app())` (`litellm/integrations/prometheus.py`). The trim runs inside the wrapped lifespan after the proxy's startup hooks have mounted `/metrics`, so the route was created and then deleted, and the gateway returned 404 even though `/metrics` is listed in `gateway/routes/allowlist.py` and the helm ingress routes `/metrics` to the gateway service

The fix mirrors the pattern the backend component already uses for its `/swagger` Mount (`BACKEND_MOUNT_PATHS`): `gateway/routes/allowlist.py` gains a `GATEWAY_MOUNT_PATHS` frozenset containing `/metrics`, and the Mount branch of `_is_gateway_route` now keeps Mounts whose path is in that set instead of returning False unconditionally. UI static mounts (`/ui`, `/_next`, `/litellm-asset-prefix/_next`) and `/swagger` remain trimmed

Tests in `tests/test_litellm/proxy/test_component_allowlists.py` previously excluded Mounts from the union-coverage assertion, which is why CI never saw this. The new tests import the real `_is_gateway_route` (restoring the lifespan wrapper and DATABASE_* env vars its import mutates) and assert that a production-shaped `/metrics` Mount survives the trim, that UI and swagger Mounts are still dropped, and that every Mount on the app is assigned to the gateway, the backend, or the UI container. The core regression test fails on the pre-fix code

Link to Devin session: https://app.devin.ai/sessions/90969e1591404372a4a9f57fcad4e023
