### PR TITLE
fix(mcp): defer proxy import so completion(tools=...) works without proxy extras

### DIFF
--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -20,7 +20,6 @@ from litellm.proxy._experimental.mcp_server.utils import (
     split_server_prefix_from_name,
     strip_known_server_prefix,
 )
-from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
 from litellm.responses.main import aresponses
 from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse
@@ -705,6 +704,10 @@ class LiteLLM_Proxy_MCP_Handler:
                 if request_tags:
                     logging_request_data["metadata"]["tags"] = request_tags
                 if user_api_key_auth is not None:
+                    from litellm.proxy.litellm_pre_call_utils import (
+                        LiteLLMProxyRequestSetup,
+                    )
+
                     LiteLLMProxyRequestSetup.add_user_api_key_auth_to_request_metadata(
                         data=logging_request_data,
                         user_api_key_dict=user_api_key_auth,

--- a/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
+++ b/tests/test_litellm/responses/mcp/test_litellm_proxy_mcp_handler.py
@@ -1,4 +1,6 @@
+import subprocess
 import sys
+import textwrap
 import types
 from unittest.mock import AsyncMock, MagicMock
 
@@ -557,3 +559,49 @@ async def test_execute_tool_calls_propagates_request_tags_to_function_setup(monk
     )
 
     assert captured["metadata"]["tags"] == ["team-a", "prod"]
+
+
+def test_completion_with_function_tools_works_without_fastapi_installed():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        class _FastapiBlocker:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "fastapi" or fullname.startswith("fastapi."):
+                    raise ModuleNotFoundError("No module named 'fastapi'")
+                return None
+
+        sys.meta_path.insert(0, _FastapiBlocker())
+
+        import litellm
+
+        response = litellm.completion(
+            model="openai/gpt-5.5",
+            messages=[{"role": "user", "content": "What is the weather in SF?"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather for a location",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
+                    },
+                }
+            ],
+            mock_response="sunny",
+        )
+        assert response.choices[0].message.content == "sunny"
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Since #31576, `litellm/responses/mcp/litellm_proxy_mcp_handler.py` imports `litellm.proxy.litellm_pre_call_utils` at module top, which imports fastapi. `completion()` imports that module whenever `tools` is passed (litellm/main.py), so any completion call with tools crashes on a base SDK install (no `[proxy]` extra) with `ModuleNotFoundError: No module named 'fastapi'`. This is also why the CodSpeed benchmark job has been red on every run since Jul 2 (its env installs base deps only)

Before the fix, on a base-deps-only env (same install the CodSpeed workflow uses):

```
$ env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen --no-default-groups \
    --with pytest==8.3.5 --with pytest-codspeed==4.3.0 \
    --with "mcp>=1.26.0,<2.0" --with "a2a-sdk>=1.1.0,<2.0" \
    pytest -p pytest_codspeed.plugin tests/benchmarks/ --codspeed -q
>   from fastapi import HTTPException, Request
E   ModuleNotFoundError: No module named 'fastapi'
litellm/proxy/litellm_pre_call_utils.py:9: ModuleNotFoundError
FAILED tests/benchmarks/test_inference_benchmarks.py::test_completion_with_tools
1 failed, 29 passed
```

After the fix, same command:

```
30 passed, 2 warnings in 120.32s (0:02:00)
```

And the end-user scenario, a real OpenAI request with tools on a base-deps-only env:

```
$ uv run --frozen --no-default-groups python -c '
import litellm
response = litellm.completion(
    model="openai/gpt-5.5",
    messages=[{"role": "user", "content": "What is the weather in San Francisco? Use the tool."}],
    tools=[{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a location", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}],
)
print("tool_calls:", response.choices[0].message.tool_calls)'
tool_calls: [ChatCompletionMessageToolCall(function=Function(arguments='{"location":"San Francisco"}', name='get_weather'), id='call_M425bMiagxdJKkSYiGNQodr7', type='function')]
```

Screen recording of the end-to-end verification on a base SDK install without the proxy extra, showing the crash on the unfixed merge-base and the success on this branch

![End-to-end verification of PR 32339](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMjg0NDk2YWMtMGVmZi00NGNkLThiOWMtZTkxMTk0Y2IxZTU4IiwiaWF0IjoxNzgzNDM2ODEyLCJleHAiOjE3ODQwNDE2MTIsImZpbGVuYW1lIjoiZGVtby53ZWJwIn0.NKrqd0xKXe1Q4HYEQjRf6_dWyJYEP00ZP9q53PZeszM)

## Type

🐛 Bug Fix

## Changes

Moves the `LiteLLMProxyRequestSetup` import from module top into its single call site, which only runs when `user_api_key_auth` is set (proxy context, where fastapi is guaranteed installed). This matches the module's existing pattern: every other proxy-only dependency in this file is already imported lazily inside the function that needs it, precisely so the module stays importable on base SDK installs

Adds a regression test that runs `completion()` with function tools in a subprocess where fastapi imports are blocked, so a top-level proxy import can never leak into this path again without failing tests


Link to Devin session: https://app.devin.ai/sessions/e3ebfe88cf5744afa6f27d0e61ae8b60