### PR TITLE
fix(bedrock_mantle): forward AWS creds through the chat->responses bridge

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5279,6 +5279,14 @@ def completion(  # type: ignore
             use_xai_oauth=kwargs.get("use_xai_oauth", False),
             aws_bedrock_project_id=kwargs.get("aws_bedrock_project_id"),
         )
+        # get_litellm_params() only extracts OPTIONAL_KWARGS_KEYS from its own
+        # **kwargs, which is not forwarded above. Merge them back so provider auth
+        # kwargs (e.g. AWS SigV4 aws_region_name / aws_access_key_id /
+        # aws_secret_access_key) reach litellm_params — otherwise the
+        # chat->responses bridge signs Bedrock Mantle requests with empty creds.
+        for _param, _value in _supplemental_provider_params.items():
+            if litellm_params.get(_param) is None:
+                litellm_params[_param] = _value
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,
             user=user,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5279,14 +5279,6 @@ def completion(  # type: ignore
             use_xai_oauth=kwargs.get("use_xai_oauth", False),
             aws_bedrock_project_id=kwargs.get("aws_bedrock_project_id"),
         )
-        # get_litellm_params() only extracts OPTIONAL_KWARGS_KEYS from its own
-        # **kwargs, which is not forwarded above. Merge them back so provider auth
-        # kwargs (e.g. AWS SigV4 aws_region_name / aws_access_key_id /
-        # aws_secret_access_key) reach litellm_params — otherwise the
-        # chat->responses bridge signs Bedrock Mantle requests with empty creds.
-        for _param, _value in _supplemental_provider_params.items():
-            if litellm_params.get(_param) is None:
-                litellm_params[_param] = _value
         cast(LiteLLMLoggingObj, logging).update_environment_variables(
             model=model,
             user=user,
@@ -5350,6 +5342,15 @@ def completion(  # type: ignore
                     }
                 else:
                     optional_params["reasoning_effort"] = {"summary": rs_val}
+
+            # get_litellm_params() above is not passed **kwargs, so
+            # OPTIONAL_KWARGS_KEYS (e.g. AWS SigV4 aws_region_name /
+            # aws_access_key_id / aws_secret_access_key) never made it into
+            # litellm_params. Merge them in on the bridge path so the downstream
+            # responses() call can sign Bedrock Mantle requests with real creds.
+            for _param, _value in _supplemental_provider_params.items():
+                if litellm_params.get(_param) is None:
+                    litellm_params[_param] = _value
 
             return responses_api_bridge.completion(  # pyright: ignore[reportReturnType]  # bridge returns a coroutine on the acompletion path; awaited by the async caller
                 model=model,

--- a/tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py
+++ b/tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py
@@ -151,3 +151,44 @@ async def test_async_completion_forwards_aws_region_name():
         except Exception:
             pass
         assert _fake_aresponses.kwargs.get("aws_region_name") == "us-east-2"
+
+
+def test_completion_forwards_aws_creds_into_bridge_litellm_params():
+    """Regression test for https://github.com/BerriAI/litellm/issues/32336 -
+    litellm.completion() dropped aws_region_name / aws_access_key_id /
+    aws_secret_access_key before dispatching the chat->responses bridge for
+    bedrock_mantle gpt-5.* (Responses-only) models, so SigV4 signed with empty
+    creds and Bedrock Mantle rejected the request.
+
+    get_litellm_params() only extracts OPTIONAL_KWARGS_KEYS from its own
+    **kwargs, which completion() does not forward; the fix merges the
+    supplemental provider params back into litellm_params. This pins that the
+    AWS credentials survive into the litellm_params the bridge receives — the
+    handler-level tests above only cover forwarding once the params are already
+    present.
+    """
+    import litellm
+
+    captured = {}
+
+    def _fake_bridge_completion(**kwargs):
+        captured.update(kwargs)
+        return MagicMock(spec=[])
+
+    with patch(
+        "litellm.completion_extras.responses_api_bridge.completion",
+        _fake_bridge_completion,
+    ):
+        litellm.completion(
+            model="bedrock_mantle/openai.gpt-5.4",
+            messages=[{"role": "user", "content": "hi"}],
+            api_base="https://bedrock-mantle.us-east-2.api.aws/v1",
+            aws_region_name="us-east-2",
+            aws_access_key_id="AKIAEXAMPLE",
+            aws_secret_access_key="secretexample",
+        )
+
+    litellm_params = captured.get("litellm_params") or {}
+    assert litellm_params.get("aws_region_name") == "us-east-2"
+    assert litellm_params.get("aws_access_key_id") == "AKIAEXAMPLE"
+    assert litellm_params.get("aws_secret_access_key") == "secretexample"

--- a/tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py
+++ b/tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py
@@ -188,6 +188,7 @@ def test_completion_forwards_aws_creds_into_bridge_litellm_params():
             aws_secret_access_key="secretexample",
         )
 
+    assert captured, "responses_api_bridge.completion was never called"
     litellm_params = captured.get("litellm_params") or {}
     assert litellm_params.get("aws_region_name") == "us-east-2"
     assert litellm_params.get("aws_access_key_id") == "AKIAEXAMPLE"


### PR DESCRIPTION
## Relevant issues

<!-- e.g., "Fixes #000" -->
Fixes #32336

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have added meaningful tests
- [X] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [X] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

`bedrock_mantle/openai.gpt-5.*` models are Responses-API-only, so every `/chat/completions` call to them is routed through the chat->responses bridge.
On that path the caller's AWS credentials never reached the SigV4 signer.

The signer below is monkeypatched only to print the region/creds it actually receives — the request never leaves the process, so no mock replaces the code under test (`litellm.completion` -> `get_litellm_params` -> bridge -> signer):

```python
import litellm
from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM

def spy(self, service_name, headers, optional_params, request_data, api_base, **kw):
    print("SIGN region =", optional_params.get("aws_region_name"),
          "| access_key =", optional_params.get("aws_access_key_id"))
    raise RuntimeError("stop")
BaseAWSLLM._sign_request = spy

creds = dict(aws_region_name="us-east-2",
             aws_access_key_id="AKIAEXAMPLE",
             aws_secret_access_key="secretexample")

# /responses — already correct
try:
    litellm.responses(model="bedrock_mantle/openai.gpt-5.4", input="hi",
                      api_base="https://bedrock-mantle.us-east-2.api.aws/v1", **creds)
except Exception: pass

# /chat/completions bridge — standard host and VPC endpoint host
for base in ("https://bedrock-mantle.us-east-2.api.aws/v1",
             "https://vpce-020c19ce7e8af3fac-3on5ps9r.bedrock-mantle.us-east-2.vpce.amazonaws.com/v1"):
    try:
        litellm.completion(model="bedrock_mantle/openai.gpt-5.4",
                           messages=[{"role": "user", "content": "hi"}], api_base=base, **creds)
    except Exception: pass
```

**Before** (creds dropped; region also lost when the host doesn't encode it):

```
responses            -> SIGN region = us-east-2 | access_key = AKIAEXAMPLE
chat / standard host -> SIGN region = us-east-2 | access_key = None
chat / VPC endpoint  -> SIGN region = us-east-1 | access_key = None
```

Against a real Mantle endpoint the chat calls fail with HTTP 500
`invalid_api_key: "Credential should be scoped to a valid region."`.

**After** (bridge signs with the caller's creds/region, matching `/responses`):

```
responses            -> SIGN region = us-east-2 | access_key = AKIAEXAMPLE
chat / standard host -> SIGN region = us-east-2 | access_key = AKIAEXAMPLE
chat / VPC endpoint  -> SIGN region = us-east-2 | access_key = AKIAEXAMPLE
```

Added regression test:

```
$ pytest tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py -q
....                                                                     [100%]
4 passed
```

`test_completion_forwards_aws_creds_into_bridge_litellm_params` fails on `main` (asserts `aws_region_name is None`) and passes with this change.


## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

`litellm.completion()` built `litellm_params` via `get_litellm_params(...)`, but that call does not forward `**kwargs`. `get_litellm_params()` only pulls the `OPTIONAL_KWARGS_KEYS` (which include `aws_region_name` / `aws_access_key_id` / `aws_secret_access_key`) out of its **own** `**kwargs`, so with none forwarded the AWS credentials were dropped from `litellm_params`.
That aws-less `litellm_params` was then handed to `responses_api_bridge.completion(...)`, and the downstream `BedrockMantleResponsesAPIConfig.sign_request()` signed with empty credentials.
For VPC-endpoint hosts, whose URL does not match `bedrock-mantle.<region>.api.aws`, `_resolve_region()` also fell back to the default region — so both the region and the credentials were wrong.

#30083 already added the AWS keys to `OPTIONAL_KWARGS_KEYS` and forwarded a `_supplemental_provider_params` `GenericLiteLLMParams` into `get_llm_provider()` to fix provider *detection*, but the `litellm_params` passed to the bridge was never updated, so signing stayed broken.

This PR reuses that already-computed `_supplemental_provider_params` and merges it back into `litellm_params` right after `get_litellm_params(...)`, without clobbering values that are already set:

- `litellm/main.py` — merge `_supplemental_provider_params` into `litellm_params` before dispatching the responses bridge.
- `tests/test_litellm/completion_extras/test_responses_bridge_provider_propagation.py` — add a `completion()`-level regression test pinning that the AWS creds reach the bridge's `litellm_params` (the existing handler-level tests only cover forwarding once the params are already present).

The `/responses` path was already correct and is unchanged.
