### PR TITLE
fix(guardrails): walk Responses-API text taxonomy in shared content helpers

### DIFF
--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -34,8 +34,6 @@ def is_text_content_call_type(call_type: str) -> bool:
 
 TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"})
 
-_INSPECTION_SAFE_ROLES: FrozenSet[str] = frozenset({"system", "user", "assistant"})
-
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
     """Yield text fragments from a ``message.content`` value (string or
@@ -227,7 +225,5 @@ def build_inspection_messages(data: Dict[str, Any]) -> List[Dict[str, str]]:
         if not text:
             continue
         role = message.get("role", "user") or "user"
-        if role not in _INSPECTION_SAFE_ROLES:
-            role = "user"
         flattened.append({"role": role, "content": text})
     return flattened

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -23,13 +23,20 @@ from typing import Any, Callable, Dict, FrozenSet, Iterator, List
 # ``pre_call_hook`` directly with the sync name. Embedding, moderation,
 # audio, and transcription endpoints are deliberately excluded — text
 # guardrails on those paths are a separate scope.
-TEXT_CONTENT_CALL_TYPES: FrozenSet[str] = frozenset({"completion", "acompletion", "aresponses"})
+TEXT_CONTENT_CALL_TYPES: FrozenSet[str] = frozenset(
+    {"completion", "acompletion", "aresponses"}
+)
 
 
 def is_text_content_call_type(call_type: str) -> bool:
     """Return True if ``call_type`` carries free-form text that text
     guardrails should inspect (Chat Completions or Responses API)."""
     return call_type in TEXT_CONTENT_CALL_TYPES
+
+
+TEXT_PART_TYPES: FrozenSet[str] = frozenset({"text", "input_text", "output_text"})
+
+_INSPECTION_SAFE_ROLES: FrozenSet[str] = frozenset({"system", "user", "assistant"})
 
 
 def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
@@ -48,7 +55,7 @@ def _iter_text_parts_in_content(content: Any) -> Iterator[str]:
                 continue
             if not isinstance(part, dict):
                 continue
-            if part.get("type") == "text":
+            if part.get("type") in TEXT_PART_TYPES:
                 text = part.get("text")
                 if isinstance(text, str) and text:
                     yield text
@@ -58,14 +65,22 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
     """Coerce a Responses-API ``data["input"]`` value into chat-style messages."""
     if isinstance(input_value, str):
         return [{"role": "user", "content": input_value}]
-    if isinstance(input_value, list):
-        if input_value and all(isinstance(item, dict) and "role" in item for item in input_value):
-            return list(input_value)
-        # Mixed lists (content-part dicts + bare strings) and pure
-        # string/dict lists all become a single user message; the content
-        # iterator below handles each element type uniformly.
-        return [{"role": "user", "content": input_value}]
-    return []
+    if not isinstance(input_value, list):
+        return []
+    messages: List[Dict[str, Any]] = []
+    for item in input_value:
+        if isinstance(item, str):
+            messages.append({"role": "user", "content": item})
+        elif isinstance(item, dict):
+            if item.get("type") in TEXT_PART_TYPES:
+                messages.append({"role": "user", "content": [item]})
+            elif "content" in item:
+                messages.append(
+                    {"role": item.get("role") or "user", "content": item["content"]}
+                )
+            elif item.get("type") == "function_call_output" and "output" in item:
+                messages.append({"role": "tool", "content": item["output"]})
+    return messages
 
 
 def _iter_inspection_messages(data: Dict[str, Any]) -> Iterator[Dict[str, Any]]:
@@ -112,7 +127,7 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
                     new_parts.append(visit(part))
                 elif (
                     isinstance(part, dict)
-                    and part.get("type") == "text"
+                    and part.get("type") in TEXT_PART_TYPES
                     and isinstance(part.get("text"), str)
                     and part["text"]
                 ):
@@ -136,31 +151,28 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
             data["input"] = visit(input_value)
         return visited
     if isinstance(input_value, list):
-        # List of full messages: rewrite each message's content.
-        if input_value and all(isinstance(item, dict) and "role" in item for item in input_value):
-            for item in input_value:
-                if "content" in item:
-                    item["content"] = _rewrite_content(item["content"])
-            return visited
-        # List of content parts and/or bare strings: rewrite in place.
         for idx, item in enumerate(input_value):
-            if isinstance(item, str) and item:
-                visited += 1
-                input_value[idx] = visit(item)
-            elif (
-                isinstance(item, dict)
-                and item.get("type") == "text"
-                and isinstance(item.get("text"), str)
-                and item["text"]
-            ):
-                visited += 1
-                input_value[idx] = {**item, "text": visit(item["text"])}
+            if isinstance(item, str):
+                if item:
+                    visited += 1
+                    input_value[idx] = visit(item)
+            elif isinstance(item, dict):
+                if item.get("type") in TEXT_PART_TYPES:
+                    if isinstance(item.get("text"), str) and item["text"]:
+                        visited += 1
+                        input_value[idx] = {**item, "text": visit(item["text"])}
+                elif "content" in item:
+                    item["content"] = _rewrite_content(item["content"])
+                elif item.get("type") == "function_call_output" and "output" in item:
+                    item["output"] = _rewrite_content(item["output"])
         return visited
 
     return visited
 
 
-def apply_redacted_messages_back(data: Dict[str, Any], redacted_messages: List[Dict[str, Any]]) -> None:
+def apply_redacted_messages_back(
+    data: Dict[str, Any], redacted_messages: List[Dict[str, Any]]
+) -> None:
     """Write redacted messages back to whichever field(s) the caller used.
 
     Mask/anonymize paths take a synthesised messages list (from
@@ -193,7 +205,9 @@ def has_non_string_content(data: Dict[str, Any]) -> bool:
     messages = data.get("messages")
     if isinstance(messages, list):
         for message in messages:
-            if isinstance(message, dict) and not isinstance(message.get("content"), str):
+            if isinstance(message, dict) and not isinstance(
+                message.get("content"), str
+            ):
                 if message.get("content") is not None:
                     return True
     input_value = data.get("input")
@@ -221,5 +235,7 @@ def build_inspection_messages(data: Dict[str, Any]) -> List[Dict[str, str]]:
         if not text:
             continue
         role = message.get("role", "user") or "user"
+        if role not in _INSPECTION_SAFE_ROLES:
+            role = "user"
         flattened.append({"role": role, "content": text})
     return flattened

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -23,9 +23,7 @@ from typing import Any, Callable, Dict, FrozenSet, Iterator, List
 # ``pre_call_hook`` directly with the sync name. Embedding, moderation,
 # audio, and transcription endpoints are deliberately excluded — text
 # guardrails on those paths are a separate scope.
-TEXT_CONTENT_CALL_TYPES: FrozenSet[str] = frozenset(
-    {"completion", "acompletion", "aresponses"}
-)
+TEXT_CONTENT_CALL_TYPES: FrozenSet[str] = frozenset({"completion", "acompletion", "aresponses"})
 
 
 def is_text_content_call_type(call_type: str) -> bool:
@@ -75,9 +73,7 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
             if item.get("type") in TEXT_PART_TYPES:
                 messages.append({"role": "user", "content": [item]})
             elif "content" in item:
-                messages.append(
-                    {"role": item.get("role") or "user", "content": item["content"]}
-                )
+                messages.append({"role": item.get("role") or "user", "content": item["content"]})
             elif item.get("type") == "function_call_output" and "output" in item:
                 messages.append({"role": "tool", "content": item["output"]})
     return messages
@@ -170,9 +166,7 @@ def walk_user_text(data: Dict[str, Any], visit: Callable[[str], str]) -> int:
     return visited
 
 
-def apply_redacted_messages_back(
-    data: Dict[str, Any], redacted_messages: List[Dict[str, Any]]
-) -> None:
+def apply_redacted_messages_back(data: Dict[str, Any], redacted_messages: List[Dict[str, Any]]) -> None:
     """Write redacted messages back to whichever field(s) the caller used.
 
     Mask/anonymize paths take a synthesised messages list (from
@@ -205,9 +199,7 @@ def has_non_string_content(data: Dict[str, Any]) -> bool:
     messages = data.get("messages")
     if isinstance(messages, list):
         for message in messages:
-            if isinstance(message, dict) and not isinstance(
-                message.get("content"), str
-            ):
+            if isinstance(message, dict) and not isinstance(message.get("content"), str):
                 if message.get("content") is not None:
                     return True
     input_value = data.get("input")

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -75,7 +75,7 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
             elif "content" in item:
                 messages.append({"role": item.get("role") or "user", "content": item["content"]})
             elif item.get("type") == "function_call_output" and "output" in item:
-                messages.append({"role": "tool", "content": item["output"]})
+                messages.append({"role": "user", "content": item["output"]})
     return messages
 
 

--- a/litellm/proxy/guardrails/_content_utils.py
+++ b/litellm/proxy/guardrails/_content_utils.py
@@ -69,11 +69,11 @@ def _coerce_input_to_messages(input_value: Any) -> List[Dict[str, Any]]:
             messages.append({"role": "user", "content": item})
         elif isinstance(item, dict):
             if item.get("type") in TEXT_PART_TYPES:
-                messages.append({"role": "user", "content": [item]})
+                messages.append({"role": item.get("role") or "user", "content": [item]})
             elif "content" in item:
                 messages.append({"role": item.get("role") or "user", "content": item["content"]})
             elif item.get("type") == "function_call_output" and "output" in item:
-                messages.append({"role": "user", "content": item["output"]})
+                messages.append({"role": item.get("role") or "tool", "content": item["output"]})
     return messages
 
 

--- a/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/aim/aim.py
@@ -93,11 +93,10 @@ class AimGuardrail(CustomGuardrail):
             user_email=user_email,
             litellm_call_id=call_id,
         )
-        # Covers multimodal list content + Responses-API input.
         response = await self.async_handler.post(
             f"{self.api_base}/fw/v1/analyze",
             headers=headers,
-            json={"messages": build_inspection_messages(data)},
+            json={"messages": self._build_aim_inspection_messages(data)},
         )
         response.raise_for_status()
         res = response.json()
@@ -115,6 +114,15 @@ class AimGuardrail(CustomGuardrail):
         else:
             verbose_proxy_logger.error(f"Aim: {action_type} action")
         return data
+
+    @staticmethod
+    def _build_aim_inspection_messages(data: dict) -> list[dict[str, str]]:
+        """AIM validates against the OpenAI chat schema. Bare ``role: "tool"``
+        without ``tool_call_id`` and bare ``role: "function"`` without ``name``
+        are rejected; the flatten drops those fields, so any role outside
+        ``{system, user, assistant}`` collapses to ``user`` for the AIM POST."""
+        safe_roles = {"system", "user", "assistant"}
+        return [{**m, "role": "user"} if m["role"] not in safe_roles else m for m in build_inspection_messages(data)]
 
     @staticmethod
     def _rejection(message: str, *, openai_code: str | None = None) -> ProxyException:
@@ -177,7 +185,10 @@ class AimGuardrail(CustomGuardrail):
                 user_email=user_email,
                 litellm_call_id=call_id,
             ),
-            json={"messages": build_inspection_messages(request_data) + [{"role": "assistant", "content": output}]},
+            json={
+                "messages": self._build_aim_inspection_messages(request_data)
+                + [{"role": "assistant", "content": output}]
+            },
         )
         response.raise_for_status()
         res = response.json()

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_aim.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_aim.py
@@ -1,0 +1,68 @@
+"""Tests for the AIM guardrail's inspection-payload construction."""
+
+from litellm.proxy.guardrails.guardrail_hooks.aim.aim import AimGuardrail
+
+
+def test_aim_inspection_messages_coerces_chat_completions_tool_role_to_user():
+    """LIT-4294: A valid chat-completions ``role: "tool"`` message carries a
+    ``tool_call_id``, but the inspection flatten drops every field except
+    ``role`` and ``content``. A bare ``tool`` message without ``tool_call_id``
+    is schema-invalid per the OpenAI chat schema, and the customer's writeup
+    reproduced AIM's ``/fw/v1/analyze`` returning 422 on exactly that shape.
+    The AIM POST collapses the role to ``user``; the outbound request to the
+    LLM is untouched."""
+    data = {
+        "messages": [
+            {"role": "user", "content": "weather in SF"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
+        ]
+    }
+    assert AimGuardrail._build_aim_inspection_messages(data) == [
+        {"role": "user", "content": "weather in SF"},
+        {"role": "user", "content": "sunny"},
+    ]
+
+
+def test_aim_inspection_messages_coerces_non_standard_caller_role_to_user():
+    """LIT-4294: A caller-supplied role outside {system, user, assistant}
+    (e.g. ``developer``, ``function``) is coerced to ``user`` for the AIM
+    POST, since AIM validates the payload against the OpenAI chat schema
+    and rejects unknown roles the same way it rejects bare ``tool``."""
+    data = {
+        "messages": [
+            {"role": "developer", "content": "system-ish instruction"},
+            {"role": "user", "content": "normal user text"},
+        ]
+    }
+    assert AimGuardrail._build_aim_inspection_messages(data) == [
+        {"role": "user", "content": "system-ish instruction"},
+        {"role": "user", "content": "normal user text"},
+    ]
+
+
+def test_aim_inspection_messages_preserves_safe_roles():
+    """Safe roles pass through untouched — the coercion only fires for
+    roles the OpenAI chat schema flatten cannot represent standalone."""
+    data = {
+        "messages": [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+    }
+    assert AimGuardrail._build_aim_inspection_messages(data) == [
+        {"role": "system", "content": "be helpful"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_aim.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_aim.py
@@ -51,6 +51,26 @@ def test_aim_inspection_messages_coerces_non_standard_caller_role_to_user():
     ]
 
 
+def test_aim_inspection_messages_coerces_responses_function_call_output_role():
+    """LIT-4294: the shared helper synthesises ``role: "tool"`` for a
+    Responses ``function_call_output`` item (semantic equivalent of
+    chat-completions tool messages). AIM's schema-validating POST cannot
+    carry ``tool_call_id`` in the flat inspection payload, so AIM collapses
+    that ``tool`` role to ``user`` locally before POSTing."""
+    data = {
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "sunny"}],
+            },
+        ]
+    }
+    assert AimGuardrail._build_aim_inspection_messages(data) == [
+        {"role": "user", "content": "sunny"},
+    ]
+
+
 def test_aim_inspection_messages_preserves_safe_roles():
     """Safe roles pass through untouched — the coercion only fires for
     roles the OpenAI chat schema flatten cannot represent standalone."""

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -274,6 +274,23 @@ def test_walk_user_text_redacts_function_call_output_text():
     assert data["input"][2]["output"][0]["text"] == "[REDACTED] tool"
 
 
