### PR TITLE
fix(proxy): recover Prisma DB reconnect loop when client is disconnected

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -137,8 +137,17 @@ class PrismaWrapper:
         self.on_engine_replaced: Callable[[], None] | None = None
 
     def _get_engine_pid(self) -> int:
-        """Get the PID of the current Prisma engine subprocess, or 0 if unavailable."""
+        """Get the PID of the current Prisma engine subprocess, or 0 if unavailable.
+
+        Must never raise: it runs inside the reconnect path, where the client
+        may be in any broken state. Prisma's ``_engine`` is a property that
+        raises ``ClientNotConnectedError`` on a disconnected client; if that
+        escaped here, ``recreate_prisma_client`` would fail before it could
+        build a replacement client and the reconnect loop could never recover.
+        """
         try:
+            if self._original_prisma.is_connected() is not True:
+                return 0
             engine = self._original_prisma._engine
             process = getattr(engine, "process", None) if engine is not None else None
             if process is not None:

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4097,11 +4097,22 @@ class PrismaClient:
             raise e
 
     def _get_engine_pid(self) -> int:
+        """Get the PID of the writer's engine subprocess, or 0 if unavailable.
+
+        Must never raise: prisma's ``_engine`` property raises
+        ``ClientNotConnectedError`` on a disconnected client, and an exception
+        escaping from the reconnect path would leave it unable to recover.
+        """
         try:
-            engine = self.db._original_prisma._engine  # type: ignore[attr-defined]
+            prisma_obj = self.writer_db._original_prisma
+            if prisma_obj.is_connected() is not True:
+                return 0
+            engine = prisma_obj._engine
             process = getattr(engine, "process", None) if engine is not None else None
             if process is not None:
-                return process.pid
+                pid = process.pid
+                if isinstance(pid, int):
+                    return pid
         except (AttributeError, TypeError):
             pass
         return 0

--- a/tests/test_litellm/proxy/conftest.py
+++ b/tests/test_litellm/proxy/conftest.py
@@ -20,6 +20,31 @@ _PROXY_MODULE_GLOBALS_TO_ISOLATE = (
 )
 
 
