### PR TITLE
fix(vertex): forward realtime health check params

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -188,6 +188,12 @@ class HealthCheckHelpers:
                 api_base=model_params.get("api_base", None),
                 api_key=model_params.get("api_key", None),
                 api_version=model_params.get("api_version", None),
+                vertex_credentials=model_params.get("vertex_credentials", None)
+                or model_params.get("vertex_ai_credentials", None),
+                vertex_project=model_params.get("vertex_project", None)
+                or model_params.get("vertex_ai_project", None),
+                vertex_location=model_params.get("vertex_location", None)
+                or model_params.get("vertex_ai_location", None),
             ),
             "batch": lambda: HealthCheckHelpers._batch_health_check(
                 custom_llm_provider=custom_llm_provider,

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -515,6 +515,9 @@ async def _realtime_health_check(
     api_base: Optional[str] = None,
     api_version: Optional[str] = None,
     realtime_protocol: Optional[str] = None,
+    vertex_credentials: Optional[str] = None,
+    vertex_project: Optional[str] = None,
+    vertex_location: Optional[str] = None,
 ):
     """
     Health check for realtime API - tries connection to the realtime API websocket
@@ -550,14 +553,14 @@ async def _realtime_health_check(
     elif custom_llm_provider == "xai":
         url = xai_realtime._construct_url(api_base=api_base or "https://api.x.ai/v1", query_params={"model": model})
     elif custom_llm_provider == "vertex_ai":
-        vertex_location = litellm.vertex_location or get_secret_str("VERTEXAI_LOCATION")
-        resolved_location = vertex_llm_base.get_vertex_region(vertex_region=vertex_location, model=model)
+        resolved_vertex_location = vertex_location or litellm.vertex_location or get_secret_str("VERTEXAI_LOCATION")
+        resolved_location = vertex_llm_base.get_vertex_region(vertex_region=resolved_vertex_location, model=model)
         (
             access_token,
             resolved_project,
         ) = await vertex_llm_base._ensure_access_token_async(
-            credentials=None,
-            project_id=litellm.vertex_project or get_secret_str("VERTEXAI_PROJECT"),
+            credentials=vertex_credentials,
+            project_id=vertex_project or litellm.vertex_project or get_secret_str("VERTEXAI_PROJECT"),
             custom_llm_provider="vertex_ai",
         )
         vertex_realtime_config = VertexAIRealtimeConfig(

--- a/tests/litellm_utils_tests/test_vertex_realtime_health_check.py
+++ b/tests/litellm_utils_tests/test_vertex_realtime_health_check.py
@@ -1,0 +1,98 @@
+import os
+import sys
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+
+
+class _FakeVertexBase:
+    def __init__(self) -> None:
+        self.region_calls: list[dict[str, Any]] = []
+        self.ensure_calls: list[dict[str, Any]] = []
+
+    def get_vertex_region(self, *, vertex_region: str | None, model: str) -> str:
+        self.region_calls.append({"vertex_region": vertex_region, "model": model})
+        return vertex_region or "global"
+
+    async def _ensure_access_token_async(
+        self,
+        *,
+        credentials: str | None,
+        project_id: str | None,
+        custom_llm_provider: str,
+    ) -> tuple[str, str]:
+        self.ensure_calls.append(
+            {
+                "credentials": credentials,
+                "project_id": project_id,
+                "custom_llm_provider": custom_llm_provider,
+            }
+        )
+        return "access-token", project_id or "resolved-project"
+
+
+class _FakeWebsocketConnect:
+    def __init__(self, calls: list[dict[str, Any]], url: str, **kwargs: Any) -> None:
+        calls.append({"url": url, **kwargs})
+
+    async def __aenter__(self) -> "_FakeWebsocketConnect":
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_vertex_realtime_health_check_uses_model_vertex_params(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
+    from litellm.realtime_api import main as realtime_main
+
+    fake_vertex_base = _FakeVertexBase()
+    connect_calls: list[dict[str, Any]] = []
+
+    monkeypatch.setattr(realtime_main, "vertex_llm_base", fake_vertex_base)
+    monkeypatch.setattr(
+        "websockets.connect",
+        lambda url, **kwargs: _FakeWebsocketConnect(connect_calls, url, **kwargs),
+    )
+    monkeypatch.setattr(
+        HealthCheckHelpers,
+        "_update_model_params_with_health_check_tracking_information",
+        staticmethod(lambda model_params: model_params),
+    )
+
+    result = await litellm.ahealth_check(
+        model_params={
+            "model": "vertex_ai/gemini-live-2.5-flash-native-audio",
+            "vertex_credentials": '{"type":"service_account"}',
+            "vertex_project": "test-project",
+            "vertex_location": "us-central1",
+        },
+        mode="realtime",
+    )
+
+    assert result == {}
+    assert fake_vertex_base.region_calls == [
+        {"vertex_region": "us-central1", "model": "gemini-live-2.5-flash-native-audio"}
+    ]
+    assert fake_vertex_base.ensure_calls == [
+        {
+            "credentials": '{"type":"service_account"}',
+            "project_id": "test-project",
+            "custom_llm_provider": "vertex_ai",
+        }
+    ]
+    assert connect_calls[0]["url"] == (
+        "wss://us-central1-aiplatform.googleapis.com/ws/"
+        "google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent"
+    )
+    assert connect_calls[0]["additional_headers"] == {
+        "Authorization": "Bearer access-token",
+        "x-goog-user-project": "test-project",
+    }


### PR DESCRIPTION
## Relevant issues

Related: #22962

## What this does

Forward deployment-specific Vertex AI parameters into realtime health checks.

`litellm.ahealth_check(..., mode="realtime")` already receives the model row's `model_params`, but the realtime handler only forwarded `api_base`, `api_key`, and `api_version` into `_realtime_health_check()`. For `custom_llm_provider == "vertex_ai"`, `_realtime_health_check()` then fell back to process-global `VERTEXAI_*` settings and called `_ensure_access_token_async(credentials=None, ...)`.

This breaks Vertex AI Gemini Live deployments configured with per-model `vertex_credentials`, `vertex_project`, and `vertex_location` (for example rows added through config/dashboard/router), even though normal routed realtime calls can use those model params.

This PR forwards:
- `vertex_credentials` / `vertex_ai_credentials`
- `vertex_project` / `vertex_ai_project`
- `vertex_location` / `vertex_ai_location`

into the Vertex realtime health-check branch.

## Test

Added `tests/litellm_utils_tests/test_vertex_realtime_health_check.py`, which verifies `litellm.ahealth_check()` passes model-level Vertex params through to `VertexBase.get_vertex_region()`, `_ensure_access_token_async()`, and the websocket headers/URL.

Red before fix: the test received `vertex_region=None` and `credentials=None`.
Green after fix: model-level `us-central1`, credentials, and project are used.

## Verification

```bash
uv run --with vcrpy --with websockets pytest tests/litellm_utils_tests/test_vertex_realtime_health_check.py -q
# 1 passed

uv run --with ruff ruff check \
  litellm/realtime_api/main.py \
  litellm/litellm_core_utils/health_check_helpers.py \
  tests/litellm_utils_tests/test_vertex_realtime_health_check.py
# All checks passed

git diff --check HEAD~1..HEAD
# no output
```

Note: local `uv` prints a warning while parsing the repo's `exclude-newer = "3 days"` setting, but the targeted test and ruff check pass.