+def test_walk_user_text_redacts_function_call_output_string_output():
+    """LIT-4294: ``function_call_output.output`` is also a plain string in
+    OpenAI's Responses spec; the redact walker must handle both forms."""
+    data = {
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": "AKIAEXAMPLE tool",
+            },
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("AKIAEXAMPLE", "[REDACTED]"))
+    assert visited == 1
+    assert data["input"][0]["output"] == "[REDACTED] tool"
+
+
 def test_walk_user_text_redacts_mixed_list_input():
     """Read and write helpers must agree on coverage — bare strings inside
     a mixed ``input`` list are inspected by both."""
@@ -345,7 +362,7 @@ def test_build_inspection_messages_drops_messages_with_no_text():
 
 def test_build_inspection_messages_responses_api_tool_call_taxonomy():
     """LIT-4294: mixed Responses ``input`` (message + function_call +
-    function_call_output) must produce a non-empty inspection list — an
+    function_call_output) must produce a non-empty inspection list. An
     empty ``messages`` posted to AIM's ``/fw/v1/analyze`` gets rejected with
     a 422 ``No messages in the request`` and every other guardrail silently
     scans nothing."""

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -392,11 +392,12 @@ def test_build_inspection_messages_responses_api_tool_call_taxonomy():
     ]
 
 
