### PR TITLE
docs: clarify OSS vs Enterprise license boundary for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,15 @@
 
 Thank you for your interest in contributing to LiteLLM! We welcome contributions of all kinds - from bug fixes and documentation improvements to new features and integrations.
 
+## OSS vs Enterprise
+
+Most contributions belong in the **MIT-licensed OSS** tree (`litellm/`, `ui/`, `cookbook/`, `tests/`, etc.). The `enterprise/` folder is commercially licensed and typically requires a separate agreement to modify.
+
+- **OSS PRs**: Open to all contributors after signing the CLA. This includes the proxy server, MCP gateway, SDK, and dashboard.
+- **Enterprise PRs**: Coordinate with the BerriAI team if you need changes under `enterprise/`.
+
+See [enterprise/README.md](./enterprise/README.md) for the license boundary.
+
 ## **Checklist before submitting a PR**
 
 Here are the core requirements for any PR submitted to LiteLLM:

--- a/enterprise/README.md
+++ b/enterprise/README.md
@@ -1,9 +1,20 @@
-## LiteLLM Enterprise
+## LiteLLM Enterprise (Commercial)
 
-Code in this folder is licensed under a commercial license. Please review the [LICENSE](./LICENSE.md) file within the /enterprise folder
+Code in this folder is licensed under the [LiteLLM Commercial License](./LICENSE.md). It is **not** part of the open-source MIT-licensed core in the repository root.
 
-**These features are covered under the LiteLLM Enterprise contract**
+### OSS vs Enterprise
 
-👉 **Using in an Enterprise / Need specific features ?** Meet with us [here](https://enterprise.litellm.ai/demo?month=2024-02)
+| | **OSS (MIT)** | **Enterprise (Commercial)** |
+|---|---|---|
+| **Location** | `litellm/`, `ui/`, `cookbook/`, etc. | `enterprise/` folder only |
+| **License** | MIT — free for commercial use | Commercial license required |
+| **Proxy core** | Chat completions, routing, basic auth, MCP gateway | Advanced SSO, audit, custom guardrails, etc. |
+| **Contributing** | Welcome via standard PRs | Contact BerriAI for access |
+
+The open-source proxy and SDK are fully usable without an enterprise license. Enterprise adds optional features for teams that need advanced security, compliance, and support.
+
+**These enterprise features require a LiteLLM Enterprise contract.**
+
+👉 **Need enterprise features?** Meet with us [here](https://enterprise.litellm.ai/demo?month=2024-02)
 
 See all Enterprise Features here 👉 [Docs](https://docs.litellm.ai/docs/proxy/enterprise)


### PR DESCRIPTION
Adds an OSS vs Enterprise comparison table to enterprise/README.md and a contributing guide section explaining where OSS PRs should land.