### PR TITLE
test(responses): replace perma-skip azure shell e2e with offline coverage

### DIFF
--- a/tests/llm_responses_api_testing/base_responses_api.py
+++ b/tests/llm_responses_api_testing/base_responses_api.py
@@ -746,7 +746,8 @@ class BaseResponsesAPITest(ABC):
         E2E test for Shell tool on OpenAI Responses API.
         Passes tools=[{"type": "shell", "environment": {"type": "container_auto"}}];
         validates that the request is accepted and returns a valid response.
-        Only runs for OpenAI/Azure (Responses API with shell support).
+        Only runs for OpenAI; offline coverage for the Azure route lives in
+        tests/test_litellm/responses/test_responses_api_request_body.py.
         """
         base_completion_call_args = self.get_base_completion_call_args()
         model = (
@@ -754,8 +755,10 @@ class BaseResponsesAPITest(ABC):
             or base_completion_call_args.get("model")
             or ""
         )
-        if "openai/" not in str(model) and "azure/" not in str(model):
-            pytest.skip("Shell tool e2e is only run for OpenAI/Azure Responses API")
+        if "openai/" not in str(model):
+            pytest.skip(
+                "Shell tool e2e is OpenAI-only; no Azure deployment supports the shell tool yet, re-enable once one exists"
+            )
         tools = [{"type": "shell", "environment": {"type": "container_auto"}}]
         input_msg = "List files in /mnt/data and show python --version."
         try:

--- a/tests/llm_responses_api_testing/test_azure_responses_api.py
+++ b/tests/llm_responses_api_testing/test_azure_responses_api.py
@@ -2,7 +2,6 @@ import os
 import sys
 import pytest
 import asyncio
-from typing import Optional
 from unittest.mock import patch, AsyncMock
 
 sys.path.insert(0, os.path.abspath("../.."))
@@ -29,10 +28,6 @@ class TestAzureResponsesAPITest(BaseResponsesAPITest):
             "api_key": os.getenv("AZURE_AI_API_KEY"),
             "api_version": "2025-03-01-preview",
         }
-
-    def get_advanced_model_for_shell_tool(self) -> Optional[str]:
-        """If specified, overrides the model used by test_responses_api_shell_tool_streaming_sees_shell_output (e.g. openai/gpt-5.2 for shell support)."""
-        return "azure/gpt-5-mini"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/expected_responses_api_request/azure_shell_tool.json
+++ b/tests/test_litellm/expected_responses_api_request/azure_shell_tool.json
@@ -1,0 +1,14 @@
+{
+  "model": "gpt-5-mini",
+  "input": "List files in /mnt/data and run python --version.",
+  "tools": [
+    {
+      "type": "shell",
+      "environment": {
+        "type": "container_auto"
+      }
+    }
+  ],
+  "tool_choice": "auto",
+  "max_output_tokens": 256
+}

--- a/tests/test_litellm/responses/test_responses_api_request_body.py
+++ b/tests/test_litellm/responses/test_responses_api_request_body.py
@@ -1,6 +1,7 @@
 """
 Test that litellm.responses() / litellm.aresponses() send the expected request body
