### PR TITLE
feat(mcp/ui): expose true_passthrough and oauth_delegate auth types with a no-auth warning

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -465,8 +465,15 @@ async def _store_per_user_token_server_side(
 
 
 def _raise_if_not_oauth2(mcp_server: MCPServer) -> None:
-    """Reject a non-oauth2 server from the gateway's OAuth authorize/token/register flow."""
-    if mcp_server.auth_type == MCPAuth.oauth2:
+    """Reject a server without upstream OAuth from the gateway's authorize/token/register flow.
+
+    The client-forwarded token modes (``true_passthrough`` / ``oauth_delegate``) are allowed
+    through: the caller owns the upstream token, and this relayed flow is how a browser obtains
+    one against the upstream IdP (the admin UI's browser-only Authorize uses it). The minted
+    token is upstream-audienced and held by the caller; the gateway persists nothing for these
+    modes (DCR persistence is opt-in and never enabled on this path).
+    """
+    if mcp_server.auth_type in (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate):
         return
     raise HTTPException(
         status_code=400,
@@ -515,8 +522,7 @@ async def authorize_with_server(
     response_type: Optional[str] = None,
     scope: Optional[str] = None,
 ):
-    if mcp_server.auth_type != "oauth2":
-        raise HTTPException(status_code=400, detail="MCP server is not OAuth2")
+    _raise_if_not_oauth2(mcp_server)
     if mcp_server.authorization_url is None:
         raise HTTPException(status_code=400, detail="MCP server authorization url is not set")
 

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -473,7 +473,11 @@ def _raise_if_not_oauth2(mcp_server: MCPServer) -> None:
     token is upstream-audienced and held by the caller; the gateway persists nothing for these
     modes (DCR persistence is opt-in and never enabled on this path).
     """
-    if mcp_server.auth_type in (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate):
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (  # noqa: PLC0415  # circular import with mcp_server_manager at module load
+        _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
+    )
+
+    if mcp_server.auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES:
         return
     raise HTTPException(
         status_code=400,

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -983,8 +983,9 @@ class MCPServerManager:
             )
 
             auth_type = server_config.get("auth_type", None)
+            config_upstream_oauth_auth_types = (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate)
             if server_url and (
-                auth_type == MCPAuth.oauth2
+                auth_type in config_upstream_oauth_auth_types
                 or self._obo_needs_endpoint_discovery(
                     auth_type,
                     server_config.get("token_exchange_endpoint"),
@@ -993,7 +994,7 @@ class MCPServerManager:
             ):
                 mcp_oauth_metadata = await self._descovery_metadata(
                     server_url=server_url,
-                    allow_origin_fallback=auth_type == MCPAuth.oauth2,
+                    allow_origin_fallback=auth_type in config_upstream_oauth_auth_types,
                 )
             else:
                 mcp_oauth_metadata = None

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1384,8 +1384,9 @@ class MCPServerManager:
 
         auth_type = cast(MCPAuthType, mcp_server.auth_type)
         server_url = mcp_server.url
+        upstream_oauth_auth_types = (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate)
         needs_discovery = bool(server_url) and (
-            (auth_type == MCPAuth.oauth2 and not mcp_server.authorization_url)
+            (auth_type in upstream_oauth_auth_types and not mcp_server.authorization_url)
             or self._obo_needs_endpoint_discovery(
                 auth_type,
                 mcp_server.token_exchange_endpoint
@@ -1396,7 +1397,7 @@ class MCPServerManager:
         mcp_oauth_metadata = (
             await self._descovery_metadata(
                 server_url=server_url,  # type: ignore[arg-type]
-                allow_origin_fallback=auth_type == MCPAuth.oauth2,
+                allow_origin_fallback=auth_type in upstream_oauth_auth_types,
             )
             if needs_discovery
             else None

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -171,6 +171,16 @@ _user_env_vars_cache: dict[tuple[str, str], tuple[dict[str, str], float]] = {}
 _USER_ENV_VARS_CACHE_TTL = 60  # seconds
 _USER_ENV_VARS_CACHE_MAX_SIZE = 4096  # cap to prevent unbounded growth
 
+# Auth types whose upstream OAuth endpoints (protected-resource + authorization-server metadata) the
+# gateway discovers from the upstream itself: interactive oauth2 and the two client-forwarded modes.
+# OBO/M2M endpoint discovery is decided separately via _obo_needs_endpoint_discovery. Shared by the
+# config-YAML and DB server loaders so the two paths cannot drift on which modes trigger discovery.
+_UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES: tuple[MCPAuth, ...] = (
+    MCPAuth.oauth2,
+    MCPAuth.true_passthrough,
+    MCPAuth.oauth_delegate,
+)
+
 
 def invalidate_user_env_vars_cache(user_id: str, server_id: str) -> None:
     """Drop a cached entry after the user stores or clears their env var values
@@ -983,9 +993,8 @@ class MCPServerManager:
             )
 
             auth_type = server_config.get("auth_type", None)
-            config_upstream_oauth_auth_types = (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate)
             if server_url and (
-                auth_type in config_upstream_oauth_auth_types
+                auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES
                 or self._obo_needs_endpoint_discovery(
                     auth_type,
                     server_config.get("token_exchange_endpoint"),
@@ -994,7 +1003,7 @@ class MCPServerManager:
             ):
                 mcp_oauth_metadata = await self._descovery_metadata(
                     server_url=server_url,
-                    allow_origin_fallback=auth_type in config_upstream_oauth_auth_types,
+                    allow_origin_fallback=auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
                 )
             else:
                 mcp_oauth_metadata = None
@@ -1385,9 +1394,8 @@ class MCPServerManager:
 
         auth_type = cast(MCPAuthType, mcp_server.auth_type)
         server_url = mcp_server.url
-        upstream_oauth_auth_types = (MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate)
         needs_discovery = bool(server_url) and (
-            (auth_type in upstream_oauth_auth_types and not mcp_server.authorization_url)
+            (auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES and not mcp_server.authorization_url)
             or self._obo_needs_endpoint_discovery(
                 auth_type,
                 mcp_server.token_exchange_endpoint
@@ -1398,7 +1406,7 @@ class MCPServerManager:
         mcp_oauth_metadata = (
             await self._descovery_metadata(
                 server_url=server_url,  # type: ignore[arg-type]
-                allow_origin_fallback=auth_type in upstream_oauth_auth_types,
+                allow_origin_fallback=auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
             )
             if needs_discovery
             else None

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -69,6 +69,7 @@ if MCP_AVAILABLE:
     from mcp.types import Tool as MCPTool
 
     from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES,
         global_mcp_server_manager,
     )
     from litellm.proxy._experimental.mcp_server.oauth_utils import (
@@ -1325,11 +1326,9 @@ if MCP_AVAILABLE:
         # when the primary x-litellm-api-key header is absent, the Authorization value is the
         # caller's LiteLLM key, not an upstream token, and must never be forwarded upstream.
         oauth2_headers: Optional[Dict[str, str]] = None
-        if new_mcp_server_request.auth_type in {
-            MCPAuth.oauth2,
-            MCPAuth.true_passthrough,
-            MCPAuth.oauth_delegate,
-        } and headers.get(MCPRequestHandler.LITELLM_API_KEY_HEADER_NAME_PRIMARY):
+        if new_mcp_server_request.auth_type in _UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES and headers.get(
+            MCPRequestHandler.LITELLM_API_KEY_HEADER_NAME_PRIMARY
+        ):
             oauth2_headers = MCPRequestHandler._get_oauth2_headers_from_headers(headers)
 
         async def _list_tools_operation(client):

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1322,7 +1322,11 @@ if MCP_AVAILABLE:
                 mcp_auth_header = credentials.get("auth_value")
 
         oauth2_headers: Optional[Dict[str, str]] = None
-        if new_mcp_server_request.auth_type == MCPAuth.oauth2:
+        if new_mcp_server_request.auth_type in {
+            MCPAuth.oauth2,
+            MCPAuth.true_passthrough,
+            MCPAuth.oauth_delegate,
+        }:
             oauth2_headers = MCPRequestHandler._get_oauth2_headers_from_headers(headers)
 
         async def _list_tools_operation(client):

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -1321,12 +1321,15 @@ if MCP_AVAILABLE:
             if isinstance(credentials, dict):
                 mcp_auth_header = credentials.get("auth_value")
 
+        # Authorization doubles as the admission fallback (LITELLM_API_KEY_HEADER_NAME_SECONDARY):
+        # when the primary x-litellm-api-key header is absent, the Authorization value is the
+        # caller's LiteLLM key, not an upstream token, and must never be forwarded upstream.
         oauth2_headers: Optional[Dict[str, str]] = None
         if new_mcp_server_request.auth_type in {
             MCPAuth.oauth2,
             MCPAuth.true_passthrough,
             MCPAuth.oauth_delegate,
-        }:
+        } and headers.get(MCPRequestHandler.LITELLM_API_KEY_HEADER_NAME_PRIMARY):
             oauth2_headers = MCPRequestHandler._get_oauth2_headers_from_headers(headers)
 
         async def _list_tools_operation(client):

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -27,6 +27,7 @@ from typing import (
     Union,
     cast,
 )
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 from fastapi import FastAPI, HTTPException
@@ -103,6 +104,26 @@ _MAX_STATEFUL_SESSIONS_PER_OWNER = 100
 # prevents an authenticated client from forcing the proxy to buffer an
 # arbitrarily large body just to make a routing decision.
 _MCP_ROUTING_PEEK_MAX_BYTES = 4096
+
+
+def _redact_mcp_resource_url(url: Optional[str]) -> Optional[str]:
+    """Reduce an MCP server URL to its bare resource identifier for logging.
+
+    Keeps scheme, host, and path; drops userinfo (``user:pass@``), the query string,
+    and the fragment, so an upstream URL carrying an embedded token, userinfo, or a
+    secret query parameter never reaches spend-log metadata or logging callbacks.
+    Returns None when the URL has no host to identify (nothing safe to log).
+    """
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return None
+    if not parts.hostname:
+        return None
+    netloc = f"{parts.hostname}:{parts.port}" if parts.port else parts.hostname
+    return urlunsplit((parts.scheme, netloc, parts.path, "", "")) or None
 
 
 def _invalidate_byok_cred_cache(user_id: str, server_id: str) -> None:
@@ -3065,7 +3086,7 @@ if MCP_AVAILABLE:
                 namespaced_tool_name=namespaced_tool_name,
                 mcp_session_id=session_id,
                 mcp_auth_mode=mcp_server.auth_type,
-                mcp_server_resource=mcp_server.url,
+                mcp_server_resource=_redact_mcp_resource_url(mcp_server.url),
             )
         else:
             return StandardLoggingMCPToolCall(

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -107,11 +107,12 @@ _MCP_ROUTING_PEEK_MAX_BYTES = 4096
 
 
 def _redact_mcp_resource_url(url: Optional[str]) -> Optional[str]:
-    """Reduce an MCP server URL to its bare resource identifier for logging.
+    """Reduce an MCP server URL to its origin (scheme + host + port) for logging.
 
-    Keeps scheme, host, and path; drops userinfo (``user:pass@``), the query string,
-    and the fragment, so an upstream URL carrying an embedded token, userinfo, or a
-    secret query parameter never reaches spend-log metadata or logging callbacks.
+    Everything else is dropped: userinfo (``user:pass@``), the query string, the
+    fragment, and the path, because hosted MCP servers routinely embed the
+    credential in the path (e.g. ``/mcp/s/<token>``) and this value is persisted
+    in spend-log metadata that a caller who can invoke the tool can read back.
     Returns None when the URL has no host to identify (nothing safe to log).
     """
     if not isinstance(url, str) or not url:
@@ -123,7 +124,7 @@ def _redact_mcp_resource_url(url: Optional[str]) -> Optional[str]:
     if not parts.hostname:
         return None
     netloc = f"{parts.hostname}:{parts.port}" if parts.port else parts.hostname
-    return urlunsplit((parts.scheme, netloc, parts.path, "", "")) or None
+    return urlunsplit((parts.scheme, netloc, "", "", "")) or None
 
 
 def _invalidate_byok_cred_cache(user_id: str, server_id: str) -> None:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3064,6 +3064,8 @@ if MCP_AVAILABLE:
                 mcp_server_logo_url=mcp_info.get("logo_url"),
                 namespaced_tool_name=namespaced_tool_name,
                 mcp_session_id=session_id,
+                mcp_auth_mode=mcp_server.auth_type,
+                mcp_server_resource=mcp_server.url,
             )
         else:
             return StandardLoggingMCPToolCall(

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2523,6 +2523,20 @@ class StandardLoggingMCPToolCall(TypedDict, total=False):
     the client is driving a stateful session. Absent for stateless calls.
     """
 
+    mcp_auth_mode: Optional[str]
+    """
+    The server's auth_type for this call (e.g. `true_passthrough`, `oauth_delegate`,
+    `oauth2`). For the client-forwarded token modes this records that the caller's own
+    upstream token was relayed, so an audit can attribute a relayed request to its mode
+    without logging any credential.
+    """
+
+    mcp_server_resource: Optional[str]
+    """
+    The upstream MCP server URL (the RFC 8707 resource) the tool call was forwarded to.
+    Records which upstream received a relayed request; never a credential.
+    """
+
 
 class StandardLoggingVectorStoreRequest(TypedDict, total=False):
     """

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2533,7 +2533,9 @@ class StandardLoggingMCPToolCall(TypedDict, total=False):
 
     mcp_server_resource: Optional[str]
     """
-    The upstream MCP server URL (the RFC 8707 resource) the tool call was forwarded to.
+    The upstream MCP server resource identifier (scheme + host + path) the tool call was
+    forwarded to. Redacted for logging: userinfo, query string, and fragment are stripped so an
+    upstream URL carrying an embedded token or secret query parameter never reaches log metadata.
     Records which upstream received a relayed request; never a credential.
     """
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException
 
+from litellm.types.mcp import MCPAuth
+
 
 # Fixture to mock IP address check for all MCP tests
 # This prevents tests from failing due to IP-based access control
@@ -3401,6 +3403,83 @@ async def test_token_exchange_passes_through_upstream_expires_in():
         {"access_token": "tok", "token_type": "Bearer", "expires_in": 43200}
     )
     assert body["expires_in"] == 43200
+
+
+async def _exchange_persistence_attempted_for_auth_type(auth_type) -> bool:
+    """Run exchange_token_with_server for a server of ``auth_type`` and report whether it attempted
+    to persist the exchanged token server-side. The client-forwarded token modes must not persist:
+    their contract is that the upstream token stays browser-held, minted/stored/refreshed nowhere."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        exchange_token_with_server,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    server = MCPServer(
+        server_id="t",
+        name="t",
+        server_name="t",
+        alias="t",
+        transport=MCPTransport.http,
+        auth_type=auth_type,
+        client_id="cid",
+        client_secret="cs",
+        authorization_url="https://provider.com/oauth/authorize",
+        token_url="https://provider.com/oauth/token",
+    )
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    fake_http_response = MagicMock()
+    fake_http_response.json.return_value = {"access_token": "tok", "refresh_token": "r", "token_type": "Bearer"}
+    fake_http_response.raise_for_status = MagicMock()
+    fake_http_client = MagicMock()
+    fake_http_client.post = AsyncMock(return_value=fake_http_response)
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=fake_http_client,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._extract_user_id_from_request",
+            new_callable=AsyncMock,
+            return_value="admin-user",
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints._store_per_user_token_server_side",
+            new_callable=AsyncMock,
+        ) as mock_store,
+    ):
+        await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="c",
+            redirect_uri="http://127.0.0.1:3000/cb",
+            client_id="cid",
+            client_secret=None,
+            code_verifier=None,
+        )
+    return mock_store.await_count > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+async def test_token_exchange_does_not_persist_for_client_forwarded_modes(auth_type):
+    """The browser-only Authorize for true_passthrough / oauth_delegate must not write the upstream
+    token to the DB: these modes forward a browser-held token and persist nothing server-side."""
+    assert await _exchange_persistence_attempted_for_auth_type(auth_type) is False
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_persists_for_oauth2():
+    """Guard the test's own discriminator: a genuine oauth2 (authorization_code) server DOES persist,
+    so the passthrough no-persist assertion above is meaningful and not vacuously true."""
+    assert await _exchange_persistence_attempted_for_auth_type(MCPAuth.oauth2) is True
 
 
 # -------------------------------------------------------------------

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -120,6 +120,61 @@ async def test_authorize_endpoint_includes_response_type():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("auth_type_value", ["true_passthrough", "oauth_delegate"])
+async def test_authorize_endpoint_allows_client_forwarded_modes(auth_type_value):
+    """The browser-only Authorize relays the gateway authorize flow for the client-forwarded
+    token modes; the oauth2-only gate must let them through and redirect to the upstream IdP."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            authorize,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+        from litellm.proxy._types import MCPTransport
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    global_mcp_server_manager.registry.clear()
+
+    server = MCPServer(
+        server_id="test_cf_server",
+        name="test_cf",
+        server_name="test_cf",
+        alias="test_cf",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth(auth_type_value),
+        # Discovery stamps these onto the in-memory registry entry at build time.
+        authorization_url="https://provider.com/oauth/authorize",
+        token_url="https://provider.com/oauth/token",
+    )
+    global_mcp_server_manager.registry[server.server_id] = server
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    with patch("litellm.proxy._experimental.mcp_server.discoverable_endpoints.encrypt_value_helper") as mock_encrypt:
+        mock_encrypt.return_value = "mocked_encrypted_state"
+
+        response = await authorize(
+            request=mock_request,
+            client_id="dcr_client_id",
+            mcp_server_name="test_cf",
+            redirect_uri="http://127.0.0.1:60108/callback",
+            state="test_state",
+        )
+
+    assert response.status_code == 307
+    assert "https://provider.com/oauth/authorize" in response.headers["location"]
+    assert "client_id=dcr_client_id" in response.headers["location"]
+
+
+@pytest.mark.asyncio
 async def test_authorize_endpoint_preserves_existing_query_params():
     """Test that authorize endpoint merges OAuth params with existing query params in authorization_url"""
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6854,3 +6854,25 @@ async def test_call_tool_with_legacy_db_m2m_server_resolves_oauth2_flow():
     resolved = captured_servers["allowed"]
     assert resolved and resolved[0].oauth2_flow == "client_credentials"
     assert resolved[0].has_client_credentials is True
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        # userinfo + secret query param must both be stripped from the logged resource
+        ("https://user:s3cr3t@mcp.example.com/mcp?token=abcd1234&x=1", "https://mcp.example.com/mcp"),
+        ("https://mcp.example.com/mcp#frag", "https://mcp.example.com/mcp"),
+        ("https://host:8443/a/b?q=1", "https://host:8443/a/b"),
+        ("https://mcp.notion.com/mcp", "https://mcp.notion.com/mcp"),
+        (None, None),
+        ("", None),
+        ("not a url", None),
+    ],
+)
+def test_redact_mcp_resource_url_strips_credentials(url, expected):
+    """The MCP tool-call log records the upstream resource, so the URL must be redacted to
+    scheme+host+path: userinfo, query string, and fragment (which can carry embedded tokens or
+    secret parameters) must never reach spend-log metadata or logging callbacks."""
+    from litellm.proxy._experimental.mcp_server.server import _redact_mcp_resource_url
+
+    assert _redact_mcp_resource_url(url) == expected

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -6859,11 +6859,13 @@ async def test_call_tool_with_legacy_db_m2m_server_resolves_oauth2_flow():
 @pytest.mark.parametrize(
     "url, expected",
     [
-        # userinfo + secret query param must both be stripped from the logged resource
-        ("https://user:s3cr3t@mcp.example.com/mcp?token=abcd1234&x=1", "https://mcp.example.com/mcp"),
-        ("https://mcp.example.com/mcp#frag", "https://mcp.example.com/mcp"),
-        ("https://host:8443/a/b?q=1", "https://host:8443/a/b"),
-        ("https://mcp.notion.com/mcp", "https://mcp.notion.com/mcp"),
+        # only the origin may be logged: userinfo, query, fragment, and the PATH are all stripped,
+        # because hosted MCP servers routinely embed the credential in the path (e.g. /mcp/s/<token>)
+        ("https://user:s3cr3t@mcp.example.com/mcp?token=abcd1234&x=1", "https://mcp.example.com"),
+        ("https://mcp.example.com/mcp#frag", "https://mcp.example.com"),
+        ("https://host:8443/a/b?q=1", "https://host:8443"),
+        ("https://mcp.zapier.com/api/mcp/s/NDgzcret-token/mcp", "https://mcp.zapier.com"),
+        ("https://mcp.notion.com/mcp", "https://mcp.notion.com"),
         (None, None),
         ("", None),
         ("not a url", None),

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -833,6 +833,39 @@ class TestMCPServerManager:
         assert spec is not None and isinstance(spec.config, TokenExchangeConfig)
         assert spec.config.profile == "entra_obo"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+    async def test_build_from_table_discovers_upstream_oauth_for_client_forwarded_modes(self, auth_type):
+        """The gateway's relayed authorize flow (used by the browser-only Authorize) needs the
+        upstream's authorization_url on the registry entry, and these rows never persist one, so
+        the DB build must discover it the same way oauth2 rows do."""
+        from types import SimpleNamespace
+
+        manager = MCPServerManager()
+        row = LiteLLM_MCPServerTable(
+            server_id="cf-db-1",
+            alias="cf_db",
+            description="client-forwarded from db",
+            url="https://up.example.com/mcp",
+            transport=MCPTransport.http,
+            auth_type=auth_type,
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+
+        metadata = SimpleNamespace(
+            authorization_url="https://idp.example.com/authorize",
+            token_url="https://idp.example.com/token",
+            registration_url="https://idp.example.com/register",
+            scopes=None,
+        )
+        with patch.object(manager, "_descovery_metadata", new=AsyncMock(return_value=metadata)) as mock_discovery:
+            built = await manager.build_mcp_server_from_table(row, credentials_are_encrypted=False)
+
+        mock_discovery.assert_awaited_once()
+        assert built.authorization_url == "https://idp.example.com/authorize"
+        assert built.token_url == "https://idp.example.com/token"
+
     async def _capture_subject_token(self, call) -> Optional[str]:
         """Run a manager method (via ``call(manager)``) and return the subject_token it threaded
         into ``_create_mcp_client``."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -37,10 +37,7 @@ def _build_request(
         body_bytes = body
     else:
         body_bytes = b""
