### PR TITLE
chore: bump litellm-enterprise 0.1.47 -> 0.1.48, litellm 1.92.0 -> 1.93.0

### DIFF
--- a/enterprise/pyproject.toml
+++ b/enterprise/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-enterprise"
-version = "0.1.47"
+version = "0.1.48"
 description = "Package for LiteLLM Enterprise features"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.1.47"
+version = "0.1.48"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-enterprise==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.92.0"
+version = "1.93.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.14"
@@ -63,7 +63,7 @@ proxy = [
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.26.0,<2.0",
     "litellm-proxy-extras==0.4.75",
-    "litellm-enterprise==0.1.47",
+    "litellm-enterprise==0.1.48",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",
     "polars>=1.38.1,<2.0",
@@ -279,7 +279,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.92.0"
+version = "1.93.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-01T21:29:59.740039Z"
+exclude-newer = "2026-07-04T17:13:14.93495Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -3274,7 +3274,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.92.0"
+version = "1.93.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -3639,7 +3639,7 @@ proxy-dev = [
 
 [[package]]
 name = "litellm-enterprise"
-version = "0.1.47"
+version = "0.1.48"
 source = { editable = "enterprise" }
 
 [[package]]


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Version-bump-only change; there is no runtime behavior to demonstrate. The bumps are what `scripts/detect_bumps.sh` reports as due before promoting `litellm_internal_staging` into `main`: `litellm-enterprise` changed since the last release and was still at main's `0.1.47`, and the `1.92.0` line has already graduated to an rc (`v1.92.0-rc.1`), so this promotion opens the `1.93` line

## Type

🚄 Infrastructure

## Changes

Prep the version bumps needed before promoting `litellm_internal_staging` into `main`

`litellm-enterprise` bumped `0.1.47 -> 0.1.48` (PATCH); its folder changed since the last release and both main and staging still carried `0.1.47`. The root `litellm-enterprise==` pin moves with it

`litellm` (root) bumped `1.92.0 -> 1.93.0` (MINOR); the `1.92.0` line already has an rc tag (`v1.92.0-rc.1`), so it has graduated and this promotion opens the next minor line

`litellm-proxy-extras` is unchanged since the last release, so it is deliberately left at `0.4.75`

`uv.lock` refreshed at the repo root against the bumped versions; the only resolution changes are the two bumped editable packages (the `exclude-newer` timestamp moved because the lock uses a rolling `P3D` window)
