### PR TITLE
fix(passthrough): stop request params from clobbering merged target query params

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -820,21 +820,21 @@ async def pass_through_request(
             forward_headers=forward_headers,
         )
 
+        requested_query_params: Optional[dict] = query_params or dict(request.query_params)
+
         # Apply default query parameters if provided, regardless of merge_query_params setting
         if default_query_params or merge_query_params:
-            # Determine what to merge based on settings
-            request_params = dict(request.query_params) if merge_query_params else {}
-
             # Create a new URL with the merged query params
             url = url.copy_with(
                 query=urlencode(
                     HttpPassThroughEndpointHelpers.get_merged_query_parameters(
                         existing_url=url,
-                        request_query_params=request_params,
+                        request_query_params=requested_query_params,
                         default_query_params=default_query_params,
                     )
                 ).encode("ascii")
             )
+            requested_query_params = None
 
         endpoint_type: EndpointType = HttpPassThroughEndpointHelpers.get_endpoint_type(str(url))
 
@@ -951,9 +951,6 @@ async def pass_through_request(
             call_type="pass_through_endpoint",
         )
         logging_obj.model_call_details["litellm_call_id"] = litellm_call_id
-
-        # combine url with query params for logging
-        requested_query_params: Optional[dict] = query_params or dict(request.query_params)
 
         ## PASSTHROUGH MANAGED ID RESOLUTION (INPUT) ##
         # Resolve managed IDs in path, query params, and body back to raw

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -822,20 +822,6 @@ async def pass_through_request(
 
         requested_query_params: Optional[dict] = query_params or dict(request.query_params)
 
-        # Apply default query parameters if provided, regardless of merge_query_params setting
-        if default_query_params or merge_query_params:
-            # Create a new URL with the merged query params
-            url = url.copy_with(
-                query=urlencode(
-                    HttpPassThroughEndpointHelpers.get_merged_query_parameters(
-                        existing_url=url,
-                        request_query_params=requested_query_params,
-                        default_query_params=default_query_params,
-                    )
-                ).encode("ascii")
-            )
-            requested_query_params = None
-
         endpoint_type: EndpointType = HttpPassThroughEndpointHelpers.get_endpoint_type(str(url))
 
         # SigV4-signed callers (e.g. Bedrock) attach the exact bytes that were
@@ -1020,6 +1006,20 @@ async def pass_through_request(
                     request.url.path,
                     request.method,
                 )
+
+        # Apply default query parameters if provided, regardless of merge_query_params setting
+        if default_query_params or merge_query_params:
+            # Create a new URL with the merged query params
+            url = url.copy_with(
+                query=urlencode(
+                    HttpPassThroughEndpointHelpers.get_merged_query_parameters(
+                        existing_url=url,
+                        request_query_params=requested_query_params,
+                        default_query_params=default_query_params,
+                    )
+                ).encode("ascii")
+            )
+            requested_query_params = None
 
         ## PASSTHROUGH MANAGED LIST (DB-only response) ##
         # For GET /v1/files and GET /v1/batches passthrough routes, serve the

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -30,6 +30,7 @@ from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (
     resolve_pass_through_request_timeout,
     resolve_llm_passthrough_timeout,
 )
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_RAW_BODY_STATE_KEY,
 )
@@ -2252,11 +2253,22 @@ async def test_pass_through_request_query_params_forwarding():
                         assert call_kwargs["_parsed_body"] == test_body
 
 
+class _FakeManagedFilesHook:
+    def __init__(self, file_row: SimpleNamespace):
+        self._file_row = file_row
+
+    async def get_unified_file_id(self, file_id: str, litellm_parent_otel_span=None) -> SimpleNamespace:
+        return self._file_row
+
+
 async def _run_pass_through_and_capture_wire_url(
     target: str,
     incoming_query: str,
     merge_query_params: bool = False,
     default_query_params: Optional[dict] = None,
+    custom_llm_provider: Optional[str] = None,
+    managed_files_hook: Optional[_FakeManagedFilesHook] = None,
+    user_api_key_dict: Optional[UserAPIKeyAuth] = None,
 ) -> httpx.URL:
     import litellm
     from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
