### PR TITLE
fix: handle anthropic passthrough token counts

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -27,6 +27,7 @@ from litellm.types.utils import (
     LiteLLMBatch,
     Message,
     ModelResponse,
+    StandardPassThroughResponseObject,
     TextCompletionResponse,
 )
 
@@ -71,6 +72,12 @@ class AnthropicPassthroughLoggingHandler:
                 request_body=request_body,
                 **kwargs,
             )
+
+        if not isinstance(response_body.get("content"), list):
+            return {
+                "result": StandardPassThroughResponseObject(response=response_body),
+                "kwargs": kwargs,
+            }
 
         model = response_body.get("model", "")
         anthropic_config = get_anthropic_config(url_route)

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -2,9 +2,10 @@ import json
 import os
 import sys
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import List
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 sys.path.insert(
@@ -15,6 +16,7 @@ from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
 from litellm.proxy.pass_through_endpoints.llm_provider_handlers.anthropic_passthrough_logging_handler import (
     AnthropicPassthroughLoggingHandler,
 )
+from litellm.types.utils import StandardPassThroughResponseObject
 
 
 class TestAnthropicLoggingHandlerModelFallback:
@@ -192,6 +194,29 @@ class TestAnthropicLoggingHandlerModelFallback:
             model = logging_obj.model_call_details.get("model")
 
         assert model == ""  # Should remain empty
+
+
+def test_count_tokens_response_logs_as_passthrough_response():
+    response_body = {"input_tokens": 12}
+    logging_obj = MagicMock()
+    logging_obj.model_call_details = {}
+
+    result = AnthropicPassthroughLoggingHandler.anthropic_passthrough_handler(
+        httpx_response=httpx.Response(200, json=response_body),
+        response_body=response_body,
+        logging_obj=logging_obj,
+        url_route="/anthropic/v1/messages/count_tokens",
+        result=json.dumps(response_body),
+        start_time=datetime.now(),
+        end_time=datetime.now(),
+        cache_hit=False,
+        request_body={
+            "model": "claude-3-5-haiku-20241022",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert result["result"] == StandardPassThroughResponseObject(response=response_body)
 
 
 class TestAzureAnthropicCostCalculation:
@@ -1697,9 +1722,6 @@ class TestStreamFalseDeduplication:
         This is the _is_assembled_stream_success gate: with stream=False it
         always returned False and the guard was permanently disabled.
         """
-        from litellm.types.passthrough_endpoints.pass_through_endpoints import (
-            EndpointType,
-        )
         from litellm.types.utils import ModelResponse
 
         # Simulate what pass_through_endpoints.py now does after stream detection


### PR DESCRIPTION
## Relevant issues

Fixes #32280

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in this PR being merged, ping the LiteLLM Team on Slack (#pr-review)

## Screenshots / Proof of Fix

Regression proof captured locally on commit `498506708c`:

Before the fix, the new regression test failed with `KeyError: 'content'` in `AnthropicConfig.extract_response_content` when logging an Anthropic `/v1/messages/count_tokens` response body shaped like `{input_tokens: 12}`

After the fix:

```bash
C:\Users\Jupiter\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py::test_count_tokens_response_logs_as_passthrough_response -q
```

Output:

```text
1 passed, 1 warning in 5.58s
```

I did not capture a live Anthropic proxy curl because this local Windows environment does not have the LiteLLM proxy + real Anthropic credentials configured for an end-to-end paid call

## Type

Bug Fix
Test

## Changes

This PR keeps Anthropic passthrough logging from treating non-Messages JSON responses as full Messages responses. If an Anthropic passthrough response body does not have a top-level `content` list, the handler now returns the raw response body as a standard passthrough logging object instead of calling the Messages `transform_response` path that requires `content`

This preserves the existing Messages and batch handling paths while allowing `/v1/messages/count_tokens` and similar non-Messages responses to continue through the passthrough logging pipeline without crashing the async logging worker

Local checks run:

```bash
C:\Users\Jupiter\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py -q
C:\Users\Jupiter\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m ruff check litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
C:\Users\Jupiter\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m ruff format --check --exclude '/enterprise/' litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
git diff --cached --check
```

`make pre-commit` could not run locally because `make` is not available in this Windows shell. The direct Prisma pre-commit substep also could not run in the bundled Python environment because the `prisma` package is not installed

