### PR TITLE
feat(skills): add explain-ticket skill for comprehensive Linear ticket investigation

### DIFF
--- a/.claude/skills/explain-ticket/SKILL.md
+++ b/.claude/skills/explain-ticket/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: explain-ticket
+description: Comprehensively explain a Linear ticket by reading the ticket plus every explicitly attached Slack, Pylon, email, and GitHub resource, and by inspecting the code in two parallel worktrees (the version reported in the ticket, if any, and the latest litellm_internal_staging). Use when asked to explain, investigate, or get up to speed on a Linear ticket.
+argument-hint: <ticket id or Linear URL>
+---
+
+# Explain a Linear ticket
+
+The deliverable is an explanation of the ticket, not a fix. Do not change code, do not open PRs, and do not comment on the ticket unless explicitly asked. Read comprehensively, then report
+
+## 1. Read the ticket itself
+
+Resolve the ticket id or URL from the arguments. If none was given, ask for it instead of guessing
+
+Using the Linear MCP tools, fetch the issue (get_issue), all comments (list_comments), and its attachments/links. Note the reporter, assignee, status, labels, customer needs, parent/child issues, and any linked PRs or commits. Extract from the ticket text: the symptom, the expected behavior, any error messages or stack traces, and the LiteLLM version the reporter was running (if stated anywhere in the ticket, comments, or attached threads)
+
+## 2. Follow explicitly attached context only
+
+Hard rule: never use search tools against Slack, Pylon, or Gmail to find threads that "might" be related. Only open resources that are explicitly linked or attached, starting from the ticket
+
+Chaining is allowed and encouraged, as long as every hop derives from an explicit attachment. Examples of the intended traversal:
+
+- The ticket links a Pylon issue: fetch it (get_issue, get_issue_messages) and read the full conversation
+- That Pylon issue has a Slack thread attached: read it with slack_read_thread
+- The ticket or a thread links an email thread: fetch that specific thread with the Gmail get_thread/get_message tools
+- A thread links a GitHub issue, PR, or gist: fetch it with the GitHub MCP tools
+- Any of those link further resources (docs, screenshots, config files, follow-up threads): keep going
+
+The distinction is navigation vs discovery. Following a link someone attached is navigation and is always fine, to any depth. Querying Slack/Pylon/Gmail search endpoints to discover unlinked context is forbidden, even if you are confident a related thread exists
+
+While reading, collect concrete reproduction details: config snippets, model names, request payloads, curl commands, versions, and timestamps. Quote error messages verbatim in your notes; they anchor the code investigation
+
+## 3. Investigate the code in two parallel worktrees
+
+Create fresh worktrees outside the main checkout so the primary working tree is untouched (a scratch directory is fine):
+
+1. If the ticket reports a version (e.g. "v1.80.5" or "1.80.5-stable"), find the matching tag (`git tag --list '*<version>*'`) and add a worktree at it: `git worktree add <scratch>/litellm-reported <tag>`
+2. Always fetch and add a worktree at the latest staging head: `git fetch origin litellm_internal_staging && git worktree add <scratch>/litellm-staging origin/litellm_internal_staging`
+
+If no version is reported, skip the first worktree and investigate staging only
+
+Launch one Explore subagent per worktree, in parallel (a single message with multiple Agent calls). Give each agent the symptom, verbatim error messages, and repro details from steps 1-2, and ask it to locate the code paths involved, explain the relevant behavior at that revision, and assess whether the reported behavior is plausible there. Then compare the two answers: does the bug exist at the reported version, does it still exist on staging, was it introduced or fixed in between (use `git log`/`git blame` on the implicated files to find the commit if so)
+
+Clean up when done: `git worktree remove <path>` for each worktree you added
+
+## 4. Report
+
+Lead with a short plain-language summary of what the ticket is about and what is actually going on. Then cover, in prose:
+
+- Who reported it and through which channel(s), with what they were trying to do
+- The symptom and the exact error, plus repro details gathered from the threads
+- What the code does today: the root cause (or best-supported hypothesis, clearly labeled as such) with `file:line` references
+- The reported version vs staging comparison: still broken, already fixed (by which commit/PR), or behavior changed
+- Anything the threads reveal that the ticket text omits: workarounds already suggested, customer urgency, related tickets, constraints on the fix
+- Open questions that block a confident diagnosis, and what would resolve them
+
+Cite where each key fact came from (ticket, specific comment, Slack thread, Pylon message, email) so the reader can verify without redoing the traversal

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .venv
 .venv_policy_test
 .env
-.claude
+.claude/*
+!.claude/skills/
 .newenv
 newenv/*
 litellm/proxy/myenv/*

--- a/.semgrep/rules/security/no-claude-directory.yml
+++ b/.semgrep/rules/security/no-claude-directory.yml
@@ -1,16 +1,19 @@
 rules:
   - id: no-claude-directory-committed
     message: >
-      .claude/ directory must not be committed to the repository.
-      It contains local Claude Code settings (permissions, worktree paths) that are
+      .claude/ directory must not be committed to the repository, except for
+      shared project skills under .claude/skills/. Everything else in it is
+      local Claude Code settings (permissions, worktree paths) that are
       developer-machine-specific and may expose internal paths or credentials.
-      Add .claude/ to .gitignore instead.
+      Keep .claude/ gitignored apart from the .claude/skills/ carve-out.
     severity: ERROR
     languages: [generic]
     paths:
       include:
         - "/.claude/**"
         - "/.claude/*"
+      exclude:
+        - "/.claude/skills/**"
     pattern-regex: '[\s\S]+'
     metadata:
       category: security


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (n/a; this adds a markdown skill definition with no runtime code)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

In a Claude Code session in this repo, run `/explain-ticket LIT-1234` (any real ticket id or Linear URL). Claude should read the ticket and its explicitly attached Slack/Pylon/email/GitHub context without issuing any Slack, Pylon, or Gmail searches, spin up two worktrees (the reported version tag and origin/litellm_internal_staging), compare them, and reply with a sourced explanation of the ticket

To verify the semgrep rule still blocks everything else under `.claude/` while allowing skills, run `uv tool run --from 'semgrep==1.157.0' semgrep scan --config .semgrep/rules . --error`; it reports 0 findings on this branch and reports a blocking finding if you track any non-skills file under `.claude/`

## Type

🆕 New Feature

## Changes

Adds a project skill at `.claude/skills/explain-ticket/SKILL.md`, invocable as `/explain-ticket <ticket id or Linear URL>`, that codifies our ticket-investigation workflow: read the Linear issue with all comments and attachments, then follow explicitly attached context (Pylon issues, Slack threads, email threads, GitHub links) to any depth, while forbidding search against Slack, Pylon, or Gmail so only navigation from explicit attachments is allowed. It then inspects the code in two parallel worktrees, one at the version reported in the ticket (when stated) and one at the latest litellm_internal_staging, to determine whether the issue still reproduces, was fixed, or regressed, and finishes with a sourced write-up covering symptom, root cause, version comparison, and open questions

Also carves `.claude/skills/` out of `.gitignore` (previously the whole `.claude` directory was ignored) so project skills are version controlled while local settings like `.claude/settings.local.json` stay ignored, and adds the matching exclusion to the `no-claude-directory-committed` semgrep rule so CI keeps blocking machine-local `.claude/` files without flagging shared skills