@@ -2273,7 +2285,11 @@ async def _run_pass_through_and_capture_wire_url(
         params={"timeout": resolve_pass_through_request_timeout(None)},
     )
     cache_dict = litellm.in_memory_llm_clients_cache.cache_dict
-    cache_key = next(key for key, cached in cache_dict.items() if cached is real_handler)
+    cache_key = next((key for key, cached in cache_dict.items() if cached is real_handler), None)
+    assert cache_key is not None, (
+        "PassThroughEndpoint client not found in in_memory_llm_clients_cache; "
+        "get_async_httpx_client may not be caching this provider."
+    )
     cache_dict[cache_key] = SimpleNamespace(
         client=httpx.AsyncClient(transport=httpx.MockTransport(transport_handler))
     )
@@ -2290,16 +2306,29 @@ async def _run_pass_through_and_capture_wire_url(
     )
     mock_proxy_logging.post_call_failure_hook = AsyncMock()
     mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+    mock_proxy_logging.get_proxy_hook = MagicMock(return_value=managed_files_hook)
 
     try:
-        with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging)
+            )
+            if managed_files_hook is not None:
+                stack.enter_context(
+                    patch(
+                        "litellm.proxy.proxy_server.general_settings",
+                        {"passthrough_managed_object_ids": True},
+                    )
+                )
+                stack.enter_context(patch("litellm.proxy.proxy_server.prisma_client", None))
             response = await pass_through_request(
                 request=mock_request,
                 target=target,
                 custom_headers={},
-                user_api_key_dict=MagicMock(),
+                user_api_key_dict=user_api_key_dict if user_api_key_dict is not None else MagicMock(),
                 merge_query_params=merge_query_params,
                 default_query_params=default_query_params,
+                custom_llm_provider=custom_llm_provider,
             )
     finally:
         cache_dict[cache_key] = real_handler
