### PR TITLE
feat(ui): point Organization Settings save at /v2/organization/{id}

### DIFF
--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,5 +1,5 @@
 {
-  "@typescript-eslint/no-explicit-any": 1990,
+  "@typescript-eslint/no-explicit-any": 1989,
   "complexity": 128,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -32,6 +32,7 @@ import NotificationsManager from "./molecules/notifications_manager";
 import type { MCPUserEnvVarsStatus } from "./mcp_tools/types";
 import { MCP_TOOLS_PREVIEW_FORBIDDEN_MESSAGE } from "./mcp_tools/constants";
 import { createApiClient, deriveErrorMessage } from "@/lib/http/client";
+import type { components } from "@/lib/http/schema";
 import { resolveApiBase } from "@/lib/http/resolveApiBase";
 import { serverRootPath, setServerRootPath } from "@/lib/serverRootPath";
 
@@ -1210,6 +1211,22 @@ export const organizationUpdateCall = async (
     // Handle success - you might want to update some state or UI based on the created key
   } catch (error) {
     console.error("Failed to create key:", error);
+    throw error;
+  }
+};
+
+export const organizationUpdateV2Call = async (
+  accessToken: string,
+  organizationId: string,
+  body: components["schemas"]["OrganizationUpdateRequestV2"],
+): Promise<components["schemas"]["LiteLLM_OrganizationTableWithMembers"]> => {
+  try {
+    return await apiClient.patch<components["schemas"]["LiteLLM_OrganizationTableWithMembers"]>(
+      `/v2/organization/${encodeURIComponent(organizationId)}`,
+      { accessToken, body },
+    );
+  } catch (error) {
+    console.error("Failed to update organization:", error);
     throw error;
   }
 };

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
@@ -2,24 +2,16 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildOrganizationUpdateV2Payload,
-  buildOrgSettingsBaseline,
   OrgMetadataParseError,
   parseMetadata,
   toNumberOrNull,
-  type OrgSettingsBaseline,
+  type OrgSettingsFormValues,
 } from "./organizationUpdatePayload";
 
