### PR TITLE
fix(guardrails): forward grayswan scan id header

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -213,9 +213,7 @@ class GraySwanGuardrail(CustomGuardrail):
             verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
 
         # Prepare and send payload
-        payload = self._prepare_payload(
-            messages, dynamic_body, request_data, logging_obj
-        )
+        payload = self._prepare_payload(messages, dynamic_body, request_data, logging_obj)
         if payload is None:
             return inputs
 
@@ -514,16 +512,9 @@ class GraySwanGuardrail(CustomGuardrail):
             headers = request_data.get("headers")
         if not headers:
             headers = (request_data.get("metadata") or {}).get("headers")
-        if (
-            not headers
-            and logging_obj
-            and getattr(logging_obj, "model_call_details", None)
-        ):
+        if not headers and logging_obj and getattr(logging_obj, "model_call_details", None):
             headers = (
-                (logging_obj.model_call_details or {})
-                .get("litellm_params", {})
-                .get("metadata", {})
-                .get("headers")
+                (logging_obj.model_call_details or {}).get("litellm_params", {}).get("metadata", {}).get("headers")
             )
         if not isinstance(headers, dict):
             return None
@@ -568,9 +559,7 @@ class GraySwanGuardrail(CustomGuardrail):
             if inbound_headers:
                 existing_headers = cleaned_litellm_metadata.get("headers")
                 cleaned_litellm_metadata["headers"] = (
-                    {**existing_headers, **inbound_headers}
-                    if isinstance(existing_headers, dict)
-                    else inbound_headers
+                    {**existing_headers, **inbound_headers} if isinstance(existing_headers, dict) else inbound_headers
                 )
             # cleaned_litellm_metadata.pop("user_api_key_auth", None)
             sanitized = safe_json_loads(safe_dumps(cleaned_litellm_metadata), default={})

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -506,7 +506,7 @@ class GraySwanGuardrail(CustomGuardrail):
         self,
         request_data: dict,
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
-    ) -> Optional[Dict[str, str]]:
+    ) -> Optional[dict[str, str]]:
         headers = request_data.get("proxy_server_request", {}).get("headers")
         if not headers:
             headers = request_data.get("headers")
@@ -528,12 +528,12 @@ class GraySwanGuardrail(CustomGuardrail):
 
     def _prepare_payload(
         self,
-        messages: List[Dict[str, str]],
+        messages: list[dict[str, str]],
         dynamic_body: dict,
         request_data: dict,
         logging_obj: Optional["LiteLLMLoggingObj"] = None,
-    ) -> Optional[Dict[str, Any]]:
-        payload: Dict[str, Any] = {"messages": messages}
+    ) -> Optional[dict[str, Any]]:
+        payload: dict[str, Any] = {"messages": messages}
 
         categories = dynamic_body.get("categories") or self.categories
         if categories:

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -213,7 +213,9 @@ class GraySwanGuardrail(CustomGuardrail):
             verbose_proxy_logger.debug("Gray Swan Guardrail: dynamic extra_body=%s", safe_dumps(dynamic_body))
 
         # Prepare and send payload
-        payload = self._prepare_payload(messages, dynamic_body, request_data)
+        payload = self._prepare_payload(
+            messages, dynamic_body, request_data, logging_obj
+        )
         if payload is None:
             return inputs
 
@@ -502,8 +504,43 @@ class GraySwanGuardrail(CustomGuardrail):
             "grayswan-api-key": self.api_key,
         }
 
+    def _extract_inbound_headers(
+        self,
+        request_data: dict,
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
+    ) -> Optional[Dict[str, str]]:
+        headers = request_data.get("proxy_server_request", {}).get("headers")
+        if not headers:
+            headers = request_data.get("headers")
+        if not headers:
+            headers = (request_data.get("metadata") or {}).get("headers")
+        if (
+            not headers
+            and logging_obj
+            and getattr(logging_obj, "model_call_details", None)
+        ):
+            headers = (
+                (logging_obj.model_call_details or {})
+                .get("litellm_params", {})
+                .get("metadata", {})
+                .get("headers")
+            )
+        if not isinstance(headers, dict):
+            return None
+
+        forwarded_header_names = ("shade_scan_id",)
+        forwarded_headers = {}
+        for key, value in headers.items():
+            if str(key).lower() in forwarded_header_names:
+                forwarded_headers[str(key)] = str(value)
+        return forwarded_headers or None
+
     def _prepare_payload(
-        self, messages: List[Dict[str, str]], dynamic_body: dict, request_data: dict
+        self,
+        messages: List[Dict[str, str]],
+        dynamic_body: dict,
+        request_data: dict,
+        logging_obj: Optional["LiteLLMLoggingObj"] = None,
     ) -> Optional[Dict[str, Any]]:
         payload: Dict[str, Any] = {"messages": messages}
 
@@ -523,13 +560,19 @@ class GraySwanGuardrail(CustomGuardrail):
         if "metadata" in dynamic_body:
             payload["metadata"] = dynamic_body["metadata"]
 
