### PR TITLE
fix(mcp): re-register DCR client when proxy origin no longer matches its registered redirect_uri

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -910,9 +910,10 @@ async def _reuse_persisted_dcr_client_if_available(
         return False
     persisted_mcp_server, credentials = persisted
     if current_redirect_uri is not None and _redirect_uri_not_registered(credentials, current_redirect_uri):
-        verbose_logger.warning(
+        verbose_logger.debug(
             "register_client_with_server: not reusing persisted DCR client for server_id=%s; its registered "
-            "redirect_uris=%s do not include the current callback %s",
+            "redirect_uris=%s do not include the current callback %s. The operator-facing warning for this "
+            "re-registration event is emitted once by _persisted_dcr_redirect_uri_is_stale.",
             mcp_server.server_id,
             credentials.redirect_uris,
             current_redirect_uri,

--- a/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/discoverable_endpoints.py
@@ -820,6 +820,22 @@ class _PersistedDcrCredentials(BaseModel):
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
     token_endpoint_auth_method: Optional[str] = None
+    redirect_uris: Optional[list[str]] = None
+
+
+def _redirect_uri_not_registered(credentials: _PersistedDcrCredentials, current_redirect_uri: str) -> bool:
+    """Whether a persisted DCR client is positively known NOT to cover the current callback.
+
+    A DCR client is bound to the redirect_uris it was registered with; if the proxy's
+    resolved public origin has since changed, every authorize built for it will be
+    rejected by the IdP. Clients persisted before ``redirect_uris`` was recorded (and
+    admin-configured clients, which never get a recording) return False so they are
+    grandfathered rather than re-registered, because re-minting a client_id orphans
+    every user's refresh tokens for that server."""
+    recorded = credentials.redirect_uris
+    if not recorded:
+        return False
+    return current_redirect_uri not in recorded
 
 
 def _get_persisted_dcr_credentials(credentials: object) -> Optional[_PersistedDcrCredentials]:
@@ -886,11 +902,22 @@ async def _get_persisted_mcp_server_with_dcr_client_id(
     return persisted_mcp_server, credentials
 
 
-async def _reuse_persisted_dcr_client_if_available(mcp_server: MCPServer) -> bool:
+async def _reuse_persisted_dcr_client_if_available(
+    mcp_server: MCPServer, current_redirect_uri: Optional[str] = None
+) -> bool:
     persisted = await _get_persisted_mcp_server_with_dcr_client_id(mcp_server)
     if persisted is None:
         return False
     persisted_mcp_server, credentials = persisted
+    if current_redirect_uri is not None and _redirect_uri_not_registered(credentials, current_redirect_uri):
+        verbose_logger.warning(
+            "register_client_with_server: not reusing persisted DCR client for server_id=%s; its registered "
+            "redirect_uris=%s do not include the current callback %s",
+            mcp_server.server_id,
+            credentials.redirect_uris,
+            current_redirect_uri,
+        )
+        return False
     if not _apply_persisted_dcr_credentials(mcp_server, credentials):
         return False
 
@@ -909,11 +936,36 @@ async def _reuse_persisted_dcr_client_if_available(mcp_server: MCPServer) -> boo
     return bool(mcp_server.client_id)
 
 
+async def _persisted_dcr_redirect_uri_is_stale(mcp_server: MCPServer, current_redirect_uri: str) -> bool:
+    """Whether the server's persisted DCR client is bound to redirect_uris that no longer
+    cover the current proxy callback, meaning authorize is guaranteed to fail IdP-side.
+
+    Consulted when the in-memory server already carries a hydrated client_id, which
+    otherwise short-circuits registration before any redirect check can run. Servers
+    without a persisted DCR recording (admin-configured client_id, or registered before
+    redirect_uris were recorded) are never reported stale."""
+    persisted = await _get_persisted_mcp_server_with_dcr_client_id(mcp_server)
+    if persisted is None:
+        return False
+    _, credentials = persisted
+    if not _redirect_uri_not_registered(credentials, current_redirect_uri):
+        return False
+    verbose_logger.warning(
+        "register_client_with_server: persisted DCR client for server_id=%s is registered with redirect_uris=%s "
+        "which do not include the current callback %s (proxy origin changed); registering a replacement client. "
+        "Users previously signed in to this server will need to re-authenticate.",
+        mcp_server.server_id,
+        credentials.redirect_uris,
+        current_redirect_uri,
+    )
+    return True
+
+
 DcrRegistrationPersistenceResult = Literal["persisted", "reused", "skipped", "failed"]
 
 
 async def _persist_dcr_client_registration(
-    mcp_server: MCPServer, registration_response: object
+    mcp_server: MCPServer, registration_response: object, current_redirect_uri: str
 ) -> DcrRegistrationPersistenceResult:
     """Persist the dynamically registered OAuth client (RFC 7591) onto the MCP server row.
 
@@ -929,6 +981,13 @@ async def _persist_dcr_client_registration(
     client identity for these servers. Persisting here would stamp ``oauth2_flow`` and a
     ``client_id`` onto a server whose mode promises the gateway stores nothing, making a
     fresh pass-through server read as gateway-authorized.
+
+    ``redirect_uris`` records what the client is bound to so a later origin change can be
+    detected as a positive mismatch and trigger re-registration instead of stranding the
+    server on IdP-side redirect_uri rejections. ``client_secret`` and
+    ``token_endpoint_auth_method`` are written explicitly (None when absent) because
+    ``update_mcp_server`` merges credential blobs: a re-registered public client must not
+    inherit the previous client's secret or auth method.
     """
     if mcp_server.is_true_passthrough or mcp_server.is_oauth_delegate:
         return "skipped"
@@ -944,17 +1003,16 @@ async def _persist_dcr_client_registration(
         )
         return "failed"
 
-    if await _reuse_persisted_dcr_client_if_available(mcp_server):
+    if await _reuse_persisted_dcr_client_if_available(mcp_server, current_redirect_uri=current_redirect_uri):
         return "reused"
 
     credentials: MCPCredentials = {
         "client_id": registration.client_id,
-        **({"client_secret": registration.client_secret} if registration.client_secret is not None else {}),
-        **(
-            {"token_endpoint_auth_method": "client_secret_basic"}
-            if registration.token_endpoint_auth_method == "client_secret_basic"
-            else {}
+        "client_secret": registration.client_secret,
+        "token_endpoint_auth_method": (
+            "client_secret_basic" if registration.token_endpoint_auth_method == "client_secret_basic" else None
         ),
+        "redirect_uris": [current_redirect_uri],
     }
 
     from litellm.proxy._experimental.mcp_server.db import update_mcp_server  # noqa: PLC0415
@@ -1017,16 +1075,24 @@ async def register_client_with_server(
 ):
     _raise_if_not_oauth2(mcp_server)
     request_base_url = get_request_base_url(request)
+    current_redirect_uri = f"{request_base_url}/callback"
     dummy_return = {
         "client_id": fallback_client_id or mcp_server.server_name,
         "client_secret": "dummy",
-        "redirect_uris": [f"{request_base_url}/callback"],
+        "redirect_uris": [current_redirect_uri],
     }
 
-    if mcp_server.client_id:
+    if mcp_server.client_id and not (
+        persist_credentials
+        and mcp_server.registration_url
+        and await _persisted_dcr_redirect_uri_is_stale(mcp_server, current_redirect_uri)
+    ):
         return dummy_return
 
-    if await _reuse_persisted_dcr_client_if_available(mcp_server):
+    if await _reuse_persisted_dcr_client_if_available(
+        mcp_server,
+        current_redirect_uri=current_redirect_uri if persist_credentials else None,
+    ):
         return dummy_return
 
     if mcp_server.authorization_url is None:
@@ -1044,7 +1110,7 @@ async def register_client_with_server(
 
     register_data = {
         "client_name": client_name,
-        "redirect_uris": client_redirect_uris if bridge_relay else [f"{request_base_url}/callback"],
+        "redirect_uris": client_redirect_uris if bridge_relay else [current_redirect_uri],
         "grant_types": grant_types or (["authorization_code", "refresh_token"] if bridge_relay else []),
         "response_types": response_types or (["code"] if bridge_relay else []),
         "token_endpoint_auth_method": token_endpoint_auth_method or ("none" if bridge_relay else ""),
@@ -1072,7 +1138,7 @@ async def register_client_with_server(
     token_response = response.json()
 
     if persist_credentials and not bridge_relay:
-        persistence_result = await _persist_dcr_client_registration(mcp_server, token_response)
+        persistence_result = await _persist_dcr_client_registration(mcp_server, token_response, current_redirect_uri)
         if persistence_result == "reused":
             return dummy_return
 

--- a/litellm/types/mcp.py
+++ b/litellm/types/mcp.py
@@ -165,6 +165,15 @@ class MCPCredentials(TypedDict, total=False):
     sends HTTP Basic; defaults to "client_secret_post" when unset.
     """
 
+    redirect_uris: Optional[List[str]]
+    """
+    The redirect URIs a dynamically registered (RFC 7591) OAuth client was bound to at
+    registration time. Lets a later registration detect that the proxy's public origin no
+    longer matches the registered callback and re-register instead of reusing a client the
+    IdP will reject. Absent for admin-configured clients and for clients registered before
+    this field existed. Not a secret; stored unencrypted.
+    """
+
     token_exchange_profile: Optional[str]
     """
     Token exchange wire dialect: "rfc8693" (default, the standard token-exchange grant) or

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py
@@ -660,6 +660,7 @@ async def test_register_client_persists_dcr_client_identity():
     assert update_data.credentials["client_id"] == "generated-client"
     assert update_data.credentials["client_secret"] == "generated-secret"
     assert update_data.credentials["token_endpoint_auth_method"] == "client_secret_basic"
+    assert update_data.credentials["redirect_uris"] == ["https://proxy.litellm.example/callback"]
     assert update_data.oauth2_flow == "authorization_code"
 
     mock_update_server.assert_called_once()
@@ -1139,6 +1140,296 @@ async def test_register_client_returns_reused_client_when_concurrent_persist_win
     mock_async_client.post.assert_called_once()
     mock_update_mcp_server.assert_not_called()
     mock_update_server.assert_called_once_with(persisted_server)
+
+
+def _dcr_redirect_test_server(client_id):
+    from litellm.proxy._types import MCPTransport
+    from litellm.types.mcp import MCPAuth
+    from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+    return MCPServer(
+        server_id="remote_server",
+        name="remote_server",
+        server_name="remote_server",
+        alias="remote_server",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.oauth2,
+        client_id=client_id,
+        client_secret=None,
+        authorization_url="https://provider.example/oauth/authorize",
+        token_url="https://provider.example/oauth/token",
+        registration_url="https://provider.example/oauth/register",
+    )
+
+
+@pytest.mark.asyncio
+async def test_register_client_re_registers_when_persisted_redirect_uri_no_longer_matches_origin():
+    """A persisted DCR client is bound to the redirect_uri it was registered with. When the
+    proxy's resolved public origin changes, every authorize built for the reused client is
+    rejected IdP-side and the server is permanently stranded (GH #32473). A positive mismatch
+    between the recorded redirect_uris and the current callback must therefore re-register on
+    the admin path and persist the replacement client, with the new binding recorded and the
+    old client's secret/auth method cleared rather than merged into the new identity."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            register_client_with_server,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    oauth2_server = _dcr_redirect_test_server(client_id="stale-client")
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "client_id": "fresh-client",
+        "redirect_uris": ["https://proxy.litellm.example/callback"],
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock(return_value=mock_response)
+
+    persisted_server = MagicMock()
+    persisted_server.credentials = {
+        "client_id": "stale-client",
+        "client_secret": "stale-secret",
+        "token_endpoint_auth_method": "client_secret_basic",
+        "redirect_uris": ["https://old-origin.example/callback"],
+    }
+    mock_get_mcp_server = AsyncMock(return_value=persisted_server)
+    mock_update_mcp_server = AsyncMock(return_value=MagicMock())
+    mock_update_server = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch("litellm.proxy.utils.get_prisma_client_or_throw", return_value=MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_mcp_server",
+            new=mock_get_mcp_server,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+            new=mock_update_mcp_server,
+        ),
+        patch.object(global_mcp_server_manager, "update_server", new=mock_update_server),
+    ):
+        response = await register_client_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            client_name="Litellm Proxy",
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            persist_credentials=True,
+        )
+
+    mock_async_client.post.assert_called_once()
+    register_payload = mock_async_client.post.call_args.kwargs["json"]
+    assert register_payload["redirect_uris"] == ["https://proxy.litellm.example/callback"]
+
+    mock_update_mcp_server.assert_called_once()
+    update_data = mock_update_mcp_server.call_args.kwargs["data"]
+    assert update_data.credentials["client_id"] == "fresh-client"
+    assert update_data.credentials["redirect_uris"] == ["https://proxy.litellm.example/callback"]
+    assert update_data.credentials["client_secret"] is None
+    assert update_data.credentials["token_endpoint_auth_method"] is None
+
+    assert response.status_code == 200
+    assert json.loads(response.body.decode("utf-8"))["client_id"] == "fresh-client"
+
+
+@pytest.mark.asyncio
+async def test_register_client_grandfathers_persisted_client_without_recorded_redirect_uris():
+    """Clients persisted before redirect_uris were recorded (and admin-configured clients,
+    which never get a recording) have nothing to compare against; treating that as a mismatch
+    would re-mint a client_id for every existing install on upgrade and orphan all users'
+    refresh tokens for those servers. A missing recording must read as a match: no DCR call,
+    no persistence write, existing client returned."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            register_client_with_server,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    oauth2_server = _dcr_redirect_test_server(client_id="legacy-client")
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock()
+
+    persisted_server = MagicMock()
+    persisted_server.credentials = {"client_id": "legacy-client"}
+    mock_get_mcp_server = AsyncMock(return_value=persisted_server)
+    mock_update_mcp_server = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch("litellm.proxy.utils.get_prisma_client_or_throw", return_value=MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_mcp_server",
+            new=mock_get_mcp_server,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+            new=mock_update_mcp_server,
+        ),
+    ):
+        response = await register_client_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            client_name="Litellm Proxy",
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            persist_credentials=True,
+        )
+
+    mock_async_client.post.assert_not_called()
+    mock_update_mcp_server.assert_not_called()
+    assert response["client_secret"] == "dummy"
+    assert oauth2_server.client_id == "legacy-client"
+
+
+@pytest.mark.asyncio
+async def test_register_client_keeps_persisted_client_when_recorded_redirect_uri_matches_origin():
+    """When the recorded redirect_uris still cover the current callback the persisted client
+    is valid; re-registering would orphan refresh tokens for no reason."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            register_client_with_server,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    oauth2_server = _dcr_redirect_test_server(client_id="kept-client")
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock()
+
+    persisted_server = MagicMock()
+    persisted_server.credentials = {
+        "client_id": "kept-client",
+        "redirect_uris": ["https://proxy.litellm.example/callback"],
+    }
+    mock_get_mcp_server = AsyncMock(return_value=persisted_server)
+    mock_update_mcp_server = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch("litellm.proxy.utils.get_prisma_client_or_throw", return_value=MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_mcp_server",
+            new=mock_get_mcp_server,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.update_mcp_server",
+            new=mock_update_mcp_server,
+        ),
+    ):
+        response = await register_client_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            client_name="Litellm Proxy",
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            persist_credentials=True,
+        )
+
+    mock_async_client.post.assert_not_called()
+    mock_update_mcp_server.assert_not_called()
+    assert response["client_secret"] == "dummy"
+
+
+@pytest.mark.asyncio
+async def test_register_client_non_admin_reuses_persisted_client_despite_redirect_mismatch():
+    """Non-persisting callers (the public register routes and non-admin users) must keep
+    today's reuse behavior even when the recorded redirect_uris mismatch: re-registering
+    without persistence would mint an orphan upstream client on every connect while the
+    stored client keeps being used at authorize time. Only the admin path re-registers."""
+    try:
+        from fastapi import Request
+
+        from litellm.proxy._experimental.mcp_server.discoverable_endpoints import (
+            register_client_with_server,
+        )
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+    except ImportError:
+        pytest.skip("MCP discoverable endpoints not available")
+
+    oauth2_server = _dcr_redirect_test_server(client_id=None)
+
+    mock_request = MagicMock(spec=Request)
+    mock_request.base_url = "https://proxy.litellm.example/"
+    mock_request.headers = {}
+
+    mock_async_client = MagicMock()
+    mock_async_client.post = AsyncMock()
+
+    persisted_server = MagicMock()
+    persisted_server.credentials = {
+        "client_id": "persisted-client",
+        "redirect_uris": ["https://old-origin.example/callback"],
+    }
+    mock_get_mcp_server = AsyncMock(return_value=persisted_server)
+    mock_update_server = AsyncMock()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.discoverable_endpoints.get_async_httpx_client",
+            return_value=mock_async_client,
+        ),
+        patch("litellm.proxy.utils.get_prisma_client_or_throw", return_value=MagicMock()),
+        patch(
+            "litellm.proxy._experimental.mcp_server.db.get_mcp_server",
+            new=mock_get_mcp_server,
+        ),
+        patch.object(global_mcp_server_manager, "update_server", new=mock_update_server),
+    ):
+        response = await register_client_with_server(
+            request=mock_request,
+            mcp_server=oauth2_server,
+            client_name="Litellm Proxy",
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+            persist_credentials=False,
+        )
+
+    mock_async_client.post.assert_not_called()
+    assert oauth2_server.client_id == "persisted-client"
+    assert response["client_secret"] == "dummy"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Behavior after this PR

**1. Existing MCP server (DCR client persisted before this PR, so the row has no recorded `redirect_uris`)**
- Reused exactly as today, even if the proxy origin has changed: a missing recording is treated as a match, so upgrading never re-mints client_ids or orphans users' refresh tokens
- A server already stranded by a past origin change stays on its old client (there is no recording to detect the mismatch against); recovery for those rows needs one manual admin step, see "Rollout ordering and recovery" below

**2. Freshly created server (first connect happens on this build)**
- DCR runs as before; the persisted credentials now additionally record the `redirect_uris` the client was registered with
- No behavior change while the proxy origin stays the same

**3. Recorded server after the proxy origin changes (the case this PR fixes)**
- The next admin register call detects that the recording does not cover the current `{origin}/callback`, registers a replacement client upstream and persists it, logging a warning that users of this server must re-authenticate once
- Authorize works again at the new origin instead of failing forever with "The redirect_uri parameter is invalid"

**4. Admin-configured `client_id`, and non-admin or public register callers**
- Configured clients are never re-registered (they have no recording, so they always match); non-persisting callers keep today's reuse behavior even when the recording mismatches

## Rollout ordering and recovery

This PR and #32921 fix two different triggers of the same IdP-side rejection. This PR covers the callback the proxy sends changing out from under a registered client: renaming the host, moving TLS termination, or setting `PROXY_BASE_URL` for the first time. #32921 covers the proxy sending a non-canonical `https://host:443/callback` that literal-matching IdPs reject against a canonically registered URI

Land this PR before #32921. To a literal-matching IdP, the port strip in #32921 is itself an origin change: every DCR client registered under the `:443` form stops matching the callback the proxy sends afterwards. With this PR in first, rows registered from then on carry a recording, so that transition reads as a positive mismatch and heals on the next admin register. In the reverse order those clients would strand with no recording and no self-heal path

Two populations still need one manual admin step: rows stranded before this PR shipped, and unrecorded rows that cross the #32921 transition on deployments whose ingress sends `X-Forwarded-Port: 443` without `PROXY_BASE_URL` set. Neither has a recording, so the mismatch check deliberately stays silent for them. The admin can delete and recreate the server, or more gently edit it, switch the auth type away from oauth2, save, then switch back and save again; `update_mcp_server` replaces the credentials blob whenever the auth type changes, so the stale client_id is dropped while the server_id, access groups and remaining settings survive. The next admin register then mints a fresh client under the current origin and records the binding. Users of that server re-authenticate once either way, since their refresh tokens were bound to the replaced client

Setting `PROXY_BASE_URL` stays the recommended configuration: it pins the resolved origin, which both avoids the `:443` reconstruction that #32921 patches and prevents per-request origin variance from tripping the mismatch check after this PR

## Relevant issues

Closes #32473 (reported by @katzdave)

Related: #32921 (non-canonical `:443` in `redirect_uri`); land this PR first, see the rollout section above

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig: a strict stub IdP plus MCP resource server on localhost:9500 (RFC 9728/8414 discovery, RFC 7591 `/register` that records each client's `redirect_uris`, `/authorize` that returns the standard 400 on a redirect mismatch exactly like a strict production IdP) and the proxy on localhost:4100 backed by Postgres. The origin change is simulated by restarting the proxy with a different `PROXY_BASE_URL`, which is the production trigger described in the issue

### Before the fix: the server is permanently stranded

Proxy started with `PROXY_BASE_URL=http://localhost:4100`, MCP server created pointing at the stub, then the admin register endpoint mints and persists the DCR client

```
$ curl -sS -X POST http://localhost:4100/v1/mcp/server/oauth/stub-dcr-gh32473/register \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"client_name":"litellm-gateway","grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}'
{"client_id":"client-1","redirect_uris":["http://localhost:4100/callback"],"token_endpoint_auth_method":"none"}

$ curl -sS http://localhost:9500/registrations
{"client-1":{"client_id":"client-1","client_name":"litellm-gateway","redirect_uris":["http://localhost:4100/callback"]}}
```

Authorize works at this origin (the IdP 302s back with a code). Now the proxy is restarted with `PROXY_BASE_URL=https://litellm.example.com`. Register becomes a silent no-op (the persisted client short-circuits it, nothing reaches the IdP) and authorize builds the poison pair of old client and new callback

```
$ curl -sS -X POST http://localhost:4100/v1/mcp/server/oauth/stub-dcr-gh32473/register ... (same body)
{"client_id":"stub-dcr-gh32473","client_secret":"dummy","redirect_uris":["https://litellm.example.com/callback"]}

$ echo "$LOC"    # Location captured from GET /v1/mcp/server/oauth/stub-dcr-gh32473/authorize
http://localhost:9500/authorize?client_id=client-1&redirect_uri=https%3A%2F%2Flitellm.example.com%2Fcallback&...

$ curl -sS -i "$LOC"
HTTP/1.1 400 Bad Request
{"error":"invalid_request","error_description":"The redirect_uri parameter is invalid"}
```

The stub logs `AUTHORIZE REJECTED client-1: redirect_uri='https://litellm.example.com/callback' not in registered ['http://localhost:4100/callback']`. Every subsequent connect fails the same way and nothing ever re-registers

### After the fix: grandfathering holds for pre-existing rows

On the fixed build, the same register call against the row persisted by the old code (which has no `redirect_uris` recording) still reuses the existing client and sends nothing to the IdP, so upgrading does not re-mint client_ids or orphan refresh tokens for existing installs

```
$ curl -sS -X POST http://localhost:4100/v1/mcp/server/oauth/stub-dcr-gh32473/register ... (same body)
{"client_id":"stub-dcr-gh32473","client_secret":"dummy","redirect_uris":["https://litellm.example.com/callback"]}

$ curl -sS http://localhost:9500/registrations
{"client-1":{...,"redirect_uris":["http://localhost:4100/callback"]}}    # still only client-1
```

### After the fix: a recorded row self-heals on origin change

Server recreated on the fixed build at origin A; the persisted blob now records the binding (client_id stays encrypted, the recording is not a secret)

```
$ psql ... "select credentials from \"LiteLLM_MCPServerTable\" where server_id='stub-dcr-gh32473'"
{'client_id': '<encrypted>', 'client_secret': None, 'redirect_uris': ['http://localhost:4100/callback'], 'token_endpoint_auth_method': None}
```

Proxy restarted with `PROXY_BASE_URL=https://litellm.example.com`, then the same admin register call detects the positive mismatch and re-registers instead of reusing

```
$ curl -sS -X POST http://localhost:4100/v1/mcp/server/oauth/stub-dcr-gh32473/register ... (same body)
{"client_id":"client-2","redirect_uris":["https://litellm.example.com/callback"],"token_endpoint_auth_method":"none"}

$ curl -sS http://localhost:9500/registrations
{"client-1":{...,"redirect_uris":["http://localhost:4100/callback"]},
 "client-2":{...,"redirect_uris":["https://litellm.example.com/callback"]}}

$ echo "$LOC"    # authorize Location now carries the replacement client
http://localhost:9500/authorize?client_id=client-2&redirect_uri=https%3A%2F%2Flitellm.example.com%2Fcallback&...

$ curl -sS -i "$LOC"
HTTP/1.1 302 Found
```

The DB blob after healing records the new binding (`redirect_uris: ['https://litellm.example.com/callback']`) and the proxy logs an operator-visible warning: "persisted DCR client for server_id=stub-dcr-gh32473 is registered with redirect_uris=['http://localhost:4100/callback'] which do not include the current callback https://litellm.example.com/callback (proxy origin changed); registering a replacement client. Users previously signed in to this server will need to re-authenticate."

## Type

🐛 Bug Fix

## Changes

Root cause: the DCR persist introduced in #31912 stores `client_id`, `client_secret` and `token_endpoint_auth_method` on the server row but discards the `redirect_uris` the client was registered with. Every later connect short-circuits registration (either on the hydrated `client_id` or through `_reuse_persisted_dcr_client_if_available`), while `authorize_with_server` re-derives `{current_origin}/callback` on every request. Once the resolved origin changes, the IdP rejects the mismatched pair forever; the rejection happens on the IdP side so nothing surfaces in proxy logs, and the only recovery was deleting and recreating the server

The fix records `redirect_uris` in the persisted credentials at DCR time and treats a positive mismatch with the current callback as a stale client on the admin register path (`persist_credentials=True`), falling through to a fresh registration that overwrites the persisted identity. A missing recording is treated as a match, which grandfathers both rows persisted before this field existed and admin-configured clients; this is deliberate, since re-minting a client_id orphans every user's refresh tokens for that server (the invariant `test_register_client_reuses_existing_client_id_without_re_dcr` guards). Public register routes and non-admin callers keep today's behavior exactly, so recovery is an admin re-running the connect flow rather than any caller being able to churn upstream clients

Because `update_mcp_server` merges credential blobs, the persist now writes `client_secret` and `token_endpoint_auth_method` explicitly as `None` when the registration response omits them; otherwise a re-registered public client would inherit the previous client's encrypted secret and auth method through the merge. `redirect_uris` records the callback the gateway sent rather than the IdP's echo so a normalizing IdP cannot cause a re-register loop. When re-registration happens the proxy logs a warning naming both bindings, which also covers the issue's request to surface the stranded state

Regression tests cover the four contract points: positive mismatch re-registers and persists the replacement (fails on unfixed code), a missing recording is grandfathered, a matching recording keeps the client, and the non-admin path reuses even on mismatch. The existing persist test now also pins the recorded `redirect_uris`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth DCR persistence and client reuse; wrong mismatch logic could re-mint client_ids and force re-auth, but grandfathering and scoped admin-only re-register limit blast radius.
> 
> **Overview**
> Fixes MCP OAuth servers getting **permanently stranded** after the proxy’s public origin changes: persisted DCR clients were reused while **authorize** always used the new `{origin}/callback`, so strict IdPs rejected the pair with invalid `redirect_uri`.
> 
> **Persisted credentials** now store `redirect_uris` at registration time (`MCPCredentials` / `_PersistedDcrCredentials`). On the **admin register path** (`persist_credentials=True`), a **recorded** binding that does not include the current callback is treated as stale: registration is not short-circuited on the in-memory `client_id`, reuse is skipped, upstream DCR runs again, and the row is overwritten with the new client plus explicit `None` for `client_secret` / `token_endpoint_auth_method` so merged credential blobs do not leak the old secret.
> 
> **Missing `redirect_uris`** (pre-upgrade rows and admin-configured clients) is **grandfathered**—no automatic re-mint. **Public / non-persisting register** callers still reuse persisted clients even on mismatch, avoiding orphan upstream clients without persistence.
> 
> Operator **warning** when re-registration happens; tests cover mismatch re-register, grandfathering, match reuse, and non-admin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2254ffb7f82633dc81c33ae1c5c104ddf6a3c3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

