### PR TITLE
fix(mcp): stop 'Team doesn't exist' warnings for UI dashboard sessions

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -8,6 +8,7 @@ from starlette.types import Scope
 
 from litellm._logging import verbose_logger
 from litellm.proxy._types import (
+    UI_TEAM_ID,
     LiteLLM_TeamTable,
     ProxyException,
     SpecialHeaders,
@@ -726,6 +727,9 @@ class MCPRequestHandler:
         if not user_api_key_auth or not user_api_key_auth.team_id or not prisma_client:
             return None
 
+        if user_api_key_auth.team_id == UI_TEAM_ID:
+            return None
+
         # Get the team object (which has object_permission already loaded)
         team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
             team_id=user_api_key_auth.team_id,
@@ -1019,6 +1023,9 @@ class MCPRequestHandler:
             )
 
             if user_api_key_auth is None or not user_api_key_auth.team_id or prisma_client is None:
+                return []
+
+            if user_api_key_auth.team_id == UI_TEAM_ID:
                 return []
 
             team_obj: Optional[LiteLLM_TeamTable] = await get_team_object(
@@ -1501,6 +1508,9 @@ class MCPRequestHandler:
 
         if prisma_client is None:
             verbose_logger.debug("prisma_client is None")
+            return []
+
+        if user_api_key_auth.team_id == UI_TEAM_ID:
             return []
 
         try:

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -26,6 +26,7 @@ from litellm._uuid import uuid
 from litellm.integrations.prometheus import PrometheusLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import (
+    UI_TEAM_ID,
     BlockTeamRequest,
     CommonProxyErrors,
     DeleteTeamRequest,
@@ -1046,6 +1047,13 @@ async def new_team(
         if data.team_id is None:
             data.team_id = str(uuid.uuid4())
         else:
+            if data.team_id == UI_TEAM_ID:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "error": f"team_id '{UI_TEAM_ID}' is reserved for LiteLLM UI dashboard sessions and cannot be used for a real team. Please use a different team id."
+                    },
+                )
             # Check if team_id exists already
             _existing_team_id = await prisma_client.get_data(
                 team_id=data.team_id, table_name="team", query_type="find_unique"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -3106,6 +3106,106 @@ async def test_get_team_object_permission_with_core_auth_auto_loading():
 
 
 @pytest.mark.asyncio
+async def test_get_team_object_permission_ui_session_team_skips_db_lookup():
+    """
+    UI session tokens carry the virtual team_id "litellm-dashboard" (UI_TEAM_ID),
+    which is never persisted. The lookup must short-circuit to None without
+    calling get_team_object; otherwise every MCP tools listing from the
+    dashboard logs a "Team doesn't exist in db" warning per server.
+    """
+    from litellm.proxy._types import UI_TEAM_ID
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id=UI_TEAM_ID,
+    )
+
+    mock_prisma = MagicMock()
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        with patch("litellm.proxy.auth.auth_checks.get_team_object") as mock_get_team:
+            result = await MCPRequestHandler._get_team_object_permission(
+                mock_user_auth
+            )
+
+            assert result is None
+            mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "helper_name,expected",
+    [
+        ("_get_allowed_mcp_servers_for_team", []),
+        ("_get_mcp_access_groups_for_team", []),
+    ],
+)
+async def test_team_mcp_helpers_ui_session_team_skip_db_lookup(helper_name, expected):
+    """
+    The server-permission and access-group helpers hit get_team_object with the
+    session's team_id too; for the virtual UI team each used to 404 into its
+    own swallowed warning per MCP listing. They must short-circuit without a
+    DB lookup.
+    """
+    from litellm.proxy._types import UI_TEAM_ID
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id=UI_TEAM_ID,
+    )
+
+    mock_prisma = MagicMock()
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        with patch("litellm.proxy.auth.auth_checks.get_team_object") as mock_get_team:
+            helper = getattr(MCPRequestHandler, helper_name)
+            result = await helper(mock_user_auth)
+
+            assert result == expected
+            mock_get_team.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_allowed_tools_for_server_ui_session_team_keeps_key_restrictions():
+    """
+    Regression: the 404 raised by get_team_object for the virtual UI team used
+    to escape into get_allowed_tools_for_server's blanket except, dropping
+    key-level tool restrictions (fail-open) and logging a warning. With the
+    short-circuit, key restrictions still apply for UI sessions.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._types import UI_TEAM_ID
+
+    user_api_key_auth = UserAPIKeyAuth(
+        api_key="test-key",
+        user_id="test-user",
+        team_id=UI_TEAM_ID,
+    )
+    key_perm = MagicMock()
+    key_perm.mcp_tool_permissions = {"server_1": ["tool_a"]}
+
+    mock_prisma = MagicMock()
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        with patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            side_effect=HTTPException(
+                status_code=404,
+                detail={"error": "Team doesn't exist in db. Team=litellm-dashboard."},
+            ),
+        ):
+            with patch.object(
+                MCPRequestHandler, "_get_key_object_permission", return_value=key_perm
+            ):
+                result = await MCPRequestHandler.get_allowed_tools_for_server(
+                    server_id="server_1",
+                    user_api_key_auth=user_api_key_auth,
+                )
+
+                assert result == ["tool_a"]
+
+
+@pytest.mark.asyncio
 async def test_get_allowed_mcp_servers_for_team_uses_helper():
     """
     Test that _get_allowed_mcp_servers_for_team resolves both legacy

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -9495,3 +9495,43 @@ class TestEmitTeamMembersMetric:
         # A metric failure must be swallowed, not propagated to the handler.
         _emit_team_members_metric(self._team(1))
         fake_logger.set_team_members_metric.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_new_team_rejects_reserved_ui_session_team_id():