+        inbound_headers = self._extract_inbound_headers(request_data, logging_obj)
+
         litellm_metadata = request_data.get("litellm_metadata")
         if isinstance(litellm_metadata, dict) and litellm_metadata:
             cleaned_litellm_metadata = dict(litellm_metadata)
+            if inbound_headers:
+                cleaned_litellm_metadata["headers"] = inbound_headers
             # cleaned_litellm_metadata.pop("user_api_key_auth", None)
             sanitized = safe_json_loads(safe_dumps(cleaned_litellm_metadata), default={})
             if isinstance(sanitized, dict) and sanitized:
                 payload["litellm_metadata"] = sanitized
+        elif inbound_headers:
+            payload["litellm_metadata"] = {"headers": inbound_headers}
 
         return payload
 

--- a/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/grayswan/grayswan.py
@@ -566,7 +566,12 @@ class GraySwanGuardrail(CustomGuardrail):
         if isinstance(litellm_metadata, dict) and litellm_metadata:
             cleaned_litellm_metadata = dict(litellm_metadata)
             if inbound_headers:
-                cleaned_litellm_metadata["headers"] = inbound_headers
+                existing_headers = cleaned_litellm_metadata.get("headers")
+                cleaned_litellm_metadata["headers"] = (
+                    {**existing_headers, **inbound_headers}
+                    if isinstance(existing_headers, dict)
+                    else inbound_headers
+                )
             # cleaned_litellm_metadata.pop("user_api_key_auth", None)
             sanitized = safe_json_loads(safe_dumps(cleaned_litellm_metadata), default={})
             if isinstance(sanitized, dict) and sanitized:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -70,6 +70,28 @@ def test_prepare_payload_includes_dynamic_metadata(
     assert payload["metadata"] == dynamic_body["metadata"]
 
 
+def test_prepare_payload_forwards_only_scan_id_header(
+    grayswan_guardrail: GraySwanGuardrail,
+) -> None:
+    messages = [{"role": "user", "content": "hello"}]
+    request_data = {
+        "proxy_server_request": {
+            "headers": {
+                "shade_scan_id": "scan-123",
+                "authorization": "Bearer secret",
+            }
+        },
+        "litellm_metadata": {"request_id": "request-123"},
+    }
+
+    payload = grayswan_guardrail._prepare_payload(messages, {}, request_data)
+
+    assert payload["litellm_metadata"] == {
+        "request_id": "request-123",
+        "headers": {"shade_scan_id": "scan-123"},
+    }
+
+
 def test_process_response_does_not_block_under_threshold(
     grayswan_guardrail: GraySwanGuardrail,
 ) -> None:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -77,7 +77,7 @@ def test_prepare_payload_forwards_only_scan_id_header(
     request_data = {
         "proxy_server_request": {
             "headers": {
-                "shade_scan_id": "scan-123",
+                "SHADE_SCAN_ID": "scan-123",
                 "authorization": "Bearer secret",
             }
         },
@@ -88,7 +88,7 @@ def test_prepare_payload_forwards_only_scan_id_header(
 
     assert payload["litellm_metadata"] == {
         "request_id": "request-123",
-        "headers": {"shade_scan_id": "scan-123"},
+        "headers": {"SHADE_SCAN_ID": "scan-123"},
     }
 
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_grayswan.py
@@ -92,12 +92,37 @@ def test_prepare_payload_forwards_only_scan_id_header(
     }
 
 
+def test_prepare_payload_merges_scan_id_with_existing_metadata_headers(
+    grayswan_guardrail: GraySwanGuardrail,
+) -> None:
+    messages = [{"role": "user", "content": "hello"}]
+    request_data = {
+        "proxy_server_request": {
+            "headers": {
+                "shade_scan_id": "scan-123",
+            }
+        },
+        "litellm_metadata": {
+            "request_id": "request-123",
+            "headers": {"x-existing": "keep-me"},
+        },
+    }
+
+    payload = grayswan_guardrail._prepare_payload(messages, {}, request_data)
+
+    assert payload["litellm_metadata"] == {
+        "request_id": "request-123",
+        "headers": {
+            "x-existing": "keep-me",
+            "shade_scan_id": "scan-123",
+        },
+    }
+
+
 def test_process_response_does_not_block_under_threshold(
     grayswan_guardrail: GraySwanGuardrail,
 ) -> None:
-    grayswan_guardrail._process_grayswan_response(
-        {"violation": 0.3, "violated_rules": []}
-    )
+    grayswan_guardrail._process_grayswan_response({"violation": 0.3, "violated_rules": []})
 
 
 def test_process_response_blocks_when_threshold_exceeded() -> None:
@@ -149,16 +174,12 @@ class _DummyClient:
         self.calls: list[dict] = []
 
     async def post(self, *, url: str, headers: dict, json: dict, timeout: float):
-        self.calls.append(
-            {"url": url, "headers": headers, "json": json, "timeout": timeout}
-        )
+        self.calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
         return _DummyResponse(self.payload)
 
 
 @pytest.mark.asyncio
-async def test_run_guardrail_posts_payload(
-    monkeypatch, grayswan_guardrail: GraySwanGuardrail
-) -> None:
+async def test_run_guardrail_posts_payload(monkeypatch, grayswan_guardrail: GraySwanGuardrail) -> None:
     dummy_client = _DummyClient({"violation": 0.1})
     grayswan_guardrail.async_handler = dummy_client
 
@@ -330,9 +351,7 @@ def test_process_response_passthrough_raises_exception_in_pre_call() -> None:
 
     # Should raise ModifyResponseException
     with pytest.raises(ModifyResponseException) as exc:
-        guardrail._process_grayswan_response(
-            response_json, data, GuardrailEventHooks.pre_call
-        )
+        guardrail._process_grayswan_response(response_json, data, GuardrailEventHooks.pre_call)
 
     assert "Gray Swan Cygnal Guardrail" in exc.value.message
     assert exc.value.model == "gpt-4"
@@ -360,9 +379,7 @@ def test_process_response_passthrough_raises_exception_in_during_call() -> None:
 
     # Should raise ModifyResponseException
     with pytest.raises(ModifyResponseException) as exc:
-        guardrail._process_grayswan_response(
-            response_json, data, GuardrailEventHooks.during_call
-        )
+        guardrail._process_grayswan_response(response_json, data, GuardrailEventHooks.during_call)
 
     assert "Gray Swan Cygnal Guardrail" in exc.value.message
     assert exc.value.model == "gpt-4"
@@ -387,9 +404,7 @@ def test_process_response_passthrough_stores_detection_info_in_post_call() -> No
     }
 
     # Should NOT raise an exception in post_call
-    guardrail._process_grayswan_response(
-        response_json, data, GuardrailEventHooks.post_call
-    )
+    guardrail._process_grayswan_response(response_json, data, GuardrailEventHooks.post_call)
 
     # Verify detection info was stored in metadata
     assert "metadata" in data
@@ -422,9 +437,7 @@ def test_process_response_passthrough_does_not_raise_if_under_threshold() -> Non
     }
 
     # Should not raise an exception since under threshold
-    guardrail._process_grayswan_response(
-        response_json, data, GuardrailEventHooks.pre_call
-    )
+    guardrail._process_grayswan_response(response_json, data, GuardrailEventHooks.pre_call)
 
     # Should not have any detection info since it didn't exceed threshold
     assert "guardrail_detections" not in data.get("metadata", {})
@@ -458,10 +471,7 @@ def test_format_violation_message() -> None:
     assert "Gray Swan Cygnal Guardrail" in message
     assert "the input query has a violation score of 0.85" in message
     assert "violating the rule(s): 1, 3, 5" in message
-    assert (
-        "Mutation effort to make the harmful intention disguised was DETECTED"
-        in message
-    )
+    assert "Mutation effort to make the harmful intention disguised was DETECTED" in message
     # IPI should not be in message since it's False
     assert "Indirect Prompt Injection was DETECTED" not in message
 
@@ -472,10 +482,7 @@ def test_format_violation_message() -> None:
     assert "Gray Swan Cygnal Guardrail" in message
     assert "the model response has a violation score of 0.85" in message
     assert "violating the rule(s): 1, 3, 5" in message
-    assert (
-        "Mutation effort to make the harmful intention disguised was DETECTED"
-        in message
-    )
+    assert "Mutation effort to make the harmful intention disguised was DETECTED" in message
 
 
 def test_prepare_payload_includes_litellm_metadata(


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Test script:

```
import json

from litellm.proxy.guardrails.guardrail_hooks.grayswan.grayswan import GraySwanGuardrail
from litellm.types.guardrails import GuardrailEventHooks


guardrail = GraySwanGuardrail(
    guardrail_name="grayswan-test",
    api_key="test-key",
    event_hook=GuardrailEventHooks.pre_call,
)

payload = guardrail._prepare_payload(
    [{"role": "user", "content": "hello"}],
    {},
    {
        "proxy_server_request": {
            "headers": {
                "shade_scan_id": "scan-123",
                "authorization": "Bearer secret",
            }
        },
        "litellm_metadata": {"request_id": "request-123"},
    },
)

print(json.dumps(payload["litellm_metadata"], sort_keys=True))
```

Using the above script, here is the before/after:

Before:
`{"request_id": "request-123"}`

After:
`{"headers": {"shade_scan_id": "scan-123"}, "request_id": "request-123"}`

## Type

🐛 Bug Fix
✅ Test

## Changes

Adds support for forwarding whitelisted headers to the GraySwan guardrail, for now this is just `shade_scan_id` which is forwarded in the body of the guardrail request as `litellm_metadata.headers.shade_scan_id`