### PR TITLE
fix(ui/mcp): do not reset in-flight OAuth resume when create modal mounts closed

### DIFF
--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.test.tsx
@@ -1067,6 +1067,22 @@ describe("CreateMCPServer", () => {
       const reopenedUrlInput = screen.getByPlaceholderText("https://your-mcp-server.com") as HTMLInputElement;
       expect(reopenedUrlInput.value).toBe("");
     });
+
+    it("does not reset an in-flight OAuth resume when mounted with the modal closed (post-redirect restore)", () => {
+      // After the "Authorize & Fetch Token" redirect the page reloads and this
+      // component mounts with isModalVisible=false while useMcpOAuthFlow is still
+      // exchanging the authorization code. Calling reset() during that mount bumps
+      // the hook's reset version and the fetched token is silently discarded, so
+      // the user sees no Connection Status / Tool Configuration and must authorize
+      // again after saving.
+      const { rerender } = render(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+      expect(oauthHook.reset).not.toHaveBeenCalled();
+
+      // A real open -> closed transition must still reset (the #30000 leak fix).
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={true} />);
+      rerender(<CreateMCPServer {...defaultProps} isModalVisible={false} />);
+      expect(oauthHook.reset).toHaveBeenCalled();
+    });
   });
 
   describe("when stdio transport is selected", () => {

--- a/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/create_mcp_server.tsx
@@ -626,9 +626,15 @@ const CreateMCPServer: React.FC<CreateMCPServerProps> = ({
   // Clear form, tools, and OAuth state when the modal closes so a previous server's
   // authorization, credentials, or tool list never bleed into the next "Add New MCP
   // Server" session, including when a parent dismisses the modal without routing
-  // through handleCancel or handleCreate.
+  // through handleCancel or handleCreate. Only a real open -> closed transition may
+  // trigger this: on the post-OAuth-redirect remount the modal starts closed while
+  // resumeOAuthFlow's token exchange is in flight, and resetting then discards the
+  // fetched token.
+  const wasModalVisibleRef = React.useRef(isModalVisible);
   React.useEffect(() => {
-    if (!isModalVisible) {
+    const wasVisible = wasModalVisibleRef.current;
+    wasModalVisibleRef.current = isModalVisible;
+    if (!isModalVisible && wasVisible) {
       form.resetFields();
       setFormValues({});
       setOauthAccessToken(null);


### PR DESCRIPTION
## Relevant issues

Regression introduced by #30000

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI-only fix, so the proof is the on-create OAuth flow in the Admin UI. Steps to reproduce and verify:

1. Run the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`) and the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`)
2. Go to MCP Servers, click "Add New MCP Server"
3. Fill in Transport = Streamable HTTP, an OAuth MCP server URL (e.g. `https://mcp.linear.app/mcp`), Authentication = OAuth, flow = Interactive (PKCE)
4. Click "Authorize & Fetch Token", approve on the upstream consent page, and get redirected back to the UI
5. Before this fix: the modal reopens with the fields restored, but the "Token fetched" confirmation never appears, Connection Status stays on "Complete required fields to test connection", Tool Configuration stays empty, and after clicking "Add MCP Server" the new server still requires clicking Authorize again
6. With this fix: after the redirect back, "Token fetched. Expires in N seconds" appears, Connection Status lists the server's tools, Tool Configuration is populated, and after "Add MCP Server" the per-user token is persisted so no second authorization is needed

The pairs below capture the create-server modal in the state it lands in after the OAuth redirect returns, before at the merge-base `4b0ac8b352` (the buggy cleanup effect) and after at this branch's head `8543e6b8fa`. Each is rendered from the dashboard dev server driving the real `CreateMCPServer` with the redirect remount replayed while `resumeOAuthFlow`'s token exchange is in flight; only the token exchange and the tools listing are stubbed, so the sole variable between the two columns is this PR's cleanup guard

The OAuth section is where the regression first shows: before, the redirect returns but the mount-time `resetOAuthFlow()` discards the exchanged token so the "Token fetched" line never renders; after, the token survives the remount and the confirmation appears

![OAuth token confirmation on the create form](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMzQ2ZjNkNWYtN2I1NC00YzkyLTg3YzMtODJiZGQzZGJjODAzIiwiaWF0IjoxNzgzNDgzNDgwLCJleHAiOjE3ODQwODgyODAsImZpbGVuYW1lIjoib2F1dGhfdG9rZW5fYmFubmVyLnBuZyJ9.N-P2DlfOmhxpzzOQnJzVBUmWf4tKsN9ut6KiUkB_9Wo)

Because the discarded token leaves `oauthAccessToken` null, Connection Status cannot test the server and stays on its "complete required fields" placeholder before; after, it lists the server as connected

![Connection Status after the redirect](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMWUxODkwN2MtOTBkMS00YzU0LTlmMDMtMjlkNTM4MDRhYjBiIiwiaWF0IjoxNzgzNDgzNDgwLCJleHAiOjE3ODQwODgyODAsImZpbGVuYW1lIjoiY29ubmVjdGlvbl9zdGF0dXMucG5nIn0.ojHnZPUENC-kjYhtChaHq_E-PSNnTCmQr1mHBRyRyVg)

Tool Configuration is driven by the same connection, so it stays empty before and populates with the server's tools ready to allowlist after

![Tool Configuration after the redirect](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvMzg2ZmEzZmEtOTkzNC00ZmJkLWIxZWItYzNiY2FmYzdjMzE4IiwiaWF0IjoxNzgzNDgzNDgxLCJleHAiOjE3ODQwODgyODEsImZpbGVuYW1lIjoidG9vbF9jb25maWd1cmF0aW9uLnBuZyJ9.Zh439HqiTA724dMKlEB-ppbP6WpQU7aBUbVLZW8oWhg)

## Type

🐛 Bug Fix

## Changes

The create-server modal has a cleanup effect that resets form, tools, and OAuth state whenever `isModalVisible` is false, added in #30000 so a previous server's token cannot bleed into the next add-server session. That effect also runs on the initial mount, which breaks the "Authorize & Fetch Token" flow: after the OAuth redirect returns, the page reloads and `CreateMCPServer` mounts with the modal still closed (the restore effect reopens it a moment later) while `useMcpOAuthFlow.resumeOAuthFlow` is already exchanging the authorization code. The mount-time `resetOAuthFlow()` bumps the hook's reset version, so when the exchange resolves the hook discards the token by design (`if (resetVersion !== resetVersionRef.current) return`). The user sees restored form fields but no token, no Connection Status, no Tool Configuration, and the saved server never receives the per-user credential, forcing a second authorization from the server card

The fix guards the cleanup so it only fires on a real open to closed transition, tracked with a ref of the previous visibility. A genuine dismissal (cancel, successful create, or a parent flipping the prop) still resets everything, which keeps the #30000 leak fix intact; the post-redirect mount, where the modal starts closed, no longer clobbers the in-flight resume

Regression test: mounting with the modal closed must not call the OAuth hook's `reset()`, while an open to closed transition still must. The test fails on the previous code (reset was called on mount) and passes with the guard. The hook-side half of the contract, reset discarding an in-flight exchange, was already pinned by `useMcpOAuthFlow.test.tsx`

Link to Devin session: https://app.devin.ai/sessions/f03da2725ec94d28b3facf766871b102