### PR TITLE
test: emit e2e coverage metrics for loki

### DIFF
--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -63,7 +63,7 @@ The harness is fully typed and new code must not add `Any` or widen the basedpyr
 
 The set of tests we want is a registry checked into this repo, one row per behavior; that file is the definition of done and the denominator. Each e2e test declares what it covers with `@pytest.mark.covers("...")`, and a small collector diffs the registry against the tests and ships coverage to the existing Grafana. No Allure, no new dependencies
 
-Coverage is organized as module > feature > test. Dashboard modules are Core LLMs, Non-Core LLMs, MCPs, Management/UI, Reliability & Performance, Logging & Guardrails, and Other. A feature is either an endpoint (`/chat/completions`) or a behavior (fallbacks, rate limits; config-driven, with no route of its own). A cell reads like `llm.chat_completions.bedrock_converse.tool_use.stream.works`
+Coverage is organized as module > feature > test. Dashboard modules are `Core LLMs`, `Non-Core LLMs`, `MCPs`, `Management/UI`, `Reliability & Performance`, `Logging & Guardrails`, and `Other`. The Loki stdout formatter maps those display modules to log-safe labels (`core_llms`, `non_core_llms`, `mcp`, `management_ui`, `reliability_performance`, `logging_guardrails`, and `other`) without changing JSON or Prometheus labels. A feature is either an endpoint (`/chat/completions`) or a behavior (fallbacks, rate limits; config-driven, with no route of its own). A cell reads like `llm.chat_completions.bedrock_converse.tool_use.stream.works`
 
 The metric is coverage: the share of registry rows that have a passing covering test, reported to Grafana per module so a gap surfaces as an uncovered row rather than a silent absence
 
@@ -71,7 +71,7 @@ Tests do not declare a dashboard module directly. They only declare the registry
 
 ### Naming grammar per module
 
-LLMs - endpoint features (subject = the route), seeded from the Claude Code compat matrix. `chat_completions`, `messages`, and `responses` are Core LLMs. Other LLM endpoints, including `batches` and `realtime`, roll up as Non-Core LLMs.
+LLMs - endpoint features (subject = the route), seeded from the Claude Code compat matrix. `chat_completions`, `messages`, and `responses` roll up to `Core LLMs`. Other LLM endpoints, including `batches` and `realtime`, roll up to `Non-Core LLMs`.
 
 ```
 llm.<endpoint>.<route>.<capability>.<streaming>.<assertion>

--- a/tests/e2e/coverage_registry/README.md
+++ b/tests/e2e/coverage_registry/README.md
@@ -9,18 +9,18 @@ note; the naming grammar lives in `tests/e2e/CLAUDE.md`.
 
 A **cell** is one customer-noticeable behavior a single e2e test can assert pass/fail
 on, for example `llm.chat_completions.bedrock_converse.tool_use.stream.works`. Cells are
-grouped `module > feature > test`, with LLM cells split into Core LLMs and Non-Core
-LLMs for dashboarding. Each cell carries a tier (P0/P1/P2), a source, and a
+grouped `module > feature > test`, with LLM cells split into `Core LLMs` and
+`Non-Core LLMs` for dashboarding. Each cell carries a tier (P0/P1/P2), a source, and a
 `fail_before_fix` flag.
 
 The rows live in per-prefix YAML files (`llm_*.yaml`, `mgmt.yaml`, `mcp.yaml`,
 `reliability.yaml`, `logging.yaml`, `guardrail.yaml`, `other.yaml`) and validate against
 the discriminated union in `schema.py`, so an LLM row cannot carry a guardrail field and
 vice versa. `llm` rows with `subject_endpoint` of `chat_completions`, `messages`, or
-`responses` roll up to "Core LLMs"; all other LLM endpoints roll up to "Non-Core
-LLMs". LLM endpoint, route, and capability values are typed in `schema.py`, so new
-taxonomy values require an explicit schema change. `logging` and `guardrail` are two
-id-prefixes that roll up into the single "Logging & Guardrails" dashboard module.
+`responses` roll up to `Core LLMs`; all other LLM endpoints roll up to `Non-Core LLMs`.
+LLM endpoint, route, and capability values are typed in `schema.py`, so new taxonomy
+values require an explicit schema change. `logging` and `guardrail` are two id-prefixes
+that roll up into the single `Logging & Guardrails` dashboard module.
 
 A test declares what it covers with a marker:
 
@@ -40,8 +40,17 @@ proxy. Whether a covered cell currently passes or fails is a separate, live conc
 cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector
 ```
 
-Use `--format prometheus` or `--format json` for CI jobs that publish coverage to
-Grafana.
+Use `--format loki` after the e2e pytest run in the same Kubernetes job/pod to print
+structured stdout lines for Loki:
+
+```
+cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector --format loki --strict
+```
+
+This emits exactly one `COVERAGE_TOTAL` line and one `COVERAGE_MODULE` line per module
+in `MODULE_ORDER`, in that order. Loki uses log-safe `module=` labels from
+`LOKI_MODULE_LABELS` (`core_llms`, `management_ui`, etc.) so existing JSON and
+Prometheus consumers keep their human-readable module names unchanged.
 
 The headline is overall coverage. The collector also lists markers that point at ids
 not in the registry, so a typo or an unenumerated behavior surfaces instead of being

--- a/tests/e2e/coverage_registry/collector.py
+++ b/tests/e2e/coverage_registry/collector.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 
 from .registry import load_registry
-from .schema import MODULE_ORDER, Cell, Tier, dashboard_module
+from .schema import MODULE_ORDER, Cell, Tier, dashboard_module, loki_module_label
 
 E2E_DIR = Path(__file__).resolve().parent.parent
 
