### PR TITLE
fix kimi-k2.7-code-highspeed pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38552,14 +38552,14 @@
         "supports_reasoning": true
     },
     "openai/kimi-k2.7-code-highspeed": {
-        "cache_read_input_token_cost": 1.9e-07,
-        "input_cost_per_token": 9.5e-07,
+        "cache_read_input_token_cost": 3.8e-07,
+        "input_cost_per_token": 1.9e-06,
         "litellm_provider": "openai",
         "max_input_tokens": 262144,
         "max_output_tokens": 262144,
         "max_tokens": 262144,
         "mode": "chat",
-        "output_cost_per_token": 4e-06,
+        "output_cost_per_token": 8e-06,
         "supports_function_calling": true,
         "supports_reasoning": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38536,6 +38536,7 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 4.4e-06,
+        "source": "https://docs.z.ai/guides/overview/pricing",
         "supports_function_calling": true,
         "supports_reasoning": true
     },
@@ -38548,6 +38549,7 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 4e-06,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k27-code",
         "supports_function_calling": true,
         "supports_reasoning": true
     },
@@ -38560,6 +38562,7 @@
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 8e-06,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k27-code",
         "supports_function_calling": true,
         "supports_reasoning": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38527,6 +38527,42 @@
         "litellm_provider": "openai",
         "mode": "chat"
     },
+    "openai/glm-5.2": {
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "litellm_provider": "openai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true
+    },
+    "openai/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true
+    },
+    "openai/kimi-k2.7-code-highspeed": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "openai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true
+    },
     "openai/sora-2": {
         "litellm_provider": "openai",
         "mode": "video_generation",

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3073,6 +3073,7 @@ def test_model_info_for_openai_kimi_and_glm_aliases(local_model_cost_map):
     assert kimi["input_cost_per_token"] == 9.5e-07
     assert kimi["output_cost_per_token"] == 4e-06
     assert kimi["cache_read_input_token_cost"] == 1.9e-07
+    assert kimi["source"] == "https://platform.kimi.ai/docs/pricing/chat-k27-code"
     assert kimi["max_input_tokens"] == 262144
 
     kimi_highspeed = litellm.get_model_info(
@@ -3083,6 +3084,7 @@ def test_model_info_for_openai_kimi_and_glm_aliases(local_model_cost_map):
     assert kimi_highspeed["input_cost_per_token"] == 1.9e-06
     assert kimi_highspeed["output_cost_per_token"] == 8e-06
     assert kimi_highspeed["cache_read_input_token_cost"] == 3.8e-07
+    assert kimi_highspeed["source"] == "https://platform.kimi.ai/docs/pricing/chat-k27-code"
     assert kimi_highspeed["max_input_tokens"] == 262144
 
     glm = litellm.get_model_info(model="openai/glm-5.2", custom_llm_provider="openai")
@@ -3091,6 +3093,7 @@ def test_model_info_for_openai_kimi_and_glm_aliases(local_model_cost_map):
     assert glm["input_cost_per_token"] == 1.4e-06
     assert glm["output_cost_per_token"] == 4.4e-06
     assert glm["cache_read_input_token_cost"] == 2.6e-07
+    assert glm["source"] == "https://docs.z.ai/guides/overview/pricing"
     assert glm["max_input_tokens"] == 262144
 
 

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3080,9 +3080,9 @@ def test_model_info_for_openai_kimi_and_glm_aliases(local_model_cost_map):
     )
     assert kimi_highspeed is not None
     assert kimi_highspeed["litellm_provider"] == "openai"
-    assert kimi_highspeed["input_cost_per_token"] == 9.5e-07
-    assert kimi_highspeed["output_cost_per_token"] == 4e-06
-    assert kimi_highspeed["cache_read_input_token_cost"] == 1.9e-07
+    assert kimi_highspeed["input_cost_per_token"] == 1.9e-06
+    assert kimi_highspeed["output_cost_per_token"] == 8e-06
+    assert kimi_highspeed["cache_read_input_token_cost"] == 3.8e-07
     assert kimi_highspeed["max_input_tokens"] == 262144
 
     glm = litellm.get_model_info(model="openai/glm-5.2", custom_llm_provider="openai")

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -3066,6 +3066,34 @@ def test_model_info_for_openrouter_kimi_k2_5():
     print("openrouter kimi-k2.5 model info", model_info)
 
 
+def test_model_info_for_openai_kimi_and_glm_aliases(local_model_cost_map):
+    kimi = litellm.get_model_info(model="openai/kimi-k2.7-code", custom_llm_provider="openai")
+    assert kimi is not None
+    assert kimi["litellm_provider"] == "openai"
+    assert kimi["input_cost_per_token"] == 9.5e-07
+    assert kimi["output_cost_per_token"] == 4e-06
+    assert kimi["cache_read_input_token_cost"] == 1.9e-07
+    assert kimi["max_input_tokens"] == 262144
+
+    kimi_highspeed = litellm.get_model_info(
+        model="openai/kimi-k2.7-code-highspeed", custom_llm_provider="openai"
+    )
+    assert kimi_highspeed is not None
+    assert kimi_highspeed["litellm_provider"] == "openai"
+    assert kimi_highspeed["input_cost_per_token"] == 9.5e-07
+    assert kimi_highspeed["output_cost_per_token"] == 4e-06
+    assert kimi_highspeed["cache_read_input_token_cost"] == 1.9e-07
+    assert kimi_highspeed["max_input_tokens"] == 262144
+
+    glm = litellm.get_model_info(model="openai/glm-5.2", custom_llm_provider="openai")
+    assert glm is not None
+    assert glm["litellm_provider"] == "openai"
+    assert glm["input_cost_per_token"] == 1.4e-06
+    assert glm["output_cost_per_token"] == 4.4e-06
+    assert glm["cache_read_input_token_cost"] == 2.6e-07
+    assert glm["max_input_tokens"] == 262144
+
+
 def test_gemini_embedding_2_ga_in_cost_map():
     """GA and Vertex preview gemini-embedding-2 entries align with multimodal unit pricing."""
     import json


### PR DESCRIPTION
Fix incorrect model pricing for openai/kimi-k2.7-code-highspeed (2x input/output/cache over standard), and update model cost regression test to official values.