### PR TITLE
fix(proxy): sanitize per-key callback config out of logged metadata

### DIFF
--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -133,6 +133,15 @@ class LangsmithLogger(CustomBatchLogger):
             "dotted_order": metadata.get("dotted_order", None),
         }
 
+    def _redact_metadata(self, metadata: dict) -> dict:
+        # helper is shallow; also scrub nested requester_metadata since
+        # LangSmith forwards the whole dict into the run
+        redacted = redact_user_api_key_info(metadata=dict(metadata))
+        nested = redacted.get("requester_metadata")
+        if isinstance(nested, dict):
+            redacted["requester_metadata"] = redact_user_api_key_info(metadata=nested)
+        return redacted
+
     def _build_extra_metadata(self, metadata: Dict):
         extra_metadata = dict(metadata)
         requester_metadata = extra_metadata.get("requester_metadata")
@@ -141,13 +150,7 @@ class LangsmithLogger(CustomBatchLogger):
                 if key in requester_metadata and key not in extra_metadata:
                     extra_metadata[key] = requester_metadata[key]
 
-        # helper is shallow; also scrub nested requester_metadata since
-        # LangSmith forwards the whole dict into `extra`
-        extra_metadata = redact_user_api_key_info(metadata=extra_metadata)
-        nested = extra_metadata.get("requester_metadata")
-        if isinstance(nested, dict):
-            extra_metadata["requester_metadata"] = redact_user_api_key_info(metadata=nested)
-        return extra_metadata
+        return self._redact_metadata(extra_metadata)
 
     def _build_outputs_with_usage(self, payload: StandardLoggingPayload) -> Dict[str, Any]:
         response = payload["response"]
@@ -200,12 +203,13 @@ class LangsmithLogger(CustomBatchLogger):
 
             metadata = payload["metadata"]
             extra_metadata = self._build_extra_metadata(dict(metadata))
