### PR TITLE
fix(responses): propagate cache_control through responses->chat completion bridge

### DIFF
--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -897,14 +897,21 @@ class LiteLLMCompletionResponsesConfig:
             # Since guardrails skip None content anyway, we return empty list to exclude it from structured messages
             if content is None:
                 return []
-            return [
-                GenericChatCompletionMessage(
-                    role=input_item.get("role") or "user",
-                    content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
-                        content
-                    ),
-                )
-            ]
+            msg = GenericChatCompletionMessage(
+                role=input_item.get("role") or "user",
+                content=LiteLLMCompletionResponsesConfig._transform_responses_api_content_to_chat_completion_content(
+                    content
+                ),
+            )
+            if input_item.get("cache_control"):
+                msg["cache_control"] = input_item.get("cache_control")
+                # Also propagate to the last content element for providers
+                # that read cache_control from content blocks (Anthropic, Bedrock)
+                if isinstance(msg["content"], list) and len(msg["content"]) > 0:
+                    last_element = msg["content"][-1]
+                    if isinstance(last_element, dict):
+                        last_element["cache_control"] = input_item["cache_control"]
+            return [msg]
 
     @staticmethod
     def _is_input_item_tool_call_output(input_item: Any) -> bool:
@@ -1017,6 +1024,9 @@ class LiteLLMCompletionResponsesConfig:
             content=_normalize_function_call_output_to_tool_content(tool_call_output.get("output")),
             tool_call_id=str(call_id),
         )
+        output_cache_control = tool_call_output.get("cache_control")
+        if output_cache_control:
+            tool_output_message["cache_control"] = output_cache_control
 
         _tool_use_definition = TOOL_CALLS_CACHE.get_cache(
             key=tool_call_output.get("call_id") or "",
@@ -1107,6 +1117,9 @@ class LiteLLMCompletionResponsesConfig:
             role="assistant",
             content=None,  # Function calls don't have content
         )
+        function_call_cache_control = function_call.get("cache_control")
+        if function_call_cache_control:
+            chat_completion_response_message["cache_control"] = function_call_cache_control
 
         return [chat_completion_response_message]
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -906,10 +906,11 @@ class LiteLLMCompletionResponsesConfig:
             if input_item.get("cache_control"):
                 msg["cache_control"] = input_item.get("cache_control")
                 # Also propagate to the last content element for providers
-                # that read cache_control from content blocks (Anthropic, Bedrock)
+                # that read cache_control from content blocks (Anthropic, Bedrock),
+                # unless that block already carries its own cache_control.
                 if isinstance(msg["content"], list) and len(msg["content"]) > 0:
                     last_element = msg["content"][-1]
-                    if isinstance(last_element, dict):
+                    if isinstance(last_element, dict) and "cache_control" not in last_element:
                         last_element["cache_control"] = input_item["cache_control"]
             return [msg]
 

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -903,15 +903,14 @@ class LiteLLMCompletionResponsesConfig:
                     content
                 ),
             )
-            if input_item.get("cache_control"):
-                msg["cache_control"] = input_item.get("cache_control")
-                # Also propagate to the last content element for providers
-                # that read cache_control from content blocks (Anthropic, Bedrock),
-                # unless that block already carries its own cache_control.
+            input_item_cache_control = input_item.get("cache_control")
+            if input_item_cache_control:
+                msg["cache_control"] = input_item_cache_control
+                # Also set on the last content block for providers (Anthropic, Bedrock) that read cache_control there.
                 if isinstance(msg["content"], list) and len(msg["content"]) > 0:
                     last_element = msg["content"][-1]
                     if isinstance(last_element, dict) and "cache_control" not in last_element:
-                        last_element["cache_control"] = input_item["cache_control"]
+                        last_element["cache_control"] = input_item_cache_control
             return [msg]
 
     @staticmethod

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -759,6 +759,7 @@ class ChatCompletionToolMessage(TypedDict):
     role: Literal["tool"]
     content: Union[str, Iterable[ChatCompletionTextObject]]
     tool_call_id: str
+    cache_control: NotRequired[ChatCompletionCachedContent]
 
 
 class ChatCompletionFunctionMessage(TypedDict):
@@ -791,6 +792,7 @@ class ChatCompletionDeveloperMessage(OpenAIChatCompletionDeveloperMessage, total
 class GenericChatCompletionMessage(TypedDict, total=False):
     role: Required[str]
     content: Required[Union[str, List]]
+    cache_control: ChatCompletionCachedContent
 
 
 ValidUserMessageContentTypes = [
@@ -977,6 +979,7 @@ class ChatCompletionResponseMessage(TypedDict, total=False):
     provider_specific_fields: Optional[dict]
     reasoning_content: Optional[str]
     thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]]
+    cache_control: ChatCompletionCachedContent
 
 
 class ChatCompletionUsageBlock(TypedDict, total=False):

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2811,3 +2811,135 @@ def test_function_call_tool_id_falls_back_to_unique_id_for_degenerate_call_id():
         id="fc_2", call_id="call_tokyo", name="get_weather", arguments="{}"
     )
     assert convert(openai)["id"] == "call_tokyo"
