### PR TITLE
fix(vertex_ai): stabilize nullable tool schema request bodies and skip live test on 429

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -898,7 +898,7 @@ def _convert_schema_types(schema, depth=0):
         if isinstance(type_val, list) and len(type_val) > 1:
             # Convert type arrays to anyOf format
             # Fields that are specific to object/array types and should move into anyOf
-            type_specific_fields = {
+            type_specific_fields = (
                 "properties",
                 "required",
                 "additionalProperties",
@@ -907,7 +907,7 @@ def _convert_schema_types(schema, depth=0):
                 "maxItems",
                 "minProperties",
                 "maxProperties",
-            }
+            )
 
             any_of: List[Dict[str, Any]] = []
             for t in type_val:

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -3894,12 +3894,15 @@ def test_gemini_nullable_object_tool_schema_httpx():
         }
     ]
 
-    response = litellm.completion(
-        model="vertex_ai/gemini-2.5-flash",
-        messages=[{"role": "user", "content": "call the tool"}],
-        tools=tools,
-        tool_choice="required",
-    )
+    try:
+        response = litellm.completion(
+            model="vertex_ai/gemini-2.5-flash",
+            messages=[{"role": "user", "content": "call the tool"}],
+            tools=tools,
+            tool_choice="required",
+        )
+    except litellm.RateLimitError:
+        pytest.skip("Rate limit error")
 
     print(response)
 

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -819,6 +819,58 @@ def test_convert_schema_types_type_array_conversion():
     assert input_schema["required"] == ["studio"]
 
 
