### PR TITLE
fix(router): make cache-read fail-open explicit in usage routing

### DIFF
--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -383,7 +383,13 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
         """
 
         if tpm_values is None or rpm_values is None:
-            return None
+            verbose_router_logger.warning(
+                "usage-based-routing-v2: tpm/rpm cache read failed for model_group=%s - "
+                "falling back to routing without usage data for this request",
+                model_group,
+            )
+            tpm_values = [None] * len(tpm_keys) if tpm_values is None else tpm_values
+            rpm_values = [None] * len(rpm_keys) if rpm_values is None else rpm_values
 
         tpm_dict = {}  # {model_id: 1, ..}
         for idx, key in enumerate(tpm_keys):

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -27,6 +27,7 @@ else:
 
 class RoutingArgs(LiteLLMPydanticObjectBase):
     ttl: int = 1 * 60  # 1min (RPM/TPM expire key)
+    allow_routing_on_cache_read_failure: bool = False
 
 
 class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
@@ -383,6 +384,8 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
         """
 
         if tpm_values is None or rpm_values is None:
+            if not self.routing_args.allow_routing_on_cache_read_failure:
+                return None
             verbose_router_logger.warning(
                 "usage-based-routing-v2: tpm/rpm cache read failed for model_group=%s - "
                 "falling back to routing without usage data for this request",

--- a/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2.py
+++ b/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2.py
@@ -1,0 +1,108 @@
+"""
+Regression tests for https://github.com/BerriAI/litellm/issues/16060
+
+When the tpm/rpm usage cache read fails (DualCache.[async_]batch_get_cache
+returns None, e.g. on a transient Redis error), usage-based-routing-v2 must
+fail open and still return a healthy deployment, instead of raising
+"No deployments available" (RateLimitError / 429).
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_tpm_rpm_v2 import LowestTPMLoggingHandler_v2
+
+MODEL_GROUP = "gpt-5"
+
+HEALTHY_DEPLOYMENTS = [
+    {
+        "model_name": MODEL_GROUP,
+        "litellm_params": {"model": "azure/gpt-5", "tpm": 5_000_000},
+        "model_info": {"id": "deployment-1"},
+    },
+    {
+        "model_name": MODEL_GROUP,
+        "litellm_params": {"model": "azure/gpt-5-eu", "tpm": 5_000_000},
+        "model_info": {"id": "deployment-2"},
+    },
+]
+
+
+def _handler() -> LowestTPMLoggingHandler_v2:
+    return LowestTPMLoggingHandler_v2(router_cache=DualCache())
+
+
+@pytest.mark.asyncio
+async def test_async_cache_read_failure_fails_open():
+    """Batch cache read returning None must not fail the request."""
+    handler = _handler()
+    with patch.object(
+        handler.router_cache,
+        "async_batch_get_cache",
+        new=AsyncMock(return_value=None),
+    ):
+        deployment = await handler.async_get_available_deployments(
+            model_group=MODEL_GROUP,
+            healthy_deployments=HEALTHY_DEPLOYMENTS,
+            messages=[{"role": "user", "content": "hey"}],
+        )
+    assert deployment is not None
+    assert deployment["model_info"]["id"] in {"deployment-1", "deployment-2"}
+
+
+def test_sync_cache_read_failure_fails_open():
+    """Sync path: batch cache read returning None must not fail the request."""
+    handler = _handler()
+    with patch.object(handler.router_cache, "batch_get_cache", return_value=None):
+        deployment = handler.get_available_deployments(
+            model_group=MODEL_GROUP,
+            healthy_deployments=HEALTHY_DEPLOYMENTS,
+            messages=[{"role": "user", "content": "hey"}],
+        )
+    assert deployment is not None
+    assert deployment["model_info"]["id"] in {"deployment-1", "deployment-2"}
+
+
+@pytest.mark.asyncio
+async def test_async_over_limit_deployments_still_excluded():
+    """Fail-open must not weaken normal limit enforcement when cache reads work."""
+    handler = _handler()
+    cache_values = [5_000_001, 100, 1, 1]
+    with patch.object(
+        handler.router_cache,
+        "async_batch_get_cache",
+        new=AsyncMock(return_value=cache_values),
+    ):
+        deployment = await handler.async_get_available_deployments(
+            model_group=MODEL_GROUP,
+            healthy_deployments=HEALTHY_DEPLOYMENTS,
+            messages=[{"role": "user", "content": "hey"}],
+        )
+    assert deployment is not None
+    assert deployment["model_info"]["id"] == "deployment-2"
+
+
+@pytest.mark.asyncio
+async def test_async_all_over_limit_still_raises():
+    """When usage data is present and all deployments are over limit, keep raising."""
+    import litellm
+
+    handler = _handler()
+    cache_values = [5_000_001, 5_000_001, 1, 1]
+    with patch.object(
+        handler.router_cache,
+        "async_batch_get_cache",
+        new=AsyncMock(return_value=cache_values),
+    ):
+        with pytest.raises(litellm.RateLimitError):
+            await handler.async_get_available_deployments(
+                model_group=MODEL_GROUP,
+                healthy_deployments=HEALTHY_DEPLOYMENTS,
+                messages=[{"role": "user", "content": "hey"}],
+            )

--- a/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2.py
+++ b/tests/test_litellm/router_strategy/test_lowest_tpm_rpm_v2.py
@@ -2,8 +2,8 @@
 Regression tests for https://github.com/BerriAI/litellm/issues/16060
 
 When the tpm/rpm usage cache read fails (DualCache.[async_]batch_get_cache
-returns None, e.g. on a transient Redis error), usage-based-routing-v2 must
-fail open and still return a healthy deployment, instead of raising
+returns None, e.g. on a transient Redis error), usage-based-routing-v2 can
+explicitly opt into returning a healthy deployment instead of raising
 "No deployments available" (RateLimitError / 429).
 """
 
@@ -34,14 +34,35 @@ HEALTHY_DEPLOYMENTS = [
 ]
 
 
-def _handler() -> LowestTPMLoggingHandler_v2:
-    return LowestTPMLoggingHandler_v2(router_cache=DualCache())
+def _handler(*, allow_routing_on_cache_read_failure: bool = False) -> LowestTPMLoggingHandler_v2:
+    return LowestTPMLoggingHandler_v2(
+        router_cache=DualCache(),
+        routing_args={"allow_routing_on_cache_read_failure": allow_routing_on_cache_read_failure},
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_cache_read_failure_fails_closed_by_default():
+    import litellm
+
+    handler = _handler()
+    with patch.object(
+        handler.router_cache,
+        "async_batch_get_cache",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(litellm.RateLimitError):
+            await handler.async_get_available_deployments(
+                model_group=MODEL_GROUP,
+                healthy_deployments=HEALTHY_DEPLOYMENTS,
+                messages=[{"role": "user", "content": "hey"}],
+            )
 
 
 @pytest.mark.asyncio
 async def test_async_cache_read_failure_fails_open():
     """Batch cache read returning None must not fail the request."""
-    handler = _handler()
+    handler = _handler(allow_routing_on_cache_read_failure=True)
     with patch.object(
         handler.router_cache,
         "async_batch_get_cache",
@@ -58,7 +79,7 @@ async def test_async_cache_read_failure_fails_open():
 
 def test_sync_cache_read_failure_fails_open():
     """Sync path: batch cache read returning None must not fail the request."""
-    handler = _handler()
+    handler = _handler(allow_routing_on_cache_read_failure=True)
     with patch.object(handler.router_cache, "batch_get_cache", return_value=None):
         deployment = handler.get_available_deployments(
             model_group=MODEL_GROUP,


### PR DESCRIPTION
## Relevant issues

Fixes #16060

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

No live provider proof was captured in this maintenance pass because reproducing the failure requires a multi-deployment proxy, a forced cache outage, and paid provider traffic

## Type

Bug Fix

## Changes

`DualCache.[async_]batch_get_cache` can return `None` during a transient cache failure. Previously the router treated that failure as no available deployment and returned 429 for the entire model group

This change adds `allow_routing_on_cache_read_failure` to the usage-based-routing-v2 arguments. It defaults to `false`, preserving fail-closed limit enforcement. Operators who explicitly prefer availability can set it to `true`; only then does the router select a healthy deployment without usage data for that request

Regression coverage verifies default fail-closed behavior, opted-in sync and async fail-open behavior, selection around configured limits, and rejection when every deployment is over its limit

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
