### PR TITLE
perf(auth): negative-cache missing user/key lookups on the request hot path

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -3619,6 +3619,7 @@ class PrometheusLogger(CustomLogger):
                     hashed_token=user_api_key_dict.token,
                     prisma_client=prisma_client,
                     user_api_key_cache=user_api_key_cache,
+                    check_cache_only=True,
                 )
                 if key_object:
                     user_api_key_dict.budget_reset_at = key_object.budget_reset_at

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -1474,7 +1474,7 @@ def _should_check_db(key: str, last_db_access_time: LimitedSizeOrderedDict, db_c
     elif last_db_access_time[key][0] is not None:  # check db for non-null values (for refresh operations)
         return True
     elif last_db_access_time[key][0] is None:
-        if current_time - last_db_access_time[key] >= db_cache_expiry:
+        if current_time - last_db_access_time[key][1] >= db_cache_expiry:
             return True
     return False
 
@@ -1649,6 +1649,12 @@ async def get_user_object(
                     include={"organization_memberships": True},
                 )
             else:
+                if should_check_db:
+                    _update_last_db_access_time(
+                        key=db_access_time_key,
+                        value=None,
+                        last_db_access_time=last_db_access_time,
+                    )
                 raise Exception
 
         if response.organization_memberships is not None and len(response.organization_memberships) > 0:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2134,12 +2134,16 @@ async def cli_poll_key(
                 models=session_data.get("models", []),
             )
 
-            user_db_obj = await get_user_object(
-                user_id=user_id,
-                prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,
-                user_id_upsert=False,
-            )
+            try:
+                user_db_obj = await get_user_object(
+                    user_id=user_id,
+                    prisma_client=prisma_client,
+                    user_api_key_cache=user_api_key_cache,
+                    user_id_upsert=False,
+                )
+            except ValueError as e:
+                verbose_proxy_logger.debug(f"CLI poll: user lookup failed, proceeding without user budget: {e}")
+                user_db_obj = None
             user_budget = user_db_obj.max_budget if user_db_obj is not None else None
 
             team_budget: Optional[float] = None

--- a/tests/test_litellm/integrations/test_prometheus_budget_metrics_db_lookups.py
+++ b/tests/test_litellm/integrations/test_prometheus_budget_metrics_db_lookups.py
@@ -1,0 +1,93 @@
+"""
+Unit tests for PrometheusLogger._assemble_key_object DB access.
+
+The post-request budget metrics run for every LLM API request. Auth has
+already cached the key object for any real key in the same request, so the
+metrics path must read the cache only. Falling through to the DB turns every
+request whose token has no DB row (e.g. master-key requests, whose token is
+an alias hash that never matches a stored key) into per-request
+LiteLLM_VerificationToken and LiteLLM_DeprecatedVerificationToken queries.
+"""
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+from litellm.caching.dual_cache import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
+from litellm.integrations.prometheus import PrometheusLogger
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+@pytest.fixture(autouse=True)
+def cleanup_prometheus_registry():
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+    yield
+    collectors = list(REGISTRY._collector_to_names.keys())
+    for collector in collectors:
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def prometheus_logger():
+    return PrometheusLogger()
+
+
+@pytest.mark.asyncio
+async def test_assemble_key_object_does_not_query_db_on_cache_miss(prometheus_logger):
+    mock_prisma = MagicMock()
+    mock_prisma.get_data = AsyncMock()
+    cache = DualCache(in_memory_cache=InMemoryCache())
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", cache),
+    ):
+        result = await prometheus_logger._assemble_key_object(
+            user_api_key="hashed-token-not-in-cache",
+            user_api_key_alias="",
+            key_max_budget=None,
+            key_spend=1.0,
+            response_cost=0.5,
+        )
+
+    mock_prisma.get_data.assert_not_called()
+    assert result.spend == 1.5
+    assert result.budget_reset_at is None
+
+
+@pytest.mark.asyncio
+async def test_assemble_key_object_reads_budget_reset_at_from_cache(prometheus_logger):
+    hashed_token = "hashed-token-in-cache"
+    reset_at = datetime.datetime(2026, 8, 1, tzinfo=datetime.timezone.utc)
+    cached_key = UserAPIKeyAuth(token=hashed_token, budget_reset_at=reset_at)
+
+    mock_prisma = MagicMock()
+    mock_prisma.get_data = AsyncMock()
+    cache = DualCache(in_memory_cache=InMemoryCache())
+    await cache.async_set_cache(key=hashed_token, value=cached_key)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", cache),
+    ):
+        result = await prometheus_logger._assemble_key_object(
+            user_api_key=hashed_token,
+            user_api_key_alias="alias",
+            key_max_budget=10.0,
+            key_spend=1.0,
+            response_cost=0.5,
+        )
+
+    mock_prisma.get_data.assert_not_called()
+    assert result.budget_reset_at == reset_at