+def test_convert_schema_types_output_is_stable_across_hash_seeds():
+    """
+    The serialized Vertex schema for a nullable object tool param must be byte-identical
+    regardless of the interpreter's hash seed. _convert_schema_types used to iterate a set
+    when moving object-specific fields into the anyOf branch, so the JSON key order of
+    "properties"/"required" varied per process. That broke byte-level VCR request matching
+    in CI and forced live Vertex calls (and 429 flakes) on runs whose seed produced the
+    ordering that was not in the cassette.
+    """
+    import json
+    import subprocess
+
+    script = (
+        "import json\n"
+        "from litellm.llms.vertex_ai.common_utils import _build_vertex_schema\n"
+        "params = {\n"
+        "    'type': 'object',\n"
+        "    'additionalProperties': False,\n"
+        "    'required': ['ticket_id', 'customer_context'],\n"
+        "    'properties': {\n"
+        "        'ticket_id': {'type': 'string'},\n"
+        "        'customer_context': {\n"
+        "            'type': ['object', 'null'],\n"
+        "            'additionalProperties': False,\n"
+        "            'required': ['user_id', 'plan'],\n"
+        "            'properties': {'user_id': {'type': 'string'}, 'plan': {'type': 'string'}},\n"
+        "        },\n"
+        "    },\n"
+        "}\n"
+        "print(json.dumps(_build_vertex_schema(params), separators=(',', ':')))\n"
+    )
+    outputs = frozenset(
+        subprocess.run(
+            [sys.executable, "-c", script],
+            env={
+                **os.environ,
+                "PYTHONHASHSEED": str(seed),
+                "LITELLM_LOCAL_MODEL_COST_MAP": "True",
+            },
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        for seed in range(6)
+    )
+    assert len(outputs) == 1
+
+    object_variant = json.loads(next(iter(outputs)))["properties"]["customer_context"]["anyOf"][0]
+    assert object_variant["required"] == ["user_id", "plan"]
+    assert set(object_variant["properties"]) == {"user_id", "plan"}
+
+
 def test_fix_enum_empty_strings():
     """
     Test _fix_enum_empty_strings function replaces empty strings with None in enum arrays.


### PR DESCRIPTION
## Relevant issues

No GitHub issue; fixes the `local_testing_part1` CI flake that turns unrelated PRs red, e.g. [job 2010804](https://app.circleci.com/pipelines/github/BerriAI/litellm/jobs/2010804) on #32390

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proofs for branch `litellm_fix_vertex_429_flake_local_testing`. Before runs captured at base commit 06a43d11c4, after runs at fix commit 8ac1b05670

Before (CI): job 2010804 (`local_testing_part1` on #32390, whose diff only touches unrelated realtime test harness code) fails on exactly one test, `test_gemini_nullable_object_tool_schema_httpx`, with `litellm.RateLimitError ... 429 RESOURCE_EXHAUSTED` from a live `gemini-2.5-flash:generateContent` call. The job's VCR verdict for the test is `[VCR NOOP] played=0 entries=1` and its VCR diagnostic log shows why the cached episode was not replayed: the incoming and cached request bodies are both 807 bytes and first diverge at byte 404, where `required` and `properties` swap order inside `customer_context.anyOf[0]`

Before (local, at 06a43d11c4): the serialized request schema depends on the interpreter hash seed, producing two distinct bodies, which is exactly what makes the cassette miss and the call go live

```
$ git checkout 06a43d11c4 -- litellm/llms/vertex_ai/common_utils.py
$ for seed in 0 1 2 3 4 5 8 10; do PYTHONHASHSEED=$seed uv run python -c "
import json, hashlib
from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
params = <the exact tool parameters from test_gemini_nullable_object_tool_schema_httpx>
print('PYTHONHASHSEED=$seed body_sha256_prefix', hashlib.sha256(json.dumps(_build_vertex_schema(params), separators=(',', ':')).encode()).hexdigest()[:12])"; done
PYTHONHASHSEED=0 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=1 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=2 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=3 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=4 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=5 body_sha256_prefix 182361427b0f
PYTHONHASHSEED=8 body_sha256_prefix 182361427b0f
PYTHONHASHSEED=10 body_sha256_prefix 182361427b0f
```

After (local, at 8ac1b05670): every seed produces identical bytes, and the surviving ordering is the one the majority of seeds already recorded, so existing cassettes keep replaying

```
$ for seed in 0 1 2 3 4 5 8 10; do PYTHONHASHSEED=$seed uv run python -c "<same as above>"; done
PYTHONHASHSEED=0 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=1 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=2 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=3 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=4 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=5 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=8 body_sha256_prefix ad7bf2b3337b
PYTHONHASHSEED=10 body_sha256_prefix ad7bf2b3337b
```

After (live end-to-end, at 8ac1b05670): real Vertex AI call, no mocks, real spend, `litellm.completion(model="vertex_ai/gemini-2.5-flash", tools=<the exact flaking tool schema>, tool_choice="required")`

```
finish_reason: tool_calls
tool_call fn: create_support_ticket
args: {"customer_context": null, "ticket_id": "some-ticket-id"}
response_cost: 0.00031560000000000003
```

Supplementary check of the new skip guard (quota exhaustion cannot be triggered on demand, so this one simulates the 429 at the HTTP transport; it verifies the test plumbing only). Running `pytest tests/local_testing/test_amazing_vertex_completion.py::test_gemini_nullable_object_tool_schema_httpx` with the same forced 429:

```
# after, at 8ac1b05670
SKIPPED [1] tests/local_testing/test_amazing_vertex_completion.py:3905: Rate limit error
1 skipped in 0.16s

# before, at 06a43d11c4
1 failed in 0.35s   (litellm.exceptions.RateLimitError)
```

New regression test fails on the pre-fix code and passes with the fix, and the touched suites are green at 8ac1b05670:

```
$ pytest tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py -q
74 passed in 7.18s
$ pytest tests/test_litellm/llms/vertex_ai/gemini/ -q
238 passed, 1 skipped in 5.89s
$ git stash push -- litellm/llms/vertex_ai/common_utils.py && pytest tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py -q -k hash_seeds
FAILED tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py::test_convert_schema_types_output_is_stable_across_hash_seeds
1 failed, 73 deselected in 8.08s
```

## Type

🐛 Bug Fix

## Changes

CircleCI job `local_testing_part1` intermittently fails unrelated PRs with a Vertex AI 429 on `test_gemini_nullable_object_tool_schema_httpx` (observed on #32390, job 2010804; in a sample of 600 `build_and_test` workflows from 2026-07-03 to 2026-07-08 this was 1 of 16 `local_testing_part1` failures)

Root cause: `_convert_schema_types` in `litellm/llms/vertex_ai/common_utils.py` converts `"type": ["object", "null"]` tool params to `anyOf` and moves `properties`, `required` etc. into the object branch by iterating a Python `set`. String set iteration order varies per process under hash randomization, so the JSON key order of the serialized request body differs from run to run; this test's schema produces exactly two orderings. The local_testing VCR harness matches requests as canonical bytes and deliberately does not normalize JSON key order, so any CI worker whose seed produces the ordering that is not in the Redis cassette misses and calls the live API. That call draws on the shared CI project quota (this job alone is 4 CircleCI nodes x `pytest -n 4`, the file has 20 `gemini-2.5-flash` call sites, and all concurrent PRs share the project), so it sometimes gets a 429. The test had no guard for that: the file-level `litellm.num_retries = 3` is intentionally reset to the `None` default by the conftest isolation fixture, and unlike 22 sibling call sites in the same file there was no `except litellm.RateLimitError: pytest.skip` handler, so a single 429 turns an unrelated PR red. The failure then blocks the cassette save (the persister saves only on pass, and non-2xx responses are filtered from recording anyway), so nothing self-heals within the day, and the 24h cassette TTL restarts the record cycle daily

Fix, targeting two links of that chain. `type_specific_fields` becomes a tuple, so the `anyOf` branch is built in a fixed order and the request body is byte-identical across processes; after the first recording the cassette replays for every run regardless of seed, and only the intentional once-per-TTL re-record stays live. The test also adopts the file's standard skip-on-RateLimitError guard so that residual live call cannot fail an unrelated PR when quota happens to be exhausted. A new regression test builds the exact flaking schema through `_build_vertex_schema` in subprocesses under `PYTHONHASHSEED` 0-5 and asserts all serialized outputs are byte-identical; it fails deterministically on the pre-fix code and passes with the fix