-def test_build_inspection_messages_coerces_non_standard_role_to_user():
-    """LIT-4294: the OpenAI chat schema requires ``tool_call_id`` on a
-    ``tool`` message; AIM validates the posted payload and rejects tool
-    messages missing that field. The inspection payload only carries text,
-    so any role outside {system, user, assistant} collapses to ``user``."""
+def test_build_inspection_messages_function_call_output_becomes_user():
+    """LIT-4294: tool-result items must surface to inspection APIs, but the
+    OpenAI chat schema requires ``tool_call_id`` on any ``tool`` message.
+    AIM's ``/fw/v1/analyze`` validates the posted payload and rejects a bare
+    tool message. ``function_call_output`` maps straight to ``user`` so a
+    schema-invalid shape is never materialised, even in isolation."""
     data = {
         "input": [
             {
@@ -406,8 +407,24 @@ def test_build_inspection_messages_coerces_non_standard_role_to_user():
             },
         ]
     }
-    result = build_inspection_messages(data)
-    assert result == [{"role": "user", "content": "tool text"}]
+    assert build_inspection_messages(data) == [{"role": "user", "content": "tool text"}]
+
+
+def test_build_inspection_messages_coerces_non_standard_caller_role_to_user():
+    """LIT-4294: a caller-supplied role outside {system, user, assistant}
+    (e.g. ``developer``, ``function``) is coerced to ``user`` before the
+    payload is posted to a third-party guardrail; downstream validators
+    reject unknown roles the same way they reject bare ``tool``."""
+    data = {
+        "messages": [
+            {"role": "developer", "content": "system-ish instruction"},
+            {"role": "user", "content": "normal user text"},
+        ]
+    }
+    assert build_inspection_messages(data) == [
+        {"role": "user", "content": "system-ish instruction"},
+        {"role": "user", "content": "normal user text"},
+    ]
 
 
 def test_build_inspection_messages_empty_data():

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -427,6 +427,37 @@ def test_build_inspection_messages_coerces_non_standard_caller_role_to_user():
     ]
 
 
