### PR TITLE
fix(ui): forward refs through ui primitives and fail tests on swallowed refs

### DIFF
--- a/ui/litellm-dashboard/src/components/ui/label.tsx
+++ b/ui/litellm-dashboard/src/components/ui/label.tsx
@@ -4,9 +4,10 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-function Label({ className, ...props }: React.ComponentProps<"label">) {
-  return (
+const Label = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<"label">>(
+  ({ className, ...props }, ref) => (
     <label
+      ref={ref}
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
@@ -14,7 +15,8 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+Label.displayName = "Label";
 
 export { Label };

--- a/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
+++ b/ui/litellm-dashboard/src/components/ui/ref-forwarding.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import * as React from "react";
+import { describe, expect, it } from "vitest";
+
+import { Button } from "./button";
+import { Input } from "./input";
+import { Label } from "./label";
+import { Separator } from "./separator";
+import { Skeleton } from "./skeleton";
+import { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow } from "./table";
+import { UiLoadingSpinner } from "./ui-loading-spinner";
+
+describe("ui primitives forward refs to their DOM node", () => {
+  it("Button", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>ok</Button>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  it("Input", () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Input ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("Label", () => {
+    const ref = React.createRef<HTMLLabelElement>();
+    render(<Label ref={ref}>ok</Label>);
+    expect(ref.current).toBeInstanceOf(HTMLLabelElement);
+  });
+
+  it("Separator", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Separator ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+  });
+
+  it("Skeleton", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Skeleton ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("UiLoadingSpinner", () => {
+    const ref = React.createRef<SVGSVGElement>();
+    render(<UiLoadingSpinner ref={ref} />);
+    expect(ref.current).toBeInstanceOf(SVGSVGElement);
+  });
+
+  it("Table family", () => {
+    const table = React.createRef<HTMLTableElement>();
+    const caption = React.createRef<HTMLTableCaptionElement>();
+    const header = React.createRef<HTMLTableSectionElement>();
+    const body = React.createRef<HTMLTableSectionElement>();
+    const footer = React.createRef<HTMLTableSectionElement>();
+    const row = React.createRef<HTMLTableRowElement>();
+    const head = React.createRef<HTMLTableCellElement>();
+    const cell = React.createRef<HTMLTableCellElement>();
+
+    render(
+      <Table ref={table}>
+        <TableCaption ref={caption}>caption</TableCaption>
+        <TableHeader ref={header}>
+          <TableRow ref={row}>
+            <TableHead ref={head}>h</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody ref={body}>
+          <TableRow>
+            <TableCell ref={cell}>d</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter ref={footer}>
+          <TableRow>
+            <TableCell>f</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>,
+    );
+
+    expect(table.current).toBeInstanceOf(HTMLTableElement);
+    expect(caption.current).toBeInstanceOf(HTMLTableCaptionElement);
+    expect(header.current?.tagName).toBe("THEAD");
+    expect(body.current?.tagName).toBe("TBODY");
+    expect(footer.current?.tagName).toBe("TFOOT");
+    expect(row.current).toBeInstanceOf(HTMLTableRowElement);
+    expect(head.current?.tagName).toBe("TH");
+    expect(cell.current?.tagName).toBe("TD");
+  });
+});
+
+describe("setupTests ref tripwire", () => {
+  it("records a violation when a ref is passed to a plain function component", () => {
+    const Plain = (props: React.ComponentPropsWithoutRef<"span">) => <span {...props} />;
+    const ref = React.createRef<HTMLSpanElement>();
+    render(React.createElement(Plain as never, { ref }));
+    const consume = (globalThis as { __consumePendingRefWarnings?: () => string[] }).__consumePendingRefWarnings;
+    expect(consume).toBeDefined();
+    const violations = consume!();
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain("Function components cannot be given refs");
+  });
+});

--- a/ui/litellm-dashboard/src/components/ui/separator.tsx
+++ b/ui/litellm-dashboard/src/components/ui/separator.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
-  return (
+const Separator = React.forwardRef<React.ComponentRef<typeof SeparatorPrimitive>, SeparatorPrimitive.Props>(
+  ({ className, orientation = "horizontal", ...props }, ref) => (
     <SeparatorPrimitive
+      ref={ref}
       data-slot="separator"
       orientation={orientation}
       className={cn(
@@ -15,7 +17,8 @@ function Separator({ className, orientation = "horizontal", ...props }: Separato
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+Separator.displayName = "Separator";
 
 export { Separator };

--- a/ui/litellm-dashboard/src/components/ui/skeleton.tsx
+++ b/ui/litellm-dashboard/src/components/ui/skeleton.tsx
@@ -1,7 +1,12 @@
+import * as React from "react";
+
 import { cn } from "@/lib/cva.config";
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="skeleton" className={cn("animate-pulse rounded-md bg-accent", className)} {...props} />;
-}
+const Skeleton = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"div">>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} data-slot="skeleton" className={cn("animate-pulse rounded-md bg-accent", className)} {...props} />
+  ),
+);
+Skeleton.displayName = "Skeleton";
 
 export { Skeleton };

--- a/ui/litellm-dashboard/src/components/ui/table.tsx
+++ b/ui/litellm-dashboard/src/components/ui/table.tsx
@@ -4,35 +4,45 @@ import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
-  return (
+const Table = React.forwardRef<HTMLTableElement, React.ComponentPropsWithoutRef<"table">>(
+  ({ className, ...props }, ref) => (
     <div data-slot="table-container" className="relative w-full overflow-x-auto">
-      <table data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
+      <table ref={ref} data-slot="table" className={cn("w-full caption-bottom text-sm", className)} {...props} />
     </div>
-  );
-}
+  ),
+);
+Table.displayName = "Table";
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
-}
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.ComponentPropsWithoutRef<"thead">>(
+  ({ className, ...props }, ref) => (
+    <thead ref={ref} data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />
+  ),
+);
+TableHeader.displayName = "TableHeader";
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
-  return <tbody data-slot="table-body" className={cn("[&_tr:last-child]:border-0", className)} {...props} />;
-}
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.ComponentPropsWithoutRef<"tbody">>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} data-slot="table-body" className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+  ),
+);
+TableBody.displayName = "TableBody";
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
-  return (
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.ComponentPropsWithoutRef<"tfoot">>(
+  ({ className, ...props }, ref) => (
     <tfoot
+      ref={ref}
       data-slot="table-footer"
       className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
       {...props}
     />
-  );
-}
+  ),
+);
+TableFooter.displayName = "TableFooter";
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
-  return (
+const TableRow = React.forwardRef<HTMLTableRowElement, React.ComponentPropsWithoutRef<"tr">>(
+  ({ className, ...props }, ref) => (
     <tr
+      ref={ref}
       data-slot="table-row"
       className={cn(
         "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
@@ -40,12 +50,14 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+TableRow.displayName = "TableRow";
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
-  return (
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ComponentPropsWithoutRef<"th">>(
+  ({ className, ...props }, ref) => (
     <th
+      ref={ref}
       data-slot="table-head"
       className={cn(
         "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
@@ -53,12 +65,14 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+TableHead.displayName = "TableHead";
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
-  return (
+const TableCell = React.forwardRef<HTMLTableCellElement, React.ComponentPropsWithoutRef<"td">>(
+  ({ className, ...props }, ref) => (
     <td
+      ref={ref}
       data-slot="table-cell"
       className={cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
@@ -66,13 +80,20 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
       )}
       {...props}
     />
-  );
-}
+  ),
+);
+TableCell.displayName = "TableCell";
 
-function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
-  return (
-    <caption data-slot="table-caption" className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
-  );
-}
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.ComponentPropsWithoutRef<"caption">>(
+  ({ className, ...props }, ref) => (
+    <caption
+      ref={ref}
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  ),
+);
+TableCaption.displayName = "TableCaption";
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/ui/litellm-dashboard/src/components/ui/ui-loading-spinner.tsx
+++ b/ui/litellm-dashboard/src/components/ui/ui-loading-spinner.tsx
@@ -4,39 +4,43 @@ import { cx } from "@/lib/cva.config";
 
 type LoadingSpinnerProps = React.SVGProps<SVGSVGElement>;
 
-export function UiLoadingSpinner({ className = "", ...props }: LoadingSpinnerProps) {
-  const id = useId();
+export const UiLoadingSpinner = React.forwardRef<SVGSVGElement, LoadingSpinnerProps>(
+  ({ className = "", ...props }, ref) => {
+    const id = useId();
 
-  useSafeLayoutEffect(() => {
-    const animations = document
-      .getAnimations()
-      .filter((a) => a instanceof CSSAnimation && a.animationName === "spin") as CSSAnimation[];
+    useSafeLayoutEffect(() => {
+      const animations = document
+        .getAnimations()
+        .filter((a) => a instanceof CSSAnimation && a.animationName === "spin") as CSSAnimation[];
 
-    const self = animations.find((a) => (a.effect as KeyframeEffect).target?.getAttribute("data-spinner-id") === id);
+      const self = animations.find((a) => (a.effect as KeyframeEffect).target?.getAttribute("data-spinner-id") === id);
 
-    const anyOther = animations.find(
-      (a) => a.effect instanceof KeyframeEffect && a.effect.target?.getAttribute("data-spinner-id") !== id,
+      const anyOther = animations.find(
+        (a) => a.effect instanceof KeyframeEffect && a.effect.target?.getAttribute("data-spinner-id") !== id,
+      );
+
+      if (self && anyOther) {
+        self.currentTime = anyOther.currentTime;
+      }
+    }, [id]);
+
+    return (
+      <svg
+        ref={ref}
+        data-spinner-id={id}
+        className={cx("pointer-events-none size-12 animate-spin text-current", className)}
+        fill="none"
+        viewBox="0 0 24 24"
+        {...props}
+      >
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        ></path>
+      </svg>
     );
-
-    if (self && anyOther) {
-      self.currentTime = anyOther.currentTime;
-    }
-  }, [id]);
-
-  return (
-    <svg
-      data-spinner-id={id}
-      className={cx("pointer-events-none size-12 animate-spin text-current", className)}
-      fill="none"
-      viewBox="0 0 24 24"
-      {...props}
-    >
-      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-      <path
-        className="opacity-75"
-        fill="currentColor"
-        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-      ></path>
-    </svg>
-  );
-}
+  },
+);
+UiLoadingSpinner.displayName = "UiLoadingSpinner";

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -149,8 +149,28 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   }),
 }));
 
+const pendingRefWarnings: string[] = [];
+const consumePendingRefWarnings = (): string[] => pendingRefWarnings.splice(0, pendingRefWarnings.length);
+(globalThis as { __consumePendingRefWarnings?: () => string[] }).__consumePendingRefWarnings =
+  consumePendingRefWarnings;
+
+const originalConsoleError = console.error.bind(console);
+vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+  originalConsoleError(...args);
+  if (typeof args[0] === "string" && args[0].includes("Function components cannot be given refs")) {
+    pendingRefWarnings.push(args.map(String).join(" "));
+  }
+});
+
 afterEach(() => {
   cleanup();
+  if (consumePendingRefWarnings().length > 0) {
+    throw new Error(
+      "A ref was passed to a plain function component and silently dropped under React 18, which breaks " +
+        "ref-based composition (Base UI render triggers, tooltips, focus). Wrap the component in React.forwardRef. " +
+        "This tripwire lives in tests/setupTests.ts and can be removed after the React 19 upgrade.",
+    );
+  }
 });
 
 // Make toLocaleString deterministic in tests; individual tests can override

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -164,11 +164,13 @@ vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
 
 afterEach(() => {
   cleanup();
-  if (consumePendingRefWarnings().length > 0) {
+  const refWarnings = consumePendingRefWarnings();
+  if (refWarnings.length > 0) {
     throw new Error(
       "A ref was passed to a plain function component and silently dropped under React 18, which breaks " +
         "ref-based composition (Base UI render triggers, tooltips, focus). Wrap the component in React.forwardRef. " +
-        "This tripwire lives in tests/setupTests.ts and can be removed after the React 19 upgrade.",
+        "This tripwire lives in tests/setupTests.ts and can be removed after the React 19 upgrade.\n\n" +
+        refWarnings.join("\n\n"),
     );
   }
 });


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This fixes a latent composition bug with no user-visible surface on staging yet, so the proof is the failing-before/passing-after behavior of the new tests

Before (staging db2402754a): passing a ref to any of these primitives leaves ref.current null and React only logs a dev console warning; a Base UI `<TooltipTrigger render={<Skeleton/>}>` (or any render-prop trigger over them) silently never opens. Running the new src/components/ui/ref-forwarding.test.tsx at that commit fails 6 of 8 cases (`expected null to be an instance of HTMLElement`); only Button and Input pass since they already forwarded refs

After (762ddb1950): `cd ui/litellm-dashboard && npx vitest run src/components/ui` passes 24/24, including one contract case per primitive asserting ref.current is the real DOM node, and a self-test proving the setupTests tripwire records the React warning. PR #32393 contains the sibling fix for ui/badge.tsx where this class of bug was first hit for real (the Virtual Keys blocked-key tooltip never opened until Badge forwarded refs); the hover-opens-tooltip proof lives there

## Type

🐛 Bug Fix
✅ Test

## Changes

Under React 18.3 a ref passed to a plain function component is dropped; React logs a dev-only console warning and the ref stays null. Our components/ui primitives were generated in the React 19 shadcn style (plain functions, ref-as-prop), so any ref-based composition over them silently breaks: Base UI render-prop triggers, antd's cloneElement children, or a plain useRef for focus or measurement. ui/badge.tsx hit this for real on the shared DataTable track; only button.tsx and input.tsx already forwarded refs

Three changes. Label, Separator, Skeleton, UiLoadingSpinner and the Table family (Table, TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption) now use React.forwardRef and deliver the ref to their root DOM node. A contract test (ref-forwarding.test.tsx) renders each primitive with a ref and asserts the DOM node arrives, so a regression to plain-function style fails immediately. tests/setupTests.ts records React's "Function components cannot be given refs" warning and fails the offending test in afterEach with the captured warning text appended, so the failure names the component that swallowed the ref instead of pointing at console output. This turns the whole class from silent-in-prod into loud-in-CI, covering primitives this PR did not touch and any future `npx shadcn add` output (which will keep arriving in React 19 style until the React 19 upgrade)

The tripwire fails in afterEach rather than throwing from the console.error hook because a mid-render throw is caught by React's error recovery and the warning deduplicates on the retry, which silently defeats the guard; a self-test pins the recording path so the setup block cannot be deleted without a test failure

The Base UI wrapper components (dialog, popover, select, tooltip and friends) are deliberately left alone; they are used as direct JSX rather than render targets, the tripwire now covers them if that changes, and AntDLoadingSpinner wraps an antd Spin that accepts no ref. Everything here is inert once React 19 lands (forwardRef keeps working; the tripwire simply never fires) and can be codemodded away then