+class StubClientNotConnectedError(Exception):
+    pass
+
+
+class DisconnectedPrisma:
+    """Mimics prisma-client-py after disconnect(): ``is_connected()`` is False
+    and the ``_engine`` property raises ``ClientNotConnectedError``."""
+
+    def is_connected(self) -> bool:
+        return False
+
+    @property
+    def _engine(self) -> None:
+        raise StubClientNotConnectedError(
+            "Client is not connected to the query engine, you must call `connect()` "
+            "before attempting to query data."
+        )
+
+
+@pytest.fixture
+def disconnected_prisma() -> DisconnectedPrisma:
+    """A stand-in for a Prisma client wedged in the disconnected state."""
+    return DisconnectedPrisma()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_proxy_module_globals():
     """

--- a/tests/test_litellm/proxy/db/test_prisma_client.py
+++ b/tests/test_litellm/proxy/db/test_prisma_client.py
@@ -92,6 +92,7 @@ async def test_recreate_prisma_client_kills_old_engine_on_disconnect_failure(
     """When disconnect() fails, recreate_prisma_client must SIGTERM/SIGKILL the old engine PID."""
     mock_prisma = AsyncMock()
     mock_prisma.disconnect.side_effect = Exception("engine hung")
+    mock_prisma.is_connected = MagicMock(return_value=True)
 
     # Simulate engine subprocess with a known PID
     mock_engine = MagicMock()
@@ -122,6 +123,7 @@ async def test_recreate_prisma_client_skips_kill_on_successful_disconnect(
 ):
     """When disconnect() succeeds, no kill should be attempted."""
     mock_prisma = AsyncMock()
+    mock_prisma.is_connected = MagicMock(return_value=True)
     mock_prisma.disconnect.return_value = None
 
     wrapper = PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=False)
@@ -142,6 +144,7 @@ async def test_recreate_prisma_client_handles_missing_engine_pid(
 ):
     """When engine PID is unavailable (no _engine attr), kill is skipped gracefully."""
     mock_prisma = AsyncMock()
+    mock_prisma.is_connected = MagicMock(return_value=True)
     mock_prisma.disconnect.side_effect = Exception("engine hung")
     mock_prisma._engine = None  # No engine subprocess
 
@@ -157,4 +160,36 @@ async def test_recreate_prisma_client_handles_missing_engine_pid(
         await wrapper.recreate_prisma_client("postgresql://new")
 
     mock_kill.assert_not_called()  # PID was 0, kill skipped
+    mock_new_prisma.connect.assert_awaited_once()
+
+
+def test_get_engine_pid_returns_zero_for_disconnected_client(disconnected_prisma):
+    """A disconnected client must read as "no engine" instead of raising,
+    otherwise the reconnect path can never recover."""
+    wrapper = PrismaWrapper(
+        original_prisma=disconnected_prisma, iam_token_db_auth=False
+    )
+
+    assert wrapper._get_engine_pid() == 0
+
+
+@pytest.mark.asyncio
+async def test_recreate_prisma_client_recovers_from_disconnected_client(
+    mock_prisma_binary, disconnected_prisma
+):
+    """recreate_prisma_client must still build a replacement client when the
+    current one is disconnected."""
+    wrapper = PrismaWrapper(
+        original_prisma=disconnected_prisma, iam_token_db_auth=False
+    )
+
+    mock_new_prisma = AsyncMock()
+    mock_prisma_binary.Prisma.return_value = mock_new_prisma
+
+    with patch("os.kill") as mock_kill:
+        result = await wrapper.recreate_prisma_client("postgresql://new")
+
+    assert result is True
+    mock_kill.assert_not_called()
+    assert wrapper._original_prisma is mock_new_prisma
     mock_new_prisma.connect.assert_awaited_once()

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -42,6 +42,7 @@ def mock_prisma_binary():
 def _make_wrapper(engine_pid: int = 111, iam: bool = False) -> PrismaWrapper:
     mock_prisma = MagicMock()
     mock_prisma.connect = AsyncMock()
+    mock_prisma.is_connected = MagicMock(return_value=True)
     mock_prisma._engine = MagicMock()
     mock_prisma._engine.process.pid = engine_pid
     return PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=iam)

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -20,7 +20,7 @@ def mock_prisma_binary():
     """Mock prisma.Prisma to avoid requiring generated Prisma binaries for unit tests."""
     mock_module = MagicMock()
     with patch.dict(sys.modules, {"prisma": mock_module}):
-        yield
+        yield mock_module
 
 
 @pytest.fixture
@@ -513,6 +513,43 @@ async def test_engine_confirmed_dead_persists_across_failed_heavy_reconnect(
     # The flag must STILL be True so the next attempt re-enters the heavy
     # branch instead of silently demoting to the lightweight path.
     assert client._engine_confirmed_dead is True
+
+
+@pytest.mark.asyncio
+async def test_heavy_reconnect_recovers_from_disconnected_prisma_client(
+    mock_proxy_logging, mock_prisma_binary, disconnected_prisma
+):
+    """Once the active Prisma client is in the disconnected state, every DB
+    call raises ClientNotConnectedError. The heavy reconnect path is the only
+    way out, so it must not re-raise that same error while inspecting the
+    broken client; otherwise `recreate_prisma_client` fails before it can
+    build a replacement and the proxy loops on failed reconnects forever.
+
+    The full real reconnect path (attempt_db_reconnect -> _run_reconnect_cycle
+    -> recreate_prisma_client) must succeed from that wedged state.
+    """
+    client = PrismaClient(
+        database_url="mock://test", proxy_logging_obj=mock_proxy_logging
+    )
+    client.db._original_prisma = disconnected_prisma
+    client._engine_confirmed_dead = True
+    client._start_engine_watcher = AsyncMock()
+
+    replacement = MagicMock()
+    replacement.connect = AsyncMock()
+    mock_prisma_binary.Prisma.return_value = replacement
+
+    with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+        result = await client.attempt_db_reconnect(
+            reason="unit_test_disconnected_client",
+            force=True,
+        )
+
+    assert result is True
+    assert client.db._original_prisma is replacement
+    replacement.connect.assert_awaited_once()
+    assert client._consecutive_reconnect_failures == 0
+    assert client._engine_confirmed_dead is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_engine_watcher.py
+++ b/tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_engine_watcher.py
@@ -42,6 +42,7 @@ def test_get_engine_pid_extracts_process_pid(prisma_client: PrismaClient) -> Non
     fake_engine.process = MagicMock()
     fake_engine.process.pid = 4242
     prisma_client.db._original_prisma = MagicMock()
+    prisma_client.db._original_prisma.is_connected = MagicMock(return_value=True)
     prisma_client.db._original_prisma._engine = fake_engine
     actual = {
         "pid": prisma_client._get_engine_pid(),
@@ -55,6 +56,15 @@ def test_get_engine_pid_returns_zero_when_engine_attr_missing(
     prisma_client: PrismaClient,
 ) -> None:
     prisma_client.db._original_prisma = MagicMock(spec=[])
+    assert prisma_client._get_engine_pid() == 0
+
+
+def test_get_engine_pid_returns_zero_when_client_disconnected(
+    prisma_client: PrismaClient, disconnected_prisma
+) -> None:
+    """The reconnect path calls this on an arbitrarily-broken client; it must
+    report "no engine" instead of re-raising ClientNotConnectedError."""
+    prisma_client.db._original_prisma = disconnected_prisma
     assert prisma_client._get_engine_pid() == 0
 
 


### PR DESCRIPTION
## Relevant issues

Fixes #28322

## Linear ticket

Resolves LIT-4161

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The wedged state from issue #28322 is a Prisma client that is disconnected from its query engine; production pods reach it through rare shutdown/cancellation races after days of uptime (the issue logs show 1486+ consecutive reconnect failures over 30 days with zero recoveries). To reproduce it on demand against a live proxy, I used a custom callback as a fault injector that calls the real `disconnect()` on the active client when a magic message arrives, which puts the proxy into byte-for-byte the same state (every DB call raises `ClientNotConnectedError`)

Fault injector loaded via `litellm_settings.callbacks`:

```python
from litellm.integrations.custom_logger import CustomLogger

class DBWedgeInjector(CustomLogger):
    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
        messages = data.get("messages") or []
        if any("INJECT_DB_DISCONNECT" in str(m.get("content", "")) for m in messages):
            from litellm.proxy.proxy_server import prisma_client
            await prisma_client.db._original_prisma.disconnect()
        return data

db_wedge_injector = DBWedgeInjector()
```

Live proxy on `localhost:4161` with a real Postgres container and real OpenAI calls; watchdog tuned for a fast demo loop (`PRISMA_HEALTH_WATCHDOG_INTERVAL_SECONDS=5`, `PRISMA_RECONNECT_COOLDOWN_SECONDS=2`)

### Before (unfixed)

```bash
# baseline: virtual key works end to end
$ curl -s http://localhost:4161/v1/chat/completions -H "Authorization: Bearer $K1" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}'
OK!

# wedge the proxy (same trigger for before and after runs)
$ curl -s http://localhost:4161/v1/chat/completions -H "Authorization: Bearer sk-...master" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"INJECT_DB_DISCONNECT"}]}'

# a fresh (uncached) virtual key is now dead
$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:4161/v1/chat/completions -H "Authorization: Bearer $K2" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}'
{"error":{"message":"Service Unavailable, the authentication database is temporarily unreachable. Please retry shortly.","type":"no_db_connection","param":"None","code":"503"}}
HTTP 503
```

Proxy log: the reconnect loop fails forever with the exact error signature from the issue, and never recovers (25 consecutive failures and climbing when I stopped the run; `reconnect succeeded` count stays 0)

```
09:25:36 WARNING utils.py - Escalating to heavy reconnect after 8 consecutive failures. reason=db_health_watchdog_connection_error
09:25:36 ERROR utils.py - Prisma DB reconnect failed (9 consecutive). reason=db_health_watchdog_connection_error error=Client is not connected to the query engine, you must call `connect()` before attempting to query data.
09:25:43 WARNING utils.py - Escalating to heavy reconnect after 10 consecutive failures. reason=auth_get_key_object_lookup_failure
09:25:43 ERROR utils.py - Prisma DB reconnect failed (11 consecutive). reason=auth_get_key_object_lookup_failure error=Client is not connected to the query engine, you must call `connect()` before attempting to query data.
...
09:26:51 ERROR utils.py - Prisma DB reconnect failed (25 consecutive). reason=db_health_watchdog_connection_error error=Client is not connected to the query engine, you must call `connect()` before attempting to query data.

$ grep -c "reconnect failed" before.log ; grep -c "reconnect succeeded" before.log
25
0
```

### After (this fix)

Same trigger, same environment. The engine watcher detects the death from the disconnect and the very first reconnect attempt recovers:

```
09:27:32 INFO utils.py - Watching engine PID 94464 via waitpid thread.
09:27:38 WARNING utils.py - Attempting Prisma DB reconnect. reason=engine_process_death
09:27:38 INFO utils.py - Watching engine PID 94485 via waitpid thread.
09:27:38 INFO utils.py - Prisma DB reconnect succeeded. reason=engine_process_death

$ grep -c "reconnect failed" after.log ; grep -c "reconnect succeeded" after.log
0
1
```

```bash
# the fresh virtual key works again without restarting the pod
$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:4161/v1/chat/completions -H "Authorization: Bearer $K2" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}'
{"id":"chatcmpl-Dyta0nJQYD6iUZxr5gnKPNBDl8QqZ", ... "content":"OK!" ...}
HTTP 200
```

I also verified on a live proxy that the two adjacent scenarios still self-heal with this change: killing the query engine with the DB up (recovers in one cycle) and killing it during a `docker pause` DB outage (recovers on the first cycle after `docker unpause`)

### Independent e2e verification (Devin)

A separate Devin session independently reproduced and verified the fix end to end on its own environment (fresh clone, real Postgres 16, same fault injector, same config for both runs; only the two guarded files differ). On the fixed branch the wedge trigger leads to `Prisma DB reconnect succeeded` within one watchdog cycle (~10 seconds) with zero `reconnect failed` lines, and `GET /key/info` with a virtual key returns HTTP 200 afterwards. On the unfixed merge-base (`5b93ba0ada`) the same trigger loops `Prisma DB reconnect failed (N consecutive) ... Client is not connected to the query engine` climbing to 27 on camera with zero recoveries, `GET /key/info` returns HTTP 500 and the user-facing chat completion returns HTTP 503 `no_db_connection`. Screen recording of both runs:

_(video attached below)_

## Type

🐛 Bug Fix

## Changes

Once the active Prisma client is in the disconnected state, every DB call raises `prisma.errors.ClientNotConnectedError`. The reconnect machinery is the only way out of that state, but both `PrismaWrapper._get_engine_pid` (`litellm/proxy/db/prisma_client.py`) and `PrismaClient._get_engine_pid` (`litellm/proxy/utils.py`) inspected the broken client through prisma's `_engine` property, which re-raises that same `ClientNotConnectedError`, and they only caught `(AttributeError, TypeError)`. So `recreate_prisma_client` failed at the very first line, before it could construct a replacement client, and every subsequent attempt (health watchdog, auth-triggered reconnect, IAM token refresh) died the same way; the pod never recovered without a restart

The fix guards both implementations with `is_connected()` so a disconnected client reads as "no engine subprocess" (pid 0); the recreate path then skips the kill step and proceeds to construct and connect a fresh client, which is exactly what recovery requires. All reconnect entry points funnel through these two call sites, so the guard covers the watchdog, the auth path, the IAM refresh path and the read replica recreate for free. The guard is safe against a torn read because prisma's `_engine` property only raises when the internal engine is None, which is exactly when `is_connected()` returns False, and there is no await between the check and the access

Provenance: the narrow `except (AttributeError, TypeError)` dates back to the engine zombie-recovery work (#21899 and commit 1f04fa2461). The reconnect path that most easily produced a disconnected client in production (a `disconnect()` then `connect()` sequence, where a failed connect left the client permanently disconnected) was later replaced by the kill-then-construct flow in commit fbcdacc446, which is why recent builds rarely enter the state; the recovery gap itself stayed latent until now. Reports on issue #28322 span builds that still had the old trigger

Regression tests (all four fail on the unfixed code and pass with the fix):

- `test_get_engine_pid_returns_zero_for_disconnected_client` and `test_recreate_prisma_client_recovers_from_disconnected_client` in `tests/test_litellm/proxy/db/test_prisma_client.py`
- `test_heavy_reconnect_recovers_from_disconnected_prisma_client` in `tests/test_litellm/proxy/db/test_prisma_self_heal.py`, which drives the full real path (`attempt_db_reconnect` -> `_run_reconnect_cycle` -> `recreate_prisma_client`) from the wedged state
- `test_get_engine_pid_returns_zero_when_client_disconnected` in `tests/test_litellm/proxy/utils/prisma_and_spend/test_prisma_client_engine_watcher.py`

Two existing tests were updated to declare `is_connected() -> True` on their mocked clients, matching the state they were already simulating

