### PR TITLE
ci: skip unit test workflows when only ui or markdown files change

### DIFF
--- a/.github/workflows/test-unit-core-utils.yml
+++ b/.github/workflows/test-unit-core-utils.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-core-utils.yml
+++ b/.github/workflows/test-unit-core-utils.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-enterprise-routing.yml
+++ b/.github/workflows/test-unit-enterprise-routing.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-enterprise-routing.yml
+++ b/.github/workflows/test-unit-enterprise-routing.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-integrations.yml
+++ b/.github/workflows/test-unit-integrations.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-integrations.yml
+++ b/.github/workflows/test-unit-integrations.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-llm-providers.yml
+++ b/.github/workflows/test-unit-llm-providers.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-llm-providers.yml
+++ b/.github/workflows/test-unit-llm-providers.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-misc.yml
+++ b/.github/workflows/test-unit-misc.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-misc.yml
+++ b/.github/workflows/test-unit-misc.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-proxy-auth.yml
+++ b/.github/workflows/test-unit-proxy-auth.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-auth.yml
+++ b/.github/workflows/test-unit-proxy-auth.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - litellm_internal_staging
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -7,7 +7,6 @@ on:
       - litellm_internal_staging
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
   workflow_dispatch:

--- a/.github/workflows/test-unit-proxy-infra.yml
+++ b/.github/workflows/test-unit-proxy-infra.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-infra.yml
+++ b/.github/workflows/test-unit-proxy-infra.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-proxy-legacy.yml
+++ b/.github/workflows/test-unit-proxy-legacy.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-legacy.yml
+++ b/.github/workflows/test-unit-proxy-legacy.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 

--- a/.github/workflows/test-unit-responses-caching-types.yml
+++ b/.github/workflows/test-unit-responses-caching-types.yml
@@ -7,6 +7,11 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
+    paths-ignore:
+      - "ui/**"
+      - "docs/**"
+      - "**.md"
+      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-responses-caching-types.yml
+++ b/.github/workflows/test-unit-responses-caching-types.yml
@@ -9,7 +9,6 @@ on:
       - "litellm_**"
     paths-ignore:
       - "ui/**"
-      - "docs/**"
       - "**.md"
       - "**.mdx"
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change only touches workflow triggers, so the proof is in how the checks behave on real PRs. On this PR itself (commit 7ac15f53), all Unit Tests checks should still run, since `.github/workflows/**` files are not in the ignore list. To see the skip in action, open any PR against `litellm_internal_staging` that only edits files under `ui/` or markdown files, and confirm in the Checks tab that none of the "Unit Tests: ..." workflows are triggered, matching how the CircleCI backend jobs already halt on such PRs

## Type

🚄 Infrastructure

## Changes

CircleCI already skips its backend jobs when a PR touches nothing relevant to the backend: `.circleci/scripts/path_filter.sh` diffs against the merge base and `.circleci/scripts/classify_changes.sh` classifies `ui/*`, `docs/*`, `*.md` and `*.mdx` as not backend relevant. The GitHub Actions unit test workflows had no such filter, so a UI-only or markdown-only PR still spun up all twelve `test-unit-*.yml` workflows

This PR mirrors that filter by adding `ui/**`, `**.md` and `**.mdx` as `paths-ignore` to the `pull_request` trigger of every `test-unit-*.yml` workflow. The `docs/*` pattern from the CircleCI script is intentionally not carried over because the `docs/` folder no longer exists in this repo (the docs moved to the litellm-docs repo); that script is just stale on that point. GitHub only skips the workflow when every changed file in the PR matches the ignore list, which is exactly the CircleCI backend semantics: any single backend-relevant file still runs the full suite. Changes to the workflow files themselves also still trigger the suites since `.github/**` is not ignored

One thing to be aware of: if any of these workflows are configured as required status checks in branch protection, a path-skipped workflow reports no status and shows as "Expected", which would block merging UI-only or markdown-only PRs. In that case the required checks list needs adjusting, or the filter should move to a job-level condition instead