### PR TITLE
fix(mcp): invalidate cached per-user OAuth token on re-auth and revoke

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -457,6 +457,12 @@ async def _store_per_user_token_server_side(
         ttl=ttl,
     )
 
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (  # noqa: PLC0415
+        global_mcp_server_manager,
+    )
+
+    await global_mcp_server_manager.invalidate_user_oauth_token_cache(user_id, server.server_id)
+
 
 def _raise_if_not_oauth2(mcp_server: MCPServer) -> None:
     """Reject a non-oauth2 server from the gateway's OAuth authorize/token/register flow."""

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -690,8 +690,9 @@ class MCPServerManager:
         return auth_type == MCPAuth.oauth2_token_exchange and not (token_exchange_endpoint or token_url)
 
     def __init__(self, cred_provider: Optional[UpstreamCredentialProvider] = None):
+        self._per_user_oauth_store = LazyPerUserOAuthTokenStore(self.get_mcp_server_by_id)
         self._cred_provider = cred_provider or UpstreamCredentialProvider(
-            oauth_token_store=LazyPerUserOAuthTokenStore(self.get_mcp_server_by_id),
+            oauth_token_store=self._per_user_oauth_store,
             token_exchanger=build_token_exchanger(),
         )
         self.registry: dict[str, MCPServer] = {}
@@ -3918,6 +3919,23 @@ class MCPServerManager:
         if spec is None:
             return False
         return await self._cred_provider.has_user_token(to_subject(user_api_key_auth, None), spec)
