### PR TITLE
ci: run unit test workflows on ui-only changes (revert #32422)

### DIFF
--- a/.github/workflows/test-unit-core-utils.yml
+++ b/.github/workflows/test-unit-core-utils.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-documentation.yml
+++ b/.github/workflows/test-unit-documentation.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-enterprise-routing.yml
+++ b/.github/workflows/test-unit-enterprise-routing.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-integrations.yml
+++ b/.github/workflows/test-unit-integrations.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-llm-providers.yml
+++ b/.github/workflows/test-unit-llm-providers.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-misc.yml
+++ b/.github/workflows/test-unit-misc.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-auth.yml
+++ b/.github/workflows/test-unit-proxy-auth.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-db.yml
+++ b/.github/workflows/test-unit-proxy-db.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - litellm_internal_staging
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-endpoints.yml
+++ b/.github/workflows/test-unit-proxy-endpoints.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-unit-proxy-infra.yml
+++ b/.github/workflows/test-unit-proxy-infra.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-proxy-legacy.yml
+++ b/.github/workflows/test-unit-proxy-legacy.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read

--- a/.github/workflows/test-unit-responses-caching-types.yml
+++ b/.github/workflows/test-unit-responses-caching-types.yml
@@ -7,10 +7,6 @@ on:
       - litellm_internal_staging
       - litellm_oss_staging
       - "litellm_**"
-    paths-ignore:
-      - "ui/**"
-      - "**.md"
-      - "**.mdx"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Relevant issues

Reverts #32422

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (N/A; this reverts a GitHub Actions trigger filter, which has no unit-test surface. Proof is the workflow config diff below)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a revert of a GitHub Actions trigger-filter change, so there is no proxy or LLM surface to exercise; the meaningful proof is the workflow trigger config before and after, plus confirmation that the `paths-ignore` block is gone from all 12 files

Before this revert, every `test-unit-*.yml` had a `paths-ignore` that suppressed the job on UI-only or markdown-only PRs, so a change touching only `ui/litellm-dashboard/` (for example #32502) never ran "All Other Providers / Run tests", proxy-auth "Run tests", and the rest of the test-unit jobs

Trigger block after the revert (representative, `test-unit-proxy-auth.yml`):

```yaml
on:
  pull_request:
    branches:
      - main
      - litellm_internal_staging
      - litellm_oss_staging
      - "litellm_**"
```

Verification that the block is removed from all 12 workflows (captured at `b76073e`):

```
$ git grep -n "paths-ignore" .github/workflows/test-unit-*.yml
no matches (paths-ignore fully removed)
```

Once merged, a UI-only PR will again match the `pull_request` trigger on these workflows and run the unit test jobs

## Type

🚄 Infrastructure

## Changes

Reverts #32422, which added an identical four-line `paths-ignore` block (`ui/**`, `**.md`, `**.mdx`) to the `pull_request` trigger of all 12 `test-unit-*.yml` workflows. That filter meant UI-only and docs-only PRs skipped the backend unit test suites entirely, which we do not want since UI-only changes can still interact with proxy behavior and should be gated by these jobs. This removes the `paths-ignore` block from all 12 files and leaves the `branches:` list and everything else untouched, so the unit test workflows run again on UI-only changes
