### PR TITLE
fix(router): skip RPM cache reads when unused; add context-window checks for Responses API

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4363,17 +4363,8 @@ class Router:
 
     def _model_group_has_max_input_tokens(self, model: str) -> bool:
         """
-        Return True if any deployment in the model group resolves to a
-        max_input_tokens value via get_router_model_info().
-
-        Used to decide whether it's worth paying the cost of converting Responses
-        API `input` into `messages` just so `_pre_call_checks` can run context
-        window checks - if no deployment resolves a max_input_tokens, there's
-        nothing to check.
-
-        Mirrors _pre_call_checks' own resolution: max_input_tokens is not only a
-        user-set model_info override, it's also commonly derived from litellm's
-        model cost map, which get_router_model_info() takes into account.
+        True if any deployment resolves a max_input_tokens via get_router_model_info()
+        (not just a static model_info override - also derived from litellm's cost map).
         """
         deployments = self.get_model_list(model_name=model) or []
         for deployment in deployments:
@@ -4387,15 +4378,8 @@ class Router:
 
     def _get_messages_for_pre_call_check(self, model: str, kwargs: Dict[str, Any]) -> Optional[List[Any]]:
         """
-        Resolve the messages to use for `_pre_call_checks` context window checks.
-
-        Chat Completions style calls already pass `messages` directly. Responses
-        API calls pass `input` instead, which `_pre_call_checks` doesn't understand
-        natively - so this converts `input` to `messages` for that call path.
-
-        The conversion is skipped (returns None) unless the model group actually
-        has a deployment with `max_input_tokens` configured, since that's the only
-        check in `_pre_call_checks` that needs `messages`.
+        Converts Responses API `input` to `messages` for `_pre_call_checks`, skipping
+        the conversion unless a deployment actually has max_input_tokens configured.
         """
         messages = kwargs.get("messages")
         is_responses_api_call = kwargs.pop("_responses_api_pre_call_check", False)
@@ -9921,13 +9905,8 @@ class Router:
         _rate_limit_error = False
         parent_otel_span = _get_parent_otel_span_from_kwargs(request_kwargs)
 
-        # The RPM cache read is only useful when at least one deployment in the model
-        # group actually declares `rpm` in litellm_params - that's set directly by the
-        # user, so it's safe to check statically. max_input_tokens has no equivalent
-        # static check: get_router_model_info() also derives it from litellm's model
-        # cost map (the common case for models without a manual model_info override),
-        # so we can't know whether a deployment needs the context-window check without
-        # actually calling it.
+        # Safe to check statically since `rpm` is a direct litellm_params setting, unlike
+        # max_input_tokens which get_router_model_info() can also derive from the cost map.
         _any_deployment_has_rpm = self.routing_strategy != "usage-based-routing-v2" and any(
             (d.get("litellm_params") or {}).get("rpm") is not None for d in _returned_deployments
         )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4379,7 +4379,7 @@ class Router:
         for deployment in deployments:
             try:
                 model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
-            except Exception:
+            except ValueError:
                 continue
             if isinstance(model_info, dict) and model_info.get("max_input_tokens") is not None:
                 return True

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -157,7 +157,9 @@ from litellm.router_utils.router_callbacks.track_deployment_metrics import (
 from litellm.scheduler import FlowItem, Scheduler
 from litellm.types.llms.openai import (
     AllMessageValues,
+    ChatCompletionResponseMessage,
     FileTypes,
+    GenericChatCompletionMessage,
     OpenAIFileObject,
     OpenAIFilesPurpose,
 )
@@ -190,9 +192,11 @@ from litellm.types.router import (
 )
 from litellm.types.services import ServiceTypes
 from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
     CustomPricingLiteLLMParams,
     GenericBudgetConfigType,
     LiteLLMBatch,
+    Message,
 )
 from litellm.types.utils import ModelInfo
 from litellm.types.utils import ModelInfo as ModelMapInfo
@@ -250,6 +254,14 @@ else:
     AdaptiveRouter = Any
     QualityRouter = Any
     PreRoutingHookResponse = Any
+
+PreCallCheckMessage = (
+    AllMessageValues
+    | GenericChatCompletionMessage
+    | ChatCompletionMessageToolCall
+    | ChatCompletionResponseMessage
+    | Message
+)
 
 
 class RoutingArgs(enum.Enum):
@@ -4376,7 +4388,7 @@ class Router:
                 return True
         return False
 
-    def _get_messages_for_pre_call_check(self, model: str, kwargs: Dict[str, Any]) -> Optional[List[Any]]:
+    def _get_messages_for_pre_call_check(self, model: str, kwargs: dict[str, Any]) -> list[PreCallCheckMessage] | None:
         """
         Converts Responses API `input` to `messages` for `_pre_call_checks`, skipping
         the conversion unless a deployment actually has max_input_tokens configured.
@@ -9912,7 +9924,7 @@ class Router:
         )
 
         ## get model group RPM ##
-        model_group_cache: Optional[dict] = None
+        model_group_cache: dict[str, int] | None = None
         if _any_deployment_has_rpm:
             dt = get_utc_datetime()
             current_minute = dt.strftime("%H-%M")

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4398,10 +4398,10 @@ class Router:
         check in `_pre_call_checks` that needs `messages`.
         """
         messages = kwargs.get("messages")
+        is_responses_api_call = kwargs.pop("_responses_api_pre_call_check", False)
         if messages is not None:
             return messages
 