@@ -239,13 +239,31 @@ def render_prometheus(report: CoverageReport) -> str:
     return "\n".join(lines)
 
 
+def render_loki(report: CoverageReport) -> str:
+    lines = [
+        (
+            f"COVERAGE_TOTAL percent={report.coverage_percent:.1f} "
+            f"covered={report.covered} total={report.total}"
+        )
+    ]
+    lines.extend(
+        (
+            f"COVERAGE_MODULE module={loki_module_label(module.module)} "
+            f"percent={module.coverage_percent:.1f} "
+            f"covered={module.covered} total={module.total}"
+        )
+        for module in report.modules
+    )
+    return "\n".join(lines)
+
+
 def main() -> int:
     parser = ArgumentParser()
     parser.add_argument(
         "--format",
-        choices=("text", "json", "prometheus"),
+        choices=("text", "json", "prometheus", "loki"),
         default="text",
-        help="Output format. Use prometheus or json for Grafana ingestion jobs.",
+        help="Output format. Use loki for structured stdout lines in the e2e job.",
     )
     parser.add_argument(
         "--strict",
@@ -265,9 +283,8 @@ def main() -> int:
         "text": render,
         "json": render_json,
         "prometheus": render_prometheus,
-    }[
-        args.format
-    ](report)
+        "loki": render_loki,
+    }[args.format](report)
     print(output)  # noqa: T201  # CLI entrypoint output
     if args.strict and report.orphan_markers:
         return 1

--- a/tests/e2e/coverage_registry/schema.py
+++ b/tests/e2e/coverage_registry/schema.py
@@ -157,6 +157,16 @@ MODULE_ORDER: tuple[str, ...] = (
     "Other",
 )
 
+LOKI_MODULE_LABELS: dict[str, str] = {
+    "Core LLMs": "core_llms",
+    "Non-Core LLMs": "non_core_llms",
+    "MCPs": "mcp",
+    "Management/UI": "management_ui",
+    "Reliability & Performance": "reliability_performance",
+    "Logging & Guardrails": "logging_guardrails",
+    "Other": "other",
+}
+
 
 def dashboard_module(cell: Cell) -> str:
     """Return the Grafana/reporting module for a registry cell."""
@@ -165,3 +175,8 @@ def dashboard_module(cell: Cell) -> str:
             return "Core LLMs"
         return "Non-Core LLMs"
     return PREFIX_ROLLUP[cell.module]
+
+
+def loki_module_label(module: str) -> str:
+    """Return the log-safe Loki label for a dashboard module."""
+    return LOKI_MODULE_LABELS[module]

--- a/tests/e2e/coverage_registry/test_collector.py
+++ b/tests/e2e/coverage_registry/test_collector.py
@@ -15,6 +15,7 @@ from coverage_registry.collector import (
     compute_coverage,
     render,
     render_json,
+    render_loki,
     render_prometheus,
 )
 from coverage_registry.registry import load_registry
@@ -24,6 +25,7 @@ from coverage_registry.schema import (
     LlmEndpoint,
     LoggingCell,
     Tier,
+    loki_module_label,
 )
 
 
@@ -147,6 +149,30 @@ def test_prometheus_render_exposes_module_coverage_timeseries() -> None:
     assert 'litellm_e2e_coverage_percent{module="Core LLMs"} 100.000000' in metrics
     assert 'litellm_e2e_coverage_percent{module="Non-Core LLMs"} 0.000000' in metrics
     assert "litellm_e2e_coverage_orphan_markers 0" in metrics
+
+
+def test_loki_render_exposes_exact_stdout_lines_for_loki() -> None:
+    report = compute_coverage(
+        (_llm("llm.chat", Tier.P0), _llm("llm.batches", Tier.P0, "batches")),
+        frozenset({"llm.chat"}),
+    )
+
+    lines = render_loki(report).splitlines()
+
+    assert len(lines) == 1 + len(report.modules)
+    assert lines[0] == "COVERAGE_TOTAL percent=50.0 covered=1 total=2"
+    assert (
+        lines[1] == "COVERAGE_MODULE module=core_llms percent=100.0 covered=1 total=1"
+    )
+    assert (
+        lines[2] == "COVERAGE_MODULE module=non_core_llms percent=0.0 covered=0 total=1"
+    )
+    assert [line.split("module=", 1)[1].split(" ", 1)[0] for line in lines[1:]] == [
+        loki_module_label(module.module) for module in report.modules
+    ]
+    assert all(
+        " " not in line.split("module=", 1)[1].split(" ", 1)[0] for line in lines[1:]
+    )
 
 
 def test_real_registry_loads_and_ids_are_unique() -> None:


### PR DESCRIPTION
## What improves
- Adds `coverage_registry.collector --format loki` for structured stdout coverage lines.
- Emits exactly one `COVERAGE_TOTAL` line and one `COVERAGE_MODULE` line per module, in registry order.
- Uses Loki-only log-safe labels (`core_llms`, `management_ui`, etc.) while keeping existing JSON and Prometheus module labels unchanged.
- Documents the post-pytest command for the Kubernetes e2e job.

## Example output
```text
COVERAGE_TOTAL percent=4.6 covered=13 total=284
COVERAGE_MODULE module=core_llms percent=9.4 covered=5 total=53
```

## Checks
- `PYTHONPATH=tests/e2e uv run pytest tests/e2e/coverage_registry/test_collector.py -q`
- `PYTHONPATH=. uv run python -m coverage_registry.collector --format loki --strict`
- `uv run ruff check --target-version py312 tests/e2e/coverage_registry`
- `uv run black tests/e2e/coverage_registry`