### PR TITLE
fix: get_llm_provider no longer crashes on a bare provider name

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -218,7 +218,7 @@ def get_llm_provider(
                 dynamic_api_key=dynamic_api_key,
                 litellm_params=litellm_params,
             )
-        elif model.split("/", 1)[0] in litellm.provider_list:
+        elif model.split("/", 1)[0] in litellm.provider_list and len(model.split("/")) > 1:
             custom_llm_provider = model.split("/", 1)[0]
             model = model.split("/", 1)[1]
             if api_base is not None and not isinstance(api_base, str):

--- a/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_llm_provider_logic.py
@@ -1,0 +1,12 @@
+import pytest
+
+import litellm
+
+
+@pytest.mark.parametrize("model", ["mistral", "openai", "anthropic", "groq", "deepseek"])
+def test_get_llm_provider_bare_provider_name_raises_helpful_error(model):
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        litellm.get_llm_provider(model=model)
+    message = str(exc_info.value)
+    assert "LLM Provider NOT provided" in message
+    assert "list index out of range" not in message


### PR DESCRIPTION
## Relevant issues

Relates to #1351 (the `litellm --model mistral` edge case that the surrounding code comment already points at)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

These are pure `litellm.get_llm_provider` library bugs, so the clearest proof is calling the public API with a bare provider name and comparing the raised error before and after the fix

```python
import litellm

try:
    litellm.get_llm_provider(model="mistral")
except litellm.BadRequestError as e:
    print(e)
```

Before this change the call raises the misleading internal error

```
litellm.BadRequestError: GetLLMProvider Exception - list index out of range

original model: mistral
```

After this change it raises the intended, actionable error

```
litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=mistral
 Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers
```

## Type

🐛 Bug Fix

## Changes

When a model string is a bare provider name that happens to be in `litellm.provider_list` (for example `mistral`, `openai`, `anthropic`, `groq` or `deepseek`), `get_llm_provider` took the `elif model.split("/", 1)[0] in litellm.provider_list:` branch and then ran `model = model.split("/", 1)[1]`. Because the string has no `/`, that index access raises `IndexError: list index out of range`, which `get_llm_provider` wraps into `litellm.BadRequestError: GetLLMProvider Exception - list index out of range`. The user gets an opaque internal message instead of the "LLM Provider NOT provided" guidance the function raises for this exact situation a few lines further down

The preceding `if` branch that also splits on `/` already guards itself with `len(model.split("/")) > 1`; the buggy `elif` was simply missing the same guard. This adds `and len(model.split("/")) > 1` to that `elif` so a bare provider name no longer matches it and instead falls through to the existing helpful error. Inputs that carry a provider prefix such as `mistral/mistral-large-latest` still contain a `/`, so they continue to take this branch exactly as before; only the no-slash case changes

The regression test passes a set of bare provider names and asserts that each raises `BadRequestError` with the "LLM Provider NOT provided" text and never the "list index out of range" text, so the crash cannot silently return
