### PR TITLE
fix(responses): guard empty choices in streaming delta extraction

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -1055,6 +1055,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
         It's unclear how users expect litellm to translate multiple-choices-per-chunk to the responses API output.
         """
+        if not choices:
+            return ""
         choice = choices[0]
         chat_completion_delta: ChatCompletionDelta = choice.delta
         return chat_completion_delta.content or ""

--- a/tests/test_litellm/responses/test_streaming_empty_choices.py
+++ b/tests/test_litellm/responses/test_streaming_empty_choices.py
@@ -1,0 +1,33 @@
+"""
+Test for the empty-choices guard in the Responses API streaming iterator.
+
+Providers such as DeepSeek emit a terminal streaming chunk with "choices": []
+(finish/usage chunk). _get_delta_string_from_streaming_choices must return ""
+for it instead of raising IndexError and killing the /v1/responses stream.
+"""
+
+from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+    LiteLLMCompletionStreamingIterator,
+)
+from litellm.types.utils import Delta, StreamingChoices
+
+
+class TestEmptyChoicesGuard:
+    def test_empty_choices_returns_empty_string(self):
+        """A terminal chunk with choices: [] must not raise IndexError."""
+        result = LiteLLMCompletionStreamingIterator._get_delta_string_from_streaming_choices(
+            None, []
+        )
+        assert result == ""
+
+    def test_non_empty_choices_returns_delta_content(self):
+        """The normal path is unchanged: first choice's delta content is returned."""
+        choice = StreamingChoices(
+            index=0,
+            delta=Delta(content="hello", role="assistant"),
+            finish_reason=None,
+        )
+        result = LiteLLMCompletionStreamingIterator._get_delta_string_from_streaming_choices(
+            None, [choice]
+        )
+        assert result == "hello"


### PR DESCRIPTION
## What
`_get_delta_string_from_streaming_choices` in
`litellm/responses/litellm_completion_transformation/streaming_iterator.py` indexes `choices[0]`
without checking for an empty list.

## Repro
Proxy config bridging `/v1/responses` to an OpenAI-compatible chat-completions backend
(`use_chat_completions_api: true`). DeepSeek (tested: `deepseek-v4-flash` behind a custom
`api_base`) emits a terminal streaming chunk with `"choices": []`. Result:

```
File ".../streaming_iterator.py", in _get_delta_string_from_streaming_choices
    choice = choices[0]
IndexError: list index out of range
```

The stream dies with `data: {"error": {"message": "list index out of range", ... "code": "500"}}`
after the content has already streamed.

## Fix
Return `""` when `choices` is empty — the same `chunk.choices and ...` guard every other access in
this file already uses (annotation, reasoning and tool-call paths). Unit test covers both branches.

Tested locally on 1.91.0: with the guard, the same request terminates cleanly with
`response.completed` + `data: [DONE]` and usage intact.

## Note
Supersedes #32468 (same fix, was wrongly targeted at `main` from a fork; this one targets
`litellm_oss_staging` per the source-branch policy, plus the missing test coverage).
