### PR TITLE
fix(health): bridge litellm_metadata into logging object in _batch_health_check

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -95,24 +95,15 @@ class HealthCheckHelpers:
         """
         import litellm
 
-        # alist_batches never calls update_environment_variables and @client skips
-        # function_setup() when litellm_logging_obj already exists in kwargs.
-        _logging_obj = filtered_model_params.get("litellm_logging_obj")
-        _litellm_metadata = filtered_model_params.get("litellm_metadata")
-        if _logging_obj is not None and isinstance(_litellm_metadata, dict):
-            _metadata_copy = _litellm_metadata.copy()
-            _litellm_params: Dict = {
-                "metadata": _metadata_copy,
-                "litellm_metadata": _metadata_copy,
-            }
-            _api_base = filtered_model_params.get("api_base")
-            if _api_base:
-                _litellm_params["api_base"] = _api_base
-            _logging_obj.update_environment_variables(
+        logging_obj = filtered_model_params.get("litellm_logging_obj")
+        if logging_obj is not None:
+            api_base = filtered_model_params.get("api_base")
+            logging_obj.update_from_kwargs(
+                kwargs=filtered_model_params,
                 model=filtered_model_params.get("model"),
-                user="",
+                user=None,
                 optional_params={},
-                litellm_params=_litellm_params,
+                litellm_params={"api_base": api_base} if api_base else None,
             )
 
         if custom_llm_provider in LIST_BATCHES_SUPPORTED_PROVIDERS:

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -110,7 +110,7 @@ class HealthCheckHelpers:
                 user="",
                 optional_params={},
                 litellm_params={
-                    "api_base": "",
+                    "api_base": filtered_model_params.get("api_base", ""),
                     "metadata": _litellm_metadata.copy(),
                     "litellm_metadata": _litellm_metadata.copy(),
                 },

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -95,6 +95,27 @@ class HealthCheckHelpers:
         """
         import litellm
 
