### PR TITLE
fix: token_counter no longer crashes on a tool array parameter without items

### DIFF
--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -814,8 +814,9 @@ def _format_type(props, indent):
             return " | ".join([f'"{item}"' for item in props["enum"]])
         return "string"
     elif type == "array":
-        # items is required, OpenAI throws an error if it's missing
-        return f"{_format_type(props['items'], indent)}[]"
+        items = props.get("items")
+        items = items if isinstance(items, dict) else {}
+        return f"{_format_type(items, indent)}[]"
     elif type == "object":
         return f"{{\n{_format_object_parameters(props, indent + 2)}\n}}"
     elif type in ["integer", "number"]:

--- a/tests/test_litellm/litellm_core_utils/test_token_counter.py
+++ b/tests/test_litellm/litellm_core_utils/test_token_counter.py
@@ -1114,3 +1114,53 @@ def test_count_content_list_rejects_unknown_type():
     message = str(exc_info.value)
     assert "Invalid content item type: totally_unknown_block" in message
     assert "tool_reference" in message
+
+
+@pytest.mark.parametrize(
+    "tools",
+    [
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"tags": {"type": "array"}},
+                        "required": ["tags"],
+                    },
+                },
+            }
+        ],
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "f",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"tags": {"type": "array", "items": [{"type": "string"}]}},
+                        "required": ["tags"],
+                    },
+                },
+            }
+        ],
+        [
+            {
+                "name": "f",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"tags": {"type": "array"}},
+                    "required": ["tags"],
+                },
+            }
+        ],
+    ],
+    ids=["openai_array_without_items", "openai_array_items_as_list", "anthropic_array_without_items"],
+)
+def test_token_counter_tool_array_param_missing_or_invalid_items(tools):
+    result = litellm.token_counter(
+        model="gpt-4o", messages=[{"role": "user", "content": "hi"}], tools=tools
+    )
+    assert isinstance(result, int)
+    assert result > 0


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`litellm.token_counter` renders tool/function JSON schemas into a TypeScript-like string to estimate token usage. In `_format_type` (litellm/litellm_core_utils/token_counter.py), an array property was formatted with `_format_type(props['items'], indent)`, assuming `items` is always present and is a dict. A comment claimed `items` is required because OpenAI rejects arrays without it, but `token_counter` is a client-side estimator that is routinely handed schemas that were never validated by the OpenAI endpoint; Anthropic tool `input_schema` and many hand-built tool definitions include `{"type": "array"}` with no `items`. In that case the direct subscript raised `KeyError: 'items'` and the whole `token_counter` call crashed. A related shape, `items` present but given as a list rather than a dict, hit an `AttributeError` inside the recursive call for the same reason

The fix reads `items` defensively: `items = props.get("items")` then falls back to `{}` when it is not a dict, so a missing or non-dict `items` degrades to formatting the element type as `any[]` instead of raising. Valid schemas that carry a proper `items` dict are unchanged

## Screenshots / Proof of Fix

```python
import litellm

tools = [
    {
        "type": "function",
        "function": {
            "name": "f",
            "parameters": {
                "type": "object",
                "properties": {"tags": {"type": "array"}},  # no "items"
                "required": ["tags"],
            },
        },
    }
]

print(litellm.token_counter(model="gpt-4o", messages=[{"role": "user", "content": "hi"}], tools=tools))
```

Before this change the call raised `KeyError: 'items'` from `_format_type`. After the change it returns an integer token count (for example `31`), and schemas that do supply a valid `items` dict produce the same output as before

