### PR TITLE
fix(proxy): handle legacy response id payloads

### DIFF
--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -104,12 +104,13 @@ class ResponsesIDSecurity(CustomLogger):
         return True
 
     def _is_encrypted_response_id(self, response_id: str) -> bool:
-        split_result = response_id.split("resp_")
-        if len(split_result) < 2:
+        if not response_id.startswith("resp_"):
             return False
 
-        remaining_string = split_result[1]
-        decrypted_value = decrypt_value_helper(value=remaining_string, key="response_id", return_original_value=True)
+        remaining_string = response_id.split("resp_", 1)[1]
+        decrypted_value = decrypt_value_helper(
+            value=remaining_string, key="response_id", return_original_value=True
+        )
 
         if decrypted_value is None:
             return False
@@ -125,37 +126,39 @@ class ResponsesIDSecurity(CustomLogger):
          - user_id: the user id
          - team_id: the team id
         """
-        split_result = response_id.split("resp_")
-        if len(split_result) < 2:
+        if not response_id.startswith("resp_"):
             return response_id, None, None
 
-        remaining_string = split_result[1]
-        decrypted_value = decrypt_value_helper(value=remaining_string, key="response_id", return_original_value=True)
+        remaining_string = response_id.split("resp_", 1)[1]
+        decrypted_value = decrypt_value_helper(
+            value=remaining_string, key="response_id", return_original_value=True
+        )
 
         if decrypted_value is None:
             return response_id, None, None
 
         if decrypted_value.startswith(SpecialEnums.LITELM_MANAGED_FILE_ID_PREFIX.value):
-            # Expected format: "litellm_proxy:responses_api:response_id:{response_id};user_id:{user_id}"
-            parts = decrypted_value.split(";")
-
-            if len(parts) >= 2:
-                # Extract response_id from "litellm_proxy:responses_api:response_id:{response_id}"
-                response_id_part = parts[0]
-                original_response_id = response_id_part.split("response_id:")[-1]
-
-                # Extract user_id from "user_id:{user_id}"
-                user_id_part = parts[1]
-                user_id = user_id_part.split("user_id:")[-1]
-
-                # Extract team_id from "team_id:{team_id}"
-                team_id_part = parts[2]
-                team_id = team_id_part.split("team_id:")[-1]
-
-                return original_response_id, user_id, team_id
-            else:
-                # Fallback if format is unexpected
+            # Expected format:
+            # "litellm_proxy:responses_api:response_id:{response_id};user_id:{user_id};team_id:{team_id}"
+            # Older encrypted ids may not include the team_id segment.
+            response_id_part, *metadata_parts = decrypted_value.split(";")
+            if "response_id:" not in response_id_part:
                 return response_id, None, None
+
+            original_response_id = response_id_part.split("response_id:", 1)[1]
+
+            user_id = None
+            team_id = None
+            for part in metadata_parts:
+                key, separator, value = part.partition(":")
+                if not separator:
+                    continue
+                if key == "user_id":
+                    user_id = value or None
+                elif key == "team_id":
+                    team_id = value or None
+
+            return original_response_id, user_id, team_id
         return response_id, None, None
 
     def _get_signing_key(self) -> Optional[str]:

--- a/tests/test_litellm/test_responses_id_security.py
+++ b/tests/test_litellm/test_responses_id_security.py
@@ -87,6 +87,24 @@ class TestDecryptResponseId:
             assert user_id == "user-456"
             assert team_id == "team-789"
 
+    def test_decrypt_response_id_legacy_without_team_id(self, responses_id_security):
+        """Legacy encrypted response IDs did not always include team_id."""
+        import litellm.proxy.hooks.responses_id_security as responses_module
+
+        with patch.object(responses_module, "decrypt_value_helper") as mock_decrypt:
+            mock_decrypt.return_value = (
+                f"{SpecialEnums.LITELM_MANAGED_FILE_ID_PREFIX.value}"
+                "response_id:resp_original_123;user_id:user-456"
+            )
+
+            original_id, user_id, team_id = responses_id_security._decrypt_response_id(
+                "resp_encrypted_value"
+            )
+
+            assert original_id == "resp_original_123"
+            assert user_id == "user-456"
+            assert team_id is None
+
     def test_decrypt_response_id_no_encryption(self, responses_id_security):
         """Test decrypting a non-encrypted response ID"""
         # Patch at the module level where it's imported


### PR DESCRIPTION
## Summary

Fix `ResponsesIDSecurity._decrypt_response_id()` so it can safely handle legacy managed Responses API ids that do not include a `team_id` segment.

## Problem

The hook currently assumes decrypted managed response-id payloads always have:

```text
litellm_proxy:responses_api:response_id:{response_id};user_id:{user_id};team_id:{team_id}
```

However older/legacy payloads may only contain:

```text
litellm_proxy:responses_api:response_id:{response_id};user_id:{user_id}
```

When such an id is passed as `previous_response_id` or to retrieve/delete/cancel/list-input-items, `_is_encrypted_response_id()` identifies it as managed, then `_decrypt_response_id()` indexes `parts[2]` and raises `IndexError`. That turns a security-boundary check into a 500 instead of preserving the original user-bound access check.

## Changes

- Require ids to actually start with `resp_` before attempting managed response-id decryption.
- Split the `resp_` prefix only once.
- Parse decrypted metadata by field name instead of fixed indexes.
- Treat a missing `team_id` as `None` for backward compatibility.
- Add a regression test for legacy payloads without `team_id`.

## Tests

```bash
python3 -m pytest tests/test_litellm/test_responses_id_security.py::TestDecryptResponseId -q
python3 -m pytest tests/test_litellm/test_responses_id_security.py::TestIsEncryptedResponseId -q
PYTHONPATH=/private/tmp/litellm-pytest-asyncio python3 -m pytest tests/test_litellm/test_responses_id_security.py -q
python3 -m compileall -q litellm/proxy/hooks/responses_id_security.py tests/test_litellm/test_responses_id_security.py
git diff --check
```

Full `test_responses_id_security.py` result: `24 passed, 2 skipped`.
