### PR TITLE
ci: add OSS daily branch workflow

### DIFF
--- a/.github/workflows/create_daily_oss_branch.yml
+++ b/.github/workflows/create_daily_oss_branch.yml
@@ -1,0 +1,61 @@
+name: Create Daily OSS Branch
+
+on:
+  schedule:
+    - cron: "0 16 * * 1-5" # 9am PT during daylight saving time, weekdays.
+  workflow_dispatch:
+    inputs:
+      date:
+        description: "Branch date in YYYY_MM_DD format. Defaults to today's UTC date."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-oss-branch:
+    if: github.repository == 'BerriAI/litellm'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create dated OSS branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED_DATE: ${{ inputs.date }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "${REQUESTED_DATE}" ]; then
+            if ! echo "${REQUESTED_DATE}" | grep -Eq '^[0-9]{4}_[0-9]{2}_[0-9]{2}$'; then
+              echo "::error::date must use YYYY_MM_DD format, got '${REQUESTED_DATE}'"
+              exit 1
+            fi
+            BRANCH_DATE="${REQUESTED_DATE}"
+          else
+            BRANCH_DATE="$(date -u +'%Y_%m_%d')"
+          fi
+
+          BRANCH_NAME="litellm_oss_daily_${BRANCH_DATE}"
+          echo "Creating branch: ${BRANCH_NAME}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin main "${BRANCH_NAME}" || true
+
+          if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}"; then
+            echo "Branch ${BRANCH_NAME} already exists. Skipping creation."
+            exit 0
+          fi
+
+          git checkout -b "${BRANCH_NAME}" origin/main
+          git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${BRANCH_NAME}"
+          echo "Successfully created and pushed branch: ${BRANCH_NAME}"

--- a/.github/workflows/oss_daily_guardrails.yml
+++ b/.github/workflows/oss_daily_guardrails.yml
@@ -1,0 +1,109 @@
+name: OSS Daily Guardrails
+
+on:
+  push:
+    branches:
+      - "litellm_oss_daily_20*"
+  pull_request:
+    branches:
+      - "litellm_oss_daily_20*"
+      - litellm_internal_staging
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sensitive-file-guard:
+    name: Block sensitive OSS daily changes
+    if: startsWith(github.ref_name, 'litellm_oss_daily_20') || startsWith(github.head_ref, 'litellm_oss_daily_20') || startsWith(github.base_ref, 'litellm_oss_daily_20')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Check for sensitive file changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF_NAME: ${{ github.base_ref }}
+          HEAD_REF_NAME: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "${EVENT_NAME}" = "pull_request" ] && echo "${HEAD_REF_NAME}" | grep -Eq '^litellm_oss_daily_20[0-9]{2}_[0-9]{2}_[0-9]{2}$'; then
+            # Final daily OSS branch PR into staging: review only the OSS delta
+            # accumulated on top of main, not unrelated main/staging drift.
+            BASE_REF="origin/main"
+            git fetch origin main
+          elif [ "${EVENT_NAME}" = "pull_request" ]; then
+            # PR targeting the daily OSS branch: review the incoming PR delta.
+            BASE_REF="origin/${BASE_REF_NAME}"
+            git fetch origin "${BASE_REF_NAME}"
+          else
+            # Push to the daily OSS branch: review the accumulated OSS delta.
+            BASE_REF="origin/main"
+            git fetch origin main
+          fi
+
+          CHANGED_FILES="$(git diff --name-only "${BASE_REF}...HEAD")"
+
+          if [ -z "${CHANGED_FILES}" ]; then
+            echo "No changed files detected."
+            exit 0
+          fi
+
+          echo "Changed files:"
+          echo "${CHANGED_FILES}"
+
+          BLOCKED_FILES="$(
+            echo "${CHANGED_FILES}" | grep -E '(^\.github/workflows/|^\.github/actions/|^\.circleci/|^\.cursor/|^Dockerfile$|(^|/)Dockerfile$|^Makefile$|(^|/)Makefile$|(^|/)pyproject\.toml$|(^|/)uv\.lock$|(^|/)poetry\.lock$|(^|/)requirements[^/]*\.txt$|(^|/)package\.json$|(^|/)package-lock\.json$|(^|/)pnpm-lock\.yaml$|(^|/)yarn\.lock$|(^|/)tsconfig[^/]*\.json$|(^|/)(ruff|mypy|pytest|eslint|prettier|vitest|next|vite|jest)\.config\.)' || true
+          )"
+
+          if [ -n "${BLOCKED_FILES}" ]; then
+            echo "::error::OSS daily branch contains sensitive workflow, config, dependency, or lockfile changes. Split these into a separate internal/security-reviewed PR."
+            echo "${BLOCKED_FILES}"
+            exit 1
+          fi
+
+          echo "No sensitive OSS daily file changes detected."
+
+  oss-safe-checks:
+    name: Run OSS daily safe checks
+    if: startsWith(github.ref_name, 'litellm_oss_daily_20') || startsWith(github.head_ref, 'litellm_oss_daily_20') || startsWith(github.base_ref, 'litellm_oss_daily_20')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.10.9"
+
+      - name: Run secret scan test
+        run: |
+          uv run --frozen --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
+
+      - name: Run Ruff
+        run: |
+          uv sync --frozen
+          cd litellm
+          uv run --no-sync ruff check .

