### PR TITLE
fix(mcp): exclude tools whose prefixed name exceeds the 64 char provider limit

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -115,6 +115,11 @@ MCP_PER_USER_TOKEN_DEFAULT_TTL = int(
 )
 MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS = int(os.getenv("MCP_PER_USER_TOKEN_EXPIRY_BUFFER_SECONDS", "60"))
 
+# Providers such as AWS Bedrock, OpenAI, and Gemini reject tool names longer than
+# 64 characters, so MCP tools whose final (prefixed) name exceeds this are excluded
+# from tool listings. Set to 0 or a negative value to disable the exclusion.
+MCP_MAX_TOOL_NAME_LENGTH = int(os.getenv("LITELLM_MCP_MAX_TOOL_NAME_LENGTH", "64"))
+
 # MCP timeout defaults (seconds). Override via env vars for slow/custom MCP servers.
 MCP_CLIENT_TIMEOUT = float(os.getenv("LITELLM_MCP_CLIENT_TIMEOUT", "60.0"))
 MCP_TOOL_LISTING_TIMEOUT = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "30.0"))

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -3198,12 +3198,17 @@ class MCPServerManager:
         kept, dropped = split_tools_by_name_length(tools, MCP_MAX_TOOL_NAME_LENGTH)
         if dropped:
             dropped_names = ", ".join(f"{tool.name} ({len(tool.name)} chars)" for tool in dropped)
+            server_label = (
+                server.name
+                if not server.alias or server.alias == server.name
+                else f"{server.name} (alias {server.alias})"
+            )
             verbose_logger.warning(
                 "MCP server %s has %d tool(s) whose name exceeds %d characters, which providers such as "
                 "AWS Bedrock, OpenAI, and Gemini reject. Excluding them from tool listings: %s. "
                 "Use a shorter server alias, rename the tools on the MCP server, or set "
                 "LITELLM_MCP_MAX_TOOL_NAME_LENGTH to change the limit.",
-                server.name,
+                server_label,
                 len(dropped),
                 MCP_MAX_TOOL_NAME_LENGTH,
                 dropped_names,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -38,6 +38,7 @@ from litellm._logging import verbose_logger
 from litellm.constants import (
     MCP_CLIENT_TIMEOUT,
     MCP_HEALTH_CHECK_TIMEOUT,
+    MCP_MAX_TOOL_NAME_LENGTH,
     MCP_METADATA_TIMEOUT,
     MCP_NPM_CACHE_DIR,
     MCP_STDIO_ALLOWED_COMMANDS,
@@ -97,6 +98,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     normalize_server_name,
     parse_admin_env_vars,
     split_server_prefix_from_name,
+    split_tools_by_name_length,
     strip_known_server_prefix,
     validate_mcp_server_name,
 )
@@ -2465,14 +2467,14 @@ class MCPServerManager:
                         )
                         for t in tools
                     ]
-                return tools
+                return self._drop_tools_exceeding_name_length(tools, server)
             else:
                 tools = await self._fetch_tools_with_timeout(client, server.name)
                 self._remember_upstream_initialize_instructions(server, client)
 
             prefixed_or_original_tools = self._create_prefixed_tools(tools, server, add_prefix=add_prefix)
 
-            return prefixed_or_original_tools
+            return self._drop_tools_exceeding_name_length(prefixed_or_original_tools, server)
 
         except MCPUpstreamAuthError:
             # Pass-through 401 must surface to single-server routes so the
@@ -3184,6 +3186,29 @@ class MCPServerManager:
             f"{server.server_id} after {self._SHORT_PREFIX_MAX_REHASH_ATTEMPTS} "
             "attempts; the 3-character prefix space is too crowded."
         )
+
+    def _drop_tools_exceeding_name_length(self, tools: list[MCPTool], server: MCPServer) -> list[MCPTool]:
+        """Exclude tools whose final listed name exceeds ``MCP_MAX_TOOL_NAME_LENGTH``.
+
+        Providers such as AWS Bedrock, OpenAI, and Gemini reject tool names longer
+        than 64 characters, so listing them would make every downstream LLM request
+        carrying the full tool list fail. The tools stay callable by name; they are
+        only excluded from listings.
+        """
+        kept, dropped = split_tools_by_name_length(tools, MCP_MAX_TOOL_NAME_LENGTH)
+        if dropped:
+            dropped_names = ", ".join(f"{tool.name} ({len(tool.name)} chars)" for tool in dropped)
+            verbose_logger.warning(
+                "MCP server %s has %d tool(s) whose name exceeds %d characters, which providers such as "
+                "AWS Bedrock, OpenAI, and Gemini reject. Excluding them from tool listings: %s. "
+                "Use a shorter server alias, rename the tools on the MCP server, or set "
+                "LITELLM_MCP_MAX_TOOL_NAME_LENGTH to change the limit.",
+                server.name,
+                len(dropped),
+                MCP_MAX_TOOL_NAME_LENGTH,
+                dropped_names,
+            )
+        return kept
 
     def _create_prefixed_tools(self, tools: list[MCPTool], server: MCPServer, add_prefix: bool = True) -> list[MCPTool]:
         """

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -100,6 +100,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     split_server_prefix_from_name,
     split_tools_by_name_length,
     strip_known_server_prefix,
+    tool_name_length_disabled_reason,
     validate_mcp_server_name,
 )
 from litellm.proxy._types import (
@@ -2355,6 +2356,7 @@ class MCPServerManager:
         raw_headers: Optional[dict[str, str]] = None,
         user_api_key_auth: Optional[UserAPIKeyAuth] = None,
         oauth2_headers: Optional[dict[str, str]] = None,
+        drop_overlong_names: bool = True,
     ) -> list[MCPTool]:
         """
         Helper method to get tools from a single MCP server with prefixed names.
@@ -2362,6 +2364,10 @@ class MCPServerManager:
         Args:
             server (MCPServer): The server to query tools from
             mcp_auth_header: Optional auth header for MCP server
+            drop_overlong_names: When True (every LLM-facing path), tools whose
+                final listed name exceeds ``MCP_MAX_TOOL_NAME_LENGTH`` are
+                excluded. The admin UI listing passes False so those tools stay
+                visible and can be rendered as disabled.
 
         Returns:
             List[MCPTool]: List of tools available on the server with prefixed names
@@ -2467,13 +2473,15 @@ class MCPServerManager:
                         )
                         for t in tools
                     ]
-                return self._drop_tools_exceeding_name_length(tools, server)
+                return self._drop_tools_exceeding_name_length(tools, server) if drop_overlong_names else tools
             else:
                 tools = await self._fetch_tools_with_timeout(client, server.name)
                 self._remember_upstream_initialize_instructions(server, client)
 
             prefixed_or_original_tools = self._create_prefixed_tools(tools, server, add_prefix=add_prefix)
 
+            if not drop_overlong_names:
+                return prefixed_or_original_tools
             return self._drop_tools_exceeding_name_length(prefixed_or_original_tools, server)
 
         except MCPUpstreamAuthError:
