### PR TITLE
fix: honor the global litellm.drop_params flag in GradientAI

### DIFF
--- a/litellm/llms/gradient_ai/chat/transformation.py
+++ b/litellm/llms/gradient_ai/chat/transformation.py
@@ -1,5 +1,6 @@
 from typing import List, Optional, Tuple, Union, Dict, Literal
 
+import litellm
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
     AllMessageValues,
@@ -138,7 +139,7 @@ class GradientAIConfig(OpenAILikeChatConfig):
         for param, value in non_default_params.items():
             if param in supported_openai_params:
                 optional_params[param] = value
-            elif not drop_params:
+            elif not (drop_params or litellm.drop_params):
                 from litellm.utils import UnsupportedParamsError
 
                 raise UnsupportedParamsError(

--- a/tests/test_litellm/llms/gradient_ai/chat/test_gradient_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/gradient_ai/chat/test_gradient_ai_chat_transformation.py
@@ -1,0 +1,24 @@
+import pytest
+
+import litellm
+from litellm.utils import UnsupportedParamsError
+
+
+def test_gradient_ai_honors_global_drop_params():
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = litellm.get_optional_params(model="llama3", custom_llm_provider="gradient_ai", user="abc")
+        assert "user" not in result
+    finally:
+        litellm.drop_params = original
+
+
+def test_gradient_ai_raises_for_unsupported_param_without_drop_params():
+    original = litellm.drop_params
+    litellm.drop_params = False
+    try:
+        with pytest.raises(UnsupportedParamsError):
+            litellm.get_optional_params(model="llama3", custom_llm_provider="gradient_ai", user="abc")
+    finally:
+        litellm.drop_params = original


### PR DESCRIPTION
## Relevant issues

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`GradientAIConfig.map_openai_params` only consulted the per-call `drop_params` argument when deciding what to do with a parameter GradientAI does not support. Every other place in litellm that drops unsupported params also honors the module-level `litellm.drop_params` global, so a user who set `litellm.drop_params = True` once (rather than passing `drop_params=True` on each call) still got an `UnsupportedParamsError` from GradientAI. This made the global flag silently ineffective for this provider

The fix widens the guard from `elif not drop_params` to `elif not (drop_params or litellm.drop_params)`, so an unsupported param is dropped when either the per-call argument or the global flag is set, matching the behavior of the shared `get_optional_params` path. The module is imported at the top of the file for the reference. Behavior is unchanged when both flags are False; an unsupported param still raises `UnsupportedParamsError`

## Screenshots / Proof of Fix

```python
import litellm

litellm.drop_params = True  # set once, globally

# Before this change: raises litellm.UnsupportedParamsError
#   "GradientAI does not support parameter 'user'. To drop unsupported params, set `drop_params=True`."
# After this change: the unsupported param is dropped and no error is raised
result = litellm.get_optional_params(
    model="llama3",
    custom_llm_provider="gradient_ai",
    user="abc",
)
print("user" in result)  # -> False
```

