### PR TITLE
fix: skip post-call redis writes for keys with no rate limits configured

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -509,6 +509,17 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 team_metadata=user_api_key_team_metadata,
             )
 
+            # The full UserAPIKeyAuth with populated rate-limit fields (rpm_limit,
+            # tpm_limit, user_rpm_limit, etc.) is stashed in metadata by the auth
+            # layer.  The locally-reconstructed user_api_key_dict above does NOT
+            # carry those fields, so we need the original for limit checks.
+            # If the object is missing (e.g. non-proxy callers), we cannot make
+            # positive "no limit set" determinations and must keep writing
+            # unconditionally to stay safe.
+            full_user_api_key_dict: Optional[UserAPIKeyAuth] = (
+                kwargs.get("litellm_params", {}).get("metadata", {}).get("user_api_key_auth")
+            )
+
             # ------------
             # Setup values
             # ------------
@@ -540,7 +551,12 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
 
             values_to_update_in_cache = []
 
-            if user_api_key is not None:
+            if user_api_key is not None and (
+                full_user_api_key_dict is None
+                or getattr(full_user_api_key_dict, "rpm_limit", None) is not None
+                or getattr(full_user_api_key_dict, "tpm_limit", None) is not None
+                or getattr(full_user_api_key_dict, "max_parallel_requests", None) is not None
+            ):
                 request_count_api_key = f"{user_api_key}::{precise_minute}::request_count"
 
                 current = await self.internal_usage_cache.async_get_cache(
@@ -605,7 +621,11 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - User
             # ------------
-            if user_api_key_user_id is not None:
+            if user_api_key_user_id is not None and (
+                full_user_api_key_dict is None
+                or getattr(full_user_api_key_dict, "user_rpm_limit", None) is not None
+                or getattr(full_user_api_key_dict, "user_tpm_limit", None) is not None
+            ):
                 total_tokens = 0
 
                 if isinstance(
@@ -637,7 +657,11 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - Team
             # ------------
-            if user_api_key_team_id is not None:
+            if user_api_key_team_id is not None and (
+                full_user_api_key_dict is None
+                or getattr(full_user_api_key_dict, "team_rpm_limit", None) is not None
+                or getattr(full_user_api_key_dict, "team_tpm_limit", None) is not None
+            ):
                 total_tokens = 0
 
                 if isinstance(
@@ -669,7 +693,11 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - End User
             # ------------
-            if user_api_key_end_user_id is not None:
+            if user_api_key_end_user_id is not None and (
+                full_user_api_key_dict is None
+                or getattr(full_user_api_key_dict, "end_user_rpm_limit", None) is not None
+                or getattr(full_user_api_key_dict, "end_user_tpm_limit", None) is not None
+            ):
                 total_tokens = 0
 
                 if isinstance(

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -49,7 +49,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
     @staticmethod
     def _entity_has_any_limit(
         full_user_api_key_dict: Optional[UserAPIKeyAuth],
-        limit_fields: List[str],
+        limit_fields: list[str],
     ) -> bool:
         """
         True if we should write cache for this entity: either we can't

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -638,6 +638,12 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # since those fields don't exist on UserAPIKeyAuth yet (see TODOs in
             # async_pre_call_hook). Add them to the limit_fields list here once
             # implemented, to avoid a current_requests leak for those scopes.
+            #
+            # Also applies to the key scope above: if rpm_limit, tpm_limit, and
+            # max_parallel_requests are all None, current_requests still grows
+            # un-decremented within a minute window. Harmless today since the
+            # pre-call effective limit is sys.maxsize in that case (no false
+            # rate-limit), but noting for completeness per review feedback.
             if user_api_key_user_id is not None and self._entity_has_any_limit(
                 full_user_api_key_dict,
                 ["user_rpm_limit", "user_tpm_limit"],

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -46,6 +46,21 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
     def __init__(self, internal_usage_cache: InternalUsageCache):
         self.internal_usage_cache = internal_usage_cache
 
+    @staticmethod
+    def _entity_has_any_limit(
+        full_user_api_key_dict: Optional[UserAPIKeyAuth],
+        limit_fields: List[str],
+    ) -> bool:
+        """
+        True if we should write cache for this entity: either we can't
+        positively confirm no limit is set (auth object missing -> safe
+        fallback), or at least one of the given limit field names is
+        non-None on the auth object.
+        """
+        if full_user_api_key_dict is None:
+            return True
+        return any(getattr(full_user_api_key_dict, field, None) is not None for field in limit_fields)
+
     def print_verbose(self, print_statement):
         try:
             verbose_proxy_logger.debug(print_statement)
@@ -551,11 +566,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
 
             values_to_update_in_cache = []
 
-            if user_api_key is not None and (
-                full_user_api_key_dict is None
-                or getattr(full_user_api_key_dict, "rpm_limit", None) is not None
-                or getattr(full_user_api_key_dict, "tpm_limit", None) is not None
-                or getattr(full_user_api_key_dict, "max_parallel_requests", None) is not None
+            if user_api_key is not None and self._entity_has_any_limit(
+                full_user_api_key_dict,
+                ["rpm_limit", "tpm_limit", "max_parallel_requests"],
             ):
                 request_count_api_key = f"{user_api_key}::{precise_minute}::request_count"
 
@@ -621,10 +634,13 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - User
             # ------------
-            if user_api_key_user_id is not None and (
-                full_user_api_key_dict is None
-                or getattr(full_user_api_key_dict, "user_rpm_limit", None) is not None
-                or getattr(full_user_api_key_dict, "user_tpm_limit", None) is not None
+            # NOTE: does not yet gate on user/team/end_user max_parallel_requests,
+            # since those fields don't exist on UserAPIKeyAuth yet (see TODOs in
+            # async_pre_call_hook). Add them to the limit_fields list here once
+            # implemented, to avoid a current_requests leak for those scopes.
+            if user_api_key_user_id is not None and self._entity_has_any_limit(
+                full_user_api_key_dict,
+                ["user_rpm_limit", "user_tpm_limit"],
             ):
                 total_tokens = 0
 
@@ -657,10 +673,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - Team
             # ------------
-            if user_api_key_team_id is not None and (
-                full_user_api_key_dict is None
-                or getattr(full_user_api_key_dict, "team_rpm_limit", None) is not None
-                or getattr(full_user_api_key_dict, "team_tpm_limit", None) is not None
+            if user_api_key_team_id is not None and self._entity_has_any_limit(
+                full_user_api_key_dict,
+                ["team_rpm_limit", "team_tpm_limit"],
             ):
                 total_tokens = 0
 
@@ -693,10 +708,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - End User
             # ------------
-            if user_api_key_end_user_id is not None and (
-                full_user_api_key_dict is None
-                or getattr(full_user_api_key_dict, "end_user_rpm_limit", None) is not None
-                or getattr(full_user_api_key_dict, "end_user_tpm_limit", None) is not None
+            if user_api_key_end_user_id is not None and self._entity_has_any_limit(
+                full_user_api_key_dict,
+                ["end_user_rpm_limit", "end_user_tpm_limit"],
             ):
                 total_tokens = 0
 
@@ -741,6 +755,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             _metadata = kwargs["litellm_params"].get("metadata", {}) or {}
             global_max_parallel_requests = _metadata.get("global_max_parallel_requests", None)
             user_api_key = _metadata.get("user_api_key", None)
+            full_user_api_key_dict: Optional[UserAPIKeyAuth] = _metadata.get("user_api_key_auth")
             self.print_verbose(f"user_api_key: [set={user_api_key is not None}]")
             if user_api_key is None:
                 return
@@ -781,28 +796,32 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # ------------
                 # Update usage
                 # ------------
-                current = await self.internal_usage_cache.async_get_cache(
-                    key=request_count_api_key,
-                    litellm_parent_otel_span=litellm_parent_otel_span,
-                ) or {
-                    "current_requests": 1,
-                    "current_tpm": 0,
-                    "current_rpm": 0,
-                }
+                if self._entity_has_any_limit(
+                    full_user_api_key_dict,
+                    ["rpm_limit", "tpm_limit", "max_parallel_requests"],
+                ):
+                    current = await self.internal_usage_cache.async_get_cache(
+                        key=request_count_api_key,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    ) or {
+                        "current_requests": 1,
+                        "current_tpm": 0,
+                        "current_rpm": 0,
+                    }
 
-                new_val = {
-                    "current_requests": max(current["current_requests"] - 1, 0),
-                    "current_tpm": current["current_tpm"],
-                    "current_rpm": current["current_rpm"],
-                }
+                    new_val = {
+                        "current_requests": max(current["current_requests"] - 1, 0),
+                        "current_tpm": current["current_tpm"],
+                        "current_rpm": current["current_rpm"],
+                    }
 
-                self.print_verbose(f"updated_value in failure call: {new_val}")
-                await self.internal_usage_cache.async_set_cache(
-                    request_count_api_key,
-                    new_val,
-                    ttl=60,
-                    litellm_parent_otel_span=litellm_parent_otel_span,
-                )  # save in cache for up to 1 min.
+                    self.print_verbose(f"updated_value in failure call: {new_val}")
+                    await self.internal_usage_cache.async_set_cache(
+                        request_count_api_key,
+                        new_val,
+                        ttl=60,
+                        litellm_parent_otel_span=litellm_parent_otel_span,
+                    )  # save in cache for up to 1 min.
         except Exception as e:
             verbose_proxy_logger.exception("Inside Parallel Request Limiter: An exception occurred - {}".format(str(e)))
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -567,8 +567,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             values_to_update_in_cache = []
 
             if user_api_key is not None and self._entity_has_any_limit(
-                full_user_api_key_dict,
-                ["rpm_limit", "tpm_limit", "max_parallel_requests"],
+                full_user_api_key_dict, ["rpm_limit", "tpm_limit", "max_parallel_requests"]
             ):
                 request_count_api_key = f"{user_api_key}::{precise_minute}::request_count"
 
@@ -645,8 +644,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # pre-call effective limit is sys.maxsize in that case (no false
             # rate-limit), but noting for completeness per review feedback.
             if user_api_key_user_id is not None and self._entity_has_any_limit(
-                full_user_api_key_dict,
-                ["user_rpm_limit", "user_tpm_limit"],
+                full_user_api_key_dict, ["user_rpm_limit", "user_tpm_limit"]
             ):
                 total_tokens = 0
 
@@ -680,8 +678,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # Update usage - Team
             # ------------
             if user_api_key_team_id is not None and self._entity_has_any_limit(
-                full_user_api_key_dict,
-                ["team_rpm_limit", "team_tpm_limit"],
+                full_user_api_key_dict, ["team_rpm_limit", "team_tpm_limit"]
             ):
                 total_tokens = 0
 
@@ -714,9 +711,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             # ------------
             # Update usage - End User
             # ------------
+            _end_user_limit_fields = ["end_user_rpm_limit", "end_user_tpm_limit"]
             if user_api_key_end_user_id is not None and self._entity_has_any_limit(
-                full_user_api_key_dict,
-                ["end_user_rpm_limit", "end_user_tpm_limit"],
+                full_user_api_key_dict, _end_user_limit_fields
             ):
                 total_tokens = 0
 
@@ -803,8 +800,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                 # Update usage
                 # ------------
                 if self._entity_has_any_limit(
-                    full_user_api_key_dict,
-                    ["rpm_limit", "tpm_limit", "max_parallel_requests"],
+                    full_user_api_key_dict, ["rpm_limit", "tpm_limit", "max_parallel_requests"]
                 ):
                     current = await self.internal_usage_cache.async_get_cache(
                         key=request_count_api_key,

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -3,10 +3,12 @@ Unit Tests for the max parallel request limiter v1 for the proxy
 """
 
 from datetime import datetime
+from typing import Optional
 
 import pytest
 
 from litellm.caching.caching import DualCache
+from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.hooks.parallel_request_limiter import (
     _PROXY_MaxParallelRequestsHandler,
 )
@@ -39,9 +41,7 @@ async def test_async_log_success_event_counts_non_chat_response_tokens(response_
     team_id = "litellm-team"
     end_user_id = "customer-1"
 
-    parallel_request_handler = _PROXY_MaxParallelRequestsHandler(
-        internal_usage_cache=InternalUsageCache(DualCache())
-    )
+    parallel_request_handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
 
     current_date = datetime.now().strftime("%Y-%m-%d")
     current_hour = datetime.now().strftime("%H")
@@ -80,7 +80,223 @@ async def test_async_log_success_event_counts_non_chat_response_tokens(response_
             key=f"{scope_id}::{precise_minute}::request_count",
             litellm_parent_otel_span=None,
         )
-        assert current["current_tpm"] == 50, (
-            f"expected 50 tokens counted for {scope_id}, "
-            f"got {current['current_tpm']}"
+        assert current["current_tpm"] == 50, f"expected 50 tokens counted for {scope_id}, got {current['current_tpm']}"
+
+
+def _build_kwargs(
+    *,
+    api_key: str,
+    user_id: Optional[str] = None,
+    team_id: Optional[str] = None,
+    end_user_id: Optional[str] = None,
+    auth_object: Optional[UserAPIKeyAuth] = None,
+    user_api_key_metadata: Optional[dict] = None,
+    user_api_key_team_metadata: Optional[dict] = None,
+    user_api_key_model_max_budget: Optional[dict] = None,
+) -> dict:
+    metadata = {
+        "user_api_key": api_key,
+        "user_api_key_user_id": user_id,
+        "user_api_key_team_id": team_id,
+        "user_api_key_model_max_budget": user_api_key_model_max_budget or {},
+    }
+    if auth_object is not None:
+        metadata["user_api_key_auth"] = auth_object
+    if user_api_key_metadata is not None:
+        metadata["user_api_key_metadata"] = user_api_key_metadata
+    if user_api_key_team_metadata is not None:
+        metadata["user_api_key_team_metadata"] = user_api_key_team_metadata
+    kwargs: dict = {"litellm_params": {"metadata": metadata}}
+    if end_user_id is not None:
+        kwargs["user"] = end_user_id
+    return kwargs
+
+
+def _make_response(total_tokens: int = 10) -> EmbeddingResponse:
+    return EmbeddingResponse(
+        model="text-embedding-3-small",
+        usage=Usage(prompt_tokens=total_tokens, completion_tokens=0, total_tokens=total_tokens),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_write_when_no_key_limits_configured():
+    _api_key = hash_token("sk-no-limits")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        auth_object=UserAPIKeyAuth(api_key=_api_key),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::{datetime.now().strftime('%Y-%m-%d-%H-%M')}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is None, "cache write should be skipped when no key limits are set"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_writes_when_key_rpm_limit_configured():
+    _api_key = hash_token("sk-with-rpm")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        auth_object=UserAPIKeyAuth(api_key=_api_key, rpm_limit=100),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is not None, "cache write should happen when rpm_limit is configured"
+    assert current["current_tpm"] == 10
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_write_when_no_user_limits_configured():
+    _api_key = hash_token("sk-user-no-limits")
+    user_id = "user-no-limits"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        user_id=user_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{user_id}::{datetime.now().strftime('%Y-%m-%d-%H-%M')}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is None, "user cache write should be skipped when no user limits are set"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_write_when_no_team_limits_configured():
+    _api_key = hash_token("sk-team-no-limits")
+    team_id = "team-no-limits"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        team_id=team_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{team_id}::{datetime.now().strftime('%Y-%m-%d-%H-%M')}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is None, "team cache write should be skipped when no team limits are set"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_skips_write_when_no_end_user_limits_configured():
+    _api_key = hash_token("sk-enduser-no-limits")
+    end_user_id = "enduser-no-limits"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        end_user_id=end_user_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{end_user_id}::{datetime.now().strftime('%Y-%m-%d-%H-%M')}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is None, "end user cache write should be skipped when no end user limits are set"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_writes_when_auth_object_missing_from_metadata():
+    _api_key = hash_token("sk-no-auth-obj")
+    user_id = "user-fallback"
+    team_id = "team-fallback"
+    end_user_id = "enduser-fallback"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        user_id=user_id,
+        team_id=team_id,
+        end_user_id=end_user_id,
+    )
+    assert "user_api_key_auth" not in kwargs["litellm_params"]["metadata"]
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    for scope_id in [_api_key, user_id, team_id, end_user_id]:
+        current = await handler.internal_usage_cache.async_get_cache(
+            key=f"{scope_id}::{precise_minute}::request_count",
+            litellm_parent_otel_span=None,
         )
+        assert current is not None, f"cache write for {scope_id} must happen when auth object is missing"
+        assert current["current_tpm"] > 0
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_model_key_block_unaffected():
+    _api_key = hash_token("sk-model-key")
+    model_rpm_limit = {"gpt-4": 100}
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    await handler.internal_usage_cache.async_set_cache(
+        key=f"{_api_key}::gpt-4::{precise_minute}::request_count",
+        value={"current_requests": 1, "current_tpm": 0, "current_rpm": 1},
+        litellm_parent_otel_span=None,
+    )
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        auth_object=UserAPIKeyAuth(api_key=_api_key),
+        user_api_key_metadata={"model_rpm_limit": model_rpm_limit},
+    )
+    kwargs["litellm_params"]["metadata"]["model_group"] = "gpt-4"
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(20),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::gpt-4::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is not None, "model+key block should still write when model_rpm_limit is set"
+    assert current["current_tpm"] == 20

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -550,3 +550,87 @@ async def test_async_log_failure_event_decrements_global_max_parallel_requests()
         litellm_parent_otel_span=None,
     )
     assert val == 99, f"global_max_parallel_requests should be 99 after failure decrement, got {val}"
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_writes_when_user_limit_configured():
+    _api_key = hash_token("sk-with-user-rpm")
+    user_id = "user-with-limit"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        user_id=user_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key, user_rpm_limit=100),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{user_id}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is not None, "cache write should happen when user_rpm_limit is configured"
+    assert current["current_tpm"] == 20
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_writes_when_team_limit_configured():
+    _api_key = hash_token("sk-with-team-rpm")
+    team_id = "team-with-limit"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        team_id=team_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key, team_rpm_limit=100),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{team_id}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is not None, "cache write should happen when team_rpm_limit is configured"
+    assert current["current_tpm"] == 20
+
+
+@pytest.mark.asyncio
+async def test_async_log_success_event_writes_when_end_user_limit_configured():
+    _api_key = hash_token("sk-with-enduser-rpm")
+    end_user_id = "enduser-with-limit"
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    kwargs = _build_kwargs(
+        api_key=_api_key,
+        end_user_id=end_user_id,
+        auth_object=UserAPIKeyAuth(api_key=_api_key, end_user_rpm_limit=100),
+    )
+    await handler.async_log_success_event(
+        kwargs=kwargs,
+        response_obj=_make_response(10),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{end_user_id}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current is not None, "cache write should happen when end_user_rpm_limit is configured"
+    assert current["current_tpm"] == 20

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -307,3 +307,89 @@ async def test_async_log_success_event_model_key_block_unaffected():
     )
     assert current is not None, "model+key block should still write when model_rpm_limit is set"
     assert current["current_tpm"] == 20
+
+
+def test_entity_has_any_limit_returns_true_when_auth_object_missing():
+    assert _PROXY_MaxParallelRequestsHandler._entity_has_any_limit(None, ["rpm_limit"]) is True
+
+
+def test_entity_has_any_limit_returns_false_when_all_fields_none():
+    auth = UserAPIKeyAuth(api_key="sk-test")
+    assert auth.rpm_limit is None
+    assert auth.tpm_limit is None
+    assert _PROXY_MaxParallelRequestsHandler._entity_has_any_limit(auth, ["rpm_limit", "tpm_limit"]) is False
+
+
+def test_entity_has_any_limit_returns_true_when_one_field_set():
+    auth = UserAPIKeyAuth(api_key="sk-test", rpm_limit=100)
+    assert _PROXY_MaxParallelRequestsHandler._entity_has_any_limit(auth, ["rpm_limit", "tpm_limit"]) is True
+
+
+@pytest.mark.asyncio
+async def test_async_log_failure_event_skips_decrement_when_no_limits_configured():
+    _api_key = hash_token("sk-fail-no-limits")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    await handler.internal_usage_cache.async_set_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        value={"current_requests": 1, "current_tpm": 0, "current_rpm": 1},
+        litellm_parent_otel_span=None,
+    )
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": _api_key,
+                "user_api_key_auth": UserAPIKeyAuth(api_key=_api_key),
+            }
+        },
+        "exception": ValueError("test error"),
+    }
+    await handler.async_log_failure_event(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current["current_requests"] == 1, "failure decrement should be skipped when no limits are configured"
+
+
+@pytest.mark.asyncio
+async def test_async_log_failure_event_decrements_when_limit_configured():
+    _api_key = hash_token("sk-fail-with-limit")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    await handler.internal_usage_cache.async_set_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        value={"current_requests": 1, "current_tpm": 0, "current_rpm": 1},
+        litellm_parent_otel_span=None,
+    )
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": _api_key,
+                "user_api_key_auth": UserAPIKeyAuth(api_key=_api_key, rpm_limit=100),
+            }
+        },
+        "exception": ValueError("test error"),
+    }
+    await handler.async_log_failure_event(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current["current_requests"] == 0, "failure decrement should happen when limit is configured"

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -14,6 +14,8 @@ from litellm.proxy.hooks.parallel_request_limiter import (
 )
 from litellm.proxy.utils import InternalUsageCache, hash_token
 from litellm.types.utils import EmbeddingResponse, TextCompletionResponse, Usage
+from litellm.exceptions import RateLimitType
+from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
 
 
 @pytest.mark.parametrize(
@@ -393,3 +395,84 @@ async def test_async_log_failure_event_decrements_when_limit_configured():
         litellm_parent_otel_span=None,
     )
     assert current["current_requests"] == 0, "failure decrement should happen when limit is configured"
+
+
+@pytest.mark.asyncio
+async def test_check_key_in_limits_tpm_zero_triggers_tokens_type():
+    """base case: tpm_limit=0 should raise with rate_limit_type=TOKENS (line 97-98)."""
+    internal_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(internal_cache)
+    )
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await handler.check_key_in_limits(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={},
+            call_type="completion",
+            max_parallel_requests=10,
+            tpm_limit=0,
+            rpm_limit=10,
+            current=None,
+            request_count_api_key="test-key::minute::request_count",
+            rate_limit_type="key",
+            values_to_update_in_cache=[],
+        )
+    assert exc_info.value.rate_limit_type == RateLimitType.TOKENS
+
+
+@pytest.mark.asyncio
+async def test_check_key_in_limits_rpm_zero_triggers_requests_type():
+    """base case: rpm_limit=0 (only) should fall to the else -> REQUESTS (line 99)."""
+    internal_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(internal_cache)
+    )
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+
+    with pytest.raises(ProxyRateLimitError) as exc_info:
+        await handler.check_key_in_limits(
+            user_api_key_dict=user_api_key_dict,
+            cache=DualCache(),
+            data={},
+            call_type="completion",
+            max_parallel_requests=10,
+            tpm_limit=10,
+            rpm_limit=0,
+            current=None,
+            request_count_api_key="test-key::minute::request_count",
+            rate_limit_type="key",
+            values_to_update_in_cache=[],
+        )
+    assert exc_info.value.rate_limit_type == RateLimitType.REQUESTS
+
+
+@pytest.mark.asyncio
+async def test_check_key_in_limits_writes_new_val_when_no_current():
+    """current=None, no dimension is 0 -> writes initial new_val (lines 107-111)."""
+    internal_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(internal_cache)
+    )
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+    values_to_update_in_cache = []
+
+    result = await handler.check_key_in_limits(
+        user_api_key_dict=user_api_key_dict,
+        cache=DualCache(),
+        data={},
+        call_type="completion",
+        max_parallel_requests=10,
+        tpm_limit=1000,
+        rpm_limit=10,
+        current=None,
+        request_count_api_key="test-key::minute::request_count",
+        rate_limit_type="key",
+        values_to_update_in_cache=values_to_update_in_cache,
+    )
+    assert result == {"current_requests": 1, "current_tpm": 0, "current_rpm": 1}
+    assert values_to_update_in_cache == [
+        ("test-key::minute::request_count", {"current_requests": 1, "current_tpm": 0, "current_rpm": 1})
+    ]

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -63,6 +63,13 @@ async def test_async_log_success_event_counts_non_chat_response_tokens(response_
                 "user_api_key_user_id": user_id,
                 "user_api_key_team_id": team_id,
                 "user_api_key_model_max_budget": {},
+                "user_api_key_auth": UserAPIKeyAuth(
+                    api_key=_api_key,
+                    rpm_limit=100,
+                    user_rpm_limit=100,
+                    team_rpm_limit=100,
+                    end_user_rpm_limit=100,
+                ),
             }
         },
         "user": end_user_id,

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py
@@ -16,6 +16,7 @@ from litellm.proxy.utils import InternalUsageCache, hash_token
 from litellm.types.utils import EmbeddingResponse, TextCompletionResponse, Usage
 from litellm.exceptions import RateLimitType
 from litellm.proxy.common_utils.proxy_rate_limit_error import ProxyRateLimitError
