### PR TITLE
fix(langfuse_otel): build per-request OTLP exporter from key and team dynamic Langfuse credentials

### DIFF
--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -267,29 +267,10 @@ class LangfuseOtelLogger(OpenTelemetry):
             # If no keys, return default from env (likely logging to console or something else)
             return OpenTelemetryConfig.from_env()
 
-        # Determine endpoint - default to US cloud
-        langfuse_host = LangfuseOtelLogger._get_langfuse_otel_host()
-
-        if langfuse_host:
-            # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            if not langfuse_host.startswith("http"):
-                langfuse_host = "https://" + langfuse_host
-            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
-            verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
-        else:
-            # Default to US cloud endpoint
-            endpoint = LANGFUSE_CLOUD_US_ENDPOINT
-            verbose_logger.debug(f"Using Langfuse US cloud endpoint: {endpoint}")
-
-        auth_header = LangfuseOtelLogger._get_langfuse_authorization_header(
-            public_key=public_key, secret_key=secret_key
-        )
-        otlp_auth_headers = f"Authorization={auth_header}"
-
-        return OpenTelemetryConfig(
-            exporter="otlp_http",
-            endpoint=endpoint,
-            headers=otlp_auth_headers,
+        return LangfuseOtelLogger._build_langfuse_otel_config(
+            public_key=public_key,
+            secret_key=secret_key,
+            langfuse_host=LangfuseOtelLogger._get_langfuse_otel_host(),
         )
 
     @staticmethod
@@ -316,33 +297,36 @@ class LangfuseOtelLogger(OpenTelemetry):
                 "LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY must be set for Langfuse OpenTelemetry integration."
             )
 
-        # Determine endpoint - default to US cloud
-        langfuse_host = LangfuseOtelLogger._get_langfuse_otel_host()
+        return LangfuseOtelLogger._build_langfuse_otel_config(
+            public_key=public_key,
+            secret_key=secret_key,
+            langfuse_host=LangfuseOtelLogger._get_langfuse_otel_host(),
+        )
 
+    @staticmethod
+    def _build_langfuse_otel_config(
+        public_key: str, secret_key: str, langfuse_host: Optional[str]
+    ) -> "OpenTelemetryConfig":
+        """
+        Builds an OTLP HTTP config pointing at the Langfuse OTEL endpoint for the
+        given host (US cloud when no host is provided), authorized with the given keys.
+        """
         if langfuse_host:
-            # If LANGFUSE_HOST is provided, construct OTEL endpoint from it
-            if not langfuse_host.startswith("http"):
-                langfuse_host = "https://" + langfuse_host
-            endpoint = f"{langfuse_host.rstrip('/')}/api/public/otel"
+            normalized_host = langfuse_host if langfuse_host.startswith("http") else f"https://{langfuse_host}"
+            endpoint = f"{normalized_host.rstrip('/')}/api/public/otel"
             verbose_logger.debug(f"Using Langfuse OTEL endpoint from host: {endpoint}")
         else:
-            # Default to US cloud endpoint
             endpoint = LANGFUSE_CLOUD_US_ENDPOINT
             verbose_logger.debug(f"Using Langfuse US cloud endpoint: {endpoint}")
 
         auth_header = LangfuseOtelLogger._get_langfuse_authorization_header(
             public_key=public_key, secret_key=secret_key
         )
-        otlp_auth_headers = f"Authorization={auth_header}"
-
-        # Prevent modification of global env vars which causes leakage
-        # os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
-        # os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = otlp_auth_headers
 
         return OpenTelemetryConfig(
             exporter="otlp_http",
             endpoint=endpoint,
-            headers=otlp_auth_headers,
+            headers=f"Authorization={auth_header}",
         )
 
     @staticmethod
@@ -377,6 +361,29 @@ class LangfuseOtelLogger(OpenTelemetry):
             dynamic_headers["Authorization"] = auth_header
 
         return dynamic_headers
