### PR TITLE
feat(azure_ai): add kimi-k2.7-code to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8496,6 +8496,26 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-7-code-in-microsoft-foundry/4532286",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "azure_ai/ministral-3b": {
         "input_cost_per_token": 4e-08,
         "litellm_provider": "azure_ai",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8496,6 +8496,26 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "azure_ai/kimi-k2.7-code": {
+        "cache_read_input_token_cost": 1.9e-07,
+        "input_cost_per_token": 9.5e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4e-06,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-7-code-in-microsoft-foundry/4532286",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "azure_ai/ministral-3b": {
         "input_cost_per_token": 4e-08,
         "litellm_provider": "azure_ai",

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_k27_code_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_k27_code_metadata.py
@@ -1,0 +1,92 @@
+"""
+Test Azure AI Kimi K2.7 Code model metadata.
+"""
+
+import json
+from importlib.resources import files
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm")
+        .joinpath("model_prices_and_context_window_backup.json")
+        .read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+def test_azure_ai_kimi_k27_code_model_info(use_local_model_cost_map):
+    model_info = use_local_model_cost_map.get_model_info(model="azure_ai/kimi-k2.7-code")
+
+    assert model_info["litellm_provider"] == "azure_ai"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 262144
+    assert model_info["max_output_tokens"] == 262144
+    assert model_info["max_tokens"] == 262144
+    assert model_info["input_cost_per_token"] == pytest.approx(9.5e-07)
+    assert model_info["output_cost_per_token"] == pytest.approx(4e-06)
+    assert model_info["cache_read_input_token_cost"] == pytest.approx(1.9e-07)
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_reasoning"] is True
+    assert model_info["supports_tool_choice"] is True
+
+
+def test_azure_ai_kimi_k27_code_raw_model_cost_entry(use_local_model_cost_map):
+    model_info = use_local_model_cost_map.model_cost["azure_ai/kimi-k2.7-code"]
+
+    assert model_info["supported_modalities"] == ["text"]
+    assert model_info["supported_output_modalities"] == ["text"]
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_reasoning"] is True
+    assert model_info["supports_tool_choice"] is True
+
+
+def test_azure_ai_kimi_k27_code_cost_per_token(use_local_model_cost_map):
+    from litellm.llms.azure_ai.cost_calculator import cost_per_token
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+        total_tokens=2_000_000,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model="kimi-k2.7-code", usage=usage)
+
+    assert prompt_cost == pytest.approx(0.95)
+    assert completion_cost == pytest.approx(4.0)
+
+
+def test_azure_ai_kimi_k27_code_cached_input_cost(use_local_model_cost_map):
+    from litellm.llms.azure_ai.cost_calculator import cost_per_token
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    usage = Usage(
+        prompt_tokens=1_000_000,
+        completion_tokens=0,
+        total_tokens=1_000_000,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=500_000),
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model="kimi-k2.7-code", usage=usage)
+
+    assert prompt_cost == pytest.approx(500_000 * 9.5e-07 + 500_000 * 1.9e-07)
+    assert completion_cost == pytest.approx(0.0)


### PR DESCRIPTION
## Relevant issues
NA

## Linear ticket
NA

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)


## Screenshots / Proof of Fix

Captured at commit 4af36b5bde. Started a live proxy with the new model and verified pricing metadata and cost calculation end to end with no mocks. A real completion call was not possible because I do not have an Azure AI Foundry deployment of this model; the pricing below is taken from the [Microsoft announcement](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-7-code-in-microsoft-foundry/4532286) ($0.95/1M input, $4.00/1M output, $0.19/1M cached input)

```bash
cat > kimi_k27_config.yaml <<'EOF'
model_list:
  - model_name: kimi-k2.7-code
    litellm_params:
      model: azure_ai/kimi-k2.7-code
      api_base: https://my-foundry-resource.services.ai.azure.com
      api_key: os.environ/AZURE_AI_API_KEY

general_settings:
  master_key: sk-1234
EOF
LITELLM_LOCAL_MODEL_COST_MAP=True AZURE_AI_API_KEY=placeholder uv run --extra proxy litellm --config kimi_k27_config.yaml --port 4000
```

Pricing metadata served by the proxy:

```bash
$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234" \
    | jq '.data[0].model_info | {key, max_input_tokens, max_output_tokens, input_cost_per_token, output_cost_per_token, cache_read_input_token_cost, supports_function_calling, supports_tool_choice, supports_reasoning}'
{
  "key": "azure_ai/kimi-k2.7-code",
  "max_input_tokens": 262144,
  "max_output_tokens": 262144,
  "input_cost_per_token": 9.5e-07,
  "output_cost_per_token": 4e-06,
  "cache_read_input_token_cost": 1.9e-07,
  "supports_function_calling": true,
  "supports_tool_choice": true,
  "supports_reasoning": true
}
```

Cost tracking for 1M input + 1M output tokens ($0.95 + $4.00):

```bash
$ curl -s http://localhost:4000/spend/calculate -X POST -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "completion_response": {
    "id": "chatcmpl-123",
    "model": "azure_ai/kimi-k2.7-code",
    "object": "chat.completion",
    "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "def add(a, b): return a + b"}}],
    "usage": {"prompt_tokens": 1000000, "completion_tokens": 1000000, "total_tokens": 2000000}
  }
}'
{"cost":4.95}
```

Cached input discount for 1M input tokens where 500k are cache hits (500k x $0.95/1M + 500k x $0.19/1M = $0.57):

```bash
$ curl -s http://localhost:4000/spend/calculate -X POST -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "completion_response": {
    "id": "chatcmpl-456",
    "model": "azure_ai/kimi-k2.7-code",
    "object": "chat.completion",
    "choices": [{"index": 0, "finish_reason": "stop", "message": {"role": "assistant", "content": "ok"}}],
    "usage": {"prompt_tokens": 1000000, "completion_tokens": 0, "total_tokens": 1000000, "prompt_tokens_details": {"cached_tokens": 500000}}
  }
}'
{"cost":0.57}
```

## Type

🆕 New Feature

## Changes

Adds `azure_ai/kimi-k2.7-code` to `model_prices_and_context_window.json` and `litellm/model_prices_and_context_window_backup.json`. Kimi K2.7 Code from Moonshot AI is available in Microsoft Foundry in public preview since July 1, 2026; pricing and availability are documented in the [Foundry announcement](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k2-7-code-in-microsoft-foundry/4532286)

The entry uses the Global Standard deployment pricing from the announcement: $0.95 per 1M input tokens, $4.00 per 1M output tokens, and $0.19 per 1M cached input tokens. Context window and capability flags (262144 tokens, function calling, tool choice, reasoning, text only) match the existing entries for the same model on other providers (`cloudflare/@cf/moonshotai/kimi-k2.7-code`, `fireworks_ai/kimi-k2p7-code`). Vision is deliberately not claimed since the announcement does not mention image input for this model

Tests are in `tests/test_litellm/llms/azure_ai/test_azure_ai_kimi_k27_code_metadata.py`, mirroring the existing `test_azure_ai_kimi_k26_metadata.py`: model info assertions, raw cost map entry assertions, a `cost_per_token` check for base input/output pricing, and a cached input cost check covering the new `cache_read_input_token_cost` field
