### PR TITLE
feat(helm): make Deployment revisionHistoryLimit configurable in litellm-helm chart

### DIFF
--- a/deploy/charts/litellm-helm/templates/deployment.yaml
+++ b/deploy/charts/litellm-helm/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
   {{- if and (not .Values.keda.enabled) (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}

--- a/deploy/charts/litellm-helm/tests/deployment_tests.yaml
+++ b/deploy/charts/litellm-helm/tests/deployment_tests.yaml
@@ -319,6 +319,20 @@ tests:
     asserts:
       - notExists:
           path: spec.minReadySeconds
+  - it: should default revisionHistoryLimit to 10
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 10
+  - it: should be able to set revisionHistoryLimit
+    template: deployment.yaml
+    set:
+      revisionHistoryLimit: 3
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3
   - it: should work with extraInitContainers
     template: deployment.yaml
     set:

--- a/deploy/charts/litellm-helm/values.yaml
+++ b/deploy/charts/litellm-helm/values.yaml
@@ -33,6 +33,10 @@ deploymentAnnotations: {}
 deploymentLabels: {}
 deploymentMinReadySeconds: 0
 
+# -- Number of old ReplicaSets to retain for rollback history. Matches the
+# Kubernetes default so existing installs see no behavior change.
+revisionHistoryLimit: 10
+
 # annotations for litellm pods
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
## Summary

`deploy/charts/litellm-helm/templates/deployment.yaml` never sets `spec.revisionHistoryLimit`, so every install is stuck on the Kubernetes default of 10 retained ReplicaSets with no way to override it via values. This makes it impossible to keep old ReplicaSets from piling up in clusters with frequent rollouts.

This PR adds a `revisionHistoryLimit` value (default `10`, matching today's implicit behavior so existing installs see no change) and wires it into the Deployment template.

## Changes
- `values.yaml`: add `revisionHistoryLimit: 10`
- `templates/deployment.yaml`: set `spec.revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}`
- `tests/deployment_tests.yaml`: add two `helm-unittest` cases (default value, and override)

## Test plan
- [x] `helm unittest -f 'tests/*.yaml' deploy/charts/litellm-helm` — 59/59 passing (57 pre-existing + 2 new)
- [x] `helm template` confirms `spec.revisionHistoryLimit: 10` renders by default and reflects overrides

Note: `helm/litellm` (the newer componentized chart) has separate `deployment.yaml` templates per component and isn't touched here — happy to extend if maintainers want the same fix there.