-        is_responses_api_call = kwargs.pop("_responses_api_pre_call_check", False)
         if (
             not is_responses_api_call
             or not self.enable_pre_call_checks

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4363,16 +4363,24 @@ class Router:
 
     def _model_group_has_max_input_tokens(self, model: str) -> bool:
         """
-        Return True if any deployment in the model group has max_input_tokens set.
+        Return True if any deployment in the model group resolves to a
+        max_input_tokens value via get_router_model_info().
 
         Used to decide whether it's worth paying the cost of converting Responses
         API `input` into `messages` just so `_pre_call_checks` can run context
-        window checks - if no deployment declares max_input_tokens, there's
+        window checks - if no deployment resolves a max_input_tokens, there's
         nothing to check.
+
+        Mirrors _pre_call_checks' own resolution: max_input_tokens is not only a
+        user-set model_info override, it's also commonly derived from litellm's
+        model cost map, which get_router_model_info() takes into account.
         """
         deployments = self.get_model_list(model_name=model) or []
         for deployment in deployments:
-            model_info = deployment.get("model_info")
+            try:
+                model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
+            except Exception:
+                continue
             if isinstance(model_info, dict) and model_info.get("max_input_tokens") is not None:
                 return True
         return False
@@ -9913,13 +9921,13 @@ class Router:
         _rate_limit_error = False
         parent_otel_span = _get_parent_otel_span_from_kwargs(request_kwargs)
 
-        # get_router_model_info() and RPM cache reads are only useful when at least one
-        # deployment in the model group actually declares the relevant config. Precompute
-        # these once so we can skip the expensive per-deployment lookups entirely for
-        # model groups that don't use them.
-        _any_deployment_has_max_input_tokens = any(
-            (d.get("model_info") or {}).get("max_input_tokens") is not None for d in _returned_deployments
-        )
+        # The RPM cache read is only useful when at least one deployment in the model
+        # group actually declares `rpm` in litellm_params - that's set directly by the
+        # user, so it's safe to check statically. max_input_tokens has no equivalent
+        # static check: get_router_model_info() also derives it from litellm's model
+        # cost map (the common case for models without a manual model_info override),
+        # so we can't know whether a deployment needs the context-window check without
+        # actually calling it.
         _any_deployment_has_rpm = self.routing_strategy != "usage-based-routing-v2" and any(
             (d.get("litellm_params") or {}).get("rpm") is not None for d in _returned_deployments
         )
@@ -9940,37 +9948,36 @@ class Router:
 
             # see if we have the info for this model
             _deployment_model = None  # per-deployment model name (avoids overwriting the outer `model` group name)
-            if _any_deployment_has_max_input_tokens:
-                try:
-                    base_model = _model_info.get("base_model", None)
-                    if base_model is None:
-                        base_model = _litellm_params.get("base_model", None)
-                    model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
-                    _deployment_model = base_model or _litellm_params.get("model", None)
+            try:
+                base_model = _model_info.get("base_model", None)
+                if base_model is None:
+                    base_model = _litellm_params.get("base_model", None)
+                model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
+                _deployment_model = base_model or _litellm_params.get("model", None)
 
-                    max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
-                    if isinstance(max_input_tokens, int):
-                        if input_tokens is None:
-                            try:
-                                input_tokens = litellm.token_counter(messages=messages)
-                            except Exception as e:
-                                verbose_router_logger.error(
-                                    "litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {}".format(
-                                        str(e)
-                                    )
+                max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
+                if isinstance(max_input_tokens, int):
+                    if input_tokens is None:
+                        try:
+                            input_tokens = litellm.token_counter(messages=messages)
+                        except Exception as e:
+                            verbose_router_logger.error(
+                                "litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {}".format(
+                                    str(e)
                                 )
-                                return _returned_deployments
-                        if input_tokens > max_input_tokens:
-                            invalid_model_indices.add(idx)
-                            _context_window_error = True
-                            _potential_error_str += "Model={}, Max Input Tokens={}, Got={}".format(
-                                _deployment_model,
-                                max_input_tokens,
-                                input_tokens,
                             )
-                            continue
-                except Exception as e:
-                    verbose_router_logger.exception("An error occurs - {}".format(str(e)))
+                            return _returned_deployments
+                    if input_tokens > max_input_tokens:
+                        invalid_model_indices.add(idx)
+                        _context_window_error = True
+                        _potential_error_str += "Model={}, Max Input Tokens={}, Got={}".format(
+                            _deployment_model,
+                            max_input_tokens,
+                            input_tokens,
+                        )
+                        continue
+            except Exception as e:
+                verbose_router_logger.exception("An error occurs - {}".format(str(e)))
 
             ## RPM CHECK ##
             if _any_deployment_has_rpm and isinstance(model_group_cache, dict):
@@ -10004,11 +10011,7 @@ class Router:
 
             ## INVALID PARAMS ## -> catch 'gpt-3.5-turbo-16k' not supporting 'response_format' param
             if request_kwargs is not None and litellm.drop_params is False:
-                # get supported params — use per-deployment model to avoid overwriting the outer model group name.
-                # _deployment_model is only populated above when the max_input_tokens check ran; fall back to the
-                # deployment's own litellm_params model here so we don't end up using the model *group* name below.
-                if _deployment_model is None:
-                    _deployment_model = _litellm_params.get("model", None)
+                # get supported params — use per-deployment model to avoid overwriting the outer model group name
                 _dep_model_for_params = _deployment_model or model
                 (
                     _dep_model_for_params,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -78,6 +78,9 @@ from litellm.litellm_core_utils.sensitive_data_masker import (
     mask_sensitive_structure,
 )
 from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
 from litellm.router_strategy.budget_limiter import RouterBudgetLimiting
 from litellm.router_strategy.least_busy import LeastBusyLoggingHandler
 from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
@@ -4358,6 +4361,52 @@ class Router:
             kwargs["endpoint"] = kwargs["endpoint"].replace(model, replacement_model_name)
         return kwargs
 
+    def _model_group_has_max_input_tokens(self, model: str) -> bool:
+        """
+        Return True if any deployment in the model group has max_input_tokens set.
+
+        Used to decide whether it's worth paying the cost of converting Responses
+        API `input` into `messages` just so `_pre_call_checks` can run context
+        window checks - if no deployment declares max_input_tokens, there's
+        nothing to check.
+        """
+        deployments = self.get_model_list(model_name=model) or []
+        for deployment in deployments:
+            model_info = deployment.get("model_info")
+            if isinstance(model_info, dict) and model_info.get("max_input_tokens") is not None:
+                return True
+        return False
+
+    def _get_messages_for_pre_call_check(self, model: str, kwargs: Dict[str, Any]) -> Optional[List[Any]]:
+        """
+        Resolve the messages to use for `_pre_call_checks` context window checks.
+
+        Chat Completions style calls already pass `messages` directly. Responses
+        API calls pass `input` instead, which `_pre_call_checks` doesn't understand
+        natively - so this converts `input` to `messages` for that call path.
+
+        The conversion is skipped (returns None) unless the model group actually
+        has a deployment with `max_input_tokens` configured, since that's the only
+        check in `_pre_call_checks` that needs `messages`.
+        """
+        messages = kwargs.get("messages")
+        if messages is not None:
+            return messages
+
+        is_responses_api_call = kwargs.pop("_responses_api_pre_call_check", False)
+        if (
+            not is_responses_api_call
+            or not self.enable_pre_call_checks
+            or kwargs.get("input") is None
+            or not self._model_group_has_max_input_tokens(model)
+        ):
+            return None
+
+        return LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=kwargs["input"],
+            responses_api_request=kwargs,
+        )
+
     async def _ageneric_api_call_with_fallbacks_helper(self, model: str, original_generic_function: Callable, **kwargs):
         """
         Helper function to make a generic LLM API call through the router, this allows you to use retries/fallbacks with litellm router
@@ -4368,10 +4417,11 @@ class Router:
         try:
             parent_otel_span = _get_parent_otel_span_from_kwargs(kwargs)
             try:
+                messages = self._get_messages_for_pre_call_check(model, kwargs)
                 deployment = await self.async_get_available_deployment(
                     model=model,
                     request_kwargs=kwargs,
-                    messages=kwargs.get("messages", None),
+                    messages=messages,
                     specific_deployment=kwargs.pop("specific_deployment", None),
                 )
             except Exception as e:
@@ -4516,9 +4566,10 @@ class Router:
                 kwargs=kwargs,
                 metadata_variable_name=metadata_variable_name,
             )
+            messages = self._get_messages_for_pre_call_check(model, kwargs)
             deployment = self.get_available_deployment(
                 model=model,
-                messages=kwargs.get("messages", None),
+                messages=messages,
                 specific_deployment=kwargs.pop("specific_deployment", None),
                 request_kwargs=kwargs,
             )
@@ -5533,6 +5584,8 @@ class Router:
                 client: Optional[Any] = None,
                 **kwargs,
             ):
+                if call_type == "responses":
+                    kwargs["_responses_api_pre_call_check"] = True
                 return self._generic_api_call_with_fallbacks(original_function=original_function, **kwargs)
 
             return sync_wrapper
@@ -5636,6 +5689,7 @@ class Router:
                     **kwargs,
                 )
             elif call_type == "aresponses":
+                kwargs["_responses_api_pre_call_check"] = True
                 return await self._aresponses_with_streaming_fallbacks(
                     original_function=original_function,
                     **kwargs,
@@ -9859,13 +9913,26 @@ class Router:
         _rate_limit_error = False
         parent_otel_span = _get_parent_otel_span_from_kwargs(request_kwargs)
 
+        # get_router_model_info() and RPM cache reads are only useful when at least one
+        # deployment in the model group actually declares the relevant config. Precompute
+        # these once so we can skip the expensive per-deployment lookups entirely for
+        # model groups that don't use them.
+        _any_deployment_has_max_input_tokens = any(
+            (d.get("model_info") or {}).get("max_input_tokens") is not None for d in _returned_deployments
+        )
+        _any_deployment_has_rpm = self.routing_strategy != "usage-based-routing-v2" and any(
+            (d.get("litellm_params") or {}).get("rpm") is not None for d in _returned_deployments
+        )
+
         ## get model group RPM ##
-        dt = get_utc_datetime()
-        current_minute = dt.strftime("%H-%M")
-        rpm_key = f"{model}:rpm:{current_minute}"
-        model_group_cache = (
-            self.cache.get_cache(key=rpm_key, local_only=True, parent_otel_span=parent_otel_span) or {}
-        )  # check the in-memory cache used by lowest_latency and usage-based routing. Only check the local cache.
+        model_group_cache: Optional[dict] = None
+        if _any_deployment_has_rpm:
+            dt = get_utc_datetime()
+            current_minute = dt.strftime("%H-%M")
+            rpm_key = f"{model}:rpm:{current_minute}"
+            model_group_cache = (
+                self.cache.get_cache(key=rpm_key, local_only=True, parent_otel_span=parent_otel_span) or {}
+            )  # check the in-memory cache used by lowest_latency and usage-based routing. Only check the local cache.
         for idx, deployment in enumerate(_returned_deployments):
             # Cache nested dict access to avoid repeated temporary dict allocations
             _litellm_params = deployment.get("litellm_params", {})
@@ -9873,45 +9940,46 @@ class Router:
 
             # see if we have the info for this model
             _deployment_model = None  # per-deployment model name (avoids overwriting the outer `model` group name)
-            try:
-                base_model = _model_info.get("base_model", None)
-                if base_model is None:
-                    base_model = _litellm_params.get("base_model", None)
-                model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
-                _deployment_model = base_model or _litellm_params.get("model", None)
+            if _any_deployment_has_max_input_tokens:
+                try:
+                    base_model = _model_info.get("base_model", None)
+                    if base_model is None:
+                        base_model = _litellm_params.get("base_model", None)
+                    model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
+                    _deployment_model = base_model or _litellm_params.get("model", None)
 
-                max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
-                if isinstance(max_input_tokens, int):
-                    if input_tokens is None:
-                        try:
-                            input_tokens = litellm.token_counter(messages=messages)
-                        except Exception as e:
-                            verbose_router_logger.error(
-                                "litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {}".format(
-                                    str(e)
+                    max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
+                    if isinstance(max_input_tokens, int):
+                        if input_tokens is None:
+                            try:
+                                input_tokens = litellm.token_counter(messages=messages)
+                            except Exception as e:
+                                verbose_router_logger.error(
+                                    "litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {}".format(
+                                        str(e)
+                                    )
                                 )
+                                return _returned_deployments
+                        if input_tokens > max_input_tokens:
+                            invalid_model_indices.add(idx)
+                            _context_window_error = True
+                            _potential_error_str += "Model={}, Max Input Tokens={}, Got={}".format(
+                                _deployment_model,
+                                max_input_tokens,
+                                input_tokens,
                             )
-                            return _returned_deployments
-                    if input_tokens > max_input_tokens:
-                        invalid_model_indices.add(idx)
-                        _context_window_error = True
-                        _potential_error_str += "Model={}, Max Input Tokens={}, Got={}".format(
-                            _deployment_model,
-                            max_input_tokens,
-                            input_tokens,
-                        )
-                        continue
-            except Exception as e:
-                verbose_router_logger.exception("An error occurs - {}".format(str(e)))
+                            continue
+                except Exception as e:
+                    verbose_router_logger.exception("An error occurs - {}".format(str(e)))
 
-            model_id = _model_info.get("id", "")
             ## RPM CHECK ##
-            ### get local router cache ###
-            current_request_cache_local = (
-                self.cache.get_cache(key=model_id, local_only=True, parent_otel_span=parent_otel_span) or 0
-            )
-            ### get usage based cache ###
-            if isinstance(model_group_cache, dict) and self.routing_strategy != "usage-based-routing-v2":
+            if _any_deployment_has_rpm and isinstance(model_group_cache, dict):
+                model_id = _model_info.get("id", "")
+                ### get local router cache ###
+                current_request_cache_local = (
+                    self.cache.get_cache(key=model_id, local_only=True, parent_otel_span=parent_otel_span) or 0
+                )
+                ### get usage based cache ###
                 model_group_cache[model_id] = model_group_cache.get(model_id, 0)
 
                 current_request = max(current_request_cache_local, model_group_cache[model_id])
@@ -9936,7 +10004,11 @@ class Router:
 
             ## INVALID PARAMS ## -> catch 'gpt-3.5-turbo-16k' not supporting 'response_format' param
             if request_kwargs is not None and litellm.drop_params is False:
-                # get supported params — use per-deployment model to avoid overwriting the outer model group name
+                # get supported params — use per-deployment model to avoid overwriting the outer model group name.
+                # _deployment_model is only populated above when the max_input_tokens check ran; fall back to the
+                # deployment's own litellm_params model here so we don't end up using the model *group* name below.
+                if _deployment_model is None:
+                    _deployment_model = _litellm_params.get("model", None)
                 _dep_model_for_params = _deployment_model or model
                 (
                     _dep_model_for_params,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4383,7 +4383,7 @@ class Router:
         """
         messages = kwargs.get("messages")
         is_responses_api_call = kwargs.pop("_responses_api_pre_call_check", False)
-        if messages is not None:
+        if messages is not None and not is_responses_api_call:
             return messages
 
         if (

--- a/tests/router_unit_tests/test_pre_call_checks_optimization.py
+++ b/tests/router_unit_tests/test_pre_call_checks_optimization.py
@@ -16,7 +16,11 @@ Critical Requirement:
 """
 
 import copy
+from unittest.mock import patch
+
 import pytest
+
+import litellm
 from litellm import Router
 
 
@@ -71,13 +75,9 @@ class TestPreCallChecksOptimization:
         # 1. Same number of items
         assert len(deployments) == original_length, "List length changed!"
         # 2. Same deployment objects (not replaced with copies)
-        assert [
-            id(d) for d in deployments
-        ] == original_deployment_ids, "Deployment dicts replaced!"
+        assert [id(d) for d in deployments] == original_deployment_ids, "Deployment dicts replaced!"
         # 3. Same nested objects (not replaced with copies)
-        assert [
-            id(d["litellm_params"]) for d in deployments
-        ] == original_litellm_params_ids, "Nested dicts replaced!"
+        assert [id(d["litellm_params"]) for d in deployments] == original_litellm_params_ids, "Nested dicts replaced!"
         # 4. Same values (catches any mutation)
         assert deployments == snapshot, "Values were mutated!"
 
@@ -120,29 +120,334 @@ class TestPreCallChecksOptimization:
         )
 
         # Verify the filtered result only contains the large deployment
-        assert (
-            len(filtered) == 1
-        ), f"Expected 1 deployment after filtering, got {len(filtered)}"
-        assert (
-            filtered[0]["model_info"]["id"] == "large"
-        ), "Wrong deployment kept after filtering"
+        assert len(filtered) == 1, f"Expected 1 deployment after filtering, got {len(filtered)}"
+        assert filtered[0]["model_info"]["id"] == "large", "Wrong deployment kept after filtering"
 
         # Verify the original list still has both deployments
-        assert (
-            len(deployments) == 2
-        ), f"Original list was modified! Expected 2, got {len(deployments)}"
-        assert (
-            deployments[0] is original_small_deployment
-        ), "First deployment object replaced!"
-        assert (
-            deployments[1] is original_large_deployment
-        ), "Second deployment object replaced!"
-        assert (
-            deployments[0].get("model_info", {}).get("id") == "small"
-        ), "First deployment ID changed!"
-        assert (
-            deployments[1].get("model_info", {}).get("id") == "large"
-        ), "Second deployment ID changed!"
+        assert len(deployments) == 2, f"Original list was modified! Expected 2, got {len(deployments)}"
+        assert deployments[0] is original_small_deployment, "First deployment object replaced!"
+        assert deployments[1] is original_large_deployment, "Second deployment object replaced!"
+        assert deployments[0].get("model_info", {}).get("id") == "small", "First deployment ID changed!"
+        assert deployments[1].get("model_info", {}).get("id") == "large", "Second deployment ID changed!"
+
+
+class TestPreCallChecksLazyGuarding:
+    """
+    Verify that each pre-call check is only performed when the deployment
+    has the relevant configuration variable set.
+
+    These tests ensure expensive operations (tokenization, model-info
+    lookups, cache reads) are skipped for deployments that don't need them.
+    """
+
+    @pytest.fixture()
+    def router_no_limits(self):
+        """Router with two deployments, neither has max_input_tokens or rpm."""
+        return Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "dep-1"},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "dep-2"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+    @pytest.fixture()
+    def router_with_context_limit(self):
+        """Router where one deployment has max_input_tokens, the other doesn't."""
+        return Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "no-limit"},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "has-limit", "max_input_tokens": 500000},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+    @pytest.fixture()
+    def router_with_rpm(self):
+        """Router where one deployment has rpm, the other doesn't."""
+        return Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "no-rpm"},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {
+                        "model": "gpt-5.5",
+                        "api_key": "sk-test",
+                        "rpm": 100,
+                    },
+                    "model_info": {"id": "has-rpm"},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+    def test_no_tokenization_when_no_deployment_has_max_input_tokens(self, router_no_limits):
+        """token_counter must not be called when no deployment has max_input_tokens."""
+        deployments = router_no_limits.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch("litellm.token_counter") as mock_token_counter:
+            result = router_no_limits._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello world"}],
+            )
+
+        mock_token_counter.assert_not_called()
+        assert len(result) == 2, "All deployments should be returned"
+
+    def test_no_model_info_lookup_when_no_deployment_has_max_input_tokens(self, router_no_limits):
+        """get_router_model_info must not be called when no deployment has max_input_tokens."""
+        deployments = router_no_limits.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch.object(router_no_limits, "get_router_model_info") as mock_get_info:
+            result = router_no_limits._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello world"}],
+            )
+
+        mock_get_info.assert_not_called()
+        assert len(result) == 2
+
+    def test_no_rpm_cache_lookup_when_no_deployment_has_rpm(self, router_no_limits):
+        """The RPM cache must not be queried when no deployment has rpm configured."""
+        deployments = router_no_limits.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch.object(router_no_limits.cache, "get_cache", wraps=router_no_limits.cache.get_cache) as mock_cache:
+            result = router_no_limits._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        mock_cache.assert_not_called()
+        assert len(result) == 2
+
+    def test_zero_calls_when_nothing_configured(self, router_no_limits):
+        """
+        A router with zero max_input_tokens-configured and zero rpm-configured
+        deployments must make zero calls to litellm.token_counter(),
+        get_router_model_info(), and the RPM cache get - regardless of message size.
+        """
+        deployments = router_no_limits.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with (
+            patch("litellm.token_counter") as mock_token_counter,
+            patch.object(router_no_limits, "get_router_model_info") as mock_get_info,
+            patch.object(
+                router_no_limits.cache,
+                "get_cache",
+                wraps=router_no_limits.cache.get_cache,
+            ) as mock_cache,
+        ):
+            result = router_no_limits._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": " ".join(["word"] * 10000)}],
+            )
+
+        mock_token_counter.assert_not_called()
+        mock_get_info.assert_not_called()
+        mock_cache.assert_not_called()
+        assert len(result) == 2, "All deployments should pass when no limits are configured"
+
+    def test_tokenization_only_when_deployment_has_max_input_tokens(self, router_with_context_limit):
+        """token_counter should be called exactly once when at least one deployment has max_input_tokens."""
+        deployments = router_with_context_limit.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch("litellm.token_counter", return_value=100) as mock_token_counter:
+            result = router_with_context_limit._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello world"}],
+            )
+
+        mock_token_counter.assert_called_once()
+        assert len(result) == 2, "Both deployments should pass (100 < 500000)"
+
+    def test_model_info_lookup_only_for_deployment_with_max_input_tokens(self, router_with_context_limit):
+        """get_router_model_info should only be called for the deployment that has max_input_tokens."""
+        deployments = router_with_context_limit.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        original_get_info = router_with_context_limit.get_router_model_info
+        call_deployment_ids = []
+
+        def tracking_get_info(deployment, received_model_name, **kwargs):
+            dep_id = (deployment.get("model_info") or {}).get("id")
+            call_deployment_ids.append(dep_id)
+            return original_get_info(deployment=deployment, received_model_name=received_model_name, **kwargs)
+
+        with patch.object(
+            router_with_context_limit,
+            "get_router_model_info",
+            side_effect=tracking_get_info,
+        ):
+            router_with_context_limit._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello world"}],
+            )
+
+        # get_router_model_info is called for every deployment once any deployment in the
+        # group needs the max_input_tokens check, but only "has-limit" declares the limit.
+        assert "has-limit" in call_deployment_ids
+
+    def test_token_count_computed_once_for_multiple_limited_deployments(self):
+        """When multiple deployments have max_input_tokens, token_counter is called exactly once."""
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "limit-a", "max_input_tokens": 1000},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "limit-b", "max_input_tokens": 500000},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+        deployments = router.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch("litellm.token_counter", return_value=50) as mock_token_counter:
+            result = router._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        mock_token_counter.assert_called_once()
+        assert len(result) == 2
+
+    def test_token_counter_failure_skips_context_checks_gracefully(self, router_with_context_limit):
+        """If token_counter raises, all deployments should be returned (fail-open)."""
+        deployments = router_with_context_limit.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch("litellm.token_counter", side_effect=Exception("tokenizer error")):
+            result = router_with_context_limit._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert len(result) == 2, "All deployments should be returned on token count failure"
+
+    def test_rpm_cache_lookup_only_when_deployment_has_rpm(self, router_with_rpm):
+        """Cache should be queried when at least one deployment has rpm configured."""
+        deployments = router_with_rpm.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with patch.object(router_with_rpm.cache, "get_cache", return_value={}) as mock_cache:
+            result = router_with_rpm._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": "hello"}],
+            )
+
+        assert mock_cache.call_count > 0, "Cache should be queried when rpm is configured"
+        assert len(result) == 2
+
+    def test_context_window_filtering_with_mixed_deployments(self):
+        """
+        In a model group with mixed deployments (some with max_input_tokens,
+        some without), only the limited deployment should be filtered when
+        input exceeds its limit. Unlimited deployments always pass.
+        """
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "unlimited"},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "limited", "max_input_tokens": 50},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        deployments = router.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        # 100 words will exceed 50 tokens
+        filtered = router._pre_call_checks(
+            model="test-model",
+            healthy_deployments=deployments,
+            messages=[{"role": "user", "content": " ".join(["word"] * 100)}],
+        )
+
+        assert len(filtered) == 1, f"Expected 1 deployment, got {len(filtered)}"
+        assert filtered[0]["model_info"]["id"] == "unlimited"
+
+    def test_context_window_exceeded_error_when_all_limited_deployments_exceeded(self):
+        """
+        When ALL deployments have max_input_tokens and all are exceeded,
+        ContextWindowExceededError should be raised.
+        """
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                    "model_info": {"id": "small-a", "max_input_tokens": 10},
+                },
+                {
+                    "model_name": "test-model",
+                    "litellm_params": {"model": "gpt-5.5", "api_key": "sk-test"},
+                    "model_info": {"id": "small-b", "max_input_tokens": 20},
+                },
+            ],
+            set_verbose=False,
+            enable_pre_call_checks=True,
+        )
+
+        deployments = router.get_model_list(model_name="test-model")
+        assert deployments is not None
+
+        with pytest.raises(litellm.ContextWindowExceededError):
+            router._pre_call_checks(
+                model="test-model",
+                healthy_deployments=deployments,
+                messages=[{"role": "user", "content": " ".join(["word"] * 200)}],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/router_unit_tests/test_pre_call_checks_optimization.py
+++ b/tests/router_unit_tests/test_pre_call_checks_optimization.py
@@ -204,12 +204,20 @@ class TestPreCallChecksLazyGuarding:
             enable_pre_call_checks=True,
         )
 