@@ -3192,8 +3200,9 @@ class MCPServerManager:
 
         Providers such as AWS Bedrock, OpenAI, and Gemini reject tool names longer
         than 64 characters, so listing them would make every downstream LLM request
-        carrying the full tool list fail. The tools stay callable by name; they are
-        only excluded from listings.
+        carrying the full tool list fail. The admin UI listing keeps these tools
+        visible (rendered as disabled) via ``drop_overlong_names=False``, and
+        ``call_tool`` rejects direct calls to them with the same reason.
         """
         kept, dropped = split_tools_by_name_length(tools, MCP_MAX_TOOL_NAME_LENGTH)
         if dropped:
@@ -3205,7 +3214,8 @@ class MCPServerManager:
             )
             verbose_logger.warning(
                 "MCP server %s has %d tool(s) whose name exceeds %d characters, which providers such as "
-                "AWS Bedrock, OpenAI, and Gemini reject. Excluding them from tool listings: %s. "
+                "AWS Bedrock, OpenAI, and Gemini reject. Disabling them: excluded from tool listings "
+                "sent to LLMs and direct calls are rejected: %s. "
                 "Use a shorter server alias, rename the tools on the MCP server, or set "
                 "LITELLM_MCP_MAX_TOOL_NAME_LENGTH to change the limit.",
                 server_label,
@@ -4029,6 +4039,18 @@ class MCPServerManager:
         """
         start_time = datetime.datetime.now()
         mcp_server = self._resolve_mcp_server_for_tool_call(server_name, name)
