### PR TITLE
test(mcp): cover required OpenAPI body params and MCP REST validation

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -244,7 +244,12 @@ def extract_parameters(operation: Dict[str, Any]) -> tuple:
 
 
 def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
-    """Build MCP input schema from OpenAPI operation."""
+    """Build MCP input schema from OpenAPI operation.
+
+    OpenAPI 3.x ``requestBody`` is exposed as a top-level ``body`` property.
+    When ``requestBody.required`` is true, ``body`` is listed in the schema's
+    ``required`` array so MCP clients know the parameter must be supplied.
+    """
     properties = {}
     required = []
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -410,6 +410,50 @@ class TestBuildInputSchema:
         # Required should include original names
         assert "repository-id" in schema["required"]
 
+    def test_required_request_body_marked_in_schema(self):
+        """OpenAPI requestBody.required=True should add 'body' to top-level required."""
+        operation = {
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {"title": {"type": "string"}},
+                            "required": ["title"],
+                        }
+                    }
+                },
+            }
+        }
+
+        schema = build_input_schema(operation)
+
+        assert "body" in schema["properties"]
+        assert "body" in schema["required"]
+        assert "title" in schema["properties"]["body"]["properties"]
+
+    def test_optional_request_body_not_in_required(self):
+        """OpenAPI requestBody.required=False should not add 'body' to required."""
+        operation = {
+            "requestBody": {
+                "required": False,
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {"note": {"type": "string"}},
+                        }
+                    }
+                },
+            }
+        }
+
+        schema = build_input_schema(operation)
+
+        assert "body" in schema["properties"]
+        assert "body" not in schema["required"]
+
 
 class TestExtractParameters:
     """Test parameter extraction from OpenAPI operations."""

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -1426,6 +1426,40 @@ class TestListToolsRestAPI:
 class TestCallToolRestAPI:
     pytestmark = pytest.mark.asyncio
 
+    async def test_rejects_missing_server_id(self):
+        request = _build_request(
+            path="/mcp-rest/tools/call",
+            method="POST",
+            json_body={"name": "demo-tool", "arguments": {}},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rest_endpoints.call_tool_rest_api(
+                request,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "missing_parameter"
+        assert "server_id" in exc_info.value.detail["message"]
+
+    async def test_rejects_missing_tool_name(self):
+        request = _build_request(
+            path="/mcp-rest/tools/call",
+            method="POST",
+            json_body={"server_id": "server-1", "arguments": {}},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await rest_endpoints.call_tool_rest_api(
+                request,
+                user_api_key_dict=UserAPIKeyAuth(),
+            )
+
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail["error"] == "missing_parameter"
+        assert "name" in exc_info.value.detail["message"]
+
     async def test_rejects_disallowed_server(self, monkeypatch):
         async def fake_contexts(user_api_key_auth):
             return [user_api_key_auth]


### PR DESCRIPTION
﻿Adds tests asserting requestBody.required maps to top-level body in MCP input schema. Adds tests for 400 missing_parameter when server_id or name absent from /mcp-rest/tools/call.