+    """
+    /team/new must reject team_id "litellm-dashboard" (UI_TEAM_ID): it is the
+    virtual team stamped on every UI dashboard session token, so a real DB row
+    with that id would bind its budget and permissions to every UI session.
+    """
+    from fastapi import Request
+
+    from litellm.proxy._types import UI_TEAM_ID, NewTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import new_team
+
+    team_request = NewTeamRequest(
+        team_alias="dashboard-clone",
+        team_id=UI_TEAM_ID,
+    )
+    dummy_request = MagicMock(spec=Request)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma,
+        patch("litellm.proxy.proxy_server._license_check") as mock_license,
+    ):
+        mock_prisma.db.litellm_teamtable.count = AsyncMock(return_value=0)
+        mock_license.is_team_count_over_limit.return_value = False
+        mock_prisma.get_data = AsyncMock(return_value=None)
+
+        with pytest.raises(ProxyException) as exc_info:
+            await new_team(
+                data=team_request,
+                http_request=dummy_request,
+                user_api_key_dict=UserAPIKeyAuth(
+                    user_role=LitellmUserRoles.PROXY_ADMIN
+                ),
+            )
+
+        assert exc_info.value.code == "400"
+        assert "reserved" in str(exc_info.value.message)
+        mock_prisma.get_data.assert_not_called()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4227

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

A customer reported their proxy logs flooding with `Failed to get allowed tools for server: 404: {'error': "Team doesn't exist in db. Team=litellm-dashboard. ..."}`, one line per configured MCP server on every MCP tools listing from the dashboard, and was confused because they never created a team with that id. They are right that it does not exist; `litellm-dashboard` is the virtual team id LiteLLM stamps on every UI session token (`UI_TEAM_ID`), which is never persisted. The MCP team-permission helpers passed it to `get_team_object` anyway

Setup for both runs: fresh Postgres, 3 MCP servers pointing at the public DeepWiki MCP server, `EXPERIMENTAL_UI_LOGIN=true` (with plain sk- session keys the main auth flow happens to mask the 404 by caching a fabricated team object at `user_api_key_auth.py:1916`; the experimental UI JWT branch returns early at `user_api_key_auth.py:1541` before that fallback runs, so it reproduces the exact flow the customer hit)

```yaml
# lit4227_repro_config.yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
mcp_servers:
  deepwiki_1:
    url: https://mcp.deepwiki.com/mcp
    transport: http
  deepwiki_2:
    url: https://mcp.deepwiki.com/mcp
    transport: http
  deepwiki_3:
    url: https://mcp.deepwiki.com/mcp
    transport: http
general_settings:
  master_key: sk-1234
```

