### PR TITLE
fix(vertex_ai): build full request path when custom api_base has no path

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -9,6 +9,7 @@ import json
 import os
 import threading
 from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple
+from urllib.parse import urlparse
 
 import litellm
 from litellm._logging import verbose_logger
@@ -615,7 +616,8 @@ class VertexBase:
 
         Handles custom api_base for:
         1. Gemini (Google AI Studio) - constructs /models/{model}:{endpoint}
-        2. Vertex AI with standard proxies - constructs {api_base}:{endpoint}
+        2. Vertex AI with standard proxies - constructs {api_base}:{endpoint};
+           if api_base has no path (bare host), grafts the default vertex URL path onto it
         3. Vertex AI with PSC endpoints - constructs full path structure
            {api_base}/v1/projects/{project}/locations/{location}/endpoints/{model}:{endpoint}
            (only when use_psc_endpoint_format=True)
@@ -660,8 +662,9 @@ class VertexBase:
                         model_for_url,
                         endpoint,
                     )
+                elif urlparse(api_base).path in ("", "/"):
+                    url = api_base.rstrip("/") + urlparse(url).path
                 else:
-                    # Fallback to simple format if we don't have all parameters
                     url = "{}:{}".format(api_base, endpoint)
             if stream is True:
                 url = url + "?alt=sse"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_psc_endpoint_support.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_psc_endpoint_support.py
@@ -152,9 +152,9 @@ class TestVertexAIPSCEndpointSupport:
         assert url == expected_url, f"Expected {expected_url}, but got {url}"
 
     def test_standard_proxy_with_googleapis(self):
-        """Test that standard proxies with googleapis.com in URL use simple format"""
+        """Test that standard proxies with a path in the URL use simple format"""
         vertex_base = VertexBase()
-        proxy_api_base = "https://my-proxy.googleapis.com"
+        proxy_api_base = "https://my-proxy.googleapis.com/vertex-proxy"
         endpoint_id = "gemini-pro"  # Not numeric
         project_id = "test-project"
         location = "us-central1"

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -774,7 +774,7 @@ class TestVertexBase:
                 "https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro:generateContent",
                 "gemini-pro",
                 "Bearer token123",