+
+    def construct_dynamic_otel_config(
+        self, standard_callback_dynamic_params: StandardCallbackDynamicParams
+    ) -> Optional["OpenTelemetryConfig"]:
+        """
+        Build a full per-request OTLP config from team/key dynamic Langfuse credentials.
+
+        Key-scoped credentials must define the export target, not just the auth
+        headers: without this, a proxy with no global LANGFUSE_* env vars keeps its
+        init-time fallback exporter (console), so key-level langfuse_otel silently
+        never reaches Langfuse.
+        """
+        public_key = standard_callback_dynamic_params.get("langfuse_public_key")
+        secret_key = standard_callback_dynamic_params.get("langfuse_secret_key")
+        if not public_key or not secret_key:
+            return None
+
+        langfuse_host = standard_callback_dynamic_params.get("langfuse_host") or self._get_langfuse_otel_host()
+        return LangfuseOtelLogger._build_langfuse_otel_config(
+            public_key=public_key,
+            secret_key=secret_key,
+            langfuse_host=langfuse_host,
+        )
 
     def create_litellm_proxy_request_started_span(
         self,

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -948,6 +948,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         Returns:
             Tracer: The tracer to use for this request
         """
+        dynamic_config = self._get_dynamic_otel_config_from_kwargs(kwargs)
+        if dynamic_config is not None:
+            verbose_logger.debug(
+                "[OTEL DEBUG] Using DYNAMIC config tracer with endpoint: %s",
+                dynamic_config.endpoint,
+            )
+            return self._get_tracer_with_dynamic_config(dynamic_config)
+
         dynamic_headers = self._get_dynamic_otel_headers_from_kwargs(kwargs)
 
         if dynamic_headers is not None:
@@ -989,6 +997,32 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         return dynamic_headers if dynamic_headers else None
 
+    def _get_dynamic_otel_config_from_kwargs(self, kwargs: dict) -> Optional[OpenTelemetryConfig]:
+        """Extract a full dynamic exporter config from kwargs if available."""
+        standard_callback_dynamic_params: Optional[StandardCallbackDynamicParams] = kwargs.get(
+            "standard_callback_dynamic_params"
+        )
+
+        if not standard_callback_dynamic_params:
+            return None
+
+        return self.construct_dynamic_otel_config(standard_callback_dynamic_params=standard_callback_dynamic_params)
+
+    def _get_tracer_with_dynamic_config(self, dynamic_config: OpenTelemetryConfig):
+        """Create (or reuse) a tracer whose exporter target comes from a per-request config."""
+        from opentelemetry.sdk.trace import TracerProvider
+
+        cache_key = f"dynamic_config:{dynamic_config.exporter}:{dynamic_config.endpoint}:{dynamic_config.headers}"
+        if cache_key in self._tracer_provider_cache:
+            return self._tracer_provider_cache[cache_key].get_tracer(LITELLM_TRACER_NAME)
+
+        temp_provider = TracerProvider(resource=self._get_litellm_resource(self.config))
+        temp_provider.add_span_processor(self._get_span_processor(config_override=dynamic_config))
+
+        self._tracer_provider_cache[cache_key] = temp_provider
+
+        return temp_provider.get_tracer(LITELLM_TRACER_NAME)
+
     def _get_tracer_with_dynamic_headers(self, dynamic_headers: dict):
         """Create a temporary tracer with dynamic headers for this request only."""
         from opentelemetry.sdk.trace import TracerProvider
@@ -1017,6 +1051,19 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
         Returns:
             dict: A dictionary of dynamic headers
+        """
+        return None
+
+    def construct_dynamic_otel_config(
+        self, standard_callback_dynamic_params: StandardCallbackDynamicParams
+    ) -> Optional[OpenTelemetryConfig]:
+        """
+        Construct a full exporter config from standard callback dynamic params.
+
+        Override this when team/key dynamic params must control the export
+        target (exporter kind + endpoint), not just the request headers. When
+        this returns a config, it takes precedence over
+        construct_dynamic_otel_headers for the request.
         """
         return None
 
@@ -2747,7 +2794,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         verbose_logger.debug("OpenTelemetry: No parent context found, creating root span")
         return None, None
 
-    def _get_span_processor(self, dynamic_headers: Optional[dict] = None):
+    def _get_span_processor(
+        self,
+        dynamic_headers: Optional[dict] = None,
+        config_override: Optional[OpenTelemetryConfig] = None,
+    ):
         from opentelemetry.sdk.trace.export import (
             BatchSpanProcessor,
             ConsoleSpanExporter,
@@ -2755,13 +2806,17 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             SpanExporter,
         )
 
+        otel_exporter = config_override.exporter if config_override else self.OTEL_EXPORTER
+        otel_endpoint = config_override.endpoint if config_override else self.OTEL_ENDPOINT
+        otel_headers = config_override.headers if config_override else self.OTEL_HEADERS
+
         verbose_logger.debug(
-            "OpenTelemetry Logger, initializing span processor \nself.OTEL_EXPORTER: %s\nself.OTEL_ENDPOINT: %s\nself.OTEL_HEADERS: %s",
-            self.OTEL_EXPORTER,
-            self.OTEL_ENDPOINT,
-            self.OTEL_HEADERS,
+            "OpenTelemetry Logger, initializing span processor \nexporter: %s\nendpoint: %s\nheaders: %s",
+            otel_exporter,
+            otel_endpoint,
+            otel_headers,
         )
-        _split_otel_headers = OpenTelemetry._get_headers_dictionary(headers=dynamic_headers or self.OTEL_HEADERS)
+        _split_otel_headers = OpenTelemetry._get_headers_dictionary(headers=dynamic_headers or otel_headers)
 
         if dynamic_headers:
             verbose_logger.debug(
@@ -2771,24 +2826,20 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         else:
             verbose_logger.debug("[OTEL DEBUG] Creating span processor with GLOBAL headers")
 
-        if hasattr(self.OTEL_EXPORTER, "export"):  # Check if it has the export method that SpanExporter requires
+        if hasattr(otel_exporter, "export"):  # Check if it has the export method that SpanExporter requires
             verbose_logger.debug(
                 "OpenTelemetry: intiializing SpanExporter. Value of OTEL_EXPORTER: %s",
-                self.OTEL_EXPORTER,
+                otel_exporter,
             )
-            return SimpleSpanProcessor(cast(SpanExporter, self.OTEL_EXPORTER))
+            return SimpleSpanProcessor(cast(SpanExporter, otel_exporter))
 
-        if self.OTEL_EXPORTER == "console":
+        if otel_exporter == "console":
             verbose_logger.debug(
                 "OpenTelemetry: intiializing console exporter. Value of OTEL_EXPORTER: %s",
-                self.OTEL_EXPORTER,
+                otel_exporter,
             )
             return BatchSpanProcessor(ConsoleSpanExporter())
-        elif (
-            self.OTEL_EXPORTER == "otlp_http"
-            or self.OTEL_EXPORTER == "http/protobuf"
-            or self.OTEL_EXPORTER == "http/json"
-        ):
+        elif otel_exporter == "otlp_http" or otel_exporter == "http/protobuf" or otel_exporter == "http/json":
             try:
                 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
                     OTLPSpanExporter as OTLPSpanExporterHTTP,
@@ -2801,13 +2852,13 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
             verbose_logger.debug(
                 "OpenTelemetry: intiializing http exporter. Value of OTEL_EXPORTER: %s",
-                self.OTEL_EXPORTER,
+                otel_exporter,
             )
-            normalized_endpoint = self._normalize_otel_endpoint(self.OTEL_ENDPOINT, "traces")
+            normalized_endpoint = self._normalize_otel_endpoint(otel_endpoint, "traces")
             return BatchSpanProcessor(
                 OTLPSpanExporterHTTP(endpoint=normalized_endpoint, headers=_split_otel_headers),
             )
-        elif self.OTEL_EXPORTER == "otlp_grpc" or self.OTEL_EXPORTER == "grpc":
+        elif otel_exporter == "otlp_grpc" or otel_exporter == "grpc":
             try:
                 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
                     OTLPSpanExporter as OTLPSpanExporterGRPC,
@@ -2820,16 +2871,16 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
 
             verbose_logger.debug(
                 "OpenTelemetry: intiializing grpc exporter. Value of OTEL_EXPORTER: %s",
-                self.OTEL_EXPORTER,
+                otel_exporter,
             )
-            normalized_endpoint = self._normalize_otel_endpoint(self.OTEL_ENDPOINT, "traces")
+            normalized_endpoint = self._normalize_otel_endpoint(otel_endpoint, "traces")
             return BatchSpanProcessor(
                 OTLPSpanExporterGRPC(endpoint=normalized_endpoint, headers=_split_otel_headers),
             )
         else:
             verbose_logger.debug(
                 "OpenTelemetry: intiializing console exporter. Value of OTEL_EXPORTER: %s",
-                self.OTEL_EXPORTER,
+                otel_exporter,
             )
             return BatchSpanProcessor(ConsoleSpanExporter())
 

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -28,6 +28,7 @@ from litellm.integrations.opentelemetry_utils.gen_ai_semconv import (
     parse_semconv_opt_in,
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+from litellm.litellm_core_utils.secret_redaction import redact_string
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
 from litellm.types.services import ServiceLoggerPayload
 from litellm.types.utils import (
@@ -961,7 +962,9 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         if dynamic_headers is not None:
             # Create spans using a temporary tracer with dynamic headers
             tracer_to_use = self._get_tracer_with_dynamic_headers(dynamic_headers)
-            verbose_logger.debug("[OTEL DEBUG] Using DYNAMIC tracer with headers: %s", dynamic_headers)
+            verbose_logger.debug(
+                "[OTEL DEBUG] Using DYNAMIC tracer with headers: %s", redact_string(str(dynamic_headers))
+            )
         else:
             # For langfuse_otel without dynamic headers, create a provider with env var credentials
             if hasattr(self, "callback_name") and self.callback_name == "langfuse_otel":
@@ -2814,14 +2817,14 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "OpenTelemetry Logger, initializing span processor \nexporter: %s\nendpoint: %s\nheaders: %s",
             otel_exporter,
             otel_endpoint,
-            otel_headers,
+            redact_string(str(otel_headers)),
         )
         _split_otel_headers = OpenTelemetry._get_headers_dictionary(headers=dynamic_headers or otel_headers)
 
         if dynamic_headers:
             verbose_logger.debug(
                 "[OTEL DEBUG] Creating span processor with DYNAMIC headers: %s",
-                {k: v[:20] + "..." if len(str(v)) > 20 else v for k, v in _split_otel_headers.items()},
+                redact_string(str(_split_otel_headers)),
             )
         elif config_override:
             verbose_logger.debug(
@@ -2897,7 +2900,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "OpenTelemetry Logger, initializing log exporter \nself.OTEL_EXPORTER: %s\nself.OTEL_ENDPOINT: %s\nself.OTEL_HEADERS: %s",
             self.OTEL_EXPORTER,
             self.OTEL_ENDPOINT,
-            self.OTEL_HEADERS,
+            redact_string(str(self.OTEL_HEADERS)),
         )
 
         _split_otel_headers = OpenTelemetry._get_headers_dictionary(self.OTEL_HEADERS)
@@ -2984,7 +2987,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "OpenTelemetry Logger, initializing metric reader\nself.OTEL_EXPORTER: %s\nself.OTEL_ENDPOINT: %s\nself.OTEL_HEADERS: %s",
             self.OTEL_EXPORTER,
             self.OTEL_ENDPOINT,
-            self.OTEL_HEADERS,
+            redact_string(str(self.OTEL_HEADERS)),
         )
 
         _split_otel_headers = OpenTelemetry._get_headers_dictionary(self.OTEL_HEADERS)

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -2823,6 +2823,11 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 "[OTEL DEBUG] Creating span processor with DYNAMIC headers: %s",
                 {k: v[:20] + "..." if len(str(v)) > 20 else v for k, v in _split_otel_headers.items()},
             )
+        elif config_override:
+            verbose_logger.debug(
+                "[OTEL DEBUG] Creating span processor with DYNAMIC config, endpoint: %s",
+                otel_endpoint,
+            )
         else:
             verbose_logger.debug("[OTEL DEBUG] Creating span processor with GLOBAL headers")
 

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -412,6 +412,135 @@ class TestLangfuseOtelIntegration:
             # Endpoint assertion removed as side effect is gone
 
 
+class TestLangfuseOtelKeyDynamicConfig:
+    """Key/team-scoped Langfuse credentials must define the full export target
+    (OTLP endpoint + auth), not just auth headers on the init-time exporter."""
+
+    CLEAN_ENV_VARS = [
+        "LANGFUSE_PUBLIC_KEY",
+        "LANGFUSE_SECRET_KEY",
+        "LANGFUSE_HOST",
+        "LANGFUSE_OTEL_HOST",
+        "OTEL_EXPORTER",
+        "OTEL_EXPORTER_OTLP_PROTOCOL",
+        "OTEL_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_HEADERS",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+    ]
+
+    def _clean_env(self):
+        cleaned = {k: v for k, v in os.environ.items() if k not in self.CLEAN_ENV_VARS}
+        return patch.dict(os.environ, cleaned, clear=True)
+
+    def _dynamic_params(self, **overrides):
+        from litellm.types.utils import StandardCallbackDynamicParams
+
+        params = {
+            "langfuse_public_key": "key_public",
+            "langfuse_secret_key": "key_secret",
+            "langfuse_host": "https://langfuse.example.com",
+        }
+        params.update(overrides)
+        return StandardCallbackDynamicParams(**{k: v for k, v in params.items() if v is not None})
+
+    def test_construct_dynamic_otel_config_with_key_credentials(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            config = logger.construct_dynamic_otel_config(self._dynamic_params())
+
+        assert config is not None
+        assert config.exporter == "otlp_http"
+        assert config.endpoint == "https://langfuse.example.com/api/public/otel"
+
+        import base64
+
+        expected_auth = base64.b64encode(b"key_public:key_secret").decode()
+        assert config.headers == f"Authorization=Basic {expected_auth}"
+
+    def test_construct_dynamic_otel_config_host_without_protocol(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            config = logger.construct_dynamic_otel_config(self._dynamic_params(langfuse_host="langfuse.example.com"))
+
+        assert config is not None
+        assert config.endpoint == "https://langfuse.example.com/api/public/otel"
+
+    def test_construct_dynamic_otel_config_defaults_to_us_cloud(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            config = logger.construct_dynamic_otel_config(self._dynamic_params(langfuse_host=None))
+
+        assert config is not None
+        assert config.endpoint == "https://us.cloud.langfuse.com/api/public/otel"
+
+    def test_construct_dynamic_otel_config_falls_back_to_env_host(self):
+        with self._clean_env():
+            with patch.dict(os.environ, {"LANGFUSE_HOST": "https://env-host.example.com"}):
+                logger = LangfuseOtelLogger()
+                config = logger.construct_dynamic_otel_config(self._dynamic_params(langfuse_host=None))
+
+        assert config is not None
+        assert config.endpoint == "https://env-host.example.com/api/public/otel"
+
+    def test_construct_dynamic_otel_config_requires_both_keys(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+
+            assert logger.construct_dynamic_otel_config(self._dynamic_params(langfuse_secret_key=None)) is None
+            assert logger.construct_dynamic_otel_config(self._dynamic_params(langfuse_public_key=None)) is None
+
+    def test_key_dynamic_params_create_otlp_exporter_without_global_env(self):
+        """Without global LANGFUSE_* env vars, a request carrying key-scoped Langfuse
+        credentials must get a tracer exporting via OTLP HTTP to that key's host."""
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            assert logger.OTEL_EXPORTER == "console"
+
+            tracer = logger.get_tracer_to_use_for_request(
+                {"standard_callback_dynamic_params": self._dynamic_params()}
+            )
+
+        assert tracer is not logger.tracer
+        assert len(logger._tracer_provider_cache) == 1
+
+        provider = next(iter(logger._tracer_provider_cache.values()))
+        span_processors = provider._active_span_processor._span_processors
+        assert len(span_processors) == 1
+        assert isinstance(span_processors[0], BatchSpanProcessor)
+
+        exporter = span_processors[0].span_exporter
+        assert isinstance(exporter, OTLPSpanExporter)
+        assert exporter._endpoint == "https://langfuse.example.com/api/public/otel/v1/traces"
+
+        import base64
+
+        expected_auth = base64.b64encode(b"key_public:key_secret").decode()
+        assert exporter._headers == {"Authorization": f"Basic {expected_auth}"}
+
+    def test_key_dynamic_params_reuse_cached_provider(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            kwargs = {"standard_callback_dynamic_params": self._dynamic_params()}
+            logger.get_tracer_to_use_for_request(kwargs)
+            logger.get_tracer_to_use_for_request(kwargs)
+
+        assert len(logger._tracer_provider_cache) == 1
+
+    def test_no_dynamic_params_keeps_default_tracer(self):
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            tracer = logger.get_tracer_to_use_for_request({})
+
+        assert tracer is logger.tracer
+        assert logger._tracer_provider_cache == {}
+
+
 class TestLangfuseOtelResponsesAPI:
     """Test suite for Langfuse OTEL integration with ResponsesAPI"""
 

--- a/tests/test_litellm/integrations/test_langfuse_otel.py
+++ b/tests/test_litellm/integrations/test_langfuse_otel.py
@@ -540,6 +540,42 @@ class TestLangfuseOtelKeyDynamicConfig:
         assert tracer is logger.tracer
         assert logger._tracer_provider_cache == {}
 
+    def test_key_credentials_never_passed_to_debug_logger(self):
+        """The span-processor debug logs must receive a redacted header value, so the
+        key-scoped Langfuse secret never enters a log record regardless of downstream
+        handler configuration, while the exporter still gets the real header."""
+        import base64
+
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+
+        from litellm.integrations import opentelemetry as otel_module
+
+        secret = base64.b64encode(b"key_public:key_secret").decode()
+
+        recorded_arguments = []
+
+        def _spy(message, *args, **kwargs):
+            recorded_arguments.append(" ".join(str(part) for part in (message, *args)))
+
+        with self._clean_env():
+            logger = LangfuseOtelLogger()
+            with patch.object(otel_module.verbose_logger, "debug", side_effect=_spy):
+                logger.get_tracer_to_use_for_request(
+                    {"standard_callback_dynamic_params": self._dynamic_params()}
+                )
+
+        logged = "\n".join(recorded_arguments)
+        assert "initializing span processor" in logged
+        assert secret not in logged
+        assert f"Basic {secret}" not in logged
+
+        provider = next(iter(logger._tracer_provider_cache.values()))
+        exporter = provider._active_span_processor._span_processors[0].span_exporter
+        assert isinstance(exporter, OTLPSpanExporter)
+        assert exporter._headers == {"Authorization": f"Basic {secret}"}
+
 
 class TestLangfuseOtelResponsesAPI:
     """Test suite for Langfuse OTEL integration with ResponsesAPI"""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-3976

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Setup: a real self-hosted Langfuse v3.206.0 (docker compose: web, worker, clickhouse, minio, redis, postgres) on `http://127.0.0.1:3976` with a provisioned project key pair, and the proxy running against Postgres with NO `LANGFUSE_*` environment variables set. The virtual key carries the Langfuse credentials in its metadata, exactly as the UI's key-level logging settings store them

```bash
curl -s http://127.0.0.1:4976/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{
  "key_alias": "litfix-3976",
  "metadata": {"logging": [{"callback_name": "langfuse_otel", "callback_type": "success", "callback_vars": {"langfuse_public_key": "pk-lf-litfix-3976", "langfuse_secret_key": "sk-lf-litfix-3976", "langfuse_host": "http://127.0.0.1:3976"}}]}
}'

curl -s http://127.0.0.1:4976/v1/chat/completions -H "Authorization: Bearer $VIRTUAL_KEY" -H "Content-Type: application/json" -d '{
  "model": "gpt-5.2",
  "messages": [{"role": "user", "content": "Reply with exactly one word: verified"}]
}'

curl -s -u pk-lf-litfix-3976:sk-lf-litfix-3976 http://127.0.0.1:3976/api/public/traces
```

Before the fix (real gpt-5.2 call succeeded, spans went to the init-time console exporter, nothing reached Langfuse):

```text
traces in Langfuse: 0
```

proxy log on the unfixed code shows the key's auth header being attached to a console exporter:

```text
[OTEL DEBUG] Creating span processor with DYNAMIC headers: {'Authorization': 'Basic cGstbGYtbGl0Zml4...'}
OpenTelemetry: intiializing console exporter. Value of OTEL_EXPORTER:
```

After the fix, the same flow exports to the key's Langfuse host:

```text
[OTEL DEBUG] Using DYNAMIC config tracer with endpoint: http://127.0.0.1:3976/api/public/otel
OpenTelemetry: intiializing http exporter. Value of OTEL_EXPORTER: otlp_http

traces in Langfuse: 1
observation: litellm_request | type: GENERATION | model: gpt-5.2
  input: [{"role": "user", "content": "Reply with exactly one word: verified"}]
  output: {"role": "assistant", "content": "verified"}
```

No regression for the global-env-only setup (proxy restarted with `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_HOST` set and `callbacks: ["langfuse_otel"]`, master key request, no key-level credentials):

```text
traces in Langfuse now: 2
```

### Independent e2e verification (Devin session, recorded)

A separate agent session independently verified the fix end to end on a fresh VM: self-hosted Langfuse v3 provisioned headlessly, the proxy on this branch with Postgres and no `LANGFUSE_*` or `OTEL_*` environment variables on the process, and a real `gpt-5.2` completion via OpenAI. The admin UI gates key-level Logging Settings behind enterprise, so the virtual key was created with `POST /key/generate` carrying the `langfuse_otel` callback_vars, which is the same path the UI uses. The completion produced a `litellm_request` trace in the Langfuse UI with the request input, the model output, `llm.provider=openai`, `llm.model_name=gpt-5.2`, and token counts

Full flow recording (key creation, completion, trace appearing in Langfuse):

![e2e flow recording](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-32437/langfuse_otel_e2e.gif)

![key generate storing langfuse_otel callback_vars](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-32437/02_curl_key_generate_callback_vars.png)

![real gpt-5.2 completion through the proxy](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-32437/03_curl_completion_gpt52.png)

![litellm_request trace in Langfuse with input, output and gpt-5.2 metadata](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-32437/04_langfuse_trace_detail.png)

![admin UI key-level logging settings enterprise gated](https://raw.githubusercontent.com/yassin-berriai/litellm-pr-media/main/pr-32437/01_key_logging_settings_enterprise.png)

## Type

🐛 Bug Fix

## Changes

Key or team scoped `langfuse_otel` credentials only produced an `Authorization` header for the request's tracer, while the exporter kind and endpoint stayed whatever the logger was initialized with. On a proxy without global `LANGFUSE_*` environment variables that init-time exporter is the console fallback, so key-level Langfuse OTEL silently never exported; with global env vars pointing at a different Langfuse instance, traces went to the wrong host with the key's auth

`OpenTelemetry` gains a `construct_dynamic_otel_config` hook that lets a subclass build a full per-request exporter config from `standard_callback_dynamic_params`; when it returns one, `get_tracer_to_use_for_request` builds (and caches) a tracer provider from that config instead of only swapping headers, via a new `config_override` parameter on `_get_span_processor`. `LangfuseOtelLogger` overrides the hook to build `otlp_http` against `{langfuse_host}/api/public/otel` with basic auth from the key's credentials, falling back to the env host and then the US cloud endpoint when the key carries no host. The duplicated endpoint construction in `_create_open_telemetry_config_from_langfuse_env` and `get_langfuse_otel_config` is folded into a shared `_build_langfuse_otel_config`

Regression tests in `tests/test_litellm/integrations/test_langfuse_otel.py` cover the full wiring (key credentials on a proxy with no global env produce an OTLP HTTP exporter pointed at the key's host with the key's basic auth), host normalization and fallbacks, provider caching, and the unchanged default path

While here, the exporter debug logs that printed the OTLP headers now run those values through the shared `redact_string` helper, so the per-request `Authorization=Basic` credential for a key or team scoped Langfuse project is emitted as `Authorization=REDACTED` in the span-processor, log-exporter and metric-reader debug lines; the exporter still receives the real header. This holds even when the global secret-redaction log filter is turned off, and a spy-based regression test asserts the secret never reaches a log record while the exporter keeps the real credential

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes per-request tracing export routing and credential handling for Langfuse OTEL; incorrect config could misroute traces or leak secrets in logs, though behavior is covered by new tests and redaction is tightened.
> 
> **Overview**
> Fixes **key/team-scoped `langfuse_otel`** so traces actually reach Langfuse when the proxy has no global `LANGFUSE_*` env vars (or would otherwise keep the init-time **console** exporter while only swapping auth headers).
> 
> **OpenTelemetry** adds a **`construct_dynamic_otel_config`** hook that takes precedence over header-only dynamic tracers; per-request configs build a **cached** `TracerProvider` via **`_get_span_processor(config_override=...)`**. **LangfuseOtelLogger** implements the hook (OTLP HTTP to `{host}/api/public/otel` + basic auth) and deduplicates env-based setup in **`_build_langfuse_otel_config`**.
> 
> OTLP **debug logs** now **redact** authorization headers with **`redact_string`** while exporters still get real credentials. New integration tests cover dynamic config, caching, and log redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963194c6e6616511d2e3847d6d3fa5573b1bcff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->