```bash
docker run -d --name lit4227-pg -e POSTGRES_PASSWORD=postgres -p 5434:5432 postgres:16
DATABASE_URL="postgresql://postgres:postgres@localhost:5434/postgres" EXPERIMENTAL_UI_LOGIN=true \
  python litellm/proxy/proxy_cli.py --config litellm/proxy/lit4227_repro_config.yaml \
  --detailed_debug --use_v2_migration_resolver 2>&1 | tee litellm.log

# mint a UI dashboard session exactly like the browser login does, pull the session token out of the cookie JWT
TOKEN=$(curl -s -i -X POST http://localhost:4000/login -d 'username=admin&password=sk-1234' \
  | grep -i '^set-cookie: token=' | sed 's/^[Ss]et-[Cc]ookie: token=//; s/;.*//')
KEY=$(python -c "import base64,json; p='$TOKEN'.split('.')[1]; p+='='*(-len(p)%4); print(json.loads(base64.urlsafe_b64decode(p))['key'])")

# MCP protocol tools/list with the UI session, same as the dashboard tool panel / any MCP client
SESSION=$(curl -s -D - -o /dev/null -X POST http://localhost:4000/mcp/ -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}' \
  | grep -i '^mcp-session-id:' | tr -d '\r' | cut -d' ' -f2)
curl -s -X POST http://localhost:4000/mcp/ -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" -H "Mcp-Session-Id: $SESSION" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | grep -o '"name":"[^"]*"' | wc -l
```

Before (parent commit 5e73994441): tools/list returns 9 tools and the log gets one warning per configured server, the customer's exact flood