+def test_build_inspection_messages_coerces_chat_completions_tool_role_to_user():
+    """LIT-4294: a valid chat-completions ``role: "tool"`` message carries a
+    ``tool_call_id``, but the inspection flatten drops every field except
+    ``role`` and ``content``. A bare ``tool`` message without ``tool_call_id``
+    is schema-invalid; AIM's ``/fw/v1/analyze`` rejects it with 422. The role
+    must collapse to ``user`` so a legitimate tool-replay conversation reaches
+    the guardrail cleanly on chat completions the same way it does on
+    Responses."""
+    data = {
+        "messages": [
+            {"role": "user", "content": "what's the weather"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
+        ]
+    }
+    assert build_inspection_messages(data) == [
+        {"role": "user", "content": "what's the weather"},
+        {"role": "user", "content": "sunny"},
+    ]
+
+
 def test_build_inspection_messages_empty_data():
     assert build_inspection_messages({}) == []
     assert build_inspection_messages({"messages": []}) == []

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -320,17 +320,13 @@ def test_build_inspection_messages_joins_multimodal_text_parts():
             }
         ]
     }
-    assert build_inspection_messages(data) == [
-        {"role": "user", "content": "first part\nsecond part"}
-    ]
+    assert build_inspection_messages(data) == [{"role": "user", "content": "first part\nsecond part"}]
 
 
 def test_build_inspection_messages_lifts_responses_api_input():
     """fniVO9-F: ``input`` must be visible to hooks that POST messages to a remote API."""
     data = {"input": "responses-api content"}
-    assert build_inspection_messages(data) == [
-        {"role": "user", "content": "responses-api content"}
-    ]
+    assert build_inspection_messages(data) == [{"role": "user", "content": "responses-api content"}]
 
 
 def test_build_inspection_messages_drops_messages_with_no_text():

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -362,10 +362,11 @@ def test_build_inspection_messages_drops_messages_with_no_text():
 
 def test_build_inspection_messages_responses_api_tool_call_taxonomy():
     """LIT-4294: mixed Responses ``input`` (message + function_call +
-    function_call_output) must produce a non-empty inspection list. An
-    empty ``messages`` posted to AIM's ``/fw/v1/analyze`` gets rejected with
-    a 422 ``No messages in the request`` and every other guardrail silently
-    scans nothing."""
+    function_call_output) must produce a non-empty inspection list. The
+    customer's writeup reproduced a 422 from AIM's ``/fw/v1/analyze``
+    (``No messages in the request``) when this synthesised list came back
+    empty; every other guardrail silently scanned nothing on the same
+    input."""
     data = {
         "input": [
             {
@@ -393,11 +394,14 @@ def test_build_inspection_messages_responses_api_tool_call_taxonomy():
 
 
 def test_build_inspection_messages_function_call_output_becomes_user():
-    """LIT-4294: tool-result items must surface to inspection APIs, but the
-    OpenAI chat schema requires ``tool_call_id`` on any ``tool`` message.
-    AIM's ``/fw/v1/analyze`` validates the posted payload and rejects a bare
-    tool message. ``function_call_output`` maps straight to ``user`` so a
-    schema-invalid shape is never materialised, even in isolation."""
+    """LIT-4294: tool-result items must surface to inspection APIs. The
+    OpenAI chat schema requires ``tool_call_id`` on any ``tool`` message,
+    and the customer's writeup reproduced a 422 from AIM's ``/fw/v1/analyze``
+    (``Tool Call ID required on tool calls``) when a ``function_call_output``
+    was mapped to bare ``role: "tool"`` without that field. Any guardrail
+    API that validates the posted payload against the OpenAI schema will
+    reject the same shape, so ``function_call_output`` maps straight to
+    ``user`` and a schema-invalid shape is never materialised."""
     data = {
         "input": [
             {
@@ -413,8 +417,9 @@ def test_build_inspection_messages_function_call_output_becomes_user():
 def test_build_inspection_messages_coerces_non_standard_caller_role_to_user():
     """LIT-4294: a caller-supplied role outside {system, user, assistant}
     (e.g. ``developer``, ``function``) is coerced to ``user`` before the