-const baseline = (overrides: Partial<OrgSettingsBaseline> = {}): OrgSettingsBaseline => ({
-  organization_alias: "acme",
-  models: ["gpt-4"],
-  tpm_limit: 100,
-  rpm_limit: 50,
-  max_budget: 10,
-  budget_duration: "30d",
-  metadata: { team: "core" },
-  object_permission: { vector_stores: [], mcp_servers: [], mcp_access_groups: [] },
-  ...overrides,
-});
+const touched =
+  (...names: string[]) =>
+  (name: string): boolean =>
+    names.includes(name);
 
 describe("toNumberOrNull", () => {
   it("maps empty-ish and non-numeric inputs to null", () => {
@@ -59,86 +51,8 @@ describe("parseMetadata", () => {
 });
 
 describe("buildOrganizationUpdateV2Payload", () => {
-  it("sends a changed limit", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: 500 }, baseline: baseline() })).toEqual({
-      tpm_limit: 500,
-    });
-  });
-
-  it("sends null for a cleared limit", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: null }, baseline: baseline() })).toEqual({
-      tpm_limit: null,
-    });
-  });
-
-  it("coerces an emptied numeric input to null, never an empty string", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: "" }, baseline: baseline() })).toEqual({
-      tpm_limit: null,
-    });
-  });
-
-  it("omits a limit whose value is unchanged", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: 100 }, baseline: baseline() })).toEqual({});
-  });
-
-  it("omits an absent (untouched) limit", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: {}, baseline: baseline() })).toEqual({});
-  });
-
-  it("sets metadata", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({ values: { metadata: '{"a":1}' }, baseline: baseline({ metadata: null }) }),
-    ).toEqual({ metadata: { a: 1 } });
-  });
-
-  it("edits a metadata value", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({ values: { metadata: '{"a":2}' }, baseline: baseline({ metadata: { a: 1 } }) }),
-    ).toEqual({ metadata: { a: 2 } });
-  });
-
-  it("clears metadata to null when the box is emptied", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({ values: { metadata: "" }, baseline: baseline({ metadata: { a: 1 } }) }),
-    ).toEqual({ metadata: null });
-  });
-
-  it("omits metadata that is deep-equal to the baseline", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { metadata: '{"team":"core"}' }, baseline: baseline() })).toEqual(
-      {},
-    );
-  });
-
-  it("throws on invalid metadata JSON so Save can be blocked", () => {
-    expect(() => buildOrganizationUpdateV2Payload({ values: { metadata: "{oops" }, baseline: baseline() })).toThrow(
-      OrgMetadataParseError,
-    );
-  });
-
-  it("sends changed and cleared models", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({ values: { models: ["a", "b"] }, baseline: baseline({ models: ["a"] }) }),
-    ).toEqual({ models: ["a", "b"] });
-    expect(buildOrganizationUpdateV2Payload({ values: { models: [] }, baseline: baseline({ models: ["a"] }) })).toEqual(
-      { models: [] },
-    );
-  });
-
-  it("omits models that are unchanged", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { models: ["gpt-4"] }, baseline: baseline() })).toEqual({});
-  });
-
-  it("sends a changed alias and budget_duration", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({ values: { organization_alias: "new-name" }, baseline: baseline() }),
-    ).toEqual({ organization_alias: "new-name" });
-    expect(buildOrganizationUpdateV2Payload({ values: { budget_duration: "7d" }, baseline: baseline() })).toEqual({
-      budget_duration: "7d",
-    });
-  });
-
-  it("returns an empty body when a full form submit changed nothing", () => {
-    const values = {
+  it("sends nothing when no field is touched", () => {
+    const values: OrgSettingsFormValues = {
       organization_alias: "acme",
       models: ["gpt-4"],
       tpm_limit: 100,
@@ -146,73 +60,111 @@ describe("buildOrganizationUpdateV2Payload", () => {
       max_budget: 10,
       budget_duration: "30d",
       metadata: '{"team":"core"}',
+      vector_stores: ["vs-1"],
+      mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: ["grp-1"] },
     };
-    expect(buildOrganizationUpdateV2Payload({ values, baseline: baseline() })).toEqual({});
+    expect(buildOrganizationUpdateV2Payload(values, touched())).toEqual({});
   });
 
-  it("bundles multiple sets and clears into one payload", () => {
-    const payload = buildOrganizationUpdateV2Payload({
-      values: { tpm_limit: null, rpm_limit: 25, metadata: "" },
-      baseline: baseline(),
+  it("omits a field that has a value but was not touched", () => {
+    expect(buildOrganizationUpdateV2Payload({ tpm_limit: 500 }, touched())).toEqual({});
+  });
+
+  it("sends a touched alias", () => {
+    expect(buildOrganizationUpdateV2Payload({ organization_alias: "new-name" }, touched("organization_alias"))).toEqual(
+      {
+        organization_alias: "new-name",
+      },
+    );
+  });
+
+  it("sends a touched budget_duration and clears it to null when emptied", () => {
+    expect(buildOrganizationUpdateV2Payload({ budget_duration: "7d" }, touched("budget_duration"))).toEqual({
+      budget_duration: "7d",
     });
-    expect(payload).toEqual({ tpm_limit: null, rpm_limit: 25, metadata: null });
+    expect(buildOrganizationUpdateV2Payload({ budget_duration: "" }, touched("budget_duration"))).toEqual({
+      budget_duration: null,
+    });
   });
 
-  it("sends object_permission when vector stores change", () => {
-    expect(buildOrganizationUpdateV2Payload({ values: { vector_stores: ["vs-1"] }, baseline: baseline() })).toEqual({
+  it("sends touched models, including an empty array to clear", () => {
+    expect(buildOrganizationUpdateV2Payload({ models: ["a", "b"] }, touched("models"))).toEqual({
+      models: ["a", "b"],
+    });
+    expect(buildOrganizationUpdateV2Payload({ models: [] }, touched("models"))).toEqual({ models: [] });
+    expect(buildOrganizationUpdateV2Payload({ models: undefined }, touched("models"))).toEqual({ models: [] });
+  });
+
+  it("sends a touched numeric value, including 0", () => {
+    expect(buildOrganizationUpdateV2Payload({ tpm_limit: 500 }, touched("tpm_limit"))).toEqual({ tpm_limit: 500 });
+    expect(buildOrganizationUpdateV2Payload({ max_budget: 0 }, touched("max_budget"))).toEqual({ max_budget: 0 });
+  });
+
+  it("coerces a touched but emptied numeric input to null", () => {
+    expect(buildOrganizationUpdateV2Payload({ tpm_limit: "" }, touched("tpm_limit"))).toEqual({ tpm_limit: null });
+    expect(buildOrganizationUpdateV2Payload({ rpm_limit: null }, touched("rpm_limit"))).toEqual({ rpm_limit: null });
+  });
+
+  it("sends touched metadata as a parsed object", () => {
+    expect(buildOrganizationUpdateV2Payload({ metadata: '{"a":1}' }, touched("metadata"))).toEqual({
+      metadata: { a: 1 },
+    });
+  });
+
+  it("clears touched metadata to null when the box is emptied", () => {
+    expect(buildOrganizationUpdateV2Payload({ metadata: "" }, touched("metadata"))).toEqual({ metadata: null });
+  });
+
+  it("throws on invalid metadata JSON so Save can be blocked", () => {
+    expect(() => buildOrganizationUpdateV2Payload({ metadata: "{oops" }, touched("metadata"))).toThrow(
+      OrgMetadataParseError,
+    );
+  });
+
+  it("does not parse untouched metadata, so invalid JSON left untouched never throws", () => {
+    expect(buildOrganizationUpdateV2Payload({ metadata: "{oops" }, touched())).toEqual({});
+  });
+
+  it("sends object_permission when vector_stores is touched", () => {
+    expect(buildOrganizationUpdateV2Payload({ vector_stores: ["vs-1"] }, touched("vector_stores"))).toEqual({
       object_permission: { vector_stores: ["vs-1"], mcp_servers: [], mcp_access_groups: [] },
     });
   });
 
-  it("clears mcp servers with [] while preserving unchanged vector stores", () => {
+  it("sends object_permission when mcp_servers_and_groups is touched", () => {
     expect(
-      buildOrganizationUpdateV2Payload({
-        values: { vector_stores: ["vs-1"], mcp_servers_and_groups: { servers: [], accessGroups: [] } },
-        baseline: baseline({
-          object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: [] },
-        }),
-      }),
-    ).toEqual({ object_permission: { vector_stores: ["vs-1"], mcp_servers: [], mcp_access_groups: [] } });
-  });
-
-  it("omits object_permission when nothing in it changed", () => {
-    expect(
-      buildOrganizationUpdateV2Payload({
-        values: { vector_stores: [], mcp_servers_and_groups: { servers: [], accessGroups: [] } },
-        baseline: baseline(),
-      }),
-    ).toEqual({});
-  });
-});
-
-describe("buildOrgSettingsBaseline", () => {
-  it("extracts a baseline from an org row", () => {
-    expect(
-      buildOrgSettingsBaseline({
-        organization_alias: "acme",
-        models: ["gpt-4"],
-        metadata: { team: "core" },
-        litellm_budget_table: { tpm_limit: 100, rpm_limit: 50, max_budget: 10, budget_duration: "30d" },
-        object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: ["grp-1"] },
-      }),
+      buildOrganizationUpdateV2Payload(
+        { mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: ["grp-1"] } },
+        touched("mcp_servers_and_groups"),
+      ),
     ).toEqual({
-      organization_alias: "acme",
-      models: ["gpt-4"],
-      tpm_limit: 100,
-      rpm_limit: 50,
-      max_budget: 10,
-      budget_duration: "30d",
-      metadata: { team: "core" },
-      object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: ["grp-1"] },
+      object_permission: { vector_stores: [], mcp_servers: ["srv-1"], mcp_access_groups: ["grp-1"] },
     });
   });
 
-  it("defaults a missing budget table, metadata, and object_permission", () => {
-    const result = buildOrgSettingsBaseline({});
-    expect(result.tpm_limit).toBeNull();
-    expect(result.budget_duration).toBeNull();
-    expect(result.metadata).toBeNull();
-    expect(result.models).toBeNull();
-    expect(result.object_permission).toEqual({ vector_stores: [], mcp_servers: [], mcp_access_groups: [] });
+  it("sends the full object_permission with [] clears when either half is touched", () => {
+    expect(
+      buildOrganizationUpdateV2Payload(
+        { vector_stores: ["vs-1"], mcp_servers_and_groups: { servers: [], accessGroups: [] } },
+        touched("vector_stores"),
+      ),
+    ).toEqual({ object_permission: { vector_stores: ["vs-1"], mcp_servers: [], mcp_access_groups: [] } });
+  });
+
+  it("omits object_permission when neither vector_stores nor mcp_servers_and_groups is touched", () => {
+    expect(
+      buildOrganizationUpdateV2Payload(
+        { vector_stores: ["vs-1"], mcp_servers_and_groups: { servers: ["srv-1"], accessGroups: [] } },
+        touched("organization_alias"),
+      ),
+    ).toEqual({});
+  });
+
+  it("bundles multiple touched sets and clears into one payload", () => {
+    const payload = buildOrganizationUpdateV2Payload(
+      { tpm_limit: null, rpm_limit: 25, metadata: "" },
+      touched("tpm_limit", "rpm_limit", "metadata"),
+    );
+    expect(payload).toEqual({ tpm_limit: null, rpm_limit: 25, metadata: null });
   });
 });

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
@@ -17,6 +17,7 @@ const baseline = (overrides: Partial<OrgSettingsBaseline> = {}): OrgSettingsBase
   max_budget: 10,
   budget_duration: "30d",
   metadata: { team: "core" },
+  object_permission: { vector_stores: [], mcp_servers: [], mcp_access_groups: [] },
   ...overrides,
 });
 
@@ -156,6 +157,32 @@ describe("buildOrganizationUpdateV2Payload", () => {
     });
     expect(payload).toEqual({ tpm_limit: null, rpm_limit: 25, metadata: null });
   });
+
+  it("sends object_permission when vector stores change", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { vector_stores: ["vs-1"] }, baseline: baseline() })).toEqual({
+      object_permission: { vector_stores: ["vs-1"], mcp_servers: [], mcp_access_groups: [] },
+    });
+  });
+
+  it("clears mcp servers with [] while preserving unchanged vector stores", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({
+        values: { vector_stores: ["vs-1"], mcp_servers_and_groups: { servers: [], accessGroups: [] } },
+        baseline: baseline({
+          object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: [] },
+        }),
+      }),
+    ).toEqual({ object_permission: { vector_stores: ["vs-1"], mcp_servers: [], mcp_access_groups: [] } });
+  });
+
+  it("omits object_permission when nothing in it changed", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({
+        values: { vector_stores: [], mcp_servers_and_groups: { servers: [], accessGroups: [] } },
+        baseline: baseline(),
+      }),
+    ).toEqual({});
+  });
 });
 
 describe("buildOrgSettingsBaseline", () => {
@@ -166,6 +193,7 @@ describe("buildOrgSettingsBaseline", () => {
         models: ["gpt-4"],
         metadata: { team: "core" },
         litellm_budget_table: { tpm_limit: 100, rpm_limit: 50, max_budget: 10, budget_duration: "30d" },
+        object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: ["grp-1"] },
       }),
     ).toEqual({
       organization_alias: "acme",
@@ -175,14 +203,16 @@ describe("buildOrgSettingsBaseline", () => {
       max_budget: 10,
       budget_duration: "30d",
       metadata: { team: "core" },
+      object_permission: { vector_stores: ["vs-1"], mcp_servers: ["srv-1"], mcp_access_groups: ["grp-1"] },
     });
   });
 
