### PR TITLE
fix: supports_audio_output was reading the supports_audio_input key

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2429,7 +2429,7 @@ def supports_pdf_input(model: str, custom_llm_provider: Optional[str] = None) ->
 
 def supports_audio_output(model: str, custom_llm_provider: Optional[str] = None) -> bool:
     """Check if a given model supports audio output in a chat completion call"""
-    return _supports_factory(model=model, custom_llm_provider=custom_llm_provider, key="supports_audio_input")
+    return _supports_factory(model=model, custom_llm_provider=custom_llm_provider, key="supports_audio_output")
 
 
 def supports_prompt_caching(model: str, custom_llm_provider: Optional[str] = None) -> bool:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -1294,6 +1294,40 @@ def test_supports_computer_use_utility():
             delattr(litellm, "model_cost")
 
 
+@pytest.mark.parametrize(
+    "model, expected_bool",
+    [
+        ("gemini/gemini-2.0-flash-lite", True),
+        ("azure/gpt-realtime-whisper", False),
+        ("gpt-4o-audio-preview", True),
+    ],
+)
+def test_supports_audio_output(model, expected_bool):
+    """
+    supports_audio_output must read the supports_audio_output field, not supports_audio_input.
+    """
+    from litellm.utils import supports_audio_output
+
+    original_env_var = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP")
+    original_model_cost = getattr(litellm, "model_cost", None)
+
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    try:
+        assert supports_audio_output(model=model) == expected_bool
+    finally:
+        if original_env_var is None:
+            del os.environ["LITELLM_LOCAL_MODEL_COST_MAP"]
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = original_env_var
+
+        if original_model_cost is not None:
+            litellm.model_cost = original_model_cost
+        elif hasattr(litellm, "model_cost"):
+            delattr(litellm, "model_cost")
+
+
 def test_get_model_info_shows_supports_computer_use():
     """
     Tests if 'supports_computer_use' is correctly retrieved by get_model_info.


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`supports_audio_output` in `litellm/utils.py` delegated to `_supports_factory` with `key="supports_audio_input"`, so it reported whether a model can accept audio input rather than whether it can produce audio output. The two capabilities are stored as separate fields in the model cost map and do not always agree, so the wrong key produces wrong answers in both directions. A model that only accepts audio input, such as `azure/gpt-realtime-whisper` (`supports_audio_input: true`, no `supports_audio_output`), was incorrectly reported as supporting audio output, while a model that produces audio output but is not flagged for audio input, such as `gemini/gemini-2.0-flash-lite` (`supports_audio_output: true`, no `supports_audio_input`), was incorrectly reported as not supporting it

The fix changes the lookup key in `supports_audio_output` from `"supports_audio_input"` to `"supports_audio_output"` so the function reads the field that matches its name. This is a one-line change with no behavior change to `supports_audio_input`, which already used the correct key

Added `test_supports_audio_output` in `tests/test_litellm/test_utils.py`, covering an output-only model, an input-only model, and a model that supports both, so the two capability fields are exercised independently

## Screenshots / Proof of Fix

Pure library-function bug, so the proof is a self-contained snippet against the public API using the bundled model cost map. Run it on the base commit, then on this branch

```python
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm
litellm.model_cost = litellm.get_model_cost_map(url="")

# output-only model: model_cost has supports_audio_output=True, no supports_audio_input
print(litellm.supports_audio_output(model="gemini/gemini-2.0-flash-lite"))
# input-only model: model_cost has supports_audio_input=True, no supports_audio_output
print(litellm.supports_audio_output(model="azure/gpt-realtime-whisper"))
```

Before the fix:

```
False   # gemini/gemini-2.0-flash-lite (wrong; it does support audio output)
True    # azure/gpt-realtime-whisper (wrong; it does not support audio output)
```

After the fix:

```
True    # gemini/gemini-2.0-flash-lite
False   # azure/gpt-realtime-whisper
```