--- a/tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py
+++ b/tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py
@@ -516,3 +516,104 @@ async def test_full_hot_path_network_count():
     assert (
         summary["total_network_requests"] == 4
     ), f"Expected 4 total network requests on warm path, got {summary['total_network_requests']}"
+
+
+# ============================================================================
+# TEST: negative caching for entities that do not exist in the DB
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_user_object_missing_user_negative_cache():
+    """
+    A user_id with no DB row (e.g. the master key's default admin user_id)
+    must not trigger a DB query on every request. The first lookup hits the
+    DB; repeat lookups inside the db_cache_expiry window are throttled.
+    """
+    user_id = "user-missing-negative-cache"
+
+    cache = DualCache(in_memory_cache=InMemoryCache())
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_usertable = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+
+    for _ in range(3):
+        with pytest.raises(ValueError):
+            await get_user_object(
+                user_id=user_id,
+                prisma_client=mock_prisma,
+                user_api_key_cache=cache,
+                parent_otel_span=None,
+                proxy_logging_obj=None,
+                user_id_upsert=False,
+            )
+
+    assert mock_prisma.db.litellm_usertable.find_unique.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_user_object_missing_user_rechecks_after_expiry():
+    """
+    The negative cache must expire: a user created after a miss becomes
+    visible once the db_cache_expiry window has passed.
+    """
+    from litellm.proxy.auth.auth_checks import db_cache_expiry, last_db_access_time
+
+    user_id = "user-missing-expiry-recheck"
+
+    cache = DualCache(in_memory_cache=InMemoryCache())
+
+    mock_prisma = MagicMock()
+    mock_prisma.db = MagicMock()
+    mock_prisma.db.litellm_usertable = MagicMock()
+    mock_prisma.db.litellm_usertable.find_unique = AsyncMock(return_value=None)
+
+    with pytest.raises(ValueError):
+        await get_user_object(
+            user_id=user_id,
+            prisma_client=mock_prisma,
+            user_api_key_cache=cache,
+            parent_otel_span=None,
+            proxy_logging_obj=None,
+            user_id_upsert=False,
+        )
+    assert mock_prisma.db.litellm_usertable.find_unique.call_count == 1
+
+    last_db_access_time[f"user_id:{user_id}"] = (
+        None,
+        time.time() - (db_cache_expiry + 1),
+    )
+
+    with pytest.raises(ValueError):
+        await get_user_object(
+            user_id=user_id,
+            prisma_client=mock_prisma,
+            user_api_key_cache=cache,
+            parent_otel_span=None,
+            proxy_logging_obj=None,
+            user_id_upsert=False,
+        )
+    assert mock_prisma.db.litellm_usertable.find_unique.call_count == 2
+
+
+def test_should_check_db_negative_entry_throttles_then_expires():
+    """
+    A recorded miss (value=None) suppresses DB checks inside the expiry
+    window and allows them again after it. Exercises the timestamp element
+    of the stored (value, time) tuple directly.
+    """
+    from litellm.caching.dual_cache import LimitedSizeOrderedDict
+    from litellm.proxy.auth.auth_checks import (
+        _should_check_db,
+        _update_last_db_access_time,
+    )
+
+    tracker: LimitedSizeOrderedDict = LimitedSizeOrderedDict(max_size=10)
+
+    _update_last_db_access_time(key="k", value=None, last_db_access_time=tracker)
+    assert _should_check_db(key="k", last_db_access_time=tracker, db_cache_expiry=5) is False
+
+    tracker["k"] = (None, time.time() - 6)
+    assert _should_check_db(key="k", last_db_access_time=tracker, db_cache_expiry=5) is True

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -7131,3 +7131,54 @@ async def test_legacy_login_page_hides_credentials_hint_via_general_settings():
     assert response.status_code == 200
     assert "Default Credentials" not in body
     assert "MASTER_KEY" not in body
