### PR TITLE
fix(bedrock): keep mid-conversation system messages in place for Claude Invoke

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -94,25 +94,30 @@ class AmazonAnthropicClaudeMessagesConfig(
         return [value]
 
     def _normalize_system_role_messages_for_bedrock(self, anthropic_messages_request: dict) -> None:
-        """Bedrock Invoke rejects ``role: "system"`` entries inside ``messages`` on
-        some Claude aliases; Anthropic Messages carries that content in the
-        top-level ``system`` field. Move any such entries into ``system`` before
-        the Invoke request is built."""
+        """Bedrock Invoke rejects a conversation that opens with ``role: "system"``
+        entries inside ``messages`` ("messages.0: use the top-level 'system'
+        parameter for the initial system prompt"); Anthropic Messages carries that
+        content in the top-level ``system`` field, so hoist the leading run of
+        system entries there. Mid-conversation system entries (e.g. Claude Code's
+        ``mid-conversation-system-2026-04-07`` reminders) are accepted by Invoke in
+        place and MUST stay in place: hoisting one mutates the ``system`` prefix
+        and invalidates the prompt cache for the entire message history.
+        Billing-header system blocks are stripped from the top-level ``system``
+        field regardless of whether anything was hoisted."""
         messages = anthropic_messages_request.get("messages")
         if not isinstance(messages, list):
             return
-        system_role_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "system"]
-        if not system_role_messages:
-            return
-
-        anthropic_messages_request["messages"] = [
-            m for m in messages if not (isinstance(m, dict) and m.get("role") == "system")
-        ]
+        leading_count = next(
+            (i for i, m in enumerate(messages) if not (isinstance(m, dict) and m.get("role") == "system")),
+            len(messages),
+        )
+        if leading_count:
+            anthropic_messages_request["messages"] = messages[leading_count:]
         system_content = [
             block
             for source in (
                 anthropic_messages_request.get("system"),
-                *(m.get("content") for m in system_role_messages),
+                *(m.get("content") for m in messages[:leading_count]),
             )
             for block in self._as_system_content_blocks(source)
         ]

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -1974,6 +1974,79 @@ def test_bedrock_invoke_transform_merges_list_content_system_role_into_system():
     ]
 
 
+def test_bedrock_invoke_transform_keeps_mid_conversation_system_role_in_place():
+    """Regression test for the Bedrock prompt-cache collapse: hoisting a
+    mid-conversation ``role: "system"`` message (e.g. Claude Code's
+    ``mid-conversation-system-2026-04-07`` reminders) into the top-level
+    ``system`` field mutates the cache prefix and invalidates the cached message
+    history, so such entries must be forwarded in place. Invoke only rejects a
+    system entry at ``messages.0``. Billing-header blocks must still be stripped
+    from the top-level ``system`` field even when nothing is hoisted."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [
+        {"role": "user", "content": "read the file"},
+        {"role": "system", "content": "[Truncated: PARTIAL view of big1.txt]"},
+        {"role": "assistant", "content": "reading"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-8",
+        messages=copy.deepcopy(messages),
+        anthropic_messages_optional_request_params={
+            "max_tokens": 256,
+            "stream": False,
+            "system": [
+                {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.205;"},
+                {"type": "text", "text": "Base.", "cache_control": {"type": "ephemeral"}},
+            ],
+        },
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result["messages"] == messages
+    assert result["system"] == [
+        {"type": "text", "text": "Base.", "cache_control": {"type": "ephemeral"}}
+    ]
+
+
+def test_bedrock_invoke_transform_hoists_only_leading_system_run():
+    """Only the leading run of ``role: "system"`` messages is hoisted into the
+    top-level ``system`` field; a later system entry keeps its position in
+    ``messages`` so the serialized prefix stays stable across turns."""
+    from litellm.types.router import GenericLiteLLMParams
+
+    cfg = AmazonAnthropicClaudeMessagesConfig()
+    messages = [
+        {"role": "system", "content": "You are terse."},
+        {"role": "system", "content": "Cite sources."},
+        {"role": "user", "content": "hi"},
+        {"role": "system", "content": "mid-conversation reminder"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    result = cfg.transform_anthropic_messages_request(
+        model="anthropic.claude-opus-4-8",
+        messages=copy.deepcopy(messages),
+        anthropic_messages_optional_request_params={"max_tokens": 256, "stream": False},
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "system", "content": "mid-conversation reminder"},
+        {"role": "user", "content": "continue"},
+    ]
+    assert result["system"] == [
+        {"type": "text", "text": "You are terse."},
+        {"type": "text", "text": "Cite sources."},
+    ]
+
+
 def test_as_system_content_blocks_handles_each_shape():
     """``_as_system_content_blocks`` normalizes every system shape: ``None`` -> empty,
     a string -> a single text block, a list -> a shallow copy, and any other value


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs are live end to end against real Bedrock (`us.anthropic.claude-opus-4-8`, us-west-2) with Claude Code as the client, costing real $. The proxy config maps `claude-opus-4-8` to `bedrock/us.anthropic.claude-opus-4-8` with `aws_region_name: us-west-2`, i.e. the plain `bedrock/` prefix so `/v1/messages` traffic goes down the Invoke path

