### PR TITLE
fix(bedrock): drop toolSpec.strict for Claude Sonnet 5 and Fable 5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1374,7 +1374,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.25e-05,
@@ -1408,7 +1409,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.375e-05,
@@ -1442,7 +1444,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.375e-05,
@@ -1476,7 +1479,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-opus-4-8": {
         "bedrock_converse_supports_strict_tools": false,
@@ -1718,7 +1722,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.5e-06,
@@ -1752,7 +1757,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1786,7 +1792,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1820,7 +1827,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "au.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1854,7 +1862,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "jp.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1888,7 +1897,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1374,7 +1374,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.25e-05,
@@ -1408,7 +1409,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.375e-05,
@@ -1442,7 +1444,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-fable-5": {
         "cache_creation_input_token_cost": 1.375e-05,
@@ -1476,7 +1479,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-opus-4-8": {
         "bedrock_converse_supports_strict_tools": false,
@@ -1718,7 +1722,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.5e-06,
@@ -1752,7 +1757,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1786,7 +1792,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1820,7 +1827,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "au.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1854,7 +1862,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "jp.anthropic.claude-sonnet-5": {
         "cache_creation_input_token_cost": 2.75e-06,
@@ -1888,7 +1897,8 @@
         "supports_max_reasoning_effort": true,
         "supports_output_config": true,
         "bedrock_output_config_effort_ceiling": "xhigh",
-        "supports_parallel_tool_use_config": true
+        "supports_parallel_tool_use_config": true,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -48,6 +48,18 @@ _STRICT_TOOL = [
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        # Sonnet 5 rejects toolSpec.strict on Bedrock Converse too (verified
+        # against a live Converse call: strict -> ValidationException
+        # "tools.0.custom.strict: Extra inputs are not permitted", stripped -> 200).
+        "anthropic.claude-sonnet-5",
+        "bedrock/global.anthropic.claude-sonnet-5",
+        "bedrock/us.anthropic.claude-sonnet-5",
+        "bedrock/eu.anthropic.claude-sonnet-5",
+        # Fable 5 likewise rejects toolSpec.strict on Bedrock Converse (verified
+        # live: strict -> "tools.0.custom.strict: Extra inputs are not permitted",
+        # stripped -> 200).
+        "anthropic.claude-fable-5",
+        "bedrock/us.anthropic.claude-fable-5",
     ],
 )
 def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
@@ -129,6 +141,10 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         )
         is False
     )
+    # Sonnet 5 and Fable 5 reject strict on Bedrock Converse too
+    assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-sonnet-5") is False
+    assert bedrock_converse_supports_strict_tools("anthropic.claude-sonnet-5") is False
+    assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-fable-5") is False
 
 
 @pytest.mark.parametrize(
@@ -143,6 +159,16 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         "us.anthropic.claude-sonnet-4-20250514-v1:0",
         "eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-sonnet-5",
+        "global.anthropic.claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+        "eu.anthropic.claude-sonnet-5",
+        "au.anthropic.claude-sonnet-5",
+        "jp.anthropic.claude-sonnet-5",
+        "anthropic.claude-fable-5",
+        "global.anthropic.claude-fable-5",
+        "us.anthropic.claude-fable-5",
+        "eu.anthropic.claude-fable-5",
     ],
 )
 def test_strict_tools_flag_set_in_model_cost_map(cost_map_key: str) -> None:

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -55,17 +55,21 @@ _STRICT_TOOL = [
         "bedrock/global.anthropic.claude-sonnet-5",
         "bedrock/us.anthropic.claude-sonnet-5",
         "bedrock/eu.anthropic.claude-sonnet-5",
+        "bedrock/au.anthropic.claude-sonnet-5",
+        "bedrock/jp.anthropic.claude-sonnet-5",
         # Fable 5 likewise rejects toolSpec.strict on Bedrock Converse (verified
         # live: strict -> "tools.0.custom.strict: Extra inputs are not permitted",
         # stripped -> 200).
         "anthropic.claude-fable-5",
+        "bedrock/global.anthropic.claude-fable-5",
         "bedrock/us.anthropic.claude-fable-5",
+        "bedrock/eu.anthropic.claude-fable-5",
     ],
 )
 def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
     model_id: str,
 ) -> None:
-    """Opus 4.7/4.8 and Sonnet 4 reject toolSpec.strict and additionalProperties."""
+    """Opus 4.7/4.8, Sonnet 4, Sonnet 5, and Fable 5 reject toolSpec.strict and additionalProperties."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
     tool_spec = result[0]["toolSpec"]
     assert (
@@ -145,6 +149,7 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
     assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-sonnet-5") is False
     assert bedrock_converse_supports_strict_tools("anthropic.claude-sonnet-5") is False
     assert bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-fable-5") is False
+    assert bedrock_converse_supports_strict_tools("anthropic.claude-fable-5") is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Relevant issues

Follow-up to #31923 (Opus 4.7/4.8) and #31943 (Sonnet 4) — same root cause, two more models.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## What this fixes

Bedrock Converse routes **Claude Sonnet 5** and **Fable 5** through the same Anthropic-compatible validator as Opus 4.7/4.8 and Sonnet 4, which rejects `toolSpec.strict` even though Anthropic's native API accepts `strict` as a top-level tool field:

```
tools.0.custom.strict: Extra inputs are not permitted
```

Both models were missing the `bedrock_converse_supports_strict_tools: false` opt-out flag, so the default strict-forwarding path 400s **any tool-calling request** against `bedrock/*.claude-sonnet-5` or `bedrock/*.claude-fable-5` (SDKs like openai-agents stamp `strict` on every tool, so it fires universally at the first call).

## The change

- Add `bedrock_converse_supports_strict_tools: false` to all `bedrock_converse` Sonnet 5 (6) and Fable 5 (4) inference-profile entries in `model_prices_and_context_window.json` and its backup.
- Extend the existing strict-tools regression tests (`test_bedrock_converse_strict_tools_opus_47_48.py`) to cover Sonnet 5 / Fable 5 in the dropped-list, the helper check, and the cost-map-flag check.

No logic change — this reuses the exact mechanism from #31923/#31943; the models just needed the flag.

## Screenshots / Proof of Fix

Live Bedrock Converse calls (us-east-1, real $), captured at commit `bbb8af5`:

```
# us.anthropic.claude-sonnet-5
  BEFORE (strict forwarded, as litellm does today): 400 ValidationException — tools.0.custom.strict: Extra inputs are not permitted
  AFTER  (strict stripped, what this flag does):     200 OK (stopReason=end_turn)

# us.anthropic.claude-fable-5
  BEFORE (strict forwarded, as litellm does today): 400 ValidationException — tools.0.custom.strict: Extra inputs are not permitted
  AFTER  (strict stripped, what this flag does):     200 OK (stopReason=end_turn)
```

Confirmed for both `us.` and `global.` inference-profile variants of each model. Unit tests: `pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py` → 44 passed.

## Type

🐛 Bug Fix

Co-authored with Claude Opus 4.8.