### PR TITLE
fix(ui): serve assets under ui prefix

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -76,9 +76,16 @@ http {
     # /ui[/<page>] — the dashboard's JS hardcodes URLs under this prefix
     # (router.replace("/ui"), buildLoginUrlWithReturn("/ui/login"), ...).
     # Mirror what FastAPI StaticFiles(mount="/ui") did in the monolithic
-    # proxy_server: serve /ui/<page> from out/<page>.html, with App
-    # Router-aware fallback (out/<page>/index.html) and a final SPA
-    # fallback to out/index.html for client-side routes.
+    # proxy_server: serve /ui/assets/... from out/assets/... and serve
+    # /ui/<page> from out/<page>.html, with App Router-aware fallback
+    # (out/<page>/index.html) and a final SPA fallback to out/index.html
+    # for client-side routes.
+    location ^~ /ui/assets/ {
+      alias /usr/share/nginx/html/assets/;
+      try_files $uri =404;
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+    }
     location = /ui  { try_files /index.html =404; }
     location = /ui/ { try_files /index.html =404; }
     location ~ ^/ui/(.+)$ {


### PR DESCRIPTION
## The issue
The monolithic proxy mounts the static export under `/ui`, so `/ui/assets/...` resolves to `out/assets/...`.
Standalone `litellm-ui` image already serves `/assets/...`, but did not mirror that `/ui/assets/...` behavior.

As a result, dashboard asset URLs hardcoded under `/ui/assets/...` (the logos) could be handled by the generic `/ui` SPA fallback and return HTML instead of the requested image.

## Proof of Fix
Before, `/assets/logos/github.svg` serves image correcly, but `/ui/assets/logos/github.svg` returns identical html as `/`.
```
$ docker run -d -p 3000:3000 ghcr.io/berriai/litellm-ui:v1.92.0-rc.1
$ curl -sI http://127.0.0.1:3000/assets/logos/github.svg | grep -i content-type
Content-Type: image/svg+xml
$ curl -sI http://127.0.0.1:3000/ui/assets/logos/github.svg | grep -i content-type
Content-Type: text/html
```
After, both paths serve correct image.
```
$ docker build -f ui/Dockerfile -t litellm-ui:local-ui-assets-fix .
$ docker run -d -p 3000:3000 ghcr.io/berriai/litellm-ui:v1.92.0-rc.1
$ curl -sI http://127.0.0.1:3000/assets/logos/github.svg | grep -i content-type
Content-Type: image/svg+xml
$ curl -sI http://127.0.0.1:3000/ui/assets/logos/github.svg | grep -i content-type
Content-Type: image/svg+xml
```
## Type
🐛 Bug Fix

## Changes

Adds an explicit nginx location for `/ui/assets/` in the standalone `litellm-ui` image.

This PR maps `/ui/assets/...` to `/usr/share/nginx/html/assets/...` before the `/ui` regex fallback, preserving existing page routing such as `/ui/login`.