+        # Bridge identity/tracking metadata into the logging object so callback
+        # handlers receive user_api_key_alias, tags, etc. in model_call_details.
+        #
+        # completion() does this via update_environment_variables (main.py), but
+        # alist_batches never makes that call. The @client decorator skips
+        # function_setup() when litellm_logging_obj already exists in kwargs
+        # (injected by ahealth_check), leaving litellm_params["metadata"] empty.
+        _logging_obj = filtered_model_params.get("litellm_logging_obj")
+        _litellm_metadata = filtered_model_params.get("litellm_metadata")
+        if _logging_obj is not None and isinstance(_litellm_metadata, dict):
+            _logging_obj.update_environment_variables(
+                model=filtered_model_params.get("model"),
+                user="",
+                optional_params={},
+                litellm_params={
+                    "api_base": "",
+                    "metadata": _litellm_metadata.copy(),
+                    "litellm_metadata": _litellm_metadata.copy(),
+                },
+            )
+
         if custom_llm_provider in LIST_BATCHES_SUPPORTED_PROVIDERS:
             return await litellm.alist_batches(**filtered_model_params)
         else:

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -95,25 +95,24 @@ class HealthCheckHelpers:
         """
         import litellm
 
-        # Bridge identity/tracking metadata into the logging object so callback
-        # handlers receive user_api_key_alias, tags, etc. in model_call_details.
-        #
-        # completion() does this via update_environment_variables (main.py), but
-        # alist_batches never makes that call. The @client decorator skips
-        # function_setup() when litellm_logging_obj already exists in kwargs
-        # (injected by ahealth_check), leaving litellm_params["metadata"] empty.
+        # alist_batches never calls update_environment_variables and @client skips
+        # function_setup() when litellm_logging_obj already exists in kwargs.
         _logging_obj = filtered_model_params.get("litellm_logging_obj")
         _litellm_metadata = filtered_model_params.get("litellm_metadata")
         if _logging_obj is not None and isinstance(_litellm_metadata, dict):
+            _metadata_copy = _litellm_metadata.copy()
+            _litellm_params: Dict = {
+                "metadata": _metadata_copy,
+                "litellm_metadata": _metadata_copy,
+            }
+            _api_base = filtered_model_params.get("api_base")
+            if _api_base:
+                _litellm_params["api_base"] = _api_base
             _logging_obj.update_environment_variables(
                 model=filtered_model_params.get("model"),
                 user="",
                 optional_params={},
-                litellm_params={
-                    "api_base": filtered_model_params.get("api_base", ""),
-                    "metadata": _litellm_metadata.copy(),
-                    "litellm_metadata": _litellm_metadata.copy(),
-                },
+                litellm_params=_litellm_params,
             )
 
         if custom_llm_provider in LIST_BATCHES_SUPPORTED_PROVIDERS:

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -14,6 +14,7 @@ from litellm.constants import LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME
 from litellm.litellm_core_utils.health_check_helpers import HealthCheckHelpers
 from litellm.main import ahealth_check
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.types.utils import LIST_BATCHES_SUPPORTED_PROVIDERS
 
 
 def test_update_model_params_with_health_check_tracking_information():
@@ -140,3 +141,161 @@ async def test_ahealth_check_failure_masks_raw_request_headers():
         assert headers["Content-Type"] == "application/json"
 
     print(f"Masked Authorization header: {headers.get('Authorization', 'NOT FOUND')}")
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_bridges_metadata_into_logging_obj():
+    """_batch_health_check must call update_environment_variables on the
+    pre-injected logging object so callbacks receive identity/tracking fields
+    in model_call_details["litellm_params"]["metadata"]."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {
+        "tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME],
+        "user_api_key_alias": "health-check-key",
+    }
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "api_base": "https://api.openai.com",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    mock_logging_obj.update_environment_variables.assert_called_once()
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
+    assert call_kwargs["model"] == "openai/gpt-4"
+    assert call_kwargs["litellm_params"]["metadata"] == litellm_metadata
+    assert call_kwargs["litellm_params"]["litellm_metadata"] == litellm_metadata
+    assert call_kwargs["litellm_params"]["metadata"] is call_kwargs["litellm_params"]["litellm_metadata"]
+    assert call_kwargs["litellm_params"]["api_base"] == "https://api.openai.com"
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_omits_api_base_when_absent():
+    """api_base must not appear in litellm_params when the provider resolves
+    it implicitly (bedrock, vertex, gemini)."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "bedrock/anthropic.claude-v2",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.acompletion", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="bedrock",
+            model_params={"model": "bedrock/anthropic.claude-v2"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
+    assert "api_base" not in call_kwargs["litellm_params"]
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_skips_bridge_when_no_metadata():
+    """When litellm_metadata is absent, update_environment_variables must not
+    be called — avoids crashing on non-health-check batch calls."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "litellm_logging_obj": mock_logging_obj,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+    mock_logging_obj.update_environment_variables.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_skips_bridge_when_no_logging_obj():
+    """When litellm_logging_obj is absent, update_environment_variables must
+    not be called."""
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "openai/gpt-4",
+        "litellm_metadata": litellm_metadata,
+    }
+
+    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="openai",
+            model_params={"model": "openai/gpt-4"},
+            filtered_model_params=filtered_model_params,
+        )
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_uses_alist_batches_for_supported_providers():
+    """Providers in LIST_BATCHES_SUPPORTED_PROVIDERS dispatch to alist_batches."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    for provider in LIST_BATCHES_SUPPORTED_PROVIDERS:
+        filtered_model_params = {
+            "model": f"{provider}/some-model",
+            "litellm_logging_obj": mock_logging_obj,
+            "litellm_metadata": litellm_metadata,
+        }
+
+        with patch(
+            "litellm.alist_batches", new_callable=AsyncMock, return_value={}
+        ) as mock_alist:
+            await HealthCheckHelpers._batch_health_check(
+                custom_llm_provider=provider,
+                model_params={"model": f"{provider}/some-model"},
+                filtered_model_params=filtered_model_params,
+            )
+            mock_alist.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_batch_health_check_falls_back_to_acompletion_for_unsupported():
+    """Providers not in LIST_BATCHES_SUPPORTED_PROVIDERS fall back to acompletion."""
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.update_environment_variables = MagicMock()
+
+    litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
+
+    filtered_model_params = {
+        "model": "bedrock/anthropic.claude-v2",
+        "litellm_logging_obj": mock_logging_obj,
+        "litellm_metadata": litellm_metadata,
+    }
+
+    model_params = {"model": "bedrock/anthropic.claude-v2", "messages": []}
+
+    with (
+        patch("litellm.alist_batches", new_callable=AsyncMock) as mock_alist,
+        patch("litellm.acompletion", new_callable=AsyncMock, return_value={}) as mock_acompletion,
+    ):
+        await HealthCheckHelpers._batch_health_check(
+            custom_llm_provider="bedrock",
+            model_params=model_params,
+            filtered_model_params=filtered_model_params,
+        )
+        mock_alist.assert_not_called()
+        mock_acompletion.assert_called_once_with(**model_params)

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -145,11 +145,11 @@ async def test_ahealth_check_failure_masks_raw_request_headers():
 
 @pytest.mark.asyncio
 async def test_batch_health_check_bridges_metadata_into_logging_obj():
-    """_batch_health_check must call update_environment_variables on the
-    pre-injected logging object so callbacks receive identity/tracking fields
-    in model_call_details["litellm_params"]["metadata"]."""
+    """_batch_health_check must call update_from_kwargs on the pre-injected
+    logging object so callbacks receive identity/tracking fields in
+    model_call_details["litellm_params"]["metadata"]."""
     mock_logging_obj = MagicMock()
-    mock_logging_obj.update_environment_variables = MagicMock()
+    mock_logging_obj.update_from_kwargs = MagicMock()
 
     litellm_metadata = {
         "tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME],
@@ -170,13 +170,11 @@ async def test_batch_health_check_bridges_metadata_into_logging_obj():
             filtered_model_params=filtered_model_params,
         )
 
-    mock_logging_obj.update_environment_variables.assert_called_once()
-    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
+    mock_logging_obj.update_from_kwargs.assert_called_once()
+    call_kwargs = mock_logging_obj.update_from_kwargs.call_args[1]
     assert call_kwargs["model"] == "openai/gpt-4"
-    assert call_kwargs["litellm_params"]["metadata"] == litellm_metadata
-    assert call_kwargs["litellm_params"]["litellm_metadata"] == litellm_metadata
-    assert call_kwargs["litellm_params"]["metadata"] is call_kwargs["litellm_params"]["litellm_metadata"]
-    assert call_kwargs["litellm_params"]["api_base"] == "https://api.openai.com"
+    assert call_kwargs["kwargs"] is filtered_model_params
+    assert call_kwargs["litellm_params"] == {"api_base": "https://api.openai.com"}
 
 
 @pytest.mark.asyncio
@@ -184,7 +182,7 @@ async def test_batch_health_check_omits_api_base_when_absent():
     """api_base must not appear in litellm_params when the provider resolves
     it implicitly (bedrock, vertex, gemini)."""
     mock_logging_obj = MagicMock()
-    mock_logging_obj.update_environment_variables = MagicMock()
+    mock_logging_obj.update_from_kwargs = MagicMock()
 
     litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
 
@@ -201,36 +199,13 @@ async def test_batch_health_check_omits_api_base_when_absent():
             filtered_model_params=filtered_model_params,
         )
 
-    call_kwargs = mock_logging_obj.update_environment_variables.call_args[1]
-    assert "api_base" not in call_kwargs["litellm_params"]
-
-
-@pytest.mark.asyncio
-async def test_batch_health_check_skips_bridge_when_no_metadata():
-    """When litellm_metadata is absent, update_environment_variables must not
-    be called — avoids crashing on non-health-check batch calls."""
-    mock_logging_obj = MagicMock()
-    mock_logging_obj.update_environment_variables = MagicMock()
-
-    filtered_model_params = {
-        "model": "openai/gpt-4",
-        "litellm_logging_obj": mock_logging_obj,
-    }
-
-    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
-        await HealthCheckHelpers._batch_health_check(
-            custom_llm_provider="openai",
-            model_params={"model": "openai/gpt-4"},
-            filtered_model_params=filtered_model_params,
-        )
-
-    mock_logging_obj.update_environment_variables.assert_not_called()
+    call_kwargs = mock_logging_obj.update_from_kwargs.call_args[1]
+    assert call_kwargs["litellm_params"] is None
 
 
 @pytest.mark.asyncio
 async def test_batch_health_check_skips_bridge_when_no_logging_obj():
-    """When litellm_logging_obj is absent, update_environment_variables must
-    not be called."""
+    """When litellm_logging_obj is absent, dispatch still proceeds."""
     litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
 
     filtered_model_params = {
@@ -238,19 +213,22 @@ async def test_batch_health_check_skips_bridge_when_no_logging_obj():
         "litellm_metadata": litellm_metadata,
     }
 
-    with patch("litellm.alist_batches", new_callable=AsyncMock, return_value={}):
+    with patch(
+        "litellm.alist_batches", new_callable=AsyncMock, return_value={}
+    ) as mock_alist:
         await HealthCheckHelpers._batch_health_check(
             custom_llm_provider="openai",
             model_params={"model": "openai/gpt-4"},
             filtered_model_params=filtered_model_params,
         )
+        mock_alist.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_batch_health_check_uses_alist_batches_for_supported_providers():
     """Providers in LIST_BATCHES_SUPPORTED_PROVIDERS dispatch to alist_batches."""
     mock_logging_obj = MagicMock()
-    mock_logging_obj.update_environment_variables = MagicMock()
+    mock_logging_obj.update_from_kwargs = MagicMock()
 
     litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
 
@@ -276,7 +254,7 @@ async def test_batch_health_check_uses_alist_batches_for_supported_providers():
 async def test_batch_health_check_falls_back_to_acompletion_for_unsupported():
     """Providers not in LIST_BATCHES_SUPPORTED_PROVIDERS fall back to acompletion."""
     mock_logging_obj = MagicMock()
-    mock_logging_obj.update_environment_variables = MagicMock()
+    mock_logging_obj.update_from_kwargs = MagicMock()
 
     litellm_metadata = {"tags": [LITTELM_INTERNAL_HEALTH_SERVICE_ACCOUNT_NAME]}
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Changes

This is a copy of #30763 by @BPRMD18 rebased onto `litellm_internal_staging` so it can run through internal CI. Original author: @BPRMD18.

### Summary

Callback handlers receive empty `litellm_params` metadata for batch-mode health check calls, making it impossible for logging callbacks to resolve caller identity or health-check tracking tags.

### Problem

`ahealth_check()` in `main.py` creates a `litellm_logging_obj` and injects it into `model_params`. It also adds `litellm_metadata` (containing tags, `user_api_key_auth`) via `_update_model_params_with_health_check_tracking_information()`.

When `_batch_health_check()` calls `litellm.alist_batches(**filtered_model_params)`, the `@client` decorator on `alist_batches` finds the pre-existing `litellm_logging_obj` in kwargs and skips `function_setup()`; that skip is the code path that normally bridges `litellm_metadata` into `litellm_params["metadata"]`.

Unlike `completion()` (which explicitly calls `logging_obj.update_environment_variables()` with the metadata), `alist_batches` / `list_batches` never makes that call.

Result: `model_call_details["litellm_params"]["metadata"]` stays empty for batch health checks. Callback handlers cannot access tracking information (tags, `user_api_key_alias`, `user_api_key_user_id`, etc.) and fall back to default/unknown values.

### Fix

Call `logging_obj.update_from_kwargs()` inside `_batch_health_check()` before dispatching to `alist_batches` or `acompletion`. That helper already extracts `metadata`/`litellm_metadata` from kwargs and calls `update_environment_variables` under the hood, matching how the sibling batch/image/rerank/ocr surfaces bridge metadata onto the logging object.

### Testing

Configured a model with `mode: batch` and a logging callback; before the fix the callback receives empty metadata, after the fix it receives `tags`, `user_api_key_alias`, etc. Unit tests in `tests/test_litellm/litellm_core_utils/test_health_check_helpers.py` exercise the bridge for supported providers, the `acompletion` fallback, and the no-logging-obj path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to internal health-check logging only; behavior when no logging object is unchanged and tests lock in provider routing.
> 
> **Overview**
> Batch-mode health checks were leaving **logging callbacks without health-check tracking metadata** (`tags`, API key identity, etc.) because `alist_batches` reuses a pre-injected `litellm_logging_obj` and skips the setup path that normally copies `litellm_metadata` into `litellm_params["metadata"]`.
> 
> **`_batch_health_check`** now calls **`logging_obj.update_from_kwargs()`** (when a logging object is present) before calling `alist_batches` or the `acompletion` fallback, passing through `api_base` in `litellm_params` only when it is set.
> 
> New unit tests cover the metadata bridge, implicit-`api_base` providers, missing logging object, supported vs unsupported batch providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bbc913983bd96fdd7c95897a605193390e4e04f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->