### PR TITLE
fix(anthropic): omit custom tool type for deepseek

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1072,6 +1072,40 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 return True
         return False
 
+    @staticmethod
+    def _model_info_lookup_names(model: str) -> Tuple[str, ...]:
+        if "/" not in model:
+            return (model,)
+        model_without_provider = model.split("/", 1)[1]
+        if not model_without_provider:
+            return (model,)
+        return (model, model_without_provider)
+
+    @staticmethod
+    def _should_strip_custom_tool_type(model: str) -> bool:
+        for lookup_model in AnthropicConfig._model_info_lookup_names(model):
+            if lookup_model not in litellm.model_cost:
+                continue
+            strip_custom_tool_type = litellm.get_model_info(model=lookup_model).get("strip_custom_tool_type")
+            if isinstance(strip_custom_tool_type, bool):
+                return strip_custom_tool_type
+        return False
+
+    @staticmethod
+    def _strip_custom_tool_type(model: str, optional_params: Dict[str, Any]) -> None:
+        tools = optional_params.get("tools")
+        if not isinstance(tools, list):
+            return
+        updated_tools = tuple(
+            {key: value for key, value in tool.items() if key != "type"}
+            if isinstance(tool, dict) and tool.get("type") == "custom"
+            else tool
+            for tool in tools
+        )
+        if tuple(tools) == updated_tools or not AnthropicConfig._should_strip_custom_tool_type(model):
+            return
+        optional_params["tools"] = list(updated_tools)
+
     def _separate_deferred_tools(self, tools: List) -> Tuple[List, List]:
         """
         Separate tools into deferred and non-deferred lists.
@@ -1884,6 +1918,8 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 drop_params=litellm_params.get("drop_params") is True,
                 output_key="top_k",
             )
+
+        self._strip_custom_tool_type(model=model, optional_params=optional_params)
 
         data = {
             "model": model,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -11862,7 +11862,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "strip_custom_tool_type": true
     },
     "deepseek-reasoner": {
         "cache_read_input_token_cost": 2.8e-08,
@@ -14392,7 +14393,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "strip_custom_tool_type": true
     },
     "deepseek/deepseek-coder": {
         "input_cost_per_token": 1.4e-07,
@@ -43879,6 +43881,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "deepseek-v4-pro": {
@@ -43904,6 +43907,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "deepseek/deepseek-v4-flash": {
@@ -43929,6 +43933,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "darkbloom/gemma-4-26b": {
@@ -43988,6 +43993,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "tencent/deepseek-v4-pro": {

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -151,6 +151,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_max_reasoning_effort: Optional[bool]
     supports_output_config: Optional[bool]
     supports_image_size: Optional[bool]
+    strip_custom_tool_type: Optional[bool]
     bedrock_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]
     bedrock_converse_supports_strict_tools: Optional[bool]
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5471,6 +5471,7 @@ def _get_model_info_helper(
                 supports_low_reasoning_effort=_model_info.get("supports_low_reasoning_effort", None),
                 supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
                 supports_max_reasoning_effort=_model_info.get("supports_max_reasoning_effort", None),
+                strip_custom_tool_type=_model_info.get("strip_custom_tool_type", None),
                 bedrock_output_config_effort_ceiling=_model_info.get("bedrock_output_config_effort_ceiling", None),
                 bedrock_converse_supports_strict_tools=_model_info.get("bedrock_converse_supports_strict_tools", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -11862,7 +11862,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "strip_custom_tool_type": true
     },
     "deepseek-reasoner": {
         "cache_read_input_token_cost": 2.8e-08,
@@ -14392,7 +14393,8 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_system_messages": true,
-        "supports_tool_choice": true
+        "supports_tool_choice": true,
+        "strip_custom_tool_type": true
     },
     "deepseek/deepseek-coder": {
         "input_cost_per_token": 1.4e-07,
@@ -44112,6 +44114,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "deepseek-v4-pro": {
@@ -44137,6 +44140,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "deepseek/deepseek-v4-flash": {
@@ -44162,6 +44166,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "deepseek/deepseek-v4-pro": {
@@ -44187,6 +44192,7 @@
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_tool_choice": true,
+        "strip_custom_tool_type": true,
         "supports_vision": false
     },
     "tencent/deepseek-v4-pro": {

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1607,6 +1607,72 @@ def test_input_examples_empty_list_not_added():
     )
 
 
+def _anthropic_custom_tool():
+    return {
+        "type": "custom",
+        "name": "exec_command",
+        "description": "Run a command",
+        "input_schema": {
+            "type": "object",
+            "properties": {"cmd": {"type": "string"}},
+            "required": ["cmd"],
+        },
+    }
+
+
+def test_deepseek_anthropic_chat_strips_custom_tool_type(local_model_cost_map):
+    config = AnthropicConfig()
+    tool = _anthropic_custom_tool()
+
+    result = config.transform_request(
+        model="anthropic/deepseek-chat",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={"max_tokens": 10, "tools": [tool]},
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["tools"] == [
+        {
+            "name": "exec_command",
+            "description": "Run a command",
+            "input_schema": {
+                "type": "object",
+                "properties": {"cmd": {"type": "string"}},
+                "required": ["cmd"],
+            },
+        }
+    ]
+    assert tool["type"] == "custom"
+
+
+def test_non_deepseek_anthropic_chat_keeps_custom_tool_type():
+    config = AnthropicConfig()
+    tool = _anthropic_custom_tool()
+
+    result = config.transform_request(
+        model="claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "hello"}],
+        optional_params={"max_tokens": 10, "tools": [tool]},
+        litellm_params={},
+        headers={},
+    )
+
+    assert result["tools"] == [tool]
+
+
+def test_deepseek_anthropic_chat_ignores_non_list_tools(local_model_cost_map):
+    tools = {"type": "custom"}
+    optional_params = {"tools": tools}
+
+    AnthropicConfig._strip_custom_tool_type(
+        model="anthropic/deepseek-chat",
+        optional_params=optional_params,
+    )
+
+    assert optional_params["tools"] == tools
+
+
 # ============ Effort Parameter Tests ============
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -855,6 +855,7 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "supports_sampling_params": {"type": "boolean"},
                 "supports_output_config": {"type": "boolean"},
                 "supports_speed": {"type": "boolean"},
+                "strip_custom_tool_type": {"type": "boolean"},
                 "bedrock_output_config_effort_ceiling": {
                     "type": "string",
                     "enum": ["low", "medium", "high", "max", "xhigh"],
@@ -4667,5 +4668,3 @@ class TestValidateEnvironmentTencent:
 
         assert result["keys_in_environment"] is False
         assert "TENCENT_API_KEY" in result["missing_keys"]
-
-


### PR DESCRIPTION
## Relevant issues

No linked issue

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] This PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before this change, DeepSeek Anthropic-compatible requests could be rejected when LiteLLM forwarded Anthropic-shaped custom tools with `type: custom`; the provider rejects that tool variant before the model can answer

After this change, the live localhost proxy request with a custom tool succeeds at commit `5d36dc6ab4` (live proxy proof before the review-feedback amendment; current head is `d3edaa7c56`):

```bash
curl --noproxy 127.0.0.1 -sS --max-time 120 http://127.0.0.1:4010/v1/responses \
  -H "Content-Type: application/json" \
  -d "{\"model\":\"deepseek-v4-flash\",\"input\":\"reply hello only\",\"tools\":[{\"type\":\"custom\",\"name\":\"exec_command\",\"description\":\"Run a shell command\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"cmd\":{\"type\":\"string\"}},\"required\":[\"cmd\"]}}],\"max_output_tokens\":128}"
```

```text
http_status=200
status=completed
output_types=reasoning,message
message_text=hello
```

Focused regression tests also pass:

```bash
python -m pytest \
  tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_deepseek_anthropic_chat_strips_custom_tool_type \
  tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_non_deepseek_anthropic_chat_keeps_custom_tool_type \
  tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py::test_deepseek_anthropic_chat_ignores_non_list_tools
```

```text
3 passed
```

## Type

Bug Fix
Test

## Changes

Use model metadata (`strip_custom_tool_type`) to strip `type: custom` from Anthropic-shaped custom tools only for DeepSeek Anthropic-compatible models

Keep the existing Anthropic custom tool shape unchanged for non-DeepSeek models

Add regression coverage for DeepSeek, non-DeepSeek, and non-list tool guard paths