-    raw_headers = [
-        (key.lower().encode("latin-1"), value.encode("latin-1"))
-        for key, value in headers.items()
-    ]
+    raw_headers = [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers.items()]
     scope = {
         "type": "http",
         "http_version": "1.1",
@@ -62,25 +59,18 @@ def _build_request(
 
 def _get_route(path: str, method: str):
     for route in rest_endpoints.router.routes:
-        if getattr(route, "path", None) == path and method in getattr(
-            route, "methods", set()
-        ):
+        if getattr(route, "path", None) == path and method in getattr(route, "methods", set()):
             return route
     raise AssertionError(f"Route {method} {path} not found")
 
 
 def _route_has_dependency(route, dependency) -> bool:
-    if any(
-        getattr(dep, "dependency", None) == dependency
-        for dep in getattr(route, "dependencies", [])
-    ):
+    if any(getattr(dep, "dependency", None) == dependency for dep in getattr(route, "dependencies", [])):
         return True
     dependant = getattr(route, "dependant", None)
     if dependant is None:
         return False
-    return any(
-        getattr(dep, "call", None) == dependency for dep in dependant.dependencies
-    )
+    return any(getattr(dep, "call", None) == dependency for dep in dependant.dependencies)
 
 
 class TestExecuteWithMcpClient:
@@ -104,9 +94,7 @@ class TestExecuteWithMcpClient:
             auth_type=MCPAuth.none,
         )
 
-        result = await rest_endpoints._execute_with_mcp_client(
-            payload, failing_operation
-        )
+        result = await rest_endpoints._execute_with_mcp_client(payload, failing_operation)
 
         assert result["status"] == "error"
         assert "stack_trace" not in result
@@ -267,15 +255,10 @@ class TestExecuteWithMcpClient:
         assert result["status"] == "ok"
         # The incoming Authorization must be dropped — extra_headers should
         # contain no oauth2 headers (only static_headers, which are None here).
-        assert (
-            captured["extra_headers"] is None
-            or "Authorization" not in captured["extra_headers"]
-        )
+        assert captured["extra_headers"] is None or "Authorization" not in captured["extra_headers"]
 
     @pytest.mark.asyncio
-    async def test_interactive_oauth_resolves_forwarded_token_via_presented_store(
-        self, monkeypatch
-    ):
+    async def test_interactive_oauth_resolves_forwarded_token_via_presented_store(self, monkeypatch):
         """Interactive authorization_code preview (oauth2, no client credentials): the forwarded
         just-authorized token is resolved THROUGH the v2 resolver via a one-shot presented store
         (cred_provider), not the caller-override path. The bare token (Bearer stripped) is the
@@ -433,9 +416,7 @@ class TestExecuteWithMcpClient:
             return None
 
         async def fake_create_client(*args, **kwargs):
-            raise BaseExceptionGroup(
-                "test group", [RuntimeError("Cancelled via cancel scope")]
-            )
+            raise BaseExceptionGroup("test group", [RuntimeError("Cancelled via cancel scope")])
 
         monkeypatch.setattr(
             rest_endpoints.global_mcp_server_manager,
@@ -497,9 +478,7 @@ class TestTestToolsList:
                 "message": "Successfully retrieved tools",
             }
 
-        monkeypatch.setattr(
-            rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False
-        )
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
 
         oauth_call_counter = {"count": 0}
 
@@ -555,9 +534,7 @@ class TestTestToolsList:
                 "message": "Successfully retrieved tools",
             }
 
-        monkeypatch.setattr(
-            rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False
-        )
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
 
         oauth_headers = {"Authorization": "Bearer oauth"}
         oauth_call_counter = {"count": 0}
@@ -573,7 +550,7 @@ class TestTestToolsList:
             raising=False,
         )
 
-        request = _build_request({"authorization": "Bearer incoming"})
+        request = _build_request({"authorization": "Bearer incoming", "x-litellm-api-key": "sk-admission"})
         payload = NewMCPServerRequest(
             server_name="example",
             url="https://example.com",
@@ -627,7 +604,7 @@ class TestTestToolsList:
             raising=False,
         )
 
-        request = _build_request({"authorization": "Bearer upstream-token"})
+        request = _build_request({"authorization": "Bearer upstream-token", "x-litellm-api-key": "sk-admission"})
         payload = NewMCPServerRequest(
             server_name="example",
             url="https://example.com",
@@ -645,6 +622,48 @@ class TestTestToolsList:
         assert result["message"] == "Successfully retrieved tools"
         assert captured["mcp_auth_header"] is None
         assert captured["oauth2_headers"] == oauth_headers
+
+    @pytest.mark.parametrize("auth_type", [MCPAuth.oauth2, MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+    async def test_does_not_forward_authorization_that_satisfied_admission(self, monkeypatch, auth_type):
+        """Authorization is also the admission fallback: with no x-litellm-api-key on the request,
+        the Authorization value is the caller's LiteLLM key, so forwarding it would send the
+        admission credential to the upstream."""
+
+        captured: dict = {}
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            captured["oauth2_headers"] = oauth2_headers
+            return {
+                "tools": [],
+                "error": None,
+                "message": "Successfully retrieved tools",
+            }
+
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
+
+        request = _build_request({"authorization": "Bearer sk-litellm-admission-key"})
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=auth_type,
+        )
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["message"] == "Successfully retrieved tools"
+        assert captured["oauth2_headers"] is None
 
 
 class TestListToolsRestAPI:
@@ -775,9 +794,7 @@ class TestListToolsRestAPI:
         stub_server = StubServer()
         captured = {}
 
-        async def fake_get_tools(
-            server, server_auth_header, *args, apply_tool_filters=True, **kwargs
-        ):
+        async def fake_get_tools(server, server_auth_header, *args, apply_tool_filters=True, **kwargs):
             captured["apply_tool_filters"] = apply_tool_filters
             return ["tool-1"]
 
@@ -825,9 +842,7 @@ class TestListToolsRestAPI:
         assert captured["apply_tool_filters"] is True
 
     @pytest.mark.parametrize("upstream_status", [401, 403])
-    async def test_upstream_auth_failure_surfaces_status_and_challenge(
-        self, monkeypatch, upstream_status
-    ):
+    async def test_upstream_auth_failure_surfaces_status_and_challenge(self, monkeypatch, upstream_status):
         """A single-server pass-through request whose upstream rejects the token
         must surface the upstream status (401 or 403) plus its WWW-Authenticate
         challenge, not collapse into a 200 ``unexpected_error`` body."""
@@ -1415,9 +1430,7 @@ class TestListToolsRestAPI:
 
         oauth_headers = {"Authorization": "Bearer user-oauth-token"}
 
-        async def fake_get_user_oauth_extra_headers(
-            server, user_api_key_dict, prefetched_creds=None
-        ):
+        async def fake_get_user_oauth_extra_headers(server, user_api_key_dict, prefetched_creds=None):
             return oauth_headers
 
         captured = {}
@@ -1661,9 +1674,7 @@ class TestGetToolsForSingleServer:
 
     pytestmark = pytest.mark.asyncio
 
-    async def test_filters_tools_by_object_permission_mcp_tool_permissions(
-        self, monkeypatch
-    ):
+    async def test_filters_tools_by_object_permission_mcp_tool_permissions(self, monkeypatch):
         """Test that tools are filtered by user_api_key_auth.object_permission.mcp_tool_permissions"""
         from litellm.proxy._experimental.mcp_server.server import MCPServer
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
@@ -1826,9 +1837,7 @@ class TestGetToolsForSingleServer:
         # All tools should be returned
         assert len(result) == 2
 
-    async def test_no_filtering_when_server_not_in_mcp_tool_permissions(
-        self, monkeypatch
-    ):
+    async def test_no_filtering_when_server_not_in_mcp_tool_permissions(self, monkeypatch):
         """Test that all tools are returned when server is not in mcp_tool_permissions"""
         from litellm.proxy._experimental.mcp_server.server import MCPServer
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
@@ -1881,9 +1890,7 @@ class TestGetToolsForSingleServer:
         # All tools should be returned since server is not in permissions
         assert len(result) == 2
 
-    async def test_combines_server_allowed_tools_and_object_permission_filters(
-        self, monkeypatch
-    ):
+    async def test_combines_server_allowed_tools_and_object_permission_filters(self, monkeypatch):
         """Test that both server.allowed_tools and object_permission.mcp_tool_permissions filters are applied"""
         from litellm.proxy._experimental.mcp_server.server import MCPServer
         from litellm.proxy._types import LiteLLM_ObjectPermissionTable
@@ -2201,9 +2208,7 @@ class TestPreviewOpenAPITools:
                 "paths": {
                     "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs": {
                         "get": {
-                            "operationId": (
-                                "actions/download-job-logs-for-workflow-run"
-                            ),
+                            "operationId": ("actions/download-job-logs-for-workflow-run"),
                             "summary": "Download job logs",
                         }
                     },
@@ -2246,9 +2251,7 @@ class TestPreviewOpenAPITools:
         names = [t["name"] for t in result["tools"]]
         anthropic_re = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
         for name in names:
-            assert anthropic_re.match(
-                name
-            ), f"preview tool name {name!r} violates ^[a-zA-Z0-9_-]+$"
+            assert anthropic_re.match(name), f"preview tool name {name!r} violates ^[a-zA-Z0-9_-]+$"
         assert "actions_download-job-logs-for-workflow-run" in names
         assert "pulls_list-files" in names
 
@@ -2305,9 +2308,7 @@ class TestPreviewOpenAPITools:
 
         registered_summary_to_name: dict = {}
 
-        def fake_create_tool_function(
-            path, method, operation, base_url
-        ):  # noqa: ANN001
+        def fake_create_tool_function(path, method, operation, base_url):  # noqa: ANN001
             def _f():
                 return None
 
@@ -2320,9 +2321,7 @@ class TestPreviewOpenAPITools:
         )
 
         class _StubRegistry:
-            def register_tool(
-                self, name, description, input_schema, handler
-            ):  # noqa: ANN001
+            def register_tool(self, name, description, input_schema, handler):  # noqa: ANN001
                 registered_summary_to_name[description] = name
 
         monkeypatch.setattr(
@@ -2331,9 +2330,7 @@ class TestPreviewOpenAPITools:
             _StubRegistry(),
         )
 
-        openapi_to_mcp_generator.register_tools_from_openapi(
-            spec, base_url="https://example.invalid"
-        )
+        openapi_to_mcp_generator.register_tools_from_openapi(spec, base_url="https://example.invalid")
 
         assert preview_summary_to_name == registered_summary_to_name, (
             f"preview {preview_summary_to_name} != "
@@ -2361,15 +2358,11 @@ class TestConnectionErrorMessage:
         assert secret not in message
 
     def test_connect_error_points_at_reachability(self):
-        message = rest_endpoints._connection_error_message(
-            httpx.ConnectError("All connection attempts failed")
-        )
+        message = rest_endpoints._connection_error_message(httpx.ConnectError("All connection attempts failed"))
         assert "unreachable" in message.lower()
 
     def test_timeout_error_message(self):
-        message = rest_endpoints._connection_error_message(
-            httpx.ConnectTimeout("timed out")
-        )
+        message = rest_endpoints._connection_error_message(httpx.ConnectTimeout("timed out"))
         assert "unreachable" in message.lower()
 
     def test_http_status_error_includes_status_code(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -593,6 +593,59 @@ class TestTestToolsList:
         assert captured["oauth2_headers"] == oauth_headers
         assert oauth_call_counter["count"] == 1
 
+    @pytest.mark.parametrize("auth_type", [MCPAuth.true_passthrough, MCPAuth.oauth_delegate])
+    async def test_extracts_oauth2_headers_for_client_forwarded_modes(self, monkeypatch, auth_type):
+        """The browser-only authorize flow sends the upstream token as Authorization; the preview
+        must thread it through for the client-forwarded token modes so the passthrough arm can
+        forward it, instead of probing the upstream unauthenticated."""
+
+        captured: dict = {}
+
+        async def fake_execute(
+            request,
+            operation,
+            mcp_auth_header=None,
+            oauth2_headers=None,
+            raw_headers=None,
+        ):
+            captured["mcp_auth_header"] = mcp_auth_header
+            captured["oauth2_headers"] = oauth2_headers
+            return {
+                "tools": [],
+                "error": None,
+                "message": "Successfully retrieved tools",
+            }
+
+        monkeypatch.setattr(rest_endpoints, "_execute_with_mcp_client", fake_execute, raising=False)
+
+        oauth_headers = {"Authorization": "Bearer upstream-token"}
+
+        monkeypatch.setattr(
+            auth_mcp.MCPRequestHandler,
+            "_get_oauth2_headers_from_headers",
+            staticmethod(lambda headers: oauth_headers),
+            raising=False,
+        )
+
+        request = _build_request({"authorization": "Bearer upstream-token"})
+        payload = NewMCPServerRequest(
+            server_name="example",
+            url="https://example.com",
+            auth_type=auth_type,
+        )
+
+        from litellm.proxy._types import LitellmUserRoles
+
+        result = await rest_endpoints.test_tools_list(
+            request,
+            payload,
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+        )
+
+        assert result["message"] == "Successfully retrieved tools"
+        assert captured["mcp_auth_header"] is None
+        assert captured["oauth2_headers"] == oauth_headers
+
 
 class TestListToolsRestAPI:
     pytestmark = pytest.mark.asyncio

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
   "@typescript-eslint/no-explicit-any": 1982,
   "complexity": 128,
-  "local/no-large-inline-object-arg": 513,
+  "local/no-large-inline-object-arg": 512,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
   "@typescript-eslint/no-explicit-any": 1982,
   "complexity": 128,
-  "local/no-large-inline-object-arg": 519,
+  "local/no-large-inline-object-arg": 513,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { Button, Form, Input } from "antd";
+import { AUTH_TYPE } from "./types";
+
+interface PassthroughOAuthFlow {
+  startOAuthFlow: () => void | Promise<void>;
+  status: string;
+  error: string | null;
+  tokenResponse: { access_token?: string; expires_in?: number } | null;
+}
+
+/**
+ * Browser-only Authorize & Fetch for the client-forwarded token modes
+ * (true_passthrough / oauth_delegate). LiteLLM never stores upstream
+ * credentials for these modes, so the token obtained here lives in this
+ * browser session only: it is forwarded per-server for the tools preview and
+ * allowlist configuration, and is never written to the server row or the
+ * per-user credential store. The optional client credentials cover IdPs
+ * without dynamic client registration (e.g. a pre-registered Slack app) and
+ * ride the temporary authorize session only.
+ */
+export default function PassthroughAuthorizeSection({
+  authType,
+  oauthFlow,
+}: {
+  authType?: string | null;
+  oauthFlow: PassthroughOAuthFlow;
+}) {
+  if (authType !== AUTH_TYPE.TRUE_PASSTHROUGH && authType !== AUTH_TYPE.OAUTH_DELEGATE) return null;
+  return (
+    <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2 mb-4">
+      <p className="text-sm text-gray-600">
+        Callers bring their own upstream token for this auth type, so LiteLLM stores no upstream credentials. To preview
+        tools and configure the tool allowlist, authorize against the upstream here: the token stays in this browser
+        session only and is never saved to LiteLLM.
+      </p>
+      <Form.Item
+        label={<span className="text-sm font-medium text-gray-700">OAuth Client ID (optional, not saved)</span>}
+        name={["credentials", "client_id"]}
+        extra="Only needed when the upstream does not support dynamic client registration (e.g. a pre-registered Slack app). Used for this browser authorization only."
+      >
+        <Input.Password
+          placeholder="Leave blank to use dynamic client registration"
+          className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+        />
+      </Form.Item>
+      <Form.Item
+        label={<span className="text-sm font-medium text-gray-700">OAuth Client Secret (optional, not saved)</span>}
+        name={["credentials", "client_secret"]}
+      >
+        <Input.Password
+          placeholder="Leave blank for public clients / PKCE"
+          className="rounded-lg border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+        />
+      </Form.Item>
+      <Button
+        onClick={oauthFlow.startOAuthFlow}
+        disabled={oauthFlow.status === "authorizing" || oauthFlow.status === "exchanging"}
+      >
+        {oauthFlow.status === "authorizing"
+          ? "Waiting for authorization..."
+          : oauthFlow.status === "exchanging"
+            ? "Exchanging authorization code..."
+            : "Authorize & Fetch Tools (browser-only)"}
+      </Button>
+      {oauthFlow.error && <p className="text-sm text-red-500">{oauthFlow.error}</p>}
+      {oauthFlow.status === "success" && oauthFlow.tokenResponse?.access_token && (
+        <p className="text-sm text-green-600">
+          Token held for this browser session. Tools can now be previewed and configured; nothing was saved to LiteLLM.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/PassthroughAuthorizeSection.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Button, Form, Input } from "antd";
-import { AUTH_TYPE } from "./types";
+import { isClientForwardedTokenMode } from "./types";
 
 interface PassthroughOAuthFlow {
   startOAuthFlow: () => void | Promise<void>;
@@ -26,7 +26,12 @@ export default function PassthroughAuthorizeSection({
   authType?: string | null;
   oauthFlow: PassthroughOAuthFlow;
 }) {
-  if (authType !== AUTH_TYPE.TRUE_PASSTHROUGH && authType !== AUTH_TYPE.OAUTH_DELEGATE) return null;
+  if (!isClientForwardedTokenMode(authType)) return null;
+  const authorizeButtonLabels: Record<string, string> = {
+    authorizing: "Waiting for authorization...",
+    exchanging: "Exchanging authorization code...",
+  };
+  const authorizeButtonLabel = authorizeButtonLabels[oauthFlow.status] ?? "Authorize & Fetch Tools (browser-only)";
   return (
     <div className="rounded-lg border border-dashed border-gray-300 p-4 space-y-2 mb-4">
       <p className="text-sm text-gray-600">
@@ -57,11 +62,7 @@ export default function PassthroughAuthorizeSection({
         onClick={oauthFlow.startOAuthFlow}
         disabled={oauthFlow.status === "authorizing" || oauthFlow.status === "exchanging"}
       >
-        {oauthFlow.status === "authorizing"
-          ? "Waiting for authorization..."
-          : oauthFlow.status === "exchanging"
-            ? "Exchanging authorization code..."
-            : "Authorize & Fetch Tools (browser-only)"}
+        {authorizeButtonLabel}
       </Button>
       {oauthFlow.error && <p className="text-sm text-red-500">{oauthFlow.error}</p>}
       {oauthFlow.status === "success" && oauthFlow.tokenResponse?.access_token && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/TruePassthroughWarning.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/TruePassthroughWarning.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Alert } from "antd";
+import { AUTH_TYPE } from "./types";
+
+/**
+ * Warning shown in the create/edit MCP server forms when auth_type
+ * true_passthrough is selected: the gateway performs no admission auth for
+ * that server, so callers reach the upstream without a LiteLLM identity.
+ */
+export default function TruePassthroughWarning({ authType }: { authType?: string | null }) {
+  if (authType !== AUTH_TYPE.TRUE_PASSTHROUGH) return null;
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      className="mb-4 rounded-lg"
+      message="True Passthrough disables LiteLLM authentication for this server"
+      description="Anyone who can reach the gateway can call this server without a LiteLLM key. The caller's Authorization header is forwarded to the upstream verbatim, per-key and per-team rate limits and spend tracking do not apply, and the upstream is fully responsible for authenticating callers. Choose OAuth Delegate instead if callers should still authenticate to LiteLLM."
+    />
+  );
+}

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -189,6 +189,32 @@ describe("CreateMCPServer", () => {
       ).not.toBeInTheDocument();
     });
 
+    it.each([["True Passthrough (no LiteLLM auth)"], ["OAuth Delegate (client-supplied upstream token)"]])(
+      "should show the browser-only authorize section when %s is selected",
+      async (optionLabel) => {
+        await selectHttpTransport();
+
+        await selectAntOption("Authentication", optionLabel);
+
+        await waitFor(() => {
+          expect(screen.getByRole("button", { name: "Authorize & Fetch Tools (browser-only)" })).toBeInTheDocument();
+        });
+        expect(screen.getByText("OAuth Client ID (optional, not saved)")).toBeInTheDocument();
+        expect(screen.getByText("OAuth Client Secret (optional, not saved)")).toBeInTheDocument();
+      },
+    );
+
+    it("should not show the browser-only authorize section for API Key auth", async () => {
+      await selectHttpTransport();
+
+      await selectAntOption("Authentication", "API Key");
+
+      await waitFor(() => {
+        expect(screen.getByText("Authentication Value")).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("button", { name: "Authorize & Fetch Tools (browser-only)" })).not.toBeInTheDocument();
+    });
+
     it("should not require auth value when creating a server with API Key auth type", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -164,6 +164,31 @@ describe("CreateMCPServer", () => {
       });
     });
 
+    it("should warn that LiteLLM auth is disabled when True Passthrough is selected", async () => {
+      await selectHttpTransport();
+
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("True Passthrough disables LiteLLM authentication for this server"),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("should not show the True Passthrough warning when OAuth Delegate is selected", async () => {
+      await selectHttpTransport();
+
+      await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+
+      await waitFor(() => {
+        expect(screen.getAllByText("OAuth Delegate (client-supplied upstream token)").length).toBeGreaterThan(0);
+      });
+      expect(
+        screen.queryByText("True Passthrough disables LiteLLM authentication for this server"),
+      ).not.toBeInTheDocument();
+    });
+
     it("should not require auth value when creating a server with API Key auth type", async () => {
       await selectHttpTransport();
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -30,6 +30,7 @@ const oauthHook = vi.hoisted(() => ({
   onTokenReceived: null as
     | ((token: Record<string, unknown> | null, registeredClient?: { clientId?: string; clientSecret?: string }) => void)
     | null,
+  getCredentials: null as (() => Record<string, unknown> | undefined) | null,
 }));
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
   useMcpOAuthFlow: (opts: {
@@ -37,8 +38,10 @@ vi.mock("@/hooks/useMcpOAuthFlow", () => ({
       token: Record<string, unknown> | null,
       registeredClient?: { clientId?: string; clientSecret?: string },
     ) => void;
+    getCredentials?: () => Record<string, unknown> | undefined;
   }) => {
     oauthHook.onTokenReceived = opts.onTokenReceived;
+    oauthHook.getCredentials = opts.getCredentials ?? null;
     return {
       startOAuthFlow: vi.fn(),
       status: "idle",
@@ -347,6 +350,28 @@ describe("CreateMCPServer", () => {
       const [token, payload] = vi.mocked(networking.createMCPServer).mock.calls[0];
       expect(token).toBe("test-token");
       expect(payload.credentials).toEqual({ auth_value: "my-secret-key" });
+    });
+
+    it("does not write the browser-authorized token into form.credentials for true_passthrough", async () => {
+      await selectHttpTransport();
+
+      const user = userEvent.setup({ delay: null });
+      await user.type(getServerNameInput(), "PT_Server");
+      await user.type(screen.getByPlaceholderText("https://your-mcp-server.com"), "https://example.com/mcp");
+
+      await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+      // Simulate the browser Authorize & Fetch flow handing back an upstream token.
+      await waitFor(() => expect(oauthHook.onTokenReceived).toBeTruthy());
+      await act(async () => {
+        oauthHook.onTokenReceived!({ access_token: "upstream-tok", token_type: "Bearer" }, undefined);
+      });
+
+      // For a browser-only mode the token must never land in form.credentials, which the OAuth flow's
+      // getCredentials reads for preview requests and the redirect-persist cache serializes. Without
+      // the guard, onTokenReceived writes it here and this returns { access_token: "upstream-tok" }.
+      const credentials = oauthHook.getCredentials?.() ?? {};
+      expect(credentials.access_token).toBeUndefined();
     });
 
     it("should not show auth value field when None auth type is selected", async () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -200,23 +200,36 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     onTokenReceived: (token, registeredClient) => {
       setOauthAccessToken(token?.access_token ?? null);
 
-      if (token?.access_token) {
-        const credentials = {
-          access_token: token.access_token,
-          ...(token.refresh_token && { refresh_token: token.refresh_token }),
-          ...(token.expires_in && { expires_in: token.expires_in }),
-          ...(token.scope && { scope: token.scope }),
-          ...(registeredClient?.clientId && { client_id: registeredClient.clientId }),
-          ...(registeredClient?.clientSecret && { client_secret: registeredClient.clientSecret }),
-        };
-
-        form.setFieldsValue({ credentials });
-        setAuthorizedUrl(getOAuthAuthorizationTarget(form.getFieldsValue(true)));
-
-        NotificationsManager.success(
-          "OAuth authorization successful! Please click 'Create MCP Server' to save the configuration.",
-        );
+      if (!token?.access_token) {
+        return;
       }
+
+      if (isClientForwardedTokenMode(form.getFieldValue("auth_type"))) {
+        // Browser-only modes: the token is held in local state (oauthAccessToken) for tool preview
+        // and committed to sessionStorage on submit; it must never be written into form.credentials,
+        // which would persist it as server-level credentials on the created server row. Mirrors the
+        // edit form's onTokenReceived early return.
+        NotificationsManager.success(
+          "Token held for this browser session. Tools can now be previewed and configured; nothing will be saved to LiteLLM.",
+        );
+        return;
+      }
+
+      const credentials = {
+        access_token: token.access_token,
+        ...(token.refresh_token && { refresh_token: token.refresh_token }),
+        ...(token.expires_in && { expires_in: token.expires_in }),
+        ...(token.scope && { scope: token.scope }),
+        ...(registeredClient?.clientId && { client_id: registeredClient.clientId }),
+        ...(registeredClient?.clientSecret && { client_secret: registeredClient.clientSecret }),
+      };
+
+      form.setFieldsValue({ credentials });
+      setAuthorizedUrl(getOAuthAuthorizationTarget(form.getFieldsValue(true)));
+
+      NotificationsManager.success(
+        "OAuth authorization successful! Please click 'Create MCP Server' to save the configuration.",
+      );
     },
     onBeforeRedirect: persistCreateUiState,
     flowSource: "create",

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -137,20 +137,18 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
     }
     try {
       const values = form.getFieldsValue(true);
-      setSecureItem(
-        CREATE_OAUTH_UI_STATE_KEY,
-        JSON.stringify({
-          modalVisible: isModalVisible,
-          formValues: values,
-          transportType,
-          costConfig,
-          allowedTools,
-          hasToolAllowlistInteraction,
-          searchValue,
-          aliasManuallyEdited,
-          logoUrl,
-        }),
-      );
+      const uiState = {
+        modalVisible: isModalVisible,
+        formValues: values,
+        transportType,
+        costConfig,
+        allowedTools,
+        hasToolAllowlistInteraction,
+        searchValue,
+        aliasManuallyEdited,
+        logoUrl,
+      };
+      setSecureItem(CREATE_OAUTH_UI_STATE_KEY, JSON.stringify(uiState));
     } catch (err) {
       console.warn("Failed to persist MCP create state", err);
     }
@@ -510,23 +508,21 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
           });
           if (oauthMode === "authorization_code") {
             const scope = oauthTokenResponse.scope;
-            await storeMCPOAuthUserCredential(accessToken, response.server_id, {
+            const oauthCredentialPayload = {
               access_token: oauthTokenResponse.access_token,
               refresh_token: oauthTokenResponse.refresh_token,
               expires_in: oauthTokenResponse.expires_in,
               scopes: typeof scope === "string" && scope ? scope.split(" ") : undefined,
-            });
+            };
+            await storeMCPOAuthUserCredential(accessToken, response.server_id, oauthCredentialPayload);
           } else {
-            setToken(
-              response.server_id,
-              {
-                access_token: oauthTokenResponse.access_token,
-                expires_in: oauthTokenResponse.expires_in,
-                refresh_token: oauthTokenResponse.refresh_token,
-                token_type: oauthTokenResponse.token_type,
-              },
-              userID,
-            );
+            const browserHeldToken = {
+              access_token: oauthTokenResponse.access_token,
+              expires_in: oauthTokenResponse.expires_in,
+              refresh_token: oauthTokenResponse.refresh_token,
+              token_type: oauthTokenResponse.token_type,
+            };
+            setToken(response.server_id, browserHeldToken, userID);
           }
         }
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -184,7 +184,10 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         description: values.description,
         url,
         transport: transport === TRANSPORT.OPENAPI ? "http" : transport,
-        auth_type: AUTH_TYPE.OAUTH2,
+        auth_type:
+          values.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || values.auth_type === AUTH_TYPE.OAUTH_DELEGATE
+            ? values.auth_type
+            : AUTH_TYPE.OAUTH2,
         credentials: values.credentials,
         authorization_url: values.authorization_url,
         token_url: values.token_url,

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -17,6 +17,7 @@ import {
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import TruePassthroughWarning from "./TruePassthroughWarning";
+import PassthroughAuthorizeSection from "./PassthroughAuthorizeSection";
 import TokenExchangeFormFields from "./TokenExchangeFormFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPConnectionStatus from "./mcp_connection_status";
@@ -979,6 +980,16 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                         </Form.Item>
 
                         <TruePassthroughWarning authType={authType} />
+
+                        <PassthroughAuthorizeSection
+                          authType={authType}
+                          oauthFlow={{
+                            startOAuthFlow,
+                            status: oauthStatus,
+                            error: oauthError,
+                            tokenResponse: oauthTokenResponse,
+                          }}
+                        />
 
                         {shouldShowAuthValueField && (
                           <Form.Item

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -16,6 +16,7 @@ import {
   MCP_OAUTH2_FLOW_INTERACTIVE,
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
+import TruePassthroughWarning from "./TruePassthroughWarning";
 import TokenExchangeFormFields from "./TokenExchangeFormFields";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPConnectionStatus from "./mcp_connection_status";
@@ -970,8 +971,14 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
                             <Select.Option value="oauth2">OAuth</Select.Option>
                             <Select.Option value="oauth2_token_exchange">OAuth Token Exchange (OBO)</Select.Option>
                             <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
+                            <Select.Option value="true_passthrough">True Passthrough (no LiteLLM auth)</Select.Option>
+                            <Select.Option value="oauth_delegate">
+                              OAuth Delegate (client-supplied upstream token)
+                            </Select.Option>
                           </Select>
                         </Form.Item>
+
+                        <TruePassthroughWarning authType={authType} />
 
                         {shouldShowAuthValueField && (
                           <Form.Item

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -14,6 +14,7 @@ import {
   getMcpOAuthMode,
   MCP_OAUTH2_FLOW_M2M,
   MCP_OAUTH2_FLOW_INTERACTIVE,
+  isClientForwardedTokenMode,
 } from "./types";
 import OAuthFormFields from "./OAuthFormFields";
 import TruePassthroughWarning from "./TruePassthroughWarning";
@@ -184,10 +185,7 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
         description: values.description,
         url,
         transport: transport === TRANSPORT.OPENAPI ? "http" : transport,
-        auth_type:
-          values.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || values.auth_type === AUTH_TYPE.OAUTH_DELEGATE
-            ? values.auth_type
-            : AUTH_TYPE.OAUTH2,
+        auth_type: isClientForwardedTokenMode(values.auth_type) ? values.auth_type : AUTH_TYPE.OAUTH2,
         credentials: values.credentials,
         authorization_url: values.authorization_url,
         token_url: values.token_url,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -922,6 +922,55 @@ describe("MCPServerEdit (tool list fetch)", () => {
     expect(mockGetToken).toHaveBeenCalledWith("oauth_server_1", "user-1");
   });
 
+  it("forwards the sessionStorage token as the x-mcp header for an oauth_delegate server", async () => {
+    mockIsTokenValid.mockReturnValue(true);
+    mockGetToken.mockReturnValue({ access_token: "browser-token" });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, auth_type: "oauth_delegate" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(networking.listMCPTools).toHaveBeenCalledWith(
+        "access-token",
+        "oauth_server_1",
+        { "x-mcp-oauth_server-authorization": "Bearer browser-token" },
+        true,
+      );
+    });
+    expect(mockGetToken).toHaveBeenCalledWith("oauth_server_1", "user-1");
+  });
+
+  it("prompts for the browser-only authorize when a true_passthrough server has no token", async () => {
+    mockIsTokenValid.mockReturnValue(false);
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, auth_type: "true_passthrough" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("mcp-tool-config").getAttribute("data-external-error")).toContain(
+        "Authorize with the upstream (browser-only",
+      );
+    });
+    expect(networking.listMCPTools).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Authorize & Fetch Tools (browser-only)" })).toBeInTheDocument();
+  });
+
   it("uses the staged OAuth token to load passthrough tools after authorize", async () => {
     const passthroughServer = { ...interactiveOAuthServer, delegate_auth_to_upstream: true };
     mockIsTokenValid.mockReturnValue(false);

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -1173,6 +1173,76 @@ describe("MCPServerEdit (OAuth token persistence on save)", () => {
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
+  it.each([["true_passthrough"], ["oauth_delegate"]])(
+    "persists the staged token to sessionStorage on save for the %s mode",
+    async (authType) => {
+      // Regression: the save path classified the staged token with getMcpOAuthMode, which returns
+      // null for the client-forwarded modes, so setToken was never called and the browser-held
+      // token was dropped on save; the create form's submit path already committed it.
+      mockOauth.tokenResponse = { access_token: "cf-tok", expires_in: 1800, token_type: "bearer" };
+      vi.mocked(networking.updateMCPServer).mockResolvedValue({
+        ...interactiveOAuthServer,
+        auth_type: authType,
+      });
+
+      render(
+        <MCPServerEdit
+          mcpServer={{ ...interactiveOAuthServer, auth_type: authType }}
+          accessToken="access-token"
+          userID="user-1"
+          onCancel={vi.fn()}
+          onSuccess={vi.fn()}
+          availableAccessGroups={[]}
+        />,
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getAllByRole("button", { name: "Save Changes" })[0]);
+      });
+
+      await waitFor(() => {
+        expect(mockSetToken).toHaveBeenCalledWith(
+          "oauth_server_1",
+          expect.objectContaining({ access_token: "cf-tok" }),
+          "user-1",
+        );
+      });
+      expect(networking.storeMCPOAuthUserCredential).not.toHaveBeenCalled();
+      const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+      expect(payload.credentials).toBeUndefined();
+    },
+  );
+
+  it("forwards a newly authorized browser-held token for tool loading before the form is saved", async () => {
+    // Regression: fetchTools keyed the browser-held decision off the saved mcpServer.auth_type, so
+    // after switching the form to true_passthrough and authorizing, the fresh token was not sent as
+    // the x-mcp header until the server was saved.
+    vi.mocked(networking.listMCPTools).mockResolvedValue({ tools: [], error: null });
+    mockIsTokenValid.mockReturnValue(false);
+
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, auth_type: "api_key" }}
+        accessToken="access-token"
+        userID="user-1"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await selectAntOption("Authentication", "OAuth Delegate (client-supplied upstream token)");
+    mockOauth.tokenResponse = { access_token: "fresh-tok", token_type: "bearer" };
+    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+    await waitFor(() => {
+      const withHeaders = vi
+        .mocked(networking.listMCPTools)
+        .mock.calls.find(([, , headers]) => headers && JSON.stringify(headers).includes("fresh-tok"));
+      expect(withHeaders).toBeTruthy();
+    });
+  });
+
   it("persists the passthrough token to sessionStorage on save after authorize", async () => {
     mockOauth.tokenResponse = { access_token: "pt-tok", expires_in: 1800, token_type: "bearer" };
     vi.mocked(networking.updateMCPServer).mockResolvedValue({

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -19,14 +19,20 @@ vi.mock("../molecules/notifications_manager", () => ({
   },
 }));
 
-const mockOauth: { tokenResponse: any } = { tokenResponse: null };
+const mockOauth: {
+  tokenResponse: any;
+  getTemporaryPayload: (() => Record<string, unknown> | null) | null;
+} = { tokenResponse: null, getTemporaryPayload: null };
 vi.mock("@/hooks/useMcpOAuthFlow", () => ({
-  useMcpOAuthFlow: () => ({
-    startOAuthFlow: vi.fn(),
-    status: "idle",
-    error: null,
-    tokenResponse: mockOauth.tokenResponse,
-  }),
+  useMcpOAuthFlow: (opts: { getTemporaryPayload?: () => Record<string, unknown> | null }) => {
+    mockOauth.getTemporaryPayload = opts?.getTemporaryPayload ?? null;
+    return {
+      startOAuthFlow: vi.fn(),
+      status: "idle",
+      error: null,
+      tokenResponse: mockOauth.tokenResponse,
+    };
+  },
 }));
 
 vi.mock("./mcp_server_cost_config", () => ({
@@ -343,6 +349,30 @@ describe("MCPServerEdit (true passthrough warning)", () => {
     expect(
       screen.queryByText("True Passthrough disables LiteLLM authentication for this server"),
     ).not.toBeInTheDocument();
+  });
+
+  it("browser-authorize temp payload uses the selected auth_type, not the stored one", async () => {
+    // Stored server is oauth2; the admin switches the dropdown to true_passthrough before saving.
+    // The temp OAuth-relay payload must reflect the selection so the exchange is treated as
+    // browser-held (no DB persistence), matching onTokenReceived and the create form.
+    render(
+      <MCPServerEdit
+        mcpServer={{ ...interactiveOAuthServer, auth_type: "oauth2" }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await selectAntOption("Authentication", "True Passthrough (no LiteLLM auth)");
+
+    await waitFor(() => {
+      expect(mockOauth.getTemporaryPayload).toBeTruthy();
+    });
+    const payload = mockOauth.getTemporaryPayload!();
+    expect(payload).toBeTruthy();
+    expect(payload?.auth_type).toBe("true_passthrough");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.test.tsx
@@ -307,6 +307,45 @@ describe("MCPServerEdit (delegate auth)", () => {
   });
 });
 
+describe("MCPServerEdit (true passthrough warning)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const renderWithAuthType = (authType: string) =>
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          auth_type: authType,
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+  it("warns that LiteLLM auth is disabled for a true_passthrough server", async () => {
+    renderWithAuthType("true_passthrough");
+
+    await waitFor(() => {
+      expect(screen.getByText("True Passthrough disables LiteLLM authentication for this server")).toBeInTheDocument();
+    });
+  });
+
+  it("does not warn for an oauth_delegate server", async () => {
+    renderWithAuthType("oauth_delegate");
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Save Changes" }).length).toBeGreaterThan(0);
+    });
+    expect(
+      screen.queryByText("True Passthrough disables LiteLLM authentication for this server"),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe("MCPServerEdit (auth type switch)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -131,6 +131,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
     }
   };
 
+  // The auth mode every decision must key off: the admin's in-flight form selection wins over the
+  // saved record, so authorizing, loading tools, and saving all agree with what the form shows. Paths
+  // that read only mcpServer.auth_type go stale the moment the admin switches modes in the form.
+  const getEffectiveAuthType = () => form.getFieldValue("auth_type") ?? mcpServer.auth_type;
+
   const {
     startOAuthFlow,
     status: oauthStatus,
@@ -178,8 +183,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         return;
       }
 
-      const effectiveAuthType = form.getFieldValue("auth_type") ?? mcpServer.auth_type;
-      if (isClientForwardedTokenMode(effectiveAuthType)) {
+      if (isClientForwardedTokenMode(getEffectiveAuthType())) {
         const browserHeldToken = {
           access_token: token.access_token,
           expires_in: token.expires_in,
@@ -388,7 +392,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         oauth2_flow: mcpServer.oauth2_flow,
         delegate_auth_to_upstream: mcpServer.delegate_auth_to_upstream,
       }) === "passthrough";
-    const isBrowserHeldTokenMode = isClientForwardedTokenMode(mcpServer.auth_type);
+    const isBrowserHeldTokenMode = isClientForwardedTokenMode(getEffectiveAuthType());
     if (isPassthrough || isBrowserHeldTokenMode) {
       const token =
         oauthTokenResponse?.access_token ??
@@ -749,8 +753,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       const updated = await updateMCPServer(accessToken, payload);
 
       // Persist the token staged via "Authorize & Fetch" (mirrors the create flow's
-      // commit-on-submit): OBO writes the per-user token to the DB, passthrough keeps
-      // it in sessionStorage. M2M/static auth resolve server-side and need neither.
+      // commit-on-submit): OBO writes the per-user token to the DB; legacy passthrough and the
+      // client-forwarded modes (true_passthrough / oauth_delegate) keep it in sessionStorage and
+      // never in the server row. M2M/static auth resolve server-side and need neither.
       if (oauthTokenResponse?.access_token) {
         const oauthMode = getMcpOAuthMode({
           auth_type: restValues.auth_type,
@@ -767,7 +772,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
               scopes: typeof scope === "string" && scope ? scope.split(" ") : undefined,
             };
             await storeMCPOAuthUserCredential(accessToken, mcpServer.server_id, oauthCredentialPayload);
-          } else if (oauthMode === "passthrough") {
+          } else if (oauthMode === "passthrough" || isClientForwardedTokenMode(restValues.auth_type)) {
             const browserHeldToken = {
               access_token: oauthTokenResponse.access_token,
               expires_in: oauthTokenResponse.expires_in,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -180,16 +180,13 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
 
       const effectiveAuthType = form.getFieldValue("auth_type") ?? mcpServer.auth_type;
       if (isClientForwardedTokenMode(effectiveAuthType)) {
-        setToken(
-          mcpServer.server_id,
-          {
-            access_token: token.access_token,
-            expires_in: token.expires_in,
-            refresh_token: token.refresh_token,
-            token_type: token.token_type,
-          },
-          userID,
-        );
+        const browserHeldToken = {
+          access_token: token.access_token,
+          expires_in: token.expires_in,
+          refresh_token: token.refresh_token,
+          token_type: token.token_type,
+        };
+        setToken(mcpServer.server_id, browserHeldToken, userID);
         NotificationsManager.success(
           "Token held for this browser session. Tools can now be loaded and configured; nothing was saved to LiteLLM.",
         );
@@ -467,7 +464,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
   const handleTransportChange = (value: string) => {
     // Clear fields that are not relevant for the selected transport.
     if (value === "stdio") {
-      form.setFieldsValue({
+      const clearedForStdio = {
         url: undefined,
         spec_path: undefined,
         auth_type: undefined,
@@ -475,15 +472,17 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         authorization_url: undefined,
         token_url: undefined,
         registration_url: undefined,
-      });
+      };
+      form.setFieldsValue(clearedForStdio);
     } else if (value === TRANSPORT.OPENAPI) {
-      form.setFieldsValue({
+      const clearedForOpenapi = {
         url: undefined,
         command: undefined,
         args: undefined,
         env_json: undefined,
         stdio_config: undefined,
-      });
+      };
+      form.setFieldsValue(clearedForOpenapi);
     } else {
       form.setFieldsValue({
         spec_path: undefined,
@@ -761,23 +760,21 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         try {
           if (oauthMode === "authorization_code") {
             const scope = oauthTokenResponse.scope;
-            await storeMCPOAuthUserCredential(accessToken, mcpServer.server_id, {
+            const oauthCredentialPayload = {
               access_token: oauthTokenResponse.access_token,
               refresh_token: oauthTokenResponse.refresh_token,
               expires_in: oauthTokenResponse.expires_in,
               scopes: typeof scope === "string" && scope ? scope.split(" ") : undefined,
-            });
+            };
+            await storeMCPOAuthUserCredential(accessToken, mcpServer.server_id, oauthCredentialPayload);
           } else if (oauthMode === "passthrough") {
-            setToken(
-              mcpServer.server_id,
-              {
-                access_token: oauthTokenResponse.access_token,
-                expires_in: oauthTokenResponse.expires_in,
-                refresh_token: oauthTokenResponse.refresh_token,
-                token_type: oauthTokenResponse.token_type,
-              },
-              userID,
-            );
+            const browserHeldToken = {
+              access_token: oauthTokenResponse.access_token,
+              expires_in: oauthTokenResponse.expires_in,
+              refresh_token: oauthTokenResponse.refresh_token,
+              token_type: oauthTokenResponse.token_type,
+            };
+            setToken(mcpServer.server_id, browserHeldToken, userID);
           }
         } catch (error: unknown) {
           const message = error instanceof Error ? error.message : "";

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -19,6 +19,7 @@ import { buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
 import TruePassthroughWarning from "./TruePassthroughWarning";
+import PassthroughAuthorizeSection from "./PassthroughAuthorizeSection";
 import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
 import TokenExchangeFormFields from "./TokenExchangeFormFields";
@@ -172,20 +173,40 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       };
     },
     onTokenReceived: (token) => {
-      if (token?.access_token) {
-        const credentials = {
-          access_token: token.access_token,
-          ...(token.refresh_token && { refresh_token: token.refresh_token }),
-          ...(token.expires_in && { expires_in: token.expires_in }),
-          ...(token.scope && { scope: token.scope }),
-        };
-
-        form.setFieldsValue({ credentials });
-
-        NotificationsManager.success(
-          "OAuth authorization successful! Please click 'Update MCP Server' to save the credentials.",
-        );
+      if (!token?.access_token) {
+        return;
       }
+
+      const effectiveAuthType = form.getFieldValue("auth_type") ?? mcpServer.auth_type;
+      if (effectiveAuthType === AUTH_TYPE.TRUE_PASSTHROUGH || effectiveAuthType === AUTH_TYPE.OAUTH_DELEGATE) {
+        setToken(
+          mcpServer.server_id,
+          {
+            access_token: token.access_token,
+            expires_in: token.expires_in,
+            refresh_token: token.refresh_token,
+            token_type: token.token_type,
+          },
+          userID,
+        );
+        NotificationsManager.success(
+          "Token held for this browser session. Tools can now be loaded and configured; nothing was saved to LiteLLM.",
+        );
+        return;
+      }
+
+      const credentials = {
+        access_token: token.access_token,
+        ...(token.refresh_token && { refresh_token: token.refresh_token }),
+        ...(token.expires_in && { expires_in: token.expires_in }),
+        ...(token.scope && { scope: token.scope }),
+      };
+
+      form.setFieldsValue({ credentials });
+
+      NotificationsManager.success(
+        "OAuth authorization successful! Please click 'Update MCP Server' to save the credentials.",
+      );
     },
     onBeforeRedirect: persistEditUiState,
     flowSource: "edit",
@@ -369,7 +390,9 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         oauth2_flow: mcpServer.oauth2_flow,
         delegate_auth_to_upstream: mcpServer.delegate_auth_to_upstream,
       }) === "passthrough";
-    if (isPassthrough) {
+    const isBrowserHeldTokenMode =
+      mcpServer.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || mcpServer.auth_type === AUTH_TYPE.OAUTH_DELEGATE;
+    if (isPassthrough || isBrowserHeldTokenMode) {
       const token =
         oauthTokenResponse?.access_token ??
         (isTokenValid(mcpServer.server_id, userID)
@@ -377,7 +400,11 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
           : null);
       if (!token) {
         setTools([]);
-        setToolsError("Authenticate with this server in the Tools tab to load and configure its tools.");
+        setToolsError(
+          isBrowserHeldTokenMode
+            ? "Authorize with the upstream (browser-only, in the Authentication section) to load and configure this server's tools."
+            : "Authenticate with this server in the Tools tab to load and configure its tools.",
+        );
         return;
       }
       customHeaders = buildMcpPassthroughAuthHeader(mcpServer.alias, token);
@@ -893,6 +920,15 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
                   </Select>
                 </Form.Item>
                 <TruePassthroughWarning authType={authType} />
+                <PassthroughAuthorizeSection
+                  authType={authType}
+                  oauthFlow={{
+                    startOAuthFlow,
+                    status: oauthStatus,
+                    error: oauthError,
+                    tokenResponse: oauthTokenResponse,
+                  }}
+                />
               </>
             )}
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -18,6 +18,7 @@ import { getToken, isTokenValid, setToken } from "@/utils/mcpTokenStore";
 import { buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
 import MCPServerCostConfig from "./mcp_server_cost_config";
 import MCPPermissionManagement from "./MCPPermissionManagement";
+import TruePassthroughWarning from "./TruePassthroughWarning";
 import MCPToolConfiguration from "./mcp_tool_configuration";
 import StdioConfiguration from "./StdioConfiguration";
 import TokenExchangeFormFields from "./TokenExchangeFormFields";
@@ -874,18 +875,25 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
 
             {/* Authentication - for HTTP, SSE, and OpenAPI */}
             {!isStdioTransport && (
-              <Form.Item label="Authentication" name="auth_type" rules={[{ required: true }]}>
-                <Select>
-                  <Select.Option value="none">None</Select.Option>
-                  <Select.Option value="api_key">API Key</Select.Option>
-                  <Select.Option value="bearer_token">Bearer Token</Select.Option>
-                  <Select.Option value="token">Token</Select.Option>
-                  <Select.Option value="basic">Basic Auth</Select.Option>
-                  <Select.Option value="oauth2">OAuth</Select.Option>
-                  <Select.Option value="oauth2_token_exchange">OAuth Token Exchange (OBO)</Select.Option>
-                  <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
-                </Select>
-              </Form.Item>
+              <>
+                <Form.Item label="Authentication" name="auth_type" rules={[{ required: true }]}>
+                  <Select>
+                    <Select.Option value="none">None</Select.Option>
+                    <Select.Option value="api_key">API Key</Select.Option>
+                    <Select.Option value="bearer_token">Bearer Token</Select.Option>
+                    <Select.Option value="token">Token</Select.Option>
+                    <Select.Option value="basic">Basic Auth</Select.Option>
+                    <Select.Option value="oauth2">OAuth</Select.Option>
+                    <Select.Option value="oauth2_token_exchange">OAuth Token Exchange (OBO)</Select.Option>
+                    <Select.Option value="aws_sigv4">AWS SigV4 (Bedrock AgentCore MCPs)</Select.Option>
+                    <Select.Option value="true_passthrough">True Passthrough (no LiteLLM auth)</Select.Option>
+                    <Select.Option value="oauth_delegate">
+                      OAuth Delegate (client-supplied upstream token)
+                    </Select.Option>
+                  </Select>
+                </Form.Item>
+                <TruePassthroughWarning authType={authType} />
+              </>
             )}
 
             {isStdioTransport && (

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -164,8 +164,8 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         url,
         transport,
         auth_type:
-          mcpServer.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || mcpServer.auth_type === AUTH_TYPE.OAUTH_DELEGATE
-            ? mcpServer.auth_type
+          values.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || values.auth_type === AUTH_TYPE.OAUTH_DELEGATE
+            ? values.auth_type
             : AUTH_TYPE.OAUTH2,
         credentials: values.credentials,
         mcp_access_groups: values.mcp_access_groups || mcpServer.mcp_access_groups,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -4,6 +4,7 @@ import { InfoCircleOutlined } from "@ant-design/icons";
 import { Button, TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
 import {
   AUTH_TYPE,
+  isClientForwardedTokenMode,
   OAUTH_FLOW,
   MCP_OAUTH2_FLOW_M2M,
   MCP_OAUTH2_FLOW_INTERACTIVE,
@@ -163,10 +164,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         description: values.description || mcpServer.description,
         url,
         transport,
-        auth_type:
-          values.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || values.auth_type === AUTH_TYPE.OAUTH_DELEGATE
-            ? values.auth_type
-            : AUTH_TYPE.OAUTH2,
+        auth_type: isClientForwardedTokenMode(values.auth_type) ? values.auth_type : AUTH_TYPE.OAUTH2,
         credentials: values.credentials,
         mcp_access_groups: values.mcp_access_groups || mcpServer.mcp_access_groups,
         static_headers: staticHeaders,
@@ -181,7 +179,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
       }
 
       const effectiveAuthType = form.getFieldValue("auth_type") ?? mcpServer.auth_type;
-      if (effectiveAuthType === AUTH_TYPE.TRUE_PASSTHROUGH || effectiveAuthType === AUTH_TYPE.OAUTH_DELEGATE) {
+      if (isClientForwardedTokenMode(effectiveAuthType)) {
         setToken(
           mcpServer.server_id,
           {
@@ -393,8 +391,7 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         oauth2_flow: mcpServer.oauth2_flow,
         delegate_auth_to_upstream: mcpServer.delegate_auth_to_upstream,
       }) === "passthrough";
-    const isBrowserHeldTokenMode =
-      mcpServer.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || mcpServer.auth_type === AUTH_TYPE.OAUTH_DELEGATE;
+    const isBrowserHeldTokenMode = isClientForwardedTokenMode(mcpServer.auth_type);
     if (isPassthrough || isBrowserHeldTokenMode) {
       const token =
         oauthTokenResponse?.access_token ??

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_server_edit.tsx
@@ -163,7 +163,10 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         description: values.description || mcpServer.description,
         url,
         transport,
-        auth_type: AUTH_TYPE.OAUTH2,
+        auth_type:
+          mcpServer.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || mcpServer.auth_type === AUTH_TYPE.OAUTH_DELEGATE
+            ? mcpServer.auth_type
+            : AUTH_TYPE.OAUTH2,
         credentials: values.credentials,
         mcp_access_groups: values.mcp_access_groups || mcpServer.mcp_access_groups,
         static_headers: staticHeaders,

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.test.tsx
@@ -91,6 +91,37 @@ describe("MCPToolsViewer auth gate routing", () => {
     expect(screen.queryByText(GATE_TEXT)).not.toBeInTheDocument();
   });
 
+  it.each([["true_passthrough"], ["oauth_delegate"]])(
+    "shows the Authorize gate for a %s server without a browser token and does not list tools",
+    async (authType) => {
+      renderViewer({ auth_type: authType, oauth2_flow: null, delegate_auth_to_upstream: false });
+
+      expect(await screen.findByText(GATE_TEXT)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Authorize" })).toBeInTheDocument();
+      expect(vi.mocked(listMCPTools)).not.toHaveBeenCalled();
+      expect(vi.mocked(getMCPOAuthUserCredentialStatus)).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([["true_passthrough"], ["oauth_delegate"]])(
+    "forwards the session token via the x-mcp header for a %s server that has one",
+    async (authType) => {
+      vi.mocked(isTokenValid).mockReturnValue(true);
+      vi.mocked(getToken).mockReturnValue({ access_token: "upstream-tok" } as ReturnType<typeof getToken>);
+
+      renderViewer({ auth_type: authType, oauth2_flow: null, delegate_auth_to_upstream: false });
+
+      await waitFor(() =>
+        expect(vi.mocked(listMCPTools)).toHaveBeenCalledWith(
+          "litellm-key",
+          "srv-1",
+          expect.objectContaining({ "x-mcp-slack-authorization": "Bearer upstream-tok" }),
+        ),
+      );
+      expect(screen.queryByText(GATE_TEXT)).not.toBeInTheDocument();
+    },
+  );
+
   it("lists tools for an OBO server when the user has a DB credential, with no x-mcp header", async () => {
     renderViewer({ oauth2_flow: null, delegate_auth_to_upstream: false });
 

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { ToolTestPanel } from "./ToolTestPanel";
 import { resolveLogoSrc } from "@/lib/assetPaths";
-import { MCPTool, MCPToolsViewerProps, MCPContent, CallMCPToolResponse, getMcpOAuthMode } from "./types";
+import { AUTH_TYPE, MCPTool, MCPToolsViewerProps, MCPContent, CallMCPToolResponse, getMcpOAuthMode } from "./types";
 import { listMCPTools, callMCPTool, getMCPOAuthUserCredentialStatus } from "../networking";
 import { isTokenValid, getToken, removeToken } from "@/utils/mcpTokenStore";
 import { sanitizeMcpAliasForHeader, buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
@@ -42,19 +42,24 @@ const MCPToolsViewer = ({
   // service token and needs no gate.
   const oauthMode = getMcpOAuthMode({ auth_type, oauth2_flow, delegate_auth_to_upstream });
   const isPassthrough = oauthMode === "passthrough";
+  // The client-forwarded token modes gate the same way as PKCE passthrough: the
+  // browser session token (established via the browser-only Authorize in the
+  // create/edit forms, or right here) is the upstream credential.
+  const usesBrowserHeldToken =
+    isPassthrough || auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || auth_type === AUTH_TYPE.OAUTH_DELEGATE;
   const isAuthorizationCode = oauthMode === "authorization_code";
   const [oauthToken, setOauthToken] = useState<string | null>(() =>
-    isPassthrough && isTokenValid(serverId, userID) ? getToken(serverId, userID)?.access_token ?? null : null,
+    usesBrowserHeldToken && isTokenValid(serverId, userID) ? getToken(serverId, userID)?.access_token ?? null : null,
   );
 
   // Re-sync token when serverId/userID changes (useState initializer only runs on mount).
   useEffect(() => {
-    if (!isPassthrough) {
+    if (!usesBrowserHeldToken) {
       setOauthToken(null);
       return;
     }
     setOauthToken(isTokenValid(serverId, userID) ? getToken(serverId, userID)?.access_token ?? null : null);
-  }, [serverId, userID, isPassthrough]);
+  }, [serverId, userID, usesBrowserHeldToken]);
 
   const {
     startOAuthFlow,
@@ -109,7 +114,7 @@ const MCPToolsViewer = ({
     // x-mcp-{alias}-{header} pattern and forwards it to the upstream MCP server.
     // When no alias is available, fall back to x-mcp-auth (legacy but still supported).
     // Passthrough only: authorization_code/token_exchange/M2M tokens are attached server-side, not from the browser.
-    if (isPassthrough && oauthToken) {
+    if (usesBrowserHeldToken && oauthToken) {
       Object.assign(customHeaders, buildMcpPassthroughAuthHeader(serverAlias, oauthToken));
     }
 
@@ -164,7 +169,8 @@ const MCPToolsViewer = ({
     // Passthrough blocks until a browser session token exists; authorization_code blocks until
     // the user has a valid DB credential (else the backend returns no tools).
     enabled:
-      !!accessToken && (isPassthrough ? oauthToken !== null : isAuthorizationCode ? hasAuthorizationCodeCred : true),
+      !!accessToken &&
+      (usesBrowserHeldToken ? oauthToken !== null : isAuthorizationCode ? hasAuthorizationCodeCred : true),
     staleTime: 30000, // Consider data fresh for 30 seconds
     retry: (failureCount, error: any) => {
       // Don't retry on 401 — token is invalid, user must re-authenticate
@@ -253,7 +259,8 @@ const MCPToolsViewer = ({
   // passthrough needs a browser token; authorization_code needs a stored DB credential or a
   // still-valid one — a 401 from the list call means the backend has none even
   // after attempting a refresh, so re-authorization is required.
-  const authGateActive = (isPassthrough && !oauthToken) || authorizationCodeNeedsAuth || authorizationCodeTokenRejected;
+  const authGateActive =
+    (usesBrowserHeldToken && !oauthToken) || authorizationCodeNeedsAuth || authorizationCodeTokenRejected;
   // Treat authorization_code credential-status loading as "tools loading" so the empty state
   // doesn't flash before we know whether the user needs to authorize.
   const toolsAreaLoading = isLoadingTools || authorizationCodeStatusLoading;
@@ -359,7 +366,7 @@ const MCPToolsViewer = ({
                 </Text>
 
                 {/* Passthrough auth gate — browser session token absent */}
-                {isPassthrough && !oauthToken && (
+                {usesBrowserHeldToken && !oauthToken && (
                   <div className="p-4 text-center bg-white border border-gray-200 rounded-lg">
                     <LockOutlined className="text-2xl text-gray-400 mb-2" />
                     <p className="text-xs font-medium text-gray-700 mb-1">Authentication required</p>

--- a/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/mcp_tools.tsx
@@ -2,7 +2,14 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { ToolTestPanel } from "./ToolTestPanel";
 import { resolveLogoSrc } from "@/lib/assetPaths";
-import { AUTH_TYPE, MCPTool, MCPToolsViewerProps, MCPContent, CallMCPToolResponse, getMcpOAuthMode } from "./types";
+import {
+  isClientForwardedTokenMode,
+  MCPTool,
+  MCPToolsViewerProps,
+  MCPContent,
+  CallMCPToolResponse,
+  getMcpOAuthMode,
+} from "./types";
 import { listMCPTools, callMCPTool, getMCPOAuthUserCredentialStatus } from "../networking";
 import { isTokenValid, getToken, removeToken } from "@/utils/mcpTokenStore";
 import { sanitizeMcpAliasForHeader, buildMcpPassthroughAuthHeader } from "@/utils/mcpHeaderUtils";
@@ -45,8 +52,7 @@ const MCPToolsViewer = ({
   // The client-forwarded token modes gate the same way as PKCE passthrough: the
   // browser session token (established via the browser-only Authorize in the
   // create/edit forms, or right here) is the upstream credential.
-  const usesBrowserHeldToken =
-    isPassthrough || auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || auth_type === AUTH_TYPE.OAUTH_DELEGATE;
+  const usesBrowserHeldToken = isPassthrough || isClientForwardedTokenMode(auth_type);
   const isAuthorizationCode = oauthMode === "authorization_code";
   const [oauthToken, setOauthToken] = useState<string | null>(() =>
     usesBrowserHeldToken && isTokenValid(serverId, userID) ? getToken(serverId, userID)?.access_token ?? null : null,

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -41,6 +41,8 @@ export const AUTH_TYPE = {
   OAUTH2: "oauth2",
   OAUTH2_TOKEN_EXCHANGE: "oauth2_token_exchange",
   AWS_SIGV4: "aws_sigv4",
+  TRUE_PASSTHROUGH: "true_passthrough",
+  OAUTH_DELEGATE: "oauth_delegate",
 };
 
 export const OAUTH_FLOW = {

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -45,6 +45,13 @@ export const AUTH_TYPE = {
   OAUTH_DELEGATE: "oauth_delegate",
 };
 
+// The two client-forwarded token modes: the caller supplies the upstream Authorization (forwarded
+// verbatim for true_passthrough, alongside LiteLLM admission for oauth_delegate). The dashboard holds
+// their token in sessionStorage instead of persisting it, and the browser-authorize temp payload keeps
+// their real auth_type so the backend does not treat them as needing a stored per-user token.
+export const isClientForwardedTokenMode = (authType?: string | null): boolean =>
+  authType === AUTH_TYPE.TRUE_PASSTHROUGH || authType === AUTH_TYPE.OAUTH_DELEGATE;
+
 export const OAUTH_FLOW = {
   INTERACTIVE: "interactive",
   M2M: "m2m",

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { testMCPToolsListRequest } from "../components/networking";
-import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT } from "@/components/mcp_tools/types";
+import { AUTH_TYPE, OAUTH_FLOW, TRANSPORT, isClientForwardedTokenMode } from "@/components/mcp_tools/types";
 
 interface MCPServerConfig {
   server_id?: string;
@@ -56,8 +56,7 @@ export const useTestMCPConnection = ({
 
   // Check if we have the minimum required fields to fetch tools
   const isM2MOAuth = formValues.auth_type === AUTH_TYPE.OAUTH2 && formValues.oauth_flow_type === OAUTH_FLOW.M2M;
-  const isBrowserHeldTokenMode =
-    formValues.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || formValues.auth_type === AUTH_TYPE.OAUTH_DELEGATE;
+  const isBrowserHeldTokenMode = isClientForwardedTokenMode(formValues.auth_type);
   const requiresOAuthToken = (formValues.auth_type === AUTH_TYPE.OAUTH2 && !isM2MOAuth) || isBrowserHeldTokenMode;
   const isOpenAPITransport = formValues.transport === TRANSPORT.OPENAPI;
   const hasEndpoint = isOpenAPITransport ? !!formValues.spec_path : !!formValues.url;

--- a/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
+++ b/ui/litellm-dashboard/src/hooks/useTestMCPConnection.tsx
@@ -56,7 +56,9 @@ export const useTestMCPConnection = ({
 
   // Check if we have the minimum required fields to fetch tools
   const isM2MOAuth = formValues.auth_type === AUTH_TYPE.OAUTH2 && formValues.oauth_flow_type === OAUTH_FLOW.M2M;
-  const requiresOAuthToken = formValues.auth_type === AUTH_TYPE.OAUTH2 && !isM2MOAuth;
+  const isBrowserHeldTokenMode =
+    formValues.auth_type === AUTH_TYPE.TRUE_PASSTHROUGH || formValues.auth_type === AUTH_TYPE.OAUTH_DELEGATE;
+  const requiresOAuthToken = (formValues.auth_type === AUTH_TYPE.OAUTH2 && !isM2MOAuth) || isBrowserHeldTokenMode;
   const isOpenAPITransport = formValues.transport === TRANSPORT.OPENAPI;
   const hasEndpoint = isOpenAPITransport ? !!formValues.spec_path : !!formValues.url;
 


### PR DESCRIPTION
## Relevant issues

Follow-up to #31989 (stacked on `litellm_mcp_passthrough_delegate_modes`; retarget to `litellm_internal_staging` after it merges)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Steps to verify in the Admin UI (dev server: `npm run dev` in `ui/litellm-dashboard`, proxy on localhost:4000):

1. Go to http://localhost:4000/ui/?page=mcp-servers and click "Add New MCP Server"
2. Set Transport Type to "Streamable HTTP (Recommended)" and open the Authentication section
3. The auth dropdown now lists "True Passthrough (no LiteLLM auth)" and "OAuth Delegate (client-supplied upstream token)" after AWS SigV4
4. Select "True Passthrough (no LiteLLM auth)": a warning appears directly under the dropdown saying LiteLLM authentication is disabled for this server, rate limits and spend tracking do not apply, and OAuth Delegate is the alternative if callers should still authenticate
5. Select "OAuth Delegate (client-supplied upstream token)": the warning disappears
6. Open an existing server's edit form and repeat steps 4 and 5; the same warning shows and hides there
7. With True Passthrough or OAuth Delegate selected (create or edit), an "Authorize & Fetch Tools (browser-only)" section appears with optional client ID / client secret fields; clicking the button runs the upstream OAuth flow in the browser, after which the tools list loads and the allowlist checkboxes become configurable. Check the server row and LiteLLM_MCPUserCredentials afterwards: no credentials are persisted for these auth types

## Type

🆕 New Feature

## Changes

The parent PR added `true_passthrough` and `oauth_delegate` as first-class MCP `auth_type` values on the backend, but the dashboard's create and edit forms still only offered the legacy dropdown entries, so the only way to select the new modes was the REST API. This adds both values to the `AUTH_TYPE` constant and to the Authentication dropdown in `create_mcp_server.tsx` and `mcp_server_edit.tsx`, labeled "True Passthrough (no LiteLLM auth)" and "OAuth Delegate (client-supplied upstream token)"

Because `true_passthrough` turns off admission auth entirely for that server, selecting it now renders a warning Alert directly under the dropdown: anyone who can reach the gateway can call the server without a LiteLLM key, the caller's Authorization header is forwarded to the upstream verbatim, per-key and per-team rate limits and spend tracking do not apply, and the upstream is fully responsible for authenticating callers. The Alert points at OAuth Delegate as the alternative when callers should still authenticate to LiteLLM. The warning lives in one shared `TruePassthroughWarning` component rendered by both forms, so the copy and the trigger condition cannot drift between create and edit; it also keeps the two render functions flat, which is what the eslint complexity budget wants

Neither mode requires an authentication value or OAuth credential fields, so the existing `AUTH_TYPES_REQUIRING_AUTH_VALUE` / `AUTH_TYPES_REQUIRING_CREDENTIALS` gating is untouched and no extra fields appear for them

These modes persist no upstream credentials, which used to mean the admin had no way to preview tools or configure the tool allowlist at create/edit time; tools/list simply hit the upstream unauthenticated and 401ed. The second commit closes that gap by reusing the existing OAuth authorize machinery in browser-only mode. Selecting either auth type renders an authorize section: the admin authorizes against the upstream (dynamic client registration and PKCE by default, with optional client ID / client secret fields for IdPs that do not support dynamic registration, e.g. a pre-registered Slack app), the token lands in sessionStorage exactly like the legacy PKCE passthrough path, and the tools preview forwards it via the per-server x-mcp-{alias}-authorization header that the passthrough resolver arm already accepts. Nothing is written to the server row or the per-user credential store: the create payload keeps excluding credentials for these auth types, and the parent PR's behavior contract (server-level persist = nothing) still holds. The tool allowlist configured this way does persist, since it is server configuration rather than a credential. On the backend, the tools preview endpoint now also extracts the Authorization header for the two new auth types so a create-time preview reaches the passthrough arm authenticated

The server detail page's Tool Testing Playground had the same blind spot: it gated browser-held token handling on the legacy PKCE passthrough shape, so a server in either new mode listed tools unauthenticated and showed "Failed to fetch MCP tools" with no way to authorize. The third commit extends the playground's gate to both modes (read the sessionStorage token, forward it via the x-mcp header, evict on 401, show the playground's own Authorize gate when absent) and unblocks the gateway's relayed authorize/register/token endpoints for them; previously those endpoints 400ed for anything but oauth2, which would have sent the playground's Authorize button to an error page. Registry builds now run the same RFC 9728/8414 endpoint discovery for these modes that oauth2 rows get, since their rows never store an authorization_url. DCR persistence stays off on this path and the minted token remains browser-held

The edit form keyed two browser-held token decisions off the saved record instead of the admin's in-flight form selection (a review round caught both): fetchTools decided whether to forward the sessionStorage token from mcpServer.auth_type, so a token authorized right after switching the form to a client-forwarded mode was not used for tool loading until the server was saved, and the save path classified the staged token with getMcpOAuthMode, which returns null for the new modes, so the token was dropped on save instead of committed to sessionStorage the way the create form's submit does. A shared getEffectiveAuthType (form value falling back to the saved record) is now the single decision point for receipt and tool loading, and the save path's sessionStorage branch covers the client-forwarded modes; the token still never enters the server row

The tools preview endpoint forwarded the raw Authorization header upstream for oauth2 and the client-forwarded modes, but Authorization is also the admission fallback when x-litellm-api-key is absent, so a caller who authenticated that way had their LiteLLM key forwarded to the upstream. The preview now forwards Authorization only when the primary admission header is present, which is how the dashboard has always sent the pair

Tests: the create form suite covers the warning appearing when True Passthrough is selected and staying hidden for OAuth Delegate, the authorize section rendering for both new modes and not for API Key; the edit form suite covers the warning rendering for a stored `true_passthrough` server and not for `oauth_delegate`, the sessionStorage token being forwarded as the x-mcp header for an `oauth_delegate` server, and the authorize hint plus no unauthenticated fetch when a `true_passthrough` server has no browser token; the backend suite covers the preview endpoint extracting the Authorization header for both new auth types, the authorize endpoint redirecting to the upstream IdP for both modes, and registry builds discovering upstream OAuth endpoints for them; the playground suite covers the Authorize gate and the x-mcp header forwarding for both modes




Two further correctness fixes came out of an audit of the modes against gateway and OAuth norms. The preemptive-401 connect gate for both modes only inspected the request-wide Authorization, so a caller who bound the upstream token via the per-server `x-mcp-{alias}-authorization` header (the required shape in a multi-server aggregate, where the request-wide Authorization is withheld) was spuriously 401'd at connect even though egress already honored that header; the gate now recognizes the per-server header mode-correctly (true_passthrough treats any Authorization or the per-server header as the upstream token; oauth_delegate still requires a distinct `x-litellm-api-key` so a lone Authorization consumed for admission is never mistaken for an upstream token), and the preemptive raise is gated to single-server scopes so a multi-server aggregate degrades gracefully instead of one missing token failing the whole connect. Separately, the browser-only Authorize was writing the upstream access and refresh token to `LiteLLM_MCPUserCredentials` because the temporary OAuth-relay server was cached with a hardcoded oauth2 auth_type; the forms now send the real auth_type for these modes, so `needs_user_oauth_token` is false and the exchange skips storage while still returning the token to the browser session, keeping the persist-nothing contract. The tool-call logs also carry `mcp_auth_mode` and `mcp_server_resource` now so a relayed request can be attributed in an audit to its mode and upstream target without logging any credential; the logged resource is the origin only (scheme, host, port), because hosted MCP servers routinely embed the credential in the URL path

Deliberately out of scope for these PRs, tracked as passthrough v2 extensions so they are not re-filed as gaps. Faithful relay of a mid-session upstream 401/403 on the tool-CALL path (today it becomes a JSON-RPC isError; the REST tools/list path already relays and the aggregate already degrades to an empty list); a per-alias needs-reauth signal on the multi-server aggregate so a client can re-auth just the one server whose token expired (v1 absorbs a failing server to an empty list without naming it); a connect-time upstream probe for a present-but-revoked token (a stateless mode forwards and lets the upstream reject, so this is a UX nicety with a per-connect round-trip cost, not a correctness fix); an admission-credential-stripped attestation field on the audit log (needs the strip decision threaded from header-prep); documentation steering audience-locked tokens to `oauth2_token_exchange` rather than passthrough (forwarding a mis-audienced token and letting the upstream reject it is the correct confused-deputy-safe behavior, so the work is docs, not code); and Authorization header hygiene (duplicate/multi-scheme rejection, size caps) which is a pre-existing v1-wide concern rather than something these modes introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch OAuth relay, token persistence boundaries, and header forwarding on auth-critical MCP paths; `true_passthrough` intentionally weakens LiteLLM admission, which increases exposure if misconfigured.
> 
> **Overview**
> Exposes **`true_passthrough`** and **`oauth_delegate`** in the MCP server create/edit UI, with a **True Passthrough** warning, a **browser-only Authorize & Fetch** flow (optional client ID/secret, token in **sessionStorage** only), and the same **Authorize** gate in the tools playground.
> 
> On the **proxy**, shared **`_UPSTREAM_OAUTH_DISCOVERY_AUTH_TYPES`** drives upstream OAuth metadata discovery for these modes (not only `oauth2`). The gateway **authorize/token/register** paths allow them via **`_raise_if_not_oauth2`**, and **`authorize_with_server`** uses that guard. **Tools preview** forwards OAuth headers for client-forwarded modes only when **`x-litellm-api-key`** is present so a LiteLLM key in **`Authorization`** is not sent upstream. Tool-call logging adds **`mcp_auth_mode`** and origin-only **`mcp_server_resource`** via **`_redact_mcp_resource_url`**.
> 
> Tests cover authorize redirects, no DB persist on token exchange for client-forwarded modes, discovery on registry build, preview header behavior, URL redaction, and dashboard flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e02ac047565ed3c14e710a991436f369a08509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



