### PR TITLE
fix(proxy): surface OAuth error params in SSO callback

### DIFF
--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -1746,6 +1746,18 @@ async def auth_callback(request: Request, state: Optional[str] = None):
     """Verify login"""
     verbose_proxy_logger.info(f"Starting SSO callback with state: {state}")
 
+    oauth_error = request.query_params.get("error")
+    if oauth_error:
+        oauth_error_description = request.query_params.get("error_description")
+        verbose_proxy_logger.warning(
+            f"SSO callback received OAuth error: {oauth_error}, description: {oauth_error_description}"
+        )
+        raise HTTPException(
+            status_code=401,
+            detail=f"OAuth error: {oauth_error}"
+            + (f", error_description: {oauth_error_description}" if oauth_error_description else ""),
+        )
+
     # Check if this is a CLI login (state starts with our CLI prefix)
     from litellm.constants import LITELLM_CLI_SESSION_TOKEN_PREFIX
     from litellm.proxy._types import LiteLLM_JWTAuth

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -2711,6 +2711,7 @@ class TestCLIKeyRegenerationFlow:
 
         # Mock request
         mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"code": "some-auth-code"}
 
         cli_state = f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-new-session-key-456"
 
@@ -2752,6 +2753,7 @@ class TestCLIKeyRegenerationFlow:
         from litellm.proxy.management_endpoints.ui_sso import auth_callback
 
         mock_request = MagicMock(spec=Request)
+        mock_request.query_params = {"code": "some-auth-code"}
         cli_state = (
             f"{LITELLM_CLI_SESSION_TOKEN_PREFIX}:cli-new-session-key-456:WXYZ-2345"
         )
@@ -7182,3 +7184,61 @@ async def test_cli_poll_key_tolerates_missing_user_row():
     assert result["status"] == "ready"
     assert result["key"] == mock_jwt_token
     assert result["user_id"] == "just-created-user"
+
+
+def _make_sso_callback_request(query_params: dict) -> MagicMock:
+    mock_request = MagicMock(spec=Request)
+    mock_request.query_params = query_params
+    return mock_request
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_surfaces_oauth_error_with_description():
+    """
+    Regression: when the IdP denies access it redirects back with
+    ?error=...&error_description=... and no `code`. The callback must surface
+    that reason as a 401 instead of failing later on the missing `code` param.
+    """
+    from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+    mock_request = _make_sso_callback_request(
+        {"error": "access_denied", "error_description": "User is not assigned to the client application"}
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_callback(request=mock_request, state=None)
+
+    assert exc_info.value.status_code == 401
+    assert "access_denied" in str(exc_info.value.detail)
+    assert "User is not assigned to the client application" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_surfaces_oauth_error_without_description():
+    """error_description is optional in the OAuth error response; the 401 detail must not render 'None'."""
+    from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+    mock_request = _make_sso_callback_request({"error": "access_denied"})
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_callback(request=mock_request, state=None)
+
+    assert exc_info.value.status_code == 401
+    assert "access_denied" in str(exc_info.value.detail)
+    assert "None" not in str(exc_info.value.detail)
+    assert "error_description" not in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_without_oauth_error_proceeds_to_normal_flow():
+    """Without an `error` query param the guard must not fire; the callback proceeds into the normal flow."""
+    from litellm.proxy.management_endpoints.ui_sso import auth_callback
+
+    mock_request = _make_sso_callback_request({"code": "some-auth-code"})
+
+    with patch("litellm.proxy.proxy_server.prisma_client", None):
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_callback(request=mock_request, state=None)
+
+    assert exc_info.value.status_code == 500
+    assert "DB not connected" in str(exc_info.value.detail)


### PR DESCRIPTION
## Relevant issues

Fixes #26403

## Linear ticket

Resolves LIT-4171

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy (`python litellm/proxy/proxy_cli.py --config <config> --port 4171`) with real Postgres and `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` set, simulating exactly what the browser sends when an IdP like Okta denies access and redirects back to the callback URL

Before, at base commit d6cbf6e7e3 (unfixed):

```
$ curl -sS -i "http://localhost:4171/sso/callback?error=access_denied&error_description=User+is+not+assigned+to+the+client+application&state=abc123"
HTTP/1.1 400 Bad Request
{"detail":"'code' parameter was not found in callback request"}
```

The IdP's actual denial reason is discarded; the user only sees a confusing message about a missing `code` parameter

After, at db10cca778 (this PR):

```
$ curl -sS -i "http://localhost:4171/sso/callback?error=access_denied&error_description=User+is+not+assigned+to+the+client+application&state=abc123"
HTTP/1.1 401 Unauthorized
{"detail":"OAuth error: access_denied, error_description: User is not assigned to the client application"}

$ curl -sS -i "http://localhost:4171/sso/callback?error=access_denied"
HTTP/1.1 401 Unauthorized
{"detail":"OAuth error: access_denied"}
```

A normal callback without an `error` param is unaffected: `curl "http://localhost:4171/sso/callback?code=bogus-code&state=abc123"` still proceeds into the regular provider token exchange (verified in the proxy logs that the request reached oauthlib's token endpoint call)

Devin e2e run: https://app.devin.ai/attachments/1912f39f-2270-42ff-8ac1-e82f00d7f398/sso_oauth_error-edited.mp4

## Type

🐛 Bug Fix

## Changes

This is a port of #26640 by @skgandikota, which went stale and now conflicts with `litellm_internal_staging` because `auth_callback` was restructured since it was written (new `prisma_client` guard, JWT handler setup). All credit for the diagnosis and the original fix goes to that PR; this one re-applies it cleanly on the current branch

Per RFC 6749 section 4.1.2.1, when authorization fails the IdP redirects to the callback with `error` (and optionally `error_description`) query params and no `code`. `auth_callback` in `litellm/proxy/management_endpoints/ui_sso.py` assumed `code` was always present, so the request fell through to fastapi-sso's `verify_and_process`, which raised a generic 400 about the missing `code` parameter and hid the real reason access was denied. The fix checks for `error` at the top of the handler and raises `HTTPException(401)` carrying the IdP's error code and description

Differences from the original PR: the `isinstance(oauth_error, str)` checks are dropped since `query_params.get()` already returns `Optional[str]`; they only existed to tolerate test mocks lacking `query_params`. The two existing CLI-flow tests in `tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` that relied on that tolerance now set a real `query_params` dict on their mock requests. Three regression tests are added: error with description surfaces both in a 401, error without description renders no `None` placeholder, and a callback without an `error` param does not trip the guard. The two error-path tests fail on the unfixed code and pass with the fix

The diagnostic endpoint `/sso/debug/callback` dispatches to the same provider handlers and still shows the old behavior on an IdP error redirect; it is a debug surface used deliberately by an admin, so it is left out of scope here to keep this PR a faithful port of the original fix

Link to Devin session: https://app.devin.ai/sessions/af63ad69c1b44bdd83368f6278983b36