-    payload is posted to a third-party guardrail; downstream validators
-    reject unknown roles the same way they reject bare ``tool``."""
+    payload is posted to a third-party guardrail. Guardrail APIs that
+    validate the payload against the OpenAI chat schema reject unknown
+    roles the same way they reject bare ``tool``."""
     data = {
         "messages": [
             {"role": "developer", "content": "system-ish instruction"},
@@ -431,10 +436,12 @@ def test_build_inspection_messages_coerces_chat_completions_tool_role_to_user():
     """LIT-4294: a valid chat-completions ``role: "tool"`` message carries a
     ``tool_call_id``, but the inspection flatten drops every field except
     ``role`` and ``content``. A bare ``tool`` message without ``tool_call_id``
-    is schema-invalid; AIM's ``/fw/v1/analyze`` rejects it with 422. The role
-    must collapse to ``user`` so a legitimate tool-replay conversation reaches
-    the guardrail cleanly on chat completions the same way it does on
-    Responses."""
+    is schema-invalid per the OpenAI chat schema, and the customer's
+    writeup showed AIM's ``/fw/v1/analyze`` returning 422 on exactly this
+    shape when it was synthesised from the Responses ``function_call_output``
+    path. The role must collapse to ``user`` so a legitimate tool-replay
+    conversation reaches schema-validating guardrails cleanly on chat
+    completions the same way it does on Responses."""
     data = {
         "messages": [
             {"role": "user", "content": "what's the weather"},

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -389,16 +389,15 @@ def test_build_inspection_messages_responses_api_tool_call_taxonomy():
     }
     assert build_inspection_messages(data) == [
         {"role": "user", "content": "hello"},
-        {"role": "user", "content": "sunny"},
+        {"role": "tool", "content": "sunny"},
     ]
 
 
-def test_build_inspection_messages_function_call_output_becomes_user():
-    """LIT-4294: a Responses ``function_call_output`` item has no natural
-    ``role`` field — the walker synthesises one to flatten the item into a
-    chat-style message. It emits ``role: "user"`` rather than ``role: "tool"``
-    so no schema-invalid bare tool message (missing ``tool_call_id``) is
-    ever materialised, even in isolation."""
+def test_build_inspection_messages_function_call_output_defaults_to_tool():
+    """LIT-4294: a Responses ``function_call_output`` item is the semantic
+    equivalent of a chat-completions ``role: "tool"`` message, so the shared
+    helper synthesises ``role: "tool"`` when the item has no explicit role.
+    AIM's schema-safe coercion happens at the AIM call site, not here."""
     data = {
         "input": [
             {
@@ -408,7 +407,53 @@ def test_build_inspection_messages_function_call_output_becomes_user():
             },
         ]
     }
-    assert build_inspection_messages(data) == [{"role": "user", "content": "tool text"}]
+    assert build_inspection_messages(data) == [{"role": "tool", "content": "tool text"}]
+
+
+def test_build_inspection_messages_function_call_output_preserves_explicit_role():
+    """When ``function_call_output`` carries a caller-supplied ``role`` the
+    shared helper preserves it rather than synthesising ``tool``."""
+    data = {
+        "input": [
+            {
+                "type": "function_call_output",
+                "role": "assistant",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "tool text"}],
+            },
+        ]
+    }
+    assert build_inspection_messages(data) == [{"role": "assistant", "content": "tool text"}]
+
+
+def test_build_inspection_messages_bare_content_part_preserves_explicit_role():
+    """A bare content-part dict with an explicit ``role`` keeps it. Only
+    absent roles get defaulted to ``user``."""
+    data = {
+        "input": [
+            {"type": "input_text", "text": "no role"},
+            {"type": "output_text", "role": "assistant", "text": "with role"},
+        ]
+    }
+    assert build_inspection_messages(data) == [
+        {"role": "user", "content": "no role"},
+        {"role": "assistant", "content": "with role"},
+    ]
+
+
+def test_build_inspection_messages_message_item_preserves_role():
+    """Responses message items carry a role explicitly; the shared helper
+    passes it through untouched."""
+    data = {
+        "input": [
+            {"type": "message", "role": "system", "content": [{"type": "input_text", "text": "sys"}]},
+            {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "asst"}]},
+        ]
+    }
+    assert build_inspection_messages(data) == [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": "asst"},
+    ]
 
 
 def test_build_inspection_messages_empty_data():

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -394,14 +394,11 @@ def test_build_inspection_messages_responses_api_tool_call_taxonomy():
 
 
 def test_build_inspection_messages_function_call_output_becomes_user():
