### PR TITLE
feat(ui): sort session sidebar calls by duration or start time

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
@@ -73,11 +73,13 @@ const sessionLogs = [
 const renderSessionDrawer = () => {
   vi.mocked(sessionSpendLogsCall).mockResolvedValue({ data: sessionLogs, total: 4, total_pages: 1 });
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  render(
+  const drawer = (open: boolean) => (
     <QueryClientProvider client={queryClient}>
-      <LogDetailsDrawer open onClose={() => {}} logEntry={null} sessionId="session-1" accessToken="token" />
-    </QueryClientProvider>,
+      <LogDetailsDrawer open={open} onClose={() => {}} logEntry={null} sessionId="session-1" accessToken="token" />
+    </QueryClientProvider>
   );
+  const { rerender } = render(drawer(true));
+  return { rerender, drawer };
 };
 
 const sidebarEventNames = () =>
@@ -99,6 +101,19 @@ describe("LogDetailsDrawer session sidebar sorting", () => {
     await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-early", "tool-early", "llm-late", "tool-late"]));
 
     fireEvent.click(screen.getByText("Duration"));
+
+    await waitFor(() => expect(sidebarEventNames()).toEqual(["tool-early", "llm-late", "llm-early", "tool-late"]));
+  });
+
+  it("resets the sort mode back to duration when the drawer is closed and reopened", async () => {
+    const { rerender, drawer } = renderSessionDrawer();
+    await waitFor(() => expect(sidebarEventNames()).toHaveLength(4));
+
+    fireEvent.click(screen.getByText("Start time"));
+    await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-early", "tool-early", "llm-late", "tool-late"]));
+
+    rerender(drawer(false));
+    rerender(drawer(true));
 
     await waitFor(() => expect(sidebarEventNames()).toEqual(["tool-early", "llm-late", "llm-early", "tool-late"]));
   });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
@@ -53,13 +53,13 @@ const sessionLogs = [
     model: "tool-early",
     call_type: "call_mcp_tool",
     startTime: "2026-07-08T10:00:01.000Z",
-    endTime: "2026-07-08T10:00:01.500Z",
+    endTime: "2026-07-08T10:00:06.000Z",
   }),
   makeLog({
     request_id: "llm-late",
     model: "llm-late",
     startTime: "2026-07-08T10:00:02.000Z",
-    endTime: "2026-07-08T10:00:04.000Z",
+    endTime: "2026-07-08T10:00:05.000Z",
   }),
   makeLog({
     request_id: "mcp-late",
@@ -84,10 +84,10 @@ const sidebarEventNames = () =>
   screen.queryAllByText(/^(llm-early|llm-late|tool-early|tool-late)$/).map((el) => el.textContent);
 
 describe("LogDetailsDrawer session sidebar sorting", () => {
-  it("defaults to grouped order: LLM calls newest first, MCP calls grouped last", async () => {
+  it("defaults to duration order, longest call first across LLM and MCP calls", async () => {
     renderSessionDrawer();
     await waitFor(() => expect(sidebarEventNames()).toHaveLength(4));
-    expect(sidebarEventNames()).toEqual(["llm-late", "llm-early", "tool-late", "tool-early"]);
+    expect(sidebarEventNames()).toEqual(["tool-early", "llm-late", "llm-early", "tool-late"]);
   });
 
   it("switches to chronological order across LLM and MCP calls when Start time is selected", async () => {
@@ -98,8 +98,8 @@ describe("LogDetailsDrawer session sidebar sorting", () => {
 
     await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-early", "tool-early", "llm-late", "tool-late"]));
 
-    fireEvent.click(screen.getByText("Grouped"));
+    fireEvent.click(screen.getByText("Duration"));
 
-    await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-late", "llm-early", "tool-late", "tool-early"]));
+    await waitFor(() => expect(sidebarEventNames()).toEqual(["tool-early", "llm-late", "llm-early", "tool-late"]));
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
@@ -1,0 +1,105 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LogDetailsDrawer } from "./LogDetailsDrawer";
+import { sessionSpendLogsCall } from "../../networking";
+import { LogEntry } from "../columns";
+
+vi.mock("../../networking", () => ({
+  sessionSpendLogsCall: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/logDetails/useLogDetails", () => ({
+  useLogDetails: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("./LogDetailContent", () => ({
+  LogDetailContent: () => null,
+  GuardrailJumpLink: () => null,
+}));
+
+vi.mock("./DrawerHeader", () => ({
+  DrawerHeader: () => null,
+}));
+
+const makeLog = (overrides: Partial<LogEntry>): LogEntry => ({
+  request_id: "req",
+  api_key: "",
+  team_id: "",
+  model: "",
+  model_id: "",
+  call_type: "acompletion",
+  spend: 0,
+  total_tokens: 0,
+  prompt_tokens: 0,
+  completion_tokens: 0,
+  startTime: "2026-07-08T10:00:00.000Z",
+  endTime: "2026-07-08T10:00:01.000Z",
+  cache_hit: "false",
+  messages: [],
+  response: {},
+  ...overrides,
+});
+
+const sessionLogs = [
+  makeLog({
+    request_id: "llm-early",
+    model: "llm-early",
+    startTime: "2026-07-08T10:00:00.000Z",
+    endTime: "2026-07-08T10:00:02.000Z",
+  }),
+  makeLog({
+    request_id: "mcp-early",
+    model: "tool-early",
+    call_type: "call_mcp_tool",
+    startTime: "2026-07-08T10:00:01.000Z",
+    endTime: "2026-07-08T10:00:01.500Z",
+  }),
+  makeLog({
+    request_id: "llm-late",
+    model: "llm-late",
+    startTime: "2026-07-08T10:00:02.000Z",
+    endTime: "2026-07-08T10:00:04.000Z",
+  }),
+  makeLog({
+    request_id: "mcp-late",
+    model: "tool-late",
+    call_type: "call_mcp_tool",
+    startTime: "2026-07-08T10:00:03.000Z",
+    endTime: "2026-07-08T10:00:03.500Z",
+  }),
+];
+
+const renderSessionDrawer = () => {
+  vi.mocked(sessionSpendLogsCall).mockResolvedValue({ data: sessionLogs, total: 4, total_pages: 1 });
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <LogDetailsDrawer open onClose={() => {}} logEntry={null} sessionId="session-1" accessToken="token" />
+    </QueryClientProvider>,
+  );
+};
+
+const sidebarEventNames = () =>
+  screen.queryAllByText(/^(llm-early|llm-late|tool-early|tool-late)$/).map((el) => el.textContent);
+
+describe("LogDetailsDrawer session sidebar sorting", () => {
+  it("defaults to grouped order: LLM calls newest first, MCP calls grouped last", async () => {
+    renderSessionDrawer();
+    await waitFor(() => expect(sidebarEventNames()).toHaveLength(4));
+    expect(sidebarEventNames()).toEqual(["llm-late", "llm-early", "tool-late", "tool-early"]);
+  });
+
+  it("switches to chronological order across LLM and MCP calls when Start time is selected", async () => {
+    renderSessionDrawer();
+    await waitFor(() => expect(sidebarEventNames()).toHaveLength(4));
+
+    fireEvent.click(screen.getByText("Start time"));
+
+    await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-early", "tool-early", "llm-late", "tool-late"]));
+
+    fireEvent.click(screen.getByText("Grouped"));
+
+    await waitFor(() => expect(sidebarEventNames()).toEqual(["llm-late", "llm-early", "tool-late", "tool-early"]));
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -387,18 +387,17 @@ export function LogDetailsDrawer({
                 </div>
               )}
               {isSessionMode && (
-                <div className="mt-1.5 flex items-center gap-1.5">
-                  <span className="text-[10px] uppercase tracking-wide text-slate-500">Sort by</span>
-                  <Segmented
-                    size="small"
-                    options={[
-                      { label: "Duration", value: "duration" },
-                      { label: "Start time", value: "start_time" },
-                    ]}
-                    value={sessionSortMode}
-                    onChange={(value) => setSessionSortMode(value as SessionLogSortMode)}
-                  />
-                </div>
+                <Segmented
+                  block
+                  size="small"
+                  className="mt-1.5 [&_.ant-segmented-item-label]:text-[11px]"
+                  options={[
+                    { label: "Duration", value: "duration" },
+                    { label: "Start time", value: "start_time" },
+                  ]}
+                  value={sessionSortMode}
+                  onChange={(value) => setSessionSortMode(value as SessionLogSortMode)}
+                />
               )}
             </div>
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button, Drawer } from "antd";
+import { Button, Drawer, Segmented } from "antd";
 import { CheckOutlined, CopyOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
 import { Bot, Sparkles, Wrench } from "lucide-react";
 import { LogEntry } from "../columns";
@@ -11,7 +11,7 @@ import { LogDetailContent, GuardrailJumpLink } from "./LogDetailContent";
 import { sessionSpendLogsCall } from "../../networking";
 import { useQuery } from "@tanstack/react-query";
 import { getSpendString } from "@/utils/dataUtils";
-import { normalizeGuardrailEntries } from "./utils";
+import { normalizeGuardrailEntries, sortSessionLogs, SessionLogSortMode } from "./utils";
 import { DRAWER_WIDTH } from "./constants";
 import { useLogDetails } from "@/app/(dashboard)/hooks/logDetails/useLogDetails";
 
@@ -117,6 +117,7 @@ export function LogDetailsDrawer({
 }: LogDetailsDrawerProps) {
   const isSessionMode = Boolean(sessionId);
   const [selectedSessionRequestId, setSelectedSessionRequestId] = useState<string | null>(null);
+  const [sessionSortMode, setSessionSortMode] = useState<SessionLogSortMode>("grouped");
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [copiedLeftPanelId, setCopiedLeftPanelId] = useState(false);
 
@@ -152,26 +153,20 @@ export function LogDetailsDrawer({
       // backend omits total, so the truncation note reflects what was fetched.
       const total: number = firstPage.total ?? rows.length;
 
-      const logs = rows
-        .map((row) => ({
-          ...row,
-          request_duration_ms: row.request_duration_ms ?? Date.parse(row.endTime) - Date.parse(row.startTime),
-        }))
-        .sort((a, b) => {
-          const aIsMcp = MCP_CALL_TYPES.includes(a.call_type) ? 1 : 0;
-          const bIsMcp = MCP_CALL_TYPES.includes(b.call_type) ? 1 : 0;
-          if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
-          // Newest first, matching the all-sessions logs overview. MCP calls
-          // stay grouped last (above), newest-first within that group too.
-          return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
-        });
+      const logs = rows.map((row) => ({
+        ...row,
+        request_duration_ms: row.request_duration_ms ?? Date.parse(row.endTime) - Date.parse(row.startTime),
+      }));
 
       return { logs, total };
     },
     enabled: Boolean(open && isSessionMode && sessionId && accessToken),
   });
 
-  const sessionLogs: LogEntry[] = sessionData?.logs ?? [];
+  const sessionLogs: LogEntry[] = useMemo(
+    () => sortSessionLogs(sessionData?.logs ?? [], sessionSortMode),
+    [sessionData, sessionSortMode],
+  );
   // total reported by the backend; when the page cap truncates the fetch this
   // exceeds sessionLogs.length, which drives the "showing most recent" note.
   const sessionTotalCount = sessionData?.total ?? sessionLogs.length;
@@ -390,6 +385,18 @@ export function LogDetailsDrawer({
                 <div className="mt-1 text-[11px] text-amber-600 font-mono">
                   Showing most recent {logsForList.length} of {sessionTotalCount}
                 </div>
+              )}
+              {isSessionMode && (
+                <Segmented
+                  size="small"
+                  className="mt-1.5"
+                  options={[
+                    { label: "Grouped", value: "grouped" },
+                    { label: "Start time", value: "chronological" },
+                  ]}
+                  value={sessionSortMode}
+                  onChange={(value) => setSessionSortMode(value as SessionLogSortMode)}
+                />
               )}
             </div>
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -117,7 +117,7 @@ export function LogDetailsDrawer({
 }: LogDetailsDrawerProps) {
   const isSessionMode = Boolean(sessionId);
   const [selectedSessionRequestId, setSelectedSessionRequestId] = useState<string | null>(null);
-  const [sessionSortMode, setSessionSortMode] = useState<SessionLogSortMode>("grouped");
+  const [sessionSortMode, setSessionSortMode] = useState<SessionLogSortMode>("duration");
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [copiedLeftPanelId, setCopiedLeftPanelId] = useState(false);
 
@@ -173,9 +173,9 @@ export function LogDetailsDrawer({
   const sessionTruncated = sessionTotalCount > sessionLogs.length;
 
   // Default selection for a freshly opened session: the most recent log (latest
-  // startTime). The list is sorted newest-first, but MCP calls are grouped last,
-  // so the latest log by time is not necessarily sessionLogs[0]; compute it
-  // explicitly. A clicked/remembered log still wins over this default.
+  // startTime). The list is ordered by the selected sort mode, so the latest
+  // log by time is not necessarily sessionLogs[0]; compute it explicitly.
+  // A clicked/remembered log still wins over this default.
   const mostRecentLog = useMemo<LogEntry | null>(
     () =>
       sessionLogs.reduce<LogEntry | null>(
@@ -387,16 +387,18 @@ export function LogDetailsDrawer({
                 </div>
               )}
               {isSessionMode && (
-                <Segmented
-                  size="small"
-                  className="mt-1.5"
-                  options={[
-                    { label: "Grouped", value: "grouped" },
-                    { label: "Start time", value: "chronological" },
-                  ]}
-                  value={sessionSortMode}
-                  onChange={(value) => setSessionSortMode(value as SessionLogSortMode)}
-                />
+                <div className="mt-1.5 flex items-center gap-1.5">
+                  <span className="text-[10px] uppercase tracking-wide text-slate-500">Sort by</span>
+                  <Segmented
+                    size="small"
+                    options={[
+                      { label: "Duration", value: "duration" },
+                      { label: "Start time", value: "start_time" },
+                    ]}
+                    value={sessionSortMode}
+                    onChange={(value) => setSessionSortMode(value as SessionLogSortMode)}
+                  />
+                </div>
               )}
             </div>
 

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -217,6 +217,7 @@ export function LogDetailsDrawer({
       setIsSidebarCollapsed(false);
     } else {
       if (isSessionMode) setSelectedSessionRequestId(null);
+      setSessionSortMode("duration");
       setCopiedLeftPanelId(false);
     }
   }, [open, isSessionMode]);

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { sortSessionLogs } from "./utils";
+
+const llm = (id: string, startTime: string) => ({ request_id: id, call_type: "acompletion", startTime });
+const mcp = (id: string, startTime: string) => ({ request_id: id, call_type: "call_mcp_tool", startTime });
+
+const ids = (rows: { request_id: string }[]) => rows.map((row) => row.request_id);
+
+describe("sortSessionLogs", () => {
+  const rows = [
+    mcp("mcp-early", "2026-07-08T10:00:01.000Z"),
+    llm("llm-late", "2026-07-08T10:00:02.000Z"),
+    mcp("mcp-late", "2026-07-08T10:00:03.000Z"),
+    llm("llm-early", "2026-07-08T10:00:00.000Z"),
+  ];
+
+  it("grouped mode keeps MCP calls last, newest first within each group", () => {
+    expect(ids(sortSessionLogs(rows, "grouped"))).toEqual(["llm-late", "llm-early", "mcp-late", "mcp-early"]);
+  });
+
+  it("chronological mode interleaves all calls by start time, oldest first", () => {
+    expect(ids(sortSessionLogs(rows, "chronological"))).toEqual(["llm-early", "mcp-early", "llm-late", "mcp-late"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...rows];
+    sortSessionLogs(input, "chronological");
+    expect(ids(input)).toEqual(ids(rows));
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.test.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.test.ts
@@ -1,30 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { sortSessionLogs } from "./utils";
 
-const llm = (id: string, startTime: string) => ({ request_id: id, call_type: "acompletion", startTime });
-const mcp = (id: string, startTime: string) => ({ request_id: id, call_type: "call_mcp_tool", startTime });
+const log = (id: string, startTime: string, endTime: string, request_duration_ms?: number) => ({
+  request_id: id,
+  startTime,
+  endTime,
+  request_duration_ms,
+});
 
 const ids = (rows: { request_id: string }[]) => rows.map((row) => row.request_id);
 
 describe("sortSessionLogs", () => {
   const rows = [
-    mcp("mcp-early", "2026-07-08T10:00:01.000Z"),
-    llm("llm-late", "2026-07-08T10:00:02.000Z"),
-    mcp("mcp-late", "2026-07-08T10:00:03.000Z"),
-    llm("llm-early", "2026-07-08T10:00:00.000Z"),
+    log("mid-duration", "2026-07-08T10:00:01.000Z", "2026-07-08T10:00:01.500Z", 2000),
+    log("longest", "2026-07-08T10:00:02.000Z", "2026-07-08T10:00:02.500Z", 5000),
+    log("shortest", "2026-07-08T10:00:03.000Z", "2026-07-08T10:00:03.500Z", 300),
+    log("earliest-no-duration-field", "2026-07-08T10:00:00.000Z", "2026-07-08T10:00:04.000Z"),
   ];
 
-  it("grouped mode keeps MCP calls last, newest first within each group", () => {
-    expect(ids(sortSessionLogs(rows, "grouped"))).toEqual(["llm-late", "llm-early", "mcp-late", "mcp-early"]);
+  it("duration mode sorts longest call first, deriving duration from timestamps when the field is missing", () => {
+    expect(ids(sortSessionLogs(rows, "duration"))).toEqual([
+      "longest",
+      "earliest-no-duration-field",
+      "mid-duration",
+      "shortest",
+    ]);
   });
 
-  it("chronological mode interleaves all calls by start time, oldest first", () => {
-    expect(ids(sortSessionLogs(rows, "chronological"))).toEqual(["llm-early", "mcp-early", "llm-late", "mcp-late"]);
+  it("start_time mode sorts calls in the order they started", () => {
+    expect(ids(sortSessionLogs(rows, "start_time"))).toEqual([
+      "earliest-no-duration-field",
+      "mid-duration",
+      "longest",
+      "shortest",
+    ]);
   });
 
   it("does not mutate the input array", () => {
     const input = [...rows];
-    sortSessionLogs(input, "chronological");
+    sortSessionLogs(input, "duration");
     expect(ids(input)).toEqual(ids(rows));
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.ts
@@ -3,25 +3,18 @@
  * These functions handle data formatting, validation, and guardrail calculations.
  */
 
-import { MCP_CALL_TYPES } from "../constants";
+export type SessionLogSortMode = "duration" | "start_time";
 
-export type SessionLogSortMode = "grouped" | "chronological";
+type SortableSessionLog = { startTime: string; endTime: string; request_duration_ms?: number };
 
-export function sortSessionLogs<T extends { call_type: string; startTime: string }>(
-  rows: T[],
-  mode: SessionLogSortMode,
-): T[] {
-  if (mode === "chronological") {
+const durationMs = (row: SortableSessionLog): number =>
+  row.request_duration_ms ?? Date.parse(row.endTime) - Date.parse(row.startTime);
+
+export function sortSessionLogs<T extends SortableSessionLog>(rows: T[], mode: SessionLogSortMode): T[] {
+  if (mode === "start_time") {
     return [...rows].sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
   }
-  return [...rows].sort((a, b) => {
-    const aIsMcp = MCP_CALL_TYPES.includes(a.call_type) ? 1 : 0;
-    const bIsMcp = MCP_CALL_TYPES.includes(b.call_type) ? 1 : 0;
-    if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
-    // Newest first, matching the all-sessions logs overview. MCP calls
-    // stay grouped last (above), newest-first within that group too.
-    return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
-  });
+  return [...rows].sort((a, b) => durationMs(b) - durationMs(a));
 }
 
 /**

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/utils.ts
@@ -3,6 +3,27 @@
  * These functions handle data formatting, validation, and guardrail calculations.
  */
 
+import { MCP_CALL_TYPES } from "../constants";
+
+export type SessionLogSortMode = "grouped" | "chronological";
+
+export function sortSessionLogs<T extends { call_type: string; startTime: string }>(
+  rows: T[],
+  mode: SessionLogSortMode,
+): T[] {
+  if (mode === "chronological") {
+    return [...rows].sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+  }
+  return [...rows].sort((a, b) => {
+    const aIsMcp = MCP_CALL_TYPES.includes(a.call_type) ? 1 : 0;
+    const bIsMcp = MCP_CALL_TYPES.includes(b.call_type) ? 1 : 0;
+    if (aIsMcp !== bIsMcp) return aIsMcp - bIsMcp;
+    // Newest first, matching the all-sessions logs overview. MCP calls
+    // stay grouped last (above), newest-first within that group too.
+    return new Date(b.startTime).getTime() - new Date(a.startTime).getTime();
+  });
+}
+
 /**
  * Formats data for display. If input is a string, attempts to parse as JSON.
  * @param input - Data to format (string or object)


### PR DESCRIPTION
## Relevant issues

Fixes #32431

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before/after screenshots to be added in a comment (before at the merge base, after at 6d2090a21b). Steps to reproduce: run the proxy and the dashboard dev server, open http://localhost:3000/ui/?page=logs, click the session id of a session that mixes LLM and MCP calls, and look at the left sidebar of the drawer. Before this change the sidebar always lists LLM calls first and MCP calls last, newest first within each group, with no way to change it. After this change a Duration / Start time toggle sits under the session stats; Duration sorts the whole list by request duration, longest first, and Start time re-sorts it chronologically, interleaving LLM and MCP calls in the order they actually ran

## Type

🆕 New Feature

## Changes

The session drawer sidebar (LogDetailsDrawer) previously hardcoded its ordering inside the react-query fetch: MCP calls grouped after LLM calls, newest first within each group. That ordering is hard to reason about when debugging a session that interleaves LLM turns with MCP tool calls; you can neither see the slowest calls at a glance nor follow the actual execution order

This PR moves the ordering out of the query into a pure `sortSessionLogs(rows, mode)` helper in `LogDetailsDrawer/utils.ts` and adds a compact antd Segmented toggle to the sidebar header with two modes. `duration` is the default and sorts every call by request duration descending (falling back to endTime minus startTime when `request_duration_ms` is absent); `start_time` sorts every call by start time ascending so the list reads top to bottom in execution order. Both modes interleave LLM, agent and MCP calls; the previous group-by-type ordering is intentionally dropped since it obscured both dimensions. The toggle only renders in session mode, and the selected mode resets to duration when the drawer closes so it does not leak into the next session a user opens

Tests: unit tests for `sortSessionLogs` pin both orderings, the timestamp fallback for missing durations and non-mutation of the input, and a component test renders the drawer in session mode, asserts the default duration order, clicks Start time and asserts the interleaved chronological order, then toggles back


## Test

### Before

Tools are sorted by default by duration and don't show call order

<img width="230" height="271" alt="image" src="https://github.com/user-attachments/assets/a03e614c-854e-4401-9ff8-a429b6ab8fe0" />

### After

You can sort by duration (default) or by start time (new)

<img width="228" height="278" alt="image" src="https://github.com/user-attachments/assets/19d1d495-8134-4daa-bdcd-0d8d3b368db3" />

<img width="228" height="281" alt="image" src="https://github.com/user-attachments/assets/376c2451-670a-4a03-aa9f-775ffc9a8c31" />