+            inputs = {**payload, "metadata": self._redact_metadata(dict(metadata))}
             outputs = self._build_outputs_with_usage(payload)
 
             data = {
                 "name": fields["run_name"],
                 "run_type": "llm",
-                "inputs": payload,
+                "inputs": inputs,
                 "outputs": outputs,
                 "session_name": fields["project_name"],
                 "start_time": payload["startTime"],

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5547,18 +5547,6 @@ def scrub_sensitive_keys_in_metadata(litellm_params: Optional[dict]):
             litellm_params["_langfuse_masking_function"] = masking_fn
         litellm_params["metadata"] = metadata
 
-    ## check user_api_key_metadata for sensitive logging keys
-    cleaned_user_api_key_metadata = {}
-    if "user_api_key_metadata" in metadata and isinstance(metadata["user_api_key_metadata"], dict):
-        for k, v in metadata["user_api_key_metadata"].items():
-            if k == "logging":  # prevent logging user logging keys
-                cleaned_user_api_key_metadata[k] = "scrubbed_by_litellm_for_sensitive_keys"
-            else:
-                cleaned_user_api_key_metadata[k] = v
-
-        metadata["user_api_key_metadata"] = cleaned_user_api_key_metadata
-        litellm_params["metadata"] = metadata
-
     return litellm_params
 
 

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -31,6 +31,10 @@ _EXTRA_SENSITIVE_CALLBACK_KEYS = {"gcs_path_service_account"}
 # already-encrypted input cheaply (no decrypt-attempt round trip) and
 # avoid double-encrypting if `LITELLM_SALT_KEY` is rotated between writes.
 _CALLBACK_VAR_ENCRYPTED_PREFIX = "litellm_enc::"
+# Metadata slots that hold operator-configured callback setup (and therefore
+# integration credentials). Resolved from UserAPIKeyAuth during pre-call setup,
+# never read back off the copies stamped into request metadata.
+_CALLBACK_CONFIG_SLOTS = frozenset({"logging", "callback_settings"})
 
 blue_color_code = "\033[94m"
 reset_color_code = "\033[0m"
@@ -545,6 +549,13 @@ def normalize_callback_names(callbacks: Iterable[Any]) -> List[Any]:
     if callbacks is None:
         return []
     return [c.lower() if isinstance(c, str) else c for c in callbacks]
+
+
+def strip_callback_config(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Return key/team metadata without the slots that carry callback credentials."""
+    if not isinstance(metadata, dict):
+        return metadata
+    return {k: v for k, v in metadata.items() if k not in _CALLBACK_CONFIG_SLOTS}
 
 
 def encrypt_callback_vars(metadata: Any) -> Any:

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -35,6 +35,7 @@ from litellm.proxy._types import (
 from litellm.proxy.common_utils.callback_utils import (
     decrypt_callback_vars,
     get_metadata_variable_name_from_kwargs,
+    strip_callback_config,
 )
 from litellm.proxy.common_utils.http_parsing_utils import _safe_get_request_headers
 
@@ -1032,7 +1033,7 @@ class LiteLLMProxyRequestSetup:
             user_api_key_budget_reset_at=(
                 user_api_key_dict.budget_reset_at.isoformat() if user_api_key_dict.budget_reset_at else None
             ),
-            user_api_key_auth_metadata=user_api_key_dict.metadata,
+            user_api_key_auth_metadata=strip_callback_config(user_api_key_dict.metadata),
         )
         return user_api_key_logged_metadata
 
@@ -1670,8 +1671,8 @@ async def add_litellm_data_to_request(
     data[_metadata_variable_name]["user_api_key_user_spend"] = user_api_key_dict.user_spend
     data[_metadata_variable_name]["user_api_key_user_max_budget"] = user_api_key_dict.user_max_budget
 
-    data[_metadata_variable_name]["user_api_key_metadata"] = user_api_key_dict.metadata
-    data[_metadata_variable_name]["user_api_key_team_metadata"] = user_api_key_dict.team_metadata
+    data[_metadata_variable_name]["user_api_key_metadata"] = strip_callback_config(user_api_key_dict.metadata)
+    data[_metadata_variable_name]["user_api_key_team_metadata"] = strip_callback_config(user_api_key_dict.team_metadata)
     data[_metadata_variable_name]["user_api_key_object_permission_id"] = getattr(
         user_api_key_dict, "object_permission_id", None
     )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -109,6 +109,7 @@ from litellm.proxy.common_utils.callback_utils import (
     is_sensitive_callback_key,
     normalize_callback_names,
     process_callback,
+    strip_callback_config,
 )
 from litellm.proxy.common_utils.realtime_utils import _realtime_request_body
 from litellm.router_utils.add_retry_fallback_headers import (
@@ -13375,7 +13376,7 @@ async def async_queue_request(
             # extra_body); see above for the same guard upstream.
             data["metadata"] = {}
         data["metadata"]["user_api_key"] = user_api_key_dict.api_key
-        data["metadata"]["user_api_key_metadata"] = user_api_key_dict.metadata
+        data["metadata"]["user_api_key_metadata"] = strip_callback_config(user_api_key_dict.metadata)
         _headers = _safe_get_request_headers(request).copy()
         _headers.pop("authorization", None)  # do not store the original `sk-..` api key in the db
         data["metadata"]["headers"] = _headers

--- a/tests/test_litellm/integrations/test_langsmith_init.py
+++ b/tests/test_litellm/integrations/test_langsmith_init.py
@@ -347,3 +347,90 @@ class TestLangsmithRedactUserApiKeyInfo:
         assert "user_api_key_user_id" not in nested
         assert nested["session_id"] == "sess-1"
         assert extra["session_id"] == "sess-1"
+
+    def test_redact_enabled_strips_user_api_key_info_from_inputs(self, reset_redact_flag):
+        """
+        Regression (LIT-4306): `inputs` is the whole StandardLoggingPayload, so
+        `redact_user_api_key_info` has to cover `inputs.metadata` the same way it
+        covers `extra` - including the nested `requester_metadata` copy. Before
+        the fix `extra` was redacted and `inputs` shipped every user_api_key_*
+        field verbatim.
+        """
+        litellm.redact_user_api_key_info = True
+        logger = self._logger()
+        metadata = self._metadata_with_user_api_key_fields()
+        metadata["user_api_key_auth_metadata"] = {"priority": "high"}
+        payload = {
+            "id": "run-1",
+            "response": {"choices": []},
+            "metadata": metadata,
+            "startTime": 1.0,
+            "endTime": 2.0,
+            "request_tags": [],
+            "error_str": None,
+            "status": "success",
+            "response_cost": 0.0,
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }
+        credentials = {
+            "LANGSMITH_API_KEY": "test-key",
+            "LANGSMITH_PROJECT": "test-project",
+            "LANGSMITH_BASE_URL": "https://api.smith.langchain.com",
+        }
+
+        data = logger._prepare_log_data(
+            kwargs={"litellm_params": {"metadata": metadata}, "standard_logging_object": payload},
+            response_obj=None,
+            start_time=1.0,
+            end_time=2.0,
+            credentials=credentials,
+        )
+
+        inputs_metadata = data["inputs"]["metadata"]
+        assert [k for k in inputs_metadata if k.startswith("user_api_key")] == []
+        assert [k for k in inputs_metadata["requester_metadata"] if k.startswith("user_api_key")] == []
+        # inputs and extra must agree - they go through the same redaction now
+        assert [k for k in data["extra"] if k.startswith("user_api_key")] == []
+        # non-identity payload is untouched
+        assert inputs_metadata["model"] == "gpt-4"
+        assert inputs_metadata["requester_metadata"]["session_id"] == "sess-1"
+        assert data["inputs"]["total_tokens"] == 2
+        # the shared standard_logging_object other loggers read is not mutated
+        assert "user_api_key_hash" in payload["metadata"]
+        assert "user_api_key_user_id" in payload["metadata"]["requester_metadata"]
+
+    def test_redact_disabled_keeps_user_api_key_info_in_inputs(self, reset_redact_flag):
+        """Flag off: the identity fields stay. The flag governs them, not this fix."""
+        litellm.redact_user_api_key_info = False
+        logger = self._logger()
+        metadata = self._metadata_with_user_api_key_fields()
+        payload = {
+            "id": "run-1",
+            "response": {"choices": []},
+            "metadata": metadata,
+            "startTime": 1.0,
+            "endTime": 2.0,
+            "request_tags": [],
+            "error_str": None,
+            "status": "success",
+            "response_cost": 0.0,
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }
+
+        data = logger._prepare_log_data(
+            kwargs={"litellm_params": {"metadata": metadata}, "standard_logging_object": payload},
+            response_obj=None,
+            start_time=1.0,
+            end_time=2.0,
+            credentials={
+                "LANGSMITH_API_KEY": "test-key",
+                "LANGSMITH_PROJECT": "test-project",
+                "LANGSMITH_BASE_URL": "https://api.smith.langchain.com",
+            },
+        )
+
+        assert data["inputs"]["metadata"]["user_api_key_hash"] == "abc123"

--- a/tests/test_litellm/proxy/common_utils/test_callback_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_callback_utils.py
@@ -18,6 +18,7 @@ from litellm.proxy.common_utils.callback_utils import (
     get_remaining_tokens_and_requests_from_request_data,
     normalize_callback_names,
     sanitize_openai_provider_metadata,
+    strip_callback_config,
 )
 import litellm
 
@@ -452,3 +453,41 @@ def test_initialize_callbacks_on_proxy_non_dict_callback_specific_params_root(
         )
     finally:
         litellm.callbacks = original_callbacks
+
+
+def test_strip_callback_config_drops_credential_bearing_slots():
+    """
+    `logging` and `callback_settings` hold operator-configured integration
+    credentials. Both must be dropped from the key/team metadata the proxy
+    stamps into request metadata, while every other field survives untouched
+    (`priority` is read back by the dynamic rate limiter, `guardrails` by the
+    guardrail hooks).
+    """
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_vars": {"langsmith_api_key": "litellm_enc::ciphertext"},
+            }
+        ],
+        "callback_settings": {"callback_vars": {"langfuse_secret_key": "litellm_enc::other"}},
+        "priority": "high",
+        "guardrails": ["presidio"],
+        "langsmith_provisioning": {"api_key_id": "prov-1"},
+    }
+
+    stripped = strip_callback_config(metadata)
+
+    assert "logging" not in stripped
+    assert "callback_settings" not in stripped
+    assert stripped["priority"] == "high"
+    assert stripped["guardrails"] == ["presidio"]
+    assert stripped["langsmith_provisioning"] == {"api_key_id": "prov-1"}
+    # the caller's dict (UserAPIKeyAuth.metadata) is shared state - never mutate it
+    assert "logging" in metadata
+    assert "callback_settings" in metadata
+
+
+@pytest.mark.parametrize("value", [None, "not-a-dict", 42])
+def test_strip_callback_config_passes_through_non_dicts(value):
+    assert strip_callback_config(value) is value

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5421,3 +5421,39 @@ async def test_overwrite_user_with_key_hash_rejects_alias_without_marker(monkeyp
     )
 
     assert updated_data["user"] == "caller-chosen-id"
+
+
+def test_get_sanitized_user_information_from_key_drops_callback_config():
+    """
+    Regression (LIT-4306): `user_api_key_auth_metadata` lands in the
+    StandardLoggingPayload every integration receives, so the per-key callback
+    config (and the integration credentials inside it) must not ride along.
+    Everything else - notably `priority`, which the dynamic rate limiter reads
+    back off this exact field - has to survive.
+    """
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test-key-hash",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "langsmith",
+                    "callback_vars": {"langsmith_api_key": "litellm_enc::ciphertext"},
+                }
+            ],
+            "callback_settings": {"callback_vars": {"langfuse_secret_key": "litellm_enc::other"}},
+            "priority": "high",
+        },
+    )
+
+    result = LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key(
+        user_api_key_dict=user_api_key_dict
+    )
+
+    auth_metadata = result["user_api_key_auth_metadata"]
+    assert "logging" not in auth_metadata
+    assert "callback_settings" not in auth_metadata
+    assert "litellm_enc::" not in json.dumps(auth_metadata)
+    assert auth_metadata["priority"] == "high"
+    # UserAPIKeyAuth is the live auth object; the per-key callbacks are resolved
+    # from it during pre-call, so it must not be mutated by building the log view
+    assert "logging" in (user_api_key_dict.metadata or {})


### PR DESCRIPTION
## TLDR

Problem this solves:

- `redact_user_api_key_info` never applied to LangSmith run `inputs`
- per-key callback config rode along in every logger's metadata
- three call sites stamped raw key metadata into request metadata

How it solves it:

- sanitize key/team metadata at those three sites
- one redaction helper shared by LangSmith `inputs` and `extra`

## Relevant issues

## Linear ticket

Resolves LIT-4306

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a live proxy making real Anthropic `claude-sonnet-5` calls, with `litellm_settings.redact_user_api_key_info: true` and a per-key LangSmith callback whose `langsmith_base_url` points at a local sink that records the exact `/runs/batch` body. Before = `b9b27c2beb` (the parent commit), after = `5e34e0460b` (this PR). The chat completion response is identical either way; the observable difference is what LiteLLM POSTs to LangSmith. Values below are placeholders

Setup, identical for both runs. Create a team and a key whose metadata carries per-key LangSmith callback config, matching the reported shape

```bash
TEAM=$(curl -s http://localhost:4001/team/new \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"team_alias":"repro-team","metadata":{"logging":[{"callback_name":"langsmith","callback_type":"success_and_failure","callback_vars":{"langsmith_api_key":"lsv2_sk_TEAMLEVEL_SECRET","langsmith_project":"team-proj","langsmith_base_url":"http://127.0.0.1:4002"}}]}}' | jq -r .team_id)

KEY=$(curl -s http://localhost:4001/key/generate \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d "{\"models\":[\"claude-sonnet-5\"],\"team_id\":\"$TEAM\",\"metadata\":{\"logging\":[{\"callback_name\":\"langsmith\",\"callback_type\":\"success_and_failure\",\"callback_vars\":{\"langsmith_api_key\":\"lsv2_sk_KEYLEVEL_SECRET\",\"langsmith_project\":\"key-proj\",\"langsmith_base_url\":\"http://127.0.0.1:4002\"}}],\"langsmith_provisioning\":{\"api_key_id\":\"prov-uuid-1\",\"api_key_short\":\"lsv2_sk_a365...33b2\"},\"priority\":\"high\"}}" | jq -r .key)
```

Chat with that key. HTTP 200 in both runs, response unchanged by this PR

```bash
curl -s http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","messages":[{"role":"user","content":"say hi in one word"}],"max_tokens":16}'
```
```json
{"id":"chatcmpl-...","object":"chat.completion","model":"claude-sonnet-5","choices":[{"index":0,"message":{"role":"assistant","content":"Hi!"}}],"usage":{...}}
```

Before, on `b9b27c2beb`. Every `user_api_key_*` field ships under `inputs.metadata` even though the flag is on, and `extra` is already clean, so the two disagree

```bash
jq -r '.body.post[0] | "inputs user_api_key_* : \([.inputs.metadata|keys[]|select(startswith("user_api_key"))]|length)",
                        "extra  user_api_key_* : \([.extra|keys[]|select(startswith("user_api_key"))]|length)"' sink-capture.jsonl
```
```
inputs user_api_key_* : 20
extra  user_api_key_* : 0
```

```bash
jq -c '.body.post[0].inputs.metadata.user_api_key_auth_metadata' sink-capture.jsonl
```
```json
{"logging":[{"callback_name":"langsmith","callback_type":"success_and_failure","callback_vars":{"langsmith_api_key":"litellm_enc::pt71BYmrVlJk...","langsmith_project":"key-proj","langsmith_base_url":"http://127.0.0.1:4002"}}],"priority":"high","langsmith_provisioning":{"api_key_id":"prov-uuid-1","api_key_short":"lsv2_sk_a365...33b2"}}
```

After, on `5e34e0460b`. `inputs` now agrees with `extra`, and the key's callback config is gone from what is logged

```
inputs user_api_key_* : 0
extra  user_api_key_* : 0
```

```bash
jq -c '.body.post[0].inputs.metadata | {team_id, team_alias, model: .model, requester_metadata}' sink-capture.jsonl
```
```json
{"team_id":"d842a11f-b749-4722-9227-0d8b1a1c5536","team_alias":"repro-team","requester_metadata":{}}
```

The second half is independent of the flag. Re-running with `redact_user_api_key_info: false`, the identity fields stay (that is what the flag governs) but the callback config no longer reaches the logged payload, and `priority`, which the dynamic rate limiter reads back off this exact field, is preserved

```bash
jq -c '.body.post[0].inputs.metadata.user_api_key_auth_metadata' sink-capture.jsonl
```
```json
{"priority":"high","langsmith_provisioning":{"api_key_id":"prov-uuid-1","api_key_short":"lsv2_sk_a365...33b2"}}
```

A key with no per-key logging config, and the team-level callback, both still log and still return 200 on the after run

## Type

🐛 Bug Fix

## Changes

`LiteLLMProxyRequestSetup.get_sanitized_user_information_from_key` copied `UserAPIKeyAuth.metadata` verbatim into `user_api_key_auth_metadata`, so the key's callback configuration, including the values inside `callback_vars`, reached the `StandardLoggingPayload` that every integration receives. `add_litellm_data_to_request` and `async_queue_request` stamped the same raw metadata into `user_api_key_metadata` and `user_api_key_team_metadata`. The existing scrub in `scrub_sensitive_keys_in_metadata` only matched the literal key `logging` under one of the two field names and never covered `callback_settings`, so it missed the field that actually reaches the payload

This adds `strip_callback_config` next to the callback_vars traversal that already lives in `common_utils/callback_utils.py`, and routes all three sites through it. It drops the `logging` and `callback_settings` slots and leaves everything else untouched, so `priority` for the dynamic rate limiter, `guardrails` for the guardrail hooks, and the Arize/Phoenix project overrides all keep working. Those two slots are resolved from `UserAPIKeyAuth` during pre-call setup and are never read back off the logged copies, so nothing downstream loses input. `litellm/proxy/utils.py` builds its payload through the same helper on the proxy-error path and inherits this. With the source sanitized the old scrub is dead, so it is removed

Separately, LangSmith set the run's `inputs` to the raw `StandardLoggingPayload` while redacting only `extra`. `redact_user_api_key_info` therefore left the whole `user_api_key_*` family in `inputs.metadata`, and the nested `requester_metadata` handling that `extra` had was not applied there either. Both now go through one `_redact_metadata` helper, which is what keeps them from drifting apart again

Tests cover both halves and fail on the parent commit: `strip_callback_config` drops the two slots without mutating the caller's dict, `get_sanitized_user_information_from_key` keeps `priority` while dropping the callback config, and `_prepare_log_data` with the flag on leaves no `user_api_key_*` field in either `inputs.metadata` or its nested `requester_metadata` while leaving the shared `standard_logging_object` unmutated

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