-    """LIT-4294: tool-result items must surface to inspection APIs. The
-    OpenAI chat schema requires ``tool_call_id`` on any ``tool`` message,
-    and the customer's writeup reproduced a 422 from AIM's ``/fw/v1/analyze``
-    (``Tool Call ID required on tool calls``) when a ``function_call_output``
-    was mapped to bare ``role: "tool"`` without that field. Any guardrail
-    API that validates the posted payload against the OpenAI schema will
-    reject the same shape, so ``function_call_output`` maps straight to
-    ``user`` and a schema-invalid shape is never materialised."""
+    """LIT-4294: a Responses ``function_call_output`` item has no natural
+    ``role`` field — the walker synthesises one to flatten the item into a
+    chat-style message. It emits ``role: "user"`` rather than ``role: "tool"``
+    so no schema-invalid bare tool message (missing ``tool_call_id``) is
+    ever materialised, even in isolation."""
     data = {
         "input": [
             {
@@ -412,57 +409,6 @@ def test_build_inspection_messages_function_call_output_becomes_user():
         ]
     }
     assert build_inspection_messages(data) == [{"role": "user", "content": "tool text"}]
-
-
-def test_build_inspection_messages_coerces_non_standard_caller_role_to_user():
-    """LIT-4294: a caller-supplied role outside {system, user, assistant}
-    (e.g. ``developer``, ``function``) is coerced to ``user`` before the
-    payload is posted to a third-party guardrail. Guardrail APIs that
-    validate the payload against the OpenAI chat schema reject unknown
-    roles the same way they reject bare ``tool``."""
-    data = {
-        "messages": [
-            {"role": "developer", "content": "system-ish instruction"},
-            {"role": "user", "content": "normal user text"},
-        ]
-    }
-    assert build_inspection_messages(data) == [
-        {"role": "user", "content": "system-ish instruction"},
-        {"role": "user", "content": "normal user text"},
-    ]
-
-
-def test_build_inspection_messages_coerces_chat_completions_tool_role_to_user():
-    """LIT-4294: a valid chat-completions ``role: "tool"`` message carries a
-    ``tool_call_id``, but the inspection flatten drops every field except
-    ``role`` and ``content``. A bare ``tool`` message without ``tool_call_id``
-    is schema-invalid per the OpenAI chat schema, and the customer's
-    writeup showed AIM's ``/fw/v1/analyze`` returning 422 on exactly this
-    shape when it was synthesised from the Responses ``function_call_output``
-    path. The role must collapse to ``user`` so a legitimate tool-replay
-    conversation reaches schema-validating guardrails cleanly on chat
-    completions the same way it does on Responses."""
-    data = {
-        "messages": [
-            {"role": "user", "content": "what's the weather"},
-            {
-                "role": "assistant",
-                "content": "",
-                "tool_calls": [
-                    {
-                        "id": "c1",
-                        "type": "function",
-                        "function": {"name": "get_weather", "arguments": "{}"},
-                    }
-                ],
-            },
-            {"role": "tool", "tool_call_id": "c1", "content": "sunny"},
-        ]
-    }
-    assert build_inspection_messages(data) == [
-        {"role": "user", "content": "what's the weather"},
-        {"role": "user", "content": "sunny"},
-    ]
 
 
 def test_build_inspection_messages_empty_data():

--- a/tests/test_litellm/proxy/guardrails/test_content_utils.py
+++ b/tests/test_litellm/proxy/guardrails/test_content_utils.py
@@ -8,7 +8,6 @@ from litellm.proxy.guardrails._content_utils import (
     walk_user_text,
 )
 
-
 # ── iter_message_text ────────────────────────────────────────────────────────────
 
 
@@ -101,6 +100,55 @@ def test_iter_message_text_empty_data():
     assert list(iter_message_text({"input": ""})) == []
 
 
+def test_iter_message_text_responses_api_input_text_and_output_text_parts():
+    """LIT-4294: Responses-API content parts use ``input_text`` (request) and
+    ``output_text`` (assistant); reading only ``type == "text"`` skipped every
+    ``/v1/responses`` body and every text guardrail was a no-op on that path."""
+    data = {
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "user text"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "assistant text"}],
+            },
+        ]
+    }
+    assert list(iter_message_text(data)) == ["user text", "assistant text"]
+
+
+def test_iter_message_text_responses_api_tool_call_taxonomy():
+    """LIT-4294: a Responses ``input`` list freely mixes message items,
+    ``function_call`` (no ``role``), and ``function_call_output`` items. The
+    old ``all(item has 'role')`` gate wrapped the whole list as one blob and
+    yielded nothing; every text fragment must be visited independently."""
+    data = {
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "sunny"}],
+            },
+        ]
+    }
+    assert list(iter_message_text(data)) == ["hello", "sunny"]
+
+
 # ── walk_user_text ────────────────────────────────────────────────────────────
 
 
@@ -158,6 +206,72 @@ def test_walk_user_text_redacts_responses_api_list_input():
     assert visited == 1
     assert data["input"][0] == {"type": "text", "text": "[redacted]AKIAEXAMPLE[/]"}
     assert data["input"][1] == {"type": "image_url", "image_url": {"url": "..."}}
+
+
+def test_walk_user_text_redacts_responses_input_text_and_output_text_parts():
+    """LIT-4294: ``walk_user_text`` must recognise the Responses text-part
+    variants so masking guardrails (secret detection, PII) actually redact
+    ``/v1/responses`` bodies instead of no-op'ing on them."""
+    data = {
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "AKIAEXAMPLE"}],
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "AKIAEXAMPLE too"}],
+            },
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("AKIAEXAMPLE", "[REDACTED]"))
+    assert visited == 2
+    assert data["input"][0]["content"][0] == {
+        "type": "input_text",
+        "text": "[REDACTED]",
+    }
+    assert data["input"][1]["content"][0] == {
+        "type": "output_text",
+        "text": "[REDACTED] too",
+    }
+
+
+def test_walk_user_text_redacts_function_call_output_text():
+    """LIT-4294: tool-call round-trips carry secrets in
+    ``function_call_output.output``; the redact walker must descend into it
+    while leaving ``function_call`` items (call_id, arguments) untouched."""
+    data = {
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "AKIAEXAMPLE user"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "get_weather",
+                "arguments": '{"AKIAEXAMPLE": 1}',
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "AKIAEXAMPLE tool"}],
+            },
+        ]
+    }
+    visited = walk_user_text(data, lambda s: s.replace("AKIAEXAMPLE", "[REDACTED]"))
+    assert visited == 2
+    assert data["input"][0]["content"][0]["text"] == "[REDACTED] user"
+    assert data["input"][1] == {
+        "type": "function_call",
+        "call_id": "c1",
+        "name": "get_weather",
+        "arguments": '{"AKIAEXAMPLE": 1}',
+    }
+    assert data["input"][2]["output"][0]["text"] == "[REDACTED] tool"
 
 
 def test_walk_user_text_redacts_mixed_list_input():
@@ -231,6 +345,56 @@ def test_build_inspection_messages_drops_messages_with_no_text():
         ]
     }
     assert build_inspection_messages(data) == [{"role": "user", "content": "kept"}]
