### PR TITLE
fix(logging): route print_verbose through verbose_logger.debug

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -412,8 +412,10 @@ def _enable_debugging():
 
 def print_verbose(print_statement):
     try:
+        redacted_statement = redact_secrets(str(print_statement))
+        verbose_logger.debug(redacted_statement)
         if set_verbose:
-            print(redact_secrets(str(print_statement)))  # noqa: T201
+            print(redacted_statement)  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -412,6 +412,8 @@ def _enable_debugging():
 
 def print_verbose(print_statement):
     try:
+        if not _is_debugging_on():
+            return
         redacted_statement = redact_secrets(str(print_statement))
         verbose_logger.debug(redacted_statement)
         if set_verbose:

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -18,6 +18,7 @@ from litellm._logging import (
     JsonFormatter,
     _initialize_loggers_with_handler,
     _turn_on_json,
+    print_verbose,
     verbose_logger,
     verbose_proxy_logger,
     verbose_router_logger,
@@ -255,6 +256,34 @@ def test_initialize_loggers_with_handler_sets_propagate_false():
         assert (
             logger.propagate is False
         ), f"Logger {logger.name} has propagate set to {logger.propagate}, expected False"
+
+
+def test_print_verbose_always_emits_to_debug_logger(caplog):
+    """
+    Regression test: print_verbose() must route to verbose_logger.debug() regardless of
+    `set_verbose`, so callers relying on LITELLM_LOG=DEBUG (e.g. cache logging) are visible
+    even when the deprecated `set_verbose` flag is False.
+    """
+    with caplog.at_level(logging.DEBUG, logger=verbose_logger.name):
+        print_verbose("cache lookup for key abc123")
+
+    assert any(
+        "cache lookup for key abc123" in record.message for record in caplog.records
+    ), f"expected print_verbose message in debug logs, got: {[r.message for r in caplog.records]}"
+
+
+def test_print_verbose_redacts_secrets_before_logging(caplog):
+    """
+    Regression test: the message passed to verbose_logger.debug() by print_verbose() must
+    still be redacted, since it now reaches the logger even when `set_verbose` is False.
+    """
+    with caplog.at_level(logging.DEBUG, logger=verbose_logger.name):
+        print_verbose("using api key sk-abcdefghijklmnopqrstuvwxyz123456")
+
+    logged_messages = [record.message for record in caplog.records]
+    assert not any(
+        "sk-abcdefghijklmnopqrstuvwxyz123456" in message for message in logged_messages
+    ), f"secret leaked into debug logs: {logged_messages}"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -299,6 +299,34 @@ def test_print_verbose_still_prints_when_set_verbose_true(monkeypatch, capfd):
     assert "legacy set_verbose output" in out, f"expected print() output, got: {out!r}"
 
 
+def test_print_verbose_skips_redaction_when_debugging_is_off(monkeypatch):
+    """
+    Regression test: print_verbose() must not redact or log anything when neither
+    verbose_logger is at DEBUG level nor the legacy set_verbose flag is set. It's
+    called 60+ times per request across hot paths (litellm_logging.py, main.py,
+    caching), so paying for regex-based secret redaction on every call would add
+    real overhead in production deployments where debug logging is off.
+    """
+    import litellm._logging as logging_module
+
+    original_level = verbose_logger.level
+    verbose_logger.setLevel(logging.WARNING)
+    monkeypatch.setattr(logging_module, "set_verbose", False)
+
+    redact_calls = []
+    monkeypatch.setattr(logging_module, "redact_secrets", lambda value: redact_calls.append(value) or value)
+    debug_calls = []
+    monkeypatch.setattr(verbose_logger, "debug", lambda msg: debug_calls.append(msg))
+
+    try:
+        print_verbose("should never be redacted or logged")
+    finally:
+        verbose_logger.setLevel(original_level)
+
+    assert redact_calls == [], f"redact_secrets should not run, got calls: {redact_calls}"
+    assert debug_calls == [], f"verbose_logger.debug should not run, got calls: {debug_calls}"
+
+
 @pytest.mark.asyncio
 async def test_cache_hit_includes_custom_llm_provider():
     """

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -286,6 +286,19 @@ def test_print_verbose_redacts_secrets_before_logging(caplog):
     ), f"secret leaked into debug logs: {logged_messages}"
 
 
+def test_print_verbose_still_prints_when_set_verbose_true(monkeypatch, capfd):
+    """
+    Regression test: print_verbose() must still print() to stdout when the deprecated
+    `set_verbose` flag is True, alongside the new verbose_logger.debug() call.
+    """
+    monkeypatch.setattr("litellm._logging.set_verbose", True)
+
+    print_verbose("legacy set_verbose output")
+
+    out, _ = capfd.readouterr()
+    assert "legacy set_verbose output" in out, f"expected print() output, got: {out!r}"
+
+
 @pytest.mark.asyncio
 async def test_cache_hit_includes_custom_llm_provider():
     """


### PR DESCRIPTION
## Relevant issues

Fixes #32318

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, `print_verbose()` only reached `print()` when the deprecated `set_verbose` flag was true, so callers relying on `LITELLM_LOG=DEBUG` (for example cache logging) never showed up in the debug log stream. Reproduced with a script exercising `print_verbose` directly:

```python
import logging
from litellm._logging import print_verbose, verbose_logger

verbose_logger.setLevel(logging.DEBUG)
verbose_logger.addHandler(logging.StreamHandler())
print_verbose("cache lookup for key abc123")
```

Before: no output. After: `LiteLLM:DEBUG: cache lookup for key abc123` is emitted through `verbose_logger`, matching what a user setting `LITELLM_LOG=DEBUG` expects to see.

## Type

🐛 Bug Fix
✅ Test

## Changes

`print_verbose()` in `litellm/_logging.py` now forwards the redacted message to `verbose_logger.debug()`, in addition to the existing `print()` call gated by `set_verbose`. This means any caller of `print_verbose` (cache logging, etc.) is now visible under `LITELLM_LOG=DEBUG` regardless of the deprecated `set_verbose` flag.

Following Greptile's review, the work is now guarded by the existing `_is_debugging_on()` check, so `redact_secrets()` and `verbose_logger.debug()` only run when something will actually consume the message. `print_verbose` is called 60+ times per request across hot paths, so this avoids adding regex-based redaction overhead when debug logging is disabled, which is the common production case.

Added four tests to `tests/test_litellm/test_logging.py`:
- `test_print_verbose_always_emits_to_debug_logger`: asserts the message reaches `verbose_logger` at DEBUG level when debugging is on. Verified this fails against the pre-fix code.
- `test_print_verbose_redacts_secrets_before_logging`: asserts secrets are still redacted before reaching the logger.
- `test_print_verbose_still_prints_when_set_verbose_true`: covers the pre-existing `set_verbose=True` print() path, which had no coverage anywhere in the suite before this PR touched that line.
- `test_print_verbose_skips_redaction_when_debugging_is_off`: asserts `redact_secrets()` and `verbose_logger.debug()` are never called when neither `set_verbose` nor DEBUG-level logging is active. Verified this fails against the pre-guard code.