### PR TITLE
ci: ratchet LIT003 budget down to current count to remove suppression slack

### DIFF
--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -6,7 +6,7 @@
     "limit": 27522
   },
   "LIT003": {
-    "limit": 422
+    "limit": 292
   },
   "LIT004": {
     "limit": 44


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

At 442d8da4, the gate passes with the tightened ceiling:

```
$ python scripts/type_discipline_gate.py
OK: every LIT rule is within its codebase ceiling (base origin/litellm_internal_staging)
```

And a single new reasonless suppression now trips it (temporary edit, reverted before commit):

```
$ echo 'x = 1  # noqa' >> litellm/__init__.py && python scripts/type_discipline_gate.py
FAIL: LIT-rule totals exceed their limit (base origin/litellm_internal_staging):
  LIT003: total 293 over limit 292 (this change added 1)
    litellm/__init__.py:2314
Remove the new violations, give each a reason (`# noqa: XXX  # <reason>`, `# pyright: ignore[rule]  # <reason>`, `# mutable-ok: <reason>`, `# cast-ok: <reason>`, `# guard-ok: <reason>`, `# kwargs-ok: <reason>`), or remove an equal number elsewhere; the ceiling is the limit in type-discipline-budget.json.
```

Before this change the same edit passed silently because the LIT003 ceiling (422) sat 130 above the actual count (292)

## Type

🚄 Infrastructure

## Changes

Lowers the LIT003 limit in type-discipline-budget.json from 422 to 292, the current violation count across the `litellm` tree. LIT003 flags `# noqa` comments that lack rule codes or a reason, so the 130 violations of headroom meant new reasonless noqa comments could land without failing CI. With the ceiling at the exact current count there is zero slack: every new suppression comment must carry an explanation (`# noqa: XXX123  # <reason>`) or the gate fails

The other reason-requiring rules already have no slack, so they are untouched: LIT004 (pyright/mypy ignore without codes or reason) is at 44/44 and LIT005 (`*-ok` suppression without a reason) is frozen at 0

One pre-existing oddity worth noting: LIT009 (`# type: ignore`) counts 2509 on litellm_internal_staging against a limit of 2501, so the base is 8 over its own ceiling. The gate tolerates this because it only fails a change that adds violations beyond the base. Bringing that back under would mean fixing 8 occurrences, which is left for a separate PR since this one only removes stale headroom