### PR TITLE
fix(anthropic_responses): return string literals for tool_choice in Responses API

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -198,14 +198,26 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
     @staticmethod
     def translate_tool_choice_to_responses_api(
         tool_choice: AnthropicMessagesToolChoice,
-    ) -> Dict[str, Any]:
-        """Convert Anthropic tool_choice to Responses API tool_choice."""
+    ) -> Union[str, Dict[str, Any]]:
+        """Convert Anthropic tool_choice to Responses API tool_choice.
+
+        The Responses API accepts string literals ("auto", "none", "required")
+        or fully-typed objects (e.g. {"type": "function", "name": ...}).
+        Returning {"type": "auto"} or {"type": "required"} as objects is
+        rejected by the Responses API (and vLLM's Pydantic schema) — the
+        string form is required. See OpenAI Responses API docs:
+        https://platform.openai.com/docs/api-reference/responses
+        """
         tc_type = tool_choice.get("type")
+        if tc_type == "auto":
+            return "auto"
+        if tc_type == "none":
+            return "none"
         if tc_type == "any":
-            return {"type": "required"}
-        elif tc_type == "tool":
+            return "required"
+        if tc_type == "tool":
             return {"type": "function", "name": tool_choice.get("name", "")}
-        return {"type": "auto"}
+        return "auto"
 
     @staticmethod
     def translate_context_management_to_responses_api(

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -586,15 +586,14 @@ class TestTranslateToolsToResponsesAPI:
 class TestTranslateToolChoiceToResponsesAPI:
     """Anthropic tool_choice -> Responses API tool_choice."""
 
-    def test_auto_maps_to_auto(self):
-        assert _ADAPTER.translate_tool_choice_to_responses_api({"type": "auto"}) == {
-            "type": "auto"
-        }
+    def test_auto_maps_to_auto_string(self):
+        assert _ADAPTER.translate_tool_choice_to_responses_api({"type": "auto"}) == "auto"
 
-    def test_any_maps_to_required(self):
-        assert _ADAPTER.translate_tool_choice_to_responses_api({"type": "any"}) == {
-            "type": "required"
-        }
+    def test_none_maps_to_none_string(self):
+        assert _ADAPTER.translate_tool_choice_to_responses_api({"type": "none"}) == "none"
+
+    def test_any_maps_to_required_string(self):
+        assert _ADAPTER.translate_tool_choice_to_responses_api({"type": "any"}) == "required"
 
     def test_specific_tool_maps_to_function(self):
         result = _ADAPTER.translate_tool_choice_to_responses_api(
@@ -602,9 +601,9 @@ class TestTranslateToolChoiceToResponsesAPI:
         )
         assert result == {"type": "function", "name": "get_weather"}
 
-    def test_unknown_type_defaults_to_auto(self):
-        result = _ADAPTER.translate_tool_choice_to_responses_api({"type": "none"})
-        assert result == {"type": "auto"}
+    def test_unknown_type_defaults_to_auto_string(self):
+        result = _ADAPTER.translate_tool_choice_to_responses_api({"type": "garbage"})
+        assert result == "auto"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`translate_tool_choice_to_responses_api` in the Anthropic→Responses API adapter returns `{"type": "auto"}` and `{"type": "required"}` (object form) where the OpenAI Responses API requires string literals `"auto"` and `"required"`. This causes 400/422 errors from vLLM (and other backends that strictly validate the Responses API schema) when an Anthropic `/v1/messages` client sends `tool_choice` and the request is routed through the Responses API path.

Additionally, `{"type": "none"}` (explicit tool-disable) was silently mapped to `{"type": "auto"}` (tool-enable) — a safety bug where a client that explicitly disables tools gets tools enabled silently.

## Changes

- **`litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py`**: Return string literals `"auto"`, `"none"`, `"required"` instead of objects `{"type": "auto"}`, etc. Added `"none"` branch (was missing). Widened return type to `Union[str, Dict[str, Any]]`.
- **`tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py`**: Updated `TestTranslateToolChoiceToResponsesAPI` to assert string literals instead of objects. Added `test_none_maps_to_none_string` regression test.

## Context

Two sibling functions in the same codebase already handle this translation correctly by returning string literals:

1. `LiteLLMCompletionResponsesConfig._transform_tool_choice` — the chat-completions Responses bridge
2. `translate_anthropic_tool_choice_to_openai` — the Anthropic→Chat Completions adapter

This PR aligns the Anthropic→Responses API adapter with the same pattern.

## Test evidence

```
=== Bug demonstration (old vs new) ===
  {'type': 'auto'} -> old: {'type': 'auto'}  new: 'auto'  <-- CHANGED
  {'type': 'none'} -> old: {'type': 'auto'}  new: 'none'  <-- CHANGED (safety fix)
  {'type': 'any'}  -> old: {'type': 'required'}  new: 'required'  <-- CHANGED
  {'type': 'tool', 'name': 'foo'} -> unchanged (already correct)

=== Tests: 5 passed, 0 failed ===
```

Fixes #32505
