### PR TITLE
feat(ui): expose MCP max_concurrent_requests in server create and edit forms

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -715,8 +715,10 @@ class MCPServerManager:
         # Per-server outbound tool-call concurrency limiters, lazily created from
         # each server's max_concurrent_requests. Keyed by server_id so the cap
         # survives the registry atomic-swap on config reload; a missing key means
-        # the server has no configured limit.
-        self._server_call_semaphores: dict[str, asyncio.Semaphore] = {}
+        # the server has no configured limit. The limit is cached alongside the
+        # semaphore so an edited limit rebuilds it instead of keeping the old cap
+        # until restart.
+        self._server_call_semaphores: dict[str, tuple[int, asyncio.Semaphore]] = {}
         self.tool_name_to_mcp_server_name_mapping: dict[str, str] = {}
         """
         {
@@ -3594,10 +3596,11 @@ class MCPServerManager:
         limit = mcp_server.max_concurrent_requests
         if limit is None or limit <= 0:
             return None
-        semaphore = self._server_call_semaphores.get(mcp_server.server_id)
-        if semaphore is None:
-            semaphore = asyncio.Semaphore(limit)
-            self._server_call_semaphores[mcp_server.server_id] = semaphore
+        cached = self._server_call_semaphores.get(mcp_server.server_id)
+        if cached is not None and cached[0] == limit:
+            return cached[1]
+        semaphore = asyncio.Semaphore(limit)
+        self._server_call_semaphores[mcp_server.server_id] = (limit, semaphore)
         return semaphore
 
     @asynccontextmanager

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_max_concurrent_requests.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_max_concurrent_requests.py
@@ -164,6 +164,25 @@ async def test_openapi_backed_server_also_respects_the_cap():
     assert tracker.peak_by_server["srv-openapi"] == 2
 
 
+@pytest.mark.asyncio
+async def test_edited_limit_takes_effect_without_restart():
+    """Editing max_concurrent_requests must rebuild the cached semaphore so the
+    new cap applies to subsequent calls immediately, not only after a restart."""
+    manager = MCPServerManager()
+    server = _make_server("srv-edited", max_concurrent_requests=3)
+
+    before_edit = _ConcurrencyTracker()
+    with _patch_client_with_tracker(manager, before_edit):
+        await _fire(manager, server, n=6)
+    assert before_edit.peak_by_server["srv-edited"] == 3
+
+    server.max_concurrent_requests = 1
+    after_edit = _ConcurrencyTracker()
+    with _patch_client_with_tracker(manager, after_edit):
+        await _fire(manager, server, n=6)
+    assert after_edit.peak_by_server["srv-edited"] == 1
+
+
 def test_semaphore_is_reused_per_server_and_distinct_across_servers():
     manager = MCPServerManager()
     server_a = _make_server("srv-a", max_concurrent_requests=3)

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -433,13 +433,13 @@ describe("CreateMCPServer", () => {
     it("routes OAuth Token Exchange (OBO) config to the backend payload", async () => {
       await selectHttpTransport();
 
-      const user = userEvent.setup({ delay: null });
-
-      const nameInput = getServerNameInput();
-      await user.type(nameInput, "TE_Server");
+      // fireEvent.change over user.type: this test asserts payload shape, not
+      // keystroke behavior, and char-by-char typing re-renders the whole form
+      // per character, which pushed this test past the 30s CI timeout.
+      fireEvent.change(getServerNameInput(), { target: { value: "TE_Server" } });
 
       const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
-      await user.type(urlInput, "https://upstream.example.com/mcp");
+      fireEvent.change(urlInput, { target: { value: "https://upstream.example.com/mcp" } });
 
       await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
 
@@ -447,12 +447,15 @@ describe("CreateMCPServer", () => {
         expect(screen.getByPlaceholderText("https://idp.example.com/oauth2/token")).toBeInTheDocument();
       });
 
-      await user.type(
-        screen.getByPlaceholderText("https://idp.example.com/oauth2/token"),
-        "https://idp.example.com/oauth2/token",
-      );
-      await user.type(screen.getByPlaceholderText("Enter OAuth client ID"), "te-client-id");
-      await user.type(screen.getByPlaceholderText("Enter OAuth client secret"), "te-client-secret");
+      fireEvent.change(screen.getByPlaceholderText("https://idp.example.com/oauth2/token"), {
+        target: { value: "https://idp.example.com/oauth2/token" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Enter OAuth client ID"), {
+        target: { value: "te-client-id" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Enter OAuth client secret"), {
+        target: { value: "te-client-secret" },
+      });
 
       vi.mocked(networking.createMCPServer).mockResolvedValue({
         server_id: "new-server-te",
@@ -489,10 +492,13 @@ describe("CreateMCPServer", () => {
     it("makes scope required when the Entra OBO profile is selected", async () => {
       await selectHttpTransport();
 
-      const user = userEvent.setup({ delay: null });
-
-      await user.type(getServerNameInput(), "Entra_Server");
-      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://upstream.example.com/mcp");
+      // fireEvent.change over user.type for the same reason as the payload
+      // test above: char-by-char typing re-renders the whole form per
+      // character and pushes this test toward the 30s CI timeout.
+      fireEvent.change(getServerNameInput(), { target: { value: "Entra_Server" } });
+      fireEvent.change(screen.getByPlaceholderText("https://your-mcp-server.com"), {
+        target: { value: "https://upstream.example.com/mcp" },
+      });
 
       await selectAntOption("Authentication", "OAuth Token Exchange (OBO)");
       await waitFor(() => {
@@ -501,12 +507,15 @@ describe("CreateMCPServer", () => {
 
       await selectAntOption("Profile", "Microsoft Entra OBO");
 
-      await user.type(
-        screen.getByPlaceholderText("https://idp.example.com/oauth2/token"),
-        "https://login.microsoftonline.com/tenant/oauth2/v2.0/token",
-      );
-      await user.type(screen.getByPlaceholderText("Enter OAuth client ID"), "entra-client");
-      await user.type(screen.getByPlaceholderText("Enter OAuth client secret"), "entra-secret");
+      fireEvent.change(screen.getByPlaceholderText("https://idp.example.com/oauth2/token"), {
+        target: { value: "https://login.microsoftonline.com/tenant/oauth2/v2.0/token" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Enter OAuth client ID"), {
+        target: { value: "entra-client" },
+      });
+      fireEvent.change(screen.getByPlaceholderText("Enter OAuth client secret"), {
+        target: { value: "entra-secret" },
+      });
 
       // Selecting Entra OBO makes the scope required; submitting without one is blocked by validation
       // (rfc8693 would not require it), which confirms the profile selection took effect.

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -388,6 +388,48 @@ describe("CreateMCPServer", () => {
       expect(screen.queryByText("Subject Token Type (optional)")).not.toBeInTheDocument();
     });
 
+    it("sends max_concurrent_requests in the create payload when set", async () => {
+      await selectHttpTransport();
+
+      const user = userEvent.setup({ delay: null });
+
+      const nameInput = getServerNameInput();
+      await user.type(nameInput, "Limited_Server");
+
+      const urlInput = screen.getByPlaceholderText("https://your-mcp-server.com");
+      await user.type(urlInput, "https://example.com/mcp");
+
+      await selectAntOption("Authentication", "None");
+
+      const limitInput = screen.getByPlaceholderText("e.g. 10");
+      await user.type(limitInput, "5");
+
+      vi.mocked(networking.createMCPServer).mockResolvedValue({
+        server_id: "new-server-1",
+        server_name: "Limited_Server",
+        alias: "Limited_Server",
+        url: "https://example.com/mcp",
+        transport: "http",
+        auth_type: "none",
+        created_at: "2024-01-01T00:00:00Z",
+        created_by: "user-1",
+        updated_at: "2024-01-01T00:00:00Z",
+        updated_by: "user-1",
+      });
+
+      const submitButton = screen.getByRole("button", { name: "Add MCP Server" });
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(networking.createMCPServer).toHaveBeenCalledTimes(1);
+      });
+
+      const [, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
+      expect(payload.max_concurrent_requests).toBe(5);
+    });
+
     it("routes OAuth Token Exchange (OBO) config to the backend payload", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Modal, Tooltip, Form, Select, Input, Switch, Collapse } from "antd";
+import { Modal, Tooltip, Form, Select, Input, InputNumber, Switch, Collapse } from "antd";
 import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TextInput } from "@tremor/react";
 import { createMCPServer, registerMCPServer, storeMCPOAuthUserCredential } from "../networking";
@@ -922,6 +922,26 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                 </Form.Item>
               </>
             )}
+
+            <Form.Item
+              label={
+                <span className="text-sm font-medium text-gray-700 flex items-center">
+                  Max Concurrent Requests
+                  <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
+                    <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                  </Tooltip>
+                </span>
+              }
+              name="max_concurrent_requests"
+            >
+              <InputNumber
+                min={1}
+                precision={0}
+                placeholder="e.g. 10"
+                style={{ width: "100%" }}
+                className="rounded-lg"
+              />
+            </Form.Item>
 
             {/* Authentication - show for HTTP, SSE, and OpenAPI */}
             {transportType !== "stdio" && transportType !== "" && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -926,7 +926,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
             <Form.Item
               label={
                 <span className="text-sm font-medium text-gray-700 flex items-center">
-                  Max Concurrent Requests
+                  Max Concurrent Requests (optional)
                   <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
                     <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                   </Tooltip>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1305,3 +1305,83 @@ describe("MCPServerEdit OAuth flow prefill display", () => {
     });
   });
 });
+
+describe("MCPServerEdit (max concurrent requests)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const limitedServer = {
+    ...interactiveOAuthServer,
+    auth_type: "none",
+    max_concurrent_requests: 5,
+  };
+
+  it("prefills the existing limit and sends an updated value in the payload", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...limitedServer,
+      max_concurrent_requests: 2,
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={limitedServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const limitInput = screen.getByPlaceholderText("e.g. 10") as HTMLInputElement;
+    expect(limitInput.value).toBe("5");
+
+    fireEvent.change(limitInput, { target: { value: "2" } });
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.max_concurrent_requests).toBe(2);
+  });
+
+  it("sends null when the limit is cleared so the backend unsets it", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...limitedServer,
+      max_concurrent_requests: null,
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={limitedServer}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    const limitInput = screen.getByPlaceholderText("e.g. 10") as HTMLInputElement;
+    expect(limitInput.value).toBe("5");
+
+    fireEvent.change(limitInput, { target: { value: "" } });
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.max_concurrent_requests).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -855,7 +855,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
             <Form.Item
               label={
                 <span className="text-sm font-medium text-gray-700 flex items-center">
-                  Max Concurrent Requests
+                  Max Concurrent Requests (optional)
                   <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
                     <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
                   </Tooltip>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -852,6 +852,26 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               </Form.Item>
             )}
 
+            <Form.Item
+              label={
+                <span className="text-sm font-medium text-gray-700 flex items-center">
+                  Max Concurrent Requests
+                  <Tooltip title="Maximum number of tool calls LiteLLM will run against this server at the same time. Additional calls wait for a free slot. Leave blank for no limit.">
+                    <InfoCircleOutlined className="ml-2 text-blue-400 hover:text-blue-600 cursor-help" />
+                  </Tooltip>
+                </span>
+              }
+              name="max_concurrent_requests"
+            >
+              <InputNumber
+                min={1}
+                precision={0}
+                placeholder="e.g. 10"
+                style={{ width: "100%" }}
+                className="rounded-lg"
+              />
+            </Form.Item>
+
             {/* Authentication - for HTTP, SSE, and OpenAPI */}
             {!isStdioTransport && (
               <Form.Item label="Authentication" name="auth_type" rules={[{ required: true }]}>

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -261,6 +261,7 @@ export interface MCPServer {
   available_on_public_internet?: boolean;
   delegate_auth_to_upstream?: boolean;
   oauth_passthrough?: boolean;
+  max_concurrent_requests?: number | null;
 
   /** Stdio-only fields (present when transport === 'stdio') */
   command?: string | null;


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Setup: a stub MCP server (FastMCP, streamable HTTP, one `slow_echo` tool that sleeps 1s and tracks peak in-flight concurrency, exposed via `GET /peak` which resets on read) on `127.0.0.1:8123`, and the proxy on `localhost:4000` backed by a real Postgres. Each round fires 8 parallel tool calls through the proxy with the same shell loop, then reads the stub's observed peak

```bash
for i in $(seq 1 8); do
  curl -s -X POST http://localhost:4000/mcp-rest/tools/call \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"server_id\":\"$SID\",\"name\":\"slow_echo\",\"arguments\":{\"text\":\"c$i\"}}" -o /dev/null &
done; wait
curl -s http://127.0.0.1:8123/peak
```

Before, at `9652509e46` (staging tip, without this PR). Creating the server with a limit persists and enforces it, but editing the limit only updates the DB; the live cap keeps the old value until a proxy restart

```bash
$ curl -s -X POST http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{"server_name":"conc_probe_before","alias":"conc_probe_before","url":"http://127.0.0.1:8123/mcp","transport":"http","auth_type":"none","max_concurrent_requests":3}'
# response includes "max_concurrent_requests": 3

# 8 parallel calls
peak with limit 3 (before, unfixed): {"peak_concurrent_calls":3}

$ curl -s -X PUT http://localhost:4000/v1/mcp/server -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d "{\"server_id\":\"$SID\",\"max_concurrent_requests\":1}"
PUT -> 1

# 8 parallel calls again, same process, no restart
peak after editing limit to 1 (before, unfixed): {"peak_concurrent_calls":3}
```

After, at `0769e52f39` (this PR), same server and same commands. The edited value now applies immediately, and clearing the field removes the cap

```bash
PUT -> 3
peak with limit 3 (after, fixed): {"peak_concurrent_calls":3}

PUT -> 1
peak after editing limit to 1 (after, fixed): {"peak_concurrent_calls":1}

$ curl ... -d "{\"server_id\":\"$SID\",\"max_concurrent_requests\":null}"
PUT -> None
peak after clearing the limit (after, fixed): {"peak_concurrent_calls":8}
```

### UI (before / after)

Rendered from the real create/edit form components, staging tip `9652509e46` (before) vs this PR's head `0769e52f39` (after). The optional Max Concurrent Requests field renders above the Authentication section on both forms, for every transport and auth type

Create form, before: the URL runs straight into Authentication, with no way to cap concurrency

![create form before: no Max Concurrent Requests field](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMzJlYmY3YTEtMzMzYy00OGUwLWJjYjUtNTRkYWYzZDEyYTM0IiwiaWF0IjoxNzgzNDcyMTA0LCJleHAiOjE3ODQwNzY5MDQsImZpbGVuYW1lIjoiYmVmb3JlX2NyZWF0ZS5wbmcifQ.692Za6QqFQ4T6mh3yC4EYNB2aac3Dvie8-ljh7dkj24)

Create form, after: an optional Max Concurrent Requests input sits above Authentication (shown set to 10), flowing through `POST /v1/mcp/server`

![create form after: Max Concurrent Requests field above Authentication](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWFiNGU3ZmEtNzQ4Yi00NzU3LWE3MDAtNjdiY2VmZTkzZTEzIiwiaWF0IjoxNzgzNDcyMTA0LCJleHAiOjE3ODQwNzY5MDQsImZpbGVuYW1lIjoiYWZ0ZXJfY3JlYXRlLnBuZyJ9.eNvPHPLb0DVyRoQ4t_u90CwHtc98QZgv09Q47bc9szg)

Edit form, before: same gap, so an admin could never see or change the limit from the dashboard

![edit form before: no Max Concurrent Requests field](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZWNlYTRlMmItZTZiMi00ZjgwLWE0ODAtMTY5Mjc1ZjE0YjA3IiwiaWF0IjoxNzgzNDcyMTA0LCJleHAiOjE3ODQwNzY5MDQsImZpbGVuYW1lIjoiYmVmb3JlX2VkaXQucG5nIn0.fwaJRtluNcVkCbHyVkt72bHV9XjR2dIw1T6nnqMVi2w)

Edit form, after: the field comes back prefilled from the saved server (here 3); saving a new value or clearing it persists through `PUT /v1/mcp/server` as shown above

![edit form after: Max Concurrent Requests prefilled with the saved limit](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMTBlZmE2YTctM2NjNy00N2E2LTk3YmQtNmVlYjIzODFjNjU3IiwiaWF0IjoxNzgzNDcyMTA0LCJleHAiOjE3ODQwNzY5MDQsImZpbGVuYW1lIjoiYWZ0ZXJfZWRpdC5wbmcifQ.eW84aUaheRRHN2rWqepWxks3G52cSG75dRCijmGITjo)

## Type

🆕 New Feature
🐛 Bug Fix

## Changes

The proxy has enforced a per-server outbound tool-call concurrency cap (`max_concurrent_requests`) since #31641, covering every egress path: the regular MCP client branch (all auth types including api_key, bearer, basic, none, oauth2 in both flows, and aws_sigv4), the token-exchange (OBO) branch as of #32071, and OpenAPI-backed servers. The management API and DB column have accepted the field all along, but the dashboard offered no way to set it

This PR adds an optional Max Concurrent Requests `InputNumber` to both the create form (`create_mcp_server.tsx`) and the edit form (`mcp_server_edit.tsx`), plus the field on the `MCPServer` interface in `types.tsx`. Because enforcement is universal, the field renders for every auth type and transport rather than being gated on auth mode. Both forms already spread named form fields into the request payload, so the value flows through `POST /v1/mcp/server` and `PUT /v1/mcp/server` unchanged; clearing the field on edit sends `null`, which unsets the stored limit via the partial-update path

It also fixes a backend gap that made the edit flow misleading: `_get_call_semaphore` cached the per-server semaphore forever, so an edited limit was persisted and reloaded into the registry but the live cap kept the first-seen value until the proxy restarted. The cache now stores the limit alongside the semaphore and rebuilds it when the configured value changes

Tests: a regression test in `test_mcp_max_concurrent_requests.py` that drives 8 concurrent calls, edits the limit from 3 to 1 mid-process, and asserts the observed peak drops (fails on the unfixed code, passes with the fix); frontend tests asserting the create payload carries the typed value, the edit form prefills the stored value and sends an updated one, and clearing the input sends `null`

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102