### PR TITLE
fix(cost calc): use region_name for bedrock cost key when response model is None

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -773,7 +773,8 @@ def _select_model_name_for_cost_calc(
     elif completion_response_model is None and hidden_params is not None:
         if hidden_params.get("model", None) is not None and len(hidden_params["model"]) > 0:
             return_model = hidden_params.get("model", model)
-    elif hidden_params is not None and hidden_params.get("region_name", None) is not None:
+
+    if hidden_params is not None and hidden_params.get("region_name", None) is not None:
         region_name = hidden_params.get("region_name", None)
 
     if return_model is None and completion_response_model is not None:

--- a/tests/local_testing/test_cost_calc.py
+++ b/tests/local_testing/test_cost_calc.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel, ConfigDict
 
 import litellm
 from litellm import Router, completion_cost, stream_chunk_builder
+from litellm.cost_calculator import _select_model_name_for_cost_calc
+from litellm.types.utils import ModelResponse
 
 models = [
     dict(
@@ -119,3 +121,29 @@ def test_run(model: str):
     if output == non_stream_output:
         # assert cost is the same
         assert streaming_cost_calc == non_stream_cost_calc
+
+
+def test_select_model_name_uses_region_name_when_response_model_is_none():
+    """
+    `region_name` lives in completion_response._hidden_params (set by litellm for
+    bedrock region pricing). When the provider does not echo `model` back (so
+    completion_response.model is None), the region_name must still be applied to the
+    resolved model name. Regression: previously this branch was skipped, dropping the
+    region prefix and producing a wrong cost lookup.
+    """
+    response = ModelResponse(
+        id="x", created=0, model="", object="chat.completion", choices=[]
+    )
+    response.model = None
+    response._hidden_params = {
+        "region_name": "us-east-1",
+        "custom_llm_provider": "bedrock",
+    }
+
+    result = _select_model_name_for_cost_calc(
+        model="anthropic.claude-v2",
+        completion_response=response,
+        custom_llm_provider="bedrock",
+    )
+
+    assert result == "bedrock/us-east-1/anthropic.claude-v2"

--- a/tests/test_litellm/test_cost_calculator.py
+++ b/tests/test_litellm/test_cost_calculator.py
@@ -1000,6 +1000,60 @@ def test_per_request_custom_pricing_with_router():
     assert "gpt-3.5-turbo" in selected
 
 
+def test_region_name_applied_with_custom_pricing():
+    """region_name from _hidden_params must be embedded in the cost-calc key
+    even when custom_pricing selects the router_model_id. This covers the
+    branch that the standalone region_name `if` now reaches into.
+
+    Regression test for Greptile review on #32518.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+    from types import SimpleNamespace
+
+    custom_model_id = "claude-sonnet-4-region-test"
+    custom_pricing_info = {
+        "input_cost_per_token": 0.0003,
+        "output_cost_per_token": 0.0015,
+        "max_tokens": 8192,
+        "litellm_provider": "anthropic",
+    }
+    litellm.register_model(model_cost={custom_model_id: custom_pricing_info})
+
+    completion_response = SimpleNamespace(
+        _hidden_params={"region_name": "us-east-1"}
+    )
+
+    selected = _select_model_name_for_cost_calc(
+        model="anthropic/claude-sonnet-4-20250514",
+        completion_response=completion_response,
+        custom_pricing=True,
+        custom_llm_provider="anthropic",
+        router_model_id=custom_model_id,
+    )
+    assert selected == f"anthropic/us-east-1/{custom_model_id}"
+
+
+def test_region_name_applied_with_base_model():
+    """region_name from _hidden_params must be embedded in the cost-calc key
+    when base_model (e.g. azure) selects the return model.
+    """
+    from litellm.cost_calculator import _select_model_name_for_cost_calc
+    from types import SimpleNamespace
+
+    completion_response = SimpleNamespace(
+        _hidden_params={"region_name": "us-east-1"}
+    )
+
+    selected = _select_model_name_for_cost_calc(
+        model="azure/my-deployment",
+        completion_response=completion_response,
+        custom_pricing=False,
+        custom_llm_provider="azure",
+        base_model="gpt-4",
+    )
+    assert selected == "azure/us-east-1/gpt-4"
+
+
 def test_azure_realtime_cost_calculator():
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
     litellm.model_cost = litellm.get_model_cost_map(url="")


### PR DESCRIPTION
## Summary
- In `_select_model_name_for_cost_calc`, when the provider returns `response.model=None` but `hidden_params` carries a `region_name`, the region prefix was silently dropped because the region branch was an `elif` of the `completion_response_model is None and hidden_params is not None` branch.
- This produced a wrong cost-lookup key (e.g. `bedrock/anthropic.claude-v2` instead of `bedrock/us-east-1/anthropic.claude-v2`), causing silent mis-pricing on Bedrock.

## Test plan
- Added `test_select_model_name_uses_region_name_when_response_model_is_none` to `tests/local_testing/test_cost_calc.py`.
- Fail-before/pass-after verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>