### PR TITLE
fix(bedrock): honor cache_control ttl on message-level cachePoint blocks

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3626,6 +3626,7 @@ class BedrockImageProcessor:
 
 def _convert_to_bedrock_tool_call_invoke(
     tool_calls: list,
+    model: Optional[str] = None,
 ) -> List[BedrockContentBlock]:
     """
     OpenAI tool invokes:
@@ -3701,7 +3702,13 @@ def _convert_to_bedrock_tool_call_invoke(
                             # cache_control applies to the whole original
                             # tool call; attach after the last split block.
                             if tool.get("cache_control", None) is not None:
-                                _parts_list.append(BedrockContentBlock(cachePoint=CachePointBlock(type="default")))
+                                _cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
+                                    {"cache_control": tool["cache_control"]},
+                                    block_type="content_block",
+                                    model=model,
+                                )
+                                if _cache_point_block is not None:
+                                    _parts_list.append(_cache_point_block)
                             continue
                         # Fallback: no objects extracted — use empty dict.
                         arguments_dict = {}
@@ -3712,8 +3719,13 @@ def _convert_to_bedrock_tool_call_invoke(
 
                 # Check for cache_control and add a separate cachePoint block
                 if tool.get("cache_control", None) is not None:
-                    cache_point_block = BedrockContentBlock(cachePoint=CachePointBlock(type="default"))
-                    _parts_list.append(cache_point_block)
+                    cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
+                        {"cache_control": tool["cache_control"]},
+                        block_type="content_block",
+                        model=model,
+                    )
+                    if cache_point_block is not None:
+                        _parts_list.append(cache_point_block)
         return _parts_list
     except Exception as e:
         raise Exception(
@@ -4417,22 +4429,27 @@ class BedrockConverseMessagesProcessor:
                 tool_content.append(tool_call_result)
 
                 # Check if we need to add a separate cachePoint block
-                has_cache_control = False
+                tool_msg_cache_control = None
 
                 # Check for message-level cache_control
                 if current_message.get("cache_control", None) is not None:
-                    has_cache_control = True
+                    tool_msg_cache_control = current_message["cache_control"]
                 # Check for content-level cache_control in list content
                 elif isinstance(current_message.get("content"), list):
                     for content_element in current_message["content"]:
                         if isinstance(content_element, dict) and content_element.get("cache_control", None) is not None:
-                            has_cache_control = True
+                            tool_msg_cache_control = content_element["cache_control"]
                             break
 
                 # Add a separate cachePoint block if cache_control is present
-                if has_cache_control:
-                    cache_point_block = BedrockContentBlock(cachePoint=CachePointBlock(type="default"))
-                    tool_content.append(cache_point_block)
+                if tool_msg_cache_control is not None:
+                    cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
+                        {"cache_control": tool_msg_cache_control},
+                        block_type="content_block",
+                        model=model,
+                    )
+                    if cache_point_block is not None:
+                        tool_content.append(cache_point_block)
 
                 msg_i += 1
             # Deduplicate toolResult blocks with the same toolUseId
@@ -4529,7 +4546,7 @@ class BedrockConverseMessagesProcessor:
 
                 _tool_calls = assistant_message_block.get("tool_calls", [])
                 if _tool_calls:
-                    assistant_content.extend(_convert_to_bedrock_tool_call_invoke(_tool_calls))
+                    assistant_content.extend(_convert_to_bedrock_tool_call_invoke(_tool_calls, model=model))
 
                 msg_i += 1
 
@@ -4789,22 +4806,27 @@ def _bedrock_converse_messages_pt(
             tool_content.append(tool_call_result)
 
             # Check if we need to add a separate cachePoint block
-            has_cache_control = False
+            tool_msg_cache_control = None
 
             # Check for message-level cache_control
             if current_message.get("cache_control", None) is not None:
-                has_cache_control = True
+                tool_msg_cache_control = current_message["cache_control"]
             # Check for content-level cache_control in list content
             elif isinstance(current_message.get("content"), list):
                 for content_element in current_message["content"]:
                     if isinstance(content_element, dict) and content_element.get("cache_control", None) is not None:
-                        has_cache_control = True
+                        tool_msg_cache_control = content_element["cache_control"]
                         break
 
             # Add a separate cachePoint block if cache_control is present
-            if has_cache_control:
-                cache_point_block = BedrockContentBlock(cachePoint=CachePointBlock(type="default"))
-                tool_content.append(cache_point_block)
+            if tool_msg_cache_control is not None:
+                cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
+                    {"cache_control": tool_msg_cache_control},
+                    block_type="content_block",
+                    model=model,
+                )
+                if cache_point_block is not None:
+                    tool_content.append(cache_point_block)
 
             msg_i += 1
         # Deduplicate toolResult blocks with the same toolUseId
@@ -4902,7 +4924,7 @@ def _bedrock_converse_messages_pt(
                     assistant_content.append(_cache_point_block)
             _tool_calls = assistant_message_block.get("tool_calls", [])
             if _tool_calls:
-                assistant_content.extend(_convert_to_bedrock_tool_call_invoke(_tool_calls))
+                assistant_content.extend(_convert_to_bedrock_tool_call_invoke(_tool_calls, model=model))
 
             msg_i += 1
 

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -5671,3 +5671,99 @@ async def test_grounding_source_and_query_rendered_as_text():
     user_content = result[0]["content"]
     assert {"text": "Tokyo is the capital of Japan."} in user_content
     assert {"text": "What is the capital of Japan?"} in user_content
+
+
+def _agentic_messages_with_ttl(ttl_target: str):
+    """A tool-loop conversation with `ttl: 1h` cache_control at `ttl_target`:
+    'user', 'tool_call' (per-tool-call, on the assistant's tool call), or
+    'tool' (message-level, on the tool result - where
+    `cache_control_injection_points` with `index: -1` lands mid-loop).
+
+    Message-level cache_control on a content-less assistant message emits no
+    cachePoint at all today (a separate gap, orthogonal to ttl); per-tool-call
+    placement covers that message, so it's excluded from the params below."""
+    user: dict = {"role": "user", "content": "optimize this kernel " * 60}
+    assistant: dict = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "evaluate", "arguments": "{}"},
+            }
+        ],
+    }
+    tool: dict = {"role": "tool", "tool_call_id": "call_1", "content": "score: 42"}
+    ttl_cc = {"type": "ephemeral", "ttl": "1h"}
+    if ttl_target == "user":
+        user["cache_control"] = ttl_cc
+    elif ttl_target == "tool_call":
+        assistant["tool_calls"][0]["cache_control"] = ttl_cc
+    elif ttl_target == "tool":
+        tool["cache_control"] = ttl_cc
+    return [user, assistant, tool]
+
+
+def _collect_cache_points(result):
+    return [
+        block["cachePoint"]
+        for message in result
+        for block in message.get("content") or []
+        if "cachePoint" in block
+    ]
+
+
+@pytest.mark.parametrize("ttl_target", ["user", "tool_call", "tool"])
+@pytest.mark.asyncio
+async def test_message_level_cache_control_honors_ttl_for_supported_model(
+    ttl_target,
+):
+    """Message- and tool-call-level cache_control must carry `ttl` onto the
+    emitted cachePoint for models that support extended caching, mirroring the
+    system-message path. Regression test for the gap left by the system-only
+    fix: the message paths called `_get_cache_point_block` without `model` (or
+    hardcoded `{"type": "default"}`), silently downgrading 1h to 5m."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        BedrockConverseMessagesProcessor,
+        _bedrock_converse_messages_pt,
+    )
+
+    messages = _agentic_messages_with_ttl(ttl_target)
+
+    result = _bedrock_converse_messages_pt(
+        messages=messages,
+        model="global.anthropic.claude-opus-4-7",
+        llm_provider="bedrock_converse",
+    )
+    async_result = (
+        await BedrockConverseMessagesProcessor._bedrock_converse_messages_pt_async(
+            messages=messages,
+            model="global.anthropic.claude-opus-4-7",
+            llm_provider="bedrock_converse",
+        )
+    )
+    assert result == async_result
+
+    cache_points = _collect_cache_points(result)
+    assert len(cache_points) == 1
+    assert cache_points[0].get("ttl") == "1h"
+
+
+@pytest.mark.parametrize("ttl_target", ["user", "tool_call", "tool"])
+def test_message_level_cache_control_drops_ttl_for_unsupported_model(ttl_target):
+    """Models outside the extended-caching allow-list must keep emitting the
+    plain `{"type": "default"}` cachePoint (Bedrock rejects `ttl` for them)."""
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _bedrock_converse_messages_pt,
+    )
+
+    result = _bedrock_converse_messages_pt(
+        messages=_agentic_messages_with_ttl(ttl_target),
+        model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        llm_provider="bedrock_converse",
+    )
+
+    cache_points = _collect_cache_points(result)
+    assert len(cache_points) == 1
+    assert "ttl" not in cache_points[0]


### PR DESCRIPTION
## Relevant issues

Completes the fix for #32154. Copy of #32155 by @arashne, cherry-picked onto litellm_internal_staging so CircleCI can run on it; the code and tests are their work and the commit keeps the original authorship

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

See #32155 for the original repro (a message-level `cache_control` with `ttl: "1h"` silently emitting `cachePoint: {"type": "default"}`) and #32538 for live Bedrock usage output captured at `bfff5e8d86` (before) and `7195c2dfa2` (after), showing the full prefix served from the 1h cache on turn 2 after a 7 minute wait once `model` reaches the cachePoint builder. The paths completed here (tool-result blocks and per-tool-call `cache_control`) fail the same way on current staging: they hardcode `CachePointBlock(type="default")` without ever consulting `_get_cache_point_block`, so a requested ttl is dropped. After this change they emit `{"type": "default", "ttl": "1h"}` on supported models and keep emitting the plain default block on unsupported ones

## Type

🐛 Bug Fix

## Changes

Copy of #32155, authored by @arashne, so CircleCI can run on it

Since the original PR was opened, #32538 landed on litellm_internal_staging and covered part of the same ground: it passes `model=` at the 8 existing `_get_cache_point_block` call sites in `_bedrock_converse_messages_pt` / `_bedrock_converse_messages_pt_async`. This PR carries the remaining paths from #32155, the ones that never reached `_get_cache_point_block` at all because they hardcoded `CachePointBlock(type="default")`: tool-result blocks now capture the `cache_control` dict (previously reduced to a boolean) and route it through `_get_cache_point_block` so ttl survives, and `_convert_to_bedrock_tool_call_invoke` now accepts an optional `model` and routes per-tool-call `cache_control` the same way, with both callers passing `model=model`

The regression tests from the original PR are parameterized over user, tool-call, and tool-result placements crossed with a supported and an unsupported model, and assert the sync and async paths emit identical blocks

---

> [!NOTE]
> **Medium Risk**
> Changes Bedrock prompt shaping for cached agentic/tool loops; wrong TTL handling could affect cache behavior and API acceptance, but scope is limited to cache-point emission with new tests.
> 
> **Overview**
> Bedrock Converse message conversion no longer hardcodes `cachePoint: {"type": "default"}` for **tool results** and **assistant tool-call** `cache_control`; those paths now build cache points via `AmazonConverseConfig()._get_cache_point_block(..., model=model)` so a requested **`ttl` (e.g. `1h`)** is preserved on models that support extended caching and omitted on unsupported ones.
> 
> `_convert_to_bedrock_tool_call_invoke` gains an optional **`model`** argument and both sync/async Converse processors pass it through when converting tool calls. Tool-message handling now keeps the actual **`cache_control` dict** (message- or content-level) instead of a boolean before emitting the cache block.
> 
> Regression tests cover **user**, **per-tool-call**, and **tool-result** placements for supported vs unsupported models, including sync/async parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adb6e5aee5d68c9536d21ff957c62a13eaa11dcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>