### PR TITLE
test(vertex_ai): bump local_testing vertex tests from gemini-2.5-flash to gemini-3.5-flash

### DIFF
--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -355,7 +355,11 @@ async def test_async_vertexai_response_basic():
         user_message = "Hello, how are you?"
         messages = [{"content": user_message, "role": "user"}]
         response = await acompletion(
-            model="gemini-2.5-flash", messages=messages, temperature=0.7, timeout=5
+            model="gemini-3.5-flash",
+            messages=messages,
+            temperature=0.7,
+            timeout=5,
+            vertex_location="global",
         )
         print(f"response: {response}")
     except litellm.NotFoundError as e:
@@ -388,7 +392,7 @@ async def test_async_vertexai_streaming_response():
     )
     test_models = random.sample(list(test_models), 1)
     test_models += list(litellm.vertex_language_models)  # always test gemini-pro
-    test_models = ["gemini-2.5-flash"]
+    test_models = ["gemini-3.5-flash"]
     for model in test_models:
         if model in VERTEX_MODELS_TO_NOT_TEST or (
             "gecko" in model
@@ -412,6 +416,7 @@ async def test_async_vertexai_streaming_response():
                 temperature=0.7,
                 timeout=5,
                 stream=True,
+                vertex_location="global",
             )
             print(f"response: {response}")
             complete_response: str = ""
@@ -3840,10 +3845,11 @@ def test_vertex_schema_test():
     }
 
     response = litellm.completion(
-        model="vertex_ai/gemini-2.5-flash",
+        model="vertex_ai/gemini-3.5-flash",
         messages=[{"role": "user", "content": "call the tool"}],
         tools=[tool],
         tool_choice="required",
+        vertex_location="global",
     )
 
     print(response)
@@ -3895,10 +3901,11 @@ def test_gemini_nullable_object_tool_schema_httpx():
     ]
 
     response = litellm.completion(
-        model="vertex_ai/gemini-2.5-flash",
+        model="vertex_ai/gemini-3.5-flash",
         messages=[{"role": "user", "content": "call the tool"}],
         tools=tools,
         tool_choice="required",
+        vertex_location="global",
     )
 
     print(response)


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All proof below was captured at commit 950a9c8da1 (branch `litellm_bump_gemini_3_5_flash_local_testing`) against real Vertex AI, no mocks, real $

Why `vertex_location="global"` is required: gemini-3.5-flash is only served on the global Vertex endpoint. Same call, only the location differs

```
$ python -c "... litellm.completion(model='vertex_ai/gemini-3.5-flash', vertex_location=loc, ...) for loc in ('us-central1', 'global')"
us-central1 NotFoundError litellm.NotFoundError: Vertex_aiException - {
global OK: ok
```

Live proxy on a random unused port with the bumped model:

```yaml
model_list:
  - model_name: gemini-3.5-flash
    litellm_params:
      model: vertex_ai/gemini-3.5-flash
      vertex_project: vertex-check-481318
      vertex_location: global
```

```
$ python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 47231
```

Basic completion:

```
$ curl -s http://localhost:47231/v1/chat/completions -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' -d '{
  "model": "gemini-3.5-flash",
  "messages": [{"role": "user", "content": "Reply with exactly: bump verified"}]
}'
{"id":"...","model":"gemini-3.5-flash","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"bump verified","role":"assistant",...}}],"usage":{"completion_tokens":2,"prompt_tokens":6,"total_tokens":8,...}}
```

Forced tool call with the exact nullable-object schema from `test_gemini_nullable_object_tool_schema_httpx`:

```
$ curl -s http://localhost:47231/v1/chat/completions -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' -d '{
  "model": "gemini-3.5-flash",
  "messages": [{"role": "user", "content": "call the tool"}],
  "tool_choice": "required",
  "tools": [{"type": "function", "strict": true, "function": {"name": "create_support_ticket", "description": "Create a paid user support ticket", "parameters": {"type": "object", "additionalProperties": false, "required": ["ticket_id", "customer_context"], "properties": {"ticket_id": {"type": "string"}, "customer_context": {"type": ["object", "null"], "additionalProperties": false, "required": ["user_id", "plan"], "properties": {"user_id": {"type": "string"}, "plan": {"type": "string"}}}}}}}]
}'
tool_calls: create_support_ticket {"ticket_id": "TICKET-999", "customer_context": {"plan": "premium", "user_id": "12345"}}
```

Streaming:

```
$ curl -sN http://localhost:47231/v1/chat/completions -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' -d '{
  "model": "gemini-3.5-flash",
  "messages": [{"role": "user", "content": "Count from 1 to 5, digits only"}],
  "stream": true
}'
data: {"id":"...","object":"chat.completion.chunk","created":1783493699,"model":"gemini-3.5-flash","choices":[{"index":0,"delta":{"role":"assistant","content":"1 2 3 4 5"}}]}
```

The four bumped tests also pass live at the same commit (run with real ADC credentials against Vertex; `pytest` shown here only as validation on top of the curl proof above): `test_vertex_schema_test`, `test_gemini_nullable_object_tool_schema_httpx`, `test_async_vertexai_response_basic`, `test_async_vertexai_streaming_response`, 4 passed

## Type

✅ Test

## Changes

Bumps the four gemini-2.5-flash call sites in `tests/local_testing/test_amazing_vertex_completion.py` to gemini-3.5-flash, the latest flash model in model_prices_and_context_window.json

gemini-3.5-flash is only served on the global Vertex endpoint (regional endpoints such as us-central1 return 404, see proof), so each bumped call site now also passes `vertex_location="global"`, matching how this file's existing gemini-3 tests (`test_gemini_grounding_on_streaming`, `test_gemini_google_maps_tool_simple`) already call gemini-3 models

The gemini-2.5-flash-lite call sites are intentionally left alone; the 3.x lite line is a different model family in the cost map and out of scope here. New VCR cassettes for the changed request shapes will record on the first green CI run. Note that #32430 touches the same file, so whichever PR merges second will need a trivial rebase
