### PR TITLE
fix(rerank): stop logging query and documents at info

### DIFF
--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -158,7 +158,8 @@ def rerank(
             instruction=instruction,
             non_default_params=kwargs,
         )
-        verbose_logger.info(f"optional_rerank_params: {optional_rerank_params}")
+        loggable_rerank_params = {k: v for k, v in optional_rerank_params.items() if k not in ("query", "documents")}
+        verbose_logger.info(f"optional_rerank_params: {loggable_rerank_params}")
         if isinstance(optional_params.timeout, str):
             optional_params.timeout = float(optional_params.timeout)
 

--- a/tests/test_litellm/rerank_api/test_main.py
+++ b/tests/test_litellm/rerank_api/test_main.py
@@ -1,0 +1,68 @@
+import json
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+import litellm
+
+
+@pytest.mark.parametrize("sync_mode", [True, False])
+@patch("litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post")
+@patch("litellm.llms.custom_httpx.http_handler.HTTPHandler.post")
+def test_rerank_does_not_log_query_or_documents(mock_sync_post, mock_async_post, sync_mode, caplog):
+    """
+    rerank() used to log the full `optional_rerank_params` at INFO, which embeds the
+    caller's `query` and `documents` (their raw content). That leaked request content
+    into stdout regardless of `turn_off_message_logging`. The INFO line must carry the
+    non-content params but never the query or documents
+    """
+    mock_response_data = {
+        "id": "rerank-123",
+        "results": [
+            {"index": 0, "relevance_score": 0.9},
+            {"index": 1, "relevance_score": 0.1},
+        ],
+        "meta": {
+            "tokens": {"input_tokens": 25, "output_tokens": 0},
+            "billed_units": {"total_tokens": 25},
+        },
+    }
+
+    mock_response = MagicMock()
+    mock_response.json = lambda: mock_response_data
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.text = json.dumps(mock_response_data)
+    mock_sync_post.return_value = mock_response
+    mock_async_post.return_value = mock_response
+
+    secret_query = "PII_QUERY_ivan_petrov_account_40817810099910004312"
+    secret_document = "PII_DOCUMENT_confidential_client_report_body"
+
+    with caplog.at_level(logging.INFO, logger="LiteLLM"):
+        kwargs = dict(
+            model="cohere/rerank-english-v3.0",
+            query=secret_query,
+            documents=[secret_document, "another document"],
+            top_n=2,
+            custom_llm_provider="cohere",
+            api_key="fake-key",
+        )
+        if sync_mode:
+            litellm.rerank(**kwargs)
+        else:
+            import asyncio
+
+            asyncio.run(litellm.arerank(**kwargs))
+
+    param_logs = [record.getMessage() for record in caplog.records if "optional_rerank_params" in record.getMessage()]
+    assert param_logs, "expected an 'optional_rerank_params' INFO log to be emitted"
+
+    joined = "\n".join(param_logs)
+    assert secret_query not in joined
+    assert secret_document not in joined
+    assert "top_n" in joined


### PR DESCRIPTION
## Relevant issues

Fixes #32525

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Ran a real rerank against a live proxy (hosted_vllm reranker), then grepped the proxy log for the `optional_rerank_params` line. The request used marker strings in place of `query` and `documents`

before (unpatched, current `main`): the log line, and the JSON log's promoted top-level fields, contain the full query and documents

```
{"message": "optional_rerank_params: {'query': 'MARKER_QUERY', 'documents': ['MARKER_DOC', 'unrelated'], 'top_n': 2, 'rank_fields': None, 'return_documents': None}", "level": "INFO", "query": "MARKER_QUERY", "documents": ["MARKER_DOC", "unrelated"], "top_n": 2, ...}
```

after (patched): the marker strings appear nowhere in the logs; the line carries only the non-content params

```
{"message": "optional_rerank_params: {'top_n': 2, 'rank_fields': None, 'return_documents': None}", "level": "INFO", "top_n": 2, "rank_fields": null, "return_documents": null, ...}
```

## Type

🐛 Bug Fix

## Changes

`rerank()` logs `optional_rerank_params` at info in `litellm/rerank_api/main.py`, and that dict always carries the caller's `query` and `documents`. So every rerank call writes the raw request content to logs at the default INFO level, outside the logging object and thus bypassing `turn_off_message_logging` and the `redact_messages` guards

This is the only completion/embedding/rerank path that emits request content at info. Sibling code already keeps request content out of logs: `search/main.py`, `litellm_core_utils/litellm_logging.py` and `ocr/main.py` log their `optional_params` at debug rather than info; `bedrock/chat/agentcore/transformation.py` logs only the `optional_params` keys (not the values); and `llms/openai/openai.py` deliberately avoids logging payloads that "may contain sensitive parameters". This change brings rerank in line with that convention

Log only the non-content params; the full input still goes through `litellm_logging_obj` right below, where redaction applies.

**Files**:
- `litellm/rerank_api/main.py`
- `tests/test_litellm/rerank_api/test_main.py`
