### PR TITLE
fix(responses): preserve reasoning/non-message items through prompt management (#32335)

### DIFF
--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -635,6 +635,43 @@ def _index_of_identity(items: List[Any], target: Any) -> int:
     return -1
 
 
+def _message_id_key(item: Any) -> Optional[str]:
+    """Return a message item's stable Responses API id (e.g. ``msg_...``), if any.
+
+    Used as a fallback anchor key when a hook deep-copies messages into new objects
+    but preserves their id (e.g. the anthropic cache-control hook). Only message items
+    are considered -- non-message items (reasoning/function_call) also carry ids, but
+    they are never used as anchors.
+    """
+    if _is_responses_message_item(item):
+        message_id = item.get("id")
+        if isinstance(message_id, str) and message_id:
+            return message_id
+    return None
+
+
+def _locate_anchor_message(items: List[Any], anchor: Any) -> int:
+    """Find ``anchor`` (a message) in ``items`` by object identity first, then by its
+    message id. Returns the index or -1.
+
+    Object identity handles the common hooks that keep the original message objects
+    (pass-through, vector-store, prompt-template prepend). The id fallback additionally
+    handles hooks that deep-copy messages into new objects while preserving their id
+    (anthropic cache-control), so a non-message item can still be re-attached to the
+    correct message. Only message items are matched by id so non-message items -- which
+    also carry ids -- are never matched.
+    """
+    idx = _index_of_identity(items, anchor)
+    if idx != -1:
+        return idx
+    anchor_id = _message_id_key(anchor)
+    if anchor_id is not None:
+        for i, item in enumerate(items):
+            if _is_responses_message_item(item) and item.get("id") == anchor_id:
+                return i
+    return -1
+
+
 def _splice_messages_positional(
     original_items: List[Any], merged_messages: List[AllMessageValues]
 ) -> List[Any]:
@@ -655,17 +692,18 @@ def _splice_messages_positional(
     return result
 
 
-def _splice_messages_by_identity(
+def _splice_messages_by_anchor(
     original_items: List[Any], merged_messages: List[AllMessageValues]
 ) -> Tuple[List[Any], int]:
     """Re-attach each non-message item next to the original message it was adjacent to,
-    located in the hook output by object identity.
+    located in the hook output by object identity or message id (see
+    ``_locate_anchor_message``).
 
     Each non-message item is anchored to the message that immediately follows it in the
     original input (a ``reasoning`` item -> its assistant ``message``), or to the
     message it immediately follows if it is trailing. It is then re-inserted next to
-    that same message object wherever the hook placed it. This is position-independent,
-    so it is correct no matter where the hook injected or edited messages -- front
+    that same message wherever the hook placed it. This is position-independent, so it
+    is correct no matter where the hook injected or edited messages -- front
     (prompt-template prepend), middle, or ``insert(-1)`` (vector-store context).
 
     A non-message item is only ever placed next to *its own* message, never a different
@@ -692,7 +730,7 @@ def _splice_messages_by_identity(
     dropped = 0
 
     for anchor, items in before_groups:
-        idx = _index_of_identity(result, anchor)
+        idx = _locate_anchor_message(result, anchor)
         if idx == -1:
             # Anchor message was removed/replaced by the hook -> cannot place safely.
             dropped += len(items)
@@ -701,7 +739,7 @@ def _splice_messages_by_identity(
             result.insert(idx + offset, non_message_item)
 
     if trailing:
-        idx = _index_of_identity(result, last_message) if last_message is not None else -1
+        idx = _locate_anchor_message(result, last_message) if last_message is not None else -1
         if idx == -1:
             dropped += len(trailing)
         else:
@@ -725,17 +763,20 @@ def _merge_prompt_management_messages_into_input(
     was provided without its required 'reasoning' item: 'rs_...'"``. See
     https://github.com/BerriAI/litellm/issues/32335.
 
-    Strategy (validated against the real hooks in litellm/integrations):
-      * identity match -- the hook kept the original message objects (pass-through,
-        vector-store ``insert(-1)`` context, prompt-template ``template + messages``
-        prepend): re-attach each non-message item next to its own message, wherever the
-        hook moved it. Position-independent and never mis-pairs.
-      * else equal count with no surviving identity -- the hook deep-copied but
-        preserved order and count (anthropic cache-control): substitute messages
-        slot-for-slot.
-      * else -- the hook replaced/removed messages (e.g. a prompt template that
-        replaces the incoming conversation): re-attach whatever is still identifiable,
-        drop the rest, and warn. Nothing is ever attached to the wrong message.
+    Strategy (validated against the real hooks in litellm/integrations). A message is
+    "locatable" in the hook output if it is found by object identity or by its message
+    id (see ``_locate_anchor_message``):
+      * all messages locatable -- the hook kept the original message objects
+        (pass-through, vector-store ``insert(-1)`` context, prompt-template
+        ``template + messages`` prepend) or deep-copied them while preserving their ids
+        (anthropic cache-control): re-attach each non-message item next to its own
+        message, wherever the hook moved it. Position-independent and never mis-pairs.
+      * no message locatable but equal count -- the hook deep-copied messages that had
+        no ids, preserving order and count: substitute messages slot-for-slot.
+      * otherwise -- the hook replaced/removed some messages (e.g. a prompt template
+        that replaces the incoming conversation): re-attach every non-message item whose
+        anchor is still locatable (by identity or id), drop the rest, and warn. Nothing
+        is ever attached to the wrong message.
     """
     if isinstance(original_input, str):
         # No non-message items to preserve.
@@ -750,22 +791,26 @@ def _merge_prompt_management_messages_into_input(
     if num_original_messages == len(original_items):
         return cast(ResponseInputParam, merged_messages)
 
-    merged_identities = {id(m) for m in merged_messages}
-    num_surviving = sum(1 for m in original_messages if id(m) in merged_identities)
+    # A message counts as "locatable" if we can find it in the hook output by object
+    # identity or by its message id.
+    num_locatable = sum(
+        1 for m in original_messages if _locate_anchor_message(merged_messages, m) != -1
+    )
 
-    if num_surviving == num_original_messages:
-        # All original messages present by identity: safest, position-independent path.
-        reconstructed, dropped = _splice_messages_by_identity(original_items, merged_messages)
-    elif num_surviving == 0 and len(merged_messages) == num_original_messages:
-        # Same count, no identity preserved -> in-place deep-copy transform
-        # (e.g. anthropic cache-control). Map slot-for-slot.
+    if num_locatable == num_original_messages:
+        # Every anchor is locatable: safest, position-independent path (no drops).
+        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
+    elif num_locatable == 0 and len(merged_messages) == num_original_messages:
+        # No anchor locatable but the count is preserved -> an in-place deep-copy
+        # transform on messages that carry no ids. Map slot-for-slot.
         return cast(
             ResponseInputParam,
             _splice_messages_positional(original_items, merged_messages),
         )
     else:
-        # The hook replaced/removed messages. Preserve whatever we can still identify.
-        reconstructed, dropped = _splice_messages_by_identity(original_items, merged_messages)
+        # The hook replaced/removed some messages. Preserve every item whose anchor is
+        # still locatable (by identity or id); drop and warn for the rest.
+        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
 
     if dropped:
         verbose_logger.warning(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -10,7 +10,6 @@ from typing import (
     List,
     Literal,
     Optional,
-    Tuple,
     Type,
     Union,
     cast,
@@ -610,8 +609,8 @@ def _is_responses_message_item(item: Any) -> bool:
 
 
 def _extract_message_items_for_prompt_management(
-    input: Union[str, ResponseInputParam],
-) -> List[AllMessageValues]:
+    input: str | ResponseInputParam,
+) -> list[AllMessageValues]:
     """Extract only the role-bearing message items to feed the prompt-management hook.
 
     The hooks (``get_chat_completion_prompt`` / ``async_get_chat_completion_prompt``)
@@ -620,14 +619,10 @@ def _extract_message_items_for_prompt_management(
     """
     if isinstance(input, str):
         return [{"role": "user", "content": input}]
-    return [
-        cast(AllMessageValues, item)
-        for item in input
-        if _is_responses_message_item(item)
-    ]
+    return [cast(AllMessageValues, item) for item in input if _is_responses_message_item(item)]
 
 
-def _index_of_identity(items: List[Any], target: Any) -> int:
+def _index_of_identity(items: list[Any], target: Any) -> int:
     """Return the index of ``target`` in ``items`` by object identity, or -1."""
     for idx, item in enumerate(items):
         if item is target:
@@ -650,7 +645,7 @@ def _message_id_key(item: Any) -> Optional[str]:
     return None
 
 
-def _locate_anchor_message(items: List[Any], anchor: Any) -> int:
+def _locate_anchor_message(items: list[Any], anchor: Any) -> int:
     """Find ``anchor`` (a message) in ``items`` by object identity first, then by its
     message id. Returns the index or -1.
 
@@ -672,9 +667,7 @@ def _locate_anchor_message(items: List[Any], anchor: Any) -> int:
     return -1
 
 
-def _splice_messages_positional(
-    original_items: List[Any], merged_messages: List[AllMessageValues]
-) -> List[Any]:
+def _splice_messages_positional(original_items: list[Any], merged_messages: list[AllMessageValues]) -> list[Any]:
     """Substitute message items 1:1, in order, keeping non-message items in place.
 
     Used when the hook returned the same number of messages it was given but did not
@@ -683,7 +676,7 @@ def _splice_messages_positional(
     slot-for-slot, so each original message position takes the next hook message.
     """
     merged_iter = iter(merged_messages)
-    result: List[Any] = []
+    result: list[Any] = []
     for item in original_items:
         if _is_responses_message_item(item):
             result.append(next(merged_iter))
@@ -693,8 +686,8 @@ def _splice_messages_positional(
 
 
 def _splice_messages_by_anchor(
-    original_items: List[Any], merged_messages: List[AllMessageValues]
-) -> Tuple[List[Any], int]:
+    original_items: list[Any], merged_messages: list[AllMessageValues]
+) -> tuple[list[Any], int]:
     """Re-attach each non-message item next to the original message it was adjacent to,
     located in the hook output by object identity or message id (see
     ``_locate_anchor_message``).
@@ -713,8 +706,8 @@ def _splice_messages_by_anchor(
     """
     # Group leading non-message items by the message that follows them, plus any
     # trailing items that follow the last message.
-    before_groups: List[Tuple[Any, List[Any]]] = []
-    pending: List[Any] = []
+    before_groups: list[tuple[Any, list[Any]]] = []
+    pending: list[Any] = []
     last_message: Optional[Any] = None
     for item in original_items:
         if _is_responses_message_item(item):
@@ -726,7 +719,7 @@ def _splice_messages_by_anchor(
             pending.append(item)
     trailing = pending
 
-    result: List[Any] = list(merged_messages)
+    result: list[Any] = list(merged_messages)
     dropped = 0
 
     for anchor, items in before_groups:
@@ -750,9 +743,9 @@ def _splice_messages_by_anchor(
 
 
 def _merge_prompt_management_messages_into_input(
-    original_input: Union[str, ResponseInputParam],
-    merged_messages: List[AllMessageValues],
-) -> Union[str, ResponseInputParam]:
+    original_input: str | ResponseInputParam,
+    merged_messages: list[AllMessageValues],
+) -> str | ResponseInputParam:
     """Recombine the prompt-management hook's message output with the non-message items
     (``reasoning`` / ``function_call`` / ``function_call_output`` / ...) that were
     filtered out before the hook ran, so they are not dropped.
@@ -785,7 +778,7 @@ def _merge_prompt_management_messages_into_input(
         # No non-message items to preserve.
         return cast(ResponseInputParam, merged_messages)
 
-    original_items: List[Any] = list(original_input)
+    original_items: list[Any] = list(original_input)
     original_messages = [item for item in original_items if _is_responses_message_item(item)]
     num_original_messages = len(original_messages)
 
@@ -796,9 +789,7 @@ def _merge_prompt_management_messages_into_input(
 
     # A message counts as "locatable" if we can find it in the hook output by object
     # identity or by its message id.
-    num_locatable = sum(
-        1 for m in original_messages if _locate_anchor_message(merged_messages, m) != -1
-    )
+    num_locatable = sum(1 for m in original_messages if _locate_anchor_message(merged_messages, m) != -1)
 
     if num_locatable == num_original_messages:
         # Every anchor is locatable: safest, position-independent path (no drops).

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -622,14 +622,6 @@ def _extract_message_items_for_prompt_management(
     return [cast(AllMessageValues, item) for item in input if _is_responses_message_item(item)]
 
 
-def _index_of_identity(items: list[Any], target: Any) -> int:
-    """Return the index of ``target`` in ``items`` by object identity, or -1."""
-    for idx, item in enumerate(items):
-        if item is target:
-            return idx
-    return -1
-
-
 def _message_id_key(item: Any) -> Optional[str]:
     """Return a message item's stable Responses API id (e.g. ``msg_...``), if any.
 
@@ -645,25 +637,41 @@ def _message_id_key(item: Any) -> Optional[str]:
     return None
 
 
-def _locate_anchor_message(items: list[Any], anchor: Any) -> int:
-    """Find ``anchor`` (a message) in ``items`` by object identity first, then by its
-    message id. Returns the index or -1.
+def _build_message_index(items: list[AllMessageValues]) -> tuple[dict[int, int], dict[str, int]]:
+    """Build O(1) lookup indices for the message items in ``items``: one by object
+    identity (``id()``), one by Responses API message id. Only message items are
+    indexed -- non-message items also carry ids but are never used as anchors (see
+    ``_message_id_key``). Used by ``_locate_anchor_message`` so anchors can be
+    located in O(1) instead of a linear scan per lookup.
+    """
+    identity_index: dict[int, int] = {}
+    id_index: dict[str, int] = {}
+    for idx, item in enumerate(items):
+        if not _is_responses_message_item(item):
+            continue
+        identity_index.setdefault(id(item), idx)
+        message_id = _message_id_key(item)
+        if message_id is not None:
+            id_index.setdefault(message_id, idx)
+    return identity_index, id_index
+
+
+def _locate_anchor_message(identity_index: dict[int, int], id_index: dict[str, int], anchor: Any) -> int:
+    """Find ``anchor`` (a message) by object identity first, then by its message id,
+    using the indices built by ``_build_message_index``. Returns the index or -1.
 
     Object identity handles the common hooks that keep the original message objects
     (pass-through, vector-store, prompt-template prepend). The id fallback additionally
     handles hooks that deep-copy messages into new objects while preserving their id
     (anthropic cache-control), so a non-message item can still be re-attached to the
-    correct message. Only message items are matched by id so non-message items -- which
-    also carry ids -- are never matched.
+    correct message.
     """
-    idx = _index_of_identity(items, anchor)
+    idx = identity_index.get(id(anchor), -1)
     if idx != -1:
         return idx
     anchor_id = _message_id_key(anchor)
     if anchor_id is not None:
-        for i, item in enumerate(items):
-            if _is_responses_message_item(item) and item.get("id") == anchor_id:
-                return i
+        return id_index.get(anchor_id, -1)
     return -1
 
 
@@ -686,7 +694,10 @@ def _splice_messages_positional(original_items: list[Any], merged_messages: list
 
 
 def _splice_messages_by_anchor(
-    original_items: list[Any], merged_messages: list[AllMessageValues]
+    original_items: list[Any],
+    merged_messages: list[AllMessageValues],
+    identity_index: dict[int, int],
+    id_index: dict[str, int],
 ) -> tuple[list[Any], int]:
     """Re-attach each non-message item next to the original message it was adjacent to,
     located in the hook output by object identity or message id (see
@@ -700,9 +711,13 @@ def _splice_messages_by_anchor(
     (prompt-template prepend), middle, or ``insert(-1)`` (vector-store context).
 
     A non-message item is only ever placed next to *its own* message, never a different
-    one, so a mis-paired request can never be produced. Returns
-    ``(reconstructed, dropped)`` where ``dropped`` counts non-message items whose anchor
-    message the hook removed/replaced (so they could not be safely placed).
+    one, so a mis-paired request can never be produced. Runs in O(n): the caller passes
+    in the identity/id index (``_build_message_index``) so anchors are located in O(1)
+    instead of a linear scan per lookup, and the result is built in a single pass
+    instead of repeated ``list.insert`` calls (each of which shifts the rest of the
+    list). Returns ``(reconstructed, dropped)`` where ``dropped`` counts non-message
+    items whose anchor message the hook removed/replaced (so they could not be safely
+    placed).
     """
     # Group leading non-message items by the message that follows them, plus any
     # trailing items that follow the last message.
@@ -719,26 +734,30 @@ def _splice_messages_by_anchor(
             pending.append(item)
     trailing = pending
 
-    result: list[Any] = list(merged_messages)
+    prefix_by_index: dict[int, list[Any]] = {}
+    suffix_by_index: dict[int, list[Any]] = {}
     dropped = 0
 
     for anchor, items in before_groups:
-        idx = _locate_anchor_message(result, anchor)
+        idx = _locate_anchor_message(identity_index, id_index, anchor)
         if idx == -1:
             # Anchor message was removed/replaced by the hook -> cannot place safely.
             dropped += len(items)
             continue
-        for offset, non_message_item in enumerate(items):
-            result.insert(idx + offset, non_message_item)
+        prefix_by_index.setdefault(idx, []).extend(items)
 
     if trailing:
-        idx = _locate_anchor_message(result, last_message) if last_message is not None else -1
+        idx = _locate_anchor_message(identity_index, id_index, last_message) if last_message is not None else -1
         if idx == -1:
             dropped += len(trailing)
         else:
-            for offset, non_message_item in enumerate(trailing):
-                result.insert(idx + 1 + offset, non_message_item)
+            suffix_by_index.setdefault(idx, []).extend(trailing)
 
+    result = [
+        out_item
+        for idx, message in enumerate(merged_messages)
+        for out_item in (*prefix_by_index.get(idx, ()), message, *suffix_by_index.get(idx, ()))
+    ]
     return result, dropped
 
 
@@ -788,12 +807,14 @@ def _merge_prompt_management_messages_into_input(
         return cast(ResponseInputParam, merged_messages)
 
     # A message counts as "locatable" if we can find it in the hook output by object
-    # identity or by its message id.
-    num_locatable = sum(1 for m in original_messages if _locate_anchor_message(merged_messages, m) != -1)
+    # identity or by its message id. Indexed once (O(n)) rather than a linear scan of
+    # merged_messages per original message (which would be O(n^2)).
+    identity_index, id_index = _build_message_index(merged_messages)
+    num_locatable = sum(1 for m in original_messages if _locate_anchor_message(identity_index, id_index, m) != -1)
 
     if num_locatable == num_original_messages:
         # Every anchor is locatable: safest, position-independent path (no drops).
-        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
+        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages, identity_index, id_index)
     elif len(merged_messages) == num_original_messages:
         # The count is preserved but not every message is locatable by identity/id --
         # e.g. an id-less deep-copy, or a hook that edits/replaces some messages in
@@ -816,7 +837,7 @@ def _merge_prompt_management_messages_into_input(
         # The count changed (messages added/removed), so positional cannot map slots.
         # Preserve every item whose anchor is still locatable (by identity or id) and
         # drop + warn for the rest.
-        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
+        reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages, identity_index, id_index)
 
     if dropped:
         verbose_logger.warning(

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -771,12 +771,15 @@ def _merge_prompt_management_messages_into_input(
         ``template + messages`` prepend) or deep-copied them while preserving their ids
         (anthropic cache-control): re-attach each non-message item next to its own
         message, wherever the hook moved it. Position-independent and never mis-pairs.
-      * no message locatable but equal count -- the hook deep-copied messages that had
-        no ids, preserving order and count: substitute messages slot-for-slot.
-      * otherwise -- the hook replaced/removed some messages (e.g. a prompt template
-        that replaces the incoming conversation): re-attach every non-message item whose
-        anchor is still locatable (by identity or id), drop the rest, and warn. Nothing
-        is ever attached to the wrong message.
+      * equal count but not all locatable -- the hook deep-copied id-less messages, or
+        edited/replaced some messages in place while keeping the count. Order-preserving
+        equal-count transforms map cleanly, so substitute messages slot-for-slot; this
+        preserves every non-message item instead of dropping those anchored to an
+        unlocatable message.
+      * otherwise (count changed) -- the hook added/removed messages (e.g. a prompt
+        template that replaces the incoming conversation): re-attach every non-message
+        item whose anchor is still locatable (by identity or id), drop the rest, and
+        warn. Nothing is ever attached to the wrong message.
     """
     if isinstance(original_input, str):
         # No non-message items to preserve.
@@ -800,16 +803,28 @@ def _merge_prompt_management_messages_into_input(
     if num_locatable == num_original_messages:
         # Every anchor is locatable: safest, position-independent path (no drops).
         reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
-    elif num_locatable == 0 and len(merged_messages) == num_original_messages:
-        # No anchor locatable but the count is preserved -> an in-place deep-copy
-        # transform on messages that carry no ids. Map slot-for-slot.
+    elif len(merged_messages) == num_original_messages:
+        # The count is preserved but not every message is locatable by identity/id --
+        # e.g. an id-less deep-copy, or a hook that edits/replaces some messages in
+        # place. Equal-count, order-preserving transforms map cleanly slot-for-slot, so
+        # fall back to positional substitution to preserve the non-message items anchored
+        # to the unlocatable messages rather than dropping them.
+        if num_locatable:
+            verbose_logger.debug(
+                "litellm.responses: %s of %s prompt-management messages were not "
+                "locatable by identity or id; using positional fallback to preserve "
+                "non-message items.",
+                num_original_messages - num_locatable,
+                num_original_messages,
+            )
         return cast(
             ResponseInputParam,
             _splice_messages_positional(original_items, merged_messages),
         )
     else:
-        # The hook replaced/removed some messages. Preserve every item whose anchor is
-        # still locatable (by identity or id); drop and warn for the rest.
+        # The count changed (messages added/removed), so positional cannot map slots.
+        # Preserve every item whose anchor is still locatable (by identity or id) and
+        # drop + warn for the rest.
         reconstructed, dropped = _splice_messages_by_anchor(original_items, merged_messages)
 
     if dropped:

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Tuple,
     Type,
     Union,
     cast,
@@ -508,14 +509,10 @@ async def aresponses(
         if isinstance(
             litellm_logging_obj, LiteLLMLoggingObj
         ) and litellm_logging_obj.should_run_prompt_management_hooks(prompt_id=prompt_id, non_default_params=kwargs):
-            if isinstance(input, str):
-                client_input: List[AllMessageValues] = [{"role": "user", "content": input}]
-            else:
-                client_input = [
-                    item  # type: ignore[misc]
-                    for item in input
-                    if isinstance(item, dict) and "role" in item
-                ]
+            # Only role-bearing message items are handed to the hook; non-message items
+            # (reasoning/function_call/...) are re-merged afterwards so they are not
+            # dropped. See https://github.com/BerriAI/litellm/issues/32335.
+            client_input = _extract_message_items_for_prompt_management(input)
             (
                 model,
                 merged_input,
@@ -529,7 +526,7 @@ async def aresponses(
                 prompt_label=kwargs.get("prompt_label", None),
                 prompt_version=kwargs.get("prompt_version", None),
             )
-            input = cast(Union[str, ResponseInputParam], merged_input)
+            input = _merge_prompt_management_messages_into_input(input, merged_input)
             if model != original_model:
                 _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
             kwargs.pop("prompt_id", None)
@@ -601,6 +598,187 @@ async def aresponses(
         )
 
 
+def _is_responses_message_item(item: Any) -> bool:
+    """Return True for role-bearing (chat-style) Responses API input items.
+
+    Message items carry a ``role`` key (e.g. ``{"role": "user", ...}`` or
+    ``{"type": "message", "role": "assistant", ...}``). Non-message items such as
+    ``reasoning``, ``function_call`` and ``function_call_output`` do not, and must
+    NOT be handed to the prompt-management hooks (which expect chat messages).
+    """
+    return isinstance(item, dict) and "role" in item
+
+
+def _extract_message_items_for_prompt_management(
+    input: Union[str, ResponseInputParam],
+) -> List[AllMessageValues]:
+    """Extract only the role-bearing message items to feed the prompt-management hook.
+
+    The hooks (``get_chat_completion_prompt`` / ``async_get_chat_completion_prompt``)
+    operate on chat-style messages, so non-message items are filtered out here and
+    re-merged afterwards by ``_merge_prompt_management_messages_into_input``.
+    """
+    if isinstance(input, str):
+        return [{"role": "user", "content": input}]
+    return [
+        cast(AllMessageValues, item)
+        for item in input
+        if _is_responses_message_item(item)
+    ]
+
+
+def _index_of_identity(items: List[Any], target: Any) -> int:
+    """Return the index of ``target`` in ``items`` by object identity, or -1."""
+    for idx, item in enumerate(items):
+        if item is target:
+            return idx
+    return -1
+
+
+def _splice_messages_positional(
+    original_items: List[Any], merged_messages: List[AllMessageValues]
+) -> List[Any]:
+    """Substitute message items 1:1, in order, keeping non-message items in place.
+
+    Used when the hook returned the same number of messages it was given but did not
+    preserve object identity (e.g. the anthropic cache-control hook deep-copies the
+    messages before editing them). An order-preserving in-place transform maps cleanly
+    slot-for-slot, so each original message position takes the next hook message.
+    """
+    merged_iter = iter(merged_messages)
+    result: List[Any] = []
+    for item in original_items:
+        if _is_responses_message_item(item):
+            result.append(next(merged_iter))
+        else:
+            result.append(item)
+    return result
+
+
+def _splice_messages_by_identity(
+    original_items: List[Any], merged_messages: List[AllMessageValues]
+) -> Tuple[List[Any], int]:
+    """Re-attach each non-message item next to the original message it was adjacent to,
+    located in the hook output by object identity.
+
+    Each non-message item is anchored to the message that immediately follows it in the
+    original input (a ``reasoning`` item -> its assistant ``message``), or to the
+    message it immediately follows if it is trailing. It is then re-inserted next to
+    that same message object wherever the hook placed it. This is position-independent,
+    so it is correct no matter where the hook injected or edited messages -- front
+    (prompt-template prepend), middle, or ``insert(-1)`` (vector-store context).
+
+    A non-message item is only ever placed next to *its own* message, never a different
+    one, so a mis-paired request can never be produced. Returns
+    ``(reconstructed, dropped)`` where ``dropped`` counts non-message items whose anchor
+    message the hook removed/replaced (so they could not be safely placed).
+    """
+    # Group leading non-message items by the message that follows them, plus any
+    # trailing items that follow the last message.
+    before_groups: List[Tuple[Any, List[Any]]] = []
+    pending: List[Any] = []
+    last_message: Optional[Any] = None
+    for item in original_items:
+        if _is_responses_message_item(item):
+            if pending:
+                before_groups.append((item, pending))
+                pending = []
+            last_message = item
+        else:
+            pending.append(item)
+    trailing = pending
+
+    result: List[Any] = list(merged_messages)
+    dropped = 0
+
+    for anchor, items in before_groups:
+        idx = _index_of_identity(result, anchor)
+        if idx == -1:
+            # Anchor message was removed/replaced by the hook -> cannot place safely.
+            dropped += len(items)
+            continue
+        for offset, non_message_item in enumerate(items):
+            result.insert(idx + offset, non_message_item)
+
+    if trailing:
+        idx = _index_of_identity(result, last_message) if last_message is not None else -1
+        if idx == -1:
+            dropped += len(trailing)
+        else:
+            for offset, non_message_item in enumerate(trailing):
+                result.insert(idx + 1 + offset, non_message_item)
+
+    return result, dropped
+
+
+def _merge_prompt_management_messages_into_input(
+    original_input: Union[str, ResponseInputParam],
+    merged_messages: List[AllMessageValues],
+) -> Union[str, ResponseInputParam]:
+    """Recombine the prompt-management hook's message output with the non-message items
+    (``reasoning`` / ``function_call`` / ``function_call_output`` / ...) that were
+    filtered out before the hook ran, so they are not dropped.
+
+    Before this fix the hook output replaced ``input`` wholesale, silently discarding
+    every non-message item. For Azure's Responses API that breaks the required
+    ``reasoning`` -> ``message`` pairing and yields ``"Item 'msg_...' of type 'message'
+    was provided without its required 'reasoning' item: 'rs_...'"``. See
+    https://github.com/BerriAI/litellm/issues/32335.
+
+    Strategy (validated against the real hooks in litellm/integrations):
+      * identity match -- the hook kept the original message objects (pass-through,
+        vector-store ``insert(-1)`` context, prompt-template ``template + messages``
+        prepend): re-attach each non-message item next to its own message, wherever the
+        hook moved it. Position-independent and never mis-pairs.
+      * else equal count with no surviving identity -- the hook deep-copied but
+        preserved order and count (anthropic cache-control): substitute messages
+        slot-for-slot.
+      * else -- the hook replaced/removed messages (e.g. a prompt template that
+        replaces the incoming conversation): re-attach whatever is still identifiable,
+        drop the rest, and warn. Nothing is ever attached to the wrong message.
+    """
+    if isinstance(original_input, str):
+        # No non-message items to preserve.
+        return cast(ResponseInputParam, merged_messages)
+
+    original_items: List[Any] = list(original_input)
+    original_messages = [item for item in original_items if _is_responses_message_item(item)]
+    num_original_messages = len(original_messages)
+
+    # No non-message items to preserve -> hook output is authoritative (pure chat
+    # input; behavior unchanged).
+    if num_original_messages == len(original_items):
+        return cast(ResponseInputParam, merged_messages)
+
+    merged_identities = {id(m) for m in merged_messages}
+    num_surviving = sum(1 for m in original_messages if id(m) in merged_identities)
+
+    if num_surviving == num_original_messages:
+        # All original messages present by identity: safest, position-independent path.
+        reconstructed, dropped = _splice_messages_by_identity(original_items, merged_messages)
+    elif num_surviving == 0 and len(merged_messages) == num_original_messages:
+        # Same count, no identity preserved -> in-place deep-copy transform
+        # (e.g. anthropic cache-control). Map slot-for-slot.
+        return cast(
+            ResponseInputParam,
+            _splice_messages_positional(original_items, merged_messages),
+        )
+    else:
+        # The hook replaced/removed messages. Preserve whatever we can still identify.
+        reconstructed, dropped = _splice_messages_by_identity(original_items, merged_messages)
+
+    if dropped:
+        verbose_logger.warning(
+            "litellm.responses: prompt-management hook removed/replaced message items, so "
+            "%s non-message item(s) (reasoning/function_call/...) could not be re-attached "
+            "to their original message and were dropped. This can happen when a prompt "
+            "template replaces the incoming conversation.",
+            dropped,
+        )
+
+    return cast(ResponseInputParam, reconstructed)
+
+
 def _apply_prompt_management_to_responses_call(
     input: Union[str, ResponseInputParam],
     model: str,
@@ -619,18 +797,13 @@ def _apply_prompt_management_to_responses_call(
     prompt_variables = cast(Optional[dict], kwargs.get("prompt_variables", None))
     original_model = model
 
-    if isinstance(input, str):
-        client_input: List[AllMessageValues] = [{"role": "user", "content": input}]
-    else:
-        client_input = [
-            item  # type: ignore[misc]
-            for item in input
-            if isinstance(item, dict) and "role" in item
-        ]
-
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
         prompt_id=prompt_id, non_default_params=kwargs
     ):
+        # Only role-bearing message items are handed to the hook; non-message items
+        # (reasoning/function_call/...) are re-merged afterwards so they are not
+        # dropped. See https://github.com/BerriAI/litellm/issues/32335.
+        client_input = _extract_message_items_for_prompt_management(input)
         (
             model,
             merged_input,
@@ -644,7 +817,7 @@ def _apply_prompt_management_to_responses_call(
             prompt_label=kwargs.get("prompt_label", None),
             prompt_version=kwargs.get("prompt_version", None),
         )
-        input = cast(Union[str, ResponseInputParam], merged_input)
+        input = _merge_prompt_management_messages_into_input(input, merged_input)
         local_vars["input"] = input
         local_vars["model"] = model
         if model != original_model:

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -741,6 +741,24 @@ class TestMergePromptManagementMessagesIntoInput:
         assert FUNCTION_CALL_OUTPUT not in result
         mock_warn.assert_called_once()
 
+    def test_hook_output_used_when_original_has_no_messages(self):
+        """Edge case: the original input is entirely non-message items (e.g. a pure
+        tool-output turn with no role-bearing message), but the hook still returns a
+        template message (a prompt_id template that unconditionally prepends a system
+        message). Prompt management still runs -- it does not silently no-op just
+        because the turn had no client messages -- but the orphaned non-message item
+        has no message to anchor to, so it is dropped with a warning rather than left
+        unpaired at the front of the request."""
+        original = [FUNCTION_CALL_OUTPUT]
+        template_msg = {"role": "system", "content": "template preamble"}
+        merged = [template_msg]
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [template_msg]
+        mock_warn.assert_called_once()
+
 
 class TestResponsesReasoningPreservationEndToEnd:
     """[#32335] Reasoning/non-message items survive all the way to the downstream

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -20,7 +20,41 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.responses.main import (
+    _merge_prompt_management_messages_into_input,
+)
 from litellm.types.llms.openai import AllMessageValues
+
+# ---------------------------------------------------------------------------
+# Shared fixtures for the reasoning/non-message preservation tests (#32335)
+# ---------------------------------------------------------------------------
+
+REASONING_ITEM = {
+    "type": "reasoning",
+    "id": "rs_abc123",
+    "summary": [],
+    "encrypted_content": "gAAAA_fake_encrypted",
+}
+ASSISTANT_MESSAGE = {
+    "type": "message",
+    "id": "msg_def456",
+    "role": "assistant",
+    "status": "completed",
+    "content": [{"type": "output_text", "text": "Here is the analysis.", "annotations": []}],
+}
+USER_MESSAGE = {"role": "user", "content": "Now check for security issues too"}
+FUNCTION_CALL = {
+    "type": "function_call",
+    "id": "fc_1",
+    "call_id": "call_1",
+    "name": "get_weather",
+    "arguments": "{}",
+}
+FUNCTION_CALL_OUTPUT = {
+    "type": "function_call_output",
+    "call_id": "call_1",
+    "output": "sunny",
+}
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -393,3 +427,338 @@ class TestAsyncResponsesAPIPromptManagement:
         passed_messages = call_kwargs["messages"]
         assert all(isinstance(m, dict) and "role" in m for m in passed_messages)
         assert len(passed_messages) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #32335:
+# non-message items (reasoning / function_call / function_call_output) must NOT
+# be dropped when a prompt-management hook runs on a Responses API call.
+# ---------------------------------------------------------------------------
+
+
+class TestMergePromptManagementMessagesIntoInput:
+    """Direct unit tests for the merge helper that recombines the hook's message
+    output with the non-message items that were filtered out before the hook ran."""
+
+    def test_passthrough_hook_preserves_reasoning_in_place(self):
+        """[#32335] Hook returns the messages unchanged -> reasoning item stays put,
+        immediately preceding its paired assistant message."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        merged = [ASSISTANT_MESSAGE, USER_MESSAGE]  # message subset, unchanged
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        # reasoning immediately precedes its message
+        assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
+
+    def test_prepended_template_message_keeps_reasoning_paired(self):
+        """[#32335] Hook prepends a system/template message -> preamble goes to the
+        front, and reasoning still immediately precedes its assistant message."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        system_msg = {"role": "system", "content": "You are helpful."}
+        merged = [system_msg, ASSISTANT_MESSAGE, USER_MESSAGE]
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [system_msg, REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        # reasoning is not duplicated and still directly precedes its message
+        assert result.count(REASONING_ITEM) == 1
+        assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
+
+    def test_function_call_items_preserved(self):
+        """[#32335] function_call and function_call_output items are preserved in
+        their original positions alongside reasoning."""
+        original = [
+            REASONING_ITEM,
+            ASSISTANT_MESSAGE,
+            FUNCTION_CALL,
+            FUNCTION_CALL_OUTPUT,
+            USER_MESSAGE,
+        ]
+        merged = [ASSISTANT_MESSAGE, USER_MESSAGE]  # only the two messages are seen by the hook
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [
+            REASONING_ITEM,
+            ASSISTANT_MESSAGE,
+            FUNCTION_CALL,
+            FUNCTION_CALL_OUTPUT,
+            USER_MESSAGE,
+        ]
+
+    def test_transformed_messages_are_used(self):
+        """The hook's *transformed* message content is what ends up in the merged
+        input (we splice the hook output in, not the originals)."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        transformed_user = {"role": "user", "content": "REWRITTEN by template"}
+        merged = [ASSISTANT_MESSAGE, transformed_user]
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [REASONING_ITEM, ASSISTANT_MESSAGE, transformed_user]
+
+    def test_pure_chat_input_unchanged(self):
+        """No non-message items -> the hook output is authoritative (unchanged
+        behavior, including any prepended template messages)."""
+        original = [USER_MESSAGE]
+        system_msg = {"role": "system", "content": "template"}
+        merged = [system_msg, USER_MESSAGE]
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [system_msg, USER_MESSAGE]
+
+    def test_str_input_returns_hook_output(self):
+        """A plain-string input has no non-message items to preserve."""
+        system_msg = {"role": "system", "content": "template"}
+        merged = [system_msg, {"role": "user", "content": "hi"}]
+
+        result = _merge_prompt_management_messages_into_input("hi", merged)
+
+        assert result == merged
+
+    def test_anchor_message_removed_drops_orphan_and_warns(self):
+        """If the hook REMOVES the message a non-message item was anchored to, the
+        orphan is dropped (with a warning) rather than re-attached to an unrelated
+        message. This is the safe choice: it never produces a mis-paired request
+        (the failure mode #32335 is about), it just can't preserve an item whose
+        partner the hook deleted."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        # Hook dropped the assistant message (reasoning's anchor) but kept the user one.
+        merged = [USER_MESSAGE]
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        # reasoning is NOT silently mis-placed before the surviving (unrelated) user msg
+        assert REASONING_ITEM not in result
+        assert result == [USER_MESSAGE]
+        mock_warn.assert_called_once()
+
+    def test_vector_store_insert_at_second_to_last_keeps_pairing(self):
+        """Mirrors VectorStorePreCallHook: context inserted via ``messages.insert(-1)``
+        with the ORIGINAL message objects preserved by identity. Reasoning must stay
+        with its assistant message even though the injected message is NOT a prefix."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        context_msg = {"role": "user", "content": "Context:\n\n...retrieved..."}
+        merged = [ASSISTANT_MESSAGE, USER_MESSAGE]  # same objects (list.copy preserves refs)
+        merged.insert(-1, context_msg)  # -> [ASSISTANT, context, USER]
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [REASONING_ITEM, ASSISTANT_MESSAGE, context_msg, USER_MESSAGE]
+        # reasoning immediately precedes its OWN assistant message, not the context msg
+        assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
+
+    def test_cache_control_deepcopy_same_count_maps_positionally(self):
+        """Mirrors AnthropicCacheControlHook: messages are deep-copied (identity lost)
+        but count and order are preserved. Reasoning must still precede its message."""
+        import copy
+
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        merged = copy.deepcopy([ASSISTANT_MESSAGE, USER_MESSAGE])  # different identities
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        # value-equal to the paired ordering; reasoning stays in front of its message
+        assert result == [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        assert result[0] is REASONING_ITEM
+        assert result[1] is merged[0]  # the deep-copied assistant message was used
+        mock_warn.assert_not_called()
+
+    def test_full_template_replacement_drops_non_message_items_with_warning(self):
+        """Mirrors a prompt template that REPLACES the incoming conversation with
+        entirely new messages (different objects, different count). Non-message items
+        cannot be anchored to any surviving message, so they are dropped with a
+        warning rather than mis-placed onto an unrelated template message."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        merged = [
+            {"role": "system", "content": "Rendered template."},
+            {"role": "user", "content": "Rendered a."},
+            {"role": "user", "content": "Rendered b."},
+        ]  # 3 brand-new messages, none is an original object
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == merged
+        assert REASONING_ITEM not in result
+        mock_warn.assert_called_once()
+
+
+class TestResponsesReasoningPreservationEndToEnd:
+    """[#32335] Reasoning/non-message items survive all the way to the downstream
+    handler when a prompt-management hook is active on a /responses call."""
+
+    def _final_input(self, mock_handler):
+        return mock_handler.call_args.kwargs["input"]
+
+    def test_sync_reasoning_preserved_multi_turn(self):
+        """Reporter's exact scenario through the sync responses() path."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        # passthrough hook: returns the role-bearing subset unchanged
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[ASSISTANT_MESSAGE, USER_MESSAGE],
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=original,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="p",
+                litellm_logging_obj=logging_obj,
+            )
+
+        final_input = self._final_input(mock_handler)
+        assert REASONING_ITEM in final_input
+        assert final_input == [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        assert final_input.index(REASONING_ITEM) == final_input.index(ASSISTANT_MESSAGE) - 1
+
+    def test_sync_prepended_template_preserves_reasoning(self):
+        """Hook injects a system template message; reasoning still preserved/paired."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        system_msg = {"role": "system", "content": "You are helpful."}
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[system_msg, ASSISTANT_MESSAGE, USER_MESSAGE],
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=original,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="p",
+                litellm_logging_obj=logging_obj,
+            )
+
+        final_input = self._final_input(mock_handler)
+        assert final_input == [system_msg, REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        assert final_input.count(REASONING_ITEM) == 1
+
+    def test_sync_function_call_items_preserved(self):
+        """function_call / function_call_output items survive the same way."""
+        original = [
+            REASONING_ITEM,
+            ASSISTANT_MESSAGE,
+            FUNCTION_CALL,
+            FUNCTION_CALL_OUTPUT,
+            USER_MESSAGE,
+        ]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[ASSISTANT_MESSAGE, USER_MESSAGE],
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            litellm.responses(
+                input=original,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="p",
+                litellm_logging_obj=logging_obj,
+            )
+
+        final_input = self._final_input(mock_handler)
+        assert final_input == original
+
+    @pytest.mark.asyncio
+    async def test_async_reasoning_preserved_multi_turn(self):
+        """Reporter's exact scenario through the async aresponses() path."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        logging_obj = _make_logging_obj(
+            merged_model="openai/gpt-4o",
+            merged_messages=[ASSISTANT_MESSAGE, USER_MESSAGE],
+        )
+
+        patches = _patch_responses_dispatch()
+        with patches[0], patches[1], patches[2], patches[3] as mock_handler:
+            import litellm
+
+            await litellm.aresponses(
+                input=original,  # type: ignore[arg-type]
+                model="gpt-4o",
+                prompt_id="p",
+                litellm_logging_obj=logging_obj,
+            )
+
+        # sync hook must not re-run (async path already merged)
+        logging_obj.get_chat_completion_prompt.assert_not_called()
+        final_input = self._final_input(mock_handler)
+        assert REASONING_ITEM in final_input
+        assert final_input == [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        assert final_input.index(REASONING_ITEM) == final_input.index(ASSISTANT_MESSAGE) - 1
+
+
+class TestAzureResponsesBodyRetainsReasoning:
+    """Provider-level check: the request body reaching the Azure Responses transform
+    retains reasoning items when prompt management is active (#32335)."""
+
+    def test_azure_transform_receives_reasoning_item(self):
+        from litellm.llms.azure.responses.transformation import (
+            AzureOpenAIResponsesAPIConfig,
+        )
+
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        logging_obj = _make_logging_obj(
+            merged_model="azure/gpt-5.3-codex",
+            merged_messages=[ASSISTANT_MESSAGE, USER_MESSAGE],
+        )
+
+        captured = {}
+
+        orig_transform = AzureOpenAIResponsesAPIConfig.transform_responses_api_request
+
+        def spy_transform(self, model, input, response_api_optional_request_params, litellm_params, headers):
+            # capture the fully-built request body, then stop before any HTTP call.
+            # (litellm wraps the raised exception in APIConnectionError, so the caller
+            # catches broadly — the capture above is what the assertions rely on.)
+            body = orig_transform(
+                self, model, input, response_api_optional_request_params, litellm_params, headers
+            )
+            captured["body_input"] = body.get("input")
+            raise RuntimeError("stop-before-network")
+
+        import litellm
+
+        with patch.object(
+            AzureOpenAIResponsesAPIConfig,
+            "transform_responses_api_request",
+            spy_transform,
+        ):
+            try:
+                litellm.responses(
+                    model="azure/gpt-5.3-codex",
+                    input=original,  # type: ignore[arg-type]
+                    prompt_id="p",
+                    litellm_logging_obj=logging_obj,
+                    api_base="https://fake.openai.azure.com",
+                    api_key="fake-key",
+                    api_version="2024-05-01-preview",
+                )
+            except Exception:
+                pass
+
+        assert "body_input" in captured, "Azure transform was never reached"
+        body_input = captured["body_input"]
+        types = [
+            (i.get("type") or ("message" if "role" in i else None)) for i in body_input
+        ]
+        assert "reasoning" in types, f"reasoning dropped from Azure request body: {types}"
+        # reasoning precedes its paired assistant message
+        reasoning_idx = next(i for i, it in enumerate(body_input) if it.get("type") == "reasoning")
+        assistant_idx = next(
+            i for i, it in enumerate(body_input) if it.get("type") == "message" and it.get("role") == "assistant"
+        )
+        assert reasoning_idx == assistant_idx - 1

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -639,6 +639,39 @@ class TestMergePromptManagementMessagesIntoInput:
         assert r2 in result  # preserved via id fallback (would be dropped under identity-only)
         mock_warn.assert_not_called()
 
+    def test_partial_unlocatable_equal_count_uses_positional_fallback(self):
+        """The partial + equal-count case where a message is GENUINELY unlocatable
+        (replaced by a different message, no matching identity or id) but the count is
+        preserved. Rather than drop the item anchored to it, fall back to positional
+        substitution so it is preserved. (Order-preserving equal-count transform.)"""
+        a1 = {
+            "type": "message", "id": "msg_1", "role": "assistant",
+            "content": [{"type": "output_text", "text": "one", "annotations": []}],
+        }
+        a2 = {
+            "type": "message", "id": "msg_2", "role": "assistant",
+            "content": [{"type": "output_text", "text": "two", "annotations": []}],
+        }
+        r1 = {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "e1"}
+        r2 = {"type": "reasoning", "id": "rs_2", "summary": [], "encrypted_content": "e2"}
+        u = {"role": "user", "content": "go"}
+        original = [r1, a1, r2, a2, u]
+        # a1 kept, a2 REPLACED by a different message (id msg_99 -> not locatable), u kept;
+        # count preserved (3 messages).
+        replacement = {
+            "type": "message", "id": "msg_99", "role": "assistant",
+            "content": [{"type": "output_text", "text": "replaced", "annotations": []}],
+        }
+        merged = [a1, replacement, u]
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        # positional fallback maps a2's slot to the replacement, preserving r2
+        assert result == [r1, a1, r2, replacement, u]
+        assert r2 in result  # preserved (previously dropped-and-warned)
+        mock_warn.assert_not_called()
+
     def test_full_template_replacement_drops_non_message_items_with_warning(self):
         """Mirrors a prompt template that REPLACES the incoming conversation with
         entirely new messages (different objects, different count). Non-message items

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -14,6 +14,7 @@ Covers:
 """
 
 import asyncio
+import copy
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -55,6 +56,32 @@ FUNCTION_CALL_OUTPUT = {
     "call_id": "call_1",
     "output": "sunny",
 }
+
+# Pristine snapshot of the shared items, taken once at import.
+_CANONICAL_SHARED_ITEMS = {
+    "REASONING_ITEM": copy.deepcopy(REASONING_ITEM),
+    "ASSISTANT_MESSAGE": copy.deepcopy(ASSISTANT_MESSAGE),
+    "USER_MESSAGE": copy.deepcopy(USER_MESSAGE),
+    "FUNCTION_CALL": copy.deepcopy(FUNCTION_CALL),
+    "FUNCTION_CALL_OUTPUT": copy.deepcopy(FUNCTION_CALL_OUTPUT),
+}
+
+
+@pytest.fixture(autouse=True)
+def _fresh_shared_items():
+    """Give every test its own fresh copies of the shared message/non-message items.
+
+    The merge logic is identity/id based, so tests intentionally reuse the *same*
+    objects within a test to simulate identity-preserving hooks. Rebinding fresh
+    deep-copies of the module-level items before each test preserves that within-test
+    identity while isolating tests from one another, so a future test that mutates a
+    shared item can never leak state into another test.
+    """
+    module_globals = globals()
+    for name, template in _CANONICAL_SHARED_ITEMS.items():
+        module_globals[name] = copy.deepcopy(template)
+    yield
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -552,13 +579,12 @@ class TestMergePromptManagementMessagesIntoInput:
         # reasoning immediately precedes its OWN assistant message, not the context msg
         assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
 
-    def test_cache_control_deepcopy_same_count_maps_positionally(self):
-        """Mirrors AnthropicCacheControlHook: messages are deep-copied (identity lost)
-        but count and order are preserved. Reasoning must still precede its message."""
-        import copy
-
+    def test_cache_control_deepcopy_reattaches_via_message_id(self):
+        """Mirrors AnthropicCacheControlHook: messages are deep-copied (object identity
+        lost) but their message ids are preserved. The reasoning item is re-attached to
+        its message via the id fallback, not object identity."""
         original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
-        merged = copy.deepcopy([ASSISTANT_MESSAGE, USER_MESSAGE])  # different identities
+        merged = copy.deepcopy([ASSISTANT_MESSAGE, USER_MESSAGE])  # new objects, same ids
 
         with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
             result = _merge_prompt_management_messages_into_input(original, merged)
@@ -566,7 +592,51 @@ class TestMergePromptManagementMessagesIntoInput:
         # value-equal to the paired ordering; reasoning stays in front of its message
         assert result == [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
         assert result[0] is REASONING_ITEM
-        assert result[1] is merged[0]  # the deep-copied assistant message was used
+        assert result[1] is merged[0]  # the deep-copied assistant message (matched by id)
+        mock_warn.assert_not_called()
+
+    def test_deepcopy_without_ids_maps_positionally(self):
+        """When messages carry NO ids and are deep-copied (neither identity nor id can
+        locate them) but the count is preserved, fall back to positional slot-for-slot
+        mapping so the reasoning item still precedes its message."""
+        reasoning = {"type": "reasoning", "id": "rs_x", "summary": [], "encrypted_content": "e"}
+        assistant_no_id = {"role": "assistant", "content": "hi"}  # no id
+        user_no_id = {"role": "user", "content": "next"}  # no id
+        original = [reasoning, assistant_no_id, user_no_id]
+        merged = copy.deepcopy([assistant_no_id, user_no_id])  # no ids, no identity
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result[0] is reasoning
+        assert result == [reasoning, merged[0], merged[1]]
+        mock_warn.assert_not_called()
+
+    def test_partial_replacement_reattaches_surviving_items_via_id(self):
+        """The partial-identity + equal-count case: the hook keeps some messages by
+        identity and deep-copies another (new object, SAME id), preserving count. The id
+        fallback re-attaches BOTH reasoning items correctly -- under identity-only
+        matching the second one would have been dropped."""
+        a1 = {
+            "type": "message", "id": "msg_1", "role": "assistant",
+            "content": [{"type": "output_text", "text": "one", "annotations": []}],
+        }
+        a2 = {
+            "type": "message", "id": "msg_2", "role": "assistant",
+            "content": [{"type": "output_text", "text": "two", "annotations": []}],
+        }
+        r1 = {"type": "reasoning", "id": "rs_1", "summary": [], "encrypted_content": "e1"}
+        r2 = {"type": "reasoning", "id": "rs_2", "summary": [], "encrypted_content": "e2"}
+        u = {"role": "user", "content": "go"}
+        original = [r1, a1, r2, a2, u]
+        # a1 kept by identity, a2 deep-copied (same id), u kept by identity; count preserved
+        merged = [a1, copy.deepcopy(a2), u]
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [r1, a1, r2, merged[1], u]
+        assert r2 in result  # preserved via id fallback (would be dropped under identity-only)
         mock_warn.assert_not_called()
 
     def test_full_template_replacement_drops_non_message_items_with_warning(self):

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -15,6 +15,7 @@ Covers:
 
 import asyncio
 import copy
+import time
 from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -933,3 +934,47 @@ class TestAzureResponsesBodyRetainsReasoning:
             i for i, it in enumerate(body_input) if it.get("type") == "message" and it.get("role") == "assistant"
         )
         assert reasoning_idx == assistant_idx - 1
+
+
+class TestMergePromptManagementPerformance:
+    """[#32335] The merge helper must not degrade to quadratic time on large inputs.
+
+    A caller with a `prompt_id` configured controls both the number of role-bearing
+    messages and their ids, so a large payload (e.g. many messages plus one trailing
+    non-message item) previously drove ~26s of CPU time at 20k messages via repeated
+    linear anchor scans and list.insert() shifting -- a request-processing resource
+    exhaustion vector reachable before any provider call is made.
+    """
+
+    @staticmethod
+    def _build_case(num_messages: int) -> tuple[list, list]:
+        original = [{"role": "user", "content": f"msg {i}", "id": f"m{i}"} for i in range(num_messages)]
+        original.append({"type": "function_call_output", "call_id": "c1", "output": "ok"})
+        # deep-copied (identity lost, ids preserved) -> exercises the id-fallback path,
+        # the most expensive branch under the old O(n^2) implementation
+        merged = copy.deepcopy(original[:num_messages])
+        return original, merged
+
+    def test_large_input_scales_sub_quadratically(self):
+        small_original, small_merged = self._build_case(1000)
+        large_original, large_merged = self._build_case(8000)  # 8x the messages
+
+        start = time.perf_counter()
+        small_result = _merge_prompt_management_messages_into_input(small_original, small_merged)
+        small_elapsed = time.perf_counter() - start
+
+        start = time.perf_counter()
+        large_result = _merge_prompt_management_messages_into_input(large_original, large_merged)
+        large_elapsed = time.perf_counter() - start
+
+        assert len(small_result) == 1001
+        assert len(large_result) == 8001
+
+        # O(n^2) would grow ~64x (8^2) for an 8x input; O(n) grows ~8x. Allow generous
+        # headroom over linear (well below quadratic) to avoid CI-noise flakiness while
+        # still catching a regression to quadratic behavior.
+        max_expected = max(small_elapsed * 8 * 4, 0.5)
+        assert large_elapsed < max_expected, (
+            f"merge helper scaled worse than expected: {small_elapsed:.4f}s at 1k messages, "
+            f"{large_elapsed:.4f}s at 8k messages (limit {max_expected:.4f}s) -- looks quadratic again"
+        )

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -588,6 +588,56 @@ class TestMergePromptManagementMessagesIntoInput:
         assert REASONING_ITEM not in result
         mock_warn.assert_called_once()
 
+    def test_trailing_non_message_items_reattached_after_last_message(self):
+        """A tool-result turn: input ENDS with non-message items (function_call +
+        function_call_output) that trail the last message. They must be re-attached
+        immediately after that surviving message, in order."""
+        original = [USER_MESSAGE, ASSISTANT_MESSAGE, FUNCTION_CALL, FUNCTION_CALL_OUTPUT]
+        merged = [USER_MESSAGE, ASSISTANT_MESSAGE]  # passthrough; same objects
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [
+            USER_MESSAGE,
+            ASSISTANT_MESSAGE,
+            FUNCTION_CALL,
+            FUNCTION_CALL_OUTPUT,
+        ]
+        # trailing items kept their order and stayed after the last message
+        assert result.index(FUNCTION_CALL) == result.index(ASSISTANT_MESSAGE) + 1
+        assert result.index(FUNCTION_CALL_OUTPUT) == result.index(FUNCTION_CALL) + 1
+        mock_warn.assert_not_called()
+
+    def test_trailing_reasoning_prepended_by_template_stays_after_its_message(self):
+        """Trailing item + a hook that PREPENDS a template message (identity of the
+        originals preserved). The trailing item still lands after the last original
+        message, and the injected preamble stays at the front."""
+        system_msg = {"role": "system", "content": "Template preamble."}
+        original = [USER_MESSAGE, ASSISTANT_MESSAGE, FUNCTION_CALL_OUTPUT]
+        merged = [system_msg, USER_MESSAGE, ASSISTANT_MESSAGE]  # prepend, same originals
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [system_msg, USER_MESSAGE, ASSISTANT_MESSAGE, FUNCTION_CALL_OUTPUT]
+
+    def test_trailing_item_dropped_and_warns_when_last_message_removed(self):
+        """If the last message (the trailing item's anchor) is removed/replaced by the
+        hook, the trailing orphan is dropped with a warning rather than re-attached to
+        an unrelated message."""
+        original = [ASSISTANT_MESSAGE, FUNCTION_CALL_OUTPUT]  # trailing FCO anchored to ASSISTANT
+        merged = [
+            {"role": "system", "content": "New a."},
+            {"role": "user", "content": "New b."},
+        ]  # 2 new messages (count differs from 1 original) -> best-effort identity path
+
+        with patch("litellm.responses.main.verbose_logger.warning") as mock_warn:
+            result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == merged
+        assert FUNCTION_CALL_OUTPUT not in result
+        mock_warn.assert_called_once()
+
 
 class TestResponsesReasoningPreservationEndToEnd:
     """[#32335] Reasoning/non-message items survive all the way to the downstream

--- a/tests/test_litellm/responses/test_responses_prompt_management.py
+++ b/tests/test_litellm/responses/test_responses_prompt_management.py
@@ -580,6 +580,22 @@ class TestMergePromptManagementMessagesIntoInput:
         # reasoning immediately precedes its OWN assistant message, not the context msg
         assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
 
+    def test_stray_non_message_item_in_hook_output_is_not_treated_as_an_anchor(self):
+        """Defensive: a non-conforming hook could echo a non-message item (reasoning/
+        function_call/...) back into its output instead of returning only messages.
+        _build_message_index only indexes genuine message items, so that stray item
+        can never be mistaken for a message anchor -- it just passes through as part
+        of the hook's output, and the real reasoning item still lands next to its own
+        assistant message rather than being misattached to the stray item."""
+        original = [REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        stray_item = {"type": "function_call", "id": "fc_stray", "call_id": "c", "name": "n", "arguments": "{}"}
+        merged = [stray_item, ASSISTANT_MESSAGE, USER_MESSAGE]  # non-conforming hook output
+
+        result = _merge_prompt_management_messages_into_input(original, merged)
+
+        assert result == [stray_item, REASONING_ITEM, ASSISTANT_MESSAGE, USER_MESSAGE]
+        assert result.index(REASONING_ITEM) == result.index(ASSISTANT_MESSAGE) - 1
+
     def test_cache_control_deepcopy_reattaches_via_message_id(self):
         """Mirrors AnthropicCacheControlHook: messages are deep-copied (object identity
         lost) but their message ids are preserved. The reasoning item is re-attached to


### PR DESCRIPTION
## Summary

Fixes #32335 — a v1.83.7 regression where the `/responses` API drops `reasoning` items from multi-turn input before forwarding to Azure OpenAI.

On multi-turn Responses calls (client echoes the previous turn's output back as `input`, e.g. what the openai-agents SDK does automatically), Azure rejects the request with:

```
Item 'msg_<id>' of type 'message' was provided without its required 'reasoning' item: 'rs_<id>'.
```

This worked in v1.82.3-stable and broke in v1.83.7.

## Root cause

Prompt-management support for the Responses API (#23999, merged between v1.82.3 and v1.83.7) added, in **two** places in `litellm/responses/main.py` — the async `aresponses()` block and the sync `_apply_prompt_management_to_responses_call()` — this pattern:

```python
client_input = [item for item in input if isinstance(item, dict) and "role" in item]
...
input = cast(Union[str, ResponseInputParam], merged_input)  # replaces input wholesale
```

The prompt-management hooks (`get_chat_completion_prompt` / `async_get_chat_completion_prompt`) operate on chat-style messages, so `input` is filtered to only role-bearing items before the hook runs. But the hook's output then **replaces `input` wholesale**, permanently discarding every non-message item — `reasoning`, `function_call`, `function_call_output` (none of which carry a `role` key).

For a multi-turn input like `[reasoning, assistant_message, user_message]`, the assistant `message` (has `role`) survives but its paired `reasoning` item (no `role`) is dropped — exactly the pairing Azure's Responses API enforces.

This only triggers when `should_run_prompt_management_hooks()` returns True (a `prompt_id`, a `litellm_agent/*` model, `vector_store_ids` / `knowledge_bases` / `cache_control_injection_points`, or a configured `vector_store_registry`). The plain native path is unaffected.

A real-world report confirmed `cache_control_injection_points` alone (no `prompt_id`) as the trigger, on a non-Anthropic model (`azure/gpt-5-codex`, `mode: responses`); see https://github.com/BerriAI/litellm/issues/32335#issuecomment-4982505843.

## Fix

The message subset is still handed to the hook (unchanged), but afterwards the non-message items are **re-merged** into the result, via a shared helper used by both the sync and async paths (previously duplicated).

The merge strategy was validated against the real hooks in `litellm/integrations`, which behave differently:

| Hook | Transform | Count | Original-msg identity |
|---|---|---|---|
| pass-through (no logger) | none | M = N | preserved |
| `VectorStorePreCallHook` (`vector_store_ids`) | `messages.insert(-1, context)` | M = N+1 | preserved |
| `AnthropicCacheControlHook` (`cache_control_injection_points`) | `deepcopy` + edit | M = N | **lost (deepcopy)** |
| `PromptManagementBase` (langfuse / gitlab / dotprompt / bitbucket / generic / humanloop / arize) | `template + messages` (prepend) | M = N+k | preserved |

So a fixed "prepend" or positional assumption is wrong (e.g. the vector-store hook inserts at `-1`, not the front). `_merge_prompt_management_messages_into_input()` therefore:

- **identity match** — the hook kept the original message objects (pass-through, vector-store `insert(-1)`, template prepend): re-attach each non-message item next to *its own* message, wherever the hook moved it. Position-independent; never mis-pairs.
- **equal count, identity lost** — the hook deep-copied but preserved order/count (cache-control): substitute messages slot-for-slot.
- **hook replaced/removed messages** (full prompt-template replacement): re-attach whatever is still identifiable, drop the rest, and log a warning. A non-message item is **only ever placed next to its own message, never a different one**, so a mis-paired request can never be produced.

Pure chat-completion inputs (no non-message items) are unaffected — the hook output is used as-is.

The resolution is per-message rather than an all-or-nothing check across the whole message list: if a hook transforms some messages but leaves others untouched (e.g. a moderation hook that only rewrites flagged messages), non-message items anchored to the untouched messages are preserved even when a sibling message can't be located. Likewise, if the input has no role-bearing messages at all but the hook still returns a template message (e.g. an unconditional `prompt_id` template on a pure tool-output turn), the hook's output is still applied rather than the hook being skipped outright.

## Test coverage

`tests/test_litellm/responses/test_responses_prompt_management.py` (pre-existing tests unchanged):

- **Merge-helper unit tests**: pass-through, vector-store `insert(-1)`, cache-control deep-copy (equal-count positional), prompt-template prepend, full template replacement (drop + warn), orphaned-anchor (drop + warn), partial-identity equal-count (some messages locatable, some not), no-messages-in-input-but-hook-returns-a-template, and `function_call` / `function_call_output` ordering preservation.
- **End-to-end** through both sync `responses()` and async `aresponses()`: the reporter's `[reasoning, assistant, user]` scenario reaches the downstream handler with the reasoning item intact and correctly positioned.
- **Provider-level**: asserts the fully-built **Azure request body** retains the reasoning item, immediately preceding its paired message.

## Reproduction (before → after)

With a prompt-management hook active, multi-turn input `['reasoning', 'message', 'message(user)']`:
- **before**: forwarded as `['message', 'message(user)']` → Azure 400
- **after**: forwarded as `['reasoning', 'message', 'message(user)']` → reasoning preserved, paired