@@ -2355,6 +2384,32 @@ async def test_pass_through_request_without_merge_replaces_target_query():
         incoming_query="q=litellm",
     )
     assert dict(wire_url.params) == {"q": "litellm"}
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_merge_query_params_rewrites_managed_ids_on_the_wire():
+    """
+    Regression test: on merge-enabled endpoints the managed-ID rewrite must see
+    the incoming query params before they are folded into the URL. Folding
+    first bakes the un-rewritten managed ID into the URL and hands the rewriter
+    None, leaking the managed ID upstream.
+    """
+    from litellm.proxy.pass_through_endpoints.managed_id_codec import new_managed_id
+
+    managed_id = new_managed_id("openai", "file-raw-123")
+    hook = _FakeManagedFilesHook(SimpleNamespace(created_by="user-1", team_id=None))
+    wire_url = await _run_pass_through_and_capture_wire_url(
+        target="https://api.openai.com/v1/files/content?api-version=preview",
+        incoming_query=f"file_id={managed_id}",
+        merge_query_params=True,
+        custom_llm_provider="openai",
+        managed_files_hook=hook,
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-1"),
+    )
+    assert dict(wire_url.params) == {
+        "api-version": "preview",
+        "file_id": "file-raw-123",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -5,6 +5,7 @@ import sys
 from contextlib import ExitStack
 from io import BytesIO
 from types import SimpleNamespace
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -2249,6 +2250,111 @@ async def test_pass_through_request_query_params_forwarding():
 
                         # Verify the request body is preserved
                         assert call_kwargs["_parsed_body"] == test_body
+
+
+async def _run_pass_through_and_capture_wire_url(
+    target: str,
+    incoming_query: str,
+    merge_query_params: bool = False,
+    default_query_params: Optional[dict] = None,
+) -> httpx.URL:
+    import litellm
+    from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+    from litellm.types.llms.custom_http import httpxSpecialProvider
+
+    recorded_requests = []
+
+    def transport_handler(upstream_request: httpx.Request) -> httpx.Response:
+        recorded_requests.append(upstream_request)
+        return httpx.Response(200, json={"ok": True})
+
+    real_handler = get_async_httpx_client(
+        llm_provider=httpxSpecialProvider.PassThroughEndpoint,
+        params={"timeout": resolve_pass_through_request_timeout(None)},
+    )
+    cache_dict = litellm.in_memory_llm_clients_cache.cache_dict
+    cache_key = next(key for key, cached in cache_dict.items() if cached is real_handler)
+    cache_dict[cache_key] = SimpleNamespace(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(transport_handler))
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.method = "GET"
+    mock_request.headers = Headers({})
+    mock_request.query_params = QueryParams(incoming_query)
+    mock_request.body = AsyncMock(return_value=b"")
+
+    mock_proxy_logging = MagicMock()
+    mock_proxy_logging.pre_call_hook = AsyncMock(
+        side_effect=lambda user_api_key_dict, data, call_type: data
+    )
+    mock_proxy_logging.post_call_failure_hook = AsyncMock()
+    mock_proxy_logging.post_call_response_headers_hook = AsyncMock(return_value={})
+
+    try:
+        with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging):
+            response = await pass_through_request(
+                request=mock_request,
+                target=target,
+                custom_headers={},
+                user_api_key_dict=MagicMock(),
+                merge_query_params=merge_query_params,
+                default_query_params=default_query_params,
+            )
+    finally:
+        cache_dict[cache_key] = real_handler
+
+    assert response.status_code == 200
+    assert len(recorded_requests) == 1
+    return recorded_requests[0].url
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_merge_query_params_preserves_target_query_on_wire():
+    """
+    Regression test: with merge_query_params=True, the target URL's own query
+    params must survive on the final outgoing request. Passing the incoming
+    params via httpx's params= replaces the URL's entire query string, which
+    used to silently drop the merged target params.
+    """
+    wire_url = await _run_pass_through_and_capture_wire_url(
+        target="https://www.bing.com/search?setLang=en-US&mkt=en-US",
+        incoming_query="q=litellm",
+        merge_query_params=True,
+    )
+    assert dict(wire_url.params) == {
+        "setLang": "en-US",
+        "mkt": "en-US",
+        "q": "litellm",
+    }
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_default_query_params_reach_the_wire():
+    """
+    default_query_params are sent with every request and can be overridden
+    per-key by client-provided query params; params the client does not
+    override must not be dropped from the outgoing request.
+    """
+    wire_url = await _run_pass_through_and_capture_wire_url(
+        target="https://example.com/api",
+        incoming_query="limit=5&api-version=client-version",
+        default_query_params={"api-version": "2024-01-01", "setLang": "en-US"},
+    )
+    assert dict(wire_url.params) == {
+        "api-version": "client-version",
+        "setLang": "en-US",
+        "limit": "5",
+    }
+
+
+@pytest.mark.asyncio
+async def test_pass_through_request_without_merge_replaces_target_query():
+    wire_url = await _run_pass_through_and_capture_wire_url(
+        target="https://www.bing.com/search?setLang=en-US",
+        incoming_query="q=litellm",
+    )
+    assert dict(wire_url.params) == {"q": "litellm"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy, real Anthropic API (models list endpoint, no mocks). Config used, note the `?limit=1` baked into the target plus `merge_query_params: true`:

```yaml
general_settings:
  master_key: sk-1234
  pass_through_endpoints:
    - path: "/anthropic-models"
      target: "https://api.anthropic.com/v1/models?limit=1"
      merge_query_params: true
      headers:
        x-api-key: os.environ/ANTHROPIC_API_KEY
        anthropic-version: "2023-06-01"
```

Proxy started with `.venv/bin/python litellm/proxy/proxy_cli.py --config proof_config.yaml --host 127.0.0.1 --port 49413` (with `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` unset)

Before the fix, at base commit db2402754aac87e58cd7154070b0464c5c82f482, the target's `limit=1` never reaches Anthropic; the plain call returns the full default page and the paged call returns everything after the cursor:

```
$ git rev-parse HEAD
db2402754aac87e58cd7154070b0464c5c82f482

$ curl -s "http://127.0.0.1:49413/anthropic-models" -H "Authorization: Bearer sk-1234" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); print('num models returned:', len(d['data'])); print('has_more:', d['has_more'])"
num models returned: 10
has_more: False

$ curl -s "http://127.0.0.1:49413/anthropic-models?after_id=claude-sonnet-5" -H "Authorization: Bearer sk-1234" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); print('num models returned:', len(d['data'])); print('ids:', [m['id'] for m in d['data']]); print('has_more:', d['has_more'])"
num models returned: 9
ids: ['claude-fable-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-5-20251101', 'claude-haiku-4-5-20251001', 'claude-sonnet-4-5-20250929', 'claude-opus-4-1-20250805']
has_more: False
```

After the fix, at commit dd989af0d524742450fe22b10a5aeb4d142227f2, the same curls show `limit=1` surviving on the wire and merging with the client's `after_id`:

```
$ git rev-parse HEAD
dd989af0d524742450fe22b10a5aeb4d142227f2

$ curl -s "http://127.0.0.1:49413/anthropic-models" -H "Authorization: Bearer sk-1234" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); print('num models returned:', len(d['data'])); print('ids:', [m['id'] for m in d['data']]); print('has_more:', d['has_more'])"
num models returned: 1
ids: ['claude-sonnet-5']
has_more: True

$ curl -s "http://127.0.0.1:49413/anthropic-models?after_id=claude-sonnet-5" -H "Authorization: Bearer sk-1234" \
    | python3 -c "import json,sys; d=json.load(sys.stdin); print('num models returned:', len(d['data'])); print('ids:', [m['id'] for m in d['data']]); print('has_more:', d['has_more'])"
num models returned: 1
ids: ['claude-fable-5']
has_more: True
```

## Type

🐛 Bug Fix

## Changes

`pass_through_request` folds the target URL's own query params (and any configured `default_query_params`) into the outgoing URL when `merge_query_params` or `default_query_params` is set, but then still passed the incoming request's query params to httpx via `params=`. httpx's `params=` replaces the URL's entire query string, so the merged query was clobbered down to just the incoming request's params and the target's own query never reached the wire. Because `dict(request.query_params)` is `{}` rather than `None` when the client sends no params, even paramless requests stripped the target's query, so `merge_query_params` has effectively never worked on the wire

The fix computes the effective incoming params once (`query_params or dict(request.query_params)`, the same expression the wire previously used), folds them into the merged URL with highest precedence, and sets `requested_query_params` to `None` so httpx sends the merged URL untouched. This matches the documented `default_query_params` semantics (defaults sent with every request, overridable per key by the client) and also covers the `default_query_params`-only case, where incoming params previously were not folded into the merged URL at all. Endpoints with neither option keep their existing behavior of the incoming params replacing the target query. The streaming, multipart, and raw-body call sites all consume the same `requested_query_params` variable, so they are all fixed by this single change

The existing test for this feature only inspected the `url` kwarg handed to `httpx.AsyncClient.request`, before httpx applies `params=`, which is why it never caught the clobbering. The new regression tests assert the final wire URL instead, by injecting an `httpx.MockTransport`-backed client into litellm's client cache so the real request-building path runs: merge preserves target plus incoming params, defaults reach the wire with per-key client overrides winning, and no-merge endpoints keep replace semantics. The first two tests fail on the base commit and pass with the fix


The follow-up commit fixes an ordering regression the first commit introduced on merge-enabled endpoints that use passthrough managed object IDs: the fold ran before the managed-ID input rewrite, so `rewrite_query_ids` received `None` while the un-rewritten managed ID was already baked into the URL and would have leaked upstream. The fold-and-null now runs after the managed-ID rewrite block, so the rewritten query params are what gets merged into the URL; nothing in between depends on the URL's query string (endpoint type detection keys on host and route substrings). A new regression test drives a merge-enabled endpoint with a managed ID in a query param through a fake `managed_files` hook injected via the same `proxy_logging_obj.get_proxy_hook` seam production uses, and asserts the wire URL carries the rewritten raw ID together with the target's own params; it fails without the reordering. The test helper's cache-key lookup was also tightened per review to `next(..., None)` plus an assert with an explanatory message instead of an opaque `StopIteration`
