### PR TITLE
ci(server-root-path): retry npm/playwright installs and disable matrix fail-fast

### DIFF
--- a/.github/workflows/test_server_root_path.yml
+++ b/.github/workflows/test_server_root_path.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 30
 
     strategy:
+      fail-fast: false
       matrix:
         root_path: ["/api/v1", "/llmproxy"]
 
@@ -108,8 +109,26 @@ jobs:
       - name: Install UI deps and Chromium
         working-directory: ui/litellm-dashboard
         run: |
-          npm ci
-          npx playwright install --with-deps chromium
+          retry() {
+            local attempt=1
+            local max_attempts=4
+            until "$@"; do
+              if [ "$attempt" -ge "$max_attempts" ]; then
+                echo "Command failed after $attempt attempts: $*"
+                return 1
+              fi
+              echo "Attempt $attempt failed: $*. Retrying in $((attempt * 15))s..."
+              sleep $((attempt * 15))
+              attempt=$((attempt + 1))
+            done
+          }
+
+          npm config set fetch-retries 5
+          npm config set fetch-retry-mintimeout 20000
+          npm config set fetch-retry-maxtimeout 120000
+
+          retry npm ci
+          retry npx playwright install --with-deps chromium
 
       - name: Run SERVER_ROOT_PATH redirect e2e
         working-directory: ui/litellm-dashboard


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

This change only touches a GitHub Actions workflow, so there is no Python unit to add; the meaningful test is this PR's own `Test Proxy SERVER_ROOT_PATH Routing` run, which exercises the exact hardened step end to end on a real runner

## Screenshots / Proof of Fix

This is a CI flake fix, so the proof is the flaky run before and a clean run after on the changed workflow

Before, on unrelated PRs that cannot affect routing, the `Install UI deps and Chromium` step failed on transient network errors and then fail-fast cancelled the healthy sibling leg:

- PR #32387 (`fix(model_prices): add gpt-realtime-2.1 ...`, a JSON-only cost-map change), run https://github.com/BerriAI/litellm/actions/runs/28905457599 at commit a08d91d274479bec9e14401243a71bec35a8417c. The `/api/v1` leg (job 85751441147) reached `Uvicorn running` and then `npm ci` died with `npm error code ECONNRESET / npm error network aborted`; the `/llmproxy` leg (job 85751441148) had already finished `npm ci` and downloaded Chromium and was cancelled with `The operation was canceled.`
- An unrelated PR on `litellm_rotate_callback_vars_master_key`, run https://github.com/BerriAI/litellm/actions/runs/28898600830 at commit adf8892c6f090df2c530db5647c4a77871aa9139. Same step, different flavor: `npm ci` succeeded but `npx playwright install --with-deps chromium` failed with `E: Failed to fetch https://packages.microsoft.com/...InRelease` and `Failed to install browsers ... exited with code: 100`; the sibling leg was cancelled

Flake scope: across the last 100 runs of this workflow there was 1 completed failure plus the (originally failed, then rerun) run on PR #32387, both from this network-fragile step on changes unrelated to routing, and each one also cancelled its healthy sibling

After, at commit 48a0baf95c, the same workflow runs green on both legs of this PR: https://github.com/BerriAI/litellm/actions/runs/28911177180 (test-server-root-path (/api/v1) pass in 7m27s, test-server-root-path (/llmproxy) pass in 7m59s), and the CircleCI e2e_ui_testing_server_root_path check also passes

## Type

🚄 Infrastructure

## Changes

The `test-server-root-path` matrix had no `fail-fast: false`, so a failure in either `/api/v1` or `/llmproxy` immediately cancelled the other leg even when that leg was completely healthy, turning one transient blip into a fully red workflow

The `Install UI deps and Chromium` step ran `npm ci` and `npx playwright install --with-deps chromium` with no retries. Both are network-heavy against external registries (npm, Ubuntu and Microsoft apt repos, the Playwright browser CDN), and both were observed failing transiently on unrelated PRs

This PR sets `fail-fast: false` on the matrix so one flaky leg no longer cancels its sibling, wraps `npm ci` and the Playwright install in a bounded retry helper with backoff, and raises npm's own fetch-retry settings. The server startup path is unchanged because it was never the problem; in every failure above the container reached `Uvicorn running` well within the existing timeout