-over the wire. Expected JSON bodies are stored in expected_responses_api_request/.
+over the wire and surface provider errors correctly. Expected JSON bodies are stored
+in expected_responses_api_request/.
 """
 
 import json
@@ -18,24 +19,20 @@ def _expected_dir() -> Path:
     return Path(__file__).resolve().parent.parent / "expected_responses_api_request"
 
 
-@pytest.mark.asyncio
-async def test_aresponses_context_management_and_shell_request_body_matches_expected():
-    """
-    Call litellm.aresponses() with context_management and shell tool;
-    assert the httpx POST request body matches the expected JSON.
-    """
-    expected_path = _expected_dir() / "context_management_and_shell.json"
+def _load_expected_body(filename: str) -> dict:
+    expected_path = _expected_dir() / filename
     assert expected_path.exists(), f"Expected file not found: {expected_path}"
     with open(expected_path) as f:
-        expected_body = json.load(f)
+        return json.load(f)
 
-    # Minimal Responses API response so parsing succeeds
-    mock_response = {
-        "id": "resp_ctx_shell_test",
+
+def _minimal_responses_api_payload(response_id: str, model: str) -> dict:
+    return {
+        "id": response_id,
         "object": "response",
         "created_at": 1734366691,
         "status": "completed",
-        "model": "gpt-4o",
+        "model": model,
         "output": [
             {
                 "type": "message",
@@ -69,21 +66,41 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
         "user": None,
     }
 
-    class MockResponse:
-        def __init__(self, json_data, status_code=200):
-            self._json_data = json_data
-            self.status_code = status_code
-            self.text = json.dumps(json_data)
-            self.headers = httpx.Headers({})
 
-        def json(self):
-            return self._json_data
+class MockResponse:
+    def __init__(self, json_data, status_code=200):
+        self._json_data = json_data
+        self.status_code = status_code
+        self.text = json.dumps(json_data)
+        self.headers = httpx.Headers({})
+
+    def json(self):
+        return self._json_data
+
+
+def _assert_request_body_matches(request_body: dict, expected_body: dict) -> None:
+    for key, expected_value in expected_body.items():
+        assert key in request_body, f"Missing key in request body: {key}"
+        assert (
+            request_body[key] == expected_value
+        ), f"Mismatch for key {key}: got {request_body[key]!r}, expected {expected_value!r}"
+
+
+@pytest.mark.asyncio
+async def test_aresponses_context_management_and_shell_request_body_matches_expected():
+    """
+    Call litellm.aresponses() with context_management and shell tool;
+    assert the httpx POST request body matches the expected JSON.
+    """
+    expected_body = _load_expected_body("context_management_and_shell.json")
 
     with patch(
         "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
         new_callable=AsyncMock,
     ) as mock_post:
-        mock_post.return_value = MockResponse(mock_response, 200)
+        mock_post.return_value = MockResponse(
+            _minimal_responses_api_payload("resp_ctx_shell_test", "gpt-4o"), 200
+        )
 
         await litellm.aresponses(
             model="openai/gpt-4o",
@@ -95,10 +112,87 @@ async def test_aresponses_context_management_and_shell_request_body_matches_expe
         )
 
         mock_post.assert_called_once()
-        request_body = mock_post.call_args.kwargs["json"]
+        _assert_request_body_matches(mock_post.call_args.kwargs["json"], expected_body)
 
-        for key, expected_value in expected_body.items():
-            assert key in request_body, f"Missing key in request body: {key}"
-            assert (
-                request_body[key] == expected_value
-            ), f"Mismatch for key {key}: got {request_body[key]!r}, expected {expected_value!r}"
+
+@pytest.mark.asyncio
+async def test_aresponses_azure_shell_tool_request_body_matches_expected():
+    """
+    Call litellm.aresponses() on the Azure route with the shell tool;
+    assert the httpx POST request body carries the shell tool verbatim.
+    """
+    expected_body = _load_expected_body("azure_shell_tool.json")
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.return_value = MockResponse(
+            _minimal_responses_api_payload("resp_azure_shell_test", "gpt-5-mini"), 200
+        )
+
+        await litellm.aresponses(
+            model="azure/gpt-5-mini",
+            api_base="https://fake-resource.openai.azure.com",
+            api_key="fake-api-key",
+            api_version="2025-03-01-preview",
+            input=expected_body["input"],
+            tools=expected_body["tools"],
+            tool_choice=expected_body["tool_choice"],
+            max_output_tokens=expected_body["max_output_tokens"],
+        )
+
+        mock_post.assert_called_once()
+        _assert_request_body_matches(mock_post.call_args.kwargs["json"], expected_body)
+
+
+@pytest.mark.asyncio
+async def test_aresponses_azure_shell_tool_400_maps_to_bad_request_error():
+    """
+    Azure rejects the shell tool for unsupported deployments with a 400;
+    litellm must surface that as litellm.BadRequestError carrying the provider message.
+    """
+    error_body = {
+        "error": {
+            "message": "Tool of type 'shell' is not supported with this model.",
+            "type": "invalid_request_error",
+            "param": "tools",
+            "code": None,
+        }
+    }
+
+    def _raise_azure_400(*args, **kwargs):
+        response = httpx.Response(
+            status_code=400,
+            json=error_body,
+            request=httpx.Request(
+                "POST",
+                kwargs.get(
+                    "url",
+                    "https://fake-resource.openai.azure.com/openai/responses",
+                ),
+            ),
+        )
+        response.raise_for_status()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+        new_callable=AsyncMock,
+    ) as mock_post:
+        mock_post.side_effect = _raise_azure_400
+
+        with pytest.raises(litellm.BadRequestError) as excinfo:
+            await litellm.aresponses(
+                model="azure/gpt-5-mini",
+                api_base="https://fake-resource.openai.azure.com",
+                api_key="fake-api-key",
+                api_version="2025-03-01-preview",
+                input="List files in /mnt/data and run python --version.",
+                tools=[{"type": "shell", "environment": {"type": "container_auto"}}],
+                tool_choice="auto",
+                max_output_tokens=256,
+            )
+
+    assert excinfo.value.status_code == 400
+    assert "shell" in str(excinfo.value).lower()
+    assert "not supported" in str(excinfo.value).lower()


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only changes tests (it removes a permanently live e2e path and adds offline unit coverage), so there is no end-user surface to demonstrate on a live proxy; the proof below shows the e2e behavior before and after plus the mutation checks on the new unit tests

Before (base commit cd6e8cdf23): the Azure shell tool e2e issues a real network round trip to Azure on every run. Run against a real Azure resource it fails/skips only after the live call returns; on this resource the deployment lookup itself comes back from Azure (resource hostname redacted)

```
$ pytest "tests/llm_responses_api_testing/test_azure_responses_api.py::TestAzureResponsesAPITest::test_responses_api_shell_tool" -rs -q --disable-recording
E       litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '404 Not Found' for url 'https://<azure-resource>.openai.azure.com/openai/responses?api-version=2025-03-01-preview'
error_message = '{\n  "error": {\n    "type": "invalid_request_error",\n    "code": "DeploymentNotFound", ...'
1 failed in 0.98s
```

In CI, where the resource has a gpt-5-mini deployment, that live call returns 400 "shell not supported" and the test skips; skipped tests never persist a VCR cassette and non-2xx episodes are filtered from recording, so the test can never become a cassette HIT and stays live forever. In CircleCI job 2013288 that live call hung for 15 minutes with no output and CircleCI killed the whole llm_responses_api_testing job at 98%. PR #32424 added the complementary timeout guard (per-call timeout=90 and pytest --timeout for the job); this PR removes the pointless live call entirely

After (commit b635e6983d): the Azure variant skips statically with no credentials and no network

```
$ env -u AZURE_AI_API_BASE -u AZURE_AI_API_KEY pytest "tests/llm_responses_api_testing/test_azure_responses_api.py::TestAzureResponsesAPITest::test_responses_api_shell_tool" -rs -q
SKIPPED [1] tests/llm_responses_api_testing/base_responses_api.py:759: Shell tool e2e is OpenAI-only; no Azure deployment supports the shell tool yet, re-enable once one exists
1 skipped in 0.03s
```

The new offline unit tests pass (commit b635e6983d)

```
$ pytest tests/test_litellm/responses/test_responses_api_request_body.py -q
3 passed, 1 warning in 0.07s
```

Mutation checks: breaking shell tool passthrough in the Azure transform (popping tools from the request params in AzureOpenAIResponsesAPIConfig.transform_responses_api_request) fails test_aresponses_azure_shell_tool_request_body_matches_expected; hardcoding status_code=500 in BaseResponsesAPIConfig.get_error_class fails test_aresponses_azure_shell_tool_400_maps_to_bad_request_error

```
$ pytest tests/test_litellm/responses/test_responses_api_request_body.py -q   # with tools popped in azure transform
FAILED tests/test_litellm/responses/test_responses_api_request_body.py::test_aresponses_azure_shell_tool_request_body_matches_expected
1 failed, 2 passed, 1 warning in 0.10s

$ pytest tests/test_litellm/responses/test_responses_api_request_body.py -q   # with status_code hardcoded to 500
FAILED tests/test_litellm/responses/test_responses_api_request_body.py::test_aresponses_azure_shell_tool_400_maps_to_bad_request_error
1 failed, 2 passed, 1 warning in 0.28s
```

## Type

✅ Test

## Changes

The Azure variant of test_responses_api_shell_tool had a steady state of live-call-then-skip: azure/gpt-5-mini rejects the shell tool with a 400, the test catches it and skips, and since skipped tests never persist cassettes (and non-2xx responses are filtered from recording anyway) it re-issued a real Azure call on every CI run. That burned quota, added flake surface, and asserted nothing; when Azure held the connection open in job 2013288 it took down the whole test job

This PR makes the shell tool e2e OpenAI-only (the OpenAI variant passes and replays from its cassette) and removes the azure/gpt-5-mini override in test_azure_responses_api.py, so both Azure shell variants now skip statically with no network call. The skip reason says to re-enable once a shell-capable Azure deployment exists

What LiteLLM actually owns on that route is now covered offline in tests/test_litellm/responses/test_responses_api_request_body.py: test_aresponses_azure_shell_tool_request_body_matches_expected asserts the Azure route sends the shell tool verbatim in the request body (expected body in tests/test_litellm/expected_responses_api_request/azure_shell_tool.json, following the existing fixture pattern), and test_aresponses_azure_shell_tool_400_maps_to_bad_request_error asserts a provider 400 surfaces as litellm.BadRequestError with the provider message and status code intact, exercising the real _handle_error and get_error_class path. The pre-existing OpenAI body test was refactored to share the mock response helpers with the new tests
