### PR TITLE
fix(otel): make span-dedupe marker key JSON-serializable

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1042,11 +1042,16 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
            must be at entry granularity. Scope: the entry's stable identity.
 
         ``scope`` parts may include unhashable containers (list, dict, set);
-        they are normalized into a hashable shape via ``_freeze_for_dedupe``
-        before keying the marker dict. The marker is stored in
-        ``kwargs["litellm_params"]["metadata"]["_otel_internal"]`` so it is
-        request-local (kwargs is shared across the sync/async callbacks and
-        lifecycle hooks for one request).
+        they are normalized into a hashable shape via ``_freeze_for_dedupe``,
+        then rendered to a ``str`` before keying the marker dict. The marker
+        is stored in ``kwargs["litellm_params"]["metadata"]["_otel_internal"]``,
+        which is the same dict object snapshotted into
+        ``proxy_server_request["body"]`` for spend-log/audit purposes, so it
+        is request-local (kwargs is shared across the sync/async callbacks
+        and lifecycle hooks for one request). The key is kept as a ``str``
+        rather than a raw ``tuple`` because a tuple is a valid Python dict
+        key but not a valid JSON object key, and would be silently dropped
+        when that snapshot is later JSON-serialized downstream.
         """
         litellm_params = kwargs.get("litellm_params")
         if not isinstance(litellm_params, dict):
@@ -1068,10 +1073,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             spans_logged = {}
             _otel_internal["spans_logged"] = spans_logged
 
-        dedupe_key = (
-            self.__class__.__name__,
-            id(self),
-            *(_freeze_for_dedupe(part) for part in scope),
+        dedupe_key = repr(
+            (
+                self.__class__.__name__,
+                id(self),
+                *(_freeze_for_dedupe(part) for part in scope),
+            )
         )
         if spans_logged.get(dedupe_key) is True:
             return False

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -182,6 +182,15 @@ _UNTRUSTED_METADATA_CONTROL_FIELDS = (
     "client_disconnected",
     "error_information",
     PRE_CALL_EXECUTED_GUARDRAILS_KEY,
+    # OpenTelemetry's per-request span-dedupe marker (see
+    # OpenTelemetry._emit_once). It is server-only bookkeeping that gets
+    # echoed back to the caller in spend-log/audit request-body snapshots.
+    # A caller who replayed a previously observed marker here could make
+    # _emit_once believe a span (including a guardrail-violation span) was
+    # already emitted for their new request and skip logging it — an
+    # observability/audit-evasion bypass. Must never be seeded from client
+    # input.
+    "_otel_internal",
 )
 
 _UNTRUSTED_REQUEST_HEADER_CONTROL_FIELDS = frozenset(

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -4748,6 +4748,32 @@ class TestOpenTelemetrySpanDedupe(unittest.TestCase):
         self.assertTrue(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
         self.assertFalse(otel._emit_once(kwargs, "guardrail", "pii", 1.0, cyclic))
 
+    def test_emit_once_marker_survives_metadata_json_serialization(self):
+        """Regression for #32250: the dedupe marker is written into
+        ``kwargs["litellm_params"]["metadata"]["_otel_internal"]``, the same
+        dict object that proxy request-processing later shallow-copies by
+        reference into ``proxy_server_request["body"]`` and spend-tracking
+        serializes with ``safe_dumps`` for the DB row. A raw ``tuple`` dict
+        key is valid in Python but not in JSON, so pre-fix, ``safe_dumps``
+        silently dropped the ``spans_logged`` entry (non-``str`` keys are
+        skipped, not raising) and the dedupe marker vanished from the
+        persisted payload. Round-tripping through ``safe_dumps``/``json.loads``
+        must preserve it."""
+        otel = OpenTelemetry()
+        kwargs = self._build_kwargs()
+        otel._emit_once(kwargs, "success")
+
+        metadata = kwargs["litellm_params"]["metadata"]
+        round_tripped = json.loads(safe_dumps(metadata))
+
+        spans_logged = round_tripped.get("_otel_internal", {}).get("spans_logged", {})
+        self.assertEqual(
+            len(spans_logged),
+            1,
+            "Dedupe marker must survive JSON round-trip instead of being "
+            "silently dropped for having a non-str key",
+        )
+
     def test_create_guardrail_span_does_not_raise_on_list_mode(self):
         """End-to-end regression for LIT-3428: ``_create_guardrail_span``
         must produce exactly one span (not raise ``TypeError``) when the

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -299,6 +299,59 @@ async def test_add_litellm_data_to_request_strips_admin_injection_slots():
 
 
 @pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_otel_internal_marker():
