### PR TITLE
fix(prompt_management): select AnthropicCacheControlHook over generic prompt managers for prompt_id-less calls

### DIFF
--- a/litellm/integrations/prompt_management_base.py
+++ b/litellm/integrations/prompt_management_base.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from typing_extensions import TYPE_CHECKING, TypedDict
 
+from litellm._logging import verbose_logger
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.prompts.init_prompts import PromptSpec
 from litellm.types.utils import StandardCallbackDynamicParams
@@ -165,7 +166,15 @@ class PromptManagementBase(ABC):
         ignore_prompt_manager_optional_params: Optional[bool] = False,
     ) -> Tuple[str, List[AllMessageValues], dict]:
         if prompt_id is None:
-            raise ValueError("prompt_id is required for Prompt Management Base class")
+            # Prompt-management hooks can be triggered by dynamic params (e.g.
+            # `cache_control_injection_points`) without a prompt_id; a prompt-id-based
+            # integration has nothing to compile then, so skip instead of raising.
+            # See https://github.com/BerriAI/litellm/issues/31887
+            verbose_logger.debug(
+                "%s: no prompt_id provided, skipping prompt management",
+                self.integration_name,
+            )
+            return model, messages, non_default_params
         if not self.should_run_prompt_management(
             prompt_id=prompt_id,
             prompt_spec=prompt_spec,

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -843,6 +843,19 @@ class Logging(LiteLLMLoggingBaseClass):
             if auto_detected_logger is not None:
                 return auto_detected_logger
 
+        # Without a prompt_id, a call that reaches here was triggered by a dynamic param
+        # like `cache_control_injection_points` — the matching hook must be checked before
+        # the generic fallback below, which would select a prompt-management logger that
+        # requires a prompt_id (and raise) while never applying the injection points.
+        # See https://github.com/BerriAI/litellm/issues/31887
+        if prompt_id is None:
+            if (
+                anthropic_cache_control_logger
+                := AnthropicCacheControlHook.get_custom_logger_for_anthropic_cache_control_hook(non_default_params)
+            ):
+                self.model_call_details["prompt_integration"] = anthropic_cache_control_logger.__class__.__name__
+                return anthropic_cache_control_logger
+
         # Then check for any registered CustomPromptManagement loggers (fallback)
         prompt_management_loggers = litellm.logging_callback_manager.get_custom_loggers_for_type(
             callback_type=CustomPromptManagement

--- a/tests/test_litellm/litellm_core_utils/test_prompt_management_logger_selection.py
+++ b/tests/test_litellm/litellm_core_utils/test_prompt_management_logger_selection.py
@@ -1,0 +1,142 @@
+"""
+Regression tests for https://github.com/BerriAI/litellm/issues/31887
+
+Toggling `cache_control_injection_points` (Cache Control Injection Points in the
+proxy UI) crashed every request with
+`ValueError: prompt_id is required for Prompt Management Base class` whenever a
+prompt-id-based prompt management logger was registered: the generic
+CustomPromptManagement fallback in
+`Logging.get_custom_logger_for_prompt_management` was checked before the
+AnthropicCacheControlHook, so the wrong logger handled the (prompt_id-less)
+cache-control call and raised — and the injection points were never applied.
+"""
+
+import os
+import sys
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
+
+import litellm
+from litellm.integrations.anthropic_cache_control_hook import AnthropicCacheControlHook
+from litellm.integrations.custom_prompt_management import CustomPromptManagement
+from litellm.integrations.prompt_management_base import PromptManagementBase
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+
+
+class _PromptIdRequiringPromptManager(CustomPromptManagement):
+    """Mimics prompt managers (dotprompt, arize, Langfuse, ...) that require a prompt_id.
+
+    Reuses `PromptManagementBase.get_chat_completion_prompt`, which is the code
+    path that raised `ValueError` when selected for a prompt_id-less call.
+    """
+
+    get_chat_completion_prompt = PromptManagementBase.get_chat_completion_prompt
+
+    @property
+    def integration_name(self) -> str:
+        return "prompt-id-requiring-prompt-manager"
+
+    def _compile_prompt_helper(self, *args, **kwargs):
+        raise NotImplementedError("should never be reached in these tests")
+
+
+@pytest.fixture
+def logging_obj():
+    return LitellmLogging(
+        model="anthropic/claude-sonnet-4-5",
+        messages=[{"role": "user", "content": "Hey"}],
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="12345",
+        function_id="1245",
+    )
+
+
+@pytest.fixture
+def registered_prompt_manager():
+    """Register a prompt-id-requiring prompt manager and restore global state after."""
+    saved_callbacks = list(litellm.callbacks)
+    prompt_manager = _PromptIdRequiringPromptManager()
+    litellm.logging_callback_manager.add_litellm_callback(prompt_manager)
+    try:
+        yield prompt_manager
+    finally:
+        litellm.callbacks = saved_callbacks
+
+
+INJECTION_POINTS = [{"location": "message", "role": "user", "index": None, "control": None}]
+
+
+def test_cache_control_hook_selected_over_prompt_id_requiring_manager(logging_obj, registered_prompt_manager):
+    """Without a prompt_id, a cache-control-triggered call must select the hook,
+    not the registered prompt-id-based manager."""
+    custom_logger = logging_obj.get_custom_logger_for_prompt_management(
+        model="anthropic/claude-sonnet-4-5",
+        non_default_params={"cache_control_injection_points": INJECTION_POINTS},
+        prompt_id=None,
+        dynamic_callback_params={},
+    )
+
+    assert isinstance(custom_logger, AnthropicCacheControlHook)
+
+
+def test_cache_control_injection_applied_when_prompt_manager_registered(logging_obj, registered_prompt_manager):
+    """The full prompt path must not raise AND must actually apply the injection points.
+
+    A guard that only skips the wrongly-selected prompt manager would pass the
+    no-crash half of this test but leave the messages without cache_control.
+    """
+    messages = [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+
+    model, result_messages, non_default_params = logging_obj.get_chat_completion_prompt(
+        model="anthropic/claude-sonnet-4-5",
+        messages=messages,
+        non_default_params={"cache_control_injection_points": INJECTION_POINTS},
+        prompt_variables=None,
+        prompt_id=None,
+    )
+
+    assert model == "anthropic/claude-sonnet-4-5"
+    user_message = result_messages[0]
+    assert any(isinstance(block, dict) and block.get("cache_control") for block in user_message["content"]), (
+        f"cache_control was not injected: {user_message}"
+    )
+    # the hook consumes the message-level injection points
+    assert not non_default_params.get("cache_control_injection_points")
+
+
+def test_prompt_id_flow_still_selects_registered_prompt_manager(logging_obj, registered_prompt_manager):
+    """Calls that carry a prompt_id keep the existing selection behavior."""
+    custom_logger = logging_obj.get_custom_logger_for_prompt_management(
+        model="anthropic/claude-sonnet-4-5",
+        non_default_params={},
+        prompt_id="my-prompt",
+        dynamic_callback_params={},
+    )
+
+    assert custom_logger is registered_prompt_manager
+
+
+def test_prompt_management_base_skips_without_prompt_id():
+    """`PromptManagementBase.get_chat_completion_prompt` must skip, not raise,
+    when there is no prompt_id to compile."""
+    prompt_manager = _PromptIdRequiringPromptManager()
+    messages = [{"role": "user", "content": "Hello"}]
+    non_default_params = {"temperature": 0.5}
+
+    model, result_messages, result_params = prompt_manager.get_chat_completion_prompt(
+        model="anthropic/claude-sonnet-4-5",
+        messages=messages,
+        non_default_params=non_default_params,
+        prompt_id=None,
+        prompt_variables=None,
+        dynamic_callback_params={},
+    )
+
+    assert model == "anthropic/claude-sonnet-4-5"
+    assert result_messages == messages
+    assert result_params == non_default_params


### PR DESCRIPTION
## Relevant issues

Fixes #31887

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## What this PR does

Toggling **Cache Control Injection Points** crashed every anthropic request with
`ValueError: prompt_id is required for Prompt Management Base class` whenever a
prompt-id-based prompt management logger was registered.

As @Nithin-eashwar correctly identified in the issue, the error occurs when the
cache-control feature attaches without a `prompt_id`. However, only guarding/skipping
the prompt-management call would silently never apply the injection points — the
regression test in this PR asserts `cache_control` is actually injected into the messages.

Root cause: in `Logging.get_custom_logger_for_prompt_management`, the generic registered
`CustomPromptManagement` fallback was checked **before** `AnthropicCacheControlHook`, so a
prompt-id-requiring manager (dotprompt / arize / Langfuse / ...) handled the prompt_id-less
cache-control call and raised.

Fix (narrowly scoped):
- When `prompt_id is None`, check `AnthropicCacheControlHook` (which only matches when
  `cache_control_injection_points` is present) before the generic fallback.
  All `prompt_id`-carrying flows are unchanged.
- `PromptManagementBase.get_chat_completion_prompt` now skips (debug log + unchanged
  passthrough) instead of raising when `prompt_id is None`, as a safety net.

## Verification

- New regression tests reproduce the exact `ValueError` from the issue on unmodified main
  (3 failed / 1 passed) and pass with this fix (4/4).
- One test asserts the injection points are **actually applied**, which a skip-only guard fails.
- No regressions: `test_anthropic_cache_control_hook.py` + `test_litellm_logging.py`
  (146 tests) and `test_responses_prompt_management.py` (10 tests) all pass; ruff clean.



## Type

🐛 Bug Fix