+
+    async def invalidate_user_oauth_token_cache(self, user_id: str, server_id: str) -> None:
+        """Drop the resolver's cached per-user OAuth token after the stored credential changes
+        (re-auth or revoke). Without this the egress keeps serving the prior token from
+        ``CachedOAuthTokenStore`` until its TTL, so a revoked token keeps flowing upstream and a
+        re-authorization appears not to take. Failures are logged, never raised: the credential
+        mutation itself already succeeded.
+        """
+        try:
+            await self._per_user_oauth_store.invalidate(user_id, server_id)
+        except Exception as exc:  # noqa: BLE001
+            verbose_logger.warning(
+                "invalidate_user_oauth_token_cache: failed for user=%s server=%s: %s",
+                user_id,
+                server_id,
+                exc,
+            )
 
     async def _resolve_oauth2_headers_for_tool_call(
         self,

--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/per_user_oauth_store.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/per_user_oauth_store.py
@@ -25,7 +25,6 @@ from litellm.proxy._experimental.mcp_server.outbound_credentials.dual_cache_toke
 from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
     CachedOAuthTokenStore,
     OAuthToken,
-    OAuthTokenStore,
     RefreshCoordinator,
     RefreshingTokenStore,
     TokenCacheBackend,
@@ -51,7 +50,7 @@ if TYPE_CHECKING:
 _DEFAULT_TTL_SECONDS = 300.0
 
 ServerLookup = Callable[[str], "MCPServer | None"]
-StoreBuilder = Callable[[ServerLookup], tuple[OAuthTokenStore, bool]]
+StoreBuilder = Callable[[ServerLookup], tuple[CachedOAuthTokenStore, bool]]
 
 
 async def _read_credential(user_id: str, server_id: str) -> dict[str, object] | None:
@@ -185,7 +184,7 @@ class LazyPerUserOAuthTokenStore:
         self._server_lookup = server_lookup
         self._store_builder = store_builder
         self._redis_available = redis_available
-        self._store: OAuthTokenStore | None = None
+        self._store: CachedOAuthTokenStore | None = None
         self._uses_redis = False
         self._fetch_lock = asyncio.Condition()
         self._local_fetches = 0
@@ -203,7 +202,19 @@ class LazyPerUserOAuthTokenStore:
             if not uses_redis:
                 await self._finish_local_fetch()
 
-    async def _store_for_fetch(self) -> tuple[OAuthTokenStore, bool]:
+    async def invalidate(self, user_id: str, server_id: str) -> None:
+        """Drop the cached token for ``(user_id, server_id)`` after the stored credential changes
+        (re-auth or revoke), so the next fetch reads the new DB state instead of serving the stale
+        token until its TTL elapses.
+        """
+        store, uses_redis = await self._store_for_fetch()
+        try:
+            await store.invalidate(user_id, server_id)
+        finally:
+            if not uses_redis:
+                await self._finish_local_fetch()
+
+    async def _store_for_fetch(self) -> tuple[CachedOAuthTokenStore, bool]:
         async with self._fetch_lock:
             while (
                 self._store is not None and not self._uses_redis and self._redis_available() and self._local_fetches > 0

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1913,6 +1913,7 @@ if MCP_AVAILABLE:
             expires_in=payload.expires_in,
             scopes=payload.scopes,
         )
+        await global_mcp_server_manager.invalidate_user_oauth_token_cache(user_id, server_id)
         # Read back the persisted record so the response reflects the stored
         # expires_at rather than recomputing it here (which could diverge by
         # milliseconds or if the storage logic ever adds a grace period).
@@ -1953,6 +1954,7 @@ if MCP_AVAILABLE:
                 await delete_user_credential(prisma_client, user_id, server_id)
             except RecordNotFoundError:
                 pass  # Already gone — treat as a successful delete
+        await global_mcp_server_manager.invalidate_user_oauth_token_cache(user_id, server_id)
         return MCPOAuthUserCredentialStatus(
             server_id=server_id,
             has_credential=False,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_per_user_oauth_store.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_per_user_oauth_store.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 
 from litellm.proxy._experimental.mcp_server.outbound_credentials.oauth_token_store import (
+    CachedOAuthTokenStore,
     OAuthToken,
     OAuthTokenStore,
 )
@@ -158,3 +159,64 @@ async def test_lazy_store_waits_for_in_flight_local_fetch_before_redis_rebuild()
     assert second is not None and second.access_token == "redis"
     assert local_store.calls == [("u", "s")]
     assert redis_store.calls == [("u", "s")]
+
+
+class _MutableSourceStore:
+    """DB stand-in whose stored credential can change underneath the cache (re-auth / revoke)."""
+
+    def __init__(self, token: OAuthToken | None) -> None:
+        self.token = token
+
+    async def fetch(self, user_id: str, server_id: str) -> OAuthToken | None:
+        return self.token
+
+
+@pytest.mark.asyncio
+async def test_invalidate_drops_cached_token_after_credential_change() -> None:
+    """Revoke/re-auth regression: the cache serves the old token until TTL, so after the stored
+    credential changes the egress keeps using the revoked token (upstream 401s) unless the entry
+    is invalidated. ``invalidate`` must make the next fetch read the new stored credential."""
+    source = _MutableSourceStore(OAuthToken(access_token="old"))
+
+    def build_store(_server_lookup: ServerLookup) -> tuple[CachedOAuthTokenStore, bool]:
+        return CachedOAuthTokenStore(source, default_ttl_seconds=300.0), False
+
+    store = LazyPerUserOAuthTokenStore(
+        lambda _server_id: None,
+        store_builder=build_store,
+        redis_available=lambda: False,
+    )
+
+    first = await store.fetch("u", "s")
+    source.token = OAuthToken(access_token="new")
+    stale = await store.fetch("u", "s")
+
+    await store.invalidate("u", "s")
+    fresh = await store.fetch("u", "s")
+
+    assert first is not None and first.access_token == "old"
+    assert stale is not None and stale.access_token == "old"
+    assert fresh is not None and fresh.access_token == "new"
+
+
+@pytest.mark.asyncio
+async def test_invalidate_drops_cached_token_after_revoke() -> None:
+    """After a revoke the stored credential is gone; a cached positive token must not outlive it."""
+    source = _MutableSourceStore(OAuthToken(access_token="revoked-later"))
+
+    def build_store(_server_lookup: ServerLookup) -> tuple[CachedOAuthTokenStore, bool]:
+        return CachedOAuthTokenStore(source, default_ttl_seconds=300.0), False
+
+    store = LazyPerUserOAuthTokenStore(
+        lambda _server_id: None,
+        store_builder=build_store,
+        redis_available=lambda: False,
+    )
+
+    cached = await store.fetch("u", "s")
+    source.token = None
+    await store.invalidate("u", "s")
+    after_revoke = await store.fetch("u", "s")
+
+    assert cached is not None
+    assert after_revoke is None

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -4781,6 +4781,7 @@ class TestPerUserCredentialConfigServerResolution:
         )
         manager._build_mcp_server_table = MagicMock(return_value=record)
         manager.get_allowed_mcp_servers = AsyncMock(return_value=[])
+        manager.invalidate_user_oauth_token_cache = AsyncMock(return_value=None)
         return manager
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced on a live multi-user proxy with a per-user oauth2 (authorization_code) MCP server. Connect the server, then revoke the connection from the credentials UI, then re-authorize. Before this change the proxy keeps serving the old token from `CachedOAuthTokenStore` until the entry ages out: tool calls go upstream with the revoked bearer, and once the stale entry nears expiry the refresher presents the revoked refresh_token to the IdP

```
litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '401 Unauthorized' for url 'https://&lt;idp&gt;/oauth2/token'
...
litellm.proxy._experimental.mcp_server.exceptions.MCPUpstreamAuthError: Upstream MCP server '&lt;server&gt;' returned 401
```

The re-authorization stores a fresh token in the DB (`POST .../token` 200, credential stored), but fetch hits the cache first, so the user keeps getting challenged. Creating a brand-new server "fixes" it only because the cache is keyed by `(user_id, server_id)`. `CachedOAuthTokenStore.invalidate` already exists and its docstring names exactly this case ("after the user (re)authorizes or revokes"), but nothing calls it for this mode; `UpstreamCredentialProvider.invalidate_credentials` documents itself as a no-op for anything but token_exchange. After this change the same revoke and re-auth take effect immediately

```
uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_per_user_oauth_store.py -k invalidate
```

## Type

🐛 Bug Fix

## Changes

Expose `invalidate(user_id, server_id)` on `LazyPerUserOAuthTokenStore` (delegating to the existing `CachedOAuthTokenStore.invalidate`; with the Redis backend wired the delete propagates cross-replica), keep a reference to the store on `MCPServerManager` and surface it as `invalidate_user_oauth_token_cache` (failures logged, never raised), and call it at the three places the stored credential changes: the OAuth token endpoint's server-side store, the manual `POST /server/{id}/oauth-user-credential`, and the revoke `DELETE /server/{id}/oauth-user-credential`. Regression tests cover both directions: a re-auth must be visible on the next fetch instead of the stale token, and a revoked credential's cached token must not outlive the delete