```bash
python litellm/proxy/proxy_cli.py --config repro_config.yaml --port 4000 --detailed_debug > proxy.log 2>&1
```

The client is a real Claude Code session that grows context from ~35k to ~250k input tokens across 13 API calls by reading three ~45k-token text files plus two small ones, all seconds apart (far under the 5m cache TTL):

```bash
ANTHROPIC_BASE_URL=http://127.0.0.1:4000 ANTHROPIC_AUTH_TOKEN=sk-repro-1234 \
claude -p "Read big1.txt fully, then big2.txt fully, then big3.txt fully, then small1.txt, then small2.txt. Use exactly one Read tool call at a time, waiting for each result before issuing the next. Do not summarize anything until all five files are read; after the fifth read, reply with exactly the word: done" \
  --allowedTools "Read" --model claude-opus-4-8
```

Per-call cache usage extracted from the `message_start` events in the debug log:

```bash
grep -o '"cache_read_input_tokens": *[0-9]*, "cache_creation": {"ephemeral_5m_input_tokens": *[0-9]*' proxy.log
```

Before, at 07aeaa17a0 (current `litellm_internal_staging` HEAD):

| call | cache_read | cache_creation |
|---|---|---|
| 1 | 0 | 37,312 |
| 2 | 33,436 | 35,328 |
| 3 | 68,764 | 283 |
| 4 | 69,047 | 25,975 |
| 5 | 95,022 | 12,062 |
| 6 | **33,436** | **105,078** |
| 7 | 138,514 | 25,986 |
| 8 | 164,500 | 12,053 |
| 9 | **33,436** | **174,727** |
| 10 | 208,163 | 25,961 |
| 11 | 234,124 | 12,056 |
| 12 | 246,180 | 2,719 |
| 13 | 248,899 | 2,736 |

Each bolded collapse coincides with Claude Code appending a new mid-conversation `role: "system"` message (a Read-truncation notice on call 6, a task-tool reminder on call 9), which the current code hoists into the top-level `system` field; the mutated `system` prefix invalidates the whole cached message history, so reads pin at the 33,436-token tools + system prefix and everything after re-writes at cache-write pricing

After, at b36ba99ea5 (this branch), identical session:

| call | cache_read | cache_creation |
|---|---|---|
| 1 | 34,534 | 0 |
| 2 | 34,534 | 34,126 |
| 3 | 68,660 | 467 |
| 4 | 69,127 | 19,098 |
| 5 | 88,225 | 18,940 |
| 6 | 107,165 | 31,104 |
| 7 | 138,269 | 19,094 |
| 8 | 157,363 | 19,084 |
| 9 | 176,447 | 31,280 |
| 10 | 207,727 | 19,096 |
| 11 | 226,823 | 19,088 |
| 12 | 245,911 | 2,719 |
| 13 | 248,630 | 2,732 |

Reads grow monotonically with zero collapses and the outbound payloads carry the mid-conversation system entries in place, which Bedrock accepts with 200s (call 1 reads 34,534 because an identical warm-cache run had finished minutes earlier)

Version bisect with the same session against PyPI wheels: v1.89.1 (no hoist, passes `role: "system"` through in place) grows monotonically 33,435 -> 248,685 with no collapses; v1.91.0 (first release with the hoist) collapses from 202,378 back to 33,436 with a 212,403-token re-write on the turn a new system message arrives

## Type

🐛 Bug Fix

## Changes

#31364 fixed a real 400 (`messages.0: use the top-level 'system' parameter for the initial system prompt`) by hoisting every `role: "system"` entry from `messages` into the top-level `system` field on the Bedrock Invoke `/v1/messages` path. Bedrock's actual validation, verified live with direct `invoke-model` calls against `us.anthropic.claude-opus-4-8`, rejects a system entry only at `messages.0` or when it neither immediately precedes an assistant message nor ends the array ("messages.N: role 'system' must precede an 'assistant' message or end the array"); mid-conversation system entries as Claude Code emits them via the `mid-conversation-system-2026-04-07` beta (task reminders and tool-output truncation notices, inserted before an assistant turn or trailing) satisfy that rule and are accepted in place, which pre-hoist LiteLLM through v1.90.x relied on in production. Hoisting them is destructive for prompt caching: `system` precedes `messages` in the cache prefix, so every newly appended mid-conversation system message mutates `system` and invalidates the cache for the entire message history, re-writing 100k+ tokens at cache-write pricing on long agentic sessions

This PR hoists only the leading run of system entries (the case Invoke actually rejects) and forwards mid-conversation ones untouched. Billing-header stripping from top-level `system` previously only ran as a side effect of the hoist; it now applies regardless, so `x-anthropic-billing-header` blocks still never reach Bedrock

Two regression tests are added: one asserts a mid-conversation system message stays in place while the top-level `system` field stays byte-identical (this is the cache-collapse regression) and still strips billing-header blocks, the other asserts a mixed conversation hoists exactly the leading run and preserves the position of a later system entry. Both fail on the pre-fix code

Note that this is only a fix for Invoke because Converse (when empirically tested), rejects `role: "system"` in `messages` at any position. We have always hoisted in Converse since December 2024 (`61b35c12bb`)