+    """A caller must not be able to seed metadata._otel_internal.
+
+    OpenTelemetry._emit_once treats a pre-existing dedupe marker under
+    metadata._otel_internal.spans_logged as "already emitted" and skips span
+    emission. Since that marker is now JSON-serializable (round-trips through
+    spend-log request-body snapshots), a caller who observed one on a prior
+    request could replay it on a new request to suppress OpenTelemetry
+    logging for it — including guardrail-violation spans. It must be
+    stripped as server-only state before the request is processed further.
+    """
+    from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+
+    request_mock = MagicMock(spec=Request)
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url = MagicMock()
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+
+    replayed_marker = {"spans_logged": {"('OpenTelemetry', 1, 'success')": True}}
+    data = {
+        "model": "gpt-3.5-turbo",
+        "metadata": {"_otel_internal": replayed_marker},
+        "litellm_metadata": {"_otel_internal": replayed_marker},
+    }
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="hashed-key",
+        spend=0.0,
+        max_budget=100.0,
+        model_max_budget={},
+        team_spend=0.0,
+        team_max_budget=200.0,
+    )
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=request_mock,
+        user_api_key_dict=user_api_key_dict,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert "_otel_internal" not in (updated.get("metadata") or {})
+    assert "_otel_internal" not in (updated.get("litellm_metadata") or {})
+
+
+@pytest.mark.asyncio
 async def test_add_litellm_data_to_request_strips_all_user_api_key_prefix_keys():
     """Strip must cover the full user_api_key_* family, not a hand-maintained
     list of 2-3 names. Proxy writes a dozen such fields (user_id, alias,


### PR DESCRIPTION
## Relevant issues

Relates to #32250

## Linear ticket



## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran the new regression test both with and without the fix:

git stash push -- litellm/integrations/opentelemetry.py
python -m pytest tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetrySpanDedupe::test_emit_once_marker_survives_metadata_json_serialization -q
fails: AssertionError: 0 != 1

git stash pop
python -m pytest tests/test_litellm/integrations/test_opentelemetry.py::TestOpenTelemetrySpanDedupe::test_emit_once_marker_survives_metadata_json_serialization -q
passes


Also ran the full `test_opentelemetry.py` suite before and after; no new failures introduced by this change (remaining pre-existing failures are unrelated Windows `datetime.timestamp()` and missing-grpc-dependency issues in this environment).

## Type

🐛 Bug Fix

## Changes

`OpenTelemetry._emit_once` builds a dedupe marker for span emission and stores it as a dict key inside `kwargs["litellm_params"]["metadata"]["_otel_internal"]["spans_logged"]`. That marker key was a raw `tuple` (class name, `id(self)`, plus the frozen scope). The same `metadata` dict object is later shallow-copied by reference into `proxy_server_request["body"]` by `litellm_pre_call_utils.py` for spend-log/audit purposes, and `safe_dumps` silently drops any non-`str` dict key instead of raising, so the dedupe marker was quietly missing from the persisted spend-log payload.

I could not reproduce the `TypeError`/OOM crash as reported in #32250 against current `main` — `safe_dumps` has filtered non-`str` keys since well before the reported version, so both `safe_dumps` call sites in `spend_tracking_utils.py` degrade gracefully rather than raising. This PR fixes the underlying key-shape defect regardless: the dedupe marker key is now rendered to a `str` so it round-trips through JSON serialization intact instead of being silently dropped, whatever the current severity of the observable symptom.