### PR TITLE
fix(responses): guard empty choices in streaming delta extraction

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1033,6 +1033,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         It's unclear how users expect litellm to translate multiple-choices-per-chunk to the responses API output.
         """
+        if not choices:
+            return ""
         choice = choices[0]
         chat_completion_delta: ChatCompletionDelta = choice.delta
         return chat_completion_delta.content or ""


### PR DESCRIPTION
## What
`_get_delta_string_from_streaming_choices` in
`litellm/responses/litellm_completion_transformation/streaming_iterator.py` indexes `choices[0]`
without checking for an empty list.

## Repro
Proxy config bridging `/v1/responses` to an OpenAI-compatible chat-completions backend
(`use_chat_completions_api: true`). DeepSeek (tested: `deepseek-v4-flash` behind a custom
`api_base`) emits a terminal streaming chunk with `"choices": []`. Result:

```
File ".../litellm/responses/litellm_completion_transformation/streaming_iterator.py", line 1058, in _get_delta_string_from_streaming_choices
    choice = choices[0]
IndexError: list index out of range
```

The stream dies with `data: {"error": {"message": "list index out of range", ... "code": "500"}}`
after the content has already streamed.

## Fix
Return `""` when `choices` is empty — the same `chunk.choices and ...` guard every other access
in this file already uses (e.g. the annotation, reasoning and tool-call paths).

Tested locally on 1.91.0: with the guard, the same request terminates cleanly with
`response.completed` + `data: [DONE]` and usage intact.