+
+
+@pytest.mark.asyncio
+async def test_cli_poll_key_tolerates_missing_user_row():
+    """The CLI poll must still mint the JWT when the user lookup raises,
+    e.g. the user row was created moments ago and a negative-cache window
+    from the pre-creation SSO existence check is still active on this pod."""
+    from litellm.proxy.management_endpoints.ui_sso import (
+        _hash_cli_sso_secret,
+        cli_poll_key,
+    )
+
+    session_key = "cli-session-missing-user"
+    session_data = {
+        "user_id": "just-created-user",
+        "user_role": "internal_user",
+        "teams": [],
+        "models": ["gpt-4"],
+    }
+
+    mock_cache = MagicMock()
+    mock_cache.get_cache.return_value = {
+        "poll_secret_hash": _hash_cli_sso_secret("poll-secret"),
+        "sso_complete": True,
+        "user_code_verified": True,
+        "session_data": session_data,
+    }
+
+    mock_jwt_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.missing.user"
+
+    with (
+        patch("litellm.proxy.proxy_server.user_api_key_cache", mock_cache),
+        patch("litellm.proxy.proxy_server.prisma_client"),
+        patch(
+            "litellm.proxy.auth.auth_checks.ExperimentalUIJWTToken.get_cli_jwt_auth_token",
+            return_value=mock_jwt_token,
+        ),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_user_object",
+            new=AsyncMock(side_effect=ValueError("User doesn't exist in db. 'user_id'=just-created-user")),
+        ),
+    ):
+        result = await cli_poll_key(
+            key_id=session_key,
+            team_id=None,
+            x_litellm_cli_poll_secret="poll-secret",
+        )
+
+    assert result["status"] == "ready"
+    assert result["key"] == mock_jwt_token
+    assert result["user_id"] == "just-created-user"


### PR DESCRIPTION
## Relevant issues

Profiling a live proxy under concurrent master-key load (mock backend, Postgres + Redis, prometheus callback) shows the dominant fixed cost per request is repeated hot-path DB lookups for entities that do not exist in the DB: every master-key request issues 4 queries (2x `LiteLLM_UserTable`, 1x `LiteLLM_VerificationToken`, 1x `LiteLLM_DeprecatedVerificationToken`). cProfile attributes ~31s of a 49s capture to prisma engine HTTP traffic plus the httpcore pool scans it induces. This cost exists on every release since the negative-cache throttle silently stopped engaging, so any deployment using master-key auth with a DB pays it on every request

Three legs, one theme:

`_run_centralized_common_checks` calls `get_user_object` with the proxy admin user id on every master-key request. That user has no DB row, `get_user_object` raises before recording `last_db_access_time`, so the `_should_check_db` throttle designed for exactly this ("Prevent calling db repeatedly for items that don't exist") never engages

`_should_check_db` also has a latent bug: the expiry comparison subtracts the stored `(value, time)` tuple instead of its timestamp element, so a recorded miss would TypeError instead of throttling

