### PR TITLE
ci(codspeed): re-enable benchmarks on litellm_internal_staging

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - litellm_internal_staging
   pull_request:
     branches:
       - main
+      - litellm_internal_staging
   # Allow CodSpeed to trigger backtest performance analysis
   # in order to generate initial data
   workflow_dispatch:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   benchmarks:
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4118

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (not applicable; two-line workflow trigger change)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

#31746 disabled CodSpeed on litellm_internal_staging because unpinned `ubuntu-latest` runners put BASE and HEAD on different machines, so CodSpeed reported "Different runtime environments detected" and sub-millisecond runner noise on 3-4 ms benchmarks flip-flopped results by 25-30% (for example the -25.2% false regression on #31684, which had no LLM code changes). The same commit that disabled the staging triggers also pinned the runner to `ubuntu-24.04`, which removes that noise source: CodSpeed runs in simulation mode (instruction counting), which is deterministic on a fixed runner image, so the flapping cannot recur once BASE and HEAD are both measured on the pinned image

The first push run after this merges re-baselines litellm_internal_staging on the pinned runner, so comparisons are clean from the first post-merge PR onward

Update: #32339 has merged and this branch is rebased on top of it, so the benchmarks job on this PR now runs against fixed code. Original note kept for context: #32339 fixes the fastapi import leak from #31576 that has failed every CodSpeed run since Jul 2 (`ModuleNotFoundError: No module named 'fastapi'` in `test_completion_with_tools`); re-enabling before it lands would bring the staging red X's straight back. With that fix applied, the exact command the workflow runs passes locally on this branch:

```
$ env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --frozen --no-default-groups \
    --with pytest==8.3.5 --with pytest-codspeed==4.3.0 \
    --with "mcp>=1.26.0,<2.0" --with "a2a-sdk>=1.1.0,<2.0" \
    pytest -p pytest_codspeed.plugin tests/benchmarks/ --codspeed -q
30 passed, 2 warnings in 120.32s (0:02:00)
```

The job timeout is raised from 15 to 60 minutes because the staging suite runs much longer under CodSpeed's callgrind instrumentation than main's (~2 minute) runs; at 15 minutes the job was cancelled mid-measurement on every staging merge ref. The first completed run will show per-benchmark instruction counts on the CodSpeed dashboard, which pinpoints what grew on staging relative to main; the timeout can be tightened again once that is understood

## Type

🚄 Infrastructure

## Changes

Restores the litellm_internal_staging push and pull_request triggers in `.github/workflows/codspeed.yml` that #31746 removed, reverting the temporary disable now that its stated blocker (unpinned-runner noise) is fixed by the `ubuntu-24.04` pin from that same PR
