### PR TITLE
fix(mcp): pair token-endpoint client_secret with the same source as client_id

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -581,8 +581,12 @@ async def exchange_token_with_server(
     if mcp_server.token_url is None:
         raise HTTPException(status_code=400, detail="MCP server token url is not set")
 
+    # The id and secret must come from the same source. When the server-side client_id wins,
+    # falling back to the caller's secret pairs the persisted client with a foreign secret; the
+    # register short-circuit hands clients a placeholder secret ("dummy"), so a re-auth against a
+    # persisted public PKCE client (no stored secret) would send that placeholder and the IdP 401s.
     resolved_client_id = mcp_server.client_id if mcp_server.client_id else client_id
-    resolved_client_secret = mcp_server.client_secret if mcp_server.client_secret else client_secret
+    resolved_client_secret = mcp_server.client_secret if mcp_server.client_id else client_secret
     try:
         client_auth = build_token_endpoint_client_auth(
             auth_method=mcp_server.token_endpoint_auth_method,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -4156,3 +4156,62 @@ async def test_store_per_user_token_server_side_skips_invalidate_when_db_write_f
 
     invalidate_mock.assert_not_awaited()
     cache_set_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_token_exchange_pairs_client_secret_with_server_client_id():
+    """Re-auth regression: the register short-circuit hands the browser a placeholder
+    ``client_secret: "dummy"``, which the browser echoes back to /token. The server-side
+    persisted client_id wins the resolution, so the secret must come from the same (server)
+    source; pairing the persisted public PKCE client (no stored secret) with the caller's
+    placeholder makes the IdP reject the exchange with 401 on every re-auth."""
+    from fastapi import Request
+
+    from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+        exchange_token_with_server,
+    )
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    server = MCPServer(
+        server_id="srv-1",
+        name="srv-1",
+        server_name="srv-1",
+        alias="srv-1",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id="persisted-client",
+        client_secret=None,
+        authorization_url="https://provider.example/oauth/authorize",
+        token_url="https://provider.example/oauth/token",
+    )
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://litellm.example.com/"
+    mock_request.headers = {}
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"access_token": "at", "token_type": "Bearer"}
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+        return_value=mock_async_client,
+    ):
+        await exchange_token_with_server(
+            request=mock_request,
+            mcp_server=server,
+            grant_type="authorization_code",
+            code="auth-code",
+            redirect_uri="https://litellm.example.com/ui/mcp/oauth/callback",
+            client_id="srv-1",
+            client_secret="dummy",
+            code_verifier="verifier",
+        )
+
+    sent = mock_async_client.post.call_args.kwargs["data"]
+    assert sent["client_id"] == "persisted-client"
+    assert "client_secret" not in sent


### PR DESCRIPTION
> [!NOTE]
> This is a copy of #32471 by @katzdave, pushed to a `litellm_`-prefixed branch so the full CircleCI suite runs (fork PRs don't get CI secrets). Commit authorship is preserved — full credit to the original author.
> Retargeted to `litellm_internal_staging`: the original commit was cherry-picked onto the staging tip (test-file append conflict resolved by keeping both tails; authorship preserved).

Original PR: #32471
Related issue: #32473 (adjacent bug in the same persisted-DCR-client flow; this PR fixes the placeholder client_secret sent on re-auth, not the stale redirect_uri)

## Relevant issues

Related: #32473

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The live-proxy reproduction below is @katzdave's, from the original PR:

Reproduced on a live proxy against an MCP server whose OAuth client is minted via Dynamic Client Registration (a public PKCE client, no secret). The first connect works because a real DCR registration runs. Any later re-authorization fails: `POST /v1/mcp/server/oauth/{server_id}/token` returns 500 and the proxy log shows the IdP rejecting the exchange

```
litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '401 Unauthorized' for url 'https://&lt;idp&gt;/oauth2/token'
```

Capturing the browser's token request shows why. `register_client_with_server` short-circuits for a server with a persisted client and returns its placeholder response, and the browser echoes that placeholder back to `/token`

```
grant_type: authorization_code
client_id: &lt;server_id&gt;
client_secret: dummy
code_verifier: ...
```

`exchange_token_with_server` overrides the caller's client_id with the persisted one, but resolved the secret independently: `mcp_server.client_secret if mcp_server.client_secret else client_secret`. A DCR public client has no stored secret, so the persisted client_id got paired with the literal string "dummy" and the IdP returned 401 on every re-auth. After this change the same re-auth succeeds; the form sent to the IdP carries the persisted client_id and no client_secret at all, which is the correct shape for a public PKCE client

The regression test fails on main and passes with the fix:

```
uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py -k pairs_client_secret
```

## Type

🐛 Bug Fix

## Changes

One line in `exchange_token_with_server`: resolve `client_secret` from the same source as `client_id`. When the server-side persisted `client_id` wins the resolution, the secret also comes from the server (including None for a public client) instead of falling back to the caller's value. Callers without a server-side client keep the existing behavior, their own id and secret pair. Adds a regression test asserting the token-endpoint form carries the persisted client_id and omits client_secret when the server has none stored