![before: MCP tools/list floods the log with one 'Team doesn't exist' warning per server](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWM1OTA5ZjEtNjQ0MS00YmZkLTk1YWMtMjExYTNhYWZjMjAxIiwiaWF0IjoxNzgzNDQ0NDg5LCJleHAiOjE3ODQwNDkyODksImZpbGVuYW1lIjoicG9mNDhfYmVmb3JlX21jcC5wbmcifQ.8s1iMF5cvG9EKz2i-p0zN9_sXHliqgkQey9A9KVWzwY)

```
       9
$ grep "Failed to get allowed tools for server" litellm.log
09:36:22 - LiteLLM:WARNING: user_api_key_auth_mcp.py:832 - Failed to get allowed tools for server: 404: {'error': "Team doesn't exist in db. Team=litellm-dashboard. Create team via `/team/new` call."}
09:36:22 - LiteLLM:WARNING: user_api_key_auth_mcp.py:832 - Failed to get allowed tools for server: 404: {'error': "Team doesn't exist in db. Team=litellm-dashboard. Create team via `/team/new` call."}
09:36:22 - LiteLLM:WARNING: user_api_key_auth_mcp.py:832 - Failed to get allowed tools for server: 404: {'error': "Team doesn't exist in db. Team=litellm-dashboard. Create team via `/team/new` call."}
```

Before, second defect: `/team/new` happily creates a real team with the reserved id, whose budget and permissions would then bind to every UI session because the auth flow resolves the session's team against the DB row

![before: /team/new accepts the reserved id and the row persists in the DB](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNzI0NzdhMjctNDM5NS00NDZjLTg4YWEtYmEzMmI3YmZiZDI2IiwiaWF0IjoxNzgzNDQ0NDg5LCJleHAiOjE3ODQwNDkyODksImZpbGVuYW1lIjoicG9mNDhfYmVmb3JlX3RlYW0ucG5nIn0.VJCOBuC6dhei5VOZtppDNAcHocR3Pfp3IsJeRBuf7DY)

```
$ curl -s -X POST http://localhost:4000/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"team_id": "litellm-dashboard", "team_alias": "innocent-looking-team", "max_budget": 0.01}'
{"team_alias": "innocent-looking-team", "team_id": "litellm-dashboard", ...}   # 200

$ docker exec lit4227-pg psql -U postgres -t -c 'SELECT team_id, team_alias, max_budget FROM "LiteLLM_TeamTable";'
 litellm-dashboard | innocent-looking-team |       0.01
```

After (this PR, e84cefa6d0), same commands: tools/list still returns the same 9 tools and the log stays clean

![after: MCP tools/list still returns 9 tools and the warning count is 0](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvOGI1MzUyZDAtMGJhNi00ZjMwLWIxODAtOGJlN2I5NDc0OTMzIiwiaWF0IjoxNzgzNDQ0NDg5LCJleHAiOjE3ODQwNDkyODksImZpbGVuYW1lIjoicG9mNDhfYWZ0ZXJfbWNwLnBuZyJ9.NiZQzaPm76fGzQ3pkO6JXP5fl3UGhJ3gLXUePIm_Lms)

```
       9
$ grep -c "Failed to get allowed tools for server" litellm.log
0
```

After, `/team/new` rejects the reserved id and regular team creation is untouched

![after: /team/new returns HTTP 400 for the reserved id, only the regular team persists](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMDkwNjk3ZTctNjBlZS00MGVmLWExODUtN2U2ZDRjMTdlOGM5IiwiaWF0IjoxNzgzNDQ0NDg5LCJleHAiOjE3ODQwNDkyODksImZpbGVuYW1lIjoicG9mNDhfYWZ0ZXJfdGVhbS5wbmcifQ.ao0UZRxexl8ujvDg55znQEkKAdtGFmXGoJ2qKYuWtZE)

```
$ curl -s -w "\nHTTP status: %{http_code}\n" -X POST http://localhost:4000/team/new -H 'Authorization: Bearer sk-1234' \
    -H 'Content-Type: application/json' -d '{"team_id": "litellm-dashboard", "team_alias": "innocent-looking-team", "max_budget": 0.01}'
{"error":{"message":"{'error': \"team_id 'litellm-dashboard' is reserved for LiteLLM UI dashboard sessions and cannot be used for a real team. Please use a different team id.\"}","type":"internal_server_error","param":"None","code":"400"}}
HTTP status: 400

$ curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:4000/team/new -H 'Authorization: Bearer sk-1234' \
    -H 'Content-Type: application/json' -d '{"team_id": "regular-team-1", "team_alias": "regular team"}'
200
```

## Type

🐛 Bug Fix

## Changes

`MCPRequestHandler._get_team_object_permission`, `_get_allowed_mcp_servers_for_team` and `_get_mcp_access_groups_for_team` now short-circuit to their empty result when `user_api_key_auth.team_id == UI_TEAM_ID`, before hitting `get_team_object`. The virtual UI team can never have a DB row, so the lookup always raised HTTPException 404, which each helper swallowed into its own WARNING (the tools one fires once per server per tools/list, producing the flood) plus a wasted DB query. The 404 also aborted `get_allowed_tools_for_server` before the key-level tool permission handling ran, silently dropping key tool restrictions for such sessions; with the short-circuit the key/agent/org intersections apply normally. This mirrors the existing `UI_TEAM_ID` handling in `agent_permission_handler.py`

`/team/new` now rejects `team_id == UI_TEAM_ID` with a 400 before the duplicate check, so nobody can create a real team under the reserved id and silently attach its budget and permissions to every UI dashboard session

Regression tests: the three MCP helpers return their empty result for the UI team without calling `get_team_object` (asserted via `assert_not_called`), `get_allowed_tools_for_server` keeps key-level tool restrictions when the team lookup would 404, and `/team/new` returns 400 for the reserved id without reaching the DB duplicate check. All of them fail on the parent commit and pass with this change

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted auth guards on a known virtual team id plus team-creation validation; behavior for real teams is unchanged and tests cover the main paths.
> 
> **Overview**
> Stops MCP team-permission code from calling `get_team_object` when the session carries the virtual dashboard team id **`UI_TEAM_ID`** (`litellm-dashboard`). **`_get_team_object_permission`**, **`_get_allowed_mcp_servers_for_team`**, and **`_get_mcp_access_groups_for_team`** now return empty/`None` immediately, which removes per-server **"Team doesn't exist"** log noise on dashboard MCP `tools/list` and avoids a regression where a 404 from team lookup could skip **key-level MCP tool restrictions**.
> 
> **`/team/new`** now returns **400** if `team_id` is **`UI_TEAM_ID`**, so operators cannot create a real team row that would bind budget and permissions to every UI session.
> 
> Regression tests cover the MCP short-circuits, preserved key tool permissions for UI sessions, and rejection of the reserved id on team creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e84cefa6d08dbf156d0c759a62044a7d381edcef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->