### PR TITLE
refactor(ui): consolidate invitation flow into the dashboard layout

### DIFF
--- a/ui/litellm-dashboard/eslint-metrics.json
+++ b/ui/litellm-dashboard/eslint-metrics.json
@@ -1,7 +1,7 @@
 {
-  "@typescript-eslint/no-explicit-any": 1982,
+  "@typescript-eslint/no-explicit-any": 1980,
   "complexity": 128,
-  "local/no-large-inline-object-arg": 512,
+  "local/no-large-inline-object-arg": 519,
   "local/no-long-condition-chain": 233,
   "max-depth": 59,
   "no-console": 15

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.test.tsx
@@ -3,9 +3,13 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Layout from "./layout";
 
+const { replaceMock } = vi.hoisted(() => ({ replaceMock: vi.fn() }));
+
+let searchParamsValue = new URLSearchParams();
+
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
-  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: replaceMock })),
+  useSearchParams: vi.fn(() => searchParamsValue),
   usePathname: vi.fn(() => "/ui/guardrails"),
 }));
 
@@ -58,6 +62,7 @@ describe("(dashboard) Layout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     pendingUiConfig = createDeferred();
+    searchParamsValue = new URLSearchParams();
   });
 
   it("does not mount route content until getUiConfig has resolved", async () => {
@@ -78,5 +83,26 @@ describe("(dashboard) Layout", () => {
     await waitFor(() => expect(screen.getByTestId("page-content")).toBeTruthy());
     expect(screen.getByTestId("navbar")).toBeTruthy();
     expect(screen.queryByTestId("loading-screen")).toBeNull();
+  });
+
+  it("redirects an invitation link to the onboarding route instead of rendering the dashboard shell", async () => {
+    searchParamsValue = new URLSearchParams("invitation_id=abc123");
+
+    render(
+      <AuthProvider>
+        <Layout>
+          <div data-testid="page-content" />
+        </Layout>
+      </AuthProvider>,
+    );
+
+    pendingUiConfig.resolve();
+
+    await waitFor(() =>
+      expect(replaceMock).toHaveBeenCalledWith(expect.stringContaining("/onboarding?invitation_id=abc123")),
+    );
+    expect(screen.queryByTestId("page-content")).toBeNull();
+    expect(screen.queryByTestId("navbar")).toBeNull();
+    expect(screen.queryByTestId("sidebar")).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/layout.tsx
@@ -137,17 +137,26 @@ function DashboardShell({ children }: { children: React.ReactNode }) {
 }
 
 function LayoutContent({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
   const searchParams = useSearchParams();
   const { accessToken, authLoading } = useAuth();
   const isInvitationFlow = Boolean(searchParams.get("invitation_id"));
 
-  if (authLoading) {
+  // Legacy invitation links point at /ui/?invitation_id=; the onboarding form now lives at its own
+  // /onboarding route. Redirect once ui-config has loaded so migratedHref resolves the SERVER_ROOT_PATH base.
+  useEffect(() => {
+    if (!authLoading && isInvitationFlow) {
+      router.replace(`${migratedHref("onboarding")}?${searchParams.toString()}`);
+    }
+  }, [authLoading, isInvitationFlow, router, searchParams]);
+
+  if (authLoading || isInvitationFlow) {
     return <LoadingScreen />;
   }
 
   return (
     <ThemeProvider accessToken={accessToken}>
-      {isInvitationFlow ? children : <DashboardShell>{children}</DashboardShell>}
+      <DashboardShell>{children}</DashboardShell>
     </ThemeProvider>
   );
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import ApiKeysDashboard from "@/app/(dashboard)/api-keys/ApiKeysDashboard";
-import { teamListCall as v2TeamListCall } from "@/app/(dashboard)/hooks/teams/useTeams";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
-import { Team } from "@/components/key_team_helpers/key_list";
 import { proxyBaseUrl } from "@/components/networking";
-import UserDashboard from "@/components/user_dashboard";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
@@ -16,32 +13,20 @@ import {
 } from "@/utils/returnUrlUtils";
 import { MIGRATED_PAGES, migratedHref } from "@/utils/migratedPages";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef } from "react";
 
 function CreateKeyPageContent() {
-  const { authLoading, token, userID, userRole, userEmail, accessToken, premiumUser, setUserRole, setUserEmail } =
-    useAuth();
-
-  const [teams, setTeams] = useState<Team[] | null>(null);
-  const [keys, setKeys] = useState<null | any[]>([]);
+  const { authLoading, token } = useAuth();
 
   const router = useRouter();
   const searchParams = useSearchParams()!;
-  const [createClicked, setCreateClicked] = useState<boolean>(false);
-
-  const invitation_id = searchParams.get("invitation_id");
 
   const explicitPage = searchParams.get("page");
-  const page = explicitPage || "api-keys";
 
   // Track if we've already attempted a return URL redirect to prevent race conditions
   const hasAttemptedReturnRedirectRef = useRef(false);
 
-  const addKey = (data: any) => {
-    setKeys((prevData) => (prevData ? [...prevData, data] : [data]));
-    setCreateClicked(() => !createClicked);
-  };
-  const redirectToLogin = authLoading === false && token === null && invitation_id === null;
+  const redirectToLogin = authLoading === false && token === null;
 
   useEffect(() => {
     if (redirectToLogin) {
@@ -55,15 +40,13 @@ function CreateKeyPageContent() {
     }
   }, [redirectToLogin]);
 
-  // Redirect legacy query-param pages to their new path-based routes. Only when the page is
-  // explicitly requested via ?page=, so the bare landing renders inline and the post-login
-  // return-URL handling below stays intact.
+  // Redirect legacy ?page= deep links (old bookmarks) to their path-based routes.
   const isLegacyRedirect = explicitPage !== null && explicitPage in MIGRATED_PAGES;
   useEffect(() => {
     if (!authLoading && isLegacyRedirect) {
-      router.replace(migratedHref(MIGRATED_PAGES[page]));
+      router.replace(migratedHref(MIGRATED_PAGES[explicitPage]));
     }
-  }, [authLoading, isLegacyRedirect, page, router]);
+  }, [authLoading, isLegacyRedirect, explicitPage, router]);
 
   // Check for a stored return URL after successful authentication
   // This handles the case where user comes back from SSO and we need to redirect to the original URL
@@ -102,42 +85,11 @@ function CreateKeyPageContent() {
     }
   }, [token]);
 
-  useEffect(() => {
-    if (accessToken && userID && userRole) {
-      v2TeamListCall(accessToken, 1, 100, {
-        userID: userRole !== "Admin" && userRole !== "Admin Viewer" ? userID : null,
-      })
-        .then((response) => setTeams(response.teams ?? []))
-        .catch(console.error);
-    }
-  }, [accessToken, userID, userRole]);
-
   if (authLoading || redirectToLogin || isLegacyRedirect) {
     return <LoadingScreen />;
   }
 
-  return (
-    <>
-      {invitation_id ? (
-        <UserDashboard
-          userID={userID}
-          userRole={userRole}
-          premiumUser={premiumUser}
-          teams={teams}
-          keys={keys}
-          setUserRole={setUserRole}
-          userEmail={userEmail}
-          setUserEmail={setUserEmail}
-          setTeams={setTeams}
-          setKeys={setKeys}
-          addKey={addKey}
-          createClicked={createClicked}
-        />
-      ) : (
-        <ApiKeysDashboard />
-      )}
-    </>
-  );
+  return <ApiKeysDashboard />;
 }
 
 export default function CreateKeyPage() {

--- a/ui/litellm-dashboard/src/components/user_dashboard.tsx
+++ b/ui/litellm-dashboard/src/components/user_dashboard.tsx
@@ -2,9 +2,7 @@
 import { clearTokenCookies, getCookie } from "@/utils/cookieUtils";
 import { Col, Grid } from "@tremor/react";
 import { jwtDecode } from "jwt-decode";
-import { useSearchParams } from "next/navigation";
 import React, { useEffect, useState } from "react";
-import Onboarding from "../app/onboarding/page";
 import { fetchTeams } from "./common_components/fetch_teams";
 import { KeyResponse, Team } from "./key_team_helpers/key_list";
 import {
@@ -76,12 +74,7 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
   const [userSpendData, setUserSpendData] = useState<UserInfo | null>(null);
   const [currentOrg, setCurrentOrg] = useState<Organization | null>(null);
 
-  // Assuming useSearchParams() hook exists and works in your setup
-  const searchParams = useSearchParams()!;
-
   const token = getCookie("token");
-
-  const invitation_id = searchParams.get("invitation_id");
 
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [teamSpend, setTeamSpend] = useState<number | null>(null);
@@ -231,10 +224,6 @@ const UserDashboard: React.FC<UserDashboardProps> = ({
       setTeamSpend(sum);
     }
   }, [selectedTeam]);
-
-  if (invitation_id != null) {
-    return <Onboarding></Onboarding>;
-  }
 
   function gotoLogin() {
     // Clear token cookies using the utility function


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a behavior-preserving refactor of the dashboard shell, so the proof is that the three entry points the index touches still behave identically. Run the dev proxy (and the UI dev server if you want the fast path), log in, then walk these in order and screenshot each:

1. `http://localhost:4000/ui/` renders the API Keys landing (virtual keys table), same as before
2. `http://localhost:4000/ui/?page=teams` immediately redirects to `http://localhost:4000/ui/teams` (legacy bookmark back-compat still works)
3. Generate an invitation link from Internal Users, open it in a fresh/incognito window, and confirm it lands on the onboarding form with no sidebar or navbar. The modern link already targets `/ui/onboarding?invitation_id=`; the legacy `/ui/?invitation_id=` shape now redirects to that same onboarding route with the params preserved
4. Log out from an authed session on `/ui/` and confirm it still bounces to the SSO login with a `redirect_to` back to where you were

Local checks captured at commit 6b9fc41: `npx vitest run` on the touched suites (layout, CreateKeyPage, migratedPages, ApiKeysDashboard, user_dashboard) all green, `npm run build` compiles every route, and `make pre-commit` passes.

## Type

🧹 Refactoring

## Changes

The App Router migration is finished; every page is a real path route and the legacy `?page=` switch is already gone from the index. This is the closeout.

The `/ui/` index page carried its own duplicate copy of teams state, a teams fetch, and keys/addKey plumbing, all so it could render a second `UserDashboard` for the `invitation_id` case. That was redundant because `ApiKeysDashboard` already renders `UserDashboard` sourcing its own data. The index is thinned to just render `<ApiKeysDashboard />`; the login redirect, the legacy `?page=` deep-link redirect for old bookmarks, and the post-login return-URL handling all stay put

The invitation entry point now resolves in one place. Modern invitation links already point at the dedicated `/onboarding` route, so the dashboard layout redirects legacy `/ui/?invitation_id=` links there too, preserving the query params. It does this with `migratedHref`, the same base-path-aware redirect the index already uses for `?page=`, so `SERVER_ROOT_PATH` deployments resolve correctly. This replaces the previous approach of importing the `/onboarding` route's `page.tsx` into another module and re-rendering it inline. With that gone, the now-unreachable `if (invitation_id != null) return <Onboarding/>` branch in the shared `user_dashboard.tsx` is deleted here as well, along with its dead `Onboarding` import and `searchParams` read. A layout test asserts the redirect and fails if it regresses

While mapping this out I found that `legacyPageHref` and the sidebar's migrated-vs-legacy href fallback are not dead: the parent-category nav nodes (agentic, tools, experimental, settings) are not page routes and still flow through the legacy path builder, so removing it would break their hrefs. It is intentionally left in place, which narrows this PR from the original closeout sketch

eslint-metrics.json is resynced. The change removes two `any` casts (no-explicit-any 1982 to 1980); the snapshot also picks up pre-existing drift on no-large-inline-object-arg (512 to 519) that the gate requires the file to match, since `lint:metrics` regenerates the whole snapshot rather than a single rule
