### PR TITLE
fix(utils): resolve bedrock regional inference profiles to regional pricing in get_model_info (LIT-4056)

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5052,9 +5052,9 @@ def _get_model_info_from_generalization(
     candidates = [
         potential_model_names["combined_model_name"],
         model,
+        potential_model_names["split_model"],
         potential_model_names["combined_stripped_model_name"],
         potential_model_names["stripped_model_name"],
-        potential_model_names["split_model"],
     ]
     for candidate in candidates:
         generalized_info = match_fallback_generalization(candidate)
@@ -5093,6 +5093,11 @@ def _get_potential_model_names(
             custom_llm_provider,
             stripped_model_name,
         )
+
+    if custom_llm_provider in ("bedrock", "bedrock_converse"):
+        from litellm.llms.bedrock.common_utils import strip_bedrock_routing_prefix
+
+        split_model = strip_bedrock_routing_prefix(split_model)
 
     return PotentialModelNamesAndCustomLLMProvider(
         split_model=split_model,
@@ -5261,9 +5266,9 @@ def _get_model_info_helper(
             Check if: (in order of specificity)
             1. 'custom_llm_provider/model' in litellm.model_cost. Checks "groq/llama3-8b-8192" if model="llama3-8b-8192" and custom_llm_provider="groq"
             2. 'model' in litellm.model_cost. Checks "gemini-1.5-pro-002" in  litellm.model_cost if model="gemini-1.5-pro-002" and custom_llm_provider=None
-            3. 'combined_stripped_model_name' in litellm.model_cost. Checks if 'gemini/gemini-1.5-flash' in model map, if 'gemini/gemini-1.5-flash-001' given.
-            4. 'stripped_model_name' in litellm.model_cost. Checks if 'ft:gpt-3.5-turbo' in model map, if 'ft:gpt-3.5-turbo:my-org:custom_suffix:id' given.
-            5. 'split_model' in litellm.model_cost. Checks "llama3-8b-8192" in litellm.model_cost if model="groq/llama3-8b-8192"
+            3. 'split_model' in litellm.model_cost. Checks "au.anthropic.claude-opus-4-8" in litellm.model_cost if model="bedrock/au.anthropic.claude-opus-4-8"
+            4. 'combined_stripped_model_name' in litellm.model_cost. Checks if 'gemini/gemini-1.5-flash' in model map, if 'gemini/gemini-1.5-flash-001' given.
+            5. 'stripped_model_name' in litellm.model_cost. Checks if 'ft:gpt-3.5-turbo' in model map, if 'ft:gpt-3.5-turbo:my-org:custom_suffix:id' given.
             """
 
             _model_info: Optional[Dict[str, Any]] = None
@@ -5290,6 +5295,16 @@ def _get_model_info_helper(
                     ):
                         _model_info = None
             if _model_info is None:
+                _matched_key = _get_model_cost_key(split_model)
+                if _matched_key is not None:
+                    key = _matched_key
+                    _model_info = _get_model_info_from_model_cost(key=cast(str, key))
+                    if not _check_provider_match(
+                        model_info=_model_info,
+                        custom_llm_provider=model_cost_custom_llm_provider,
+                    ):
+                        _model_info = None
+            if _model_info is None:
                 _matched_key = _get_model_cost_key(combined_stripped_model_name)
                 if _matched_key is not None:
                     key = _matched_key
@@ -5301,16 +5316,6 @@ def _get_model_info_helper(
                         _model_info = None
             if _model_info is None:
                 _matched_key = _get_model_cost_key(stripped_model_name)
-                if _matched_key is not None:
-                    key = _matched_key
-                    _model_info = _get_model_info_from_model_cost(key=cast(str, key))
-                    if not _check_provider_match(
-                        model_info=_model_info,
-                        custom_llm_provider=model_cost_custom_llm_provider,
-                    ):
-                        _model_info = None
-            if _model_info is None:
-                _matched_key = _get_model_cost_key(split_model)
                 if _matched_key is not None:
                     key = _matched_key
                     _model_info = _get_model_info_from_model_cost(key=cast(str, key))

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2619,8 +2619,9 @@ _CACHE_PRICING_FIELDS = (
 
 def _resolve_builtin_model_cost_entry(key: str, provider: str) -> Optional[Dict[str, Any]]:
     """Best-effort lookup of a built-in ``model_cost`` entry for a custom key
-    whose shape ``get_model_info`` cannot resolve (double provider prefixes
-    like ``bedrock/bedrock/us.anthropic.claude-sonnet-4-6`` or region aliases).
+    whose shape ``get_model_info`` cannot resolve (repeated provider prefixes
+    like ``bedrock/bedrock/bedrock/us.anthropic.claude-sonnet-4-6`` or region
+    aliases).
 
     Returns a copy of the matching entry so the caller can inherit its defaults
     (most importantly cache pricing) without mutating the shared built-in.

--- a/tests/test_litellm/test_register_model_custom_pricing.py
+++ b/tests/test_litellm/test_register_model_custom_pricing.py
@@ -320,8 +320,9 @@ def test_register_model_strips_none_litellm_provider_from_get_model_info(monkeyp
 
 def test_register_model_inherits_builtin_cache_pricing_for_unmapped_key():
     """Registering a custom override under a key shape that
-    ``get_model_info`` cannot resolve (e.g. a double provider prefix like
-    ``bedrock/bedrock/us.anthropic.claude-sonnet-4-6``) must still inherit
+    ``get_model_info`` cannot resolve (e.g. a triple provider prefix like
+    ``bedrock/bedrock/bedrock/us.anthropic.claude-sonnet-4-6``; a double
+    prefix now resolves like a routing prefix) must still inherit
     the built-in cache pricing for the underlying model.
 
     Before the fix ``register_model`` fell back to an empty ``existing_model``
@@ -341,7 +342,7 @@ def test_register_model_inherits_builtin_cache_pricing_for_unmapped_key():
     litellm.model_cost = litellm.get_model_cost_map(url="")
 
     builtin_key = "us.anthropic.claude-sonnet-4-6"
-    registered_key = f"bedrock/bedrock/{builtin_key}"
+    registered_key = f"bedrock/bedrock/bedrock/{builtin_key}"
     builtin = litellm.model_cost[builtin_key]
 
     assert builtin["cache_creation_input_token_cost"] > 0

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1093,6 +1093,13 @@ def test_get_model_info_bedrock_regional_profile_without_entry_falls_back_to_bas
     assert info["key"] == "anthropic.claude-opus-4-8"
 
 
+def test_get_model_info_bedrock_double_provider_prefix_resolves(local_model_cost_map):
+    """A doubled bedrock/ prefix routes at runtime via strip_bedrock_routing_prefix,
+    so model info must resolve it to the same entry the request actually bills as."""
+    info = litellm.get_model_info(model="bedrock/bedrock/us.anthropic.claude-sonnet-4-6")
+    assert info["key"] == "us.anthropic.claude-sonnet-4-6"
+
+
 def test_openai_models_in_model_info():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1063,6 +1063,36 @@ def test_get_model_info_gemini():
             assert info.get("rpm") is not None, f"{model} does not have rpm"
 
 
+def test_get_model_info_bedrock_regional_inference_profile_pricing(local_model_cost_map):
+    """Regression LIT-4056: with the bedrock/ routing prefix (plain, converse/, or
+    invoke/), the exact regional cost-map entry must win over the region-stripped
+    base entry, matching the unprefixed control form."""
+    regional = litellm.model_cost["au.anthropic.claude-opus-4-8"]
+    base = litellm.model_cost["anthropic.claude-opus-4-8"]
+    assert regional["input_cost_per_token"] > base["input_cost_per_token"]
+
+    for model in (
+        "bedrock/au.anthropic.claude-opus-4-8",
+        "bedrock/converse/au.anthropic.claude-opus-4-8",
+        "bedrock/invoke/au.anthropic.claude-opus-4-8",
+    ):
+        info = litellm.get_model_info(model=model)
+        assert info["key"] == "au.anthropic.claude-opus-4-8", model
+        assert info["input_cost_per_token"] == regional["input_cost_per_token"], model
+        assert info["output_cost_per_token"] == regional["output_cost_per_token"], model
+
+    control = litellm.get_model_info(model="au.anthropic.claude-opus-4-8", custom_llm_provider="bedrock")
+    assert control["key"] == "au.anthropic.claude-opus-4-8"
+
+
+def test_get_model_info_bedrock_regional_profile_without_entry_falls_back_to_base(local_model_cost_map):
+    """A regional profile with no dedicated cost-map entry must still resolve to its
+    region-stripped base entry."""
+    assert "jp.anthropic.claude-opus-4-8" not in litellm.model_cost
+    info = litellm.get_model_info(model="bedrock/jp.anthropic.claude-opus-4-8")
+    assert info["key"] == "anthropic.claude-opus-4-8"
+
+
 def test_openai_models_in_model_info():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4056

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on localhost with no mocks and no database, started from a clean worktree venv with `LITELLM_LOCAL_MODEL_COST_MAP=True` and `LITELLM_MASTER_KEY=sk-qa-lit4056`, using this `qa_config.yaml`, which mirrors the deployment shape from the ticket:

```yaml
model_list:
  - model_name: claude-opus-4-8
    litellm_params:
      model: bedrock/au.anthropic.claude-opus-4-8
      aws_region_name: ap-southeast-2

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

Both runs use the exact same startup and curl commands on the same port; the only difference is the checked-out commit

```bash
.venv/bin/python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 59668
```

```bash
curl -s "http://127.0.0.1:59668/v1/model/info" -H "Authorization: Bearer sk-qa-lit4056" | jq '.data[] | {model_name, litellm_model: .litellm_params.model, key: .model_info.key, input_cost_per_token: .model_info.input_cost_per_token, output_cost_per_token: .model_info.output_cost_per_token}'
```

### Before (base commit ff6dc33291a5a6c16ee3041a425739226e81dd5c)

The AU regional inference profile resolves to the region-stripped base cost-map entry and shows base pricing

```json
{
  "model_name": "claude-opus-4-8",
  "litellm_model": "bedrock/au.anthropic.claude-opus-4-8",
  "key": "anthropic.claude-opus-4-8",
  "input_cost_per_token": 0.000005,
  "output_cost_per_token": 0.000025
}
```

### After (PR head commit dadf9268d6526e5547fe4581619dc42acec1e4b2)

The same deployment resolves to the exact regional cost-map entry with the AU premium pricing

```json
{
  "model_name": "claude-opus-4-8",
  "litellm_model": "bedrock/au.anthropic.claude-opus-4-8",
  "key": "au.anthropic.claude-opus-4-8",
  "input_cost_per_token": 0.0000055,
  "output_cost_per_token": 0.0000275
}
```

## Type

🐛 Bug Fix

## Changes

`get_model_info` resolved Bedrock regional inference profiles configured with the standard `bedrock/` routing prefix (including `bedrock/converse/` and `bedrock/invoke/`) to the region-stripped base cost-map entry instead of the exact regional entry. For example `bedrock/au.anthropic.claude-opus-4-8` returned key `anthropic.claude-opus-4-8` at $5.00/$25.00 per 1M tokens instead of `au.anthropic.claude-opus-4-8` at $5.50/$27.50, so `/v1/model/info` and the Admin UI model overview showed base pricing for premium-priced regional profiles. The unprefixed form (`model: au.anthropic.claude-opus-4-8` with `custom_llm_provider: bedrock`) already resolved correctly, so the two config spellings of the same deployment disagreed

Root cause: `_get_model_info_helper` tries lookup candidates in a fixed order and placed `split_model` (the exact name after the provider prefix) last, after the region-stripped candidates produced by `_strip_model_name`. For Bedrock, stripping removes the cross-region prefix (`us.`, `eu.`, `au.`, and so on), so the base entry always matched first whenever the model carried the `bedrock/` prefix. For the `converse/` and `invoke/` route forms, `split_model` additionally kept the route prefix, so the exact regional key was never even a candidate

The fix tries the exact `split_model` candidate before the stripped fallbacks in both `_get_model_info_helper` and `_get_model_info_from_generalization`, and normalizes Bedrock route prefixes off `split_model` in `_get_potential_model_names`. The existing provider-match guard keeps `split_model` hits from leaking across providers, and the region-stripped fallback still applies for regional profiles that have no dedicated cost-map entry, for example `bedrock/jp.anthropic.claude-opus-4-8` still resolves to the base entry. Runtime spend tracking through `cost_per_token` was already correct because completion flows pass the unprefixed model plus provider; this change aligns `get_model_info` with it

Regression tests in `tests/test_litellm/test_utils.py` cover the plain, `converse/`, and `invoke/` prefixed forms resolving to the regional entry, the unprefixed control form, and the base-entry fallback for a regional profile without a dedicated entry


One intended side effect: a doubled provider prefix such as `bedrock/bedrock/us.anthropic.claude-sonnet-4-6` now resolves too, because the second `bedrock/` is treated as the routing prefix it already is at request time (`strip_bedrock_routing_prefix` removes it before the call is sent), so model info now matches what the request actually bills as. `test_register_model_inherits_builtin_cache_pricing_for_unmapped_key` relied on that shape being unresolvable to exercise the `register_model` fallback path, so its fixture moved to a triple prefix, which still cannot resolve; the new resolution behavior is locked in by `test_get_model_info_bedrock_double_provider_prefix_resolves`
