### PR TITLE
test(benchmarks): run shared logging executor inline to make CodSpeed measurements deterministic

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -1,0 +1,36 @@
+"""Shared setup keeping CodSpeed measurements hermetic.
+
+CodSpeed's callgrind instrumentation counts instructions from every thread while
+a measurement window is open, and valgrind serializes all threads onto one
+virtual CPU. Work deferred to litellm's shared logging executor would therefore
+be attributed to whichever benchmark the valgrind scheduler resumes it under,
+flipping results between runs. Running the executor inline keeps each
+benchmark's cost self-contained and deterministic.
+"""
+
+from collections.abc import Callable, Iterator
+from concurrent.futures import Future
+from typing import ParamSpec, TypeVar
+
+import pytest
+
+from litellm.litellm_core_utils.thread_pool_executor import executor
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def _submit_inline(fn: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> Future[R]:
+    future: Future[R] = Future()
+    try:
+        future.set_result(fn(*args, **kwargs))
+    except BaseException as exc:
+        future.set_exception(exc)
+    return future
+
+
+@pytest.fixture(autouse=True, scope="session")
+def inline_logging_executor() -> Iterator[None]:
+    executor.submit = _submit_inline
+    yield
+    del executor.submit

--- a/tests/benchmarks/test_benchmarks.py
+++ b/tests/benchmarks/test_benchmarks.py
@@ -6,10 +6,13 @@ in the litellm hot path: token counting, model info lookup, provider
 resolution, and cost calculation.
 """
 
+import threading
+
 import pytest
 
 import litellm
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.thread_pool_executor import executor
 from litellm.litellm_core_utils.token_counter import token_counter
 
 
@@ -205,3 +208,21 @@ def test_get_model_cost_key_exact_match():
 def test_get_model_cost_key_case_insensitive():
     """Benchmark model cost key lookup with case-insensitive fallback."""
     litellm.utils._get_model_cost_key("GPT-4o")
+
+
+# ---------------------------------------------------------------------------
+# Measurement hermeticity guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.benchmark
+def test_logging_executor_runs_inline():
+    """Guard that the shared logging executor runs submissions inline.
+
+    Deferred submissions execute on worker threads, and callgrind attributes
+    their instructions to whichever benchmark's measurement window is open when
+    the valgrind scheduler resumes them, making results nondeterministic.
+    """
+    future = executor.submit(threading.get_ident)
+    assert future.done()
+    assert future.result() == threading.get_ident()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4260

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (unfixed, observed on production CI over a 12h window ending 2026-07-08 06:20 UTC): the CodSpeed Performance Analysis check flagged false regressions on 10 of ~40 PR heads, always in the three completion benchmarks of `tests/benchmarks/test_inference_benchmarks.py` and never in the other 27 benchmarks. The measurements are bimodal, with the same ~1.0-1.6 ms cost roaming between benchmarks run to run. For example, at PR head `661db9a` (compared against staging `6df5e1b`) the report read `test_completion_multi_turn` 3.1 ms -> 4.2 ms (-25.9%), `test_completion_simple_message` 3.8 ms -> 4.7 ms (-17.96%), `test_completion_with_tools` 4.2 ms -> 3.2 ms (+30.98%); at PR head `db24027` the same benchmarks flipped the other way. BASE values for unchanged staging code also flap (`test_completion_simple_message` was variously 3.2, 3.8, 4.1, 4.6 and 4.8 ms across the window), proving the instability is benchmark-internal rather than caused by any PR's diff

After (this PR, head `8da870f`): the CodSpeed workflow was run twice on the same commit (run 28923307313 and its rerun) and the reports agree on every benchmark. `test_completion_multi_turn` measured 3.8 ms in both runs and `test_completion_simple_message` 3.9 ms in both, with the reported efficiency deltas differing by only 0.06 percentage points between runs (-17.65% vs -17.71%, +16.75% vs +16.77%); before the fix, two runs of the same code flipped by 25 to 47 points. The new values also confirm the mechanism: they equal the old fast mode (3.1/3.2 ms) plus exactly one success handler, meaning each measurement now contains precisely its own work

Note for reviewers: the CodSpeed check on this PR reads as a small regression by design, for two reasons that both resolve on merge. The BASE it compares against is staging's still-flapping measurement, and the handler cost that was previously attributed to a random benchmark is now deterministically included, shifting the completion benchmarks up by ~0.7 ms once. The shift should be acknowledged on the CodSpeed dashboard; the property that matters, reruns of the same commit agreeing, is demonstrated above

## Type

✅ Test
🚄 Infrastructure

## Changes

The three completion benchmarks call `litellm.completion(..., mock_response=...)`, and each such call submits its success handler (cost calculation, response copying) to the shared `ThreadPoolExecutor` in `litellm/litellm_core_utils/thread_pool_executor.py` (submitted from the sync wrapper in `litellm/utils.py`). pytest-codspeed's simulation mode runs one warmup call and one measured call, toggling callgrind instrumentation around the measured call only. Callgrind counts instructions from every thread while the window is open, and valgrind serializes all threads onto one virtual CPU, so the queued handler work lands inside whichever benchmark's measured window the valgrind scheduler happens to resume it under. GC and `random` are already neutralized by pytest-codspeed itself (`gc.collect(); gc.disable()` and `random.seed(0)` around every measurement), which is why the flakiness only ever appeared in the benchmarks that enqueue background work

This PR adds `tests/benchmarks/conftest.py` with a session-scoped autouse fixture that replaces the shared executor's `submit` with an inline implementation for the benchmark session, so every measurement contains exactly its own work. This is deterministic and also more representative of the true per-request cost. A guard benchmark, `test_logging_executor_runs_inline`, asserts that submissions through the shared executor complete inline on the calling thread; it fails immediately if the fixture is removed (verified by running it with the conftest moved aside)