-                "https://custom-vertex-api.com:generateContent",
+                "https://custom-vertex-api.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-pro:generateContent",
             ),
             # Test case 4: No API base provided (should return original values)
             (
@@ -929,6 +929,101 @@ class TestVertexBase:
         assert (
             result_url_no_streaming == expected_no_streaming_url
         ), f"Expected {expected_no_streaming_url}, got {result_url_no_streaming}"
+
+    def test_check_custom_proxy_vertex_bare_host_api_base_grafts_default_path(self):
+        vertex_base = VertexBase()
+
+        result_auth_header, result_url = vertex_base._check_custom_proxy(
+            api_base="https://aiplatform.googleapis.com",
+            custom_llm_provider="vertex_ai",
+            gemini_api_key=None,
+            endpoint="embedContent",
+            stream=None,
+            auth_header="Bearer token123",
+            url="https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent",
+            model="gemini-embedding-2",
+        )
+
+        assert result_auth_header == "Bearer token123"
+        assert (
+            result_url
+            == "https://aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent"
+        )
+
+    def test_check_custom_proxy_vertex_bare_host_api_base_with_trailing_slash(self):
+        vertex_base = VertexBase()
+
+        _, result_url = vertex_base._check_custom_proxy(
+            api_base="https://internal-gateway.example.com/",
+            custom_llm_provider="vertex_ai",
+            gemini_api_key=None,
+            endpoint="embedContent",
+            stream=None,
+            auth_header="Bearer token123",
+            url="https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent",
+            model="gemini-embedding-2",
+        )
+
+        assert (
+            result_url
+            == "https://internal-gateway.example.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent"
+        )
+
+    def test_check_custom_proxy_vertex_api_base_with_path_keeps_endpoint_append(self):
+        vertex_base = VertexBase()
+        gateway_api_base = "https://gateway.ai.cloudflare.com/v1/account-id/my-gateway/google-vertex-ai/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2"
+
+        _, result_url = vertex_base._check_custom_proxy(
+            api_base=gateway_api_base,
+            custom_llm_provider="vertex_ai",
+            gemini_api_key=None,
+            endpoint="embedContent",
+            stream=None,
+            auth_header="Bearer token123",
+            url="https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-2:embedContent",
+            model="gemini-embedding-2",
+        )
+
+        assert result_url == f"{gateway_api_base}:embedContent"
+
+    def test_check_custom_proxy_vertex_bare_host_streaming_keeps_single_alt_sse(self):
+        vertex_base = VertexBase()
+
+        _, result_url = vertex_base._check_custom_proxy(
+            api_base="https://internal-gateway.example.com",
+            custom_llm_provider="vertex_ai",
+            gemini_api_key=None,
+            endpoint="streamGenerateContent",
+            stream=True,
+            auth_header="Bearer token123",
+            url="https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+            model="gemini-2.5-pro",
+        )
+
+        assert (
+            result_url
+            == "https://internal-gateway.example.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+        )
+
+    def test_check_custom_proxy_psc_endpoint_format_unaffected_by_bare_host(self):
+        vertex_base = VertexBase()
+
+        _, result_url = vertex_base._check_custom_proxy(
+            api_base="https://10.96.32.8",
+            custom_llm_provider="vertex_ai",
+            gemini_api_key=None,
+            endpoint="predict",
+            stream=None,
+            auth_header="Bearer token123",
+            url="",
+            model="1234567890",
+            vertex_project="test-project",
+            vertex_location="us-central1",
+            vertex_api_version="v1",
+            use_psc_endpoint_format=True,
+        )
+
+        assert result_url == "https://10.96.32.8/v1/projects/test-project/locations/us-central1/endpoints/1234567890:predict"
 
     @pytest.mark.parametrize(
         "api_base, custom_llm_provider, gemini_api_key, endpoint, stream, auth_header, url, model, expected_auth_header, expected_url",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3167

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced live against the real Vertex API with a proxy config containing one deployment (`gemini-embedding-2` -> `vertex_ai/gemini-embedding-2`, `vertex_location: global`, bare-host `api_base: https://aiplatform.googleapis.com`); the identical curl was run first on the base branch, then on this PR's branch

### Before (base branch, 8c0e3c0509)

```bash
curl -sS -X POST 'http://localhost:65196/embeddings' \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"model": "gemini-embedding-2", "input": ["Have we discovered everything in our solar system?"]}'
```

```
HTTP 500
{
    "error": {
        "message": "litellm.APIConnectionError: Invalid port: 'embedContent'
            Traceback (most recent call last):
              File ".../litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py", line 355, in async_batch_embeddings
                response = await async_handler.post(
              File ".../litellm/llms/custom_httpx/http_handler.py", line 622, in post
                req = self.client.build_request(
              File ".../httpx/_urlparse.py", line 411, in normalize_port
                raise InvalidURL(f"Invalid port: {port!r}")
            httpx.InvalidURL: Invalid port: 'embedContent'
            [traceback trimmed]",
        "type": null,
        "param": null,
        "code": "500"
    }
}
```

### After (this PR, bb589acfb5)

```bash
curl -sS -X POST 'http://localhost:65286/embeddings' \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"model": "gemini-embedding-2", "input": ["Have we discovered everything in our solar system?"]}'
```

```
HTTP 200
{
  "model": "gemini-embedding-2",
  "data": [
    {
      "embedding": [
        0.009381193,
        -0.0035839744,
        0.005121866,
        -0.0014076182,
        0.0033341018,
        ... 3072 floats total ...
      ],
      "index": 0,
      "object": "embedding"
    }
  ],
  "object": "list",
  "usage": {
    "completion_tokens": 0,
    "prompt_tokens": 9,
    "total_tokens": 9,
    "completion_tokens_details": null,
    "prompt_tokens_details": {
      "audio_tokens": 0,
      "cached_tokens": null,
      "text_tokens": 9,
      "image_tokens": null,
      "video_tokens": null,
      "image_count": 0,
      "video_length_seconds": 0.0,
      "audio_length_seconds": 0.0
    }
  }
}
```

The `--detailed_debug` log confirms the grafted outbound URL: `https://aiplatform.googleapis.com/v1/projects/<project>/locations/global/publishers/google/models/gemini-embedding-2:embedContent`

## Type

🐛 Bug Fix

## Changes

Vertex AI requests with a custom `api_base` that has no URL path (a bare host such as `https://aiplatform.googleapis.com` or an internal gateway host) produced invalid URLs. `VertexBase._check_custom_proxy` appended the endpoint verb with a colon, yielding e.g. `https://aiplatform.googleapis.com:embedContent`, which httpx rejects with `httpx.InvalidURL: Invalid port: 'embedContent'` before any network call. A customer hit this as 500s on /embeddings for a vertex_ai Gemini embedding model routed through `GoogleBatchEmbeddings` -> `_get_token_and_url` -> `_check_custom_proxy`, and the same flaw affected every vertex mode routed through that append (generateContent, predict, countTokens)

The colon append exists for gateway api_bases (e.g. the Cloudflare AI Gateway convention) whose `api_base` already contains the full `/v1/projects/.../models/{model}` path; for those, appending `:{endpoint}` is correct and stays unchanged. The fix parses the `api_base` and, when its path is empty, instead grafts the default-built vertex URL's path onto the bare host, so the request goes to `{api_base}/v1/projects/.../models/{model}:{endpoint}`. The PSC endpoint format branch and the gemini (Google AI Studio) branch are untouched, and chat streaming on a bare host still ends up with exactly one `?alt=sse`. A bare-host `api_base` could never produce a valid URL before, so no working setup changes behavior

Regression tests cover the bare host graft for embedContent, a bare host with a trailing slash, a path-ful gateway `api_base` keeping the colon append, chat streaming on a bare host keeping a single `?alt=sse`, and the PSC endpoint format staying intact