+
+        # Callers may pass the name prefixed or unprefixed; normalize to the
+        # canonical listed form before measuring against the provider limit.
+        canonical_name = add_server_prefix_to_name(
+            strip_known_server_prefix(name, mcp_server), get_server_prefix(mcp_server)
+        )
+        disabled_reason = tool_name_length_disabled_reason(canonical_name, MCP_MAX_TOOL_NAME_LENGTH)
+        if disabled_reason is not None:
+            raise HTTPException(
+                status_code=400,
+                detail={"error": "tool_name_too_long", "message": disabled_reason},
+            )
 
         # Resolved before any hook runs so a missing BYOK credential (401) never
         # leaves during-hook side effects (audit logging, rate-limit bookkeeping)

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -25,9 +25,12 @@ from litellm.proxy._experimental.mcp_server.ui_session_utils import (
 from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
 from litellm.proxy._experimental.mcp_server.utils import (
     MCPMissingUserEnvVarsError,
+    add_server_prefix_to_name,
     get_server_prefix,
     is_short_mcp_tool_prefix_enabled,
     merge_mcp_headers,
+    strip_known_server_prefix,
+    tool_name_length_disabled_reason,
     tool_name_length_warnings,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
@@ -262,14 +265,24 @@ if MCP_AVAILABLE:
             "server_id": server.server_id,
             "alias": server.alias,
         }
+        server_prefix = get_server_prefix(server)
+        disabled_reasons = [
+            tool_name_length_disabled_reason(
+                add_server_prefix_to_name(strip_known_server_prefix(tool.name, server), server_prefix),
+                MCP_MAX_TOOL_NAME_LENGTH,
+            )
+            for tool in tools
+        ]
         return [
             ListMCPToolsRestAPIResponseObject(
                 name=tool.name,
                 description=tool.description,
                 inputSchema=tool.inputSchema,
                 mcp_info=enriched_mcp_info,
+                disabled=reason is not None,
+                disabled_reason=reason,
             )
-            for tool in tools
+            for tool, reason in zip(tools, disabled_reasons)
         ]
 
     def _extract_mcp_headers_from_request(
@@ -412,6 +425,7 @@ if MCP_AVAILABLE:
             add_prefix=False,
             raw_headers=raw_headers,
             user_api_key_auth=user_api_key_auth,
+            drop_overlong_names=False,
         )
 
         if not apply_tool_filters:

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1294,9 +1294,25 @@ if MCP_AVAILABLE:
 
         new_mcp_server_request = _inherit_credentials_from_existing_server(new_mcp_server_request)
 
+        def _preview_warnings(tool_names: List[str]) -> List[str]:
+            # In short-prefix mode the 3-char prefix derives from the server_id
+            # assigned at create time, so without one the final length is
+            # unknowable; skip speculative warnings (runtime exclusion still warns).
+            if is_short_mcp_tool_prefix_enabled() and not new_mcp_server_request.server_id:
+                return []
+            return tool_name_length_warnings(
+                tool_names,
+                get_server_prefix(new_mcp_server_request),
+                MCP_MAX_TOOL_NAME_LENGTH,
+            )
+
         # For OpenAPI spec servers, generate tools from the spec directly
         if new_mcp_server_request.spec_path:
-            return await _preview_openapi_tools(new_mcp_server_request.spec_path)
+            openapi_preview = await _preview_openapi_tools(new_mcp_server_request.spec_path)
+            return {
+                **openapi_preview,
+                "warnings": _preview_warnings([tool["name"] for tool in openapi_preview.get("tools") or []]),
+            }
 
         from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
             MCPRequestHandler,
@@ -1326,23 +1342,11 @@ if MCP_AVAILABLE:
             list_tools_response = await client.run_with_session(_list_tools_session_operation)
             list_tools_result: List[MCPTool] = list_tools_response.tools
             model_dumped_tools: List[dict] = [tool.model_dump() for tool in list_tools_result]
-            # In short-prefix mode the 3-char prefix derives from the server_id
-            # assigned at create time, so without one the final length is
-            # unknowable; skip speculative warnings (runtime exclusion still warns).
-            warnings = (
-                []
-                if is_short_mcp_tool_prefix_enabled() and not new_mcp_server_request.server_id
-                else tool_name_length_warnings(
-                    [tool.name for tool in list_tools_result],
-                    get_server_prefix(new_mcp_server_request),
-                    MCP_MAX_TOOL_NAME_LENGTH,
-                )
-            )
             return {
                 "tools": model_dumped_tools,
                 "error": None,
                 "message": "Successfully retrieved tools",
-                "warnings": warnings,
+                "warnings": _preview_warnings([tool.name for tool in list_tools_result]),
             }
 
         return await _execute_with_mcp_client(

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -22,9 +22,12 @@ from litellm.proxy._experimental.mcp_server.exceptions import MCPUpstreamAuthErr
 from litellm.proxy._experimental.mcp_server.ui_session_utils import (
     build_effective_auth_contexts,
 )
+from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
 from litellm.proxy._experimental.mcp_server.utils import (
     MCPMissingUserEnvVarsError,
+    get_server_prefix,
     merge_mcp_headers,
+    tool_name_length_warnings,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.ip_address_utils import IPAddressUtils
@@ -1308,10 +1311,16 @@ if MCP_AVAILABLE:
             list_tools_response = await client.run_with_session(_list_tools_session_operation)
             list_tools_result: List[MCPTool] = list_tools_response.tools
             model_dumped_tools: List[dict] = [tool.model_dump() for tool in list_tools_result]
+            warnings = tool_name_length_warnings(
+                [tool.name for tool in list_tools_result],
+                get_server_prefix(new_mcp_server_request),
+                MCP_MAX_TOOL_NAME_LENGTH,
+            )
             return {
                 "tools": model_dumped_tools,
                 "error": None,
                 "message": "Successfully retrieved tools",
+                "warnings": warnings,
             }
 
         return await _execute_with_mcp_client(

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -26,6 +26,7 @@ from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
 from litellm.proxy._experimental.mcp_server.utils import (
     MCPMissingUserEnvVarsError,
     get_server_prefix,
+    is_short_mcp_tool_prefix_enabled,
     merge_mcp_headers,
     tool_name_length_warnings,
 )
@@ -1311,10 +1312,17 @@ if MCP_AVAILABLE:
             list_tools_response = await client.run_with_session(_list_tools_session_operation)
             list_tools_result: List[MCPTool] = list_tools_response.tools
             model_dumped_tools: List[dict] = [tool.model_dump() for tool in list_tools_result]
-            warnings = tool_name_length_warnings(
-                [tool.name for tool in list_tools_result],
-                get_server_prefix(new_mcp_server_request),
-                MCP_MAX_TOOL_NAME_LENGTH,
+            # In short-prefix mode the 3-char prefix derives from the server_id
+            # assigned at create time, so without one the final length is
+            # unknowable; skip speculative warnings (runtime exclusion still warns).
+            warnings = (
+                []
+                if is_short_mcp_tool_prefix_enabled() and not new_mcp_server_request.server_id
+                else tool_name_length_warnings(
+                    [tool.name for tool in list_tools_result],
+                    get_server_prefix(new_mcp_server_request),
+                    MCP_MAX_TOOL_NAME_LENGTH,
+                )
             )
             return {
                 "tools": model_dumped_tools,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -359,9 +359,16 @@ if MCP_AVAILABLE:
     class ListMCPToolsRestAPIResponseObject(MCPTool):
         """
         Object returned by the /tools/list REST API route.
+
+        ``disabled`` is True when the tool's prefixed name exceeds the
+        ``MCP_MAX_TOOL_NAME_LENGTH`` provider limit: the tool is excluded from
+        LLM-facing listings and direct calls are rejected, with the
+        explanation in ``disabled_reason``.
         """
 
         mcp_info: Optional[MCPInfo] = None
+        disabled: bool = False
+        disabled_reason: Optional[str] = None
         model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def _normalize_resource_contents(contents: list) -> List[ReadResourceContents]:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -5,6 +5,7 @@ MCP Server Utilities
 import json
 import re
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -12,10 +13,14 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
 )
+
+if TYPE_CHECKING:
+    from mcp.types import Tool as MCPTool
 
 import hashlib
 import importlib
@@ -264,6 +269,40 @@ def add_server_prefix_to_name(name: str, server_name: str) -> str:
         separator=MCP_TOOL_PREFIX_SEPARATOR,
         tool_name=name,
     )
+
+
+def split_tools_by_name_length(tools: Sequence["MCPTool"], max_length: int) -> Tuple[List["MCPTool"], List["MCPTool"]]:
+    """Split ``tools`` into (kept, dropped) by whether ``tool.name`` fits ``max_length``.
+
+    A ``max_length`` of zero or less disables the check and keeps every tool.
+    """
+    if max_length <= 0:
+        return list(tools), []
+    kept = [tool for tool in tools if len(tool.name) <= max_length]
+    dropped = [tool for tool in tools if len(tool.name) > max_length]
+    return kept, dropped
+
+
+def tool_name_length_warnings(tool_names: Iterable[str], server_prefix: str, max_length: int) -> List[str]:
+    """Warnings for tools whose prefixed name would exceed ``max_length``.
+
+    Used at server add/preview time, before the server is persisted, to flag
+    tool names that the runtime listing will exclude once the server prefix
+    (``<alias>-<tool>``) is applied.
+    """
+    if max_length <= 0:
+        return []
+    prefixed_by_name = [(name, add_server_prefix_to_name(name, server_prefix)) for name in tool_names]
+    return [
+        (
+            f"Tool '{name}' will be listed as '{prefixed}' ({len(prefixed)} characters), which exceeds the "
+            f"{max_length} character tool name limit enforced by providers such as AWS Bedrock, OpenAI, and "
+            f"Gemini. LiteLLM will exclude it from tool listings. Use a shorter server alias or rename the "
+            f"tool on the MCP server."
+        )
+        for name, prefixed in prefixed_by_name
+        if len(prefixed) > max_length
+    ]
 
 
 def get_server_prefix(server: Any) -> str:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -283,11 +283,27 @@ def split_tools_by_name_length(tools: Sequence["MCPTool"], max_length: int) -> T
     return kept, dropped
 
 
+def tool_name_length_disabled_reason(prefixed_name: str, max_length: int) -> Optional[str]:
+    """The reason a tool is disabled by the name-length limit, or ``None`` when it fits.
+
+    A ``max_length`` of zero or less disables the check entirely.
+    """
+    if max_length <= 0 or len(prefixed_name) <= max_length:
+        return None
+    return (
+        f"Tool name '{prefixed_name}' is {len(prefixed_name)} characters, which exceeds the "
+        f"{max_length} character tool name limit enforced by providers such as AWS Bedrock, OpenAI, and "
+        f"Gemini. LiteLLM disables it: it is excluded from tool listings sent to LLMs and direct calls "
+        f"are rejected. Use a shorter server alias, rename the tool on the MCP server, or set "
+        f"LITELLM_MCP_MAX_TOOL_NAME_LENGTH to change the limit."
+    )
+
+
 def tool_name_length_warnings(tool_names: Iterable[str], server_prefix: str, max_length: int) -> List[str]:
     """Warnings for tools whose prefixed name would exceed ``max_length``.
 
     Used at server add/preview time, before the server is persisted, to flag
-    tool names that the runtime listing will exclude once the server prefix
+    tool names that will be disabled once the server prefix
     (``<alias>-<tool>``) is applied.
     """
     if max_length <= 0:
@@ -297,8 +313,8 @@ def tool_name_length_warnings(tool_names: Iterable[str], server_prefix: str, max
         (
             f"Tool '{name}' will be listed as '{prefixed}' ({len(prefixed)} characters), which exceeds the "
             f"{max_length} character tool name limit enforced by providers such as AWS Bedrock, OpenAI, and "
-            f"Gemini. LiteLLM will exclude it from tool listings. Use a shorter server alias or rename the "
-            f"tool on the MCP server."
+            f"Gemini. LiteLLM will disable it: it will be excluded from tool listings sent to LLMs and "
+            f"direct calls will be rejected. Use a shorter server alias or rename the tool on the MCP server."
         )
         for name, prefixed in prefixed_by_name
         if len(prefixed) > max_length

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -1946,6 +1946,8 @@ async def test_get_tools_for_single_server():
     mock_server.mcp_info = {"server_name": "zapier"}
     mock_server.server_id = "zapier_id"
     mock_server.alias = "zapier_alias"
+    mock_server.server_name = "zapier"
+    mock_server.short_prefix = None
     mock_server.allowed_tools = None
     mock_server.disallowed_tools = None
 
@@ -1974,6 +1976,7 @@ async def test_get_tools_for_single_server():
             add_prefix=False,
             raw_headers=None,
             user_api_key_auth=None,
+            drop_overlong_names=False,
         )
 
         # Verify the result
@@ -1998,6 +2001,9 @@ async def test_get_tools_for_single_server_applies_disallowed_tools_without_allo
     mock_server.mcp_info = {"server_name": "zapier"}
     mock_server.name = "zapier"
     mock_server.server_id = "zapier"
+    mock_server.alias = "zapier"
+    mock_server.server_name = "zapier"
+    mock_server.short_prefix = None
     mock_server.allowed_tools = None
     mock_server.disallowed_tools = ["send_email"]
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6324,3 +6324,51 @@ def test_build_mcp_server_table_carries_null_oauth2_flow():
     table = manager._build_mcp_server_table(server)
 
     assert table.oauth2_flow is None
+
+
+class TestToolNameLengthExclusion:
+    """LIT-4216: tools whose final listed name exceeds MCP_MAX_TOOL_NAME_LENGTH must not be listed,
+    because providers such as AWS Bedrock, OpenAI, and Gemini reject tool names longer than 64 chars."""
+
+    def _server(self, alias: str) -> MCPServer:
+        return MCPServer(
+            server_id="len-limit",
+            name="len-limit-server",
+            alias=alias,
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+        )
+
+    async def _list_tools(self, server: MCPServer, tool_names: list, add_prefix: bool = True):
+        manager = MCPServerManager()
+        upstream_tools = [MCPTool(name=name, inputSchema={}) for name in tool_names]
+        manager._create_mcp_client = AsyncMock(return_value=object())
+        manager._fetch_tools_with_timeout = AsyncMock(return_value=upstream_tools)
+        return await manager._get_tools_from_server(server=server, add_prefix=add_prefix)
+
+    @pytest.mark.asyncio
+    async def test_drops_tool_whose_prefixed_name_exceeds_limit(self):
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+
+        alias = "network_config_audit"
+        fitting = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias) - 1)
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+        assert len(f"{alias}-{fitting}") == MCP_MAX_TOOL_NAME_LENGTH
+        assert len(f"{alias}-{too_long}") == MCP_MAX_TOOL_NAME_LENGTH + 1
+
+        tools = await self._list_tools(self._server(alias), [fitting, too_long])
+
+        assert [t.name for t in tools] == [f"{alias}-{fitting}"]
+
+    @pytest.mark.asyncio
+    async def test_unprefixed_listing_measures_the_raw_name(self):
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+
+        alias = "network_config_audit"
+        raw_at_limit = "t" * MCP_MAX_TOOL_NAME_LENGTH
+        raw_too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH + 1)
+
+        tools = await self._list_tools(self._server(alias), [raw_at_limit, raw_too_long], add_prefix=False)
+
+        assert [t.name for t in tools] == [raw_at_limit]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -6372,3 +6372,70 @@ class TestToolNameLengthExclusion:
         tools = await self._list_tools(self._server(alias), [raw_at_limit, raw_too_long], add_prefix=False)
 
         assert [t.name for t in tools] == [raw_at_limit]
+
+    @pytest.mark.asyncio
+    async def test_ui_listing_keeps_overlong_tools_when_drop_disabled(self):
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+
+        alias = "network_config_audit"
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+
+        manager = MCPServerManager()
+        manager._create_mcp_client = AsyncMock(return_value=object())
+        manager._fetch_tools_with_timeout = AsyncMock(return_value=[MCPTool(name=too_long, inputSchema={})])
+        tools = await manager._get_tools_from_server(
+            server=self._server(alias), add_prefix=False, drop_overlong_names=False
+        )
+
+        assert [t.name for t in tools] == [too_long]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_rejects_overlong_tool_with_clean_error(self):
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+
+        alias = "network_config_audit"
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+        prefixed = f"{alias}-{too_long}"
+        assert len(prefixed) == MCP_MAX_TOOL_NAME_LENGTH + 1
+
+        manager = MCPServerManager()
+        server = self._server(alias)
+        manager.registry = {server.server_id: server}
+        manager.tool_name_to_mcp_server_name_mapping[too_long] = alias
+        manager.tool_name_to_mcp_server_name_mapping[prefixed] = alias
+        manager._create_mcp_client = AsyncMock(
+            side_effect=AssertionError("must reject before connecting upstream")
+        )
+
+        for call_name in (too_long, prefixed):
+            with pytest.raises(HTTPException) as exc_info:
+                await manager.call_tool(server_name=alias, name=call_name, arguments={})
+            assert exc_info.value.status_code == 400
+            assert exc_info.value.detail["error"] == "tool_name_too_long"
+            assert "exceeds the 64 character tool name limit" in exc_info.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_call_tool_allows_tool_at_the_limit(self):
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+
+        alias = "network_config_audit"
+        fitting = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias) - 1)
+        prefixed = f"{alias}-{fitting}"
+        assert len(prefixed) == MCP_MAX_TOOL_NAME_LENGTH
+
+        manager = MCPServerManager()
+        server = self._server(alias)
+        manager.registry = {server.server_id: server}
+        manager.tool_name_to_mcp_server_name_mapping[fitting] = alias
+        manager.tool_name_to_mcp_server_name_mapping[prefixed] = alias
+
+        mock_client = AsyncMock()
+        call_result = MagicMock(spec=CallToolResult)
+        call_result.isError = False
+        call_result.content = []
+        mock_client.call_tool = AsyncMock(return_value=call_result)
+        manager._create_mcp_client = AsyncMock(return_value=mock_client)
+
+        result = await manager.call_tool(server_name=alias, name=fitting, arguments={})
+
+        assert result.isError is False

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -593,6 +593,57 @@ class TestTestToolsList:
         assert captured["oauth2_headers"] == oauth_headers
         assert oauth_call_counter["count"] == 1
 