--- a/.github/workflows/oss_daily_guardrails.yml
+++ b/.github/workflows/oss_daily_guardrails.yml
@@ -17,65 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sensitive-file-guard:
-    name: Block sensitive OSS daily changes
-    if: startsWith(github.ref_name, 'litellm_oss_daily_20') || startsWith(github.head_ref, 'litellm_oss_daily_20') || startsWith(github.base_ref, 'litellm_oss_daily_20')
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          persist-credentials: false
-
-      - name: Check for sensitive file changes
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF_NAME: ${{ github.base_ref }}
-          HEAD_REF_NAME: ${{ github.head_ref }}
-        run: |
-          set -euo pipefail
-
-          if [ "${EVENT_NAME}" = "pull_request" ] && echo "${HEAD_REF_NAME}" | grep -Eq '^litellm_oss_daily_20[0-9]{2}_[0-9]{2}_[0-9]{2}$'; then
-            # Final daily OSS branch PR into staging: review only the OSS delta
-            # accumulated on top of main, not unrelated main/staging drift.
-            BASE_REF="origin/main"
-            git fetch origin main
-          elif [ "${EVENT_NAME}" = "pull_request" ]; then
-            # PR targeting the daily OSS branch: review the incoming PR delta.
-            BASE_REF="origin/${BASE_REF_NAME}"
-            git fetch origin "${BASE_REF_NAME}"
-          else
-            # Push to the daily OSS branch: review the accumulated OSS delta.
-            BASE_REF="origin/main"
-            git fetch origin main
-          fi
-
-          CHANGED_FILES="$(git diff --name-only "${BASE_REF}...HEAD")"
-
-          if [ -z "${CHANGED_FILES}" ]; then
-            echo "No changed files detected."
-            exit 0
-          fi
-
-          echo "Changed files:"
-          echo "${CHANGED_FILES}"
-
-          BLOCKED_FILES="$(
-            echo "${CHANGED_FILES}" | grep -E '(^\.github/workflows/|^\.github/actions/|^\.circleci/|^\.cursor/|^Dockerfile$|(^|/)Dockerfile$|^Makefile$|(^|/)Makefile$|(^|/)pyproject\.toml$|(^|/)uv\.lock$|(^|/)poetry\.lock$|(^|/)requirements[^/]*\.txt$|(^|/)package\.json$|(^|/)package-lock\.json$|(^|/)pnpm-lock\.yaml$|(^|/)yarn\.lock$|(^|/)tsconfig[^/]*\.json$|(^|/)(ruff|mypy|pytest|eslint|prettier|vitest|next|vite|jest)\.config\.)' || true
-          )"
-
-          if [ -n "${BLOCKED_FILES}" ]; then
-            echo "::error::OSS daily branch contains sensitive workflow, config, dependency, or lockfile changes. Split these into a separate internal/security-reviewed PR."
-            echo "${BLOCKED_FILES}"
-            exit 1
-          fi
-
-          echo "No sensitive OSS daily file changes detected."
-
   oss-safe-checks:
     name: Run OSS daily safe checks
     if: startsWith(github.ref_name, 'litellm_oss_daily_20') || startsWith(github.head_ref, 'litellm_oss_daily_20') || startsWith(github.base_ref, 'litellm_oss_daily_20')


### PR DESCRIPTION
## Relevant issues

Internal request: create a dated GitHub daily branch flow for OSS PR intake

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

YAML parse of both workflows on the updated branch:

```
$ .venv/bin/python -c "import yaml; [print('ok', f.split('/')[-1], list(yaml.safe_load(open(f))['jobs'])) for f in files]"
ok create_daily_oss_branch.yml ['create-oss-branch']
ok oss_daily_guardrails.yml ['oss-safe-checks']
```

## Type

🚄 Infrastructure

## Changes

`Create Daily OSS Branch` creates the dated `litellm_oss_daily_YYYY_MM_DD` branch from `main` on a weekday schedule or manual dispatch. `OSS Daily Guardrails` runs OSS-safe checks for those branches, namely the hardcoded-secret test and ruff. Path-based restrictions for the OSS daily branches are handled through repository settings rather than in this workflow, so the earlier in-workflow file check has been removed
