### PR TITLE
fix(bedrock): avoid IndexError parsing base64 data URIs without a mime subtype

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3453,9 +3453,8 @@ class BedrockImageProcessor:
         # Extract MIME type using regular expression
         mime_type_match = re.match(r"data:(.*?);base64", image_metadata)
 
-        if mime_type_match:
-            mime_type = mime_type_match.group(1)
-            mime_type = mime_type.split(";")[0]
+        mime_type = mime_type_match.group(1).split(";")[0] if mime_type_match else ""
+        if "/" in mime_type:
             image_format = mime_type.split("/")[1]
         else:
             mime_type = "image/jpeg"

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -324,6 +324,21 @@ def test_bedrock_validate_format_image_or_video():
         assert result == expected, f"Expected {expected}, got {result}"
 
 
+def test_bedrock_parse_base64_image_missing_mime_subtype():
+    """A base64 data URI without a mime subtype must fall back to jpeg instead of raising IndexError."""
+
+    data = base64.b64encode(b"fake").decode()
+
+    for prefix in ["data:", "data:application"]:
+        _, mime_type, image_format = BedrockImageProcessor._parse_base64_image(f"{prefix};base64,{data}")
+        assert mime_type == "image/jpeg", f"Expected image/jpeg fallback, got {mime_type}"
+        assert image_format == "jpeg", f"Expected jpeg fallback, got {image_format}"
+
+    _, mime_type, image_format = BedrockImageProcessor._parse_base64_image(f"data:image/png;base64,{data}")
+    assert mime_type == "image/png"
+    assert image_format == "png"
+
+
 def test_bedrock_get_document_format_fallback_mimes():
     """
     Test the _get_document_format method with fallback MIME types for DOCX and XLSX.


### PR DESCRIPTION
## Relevant issues

No filed issue; this is a latent crash found while reading the Bedrock image path

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a client-side parsing crash, so it reproduces deterministically before any network call. Passing a base64 image whose data URI omits the mime subtype raises `IndexError` inside `_parse_base64_image`, which is what an end user hits when sending such an image to a Bedrock model

Before, on `litellm_internal_staging`:

```
$ python -c "
import base64
from litellm.litellm_core_utils.prompt_templates.factory import BedrockImageProcessor
data = base64.b64encode(b'fake').decode()
print(BedrockImageProcessor._parse_base64_image(f'data:;base64,{data}'))
"
Traceback (most recent call last):
  ...
  File ".../litellm/litellm_core_utils/prompt_templates/factory.py", line 3459, in _parse_base64_image
    image_format = mime_type.split("/")[1]
IndexError: list index out of range
```

After this PR:

```
$ python -c "
import base64
from litellm.litellm_core_utils.prompt_templates.factory import BedrockImageProcessor
data = base64.b64encode(b'fake').decode()
for u in [f'data:;base64,{data}', f'data:application;base64,{data}', f'data:image/png;base64,{data}']:
    print(u[:22], '->', BedrockImageProcessor._parse_base64_image(u))
"
data:;base64,ZmFrZQ==   -> ('ZmFrZQ==', 'image/jpeg', 'jpeg')
data:application;base6  -> ('ZmFrZQ==', 'image/jpeg', 'jpeg')
data:image/png;base64,  -> ('ZmFrZQ==', 'image/png', 'png')
```

Valid `image/<subtype>` data URIs are unaffected; the subtype-less inputs now take the same jpeg fallback the method already used when no mime type matches

## Type

🐛 Bug Fix

## Changes

`BedrockImageProcessor._parse_base64_image` pulls the mime type out of a `data:...;base64,...` URI with a regex and then does `mime_type.split("/")[1]` to get the image format. When the data URI carries an empty or subtype-less media type, which RFC 2397 permits (for example `data:;base64,<data>` defaults to `text/plain`), the regex still matches but `group(1)` has no `/`, so the split hits `[1]` on a single-element list and raises `IndexError`

The method already has a graceful path for the case where no mime type is present at all: it falls back to `image/jpeg` / `jpeg`. The subtype-less case simply slipped past that guard. This change routes both cases through the same fallback by checking for a `/` before splitting, so a malformed or empty media type no longer crashes and instead reaches `_validate_format` with a sensible default. The URL branch and the Nova embed path do the same split elsewhere but are already safe: the former runs its content type through `email.message.Message.get_content_type()`, which normalizes anything without exactly one `/` to `text/plain`, and the latter guards each split with a `startswith("image/" | "video/" | "audio/")` check. Only `_parse_base64_image` was exposed

The regression test covers a data URI with no media type and one with a type but no subtype, asserting the jpeg fallback, and also asserts a normal `image/png` URI still resolves to `png` so the happy path stays intact