+    async def test_flags_tool_names_exceeding_provider_limit(self, monkeypatch):
+        """LIT-4216: the add-time preview must warn when a tool's prefixed name will exceed
+        the 64-char tool name limit providers such as Bedrock/OpenAI/Gemini enforce."""
+        from types import SimpleNamespace
+
+        from mcp.types import Tool as MCPTool
+
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+        from litellm.proxy._types import LitellmUserRoles
+
+        alias = "network_config_audit"
+        fitting = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias) - 1)
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+
+        class FakeClient:
+            async def run_with_session(self, operation):
+                return SimpleNamespace(
+                    tools=[
+                        MCPTool(name=fitting, inputSchema={}),
+                        MCPTool(name=too_long, inputSchema={}),
+                    ]
+                )
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            return await operation(FakeClient())
+
+        monkeypatch.setattr(
+            rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False
+        )
+
+        result = await rest_endpoints.test_tools_list(
+            _build_request(),
+            NewMCPServerRequest(
+                server_name="example",
+                alias=alias,
+                url="https://example.com",
+                auth_type=MCPAuth.none,
+            ),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert len(result["tools"]) == 2
+        assert len(result["warnings"]) == 1
+        assert f"{alias}-{too_long}" in result["warnings"][0]
+
 
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -644,6 +644,50 @@ class TestTestToolsList:
         assert len(result["warnings"]) == 1
         assert f"{alias}-{too_long}" in result["warnings"][0]
 
+    async def test_no_speculative_warnings_in_short_prefix_mode(self, monkeypatch):
+        """In short-prefix mode without a server_id the 3-char runtime prefix is not
+        knowable yet, so the preview must not warn based on the full alias."""
+        from types import SimpleNamespace
+
+        from mcp.types import Tool as MCPTool
+
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+        from litellm.proxy._types import LitellmUserRoles
+
+        alias = "network_config_audit"
+        fits_short_prefix_only = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+
+        class FakeClient:
+            async def run_with_session(self, operation):
+                return SimpleNamespace(tools=[MCPTool(name=fits_short_prefix_only, inputSchema={})])
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            return await operation(FakeClient())
+
+        monkeypatch.setattr(
+            rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False
+        )
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "1")
+
+        result = await rest_endpoints.test_tools_list(
+            _build_request(),
+            NewMCPServerRequest(
+                server_name="example",
+                alias=alias,
+                url="https://example.com",
+                auth_type=MCPAuth.none,
+            ),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["warnings"] == []
+
 
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -688,6 +688,40 @@ class TestTestToolsList:
 
         assert result["warnings"] == []
 
+    async def test_openapi_preview_flags_tool_names_exceeding_provider_limit(self, monkeypatch):
+        """The OpenAPI spec preview must carry the same length warnings as the MCP
+        preview, since registered OpenAPI tools get the server prefix too."""
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+        from litellm.proxy._types import LitellmUserRoles
+
+        alias = "network_config_audit"
+        fitting = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias) - 1)
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+
+        async def fake_preview(spec_path):
+            return {
+                "tools": [{"name": fitting}, {"name": too_long}],
+                "error": None,
+                "message": "Found 2 tools from OpenAPI spec",
+            }
+
+        monkeypatch.setattr(rest_endpoints, "_preview_openapi_tools", fake_preview, raising=False)
+
+        result = await rest_endpoints.test_tools_list(
+            _build_request(),
+            NewMCPServerRequest(
+                server_name="example",
+                alias=alias,
+                spec_path="/tmp/spec.json",
+                auth_type=MCPAuth.none,
+            ),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert len(result["tools"]) == 2
+        assert len(result["warnings"]) == 1
+        assert f"{alias}-{too_long}" in result["warnings"][0]
+
 
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -2496,3 +2496,35 @@ class TestToolResponseMcpInfoEnrichment:
             "server_id": "server-uuid",
             "alias": None,
         }
