### PR TITLE
fix(mcp): preserve blob resource contents

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -5,6 +5,7 @@ LiteLLM MCP Server Routes
 # pyright: reportInvalidTypeForm=false, reportArgumentType=false, reportOptionalCall=false
 
 import asyncio
+import base64
 import contextlib
 import contextvars
 import hashlib
@@ -385,7 +386,7 @@ if MCP_AVAILABLE:
             elif isinstance(content, BlobResourceContents):
                 normalized.append(
                     ReadResourceContents(
-                        content=content.blob,
+                        content=base64.b64decode(content.blob),
                         mime_type=content.mimeType,
                         meta=meta,
                     )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -756,9 +756,32 @@ def test_normalize_resource_contents_blob_with_metadata():
     result = _normalize_resource_contents(contents)
 
     assert len(result) == 1
-    assert result[0].content == "aGVsbG8="
+    assert result[0].content == b"hello"
     assert result[0].mime_type == "image/png"
     assert result[0].meta == meta
+
+
+def test_normalize_resource_contents_decodes_blob_content_to_bytes():
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _normalize_resource_contents,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    contents = [
+        BlobResourceContents(
+            uri="https://example.com/archive.tar.gz",
+            blob="H4sIAAAAAAACAw==",
+            mimeType="application/gzip",
+        )
+    ]
+
+    result = _normalize_resource_contents(contents)
+
+    assert len(result) == 1
+    assert result[0].content == b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03"
+    assert result[0].mime_type == "application/gzip"
 
 
 def test_normalize_resource_contents_preserves_empty_metadata():


### PR DESCRIPTION
## Relevant issues

Fixes #32330

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If review is delayed, I will follow the project guidance in the PR template

## Screenshots / Proof of Fix

I reproduced the bug with `test_normalize_resource_contents_decodes_blob_content_to_bytes` before applying the fix. The test failed on the old behavior because `_normalize_resource_contents` returned the base64 blob as a `str`, which is the discriminator MCP lowlevel uses for `TextResourceContents`

After the fix, binary MCP resources are decoded to `bytes` before constructing `ReadResourceContents`, preserving the blob discriminator for the MCP server response path

Local validation:

```text
python -m pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q
132 passed, 5 warnings in 18.97s

python -m ruff check litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
All checks passed!
```

GitHub validation is green on the PR. Greptile reported Confidence Score 5/5, Codecov reported all modified coverable lines covered, and CodSpeed reported no performance change

I did not run a live proxy proof because this change is isolated to the internal MCP resource normalization boundary and does not require an LLM provider call

## Type

Bug Fix
Test

## Changes

This decodes `BlobResourceContents.blob` from base64 to bytes before wrapping it in `ReadResourceContents`. Text resources continue to pass through as strings, and existing metadata preservation is unchanged

The regression coverage now checks that blob resources normalize to bytes, while the existing metadata test was updated to assert the decoded blob payload rather than the previous base64 string behavior