+from litellm.proxy._types import CommonProxyErrors
 
 
 @pytest.mark.parametrize(
@@ -476,3 +477,76 @@ async def test_check_key_in_limits_writes_new_val_when_no_current():
     assert values_to_update_in_cache == [
         ("test-key::minute::request_count", {"current_requests": 1, "current_tpm": 0, "current_rpm": 1})
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_log_failure_event_ignores_max_limit_exception():
+    """When exception is max_parallel_request_limit_reached, the entire
+    decrement block is skipped (the 'pass' branch)."""
+    _api_key = hash_token("sk-fail-max-limit")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    current_date = datetime.now().strftime("%Y-%m-%d")
+    current_hour = datetime.now().strftime("%H")
+    current_minute = datetime.now().strftime("%M")
+    precise_minute = f"{current_date}-{current_hour}-{current_minute}"
+    await handler.internal_usage_cache.async_set_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        value={"current_requests": 3, "current_tpm": 0, "current_rpm": 3},
+        litellm_parent_otel_span=None,
+    )
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": _api_key,
+                "user_api_key_auth": UserAPIKeyAuth(api_key=_api_key, rpm_limit=100),
+            }
+        },
+        "exception": Exception(CommonProxyErrors.max_parallel_request_limit_reached.value),
+    }
+    await handler.async_log_failure_event(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    current = await handler.internal_usage_cache.async_get_cache(
+        key=f"{_api_key}::{precise_minute}::request_count",
+        litellm_parent_otel_span=None,
+    )
+    assert current["current_requests"] == 3, (
+        "current_requests should be unchanged when max_parallel_request_limit_reached exception is caught"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_log_failure_event_decrements_global_max_parallel_requests():
+    """global_max_parallel_requests is decremented by 1 on failure."""
+    _api_key = hash_token("sk-fail-global")
+    handler = _PROXY_MaxParallelRequestsHandler(internal_usage_cache=InternalUsageCache(DualCache()))
+    await handler.internal_usage_cache.async_increment_cache(
+        key="global_max_parallel_requests",
+        value=100,
+        local_only=True,
+        litellm_parent_otel_span=None,
+    )
+    kwargs = {
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": _api_key,
+                "user_api_key_auth": UserAPIKeyAuth(api_key=_api_key, rpm_limit=100),
+                "global_max_parallel_requests": 100,
+            }
+        },
+        "exception": ValueError("test error"),
+    }
+    await handler.async_log_failure_event(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+    )
+    val = await handler.internal_usage_cache.async_get_cache(
+        key="global_max_parallel_requests",
+        litellm_parent_otel_span=None,
+    )
+    assert val == 99, f"global_max_parallel_requests should be 99 after failure decrement, got {val}"


