### PR TITLE
fix: honor status code when mapping OpenAI invalid_request_error exceptions

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -339,7 +339,11 @@ def _map_openai_exception(
             litellm_debug_info=extra_information,
             body=getattr(original_exception, "body", None),
         )
-    elif "invalid_request_error" in error_str and "Incorrect API key provided" not in error_str:
+    elif (
+        "invalid_request_error" in error_str
+        and "Incorrect API key provided" not in error_str
+        and getattr(original_exception, "status_code", None) in (None, 400)
+    ):
         raise BadRequestError(
             message=f"{exception_provider} - {message}",
             llm_provider=custom_llm_provider,

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -668,3 +668,23 @@ def test_azure_404_with_invalid_request_error_type_maps_to_not_found():
 
     assert excinfo.value.status_code == 404
     assert "Response with id 'resp_abc' not found." in excinfo.value.message
+
+
+@pytest.mark.parametrize("provider", ["openai", "groq", "deepseek"])
+@pytest.mark.parametrize(
+    "status_code, message, expected_exception",
+    [
+        (401, "Invalid API key", litellm.AuthenticationError),
+        (404, "The model does not exist", litellm.NotFoundError),
+    ],
+)
+def test_openai_invalid_request_error_respects_status_code(provider, status_code, message, expected_exception):
+    error_message = '{"error":{"message":"' + message + '","type":"invalid_request_error"}}'
+    original_exception = OpenAIError(status_code=status_code, message=error_message, headers={})
+
+    with pytest.raises(expected_exception):
+        exception_type(
+            model="some-model",
+            original_exception=original_exception,
+            custom_llm_provider=provider,
+        )


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

```python
import litellm
from litellm.llms.openai.common_utils import OpenAIError

# An OpenAI-compatible provider returns a generic "invalid_request_error"
# body on a 404 (missing model) response
err = OpenAIError(
    status_code=404,
    message='{"error":{"message":"The model does not exist","type":"invalid_request_error"}}',
    headers={},
)

try:
    litellm.exception_type(
        model="some-model",
        original_exception=err,
        custom_llm_provider="openai",
    )
except Exception as e:
    print(type(e).__name__, getattr(e, "status_code", None))

# Before: BadRequestError 400
# After:  NotFoundError 404
```

The same holds for a 401 carrying an invalid_request_error body; before the fix it surfaced as BadRequestError 400, after the fix it surfaces as AuthenticationError 401

## Type

🐛 Bug Fix

## Changes

The OpenAI exception mapper matched any error whose body carried `"type": "invalid_request_error"` and raised `BadRequestError` (HTTP 400), ignoring the transport status code. OpenAI-compatible providers such as groq and deepseek return this generic error type on 401 and 404 responses, so genuine authentication failures and missing-model errors were flattened into 400 BadRequest; callers that branch on the exception class or status code could not distinguish an expired key or an unknown model from a malformed request

This change adds a status-code guard so the string-based `invalid_request_error` branch only fires when the exception has no status code or reports 400, which is exactly how the already-merged Azure sibling a few hundred lines down in the same file already behaves. Any other status now defers to the status-code-based mapping that follows, so a 401 raises `AuthenticationError`, a 404 raises `NotFoundError`, and other codes such as 422 and 500 likewise surface their real exception class instead of being masked as 400. The pre-existing `"Incorrect API key provided"` carve-out is left untouched, and no other branch changes

A parametrized regression test covers the 401 and 404 cases across openai, groq, and deepseek; it fails against the previous mapper (each case resolved to `BadRequestError`) and passes with the guard in place
