### PR TITLE
fix(vertex_ai): return create_vertex_url result directly for openai-path partner models with custom api_base

### DIFF
--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -316,6 +316,9 @@ class VertexBase:
             api_base=api_base,
         )
 
+        if partner == VertexPartnerProvider.llama:
+            return default_api_base
+
         if len(default_api_base.split(":")) > 1:
             endpoint = default_api_base.split(":")[-1]
         else:

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py
@@ -15,6 +15,7 @@ sys.path.insert(
 import litellm
 from litellm.llms.vertex_ai.vertex_ai_aws_wif import VertexAIAwsWifAuth
 from litellm.llms.vertex_ai.vertex_llm_base import VertexBase
+from litellm.types.llms.vertex_ai import VertexPartnerProvider
 
 
 def run_sync(coro):
@@ -1024,6 +1025,78 @@ class TestVertexBase:
         )
 
         assert result_url == "https://10.96.32.8/v1/projects/test-project/locations/us-central1/endpoints/1234567890:predict"
+
+    @pytest.mark.parametrize(
+        "custom_api_base, stream, expected_url",
+        [
+            (
+                "https://aiplatform-myendpoint.p.googleapis.com",
+                False,
+                "https://aiplatform-myendpoint.p.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions",
+            ),
+            (
+                "https://aiplatform-myendpoint.p.googleapis.com",
+                True,
+                "https://aiplatform-myendpoint.p.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions",
+            ),
+            (
+                "https://gateway.example.com/vertex-proxy",
+                False,
+                "https://gateway.example.com/vertex-proxy/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions",
+            ),
+        ],
+        ids=["psc-host", "psc-host-streaming", "api-base-with-path"],
+    )
+    def test_get_complete_vertex_url_openai_path_partner_custom_api_base(
+        self, custom_api_base, stream, expected_url
+    ):
+        vertex_base = VertexBase()
+
+        result = vertex_base.get_complete_vertex_url(
+            custom_api_base=custom_api_base,
+            vertex_location="global",
+            vertex_project="test-project",
+            project_id="test-project",
+            partner=VertexPartnerProvider.llama,
+            stream=stream,
+            model="minimaxai/minimax-m2-maas",
+        )
+
+        assert result == expected_url
+        assert result.count("://") == 1
+
+    def test_get_complete_vertex_url_openai_path_partner_default_api_base(self):
+        vertex_base = VertexBase()
+
+        result = vertex_base.get_complete_vertex_url(
+            custom_api_base=None,
+            vertex_location="us-central1",
+            vertex_project="test-project",
+            project_id="test-project",
+            partner=VertexPartnerProvider.llama,
+            stream=True,
+            model="meta/llama-3.1-405b-instruct-maas",
+        )
+
+        assert (
+            result
+            == "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/endpoints/openapi/chat/completions"
+        )
+
+    def test_get_complete_vertex_url_rawpredict_partner_custom_api_base_keeps_endpoint_format(self):
+        vertex_base = VertexBase()
+
+        result = vertex_base.get_complete_vertex_url(
+            custom_api_base="https://gateway.example.com/vertex-proxy",
+            vertex_location="us-central1",
+            vertex_project="test-project",
+            project_id="test-project",
+            partner=VertexPartnerProvider.mistralai,
+            stream=False,
+            model="mistral-large-2411",
+        )
+
+        assert result == "https://gateway.example.com/vertex-proxy:rawPredict"
 
     @pytest.mark.parametrize(
         "api_base, custom_llm_provider, gemini_api_key, endpoint, stream, auth_header, url, model, expected_auth_header, expected_url",


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4240

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live LiteLLM proxy on localhost (`.venv/bin/python litellm/proxy/proxy_cli.py --config config.yaml --port <port> --detailed_debug`), making real paid Vertex AI MiniMax MaaS calls (`vertex_ai/minimaxai/minimax-m2-maas`, location `global`); no mocks anywhere. The config has two custom `api_base` models plus a control with no `api_base`

```yaml
model_list:
  - model_name: minimax-psc
    litellm_params:
      model: vertex_ai/minimaxai/minimax-m2-maas
      vertex_project: vertex-check-481318
      vertex_location: global
      api_base: https://aiplatform.googleapis.com
  - model_name: minimax-psc-path
    litellm_params:
      model: vertex_ai/minimaxai/minimax-m2-maas
      vertex_project: vertex-check-481318
      vertex_location: global
      api_base: http://127.0.0.1:53159/vertex
  - model_name: minimax-control
    litellm_params:
      model: vertex_ai/minimaxai/minimax-m2-maas
      vertex_project: vertex-check-481318
      vertex_location: global
```

`minimax-psc-path` exercises a path-bearing `api_base` the way a PSC or gateway host in front of Vertex sees it: a local nginx listener on `127.0.0.1:53159` forwards `/vertex/` to the real `https://aiplatform.googleapis.com/`, so every request that reaches it hits the real Google API and returns real completions

```nginx
location /vertex/ {
    proxy_pass https://aiplatform.googleapis.com/;
    proxy_set_header Host aiplatform.googleapis.com;
    proxy_ssl_server_name on;
}
```

### Before (litellm_internal_staging, commit b8248a21d2ac0c102d49c0db5702a48cdf661bb9)

The path-bearing `api_base` fails with a 404, non-streaming and streaming, because the URL builder splits the already-complete URL on `:` and grafts everything after the scheme back onto the `api_base`

```
$ curl -sS http://localhost:53007/v1/chat/completions \
    -H 'Authorization: Bearer sk-qa-1234' -H 'Content-Type: application/json' \
    -d '{"model": "minimax-psc-path", "messages": [{"role": "user", "content": "Reply with exactly: PSC OK"}], "max_tokens": 4096}'
{"error":{"message":"litellm.NotFoundError: Vertex_aiException - <html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.31.2</center>\r\n</body>\r\n</html>\r\n. Received Model Group=minimax-psc-path\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}

$ curl -sS http://localhost:53007/v1/chat/completions \
    -H 'Authorization: Bearer sk-qa-1234' -H 'Content-Type: application/json' \
    -d '{"model": "minimax-psc-path", "messages": [{"role": "user", "content": "Reply with exactly: PSC OK"}], "stream": true, "max_tokens": 4096}'
{"error":{"message":"litellm.NotFoundError: Vertex_aiException - <html>\r\n<head><title>404 Not Found</title></head>\r\n<body>\r\n<center><h1>404 Not Found</h1></center>\r\n<hr><center>nginx/1.31.2</center>\r\n</body>\r\n</html>\r\n. Received Model Group=minimax-psc-path\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"404"}}
```

The proxy log (`proxy-before.log`) shows the malformed URLs LiteLLM actually called, with the port and path duplicated after a stray colon, plus the `?alt=sse` suffix on the streaming call

```
POST Request Sent from LiteLLM:
curl -X POST \
http://127.0.0.1:53159/vertex:53159/vertex/v1/projects/vertex-check-481318/locations/global/endpoints/openapi/chat/completions \
-H 'Authorization: Be****06' -H 'Content-Type: application/json' \

POST Request Sent from LiteLLM:
curl -X POST \
http://127.0.0.1:53159/vertex:53159/vertex/v1/projects/vertex-check-481318/locations/global/endpoints/openapi/chat/completions?alt=sse \
-H 'Authorization: Be****06' -H 'Content-Type: application/json' \
```

To be fully transparent about the bare-host model: `minimax-psc` succeeds on the base branch for both non-streaming and streaming, because #32367 (already on the base branch) grafts the default path onto bare-host api_bases and because the Google endpoint happens to tolerate the extra `?alt=sse` query param that the custom-api_base streaming path appends. The streaming URL on base still diverges from what the default no-api_base path sends

```
https://aiplatform.googleapis.com/v1/projects/vertex-check-481318/locations/global/endpoints/openapi/chat/completions?alt=sse \
```

### After (litellm_fix_vertex_psc_partner_api_base, commit 64c4cfe265089498cd6ba4df3184b6f15edccc17)

Same config and the exact same curls against the fix branch (proxy restarted on port 53279). The previously failing path-bearing calls now return real completions

```
$ curl -sS http://localhost:53279/v1/chat/completions \
    -H 'Authorization: Bearer sk-qa-1234' -H 'Content-Type: application/json' \
    -d '{"model": "minimax-psc-path", "messages": [{"role": "user", "content": "Reply with exactly: PSC OK"}], "max_tokens": 4096}'
{"id":"qGtNasyZEbnN998P9YbJmAc","created":1783458729,"model":"minimax-psc-path","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"<think>The user asks: \"Reply with exactly: PSC OK\". [... thinking content truncated ...]\n</think>\n\nPSC OK","role":"assistant"}}],"usage":{"completion_tokens":208,"prompt_tokens":28,"total_tokens":236,"prompt_tokens_details":{"cached_tokens":26},"extra_properties":{"google":{"traffic_type":"ON_DEMAND"}}}}

$ curl -sS http://localhost:53279/v1/chat/completions \
    -H 'Authorization: Bearer sk-qa-1234' -H 'Content-Type: application/json' \
    -d '{"model": "minimax-psc-path", "messages": [{"role": "user", "content": "Reply with exactly: PSC OK"}], "stream": true, "max_tokens": 4096}'
data: {"id":"smtNap20IPOg9LsP1ffp0A8","created":1783458739,"model":"minimax-psc-path","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"provider_specific_fields":{},"content":"","role":"assistant"}}]}

data: {"id":"smtNap20IPOg9LsP1ffp0A8","object":"chat.completion.chunk","created":1783458739,"model":"minimax-psc-path","choices":[{"index":0,"delta":{"content":"<think>We"}}]}

[... SSE chunks truncated ...]

data: {"id":"smtNap20IPOg9LsP1ffp0A8","object":"chat.completion.chunk","created":1783458739,"model":"minimax-psc-path","choices":[{"index":0,"delta":{"content":"PSC OK"}}]}

data: {"id":"smtNap20IPOg9LsP1ffp0A8","object":"chat.completion.chunk","created":1783458739,"model":"minimax-psc-path","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}

data: [DONE]
```

The proxy log (`proxy-after.log`) now shows a single clean host and path for every call, with no `?alt=sse` divergence on streaming; these are the only outbound URL shapes across the whole after run

```
http://127.0.0.1:53159/vertex/v1/projects/vertex-check-481318/locations/global/endpoints/openapi/chat/completions \
https://aiplatform.googleapis.com/v1/projects/vertex-check-481318/locations/global/endpoints/openapi/chat/completions \
```

The bare-host `minimax-psc` also succeeded non-streaming and streaming on the fix branch, and the `minimax-control` model with no `api_base` succeeded in both the before and the after runs

## Type

🐛 Bug Fix

## Changes

Users calling Vertex AI partner models served through the OpenAI-compatible route (Llama, DeepSeek, Qwen, MiniMax, Moonshot, ZAI, GPT-OSS, Gemma MaaS) with a custom `api_base`, for example a GCP Private Service Connect host like `https://aiplatform-myendpoint.p.googleapis.com`, got a malformed request URL with the host duplicated (`https://HOST://HOST/v1/projects/PROJ/locations/LOC/endpoints/openapi/chat/completions`) and the call failed with a 404

Root cause: `VertexBase.get_complete_vertex_url` first builds the complete, correct URL via `create_vertex_url` (which already honors the custom `api_base`), then splits that URL on `:` to extract a `:rawPredict` style verb and re-prefixes it onto the custom `api_base` through `_check_custom_proxy`. The OpenAI-compatible path has no `:verb` suffix, so the split grabs everything after the scheme and the host gets duplicated. Streaming requests through this path also picked up a `?alt=sse` suffix that the default no-custom-api_base path never sends to the openapi chat completions endpoint

The fix returns the `create_vertex_url` result directly for this partner path, mirroring what `litellm/llms/vertex_ai/vertex_model_garden/main.py` already does for the same reason. The rawPredict style partners (mistral, ai21, claude) are untouched and keep the existing `{api_base}:{endpoint}` custom proxy behavior

Regression tests in `tests/test_litellm/llms/vertex_ai/test_vertex_llm_base.py` assert the exact URL for a PSC style bare host, a path-bearing `api_base`, streaming parity (no `?alt=sse`), the default no-api_base path, and the unchanged mistral `{api_base}:rawPredict` format

