### PR TITLE
fix(proxy): reload DB models on router miss

### DIFF
--- a/litellm/proxy/route_llm_request.py
+++ b/litellm/proxy/route_llm_request.py
@@ -5,6 +5,7 @@ import httpx
 from fastapi import HTTPException, status
 
 import litellm
+from litellm._logging import verbose_proxy_logger
 from litellm.proxy._types import UserAPIKeyAuth
 
 # Router-internal mock_testing_* flag names — kept in sync with
@@ -246,6 +247,38 @@ async def add_shared_session_to_data(data: dict) -> None:
             pass
 
 
+async def _reload_db_models_on_router_miss() -> Optional[LitellmRouter]:
+    """
+    Reload DB-backed models into this pod's router after a model miss.
+
+    Models created through /model/new are persisted in the DB, but routing uses
+    each proxy process's in-memory router. In multi-pod deployments, another pod
+    can receive traffic before it has loaded the newly-created DB model.
+    """
+    try:
+        from litellm.proxy.proxy_server import (
+            llm_router,
+            prisma_client,
+            proxy_config,
+            proxy_logging_obj,
+            store_model_in_db,
+        )
+
+        if store_model_in_db is not True or prisma_client is None:
+            return llm_router
+
+        await proxy_config.add_deployment(
+            prisma_client=prisma_client,
+            proxy_logging_obj=proxy_logging_obj,
+        )
+        return llm_router
+    except Exception as e:
+        verbose_proxy_logger.debug(
+            "Failed to reload DB-backed models after router miss: %s", str(e)
+        )
+        return None
+
+
 async def route_request(
     data: dict,
     llm_router: Optional[LitellmRouter],
@@ -348,6 +381,7 @@ async def route_request(
         "adelete_run",
     ],
     user_api_key_dict: Optional[UserAPIKeyAuth] = None,
+    _skip_model_db_reload: bool = False,
 ):
     """
     Common helper to route the request
@@ -594,6 +628,18 @@ async def route_request(
         return getattr(litellm, f"{route_type}")(**data)
     elif route_type == "allm_passthrough_route":
         return getattr(litellm, f"{route_type}")(**data)
+
+    if not _skip_model_db_reload and llm_router is not None and data.get("model"):
+        refreshed_router = await _reload_db_models_on_router_miss()
+        if refreshed_router is not None:
+            return await route_request(
+                data=data,
+                llm_router=refreshed_router,
+                user_model=user_model,
+                route_type=route_type,
+                user_api_key_dict=user_api_key_dict,
+                _skip_model_db_reload=True,
+            )
 
     # if no route found then it's a bad request
     route_name = ROUTE_ENDPOINT_MAPPING.get(route_type, route_type)

--- a/tests/test_litellm/proxy/test_route_llm_request.py
+++ b/tests/test_litellm/proxy/test_route_llm_request.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to 
 
 from unittest.mock import MagicMock
 
-from litellm.proxy.route_llm_request import route_request
+from litellm.proxy.route_llm_request import ProxyModelNotFoundError, route_request
 
 
 @pytest.mark.parametrize(
@@ -171,6 +171,74 @@ async def test_route_request_no_model_required_with_router_settings_and_no_route
         await route_request(data, None, "gpt-3.5-turbo", "acompletion")
 
         mock_completion.assert_called_once_with(**data)
+
+
+def _router_without_model():
+    llm_router = MagicMock()
+    llm_router.router_general_settings.pass_through_all_models = False
+    llm_router.default_deployment = None
+    llm_router.pattern_router.patterns = []
+    llm_router.model_names = []
+    llm_router.has_model_id.return_value = False
+    llm_router.model_group_alias = None
+    llm_router.deployment_names = []
+    return llm_router
+
+
+@pytest.mark.asyncio
+async def test_route_request_reloads_db_models_once_on_router_miss(monkeypatch):
+    import litellm.proxy.route_llm_request as route_llm_request
+
+    data = {
+        "model": "db-backed-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    llm_router = _router_without_model()
+    llm_router.acompletion.return_value = "success"
+
+    async def reload_db_models():
+        llm_router.model_names = ["db-backed-model"]
+        return llm_router
+
+    monkeypatch.setattr(
+        route_llm_request,
+        "_reload_db_models_on_router_miss",
+        reload_db_models,
+    )
+
+    response = await route_request(data, llm_router, None, "acompletion")
+
+    assert response == "success"
+    llm_router.acompletion.assert_called_once_with(**data)
+
+
+@pytest.mark.asyncio
+async def test_route_request_does_not_reload_db_models_more_than_once(monkeypatch):
+    import litellm.proxy.route_llm_request as route_llm_request
+
+    data = {
+        "model": "unknown-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+    }
+    llm_router = _router_without_model()
+    reload_calls = 0
+
+    async def reload_db_models():
+        nonlocal reload_calls
+        reload_calls += 1
+        return llm_router
+
+    monkeypatch.setattr(
+        route_llm_request,
+        "_reload_db_models_on_router_miss",
+        reload_db_models,
+    )
+
+    with pytest.raises(ProxyModelNotFoundError):
+        await route_request(data, llm_router, None, "acompletion")
+
+    assert reload_calls == 1
+    llm_router.acompletion.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reload DB-backed proxy models once when a request misses the in-memory router model list.
- Re-run routing after the reload so models created via `/model/new` can be used on another proxy pod before its router has refreshed.
- Keep the existing `ProxyModelNotFoundError` behavior if the model is still unavailable after one reload.

## Why
In multi-pod proxy deployments, `/model/new` persists the model to the DB and refreshes the router in the pod that handled the management request. A subsequent completion request may hit a different pod whose in-memory router has not loaded that DB model yet, causing a transient `Invalid model name passed` error.

## Test Plan
- `uv run --extra proxy pytest tests/test_litellm/proxy/test_route_llm_request.py -q`
- `uv run ruff check litellm/proxy/route_llm_request.py tests/test_litellm/proxy/test_route_llm_request.py`

## Notes
- The first `uv run pytest ...` without `--extra proxy` failed because the local environment did not install proxy-only dependencies such as `websockets`.