### PR DESCRIPTION
## Relevant issues
Fixes #31880

Supersedes #32179 — that PR targeted `main`, but the repo's
`guard-main-branch` check requires external fork PRs to target
`litellm_oss_staging` instead. Same fix, retargeted branch.

## Linear ticket


## Pre-Submission checklist
- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review (received 5/5 on #32179)

## Delays in PR merge?
If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Attempted full local e2e verification (native Windows Redis binary, real
Groq API calls, `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true` to activate the
v1 handler this PR patches — v3 is the default and already correctly gated
prior to this change). Confirmed via temporary debug logging that
`full_user_api_key_dict` resolves correctly at runtime and that the gate
conditions are reached with the expected values (all limit fields `None`
for an unconfigured master key).

The live before/after Redis-write comparison was inconclusive on this
local test setup for reasons independent of the fix (response-shape-
dependent code elsewhere in those blocks). Given that, the primary
verification for this PR is the added unit test suite, which directly
exercises each gate in isolation, including several regression guards —
see Testing section below.

## Type
🐛 Bug Fix

## Changes

`async_log_success_event` and `async_log_failure_event` in the legacy
parallel request limiter (`litellm/proxy/hooks/parallel_request_limiter.py`,
active when `LEGACY_MULTI_INSTANCE_RATE_LIMITING=true`) unconditionally
wrote/decremented usage counters in cache for every API key, user, team,
and end-user on every call — even when no `rpm_limit`/`tpm_limit`/
`max_parallel_requests` was configured for that entity. Since the counter
is only ever read back for enforcement when a limit exists, this was
pure overhead at high throughput.

**How it works:**
- The locally reconstructed `user_api_key_dict` in these functions does
  not carry the real limit fields. The actual `UserAPIKeyAuth` object
  with limits populated is available at
  `kwargs["litellm_params"]["metadata"]["user_api_key_auth"]`.
- A shared `_entity_has_any_limit` helper checks the relevant limit
  fields on that real auth object before any cache write, used
  consistently across all four success-event scopes (API Key, User,
  Team, End-User) and the failure-event decrement, mirroring the
  gating pattern already used for the existing model-scoped counter.
- **Safety fallback:** if the auth object is missing from metadata for
  any reason, the code falls back to the old unconditional-write
  behavior rather than risk silently disabling tracking on incomplete
  data.

**Scope** — intentionally limited to the post-call usage-tracking path in
the legacy (v1) limiter only:
- `async_pre_call_hook` (enforcement path) is untouched — riskier to
  change and outside this issue's scope. A code comment documents the
  resulting `current_requests` asymmetry for unlimited entities
  (harmless today since the pre-call effective limit is `sys.maxsize`
  in that case).
- `parallel_request_limiter_v3.py` (the default handler for all
  deployments not setting `LEGACY_MULTI_INSTANCE_RATE_LIMITING`) is
  untouched by this PR. During investigation I found an analogous
  unconditional-write issue in v3's post-call success/failure event
  paths, independent of this one. Discussed with @deepanshululla —
  a separate, focused PR is the right approach for v3 given it's the
  default handler for the large majority of deployments.

**Testing** — `tests/test_litellm/proxy/hooks/test_parallel_request_limiter.py`:
- Skip-write cases for key/user/team/end-user with no limits configured
- Write-happens cases for all four scopes when a limit *is* configured
- Regression guard: writes still happen if the auth object is missing
- Regression guard: existing model-scoped block behavior is unchanged
- Coverage for previously-untested `check_key_in_limits` and
  `async_log_failure_event` branches (zero-limit detection, global
  max-parallel-requests decrement, max-limit-exception handling)
- Unit tests for the shared `_entity_has_any_limit` helper directly

All tests pass. `codecov/patch` at 75% (target 62%). Lint, format, and
all other CI checks green.

## Review history from #32179
This PR carries the same fix already reviewed on #32179, plus follow-up
commits addressing that review's feedback: a shared limit-check helper
(reduces duplication, addresses Greptile's note), gating added to
`async_log_failure_event` (previously ungated), and expanded test
coverage. See #32179's conversation for full original review context
from @deepanshululla and Greptile.