### PR TITLE
fix(anthropic): emit message_start only once per bridged stream

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -75,6 +75,8 @@ class AnthropicResponsesStreamWrapper:
 
         # ---- message_start ----
         if event_type == "response.created":
+            if self._sent_message_start:
+                return
             self._sent_message_start = True
             self._chunk_queue.append(self._make_message_start())
             return

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_streaming_iterator.py
@@ -6,9 +6,9 @@ Tests for AnthropicResponsesStreamWrapper
 import os
 import sys
 
-sys.path.insert(
-    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../.."))
-)
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../../..")))
 
 from litellm.llms.anthropic.experimental_pass_through.responses_adapters.streaming_iterator import (
     AnthropicResponsesStreamWrapper,
@@ -76,4 +76,41 @@ class TestProcessEventTextDeltaWithoutOutputItemAdded:
         assert [(c["type"], c["index"]) for c in chunks] == [
             ("content_block_start", 0),
             ("content_block_delta", 0),
+        ]
+
+
+class TestSingleMessageStart:
+    """Exactly one message_start must be emitted per stream, per the
+    Anthropic streaming contract.
+
+    https://github.com/BerriAI/litellm/issues/32478
+    """
+
+    @pytest.mark.asyncio
+    async def test_response_created_does_not_duplicate_eager_message_start(self):
+        async def upstream():
+            yield {"type": "response.created"}
+            yield {"type": "response.completed", "response": {"status": "completed"}}
+
+        wrapper = AnthropicResponsesStreamWrapper(responses_stream=upstream(), model="m")
+        chunks = [c async for c in wrapper]
+
+        assert [c["type"] for c in chunks] == [
+            "message_start",
+            "message_delta",
+            "message_stop",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_message_start_still_emitted_without_response_created(self):
+        async def upstream():
+            yield {"type": "response.completed", "response": {"status": "completed"}}
+
+        wrapper = AnthropicResponsesStreamWrapper(responses_stream=upstream(), model="m")
+        chunks = [c async for c in wrapper]
+
+        assert [c["type"] for c in chunks] == [
+            "message_start",
+            "message_delta",
+            "message_stop",
         ]


### PR DESCRIPTION
## Relevant issues

Fixes #32478

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## What this fixes

`AnthropicResponsesStreamWrapper.__anext__` eagerly emits `message_start` on the first pull (fallback for upstreams that never send `response.created`) and sets `_sent_message_start = True` — but `_process_event` appended **another** `message_start` on `response.created` without checking the flag. Since the eager fallback always runs before the first upstream event is processed, every normal bridged stream emitted `message_start` twice. [Anthropic's streaming contract](https://docs.claude.com/en/api/messages-streaming) specifies exactly one `message_start` per stream.

One-line guard: skip the `response.created` emission when `message_start` was already sent.

## Screenshots / Proof of Fix

Deterministic replay (script in #32478), driving the real wrapper + SSE encoder with `response.created` → `response.completed`:

**Before** (base `cd6e8cdf23`):
```
event: message_start
event: message_start
event: message_delta
event: message_stop
```

**After** (this PR `acc0f8852b`):
```
event: message_start
event: message_delta
event: message_stop
```

Tests: 2 new cases — normal stream emits exactly one `message_start`, and streams *without* `response.created` still get the eager fallback. The first fails on the unpatched code; the fallback preservation case passes on both. File: 6/6 passing.

*Prepared with AI assistance (Claude Code); reviewed and verified by the author.*
