### PR TITLE
fix(gemini): strip thought-signature suffix before matching tool_call_id

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1494,9 +1494,17 @@ def convert_to_gemini_tool_call_result(
     if last_message_with_tool_calls:
         tools = last_message_with_tool_calls.get("tool_calls", [])
         msg_tool_call_id = message.get("tool_call_id", None)
+        stripped_msg_id = (
+            msg_tool_call_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0] if isinstance(msg_tool_call_id, str) else None
+        )
         for tool in tools:
             prev_tool_call_id = tool.get("id", None)
-            if msg_tool_call_id and prev_tool_call_id and msg_tool_call_id == prev_tool_call_id:
+            stripped_prev_id = (
+                prev_tool_call_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0]
+                if isinstance(prev_tool_call_id, str)
+                else None
+            )
+            if stripped_msg_id and stripped_prev_id and stripped_msg_id == stripped_prev_id:
                 name = tool.get("function", {}).get("name", "")
 
     # Echo the OpenAI tool_call_id on functionResponse (strip thought-signature suffix).

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -669,6 +669,72 @@ def test_convert_gemini_messages():
     )
 
 
+def test_convert_gemini_tool_call_result_strips_thought_signature_suffix():
+    """
+    Codex-style clients echo the Gemini thought-signature suffix
+    ("<id>__thought__<base64>") on the function_call_output tool_call_id while the
+    assistant tool_call keeps the clean id. The name-recovery match must strip the
+    suffix from both ids before comparing, otherwise convert raises "Missing
+    corresponding tool call for tool response message".
+    Regression for: https://github.com/BerriAI/litellm/issues/29854
+    """
+    clean_id = "call_abc123"
+    suffix = "__thought__EiYKB3RleHRfMTIzEgVzb21ldGhpbmc="
+
+    def _assistant_turn(tool_call_id):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": tool_call_id,
+                    "type": "function",
+                    "index": 0,
+                    "function": {"name": "get_current_weather", "arguments": "{}"},
+                }
+            ],
+        }
+
+    # (a) suffixed response id vs clean assistant id -> matches and echoes the clean id
+    result = convert_to_gemini_tool_call_result(
+        message=ChatCompletionToolMessage(
+            role="tool", tool_call_id=clean_id + suffix, content="{}"
+        ),
+        last_message_with_tool_calls=_assistant_turn(clean_id),
+        model="gemini-3-pro-preview",
+        custom_llm_provider="gemini",
+    )
+    assert result["function_response"]["name"] == "get_current_weather"
+    assert result["function_response"]["id"] == clean_id
+
+    # suffix on the assistant tool_call instead -> also matches (either side may carry it)
+    result_reverse = convert_to_gemini_tool_call_result(
+        message=ChatCompletionToolMessage(
+            role="tool", tool_call_id=clean_id, content="{}"
+        ),
+        last_message_with_tool_calls=_assistant_turn(clean_id + suffix),
+    )
+    assert result_reverse["function_response"]["name"] == "get_current_weather"
+
+    # (b) clean vs clean -> unchanged behavior, still matches
+    result_clean = convert_to_gemini_tool_call_result(
+        message=ChatCompletionToolMessage(
+            role="tool", tool_call_id=clean_id, content="{}"
+        ),
+        last_message_with_tool_calls=_assistant_turn(clean_id),
+    )
+    assert result_clean["function_response"]["name"] == "get_current_weather"
+
+    # (c) genuinely different ids -> still raises, suffix stripping must not match unrelated ids
+    with pytest.raises(Exception, match="Missing corresponding tool call"):
+        convert_to_gemini_tool_call_result(
+            message=ChatCompletionToolMessage(
+                role="tool", tool_call_id="call_zzz" + suffix, content="{}"
+            ),
+            last_message_with_tool_calls=_assistant_turn(clean_id),
+        )
+
+
 def test_convert_gemini_tool_call_result_with_image_url():
     """
     Test that image_url content type in tool results is handled correctly for Gemini.


### PR DESCRIPTION
Codex-style clients echo Gemini's thought-signature suffix (`<id>__thought__<base64>`) on the function_call_output tool_call_id while the assistant tool_call keeps the clean id. convert_to_gemini_tool_call_result compared the two ids exactly, so the match failed, the recovered tool name stayed empty, and it raised "Missing corresponding tool call for tool response message" as an HTTP 500.

Fix: strip the THOUGHT_SIGNATURE_SEPARATOR suffix from both ids before comparing, the same way the function already does for the echoed function_response id a few lines below (and the same pattern as #27873 and #25935). Either side may or may not carry the suffix.

## Relevant issues

Addresses the thought-signature call_id half of #29854 (the namespace-tools half is covered by #29887)

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

End-to-end against a live proxy with gemini/gemini-3.5-flash (real API calls, no mocks). Turn 1 made a real tool call and Gemini returned a genuine thought signature riding on the tool_call id. Turn 2 echoed that suffixed id back on the tool response, Codex-style. Signature bodies redacted below.

Before (pre-fix factory.py):

```
# Proof of fix: BEFORE (pre-fix code, HEAD~1)
# Model: gemini/gemini-3.5-flash (Google AI Studio), real API call
# thought-signature bodies redacted; clean assistant id 'z5r3xikd' vs suffixed tool-response id

## Turn 2 request (assistant carries CLEAN id, tool response carries SUFFIXED id):
{
  "model": "gemini-3.5-flash",
  "messages": [
    {
      "role": "user",
      "content": "What is the weather in San Francisco? Use the get_weather tool."
    },
    {
      "role": "assistant",
      "content": null,
      "tool_calls": [
        {
          "id": "z5r3xikd",
          "type": "function",
          "function": {
            "name": "get_weather",
            "arguments": "{\"location\": \"San Francisco\"}"
          }
        }
      ]
    },
    {
      "role": "tool",
      "tool_call_id": "z5r3xikd__thought__EokCCoYC<REDACTED_SIGNATURE>",
      "content": "{\"temperature\": \"72F\", \"conditions\": \"sunny\"}"
    }
  ]
}

## curl command:
curl -s -w "HTTP %{http_code}\n" http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '<payload above>'

## Response: HTTP 500
litellm.APIConnectionError: Missing corresponding tool call for tool response message. Received - message={'role': 'tool', 'tool_call_id': 'z5r3xikd__thought__EokCCoYC<REDACTED_SIGNATURE>', 'content': '{"temperature": "72F", "conditions": "sunny"}'}, last_message_with_tool_calls={'role': 'assistant', 'tool_calls': [{'id': 'z5r3xikd', 'type': 'function', 'function': {'name': 'get_weather', 'arguments': '{"location": "San Francisco"}'}}]}
```

After (this fix, identical request):

```
# Proof of fix: AFTER (fix applied, committed version)
# Model: gemini/gemini-3.5-flash (Google AI Studio), real API call
# Identical turn-2 request as the BEFORE run

## Response: HTTP 200

assistant message content:
The weather in San Francisco is currently sunny with a temperature of 72°F.

usage:
{"completion_tokens":18,"prompt_tokens":55,"total_tokens":73,"completion_tokens_details":{"text_tokens":18},"prompt_tokens_details":{"text_tokens":55}}
```

Also added a regression test (test_convert_gemini_tool_call_result_strips_thought_signature_suffix) that fails on the pre-fix source with the exact exception above and passes with the fix. It covers: suffix on the response id, suffix on the assistant id, clean vs clean (no behavior change), and genuinely different ids (still raises, so stripping doesn't over-match).

Note: test_bedrock_converse_messages_pt_document_various_formats fails identically on stock code with my changes stashed — pre-existing on the base branch, unrelated to this PR.


