### PR TITLE
test(ui): pin token-exchange field visibility to the oauth2_token_exchange auth type

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -350,6 +350,30 @@ describe("CreateMCPServer", () => {
       expect(payload.credentials).toBeUndefined();
     });
 
+    it("shows the token-exchange fields only for the OAuth Token Exchange (OBO) auth type", async () => {
+      await selectHttpTransport();
+
+      // Plain OAuth must not render the token-exchange section.
+      await selectAntOption("Authentication", "OAuth");
+      await waitFor(() => {
+        expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
+
+      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await waitFor(() => {
+        expect(screen.getByText("Token Exchange Endpoint (optional)")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Subject Token Type (optional)")).toBeInTheDocument();
+
+      // Switching away hides the section again.
+      await selectAntOption("Authentication", "API Key");
+      await waitFor(() => {
+        expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
+    });
+
     it("routes OAuth Token Exchange (OBO) config to the backend payload", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -372,6 +372,20 @@ describe("CreateMCPServer", () => {
         expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
       });
       expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
+
+      // Selecting token exchange and then switching transport to stdio unmounts the
+      // whole Authentication section (the section-level transport gate), taking the
+      // token-exchange fields with it — their required client_id/client_secret rules
+      // cannot block a stdio submit because antd does not validate unmounted fields.
+      await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
+      await waitFor(() => {
+        expect(screen.getByText("Token Exchange Endpoint (optional)")).toBeInTheDocument();
+      });
+      await selectAntOption("Transport Type", "Standard Input/Output");
+      await waitFor(() => {
+        expect(screen.queryByText("Token Exchange Endpoint (optional)")).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
     });
 
     it("routes OAuth Token Exchange (OBO) config to the backend payload", async () => {


### PR DESCRIPTION
## Relevant issues

Stacked on #31772 (base is that branch; retargets to `litellm_internal_staging` when it merges). Follow-up test-only PR split out during #31772's review.

## Linear ticket

N/A

## Type

🧪 Tests

## Changes

The create form renders the token-exchange field section (`Token Exchange Endpoint`, `Client ID`, `Client Secret`, `Audience`, `Subject Token Type`, `Scopes`) only when the auth type is `oauth2_token_exchange` — both #31772 forms gate it on `authType === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE`. No test asserted that visibility contract in either direction, so a regression (e.g. rendering the section for plain `oauth2`, or dropping it for token exchange) would pass CI. This adds one test walking the auth selector OAuth → OAuth Token Exchange (OBO) → API Key and asserting the section is hidden, shown, and hidden again.

## [REQUIRED] Testing

```
npx vitest run src/components/mcp_tools/create_mcp_server.test.tsx
Test Files  1 passed (1)
     Tests  33 passed (33)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in the dashboard; no runtime behavior or API surface is modified.
> 
> **Overview**
> Adds a **Vitest** case in `create_mcp_server.test.tsx` that locks in when OAuth token-exchange UI appears on the Add MCP Server form.
> 
> The test walks **Authentication** from plain **OAuth** → **OAuth Token Exchange (OBO)** → **API Key**, asserting **Token Exchange Endpoint** and **Subject Token Type** stay hidden except for OBO. It also switches transport to **Standard Input/Output** after OBO and expects those fields to disappear with the HTTP-only Authentication block.
> 
> No application or form logic changes—only regression coverage for the `oauth2_token_exchange` visibility contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ececc3510a019473d873579e061098001dc089f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->