### PR TITLE
fix(anthropic): ignore null error field in messages response

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2260,7 +2260,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
     ):
         _hidden_params: Dict = {}
         _hidden_params["additional_headers"] = process_anthropic_headers(dict(raw_response.headers))
-        if "error" in completion_response:
+        if isinstance(completion_response, dict) and completion_response.get("error") is not None:
             response_headers = getattr(raw_response, "headers", None)
             raise AnthropicError(
                 message=str(completion_response["error"]),

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -3191,6 +3191,38 @@ def test_tool_search_tool_result_not_in_tool_results():
     assert provider_fields.get("tool_results") is None
 
 
+def test_transform_parsed_response_ignores_null_error_field():
+    import httpx
+
+    from litellm.types.utils import ModelResponse
+
+    config = AnthropicConfig()
+    raw_response = MagicMock(spec=httpx.Response)
+    raw_response.status_code = 200
+    raw_response.headers = {}
+    model_response = ModelResponse()
+
+    transformed_response = config.transform_parsed_response(
+        completion_response={
+            "id": "msg_gateway_success",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "stop_sequence": None,
+            "usage": {"input_tokens": 12, "output_tokens": 3},
+            "error": None,
+        },
+        raw_response=raw_response,
+        model_response=model_response,
+        json_mode=False,
+        prefix_prompt=None,
+    )
+
+    assert transformed_response.choices[0].message.content == "hello"
+
+
 def test_web_search_tool_result_backwards_compatibility():
     """
     Test that web_search_tool_result continues to be stored in web_search_results


### PR DESCRIPTION
## Relevant issues

No linked issue

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] This PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

Before this change, Anthropic-compatible message responses that included `"error": null` were treated as failures because the parser checked for the presence of the `error` key rather than a non-null error value

After this change, a localhost proxy running the PR branch succeeds against an Anthropic-compatible route at commit `806e300d00`:

```bash
curl --noproxy 127.0.0.1 -sS --max-time 120 http://127.0.0.1:4011/v1/responses \
  -H "Content-Type: application/json" \
  -d "{\"model\":\"deepseek-v4-flash\",\"input\":\"reply hello only\",\"max_output_tokens\":128}"
```

```text
commit=806e300d00
http_status=200
status=completed
error=None
output_types=reasoning,message
message_text=hello
```

Focused regression tests also pass:

```bash
python -m pytest tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_transform_parsed_response_ignores_null_error_field
```

```text
1 passed
```

The CI failure cases were also reproduced locally after the follow-up fix:

```text
5 passed
```

## Type

Bug Fix
Test

## Changes

Treat `"error": null` in dict Anthropic message responses as success and keep raising when the value is non-null

Avoid treating mock or non-dict response objects as provider error payloads

Add a regression test for successful Anthropic-compatible responses that include a null `error` field