+
+
+def test_build_inspection_messages_responses_api_tool_call_taxonomy():
+    """LIT-4294: mixed Responses ``input`` (message + function_call +
+    function_call_output) must produce a non-empty inspection list — an
+    empty ``messages`` posted to AIM's ``/fw/v1/analyze`` gets rejected with
+    a 422 ``No messages in the request`` and every other guardrail silently
+    scans nothing."""
+    data = {
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}],
+            },
+            {
+                "type": "function_call",
+                "call_id": "c1",
+                "name": "get_weather",
+                "arguments": "{}",
+            },
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "sunny"}],
+            },
+        ]
+    }
+    assert build_inspection_messages(data) == [
+        {"role": "user", "content": "hello"},
+        {"role": "user", "content": "sunny"},
+    ]
+
+
+def test_build_inspection_messages_coerces_non_standard_role_to_user():
+    """LIT-4294: the OpenAI chat schema requires ``tool_call_id`` on a
+    ``tool`` message; AIM validates the posted payload and rejects tool
+    messages missing that field. The inspection payload only carries text,
+    so any role outside {system, user, assistant} collapses to ``user``."""
+    data = {
+        "input": [
+            {
+                "type": "function_call_output",
+                "call_id": "c1",
+                "output": [{"type": "input_text", "text": "tool text"}],
+            },
+        ]
+    }
+    result = build_inspection_messages(data)
+    assert result == [{"role": "user", "content": "tool text"}]
 
 
 def test_build_inspection_messages_empty_data():


### PR DESCRIPTION
## Relevant issues

## Linear ticket

Resolves LIT-4294

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy repro on both `/v1/responses` and `/v1/chat/completions`. The Responses request body is the shape a chat-to-Responses bridge (e.g. Google ADK) POSTs; the guardrail is a custom `pre_call` hook that logs what `_content_utils` extracted and calls `walk_user_text` to redact `AKIAEXAMPLE`

### Before (unfixed, HEAD 0f1e29b334)

```bash
curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4o-mini",
    "input": [
      {"type": "message", "role": "user",
       "content": [{"type": "input_text", "text": "AKIAEXAMPLE"}]},
      {"type": "function_call", "call_id": "c1", "name": "get_weather", "arguments": "{}"},
      {"type": "function_call_output", "call_id": "c1",
       "output": [{"type": "input_text", "text": "another AKIAEXAMPLE inside tool result"}]}
    ]
  }'
```

proxy log:

```
LIT4294 pre_call call_type=aresponses fragments_seen=0 inspection_msgs=0
LIT4294 fragments=[]
LIT4294 inspection=[]
LIT4294 walk_user_text visited=0
```

outbound POST body to OpenAI carries the unredacted keys; every text guardrail is a no-op on this path. `/v1/chat/completions` on the same proxy sees `fragments_seen=1` and redacts correctly, so the bypass is Responses-API-only

### After (this PR, HEAD 18d3a6fe5b)

Same curl:

```
LIT4294 pre_call call_type=aresponses fragments_seen=2 inspection_msgs=2
LIT4294 fragments=['AKIAEXAMPLE', 'another AKIAEXAMPLE inside tool result']
LIT4294 inspection=[{'role': 'user', 'content': 'AKIAEXAMPLE'},
                    {'role': 'tool', 'content': 'another AKIAEXAMPLE inside tool result'}]
LIT4294 walk_user_text visited=2
```

outbound POST body to `https://api.openai.com/v1/responses`:

```
{'model': 'gpt-4o-mini', 'input': [
   {'type': 'message', 'role': 'user',
    'content': [{'type': 'input_text', 'text': '[REDACTED]'}]},
   {'type': 'function_call', 'call_id': 'c1', 'name': 'get_weather', 'arguments': '{}'},
   {'type': 'function_call_output', 'call_id': 'c1',
    'output': [{'type': 'input_text', 'text': 'another [REDACTED] inside tool result'}]}]}
```

Both user text and tool-output text are redacted end-to-end; `function_call` metadata is preserved. The inspection payload keeps role fidelity (`function_call_output` surfaces as `role: "tool"` for downstream guardrails to consume). AIM's schema-validating POST to `/fw/v1/analyze` collapses `tool` to `user` locally right before the POST, keeping AIM schema-safe without imposing that coercion on other guardrails

## Type

🐛 Bug Fix

## Changes

Two fixes in `litellm/proxy/guardrails/_content_utils.py` and one AIM-local fix in `litellm/proxy/guardrails/guardrail_hooks/aim/aim.py`.

1. `_iter_text_parts_in_content` and the list branch of `walk_user_text` now recognise `{text, input_text, output_text}` as text-carrying part types via a new `TEXT_PART_TYPES` frozenset. The Responses API uses `input_text` on request messages and `output_text` on assistant messages; the previous single-value check made every text guardrail a no-op on `/v1/responses`
2. `_coerce_input_to_messages` and the list branch of `walk_user_text` now walk the actual Responses `input` taxonomy (message items, `function_call`, `function_call_output`, bare content-part dicts, bare strings) instead of the `all(item has role)` gate. That gate returned `False` for any tool-calling turn (`function_call` and `function_call_output` have no `role`), which caused the whole list to collapse to a single-message blob whose content was never walked. `function_call` items are dropped from the inspection view since they carry no free-form text (arguments walking is LIT-4304 scope); `function_call_output` maps to `role: tool` by default, preserving the caller-supplied role when present. Role fidelity is otherwise preserved throughout: message items, bare parts, and content items pass through their original role
3. AIM's schema-validating POST to `/fw/v1/analyze` needs `{system, user, assistant}`-only roles because the flatten drops `tool_call_id` and `name`. That coercion lives in a private `AimGuardrail._build_aim_inspection_messages` helper right before the POST rather than in the shared helper, so other guardrails (Lakera, Cato, Lasso, Repello, IBM, Azure, secret detection) see the caller's original role fidelity on their inspection payloads