-  it("defaults a missing budget table and metadata to null", () => {
+  it("defaults a missing budget table, metadata, and object_permission", () => {
     const result = buildOrgSettingsBaseline({});
     expect(result.tpm_limit).toBeNull();
     expect(result.budget_duration).toBeNull();
     expect(result.metadata).toBeNull();
     expect(result.models).toBeNull();
+    expect(result.object_permission).toEqual({ vector_stores: [], mcp_servers: [], mcp_access_groups: [] });
   });
 });

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOrganizationUpdateV2Payload,
+  buildOrgSettingsBaseline,
+  OrgMetadataParseError,
+  parseMetadata,
+  toNumberOrNull,
+  type OrgSettingsBaseline,
+} from "./organizationUpdatePayload";
+
+const baseline = (overrides: Partial<OrgSettingsBaseline> = {}): OrgSettingsBaseline => ({
+  organization_alias: "acme",
+  models: ["gpt-4"],
+  tpm_limit: 100,
+  rpm_limit: 50,
+  max_budget: 10,
+  budget_duration: "30d",
+  metadata: { team: "core" },
+  ...overrides,
+});
+
+describe("toNumberOrNull", () => {
+  it("maps empty-ish and non-numeric inputs to null", () => {
+    expect(toNumberOrNull("")).toBeNull();
+    expect(toNumberOrNull(null)).toBeNull();
+    expect(toNumberOrNull(undefined)).toBeNull();
+    expect(toNumberOrNull("not-a-number")).toBeNull();
+  });
+
+  it("coerces numeric strings and numbers (including 0)", () => {
+    expect(toNumberOrNull("500")).toBe(500);
+    expect(toNumberOrNull(0)).toBe(0);
+    expect(toNumberOrNull(12.5)).toBe(12.5);
+  });
+});
+
+describe("parseMetadata", () => {
+  it("treats empty / whitespace / undefined as null", () => {
+    expect(parseMetadata("")).toBeNull();
+    expect(parseMetadata("   ")).toBeNull();
+    expect(parseMetadata(undefined)).toBeNull();
+  });
+
+  it("parses a JSON object", () => {
+    expect(parseMetadata('{"a":1}')).toEqual({ a: 1 });
+  });
+
+  it("treats literal null as cleared", () => {
+    expect(parseMetadata("null")).toBeNull();
+  });
+
+  it("rejects arrays, primitives, and invalid JSON", () => {
+    expect(() => parseMetadata("[1,2]")).toThrow(OrgMetadataParseError);
+    expect(() => parseMetadata('"a string"')).toThrow(OrgMetadataParseError);
+    expect(() => parseMetadata("{not json")).toThrow(OrgMetadataParseError);
+  });
+});
+
+describe("buildOrganizationUpdateV2Payload", () => {
+  it("sends a changed limit", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: 500 }, baseline: baseline() })).toEqual({
+      tpm_limit: 500,
+    });
+  });
+
+  it("sends null for a cleared limit", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: null }, baseline: baseline() })).toEqual({
+      tpm_limit: null,
+    });
+  });
+
+  it("coerces an emptied numeric input to null, never an empty string", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: "" }, baseline: baseline() })).toEqual({
+      tpm_limit: null,
+    });
+  });
+
+  it("omits a limit whose value is unchanged", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { tpm_limit: 100 }, baseline: baseline() })).toEqual({});
+  });
+
+  it("omits an absent (untouched) limit", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: {}, baseline: baseline() })).toEqual({});
+  });
+
+  it("sets metadata", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({ values: { metadata: '{"a":1}' }, baseline: baseline({ metadata: null }) }),
+    ).toEqual({ metadata: { a: 1 } });
+  });
+
+  it("edits a metadata value", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({ values: { metadata: '{"a":2}' }, baseline: baseline({ metadata: { a: 1 } }) }),
+    ).toEqual({ metadata: { a: 2 } });
+  });
+
+  it("clears metadata to null when the box is emptied", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({ values: { metadata: "" }, baseline: baseline({ metadata: { a: 1 } }) }),
+    ).toEqual({ metadata: null });
+  });
+
+  it("omits metadata that is deep-equal to the baseline", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { metadata: '{"team":"core"}' }, baseline: baseline() })).toEqual(
+      {},
+    );
+  });
+
+  it("throws on invalid metadata JSON so Save can be blocked", () => {
+    expect(() => buildOrganizationUpdateV2Payload({ values: { metadata: "{oops" }, baseline: baseline() })).toThrow(
+      OrgMetadataParseError,
+    );
+  });
+
+  it("sends changed and cleared models", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({ values: { models: ["a", "b"] }, baseline: baseline({ models: ["a"] }) }),
+    ).toEqual({ models: ["a", "b"] });
+    expect(buildOrganizationUpdateV2Payload({ values: { models: [] }, baseline: baseline({ models: ["a"] }) })).toEqual(
+      { models: [] },
+    );
+  });
+
+  it("omits models that are unchanged", () => {
+    expect(buildOrganizationUpdateV2Payload({ values: { models: ["gpt-4"] }, baseline: baseline() })).toEqual({});
+  });
+
+  it("sends a changed alias and budget_duration", () => {
+    expect(
+      buildOrganizationUpdateV2Payload({ values: { organization_alias: "new-name" }, baseline: baseline() }),
+    ).toEqual({ organization_alias: "new-name" });
+    expect(buildOrganizationUpdateV2Payload({ values: { budget_duration: "7d" }, baseline: baseline() })).toEqual({
+      budget_duration: "7d",
+    });
+  });
+
+  it("returns an empty body when a full form submit changed nothing", () => {
+    const values = {
+      organization_alias: "acme",
+      models: ["gpt-4"],
+      tpm_limit: 100,
+      rpm_limit: 50,
+      max_budget: 10,
+      budget_duration: "30d",
+      metadata: '{"team":"core"}',
+    };
+    expect(buildOrganizationUpdateV2Payload({ values, baseline: baseline() })).toEqual({});
+  });
+
+  it("bundles multiple sets and clears into one payload", () => {
+    const payload = buildOrganizationUpdateV2Payload({
+      values: { tpm_limit: null, rpm_limit: 25, metadata: "" },
+      baseline: baseline(),
+    });
+    expect(payload).toEqual({ tpm_limit: null, rpm_limit: 25, metadata: null });
+  });
+});
+
+describe("buildOrgSettingsBaseline", () => {
+  it("extracts a baseline from an org row", () => {
+    expect(
+      buildOrgSettingsBaseline({
+        organization_alias: "acme",
+        models: ["gpt-4"],
+        metadata: { team: "core" },
+        litellm_budget_table: { tpm_limit: 100, rpm_limit: 50, max_budget: 10, budget_duration: "30d" },
+      }),
+    ).toEqual({
+      organization_alias: "acme",
+      models: ["gpt-4"],
+      tpm_limit: 100,
+      rpm_limit: 50,
+      max_budget: 10,
+      budget_duration: "30d",
+      metadata: { team: "core" },
+    });
+  });
+
+  it("defaults a missing budget table and metadata to null", () => {
+    const result = buildOrgSettingsBaseline({});
+    expect(result.tpm_limit).toBeNull();
+    expect(result.budget_duration).toBeNull();
+    expect(result.metadata).toBeNull();
+    expect(result.models).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
@@ -10,6 +10,14 @@ export interface OrgSettingsFormValues {
   max_budget?: number | string | null;
   budget_duration?: string | null;
   metadata?: string;
+  vector_stores?: string[];
+  mcp_servers_and_groups?: { servers?: string[]; accessGroups?: string[] };
+}
+
+export interface OrgObjectPermissionBaseline {
+  vector_stores: string[];
+  mcp_servers: string[];
+  mcp_access_groups: string[];
 }
 
 export interface OrgSettingsBaseline {
@@ -20,6 +28,7 @@ export interface OrgSettingsBaseline {
   max_budget: number | null;
   budget_duration: string | null;
   metadata: Record<string, unknown> | null;
+  object_permission: OrgObjectPermissionBaseline;
 }
 
 export class OrgMetadataParseError extends Error {
@@ -79,6 +88,26 @@ const deepEqual = (a: unknown, b: unknown): boolean => {
 
 const NUMERIC_FIELDS = ["tpm_limit", "rpm_limit", "max_budget"] as const;
 
+const buildObjectPermissionUpdate = (
+  values: OrgSettingsFormValues,
+  baseline: OrgObjectPermissionBaseline,
+): OrganizationUpdateV2Body["object_permission"] | undefined => {
+  if (values.vector_stores === undefined && values.mcp_servers_and_groups === undefined) {
+    return undefined;
+  }
+  const nextVectorStores = values.vector_stores ?? [];
+  const nextServers = values.mcp_servers_and_groups?.servers ?? [];
+  const nextAccessGroups = values.mcp_servers_and_groups?.accessGroups ?? [];
+  const changed =
+    !deepEqual(nextVectorStores, baseline.vector_stores) ||
+    !deepEqual(nextServers, baseline.mcp_servers) ||
+    !deepEqual(nextAccessGroups, baseline.mcp_access_groups);
+  if (!changed) {
+    return undefined;
+  }
+  return { vector_stores: nextVectorStores, mcp_servers: nextServers, mcp_access_groups: nextAccessGroups };
+};
+
 export const buildOrganizationUpdateV2Payload = ({
   values,
   baseline,
@@ -120,6 +149,11 @@ export const buildOrganizationUpdateV2Payload = ({
     }
   }
 
+  const objectPermission = buildObjectPermissionUpdate(values, baseline.object_permission);
+  if (objectPermission !== undefined) {
+    body.object_permission = objectPermission;
+  }
+
   return body;
 };
 
@@ -133,6 +167,11 @@ export interface OrgBaselineSource {
     max_budget?: number | null;
     budget_duration?: string | null;
   } | null;
+  object_permission?: {
+    vector_stores?: string[] | null;
+    mcp_servers?: string[] | null;
+    mcp_access_groups?: string[] | null;
+  } | null;
 }
 
 export const buildOrgSettingsBaseline = (org: OrgBaselineSource): OrgSettingsBaseline => ({
@@ -143,4 +182,9 @@ export const buildOrgSettingsBaseline = (org: OrgBaselineSource): OrgSettingsBas
   max_budget: org.litellm_budget_table?.max_budget ?? null,
   budget_duration: org.litellm_budget_table?.budget_duration ?? null,
   metadata: org.metadata ?? null,
+  object_permission: {
+    vector_stores: org.object_permission?.vector_stores ?? [],
+    mcp_servers: org.object_permission?.mcp_servers ?? [],
+    mcp_access_groups: org.object_permission?.mcp_access_groups ?? [],
+  },
 });

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
@@ -1,0 +1,146 @@
+import type { components } from "@/lib/http/schema";
+
+export type OrganizationUpdateV2Body = components["schemas"]["OrganizationUpdateRequestV2"];
+
+export interface OrgSettingsFormValues {
+  organization_alias?: string;
+  models?: string[];
+  tpm_limit?: number | string | null;
+  rpm_limit?: number | string | null;
+  max_budget?: number | string | null;
+  budget_duration?: string | null;
+  metadata?: string;
+}
+
+export interface OrgSettingsBaseline {
+  organization_alias: string | null;
+  models: string[] | null;
+  tpm_limit: number | null;
+  rpm_limit: number | null;
+  max_budget: number | null;
+  budget_duration: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+export class OrgMetadataParseError extends Error {
+  constructor(message = "Metadata must be a valid JSON object") {
+    super(message);
+    this.name = "OrgMetadataParseError";
+  }
+}
+
+export const toNumberOrNull = (value: number | string | null | undefined): number | null => {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+export const parseMetadata = (raw: string | undefined): Record<string, unknown> | null => {
+  if (raw === undefined || raw.trim() === "") {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new OrgMetadataParseError();
+  }
+  if (parsed === null) {
+    return null;
+  }
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new OrgMetadataParseError();
+  }
+  return parsed as Record<string, unknown>;
+};
+
+const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") {
+    return false;
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    return a.every((item, index) => deepEqual(item, b[index]));
+  }
+  const aKeys = Object.keys(a as Record<string, unknown>);
+  const bKeys = Object.keys(b as Record<string, unknown>);
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  return aKeys.every((key) => deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]));
+};
+
+const NUMERIC_FIELDS = ["tpm_limit", "rpm_limit", "max_budget"] as const;
+
+export const buildOrganizationUpdateV2Payload = ({
+  values,
+  baseline,
+}: {
+  values: OrgSettingsFormValues;
+  baseline: OrgSettingsBaseline;
+}): OrganizationUpdateV2Body => {
+  const body: OrganizationUpdateV2Body = {};
+
+  if (values.organization_alias !== undefined && values.organization_alias !== baseline.organization_alias) {
+    body.organization_alias = values.organization_alias;
+  }
+
+  if (values.models !== undefined && !deepEqual(values.models, baseline.models ?? [])) {
+    body.models = values.models;
+  }
+
+  for (const field of NUMERIC_FIELDS) {
+    if (values[field] === undefined) {
+      continue;
+    }
+    const next = toNumberOrNull(values[field]);
+    if (next !== baseline[field]) {
+      body[field] = next;
+    }
+  }
+
+  if (values.budget_duration !== undefined) {
+    const nextBudgetDuration = values.budget_duration || null;
+    if (nextBudgetDuration !== baseline.budget_duration) {
+      body.budget_duration = nextBudgetDuration;
+    }
+  }
+
+  if (values.metadata !== undefined) {
+    const nextMetadata = parseMetadata(values.metadata);
+    if (!deepEqual(nextMetadata, baseline.metadata)) {
+      body.metadata = nextMetadata;
+    }
+  }
+
+  return body;
+};
+
+export interface OrgBaselineSource {
+  organization_alias?: string | null;
+  models?: string[] | null;
+  metadata?: Record<string, unknown> | null;
+  litellm_budget_table?: {
+    tpm_limit?: number | null;
+    rpm_limit?: number | null;
+    max_budget?: number | null;
+    budget_duration?: string | null;
+  } | null;
+}
+
+export const buildOrgSettingsBaseline = (org: OrgBaselineSource): OrgSettingsBaseline => ({
+  organization_alias: org.organization_alias ?? null,
+  models: org.models ?? null,
+  tpm_limit: org.litellm_budget_table?.tpm_limit ?? null,
+  rpm_limit: org.litellm_budget_table?.rpm_limit ?? null,
+  max_budget: org.litellm_budget_table?.max_budget ?? null,
+  budget_duration: org.litellm_budget_table?.budget_duration ?? null,
+  metadata: org.metadata ?? null,
+});

--- a/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
+++ b/ui/litellm-dashboard/src/components/organization/organizationUpdatePayload.ts
@@ -14,23 +14,6 @@ export interface OrgSettingsFormValues {
   mcp_servers_and_groups?: { servers?: string[]; accessGroups?: string[] };
 }
 
-export interface OrgObjectPermissionBaseline {
-  vector_stores: string[];
-  mcp_servers: string[];
-  mcp_access_groups: string[];
-}
-
-export interface OrgSettingsBaseline {
-  organization_alias: string | null;
-  models: string[] | null;
-  tpm_limit: number | null;
-  rpm_limit: number | null;
-  max_budget: number | null;
-  budget_duration: string | null;
-  metadata: Record<string, unknown> | null;
-  object_permission: OrgObjectPermissionBaseline;
-}
-
 export class OrgMetadataParseError extends Error {
   constructor(message = "Metadata must be a valid JSON object") {
     super(message);
@@ -65,126 +48,24 @@ export const parseMetadata = (raw: string | undefined): Record<string, unknown> 
   return parsed as Record<string, unknown>;
 };
 
-const deepEqual = (a: unknown, b: unknown): boolean => {
-  if (a === b) {
-    return true;
-  }
-  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") {
-    return false;
-  }
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
-      return false;
-    }
-    return a.every((item, index) => deepEqual(item, b[index]));
-  }
-  const aKeys = Object.keys(a as Record<string, unknown>);
-  const bKeys = Object.keys(b as Record<string, unknown>);
-  if (aKeys.length !== bKeys.length) {
-    return false;
-  }
-  return aKeys.every((key) => deepEqual((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]));
-};
-
-const NUMERIC_FIELDS = ["tpm_limit", "rpm_limit", "max_budget"] as const;
-
-const buildObjectPermissionUpdate = (
+export const buildOrganizationUpdateV2Payload = (
   values: OrgSettingsFormValues,
-  baseline: OrgObjectPermissionBaseline,
-): OrganizationUpdateV2Body["object_permission"] | undefined => {
-  if (values.vector_stores === undefined && values.mcp_servers_and_groups === undefined) {
-    return undefined;
-  }
-  const nextVectorStores = values.vector_stores ?? [];
-  const nextServers = values.mcp_servers_and_groups?.servers ?? [];
-  const nextAccessGroups = values.mcp_servers_and_groups?.accessGroups ?? [];
-  const changed =
-    !deepEqual(nextVectorStores, baseline.vector_stores) ||
-    !deepEqual(nextServers, baseline.mcp_servers) ||
-    !deepEqual(nextAccessGroups, baseline.mcp_access_groups);
-  if (!changed) {
-    return undefined;
-  }
-  return { vector_stores: nextVectorStores, mcp_servers: nextServers, mcp_access_groups: nextAccessGroups };
-};
-
-export const buildOrganizationUpdateV2Payload = ({
-  values,
-  baseline,
-}: {
-  values: OrgSettingsFormValues;
-  baseline: OrgSettingsBaseline;
-}): OrganizationUpdateV2Body => {
-  const body: OrganizationUpdateV2Body = {};
-
-  if (values.organization_alias !== undefined && values.organization_alias !== baseline.organization_alias) {
-    body.organization_alias = values.organization_alias;
-  }
-
-  if (values.models !== undefined && !deepEqual(values.models, baseline.models ?? [])) {
-    body.models = values.models;
-  }
-
-  for (const field of NUMERIC_FIELDS) {
-    if (values[field] === undefined) {
-      continue;
-    }
-    const next = toNumberOrNull(values[field]);
-    if (next !== baseline[field]) {
-      body[field] = next;
-    }
-  }
-
-  if (values.budget_duration !== undefined) {
-    const nextBudgetDuration = values.budget_duration || null;
-    if (nextBudgetDuration !== baseline.budget_duration) {
-      body.budget_duration = nextBudgetDuration;
-    }
-  }
-
-  if (values.metadata !== undefined) {
-    const nextMetadata = parseMetadata(values.metadata);
-    if (!deepEqual(nextMetadata, baseline.metadata)) {
-      body.metadata = nextMetadata;
-    }
-  }
-
-  const objectPermission = buildObjectPermissionUpdate(values, baseline.object_permission);
-  if (objectPermission !== undefined) {
-    body.object_permission = objectPermission;
-  }
-
-  return body;
-};
-
-export interface OrgBaselineSource {
-  organization_alias?: string | null;
-  models?: string[] | null;
-  metadata?: Record<string, unknown> | null;
-  litellm_budget_table?: {
-    tpm_limit?: number | null;
-    rpm_limit?: number | null;
-    max_budget?: number | null;
-    budget_duration?: string | null;
-  } | null;
-  object_permission?: {
-    vector_stores?: string[] | null;
-    mcp_servers?: string[] | null;
-    mcp_access_groups?: string[] | null;
-  } | null;
-}
-
-export const buildOrgSettingsBaseline = (org: OrgBaselineSource): OrgSettingsBaseline => ({
-  organization_alias: org.organization_alias ?? null,
-  models: org.models ?? null,
-  tpm_limit: org.litellm_budget_table?.tpm_limit ?? null,
-  rpm_limit: org.litellm_budget_table?.rpm_limit ?? null,
-  max_budget: org.litellm_budget_table?.max_budget ?? null,
-  budget_duration: org.litellm_budget_table?.budget_duration ?? null,
-  metadata: org.metadata ?? null,
-  object_permission: {
-    vector_stores: org.object_permission?.vector_stores ?? [],
-    mcp_servers: org.object_permission?.mcp_servers ?? [],
-    mcp_access_groups: org.object_permission?.mcp_access_groups ?? [],
-  },
+  isTouched: (name: string) => boolean,
+): OrganizationUpdateV2Body => ({
+  ...(isTouched("organization_alias") ? { organization_alias: values.organization_alias } : {}),
+  ...(isTouched("models") ? { models: values.models ?? [] } : {}),
+  ...(isTouched("tpm_limit") ? { tpm_limit: toNumberOrNull(values.tpm_limit) } : {}),
+  ...(isTouched("rpm_limit") ? { rpm_limit: toNumberOrNull(values.rpm_limit) } : {}),
+  ...(isTouched("max_budget") ? { max_budget: toNumberOrNull(values.max_budget) } : {}),
+  ...(isTouched("budget_duration") ? { budget_duration: values.budget_duration || null } : {}),
+  ...(isTouched("metadata") ? { metadata: parseMetadata(values.metadata) } : {}),
+  ...(isTouched("vector_stores") || isTouched("mcp_servers_and_groups")
+    ? {
+        object_permission: {
+          vector_stores: values.vector_stores ?? [],
+          mcp_servers: values.mcp_servers_and_groups?.servers ?? [],
+          mcp_access_groups: values.mcp_servers_and_groups?.accessGroups ?? [],
+        },
+      }
+    : {}),
 });

--- a/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { vi, test, expect, beforeEach } from "vitest";
 import { renderWithProviders } from "../../../tests/test-utils";
 import OrganizationInfoView from "./organization_view";
+import { organizationUpdateV2Call } from "../networking";
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 
 // Mock networking calls used by the component's mutation handlers
@@ -13,7 +14,7 @@ vi.mock("../networking", () => {
     organizationMemberAddCall: vi.fn(),
     organizationMemberUpdateCall: vi.fn(),
     organizationMemberDeleteCall: vi.fn(),
-    organizationUpdateCall: vi.fn(),
+    organizationUpdateV2Call: vi.fn(),
   };
 });
 
@@ -38,7 +39,11 @@ vi.mock("../object_permissions_view", () => ({
 }));
 vi.mock("../molecules/notifications_manager", () => ({
   __esModule: true,
-  default: { success: vi.fn(), fromBackend: vi.fn() },
+  default: { success: vi.fn(), fromBackend: vi.fn(), error: vi.fn() },
+}));
+vi.mock("../ModelSelect/ModelSelect", () => ({
+  __esModule: true,
+  ModelSelect: () => null,
 }));
 vi.mock("../team/edit_membership", () => ({
   __esModule: true,
@@ -203,4 +208,33 @@ test("should display team ID as fallback when alias is not found", async () => {
   await waitFor(() => {
     expect(screen.getByText("team_999")).toBeInTheDocument();
   });
+});
+
+test("blocks Save and does not call the update API when metadata JSON is invalid", async () => {
+  vi.mocked(organizationUpdateV2Call).mockClear();
+  mockUseOrganization.mockReturnValue({ data: mockOrg, isLoading: false } as any);
+
+  const user = userEvent.setup();
+  renderWithProviders(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={true}
+      userModels={[]}
+      editOrg={true}
+    />,
+  );
+
+  await user.click(await screen.findByRole("button", { name: /Edit Settings/i }));
+
+  const metadata = await screen.findByLabelText("Metadata");
+  await user.type(metadata, "not valid json");
+  await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+  await waitFor(() => {
+    expect(screen.getByText("Metadata must be a valid JSON object")).toBeInTheDocument();
+  });
+  expect(organizationUpdateV2Call).not.toHaveBeenCalled();
 });

--- a/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
@@ -238,3 +238,37 @@ test("blocks Save and does not call the update API when metadata JSON is invalid
   });
   expect(organizationUpdateV2Call).not.toHaveBeenCalled();
 });
+
+test("Save sends only the changed fields to the v2 endpoint", async () => {
+  vi.mocked(organizationUpdateV2Call).mockClear();
+  mockUseOrganization.mockReturnValue({ data: mockOrg, isLoading: false } as unknown as ReturnType<
+    typeof useOrganization
+  >);
+
+  const user = userEvent.setup();
+  renderWithProviders(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={true}
+      userModels={[]}
+      editOrg={true}
+    />,
+  );
+
+  await user.click(await screen.findByRole("button", { name: /Edit Settings/i }));
+
+  const alias = await screen.findByDisplayValue("Acme Corp");
+  await user.clear(alias);
+  await user.type(alias, "Renamed Org");
+  await user.click(screen.getByRole("button", { name: /Save Changes/i }));
+
+  await waitFor(() => {
+    expect(organizationUpdateV2Call).toHaveBeenCalledTimes(1);
+  });
+  expect(organizationUpdateV2Call).toHaveBeenCalledWith("test-token", "org_123", {
+    organization_alias: "Renamed Org",
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -23,11 +23,9 @@ import {
   organizationUpdateV2Call,
 } from "../networking";
 import {
-  buildOrgSettingsBaseline,
   buildOrganizationUpdateV2Payload,
   OrgMetadataParseError,
   parseMetadata,
-  type OrgSettingsBaseline,
   type OrgSettingsFormValues,
 } from "./organizationUpdatePayload";
 import ObjectPermissionsView from "../object_permissions_view";
@@ -63,7 +61,6 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
   const [selectedEditMember, setSelectedEditMember] = useState<Member | null>(null);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [isOrgSaving, setIsOrgSaving] = useState(false);
-  const [editBaseline, setEditBaseline] = useState<OrgSettingsBaseline | null>(null);
   const canEditOrg = is_org_admin || is_proxy_admin;
   const { data: teams } = useTeams();
 
@@ -139,21 +136,12 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
     }
   };
 
-  const enterEditMode = () => {
-    if (!orgData) return;
-    setEditBaseline(buildOrgSettingsBaseline(orgData));
-    setIsEditing(true);
-  };
-
   const handleOrgUpdate = async (values: OrgSettingsFormValues) => {
     try {
       if (!accessToken || !orgData) return;
       setIsOrgSaving(true);
 
-      const body = buildOrganizationUpdateV2Payload({
-        values,
-        baseline: editBaseline ?? buildOrgSettingsBaseline(orgData),
-      });
+      const body = buildOrganizationUpdateV2Payload(values, (name) => form.isFieldTouched(name));
 
       await organizationUpdateV2Call(accessToken, organizationId, body);
 
@@ -350,7 +338,9 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
               <Card className="overflow-y-auto max-h-[65vh]">
                 <div className="flex justify-between items-center mb-4">
                   <Title>Organization Settings</Title>
-                  {canEditOrg && !isEditing && <TremorButton onClick={enterEditMode}>Edit Settings</TremorButton>}
+                  {canEditOrg && !isEditing && (
+                    <TremorButton onClick={() => setIsEditing(true)}>Edit Settings</TremorButton>
+                  )}
                 </div>
 
                 {isEditing ? (
@@ -388,8 +378,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 
                     <Form.Item label="Models" name="models">
                       <ModelSelect
-                        value={form.getFieldValue("models")}
-                        onChange={(values) => form.setFieldValue("models", values)}
+                        onChange={() => {}}
                         context="organization"
                         options={{
                           includeSpecialOptions: true,
@@ -420,8 +409,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 
                     <Form.Item label="Vector Stores" name="vector_stores">
                       <VectorStoreSelector
-                        onChange={(values) => form.setFieldValue("vector_stores", values)}
-                        value={form.getFieldValue("vector_stores")}
+                        onChange={() => {}}
                         accessToken={accessToken || ""}
                         placeholder="Select vector stores"
                       />
@@ -429,8 +417,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
 
                     <Form.Item label="MCP Servers & Access Groups" name="mcp_servers_and_groups">
                       <MCPServerSelector
-                        onChange={(values) => form.setFieldValue("mcp_servers_and_groups", values)}
-                        value={form.getFieldValue("mcp_servers_and_groups")}
+                        onChange={() => {}}
                         accessToken={accessToken || ""}
                         placeholder="Select MCP servers and access groups"
                       />

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -27,7 +27,7 @@ import {
   buildOrganizationUpdateV2Payload,
   OrgMetadataParseError,
   parseMetadata,
-  type OrganizationUpdateV2Body,
+  type OrgSettingsBaseline,
   type OrgSettingsFormValues,
 } from "./organizationUpdatePayload";
 import ObjectPermissionsView from "../object_permissions_view";
@@ -63,6 +63,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
   const [selectedEditMember, setSelectedEditMember] = useState<Member | null>(null);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [isOrgSaving, setIsOrgSaving] = useState(false);
+  const [editBaseline, setEditBaseline] = useState<OrgSettingsBaseline | null>(null);
   const canEditOrg = is_org_admin || is_proxy_admin;
   const { data: teams } = useTeams();
 
@@ -138,42 +139,21 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
     }
   };
 
-  const handleOrgUpdate = async (
-    values: OrgSettingsFormValues & {
-      vector_stores?: string[];
-      mcp_servers_and_groups?: { servers?: string[]; accessGroups?: string[] };
-    },
-  ) => {
+  const enterEditMode = () => {
+    if (!orgData) return;
+    setEditBaseline(buildOrgSettingsBaseline(orgData));
+    setIsEditing(true);
+  };
+
+  const handleOrgUpdate = async (values: OrgSettingsFormValues) => {
     try {
       if (!accessToken || !orgData) return;
       setIsOrgSaving(true);
 
-      const body: OrganizationUpdateV2Body = buildOrganizationUpdateV2Payload({
+      const body = buildOrganizationUpdateV2Payload({
         values,
-        baseline: buildOrgSettingsBaseline(orgData),
+        baseline: editBaseline ?? buildOrgSettingsBaseline(orgData),
       });
-
-      if (values.vector_stores !== undefined || values.mcp_servers_and_groups !== undefined) {
-        const objectPermission: NonNullable<OrganizationUpdateV2Body["object_permission"]> = {
-          ...(orgData?.object_permission ?? {}),
-          vector_stores: values.vector_stores || [],
-        };
-
-        if (values.mcp_servers_and_groups !== undefined) {
-          const { servers, accessGroups } = values.mcp_servers_and_groups || {
-            servers: [],
-            accessGroups: [],
-          };
-          if (servers && servers.length > 0) {
-            objectPermission.mcp_servers = servers;
-          }
-          if (accessGroups && accessGroups.length > 0) {
-            objectPermission.mcp_access_groups = accessGroups;
-          }
-        }
-
-        body.object_permission = objectPermission;
-      }
 
       await organizationUpdateV2Call(accessToken, organizationId, body);
 
@@ -370,9 +350,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
               <Card className="overflow-y-auto max-h-[65vh]">
                 <div className="flex justify-between items-center mb-4">
                   <Title>Organization Settings</Title>
-                  {canEditOrg && !isEditing && (
-                    <TremorButton onClick={() => setIsEditing(true)}>Edit Settings</TremorButton>
-                  )}
+                  {canEditOrg && !isEditing && <TremorButton onClick={enterEditMode}>Edit Settings</TremorButton>}
                 </div>
 
                 {isEditing ? (

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -20,8 +20,16 @@ import {
   organizationMemberAddCall,
   organizationMemberDeleteCall,
   organizationMemberUpdateCall,
-  organizationUpdateCall,
+  organizationUpdateV2Call,
 } from "../networking";
+import {
+  buildOrgSettingsBaseline,
+  buildOrganizationUpdateV2Payload,
+  OrgMetadataParseError,
+  parseMetadata,
+  type OrganizationUpdateV2Body,
+  type OrgSettingsFormValues,
+} from "./organizationUpdatePayload";
 import ObjectPermissionsView from "../object_permissions_view";
 import NumericalInput from "../shared/numerical_input";
 import MemberModal from "../team/EditMembership";
@@ -119,28 +127,35 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
     }
   };
 
-  const handleOrgUpdate = async (values: any) => {
+  const validateMetadataJson = async (_rule: unknown, value: string | undefined): Promise<void> => {
+    if (!value || value.trim() === "") {
+      return;
+    }
     try {
-      if (!accessToken) return;
+      parseMetadata(value);
+    } catch {
+      throw new Error("Metadata must be a valid JSON object");
+    }
+  };
+
+  const handleOrgUpdate = async (
+    values: OrgSettingsFormValues & {
+      vector_stores?: string[];
+      mcp_servers_and_groups?: { servers?: string[]; accessGroups?: string[] };
+    },
+  ) => {
+    try {
+      if (!accessToken || !orgData) return;
       setIsOrgSaving(true);
 
-      const updateData: any = {
-        organization_id: organizationId,
-        organization_alias: values.organization_alias,
-        models: values.models,
-        litellm_budget_table: {
-          tpm_limit: values.tpm_limit,
-          rpm_limit: values.rpm_limit,
-          max_budget: values.max_budget,
-          budget_duration: values.budget_duration,
-        },
-        metadata: values.metadata ? JSON.parse(values.metadata) : null,
-      };
+      const body: OrganizationUpdateV2Body = buildOrganizationUpdateV2Payload({
+        values,
+        baseline: buildOrgSettingsBaseline(orgData),
+      });
 
-      // Handle object_permission updates
       if (values.vector_stores !== undefined || values.mcp_servers_and_groups !== undefined) {
-        updateData.object_permission = {
-          ...orgData?.object_permission,
+        const objectPermission: NonNullable<OrganizationUpdateV2Body["object_permission"]> = {
+          ...(orgData?.object_permission ?? {}),
           vector_stores: values.vector_stores || [],
         };
 
@@ -150,21 +165,27 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
             accessGroups: [],
           };
           if (servers && servers.length > 0) {
-            updateData.object_permission.mcp_servers = servers;
+            objectPermission.mcp_servers = servers;
           }
           if (accessGroups && accessGroups.length > 0) {
-            updateData.object_permission.mcp_access_groups = accessGroups;
+            objectPermission.mcp_access_groups = accessGroups;
           }
         }
+
+        body.object_permission = objectPermission;
       }
 
-      const response = await organizationUpdateCall(accessToken, updateData);
+      await organizationUpdateV2Call(accessToken, organizationId, body);
 
       NotificationsManager.success("Organization settings updated successfully");
       setIsEditing(false);
       queryClient.invalidateQueries({ queryKey: organizationKeys.all });
     } catch (error) {
-      NotificationsManager.fromBackend("Failed to update organization settings");
+      if (error instanceof OrgMetadataParseError) {
+        NotificationsManager.error("Metadata must be a valid JSON object");
+      } else {
+        NotificationsManager.fromBackend("Failed to update organization settings");
+      }
       console.error("Error updating organization:", error);
     } finally {
       setIsOrgSaving(false);
@@ -437,7 +458,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                       />
                     </Form.Item>
 
-                    <Form.Item label="Metadata" name="metadata">
+                    <Form.Item label="Metadata" name="metadata" rules={[{ validator: validateMetadataJson }]}>
                       <Input.TextArea rows={4} />
                     </Form.Item>
 


### PR DESCRIPTION
## Relevant issues

Stacked on #32350 (the `PATCH /v2/organization/{organization_id}` backend endpoint); this PR points the Admin UI at it. Base branch is `litellm_lit_3664_tpm_limit_ui_not_persisted`, so review/merge that one first

## Linear ticket

Refs LIT-3664

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI change, so the proof is the Organization Settings flow against a running proxy. In order:

1. Go to http://localhost:4000/ui/?page=organizations and open an organization that has a TPM limit and/or metadata set
2. On the Settings tab, click Edit Settings, clear the TPM (or RPM / Max Budget) field and/or empty the Metadata box, then click Save Changes
3. Refresh the page. The cleared values stay cleared instead of reverting. In the browser Network tab the save is a `PATCH /v2/organization/{organization_id}` whose body carries only the changed fields, with the cleared field sent as `null` (metadata as `null`)
4. Edit Settings again, type invalid JSON into the Metadata box, and click Save. Save is blocked with an inline "Metadata must be a valid JSON object" error and no request is sent

### Devin e2e QA

Ran the branch locally (PostgreSQL-backed proxy at localhost:4000 with the rebuilt Admin UI) and exercised the Organization Settings save flow through the browser, using the DevTools Network tab to confirm the request URL, the exact request body, and the no-request cases. Full write-up with screenshots and the recorded walkthroughs were shared with the author on Slack. Session: https://app.devin.ai/sessions/fd99cd1fdb5541c688a8ce91ab5f7e5f

Seven cases passed. Clearing Metadata and TPM on a populated org sent `PATCH /v2/organization/{id}` with only `{tpm_limit: null, metadata: null}` and the cleared values stayed cleared after a full refresh while the untouched RPM and Max Budget were preserved, which is the LIT-3664 regression. Saving with no edits sent an empty body. Setting Max Budget, TPM, and Metadata on an empty org sent only those fields with the numerics as JSON numbers rather than strings, and they persisted after refresh. Changing only the alias and reset-budget sent only `organization_alias` and `budget_duration`. Clearing the models multiselect sent `{models: []}`. Invalid metadata JSON blocked Save with the inline error and issued no request.

Object-permission path (follow-up, now runtime-verified). Created a vector store (`qa-vs-1`) and an MCP server (`qa_mcp_1`) with access group `qa_group_a`, then on a real org: selecting all three sent only `object_permission` with the three populated arrays and persisted after a full reload; removing all three sent only `object_permission` with `{vector_stores: [], mcp_servers: [], mcp_access_groups: []}` and the cleared state persisted after reload (budget/RPM untouched and preserved). This is the exact clear-and-persist behavior Greptile flagged as a P1 on an earlier commit, confirmed fixed at runtime.

One item to flag. The failing check `proxy-infra / Run tests` (`test_gateway_plus_backend_covers_full_app`) is unrelated to this UI diff; it fails because `/v2/organization/{organization_id}` is missing from the gateway/backend route allowlist, which belongs to the stacked base PR #32350 and should be fixed there.

## Type

🐛 Bug Fix

## Changes

The Organization Settings save was calling v1 `/organization/update`, which drops cleared fields, so clearing a limit or the Metadata box reverted on refresh (LIT-3664). This points the save at the deterministic `PATCH /v2/organization/{organization_id}` endpoint

The payload is built by a pure, typed `buildOrganizationUpdateV2Payload` that sends only the fields the user actually touched (antd `isFieldTouched`). An emptied field carries its clear-token (`null` for numbers, `[]` for arrays such as models and object permissions, `null` for metadata), an unchanged field is omitted so the backend leaves it untouched, and a numeric input coerces to `number | null` rather than an empty string. The request body and response are typed from the generated OpenAPI schema (`components["schemas"]["OrganizationUpdateRequestV2"]` and `LiteLLM_OrganizationTableWithMembers`), so the form-to-network path is typed end to end. Invalid metadata JSON blocks Save with an inline error through a `Form.Item` validator

Tests live next to the module: `organizationUpdatePayload.test.ts` covers the full set/clear/untouched matrix (limits, metadata set/edit/clear/unchanged/invalid, models, alias, budget duration, nothing-changed, and a bundled multi-change), and an added `organization_view.test.tsx` case asserts that invalid metadata blocks Save and never calls the update API