`PrometheusLogger._assemble_key_object` runs after every request and falls through to the DB when the token is not in cache. Auth caches the key object for any real key in the same request, so the only tokens that reach the DB from here are ones with no DB row (the master key's alias hash is the common case), and that lookup can never succeed. It also triggers the deprecated-key table probe on every request

## Linear ticket

Resolves LIT-4246

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy from this branch, Postgres 16 + Redis 7 in docker, one `openai/mock-gpt-4o` model pointing at a local mock server, master-key auth, `store_prompts_in_spend_logs: true`, prometheus callback on

Per-request DB queries, counted with `ALTER SYSTEM SET log_statement='all'` around exactly 30 requests:

```bash
for i in $(seq 1 30); do
  curl -s -o /dev/null -X POST http://127.0.0.1:4895/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"mock-gpt-4o","messages":[{"role":"user","content":"What is compound ID?"}]}'
done
docker logs litfix-pg 2>&1 | sed -n "$START,$END p" \
  | grep -oE 'FROM "?(public"?\."?)?"?LiteLLM_[A-Za-z_]+' | sort | uniq -c | sort -rn
```

Before (base branch):

```
  60 FROM LiteLLM_UserTable
  30 FROM LiteLLM_VerificationToken
  30 FROM LiteLLM_DeprecatedVerificationToken
```

After (this branch):

```
   2 FROM LiteLLM_UserTable
   1 FROM LiteLLM_VerificationToken
```

The remaining reads are the one probe per 5s negative-cache window; per-request cost drops from 4 queries to ~0

Throughput was measured with both variants running simultaneously (two proxies, separate Postgres and Redis each, loaded at the same instant by identical 100-user closed-loop generators for 60s), then re-run with the variants swapped across sides to cancel machine noise; sequential runs on the same machine drift too much to trust

```
run 1  unfixed: 7712 requests, 125.9 RPS, median 536ms
       fixed:  11618 requests, 193.1 RPS, median 163ms
run 2 (sides swapped)
       unfixed: 9937 requests, 162.6 RPS, median 175ms
       fixed:  12032 requests, 196.4 RPS, median 203ms
```

A closed-loop python load generator is used instead of a single curl because the defect only costs meaningful time under concurrency; the 30-request curl loop above is the query-count proof

### Independent end-to-end reverification

Reran the query-count proof on a fresh live proxy, base commit b8248a21d2 and PR head a7d2213068. Same setup as above, Postgres 16 plus Redis 7 in docker, one `openai/mock-gpt-4o` model pointing at a local mock server, master key `sk-devin-test`, `store_prompts_in_spend_logs: true`, prometheus callback on, redis cache on. Postgres `log_statement='all'`, exactly 30 `POST /chat/completions` per branch, SELECTs counted per table between log markers

Before (base `litellm_internal_staging`, b8248a21d2):

```
  60 FROM "public"."LiteLLM_UserTable"
  30 FROM "LiteLLM_VerificationToken"
  30 FROM "public"."LiteLLM_DeprecatedVerificationToken"
```

After (this branch, a7d2213068):

```
   1 FROM "public"."LiteLLM_UserTable"
   0 FROM LiteLLM_VerificationToken
   0 FROM LiteLLM_DeprecatedVerificationToken
```

Per-request hot-path reads go from 4 (120 across the 30 requests) to none, with a single `LiteLLM_UserTable` probe warming the negative-cache window for the run. No behavior regression: a valid master-key call returns 200 with the completion body, an invalid bearer key returns 401, and `/metrics` returns 200. Both regression suites pass, `python -m pytest tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py tests/test_litellm/integrations/test_prometheus_budget_metrics_db_lookups.py -q` reporting 12 passed

Base vs PR per-table SELECT counts across the 30 requests

![base vs PR per-table SELECT counts](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNDk4ZGNiZDUtN2NhZi00NjliLWJlZjYtNmQ5MGRhN2FlZjExIiwiaWF0IjoxNzgzNDU3MDEyLCJleHAiOjE3ODQwNjE4MTIsImZpbGVuYW1lIjoiYmVmb3JlX2FmdGVyX2NvdW50cy5wbmcifQ.svYpWunjWZ2X-Aka4v8GXRGw7EYDrt9TyA4Hg-Ny7O4)

Regression checks green and both suites passing

![regression checks and 12 passed](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvM2ZjZGZhZjctZjJiNC00NGYyLTg2OTctYjU4YmNhNjE0YzlhIiwiaWF0IjoxNzgzNDU3MDEyLCJleHAiOjE3ODQwNjE4MTIsImZpbGVuYW1lIjoidGVzdHNfcGFzc2luZy5wbmcifQ.OZ9n06glm_Gu97iClq2UhOFiFXPfVhDNx177h9QYk5Y)

Terminal walkthrough of the 30-curl loop and the query-count diff on base vs PR branch

![terminal walkthrough](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWI4NTg3YjAtMThhMi00YmU2LTkzMjUtMzg4ZmUzZTg2NzBhIiwiaWF0IjoxNzgzNDU3MDEzLCJleHAiOjE3ODQwNjE4MTMsImZpbGVuYW1lIjoidmVyaWZpY2F0aW9uLmdpZiJ9.NYuJIutoU5pHMJMNN2mbeJS1xlbxr_CtW3N3G7kRtYA)

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/auth/auth_checks.py`: `get_user_object` records the miss in `last_db_access_time` (only when the DB was actually checked, so the window does not slide under a steady request stream and a user created later is discovered within one expiry window); `_should_check_db` compares against the stored timestamp element instead of the tuple

`litellm/integrations/prometheus.py`: `_assemble_key_object` passes `check_cache_only=True` so the post-request budget metric never issues DB lookups for tokens that have no row

`litellm/proxy/management_endpoints/ui_sso.py`: the CLI SSO poll's user budget lookup is now guarded. The SSO flow checks whether the user exists before creating it, so with negative caching a poll that lands on the same pod within the cache-expiry window right after user creation could hit the throttled miss; the lookup failure previously propagated as a 500 out of the poll endpoint. The poll now falls back to no user budget, matching how the SSO existence precheck already treats lookup failures, and mints the JWT

Tests: `tests/test_litellm/proxy/auth/test_auth_hot_path_network_requests.py` gains negative-cache coverage (missing user queried once per window, recheck after expiry, throttle-then-expire unit test that fails with a TypeError on the tuple bug); new `tests/test_litellm/integrations/test_prometheus_budget_metrics_db_lookups.py` asserts the metrics path never queries the DB on cache miss and still reads `budget_reset_at` from cache. Each test was verified to fail on the base code and pass with the fix. The CLI poll guard has its own regression test in `tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` that fails without the guard

Link to Devin session: https://app.devin.ai/sessions/a2c7ea7d89434ce4af0d15f8d3e48948