Regression tests: `tests/test_litellm/proxy/guardrails/test_content_utils.py` covers the Responses taxonomy walk, `input_text`/`output_text` extraction and redaction, `function_call_output.output` list + string form, role preservation on bare parts and message items, and the `function_call_output` → `role: tool` default. `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_aim.py` covers the AIM-local role coercion. 41 tests pass; every new test fails on unfixed code

## QA verification

Two layers: live proxy hitting real OpenAI, and unit-level checks directly against the helpers.

**Live proxy (cases 1-9, 16):** custom `pre_call` guardrail hook logs BEFORE/AFTER snapshots of `data["messages"]` and `data["input"]`, the `iter_message_text` fragment list, and the `build_inspection_messages` role list. Proxy launched with `PYTHONPATH` pinned at the PR worktree so the exercised code is the PR source, not an installed package. One curl per case; each `AFTER` snapshot changed only leaf text values, every structural field (`role`, `type`, `call_id`, `tool_call_id`, `tool_calls`, `name`, `arguments`, `annotations`) byte-for-byte identical to `BEFORE`. OpenAI responses confirmed no `AKIAEXAMPLE` marker reached the model.

**Unit-level (cases 9-15):** import script that calls `build_inspection_messages`, `iter_message_text`, `walk_user_text`, `apply_redacted_messages_back`, and `AimGuardrail._build_aim_inspection_messages` directly with hand-constructed payloads. Uses `copy.deepcopy` between assertions. Covers shapes OpenAI's API rejects (bare `input_text`/`output_text` parts, `developer` role, exact AIM-payload role values).

**Regression gate (case 17):** ran the suite on the PR tip → 41 pass. Restored staging HEAD for `_content_utils.py` and `aim.py` while keeping the PR's tests checked out; the 4 AIM tests and 8 content-utils tests failed. Those 12 are exactly the behaviors this PR fixes.

**Before-baseline:** second proxy on staging HEAD, same curl → `fragments=[]`, `walk_visited=0`, OpenAI response echoed the raw `AKIAEXAMPLE` back. Confirmed the bug on unfixed code before verifying the fix.

Case-by-case verdict on `18d3a6fe5b`:

| # | Description | Verdict |
|---|---|---|
| 1 | chat/completions plain string | PASS |
| 2 | chat/completions multimodal text+image | PASS |
| 3 | chat/completions tool-call conversation | PASS |
| 4 | Responses raw string `input` | PASS |
| 5 | Responses message with `input_text` | PASS |
| 6 | Responses message with `output_text` | PASS |
| 7 | Responses mixed tool-calling (main repro) | PASS |
| 8 | Responses `function_call_output` string output | PASS |
| 9 | Bare `input_text`/`output_text` parts | PASS |
| 10 | Shared inspection role fidelity | PASS |
| 11 | AIM pre-call schema-safe inspection | PASS |
| 12 | AIM post-call / output inspection | PASS |
| 13 | Non-AIM guardrail role fidelity | PASS |
| 14 | Mask/write-back regression | PASS |
| 15 | Empty / non-text / unsupported items | PASS |
| 16 | Outbound request structural integrity | PASS |
| 17 | Unit/regression tests | PASS (41/41 on `18d3a6fe5b`; 12 fail on staging HEAD) |

### Caveat

The `apply_redacted_messages_back` helper writes the flat `[{role, content}]` inspection payload back over `data["messages"]`, which drops sibling `assistant.tool_calls` and any `tool_call_id` on a chat-completions tool-message masking path. That's a pre-existing structural flatten limitation, not introduced by this PR; verified case 14 does not corrupt the shape further. Fix belongs to a separate ticket.

## Known follow-up scope

The reviewer surfaced three related silent-bypass paths on the Responses-API surface that this PR deliberately leaves for follow-up commits so the change stays scoped to the customer's original repro. Tickets filed:

- LIT-4302: `custom_tool_call_output` items share the `output` shape with `function_call_output` and still bypass the helper.
- LIT-4303: `reasoning.summary_text` items replayed as `input` (ADK bridge, LangGraph-style loops) carry chain-of-thought text that guardrails do not currently walk.
- LIT-4304: `function_call.arguments` and its chat-completions sibling `message.tool_calls[i].function.arguments` are JSON strings that can carry user-supplied secrets; the shared helper does not walk them today. Pre-existing gap on both APIs, best fixed together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared proxy guardrail parsing/redaction on the security-critical pre-call path; behavior shifts for all hooks using `_content_utils`, though scope is limited to Responses API shapes and extensive tests were added.
> 
> **Overview**
> Fixes a **Responses API bypass** where text guardrails saw zero fragments on `/v1/responses` (including tool-calling turns), while chat completions kept working.
> 
> Shared `_content_utils` now treats **`text` / `input_text` / `output_text`** as text parts and **walks mixed `input` lists** item-by-item (messages, bare strings/parts, `function_call_output.output`) instead of collapsing the list when some items lack `role`. **`walk_user_text`** and **`build_inspection_messages`** follow the same rules so scan, redact, and remote inspection payloads stay aligned; `function_call_output` defaults to **`role: tool`** in the shared flatten.
> 
> **AIM** alone maps non-`{system,user,assistant}` roles to **`user`** before `/fw/v1/analyze`, avoiding 422s without changing other hooks’ role fidelity.
> 
> Regression coverage added in `test_content_utils.py` and `test_aim.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18d3a6fe5b716cfaf88fb1876052edc155a8f53f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