+
+
+class TestCacheControlPreservationOnMessages:
+    """Tests that cache_control is preserved when transforming Responses API input items
+    to Chat Completion messages. This is critical for providers like Bedrock/Anthropic
+    that use cache_control for prompt caching."""
+
+    def test_cache_control_on_user_message(self):
+        """cache_control on a user message should be passed through to GenericChatCompletionMessage"""
+        input_item = {
+            "role": "user",
+            "content": "Hello, world!",
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "user"
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_on_assistant_message(self):
+        """cache_control on an assistant message should be passed through"""
+        input_item = {
+            "role": "assistant",
+            "content": "I can help with that.",
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "assistant"
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+
+    def test_no_cache_control_when_absent(self):
+        """Messages without cache_control should not have the field set"""
+        input_item = {
+            "role": "user",
+            "content": "Hello",
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert "cache_control" not in msg
+
+    def test_cache_control_on_function_call_output(self):
+        """cache_control on a function_call_output should be passed through to tool message"""
+        TOOL_CALLS_CACHE.set_cache(
+            key="call_123",
+            value={
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "NYC"}'},
+            },
+        )
+
+        input_item = {
+            "type": "function_call_output",
+            "call_id": "call_123",
+            "output": '{"temp": 72}',
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        # Should have assistant message + tool message
+        assert len(result) == 2
+        tool_msg = result[1]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg.get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_on_function_call(self):
+        """cache_control on a function_call input should be passed through to assistant message"""
+        input_item = {
+            "type": "function_call",
+            "call_id": "call_456",
+            "name": "get_weather",
+            "arguments": '{"city": "NYC"}',
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg["role"] == "assistant"
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_preserved_in_full_input_transform(self):
+        """cache_control should survive the full transform_responses_api_input_to_messages path"""
+        input_items = [
+            {
+                "role": "user",
+                "content": "What is the weather?",
+            },
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "cache_control": {"type": "ephemeral"},
+            },
+            {
+                "role": "user",
+                "content": "Thanks!",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+
+        result = LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages(
+            input=input_items,
+            responses_api_request={},
+        )
+
+        # 3 messages, no system
+        assert len(result) == 3
+        assert "cache_control" not in result[0]
+        assert result[1].get("cache_control") == {"type": "ephemeral"}
+        assert result[2].get("cache_control") == {"type": "ephemeral"}

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py
@@ -2943,3 +2943,56 @@ class TestCacheControlPreservationOnMessages:
         assert "cache_control" not in result[0]
         assert result[1].get("cache_control") == {"type": "ephemeral"}
         assert result[2].get("cache_control") == {"type": "ephemeral"}
+
+    def test_cache_control_propagated_to_last_content_block_for_list_content(self):
+        """
+        For Anthropic/Bedrock, cache_control must also be set on the last
+        content block (not just the message level) to actually activate
+        prompt caching when content is a list of blocks.
+        """
+        input_item = {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "first block"},
+                {"type": "input_text", "text": "last block"},
+            ],
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+        assert isinstance(msg["content"], list)
+        assert "cache_control" not in msg["content"][0]
+        assert msg["content"][-1]["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_control_does_not_overwrite_existing_block_level_cache_control(self):
+        """
+        If the last content block already carries its own cache_control
+        (preserved by _transform_responses_api_content_to_chat_completion_content),
+        the message-level cache_control must not silently overwrite it.
+        """
+        input_item = {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "last block",
+                    "cache_control": {"type": "ephemeral", "ttl": "1h"},
+                },
+            ],
+            "cache_control": {"type": "ephemeral"},
+        }
+
+        result = LiteLLMCompletionResponsesConfig._transform_responses_api_input_item_to_chat_completion_message(
+            input_item=input_item
+        )
+
+        assert len(result) == 1
+        msg = result[0]
+        assert msg.get("cache_control") == {"type": "ephemeral"}
+        assert msg["content"][-1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22245,6 +22245,7 @@ export interface components {
         };
         /** ChatCompletionToolMessage */
         ChatCompletionToolMessage: {
+            cache_control?: components["schemas"]["ChatCompletionCachedContent"];
             /** Content */
             content: string | components["schemas"]["ChatCompletionTextObject"][];
             /**


### PR DESCRIPTION
When a Responses API request is routed through the `litellm_completion` transform (used for Bedrock/Anthropic among others), the `cache_control` set on an input item was dropped while building the corresponding chat completion message. That silently breaks prompt caching for any multi-turn or agentic session that goes through this bridge.

Fixed in the three functions that build messages from Responses API input items: plain user/assistant messages, tool call outputs, and function calls. For user/assistant messages, `cache_control` is also mirrored onto the last content block, since Anthropic/Bedrock read the cache breakpoint at the content-block level - unless that block already carries its own `cache_control`, in which case it's left untouched rather than silently overwritten.

## Relevant issues
https://github.com/BerriAI/litellm/issues/33687


## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is an internal transform-layer bugfix, not a user-facing feature or UI change, so there's no e2e screenshot/recording to show. Verified via targeted pytest: added `TestCacheControlPreservationOnMessages` (8 tests, including list-content block propagation and the no-overwrite-existing-block-cache_control case) to `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`, appended after the existing `TestCacheControlPreservation` class (which covers a different, content-block-level code path and was left untouched). 92/92 tests pass in that file.

## Type

🐛 Bug Fix

## Changes

- `litellm/responses/litellm_completion_transformation/transformation.py`: propagate `cache_control` in `_transform_responses_api_input_item_to_chat_completion_message`, `_transform_responses_api_tool_call_output_to_chat_completion_message`, and `_transform_responses_api_function_call_to_chat_completion_message`.
- `litellm/types/llms/openai.py`: added `cache_control` to the `ChatCompletionToolMessage` and `ChatCompletionResponseMessage` TypedDicts (required for the new assignments to type-check).
- `tests/test_litellm/responses/litellm_completion_transformation/test_litellm_completion_responses.py`: added `TestCacheControlPreservationOnMessages`.
- `ui/litellm-dashboard/src/lib/http/schema.d.ts`: regenerated via `npm run gen:api` to pick up the new `cache_control` field on `ChatCompletionToolMessage` (1-line diff).