-    def test_no_tokenization_when_no_deployment_has_max_input_tokens(self, router_no_limits):
-        """token_counter must not be called when no deployment has max_input_tokens."""
+    def test_no_tokenization_when_no_deployment_resolves_max_input_tokens(self, router_no_limits):
+        """
+        token_counter must not be called when no deployment resolves a
+        max_input_tokens value (mock get_router_model_info directly, since
+        max_input_tokens is commonly derived from litellm's model cost map
+        rather than statically declared in model_info).
+        """
         deployments = router_no_limits.get_model_list(model_name="test-model")
         assert deployments is not None
 
-        with patch("litellm.token_counter") as mock_token_counter:
+        with (
+            patch.object(router_no_limits, "get_router_model_info", return_value={}),
+            patch("litellm.token_counter") as mock_token_counter,
+        ):
             result = router_no_limits._pre_call_checks(
                 model="test-model",
                 healthy_deployments=deployments,
@@ -219,19 +227,28 @@ class TestPreCallChecksLazyGuarding:
         mock_token_counter.assert_not_called()
         assert len(result) == 2, "All deployments should be returned"
 
-    def test_no_model_info_lookup_when_no_deployment_has_max_input_tokens(self, router_no_limits):
-        """get_router_model_info must not be called when no deployment has max_input_tokens."""
+    def test_model_info_lookup_always_runs_per_deployment(self, router_no_limits):
+        """
+        get_router_model_info must be called for every deployment, since
+        max_input_tokens can come from litellm's model cost map (not just a
+        static model_info override) and there's no cheap way to know in
+        advance whether a deployment resolves a limit.
+        """
         deployments = router_no_limits.get_model_list(model_name="test-model")
         assert deployments is not None
 
-        with patch.object(router_no_limits, "get_router_model_info") as mock_get_info:
+        with patch.object(
+            router_no_limits,
+            "get_router_model_info",
+            wraps=router_no_limits.get_router_model_info,
+        ) as mock_get_info:
             result = router_no_limits._pre_call_checks(
                 model="test-model",
                 healthy_deployments=deployments,
                 messages=[{"role": "user", "content": "hello world"}],
             )
 
-        mock_get_info.assert_not_called()
+        assert mock_get_info.call_count == 2
         assert len(result) == 2
 
     def test_no_rpm_cache_lookup_when_no_deployment_has_rpm(self, router_no_limits):
@@ -249,18 +266,21 @@ class TestPreCallChecksLazyGuarding:
         mock_cache.assert_not_called()
         assert len(result) == 2
 
-    def test_zero_calls_when_nothing_configured(self, router_no_limits):
+    def test_zero_tokenization_or_rpm_cache_calls_when_nothing_configured(self, router_no_limits):
         """
-        A router with zero max_input_tokens-configured and zero rpm-configured
-        deployments must make zero calls to litellm.token_counter(),
-        get_router_model_info(), and the RPM cache get - regardless of message size.
+        A router with zero deployments resolving max_input_tokens and zero
+        rpm-configured deployments must make zero calls to
+        litellm.token_counter() and the RPM cache get - regardless of message
+        size. get_router_model_info() itself still runs per deployment (see
+        test_model_info_lookup_always_runs_per_deployment for why it can't be
+        statically skipped), it's just mocked here to return no limit.
         """
         deployments = router_no_limits.get_model_list(model_name="test-model")
         assert deployments is not None
 
         with (
+            patch.object(router_no_limits, "get_router_model_info", return_value={}),
             patch("litellm.token_counter") as mock_token_counter,
-            patch.object(router_no_limits, "get_router_model_info") as mock_get_info,
             patch.object(
                 router_no_limits.cache,
                 "get_cache",
@@ -274,7 +294,6 @@ class TestPreCallChecksLazyGuarding:
             )
 
         mock_token_counter.assert_not_called()
-        mock_get_info.assert_not_called()
         mock_cache.assert_not_called()
         assert len(result) == 2, "All deployments should pass when no limits are configured"
 
@@ -293,8 +312,8 @@ class TestPreCallChecksLazyGuarding:
         mock_token_counter.assert_called_once()
         assert len(result) == 2, "Both deployments should pass (100 < 500000)"
 
-    def test_model_info_lookup_only_for_deployment_with_max_input_tokens(self, router_with_context_limit):
-        """get_router_model_info should only be called for the deployment that has max_input_tokens."""
+    def test_model_info_lookup_includes_deployment_with_max_input_tokens(self, router_with_context_limit):
+        """get_router_model_info should be called for the deployment that has max_input_tokens."""
         deployments = router_with_context_limit.get_model_list(model_name="test-model")
         assert deployments is not None
 

--- a/tests/router_unit_tests/test_router_pre_call_check_helpers.py
+++ b/tests/router_unit_tests/test_router_pre_call_check_helpers.py
@@ -51,6 +51,18 @@ class TestRouterGetMessagesForPreCallCheck:
         result = router._get_messages_for_pre_call_check(model="gpt-5-mini", kwargs={"messages": messages})
         assert result is messages
 
+    def test_pops_responses_api_sentinel_even_when_messages_present(self):
+        """
+        _responses_api_pre_call_check must be popped from kwargs regardless of
+        which branch returns, since it's an internal signal that must never
+        reach the underlying LLM API as an unexpected kwarg.
+        """
+        router = _make_router(max_input_tokens=100)
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = {"messages": messages, "_responses_api_pre_call_check": True}
+        router._get_messages_for_pre_call_check(model="gpt-5-mini", kwargs=kwargs)
+        assert "_responses_api_pre_call_check" not in kwargs
+
     def test_returns_none_when_not_a_responses_api_call(self):
         router = _make_router(max_input_tokens=100)
         result = router._get_messages_for_pre_call_check(

--- a/tests/router_unit_tests/test_router_pre_call_check_helpers.py
+++ b/tests/router_unit_tests/test_router_pre_call_check_helpers.py
@@ -8,6 +8,8 @@ but the repo's router_code_coverage.py check only scans files whose *filename*
 contains "router", so this file calls both helpers directly to satisfy it.
 """
 
+from unittest.mock import patch
+
 from litellm import Router
 
 
@@ -33,9 +35,13 @@ class TestRouterModelGroupHasMaxInputTokens:
         router = _make_router(max_input_tokens=100)
         assert router._model_group_has_max_input_tokens(model="gpt-5-mini") is True
 
-    def test_false_when_no_deployment_has_max_input_tokens(self):
+    def test_false_when_no_deployment_resolves_max_input_tokens(self):
         router = _make_router()
-        assert router._model_group_has_max_input_tokens(model="gpt-5-mini") is False
+        # max_input_tokens can also be resolved via litellm's model cost map
+        # (get_router_model_info), not just a static model_info override -
+        # mock it directly so this test isn't coupled to gpt-5-mini's cost-map entry.
+        with patch.object(router, "get_router_model_info", return_value={}):
+            assert router._model_group_has_max_input_tokens(model="gpt-5-mini") is False
 
 
 class TestRouterGetMessagesForPreCallCheck:
@@ -52,11 +58,12 @@ class TestRouterGetMessagesForPreCallCheck:
         )
         assert result is None
 
-    def test_returns_none_when_no_deployment_has_max_input_tokens(self):
+    def test_returns_none_when_no_deployment_resolves_max_input_tokens(self):
         router = _make_router()
-        result = router._get_messages_for_pre_call_check(
-            model="gpt-5-mini", kwargs={"input": "hi", "_responses_api_pre_call_check": True}
-        )
+        with patch.object(router, "get_router_model_info", return_value={}):
+            result = router._get_messages_for_pre_call_check(
+                model="gpt-5-mini", kwargs={"input": "hi", "_responses_api_pre_call_check": True}
+            )
         assert result is None
 
     def test_converts_input_to_messages_for_responses_api_call(self):

--- a/tests/router_unit_tests/test_router_pre_call_check_helpers.py
+++ b/tests/router_unit_tests/test_router_pre_call_check_helpers.py
@@ -63,6 +63,28 @@ class TestRouterGetMessagesForPreCallCheck:
         router._get_messages_for_pre_call_check(model="gpt-5-mini", kwargs=kwargs)
         assert "_responses_api_pre_call_check" not in kwargs
 
+    def test_ignores_caller_supplied_messages_for_responses_api_call(self):
+        """
+        A Responses API call can smuggle in a `messages` kwarg alongside `input`
+        via **kwargs passthrough (litellm.aresponses accepts **kwargs). If we used
+        that `messages` for the pre-call check instead of converting the actual
+        `input`, a small/benign `messages` could mask an oversized `input` that
+        still gets forwarded to the LLM - the check would validate the wrong field.
+        """
+        router = _make_router(max_input_tokens=100)
+        small_messages = [{"role": "user", "content": "hi"}]
+        result = router._get_messages_for_pre_call_check(
+            model="gpt-5-mini",
+            kwargs={
+                "input": "hello there",
+                "messages": small_messages,
+                "_responses_api_pre_call_check": True,
+            },
+        )
+        assert result is not small_messages
+        assert result is not None
+        assert any("hello there" in str(m.get("content", "")) for m in result)
+
     def test_returns_none_when_not_a_responses_api_call(self):
         router = _make_router(max_input_tokens=100)
         result = router._get_messages_for_pre_call_check(

--- a/tests/router_unit_tests/test_router_pre_call_check_helpers.py
+++ b/tests/router_unit_tests/test_router_pre_call_check_helpers.py
@@ -1,0 +1,68 @@
+"""
+Direct unit tests for Router._model_group_has_max_input_tokens() and
+Router._get_messages_for_pre_call_check().
+
+These are exercised end-to-end via test_pre_call_checks_optimization.py and
+tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py,
+but the repo's router_code_coverage.py check only scans files whose *filename*
+contains "router", so this file calls both helpers directly to satisfy it.
+"""
+
+from litellm import Router
+
+
+def _make_router(max_input_tokens=None):
+    model_info = {"id": "test-1"}
+    if max_input_tokens is not None:
+        model_info["max_input_tokens"] = max_input_tokens
+    return Router(
+        model_list=[
+            {
+                "model_name": "gpt-5-mini",
+                "litellm_params": {"model": "gpt-5-mini", "api_key": "sk-test"},
+                "model_info": model_info,
+            },
+        ],
+        set_verbose=False,
+        enable_pre_call_checks=True,
+    )
+
+
+class TestRouterModelGroupHasMaxInputTokens:
+    def test_true_when_deployment_has_max_input_tokens(self):
+        router = _make_router(max_input_tokens=100)
+        assert router._model_group_has_max_input_tokens(model="gpt-5-mini") is True
+
+    def test_false_when_no_deployment_has_max_input_tokens(self):
+        router = _make_router()
+        assert router._model_group_has_max_input_tokens(model="gpt-5-mini") is False
+
+
+class TestRouterGetMessagesForPreCallCheck:
+    def test_returns_messages_when_present(self):
+        router = _make_router(max_input_tokens=100)
+        messages = [{"role": "user", "content": "hi"}]
+        result = router._get_messages_for_pre_call_check(model="gpt-5-mini", kwargs={"messages": messages})
+        assert result is messages
+
+    def test_returns_none_when_not_a_responses_api_call(self):
+        router = _make_router(max_input_tokens=100)
+        result = router._get_messages_for_pre_call_check(
+            model="gpt-5-mini", kwargs={"input": "hi", "_responses_api_pre_call_check": False}
+        )
+        assert result is None
+
+    def test_returns_none_when_no_deployment_has_max_input_tokens(self):
+        router = _make_router()
+        result = router._get_messages_for_pre_call_check(
+            model="gpt-5-mini", kwargs={"input": "hi", "_responses_api_pre_call_check": True}
+        )
+        assert result is None
+
+    def test_converts_input_to_messages_for_responses_api_call(self):
+        router = _make_router(max_input_tokens=100)
+        result = router._get_messages_for_pre_call_check(
+            model="gpt-5-mini", kwargs={"input": "hello there", "_responses_api_pre_call_check": True}
+        )
+        assert result is not None
+        assert any("hello there" in str(m.get("content", "")) for m in result)

--- a/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
@@ -66,8 +66,13 @@ class TestResponsesAPIPreCallCheckIntegration:
     @pytest.mark.asyncio
     async def test_responses_api_skips_conversion_without_max_input_tokens(self):
         """
-        If no deployment has max_input_tokens, the router should not convert
-        Responses API input just for pre-call checks.
+        If no deployment resolves a max_input_tokens value, the router should
+        not convert Responses API input just for pre-call checks.
+
+        max_input_tokens can be resolved via litellm's model cost map (not
+        only a static model_info override), so get_router_model_info is
+        mocked directly to simulate "no limit" regardless of the deployment's
+        underlying model.
         """
         with (
             patch("litellm.aresponses", new_callable=AsyncMock) as mock_aresponses,
@@ -80,10 +85,11 @@ class TestResponsesAPIPreCallCheckIntegration:
             mock_aresponses.return_value = expected_response
             router = _router_with_optional_max_input_tokens(max_input_tokens=None)
 
-            result = await router.aresponses(
-                model="test-model",
-                input="short input",
-            )
+            with patch.object(router, "get_router_model_info", return_value={}):
+                result = await router.aresponses(
+                    model="test-model",
+                    input="short input",
+                )
 
             assert result == expected_response
             mock_converter.assert_not_called()

--- a/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
@@ -1,5 +1,5 @@
 from typing import Any, Optional
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -123,6 +123,34 @@ class TestResponsesAPIPreCallCheckIntegration:
             assert result == expected_response
             mock_converter.assert_called_once()
             mock_aresponses.assert_called_once()
+
+    def test_sync_responses_call_type_marks_pre_call_check(self):
+        """
+        router.responses() (the sync entrypoint, factory_function's
+        sync_wrapper) must also set _responses_api_pre_call_check, mirroring
+        the aresponses async path - otherwise the sync Responses API call
+        would silently skip context-window checks entirely.
+        """
+        with (
+            patch("litellm.responses", new=MagicMock(__name__="responses")) as mock_responses,
+            patch("litellm.token_counter", return_value=101),
+            patch(
+                "litellm.router.LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages",
+                wraps=LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages,
+            ) as mock_converter,
+        ):
+            router = _router_with_optional_max_input_tokens(max_input_tokens=100)
+
+            with pytest.raises(Exception) as exc_info:
+                router.responses(
+                    model="test-model",
+                    input="large input",
+                    instructions="You are a helpful assistant.",
+                )
+
+            assert "Context Window" in str(exc_info.value) or "context window" in str(exc_info.value).lower()
+            mock_converter.assert_called_once()
+            mock_responses.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
+++ b/tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py
@@ -1,0 +1,123 @@
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from litellm import Router
+from litellm.responses.litellm_completion_transformation.transformation import (
+    LiteLLMCompletionResponsesConfig,
+)
+
+
+def _router_with_optional_max_input_tokens(max_input_tokens: Optional[int]) -> Router:
+    model_info: dict[str, Any] = {"id": "deployment-1"}
+    if max_input_tokens is not None:
+        model_info["max_input_tokens"] = max_input_tokens
+
+    return Router(
+        model_list=[
+            {
+                "model_name": "test-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4",
+                    "api_key": "sk-test",
+                },
+                "model_info": model_info,
+            },
+        ],
+        enable_pre_call_checks=True,
+    )
+
+
+class TestResponsesAPIPreCallCheckIntegration:
+    """
+    The Responses API passes `input` instead of `messages`. Without translating
+    `input` into `messages`, `_pre_call_checks` silently skips context window
+    checks for every Responses API call. These tests cover that translation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_responses_api_rejected_by_max_input_tokens(self):
+        """
+        When a Responses API request exceeds max_input_tokens, the router
+        should raise ContextWindowExceededError before sending the request.
+        """
+        with (
+            patch("litellm.aresponses", new_callable=AsyncMock) as mock_aresponses,
+            patch("litellm.token_counter", return_value=101),
+            patch(
+                "litellm.router.LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages",
+                wraps=LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages,
+            ) as mock_converter,
+        ):
+            router = _router_with_optional_max_input_tokens(max_input_tokens=100)
+
+            with pytest.raises(Exception) as exc_info:
+                await router.aresponses(
+                    model="test-model",
+                    input="large input",
+                    instructions="You are a helpful assistant.",
+                )
+
+            assert "Context Window" in str(exc_info.value) or "context window" in str(exc_info.value).lower()
+            mock_converter.assert_called_once()
+            mock_aresponses.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_responses_api_skips_conversion_without_max_input_tokens(self):
+        """
+        If no deployment has max_input_tokens, the router should not convert
+        Responses API input just for pre-call checks.
+        """
+        with (
+            patch("litellm.aresponses", new_callable=AsyncMock) as mock_aresponses,
+            patch(
+                "litellm.router.LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages"
+            ) as mock_converter,
+            patch("litellm.token_counter") as mock_token_counter,
+        ):
+            expected_response = {"id": "resp-test"}
+            mock_aresponses.return_value = expected_response
+            router = _router_with_optional_max_input_tokens(max_input_tokens=None)
+
+            result = await router.aresponses(
+                model="test-model",
+                input="short input",
+            )
+
+            assert result == expected_response
+            mock_converter.assert_not_called()
+            mock_token_counter.assert_not_called()
+            mock_aresponses.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_responses_api_allowed_within_max_input_tokens(self):
+        """
+        When a Responses API request is within max_input_tokens, the router
+        should proceed to call the original function.
+        """
+        with (
+            patch("litellm.aresponses", new_callable=AsyncMock) as mock_aresponses,
+            patch("litellm.token_counter", return_value=50),
+            patch(
+                "litellm.router.LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages",
+                wraps=LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages,
+            ) as mock_converter,
+        ):
+            expected_response = {"id": "resp-test"}
+            mock_aresponses.return_value = expected_response
+            router = _router_with_optional_max_input_tokens(max_input_tokens=100)
+
+            result = await router.aresponses(
+                model="test-model",
+                input="short input",
+                instructions="You are a helpful assistant.",
+            )
+
+            assert result == expected_response
+            mock_converter.assert_called_once()
+            mock_aresponses.assert_called_once()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
`Router._pre_call_checks()` runs on every request and read the RPM cache on every call, even when nothing in the model group set `rpm`. That check now short-circuits when no deployment in the group configures `rpm`.

Separately, context-window checks were silently skipped for every Responses API call, because the check only looked at `kwargs["messages"]` and Responses API calls pass `input` instead. Added `_get_messages_for_pre_call_check` to convert `input` to `messages` for that check, gated behind `_model_group_has_max_input_tokens` (which resolves the limit the same way `_pre_call_checks` itself does, via `get_router_model_info`, since `max_input_tokens` is commonly derived from litellm's model cost map rather than a static override) so the conversion only happens when it can actually affect routing.

**Known limitation (pre-existing, not introduced by this PR):** the context-window check only sees the current turn's `input`/`instructions`, not prior-session history that `litellm.responses()` appends later via `previous_response_id` (see `async_responses_api_session_handler`). A request whose current input is small could still be routed to a deployment whose limit the accumulated session history exceeds. Before this PR, the check was skipped entirely for every Responses API call regardless of session state, so this is a narrowing rather than a regression - but making it session-aware would need the Router to look up prior-response history before picking a deployment, which is a larger change than this PR's scope. Worth a follow-up.

## Relevant issues
https://github.com/BerriAI/litellm/issues/33686


## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is an internal router optimization/bugfix, not a user-facing feature or UI change, so there's no e2e screenshot/recording to show. Verified via targeted pytest:
- `tests/router_unit_tests/test_pre_call_checks_optimization.py` (13 tests, including `test_zero_tokenization_or_rpm_cache_calls_when_nothing_configured` and `test_no_rpm_cache_lookup_when_no_deployment_has_rpm`, which assert zero calls to `litellm.token_counter()` and the RPM cache read when unconfigured)
- `tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py` (4 tests covering the `input`→`messages` conversion path for both the async `aresponses` and sync `responses` entrypoints)
- `tests/router_unit_tests/test_router_pre_call_check_helpers.py` (7 tests calling the two new helpers directly, including a regression test that the internal `_responses_api_pre_call_check` sentinel is always popped from kwargs)
- The pre-existing `tests/test_litellm/test_router.py::test_pre_call_checks_counts_once_and_filters_on_max_input_tokens` (which monkeypatches `get_router_model_info`) still passes, confirming context-window checks are honored regardless of whether `max_input_tokens` comes from a static override or the model cost map
- Full regression: `tests/router_unit_tests/` (287 passed, 1 pre-existing unrelated failure needing `COHERE_API_KEY`) and `tests/test_litellm/router_utils/` (183 passed)

## Type

🐛 Bug Fix

## Changes

- `litellm/router.py`: added `_model_group_has_max_input_tokens()` and `_get_messages_for_pre_call_check()`; gated the RPM cache read in `_pre_call_checks()` behind whether any deployment in the group configures `rpm`.
- `tests/router_unit_tests/test_pre_call_checks_optimization.py`: added `TestPreCallChecksLazyGuarding`.
- `tests/test_litellm/router_utils/pre_call_checks/test_responses_api_context_window_check.py`: new file covering the Responses API context-window-check path.
- `tests/router_unit_tests/test_router_pre_call_check_helpers.py`: new file, directly exercises the two new helper functions (added so the repo's `router_code_coverage.py` filename-based check picks them up).
