### PR TITLE
fix(proxy): coerce default_internal_user_params.max_budget to float on config load

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4196,6 +4196,9 @@ class ProxyConfig:
                         if value.get("max_budget") is not None
                         else value
                     )
+                    verbose_proxy_logger.debug(
+                        f"{blue_color_code} setting litellm.{key}={_redact_general_setting_value(key, litellm.default_internal_user_params, is_full_admin=False)}{reset_color_code}"
+                    )
                 elif key == "custom_provider_map":
                     from litellm.utils import custom_llm_setup
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4190,6 +4190,12 @@ class ProxyConfig:
                     litellm.default_max_internal_user_budget = float(value)
                     if litellm.max_internal_user_budget is None:
                         litellm.max_internal_user_budget = litellm.default_max_internal_user_budget
+                elif key == "default_internal_user_params" and isinstance(value, dict):
+                    litellm.default_internal_user_params = (
+                        {**value, "max_budget": float(value["max_budget"])}
+                        if value.get("max_budget") is not None
+                        else value
+                    )
                 elif key == "custom_provider_map":
                     from litellm.utils import custom_llm_setup
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2630,8 +2630,16 @@ async def test_load_config_default_internal_user_params_without_max_budget(tmp_p
     """
     from litellm.proxy.proxy_server import ProxyConfig
 
-    config_file = tmp_path / "config.yaml"
-    config_file.write_text(
+    absent_config_file = tmp_path / "absent_config.yaml"
+    absent_config_file.write_text(
+        "model_list: []\n"
+        "litellm_settings:\n"
+        "  default_internal_user_params:\n"
+        "    user_role: internal_user\n"
+    )
+
+    null_config_file = tmp_path / "null_config.yaml"
+    null_config_file.write_text(
         "model_list: []\n"
         "litellm_settings:\n"
         "  default_internal_user_params:\n"
@@ -2641,7 +2649,10 @@ async def test_load_config_default_internal_user_params_without_max_budget(tmp_p
 
     original_params = litellm.default_internal_user_params
     try:
-        await ProxyConfig().load_config(router=MagicMock(), config_file_path=str(config_file))
+        await ProxyConfig().load_config(router=MagicMock(), config_file_path=str(absent_config_file))
+        assert litellm.default_internal_user_params == {"user_role": "internal_user"}
+
+        await ProxyConfig().load_config(router=MagicMock(), config_file_path=str(null_config_file))
         assert litellm.default_internal_user_params == {
             "user_role": "internal_user",
             "max_budget": None,

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -2584,6 +2584,73 @@ async def test_load_config_max_budget_env_var_coerced_to_float(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_load_config_default_internal_user_params_max_budget_scientific_notation(tmp_path):
+    """
+    Helm's toYaml renders large floats in scientific notation without a
+    decimal mantissa (e.g. 1e+09), which PyYAML parses as a string.
+    load_config must coerce default_internal_user_params.max_budget to
+    float, otherwise every consumer of the raw dict (/user/new, SSO,
+    SCIM user creation) passes the string to Prisma, which rejects it
+    since max_budget must be Float or Null. Keys outside the coercion
+    (including ones not on DefaultInternalUserParams, like
+    auto_create_key) must pass through unchanged.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "model_list: []\n"
+        "litellm_settings:\n"
+        "  default_internal_user_params:\n"
+        "    user_role: internal_user\n"
+        "    max_budget: 1e+09\n"
+        "    budget_duration: 30d\n"
+        "    auto_create_key: false\n"
+    )
+
+    original_params = litellm.default_internal_user_params
+    try:
+        await ProxyConfig().load_config(router=MagicMock(), config_file_path=str(config_file))
+        assert litellm.default_internal_user_params == {
+            "user_role": "internal_user",
+            "max_budget": 1000000000.0,
+            "budget_duration": "30d",
+            "auto_create_key": False,
+        }
+        assert isinstance(litellm.default_internal_user_params["max_budget"], float)
+    finally:
+        litellm.default_internal_user_params = original_params
+
+
+@pytest.mark.asyncio
+async def test_load_config_default_internal_user_params_without_max_budget(tmp_path):
+    """
+    default_internal_user_params without max_budget (or with an explicit
+    null) must be stored as-is and not gain a max_budget key.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        "model_list: []\n"
+        "litellm_settings:\n"
+        "  default_internal_user_params:\n"
+        "    user_role: internal_user\n"
+        "    max_budget: null\n"
+    )
+
+    original_params = litellm.default_internal_user_params
+    try:
+        await ProxyConfig().load_config(router=MagicMock(), config_file_path=str(config_file))
+        assert litellm.default_internal_user_params == {
+            "user_role": "internal_user",
+            "max_budget": None,
+        }
+    finally:
+        litellm.default_internal_user_params = original_params
+
+
+@pytest.mark.asyncio
 async def test_load_config_user_url_validation_handles_null_and_string_false(tmp_path, monkeypatch):
     from litellm.proxy.proxy_server import ProxyConfig
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4045

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs use a live proxy against a real Postgres, with this config (this is the exact shape Helm's `toYaml` renders for a large float budget; PyYAML parses `1e+09` as the string `'1e+09'` because YAML 1.1 floats require a decimal point in the mantissa):

```yaml
litellm_settings:
  default_internal_user_params:
    user_role: internal_user
    max_budget: 1e+09
    budget_duration: 30d
```

Before the fix (proxy running commit `d6cbf6e7e3`):

```bash
curl -s -w "\nHTTP:%{http_code}\n" -X POST http://localhost:44045/user/new \
  -H "Authorization: Bearer sk-...master" -H "Content-Type: application/json" \
  -d '{"user_email": "repro-lit4045@example.com"}'
```

```
{"error":{"message":"{'error': 'Internal Server Error.'}","type":"internal_server_error","param":"None","code":"500"}}
HTTP:500
```

Proxy log shows the exact error from the report:

```
prisma.errors.DataError: Unable to match input value to any allowed input type for the field. Parse errors: [... Invalid argument type. `max_budget` should be of any of the following types: `Float`, ... `Null`]
```

After the fix (proxy running commit `99c4a0ad06`), the same curl succeeds and the default budget lands as a proper float:

```
{"key_alias":null,...,"max_budget":1000000000.0,...,"budget_duration":"30d",...,"user_email":"verify-lit4045@example.com","user_role":"internal_user",...}
HTTP:200
```

Admin users still skip the defaults, verified at the same commit:

```bash
curl -s -X POST http://localhost:44045/user/new \
  -H "Authorization: Bearer sk-...master" -H "Content-Type: application/json" \
  -d '{"user_email": "verify-admin-lit4045@example.com", "user_role": "proxy_admin"}'
# -> user_role: proxy_admin | max_budget: None
```

Independent e2e verification (Devin): reproduced end to end against a live proxy and a real Postgres using the config above with the literal `max_budget: 1e+09`. On the merge-base commit `d6cbf6e7e320f64138ccb0bcb847baae394fde2b` the `POST /user/new` returned HTTP 500 with the prisma `DataError`, and on the branch head `99c4a0ad064aec61f32d567b4bd638b2061db481` the same request returned HTTP 200 with `"max_budget":1000000000.0` (a float), `budget_duration` 30d and `user_role` internal_user, while a `proxy_admin` create returned HTTP 200 with `max_budget` null

![Independent e2e verification of LIT-4045](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNjI3MzA4OGMtOWRlNS00Y2M0LTg2ZWMtMDY2MjA2NzEyZWU4IiwiaWF0IjoxNzgzNDkzODA2LCJleHAiOjE3ODQwOTg2MDYsImZpbGVuYW1lIjoibGl0NDA0NV9lMmUud2VicCJ9._FJZOK2RMyGC4d1pq1puN9Fv4vzyF6Cv1pJM-sOlUlU)

Full video: https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvNjI3MzA4OGMtOWRlNS00Y2M0LTg2ZWMtMDY2MjA2NzEyZWU4IiwiaWF0IjoxNzgzNDkzODA2LCJleHAiOjE3ODQwOTg2MDYsImZpbGVuYW1lIjoibGl0NDA0NV9lMmUud2VicCJ9._FJZOK2RMyGC4d1pq1puN9Fv4vzyF6Cv1pJM-sOlUlU

## Type

🐛 Bug Fix

## Changes

Helm's `toYaml` serializes large float values in scientific notation without a decimal mantissa (e.g. `1e+09`). PyYAML's `safe_load` parses that form as a string, not a float, so `default_internal_user_params.max_budget` was stored as `'1e+09'` on `litellm.default_internal_user_params`. Every consumer of that raw dict (`/user/new`, SSO user auto-provisioning, SCIM, JWT auth upserts) copied the string straight into the Prisma insert, which rejects it since `max_budget` must be `Float` or `Null`, turning `/user/new` into a 500

The config load path in `ProxyConfig.load_config` already coerces the sibling budget settings (`max_budget`, `max_internal_user_budget`, `default_max_internal_user_budget`) with `float()`, but `default_internal_user_params` fell through to the generic `setattr` with no coercion. This PR adds a branch that coerces its `max_budget` to float when present, preserving all other keys untouched (including ones outside `DefaultInternalUserParams`, like `auto_create_key` and `available_teams`, which downstream code reads from the raw dict). Fixing it at config load covers all consumers at once. The new branch also emits the same debug log the generic path does. Scope note: other numeric keys users can place in `default_internal_user_params` (e.g. `soft_budget`, tpm/rpm limits) could in principle hit the same PyYAML string parse if hand-written in scientific notation, but Helm only renders floats that way and the reported failure is `max_budget`, so this PR intentionally coerces only that field

Regression tests load a config with the ambiguous `1e+09` literal written as raw YAML text (a `yaml.dump` round trip would normalize it away) and assert the stored dict carries a float and that all other keys pass through unchanged; a second test asserts both an absent and an explicit null `max_budget` are stored as-is. The scientific notation test fails on the previous commit and passes with the fix


Link to Devin session: https://app.devin.ai/sessions/d6ba13ac16d5423c8e3bcebf6c8778a9