+
+
+class TestToolResponseDisabledAnnotation:
+    """LIT-4216: the UI listing keeps over-limit tools visible but flags them disabled."""
+
+    def test_marks_overlong_tool_disabled_with_reason(self):
+        from mcp.types import Tool as MCPTool
+
+        from litellm.constants import MCP_MAX_TOOL_NAME_LENGTH
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+        from litellm.types.mcp import MCPTransport
+
+        alias = "network_config_audit"
+        fitting = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias) - 1)
+        too_long = "t" * (MCP_MAX_TOOL_NAME_LENGTH - len(alias))
+        server = MCPServer(
+            server_id="len-limit",
+            name="len-limit-server",
+            alias=alias,
+            url="https://up.example.com",
+            transport=MCPTransport.http,
+        )
+
+        objects = rest_endpoints._create_tool_response_objects(
+            [MCPTool(name=fitting, inputSchema={}), MCPTool(name=too_long, inputSchema={})],
+            server,
+        )
+
+        assert [o.disabled for o in objects] == [False, True]
+        assert objects[0].disabled_reason is None
+        assert f"{alias}-{too_long}" in objects[1].disabled_reason
+        assert "direct calls" in objects[1].disabled_reason

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_tool_name_length_limit.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_tool_name_length_limit.py
@@ -1,0 +1,40 @@
+"""LIT-4216: helpers gating MCP tool names against the 64-char provider limit."""
+
+from mcp.types import Tool as MCPTool
+
+from litellm.proxy._experimental.mcp_server.utils import (
+    split_tools_by_name_length,
+    tool_name_length_warnings,
+)
+
+
+def _tool(name: str) -> MCPTool:
+    return MCPTool(name=name, inputSchema={})
+
+
+def test_split_keeps_names_at_the_limit_and_drops_longer():
+    kept, dropped = split_tools_by_name_length([_tool("a" * 64), _tool("b" * 65)], 64)
+
+    assert [tool.name for tool in kept] == ["a" * 64]
+    assert [tool.name for tool in dropped] == ["b" * 65]
+
+
+def test_split_zero_or_negative_limit_disables_the_check():
+    tools = [_tool("a" * 300)]
+
+    for limit in (0, -1):
+        kept, dropped = split_tools_by_name_length(tools, limit)
+        assert [tool.name for tool in kept] == ["a" * 300]
+        assert dropped == []
+
+
+def test_warnings_flag_only_tools_whose_prefixed_name_exceeds_the_limit():
+    warnings = tool_name_length_warnings(["short", "t" * 60], "server_alias", 64)
+
+    assert len(warnings) == 1
+    assert f"server_alias-{'t' * 60}" in warnings[0]
+    assert "(73 characters)" in warnings[0]
+
+
+def test_warnings_disabled_when_limit_is_zero():
+    assert tool_name_length_warnings(["t" * 300], "server_alias", 0) == []

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -95,6 +95,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   // Single hook call shared by MCPConnectionStatus and MCPToolConfiguration to avoid duplicate requests.
   const {
     tools,
+    toolsWarnings,
     isLoadingTools,
     toolsError,
     toolsErrorStatus,
@@ -1169,6 +1170,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             <MCPConnectionStatus
               formValues={formValues}
               tools={tools}
+              toolsWarnings={toolsWarnings}
               isLoadingTools={isLoadingTools}
               toolsError={toolsError}
               toolsErrorStatus={toolsErrorStatus}

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_connection_status.tsx
@@ -6,6 +6,7 @@ import { Card, Title, Text } from "@tremor/react";
 interface MCPConnectionStatusProps {
   formValues: Record<string, any>;
   tools: any[];
+  toolsWarnings?: string[];
   isLoadingTools: boolean;
   toolsError: string | null;
   toolsErrorStatus?: number | null;
@@ -17,6 +18,7 @@ interface MCPConnectionStatusProps {
 const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({
   formValues,
   tools,
+  toolsWarnings = [],
   isLoadingTools,
   toolsError,
   toolsErrorStatus = null,
@@ -93,6 +95,21 @@ const MCPConnectionStatus: React.FC<MCPConnectionStatusProps> = ({
                 <Spin size="large" />
                 <Text className="ml-3">Testing connection and loading tools...</Text>
               </div>
+            )}
+
+            {toolsWarnings.length > 0 && !toolsError && (
+              <Alert
+                message="Some tool names exceed the provider limit"
+                description={
+                  <ul style={{ margin: 0, paddingLeft: "16px" }}>
+                    {toolsWarnings.map((warning) => (
+                      <li key={warning}>{warning}</li>
+                    ))}
+                  </ul>
+                }
+                type="warning"
+                showIcon
+              />
             )}
 
             {toolsError && isPreviewForbidden && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -13,7 +13,7 @@ import { setSecureItem } from "@/utils/secureStorage";
 
 import { Card, Title, Text } from "@tremor/react";
 import { RobotOutlined, ToolOutlined, SearchOutlined, KeyOutlined, LockOutlined } from "@ant-design/icons";
-import { Input, Button as AntdButton } from "antd";
+import { Input, Button as AntdButton, Tooltip } from "antd";
 
 const MCPToolsViewer = ({
   serverId,
@@ -479,9 +479,11 @@ const MCPToolsViewer = ({
                               <div
                                 key={tool.name}
                                 className={`border rounded-lg p-3 cursor-pointer transition-all hover:shadow-xs ${
-                                  selectedTool?.name === tool.name
-                                    ? "border-blue-500 bg-blue-50 ring-1 ring-blue-200"
-                                    : "border-gray-200 bg-white hover:border-gray-300"
+                                  tool.disabled
+                                    ? "border-gray-200 bg-gray-50 opacity-60"
+                                    : selectedTool?.name === tool.name
+                                      ? "border-blue-500 bg-blue-50 ring-1 ring-blue-200"
+                                      : "border-gray-200 bg-white hover:border-gray-300"
                                 }`}
                                 onClick={() => {
                                   setSelectedTool(tool);
@@ -498,9 +500,22 @@ const MCPToolsViewer = ({
                                     />
                                   )}
                                   <div className="flex-1 min-w-0">
-                                    <h4 className="font-mono text-xs font-medium text-gray-900 truncate">
-                                      {tool.name}
-                                    </h4>
+                                    <div className="flex items-center gap-2 min-w-0">
+                                      <h4
+                                        className={`font-mono text-xs font-medium truncate ${
+                                          tool.disabled ? "text-gray-500" : "text-gray-900"
+                                        }`}
+                                      >
+                                        {tool.name}
+                                      </h4>
+                                      {tool.disabled && (
+                                        <Tooltip title={tool.disabled_reason}>
+                                          <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 shrink-0">
+                                            Disabled
+                                          </span>
+                                        </Tooltip>
+                                      )}
+                                    </div>
                                     <p className="text-xs text-gray-500 truncate">{tool.mcp_info.server_name}</p>
                                     <p className="text-xs text-gray-600 mt-1 line-clamp-2 leading-relaxed">
                                       {tool.description}

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -148,6 +148,10 @@ export interface MCPTool {
   description?: string;
   inputSchema: InputSchema | string; // API returns string "tool_input_schema" or the actual schema
   mcp_info: MCPInfo;
+  // True when the tool's prefixed name exceeds the provider tool-name length
+  // limit; the tool is excluded from LLM-facing listings and calls are rejected
+  disabled?: boolean;
+  disabled_reason?: string | null;
   // Function to select a tool (added in the component)
   onToolSelect?: (tool: MCPTool) => void;
 }

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -31,6 +31,7 @@ interface UseTestMCPConnectionProps {
 
 interface UseTestMCPConnectionReturn {
   tools: any[];
+  toolsWarnings: string[];
   isLoadingTools: boolean;
   toolsError: string | null;
   toolsErrorStatus: number | null;
@@ -48,6 +49,7 @@ export const useTestMCPConnection = ({
   enabled = true,
 }: UseTestMCPConnectionProps): UseTestMCPConnectionReturn => {
   const [tools, setTools] = useState<any[]>([]);
+  const [toolsWarnings, setToolsWarnings] = useState<string[]>([]);
   const [isLoadingTools, setIsLoadingTools] = useState(false);
   const [toolsError, setToolsError] = useState<string | null>(null);
   const [toolsErrorStatus, setToolsErrorStatus] = useState<number | null>(null);
@@ -157,6 +159,7 @@ export const useTestMCPConnection = ({
 
       if (toolsResponse.tools && !toolsResponse.error) {
         setTools(toolsResponse.tools);
+        setToolsWarnings(Array.isArray(toolsResponse.warnings) ? toolsResponse.warnings : []);
         setToolsError(null);
         setToolsErrorStatus(null);
         setToolsErrorStackTrace(null);
@@ -169,6 +172,7 @@ export const useTestMCPConnection = ({
         setToolsErrorStatus(typeof toolsResponse.status === "number" ? toolsResponse.status : null);
         setToolsErrorStackTrace(toolsResponse.status === 403 ? null : toolsResponse.stack_trace || null);
         setTools([]);
+        setToolsWarnings([]);
         setHasShownSuccessMessage(false);
       }
     } catch (error) {
@@ -177,6 +181,7 @@ export const useTestMCPConnection = ({
       setToolsErrorStatus(null);
       setToolsErrorStackTrace(null);
       setTools([]);
+      setToolsWarnings([]);
       setHasShownSuccessMessage(false);
     } finally {
       setIsLoadingTools(false);
@@ -185,6 +190,7 @@ export const useTestMCPConnection = ({
 
   const clearTools = useCallback(() => {
     setTools([]);
+    setToolsWarnings([]);
     setToolsError(null);
     setToolsErrorStatus(null);
     setToolsErrorStackTrace(null);
@@ -218,6 +224,7 @@ export const useTestMCPConnection = ({
 
   return {
     tools,
+    toolsWarnings,
     isLoadingTools,
     toolsError,
     toolsErrorStatus,

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -5,6 +5,7 @@ import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT } from "@/components/mcp_tools/types";
 interface MCPServerConfig {
   server_id?: string;
   server_name?: string;
+  alias?: string;
   url?: string;
   spec_path?: string;
   transport?: string;
@@ -140,6 +141,7 @@ export const useTestMCPConnection = ({
       const mcpServerConfig: MCPServerConfig = {
         server_id: formValues.server_id || "",
         server_name: formValues.server_name || "",
+        alias: formValues.alias,
         url: formValues.url,
         spec_path: formValues.spec_path,
         transport: effectiveTransport,
@@ -214,6 +216,7 @@ export const useTestMCPConnection = ({
     formValues.spec_path,
     formValues.transport,
     formValues.auth_type,
+    formValues.alias,
     accessToken,
     enabled,
     oauthAccessToken,


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4216

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Behavior

The limit is `MCP_MAX_TOOL_NAME_LENGTH` (default 64, from the Bedrock/OpenAI/Gemini tool name caps), measured against the final listed name, meaning the `<alias>-<tool>` form LiteLLM sends to LLMs. Override with the `LITELLM_MCP_MAX_TOOL_NAME_LENGTH` environment variable; 0 or negative disables the feature entirely

1. At server add time, the tools preview (`POST /mcp-rest/test/tools/list`, rendered in the create-server form) returns a warning for every tool whose prefixed name will exceed the limit, before anything is persisted. Server creation is not rejected
2. In the admin UI tool listing (`GET /mcp-rest/tools/list`, the server's Tools tab), over-limit tools stay visible but are flagged `disabled` with a `disabled_reason`; the dashboard renders them grayed out with a Disabled pill and a tooltip carrying the reason, so they do not look like they failed to load
3. In every LLM-facing listing (MCP `tools/list`, `GET /v1/mcp/tools`, tool search, Responses API MCP handler), over-limit tools are excluded entirely so the tool schema sent to providers never contains a name they would reject; each exclusion logs a warning naming the server, the tools, and the remediation
4. A direct call to a disabled tool (REST `POST /mcp-rest/tools/call`, MCP JSON-RPC `tools/call`, Responses API) is intercepted before reaching the upstream and rejected with a clean 400 `tool_name_too_long` error carrying the same reason, instead of surfacing a provider validation crash
5. Nothing is persisted about the disabled state: renaming the tool on the MCP server or shortening the server alias re-enables it automatically on the next listing

## Screenshots / Proof of Fix

Live proxy on `localhost:1337` backed by Postgres, with a real remote MCP server (`https://mcp.deepwiki.com/mcp`) registered under a 45 character alias so the three prefixed tool names land at 58, 64, and 65 characters, and real AWS Bedrock (Claude Haiku 4.5) completions

Before the fix

```bash
$ curl -s -X POST http://localhost:1337/v1/mcp/server -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -H "Content-Type: application/json" -d '{
      "server_name": "network_function_inventory_config_audit_agent",
      "alias": "network_function_inventory_config_audit_agent",
      "url": "https://mcp.deepwiki.com/mcp", "transport": "http", "auth_type": "none"}'
{"server_id": "3851738f-5b53-4bea-a472-b21dc58a0fd9", "alias": "network_function_inventory_config_audit_agent", ...}

$ curl -s http://localhost:1337/v1/mcp/tools -H "Authorization: Bearer $LITELLM_MASTER_KEY"   # name lengths annotated
65 network_function_inventory_config_audit_agent-read_wiki_structure
64 network_function_inventory_config_audit_agent-read_wiki_contents
58 network_function_inventory_config_audit_agent-ask_question
```

Live capture on the pre-PR commit (`5e73994441`, proxy on `localhost:4000`): the 65 character name is listed by `/v1/mcp/tools`, the admin listing carries no `disabled` field, and no exclusion warning is logged

![before: tool listing on the pre-PR commit](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvOWRmMzMwOTYtNjY2OC00ZGI0LTg0MTItMjE4ZTE4NGNjYzg3IiwiaWF0IjoxNzgzNDQ2MTk5LCJleHAiOjE3ODQwNTA5OTksImZpbGVuYW1lIjoicG9mMTlfYmVmb3JlX3Rlcm0ucG5nIn0.q794jm-N1fbgfzNIadl-WkP86JM-vVUo1eXDeIV6wLc)

The 65 character name is listed, so passing the listed tools to a Bedrock model fails with the exact error from the report

```bash
$ curl -s -X POST http://localhost:1337/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -H "Content-Type: application/json" -d '{"model": "bedrock-invoke-haiku-4-5", "max_tokens": 64,
      "messages": [{"role": "user", "content": "What documentation topics exist for the BerriAI/litellm repo? Use a tool."}],
      "tools": [<the 3 tools exactly as returned by /v1/mcp/tools>]}'
{"error": {"message": "litellm.BadRequestError: BedrockException - {\"message\":\"1 validation error detected: Value 'network_function_inventory_config_audit_agent-read_wiki_structure' at 'toolConfig.tools.1.member.toolSpec.name' failed to satisfy constraint: Member must have length less than or equal to 64\"} ...", "code": "400"}}
```

The add-time preview gives no indication either; its response keys are only `['error', 'message', 'tools']`

After the fix (same server row, same commands, proxy restarted on this branch)

```bash
$ curl -s http://localhost:1337/v1/mcp/tools -H "Authorization: Bearer $LITELLM_MASTER_KEY"
64 network_function_inventory_config_audit_agent-read_wiki_contents
58 network_function_inventory_config_audit_agent-ask_question
```

The 65 character tool is excluded (64 stays, the limit is inclusive) and the proxy logs why

```
23:03:36 - LiteLLM:WARNING: mcp_server_manager.py:3062 - MCP server network_function_inventory_config_audit_agent has 1 tool(s) whose name exceeds 64 characters, which providers such as AWS Bedrock, OpenAI, and Gemini reject. Excluding them from tool listings: network_function_inventory_config_audit_agent-read_wiki_structure (65 chars). Use a shorter server alias, rename the tools on the MCP server, or set LITELLM_MCP_MAX_TOOL_NAME_LENGTH to change the limit.
```

Live capture on the PR commit (`3407a2d983`, same server row): the 65 character tool is gone from `/v1/mcp/tools`, the admin listing flags it `disabled: True` with the reason, and the exclusion warning is logged

![after: tool listing on the PR commit](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNWQwOTg2NDgtZTI3Ni00YzM3LWIzNWEtZDJhYTk3NDgxODdjIiwiaWF0IjoxNzgzNDQ2MTk5LCJleHAiOjE3ODQwNTA5OTksImZpbGVuYW1lIjoicG9mMTlfYWZ0ZXJfdGVybS5wbmcifQ.NObrA-xWxXn11vlIrouJOqff5QmhP-H0KxfvLu19hQA)

The add-time preview (`POST /mcp-rest/test/tools/list`, what the UI calls when adding a server) now flags it

```json
"warnings": [
  "Tool 'read_wiki_structure' will be listed as 'network_function_inventory_config_audit_agent-read_wiki_structure' (65 characters), which exceeds the 64 character tool name limit enforced by providers such as AWS Bedrock, OpenAI, and Gemini. LiteLLM will exclude it from tool listings. Use a shorter server alias or rename the tool on the MCP server."
]
```

The same chat completion built from the now-listed tools succeeds against real Bedrock

```bash
$ curl -s -X POST http://localhost:1337/v1/chat/completions ... -d '{..., "tools": [<the 2 tools now returned by /v1/mcp/tools>]}'
model: bedrock-invoke-haiku-4-5
tool_call: network_function_inventory_config_audit_agent-read_wiki_contents
```

The admin UI tool listing keeps the disabled tool visible with the reason, so it does not look like the tool failed to load

```bash
$ curl -s "http://localhost:1337/mcp-rest/tools/list?server_id=<id>" -H "Authorization: Bearer $LITELLM_MASTER_KEY"
read_wiki_structure | disabled: True | reason: Tool name 'network_function_inventory_config_audit_agent-read_wiki_structure' is 65 characters, which exceeds ...
read_wiki_contents | disabled: False
ask_question | disabled: False
```

In the dashboard Tools tab the row renders grayed out with a red Disabled pill whose tooltip carries the reason. Before the fix the same tool is indistinguishable from the others

![before: dashboard Tools tab on the pre-PR commit](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNDVmYjM0ZWYtNmNkOC00NWU3LTk3ZGMtNmM2OGM1NDViNWJlIiwiaWF0IjoxNzgzNDQ2MTk5LCJleHAiOjE3ODQwNTA5OTksImZpbGVuYW1lIjoicG9mMTlfYmVmb3JlX3VpLnBuZyJ9.SfTIaT1OrfEJR90Ec572vsX1fFmHGdT4P-3yQjcG-f8)

After the fix it is grayed out with a red Disabled pill, and hovering the pill shows the reason

![after: dashboard Tools tab on the PR commit](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMTY4ZjYxYTItZDRlZi00MDkyLWJmZmYtYjg0Mzc5NDEzM2QyIiwiaWF0IjoxNzgzNDQ2MTk5LCJleHAiOjE3ODQwNTA5OTksImZpbGVuYW1lIjoicG9mMTlfYWZ0ZXJfdWkucG5nIn0.GCqYmUiHVhCDZ1bGlm2X3ZDupduJOFi-21xEKrxPhQo)

A direct call to the disabled tool is rejected with a clean LiteLLM error instead of being forwarded

```bash
$ curl -s -w "\nHTTP %{http_code}" -X POST http://localhost:1337/mcp-rest/tools/call -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -H "Content-Type: application/json" -d '{"server_id": "<id>", "name": "network_function_inventory_config_audit_agent-read_wiki_structure", "arguments": {"repoName": "BerriAI/litellm"}}'
{"detail":{"error":"tool_name_too_long","message":"Tool name 'network_function_inventory_config_audit_agent-read_wiki_structure' is 65 characters, which exceeds the 64 character tool name limit enforced by providers such as AWS Bedrock, OpenAI, and Gemini. LiteLLM disables it: it is excluded from tool listings sent to LLMs and direct calls are rejected. ..."}}
HTTP 400

$ curl -s -X POST http://localhost:1337/mcp-rest/tools/call ... -d '{"server_id": "<id>", "name": "network_function_inventory_config_audit_agent-ask_question", "arguments": {"repoName": "BerriAI/litellm", "question": "What is litellm?"}}'
isError: False, content starts with "LiteLLM is a unified LLM gateway"
```

## Type

🐛 Bug Fix

## Changes

The MCP gateway prefixes every upstream tool name with the server alias (`<alias>-<tool>`) but nothing anywhere in the stack enforced the 64 character tool name ceiling that AWS Bedrock, OpenAI, and Gemini apply (the only length check is the MCP SDK's 128 character SEP-986 probe), so long prefixed names flowed into LLM requests and failed with a provider 400 at request time

`litellm/constants.py` adds `MCP_MAX_TOOL_NAME_LENGTH` (default 64, override or disable via `LITELLM_MCP_MAX_TOOL_NAME_LENGTH`, zero or negative disables)

`litellm/proxy/_experimental/mcp_server/utils.py` adds two pure helpers next to `add_server_prefix_to_name`: `split_tools_by_name_length` and `tool_name_length_warnings`

`mcp_server_manager.py` applies the exclusion at both return points of `_get_tools_from_server`, so every LLM-facing listing surface is covered by the one seam (MCP JSON-RPC `tools/list`, `GET /v1/mcp/tools`, tool search, the Responses API MCP handler, and the OpenAPI-spec branch), logging an actionable warning naming the server, the disabled tools, and the override. The admin UI single-server listing opts out via `drop_overlong_names=False` so those tools stay visible, and `_create_tool_response_objects` marks them `disabled` with a `disabled_reason`. `call_tool`, the seam every tool-call surface funnels through (REST, MCP JSON-RPC, Responses API, OpenAPI), rejects calls to a disabled tool with a 400 `tool_name_too_long` HTTPException that each surface converts to a clean client error

`rest_endpoints.py` adds a `warnings` list to the `POST /mcp-rest/test/tools/list` response (the endpoint the UI calls when adding a server) computed from the would-be prefixed names, which flags the problem at add time before the server is saved

Tests: `_get_tools_from_server` drops a 65 character prefixed name and keeps a 64 character one (fails without the fix), the unprefixed path measures the raw name, the preview endpoint returns the warning (fails without the fix), and helper edge cases pin the inclusive boundary plus the disable switch. Note `tests/.../test_mcp_env_vars.py` shows a pre-existing test-isolation flake when the whole `mcp_server` test directory runs in one process; it reproduces identically on `litellm_internal_staging` with this change stashed and is unrelated

Follow-up commits address review: preview warnings are skipped in short-prefix mode when the payload has no server_id (the 3 char prefix derives from the id assigned at create time, so alias-based lengths would be false positives), and the exclusion warning labels the server with its alias when that differs from the name. The `LITELLM_MCP_MAX_TOOL_NAME_LENGTH` environment variable is documented in the environment variables reference (litellm-docs)

The final commit changes the runtime contract per customer feedback: silently hiding the tools from the UI made them look like they failed to load, and leaving them callable meant manual or routed calls still failed downstream. The dashboard Tools tab now shows disabled tools grayed out with a Disabled pill and tooltip (new `disabled`/`disabled_reason` fields on `ListMCPToolsRestAPIResponseObject`), the create-server form renders the preview warnings in the connection status panel, and direct calls are intercepted at the shared `call_tool` seam with a clean 400 instead of reaching the upstream. Renaming the tool or shortening the alias re-enables everything automatically since nothing is persisted

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tools appear in LLM-facing MCP aggregations and rejects some `call_tool` requests that previously reached upstream; behavior is configurable via env and covered by tests, but mis-tuned limits or long aliases could hide tools unexpectedly.
> 
> **Overview**
> Adds **`MCP_MAX_TOOL_NAME_LENGTH`** (default 64, env `LITELLM_MCP_MAX_TOOL_NAME_LENGTH`; ≤0 disables) and gates MCP tools on the **final prefixed name** (`alias-tool`) so Bedrock/OpenAI/Gemini no longer reject whole requests.
> 
> **LLM-facing listings** (`_get_tools_from_server` with default `drop_overlong_names=True`) drop over-limit tools and log a warning. **`call_tool`** returns HTTP 400 `tool_name_too_long` before any upstream call.
> 
> **Admin / preview paths** keep those tools visible: REST tool list sets `disabled` / `disabled_reason`; add-server **test tools list** returns a `warnings` array (skipped in short-prefix mode when `server_id` is unknown). Dashboard shows preview warnings and grayed-out tools with a Disabled tooltip.
> 
> New helpers in `utils.py`: `split_tools_by_name_length`, `tool_name_length_disabled_reason`, `tool_name_length_warnings`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6517b1a764b0e41cc9f125f53a1c240aecc55cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->