### PR TITLE
fix(router): run cooldown callback on every failed deployment attempt (#32574)

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2752,18 +2752,34 @@ class Logging(LiteLLMLoggingBaseClass):
 
     def failure_handler(self, exception, traceback_exception, start_time=None, end_time=None):
         verbose_logger.debug(f"Logging Details LiteLLM-Failure Call: {litellm.failure_callback}")
-        if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
-            return
-        litellm_params = self.model_call_details.get("litellm_params", {})
-        is_sync_request = self._is_sync_litellm_request(litellm_params)
-
         try:
+            # Always refresh failure context so the current deployment's exception
+            # is available even when observability callbacks are deduplicated.
             start_time, end_time = self._failure_handler_helper_fn(
                 exception=exception,
                 traceback_exception=traceback_exception,
                 start_time=start_time,
                 end_time=end_time,
             )
+
+            # Router cooldown is routing infrastructure, not observability.
+            # It must run once per failed deployment attempt even when the shared
+            # Logging object reuses has_logged_sync_failure across retries/fallbacks.
+            for callback in litellm.failure_callback or []:
+                if self._get_callback_name(callback) == "deployment_callback_on_failure" and callable(callback):
+                    callback(
+                        self.model_call_details,
+                        None,
+                        start_time,
+                        end_time,
+                    )
+
+            if not self.should_run_logging(event_type="sync_failure"):  # prevent double logging
+                return
+
+            litellm_params = self.model_call_details.get("litellm_params", {})
+            is_sync_request = self._is_sync_litellm_request(litellm_params)
+
             callbacks = self.get_combined_callback_list(
                 dynamic_success_callbacks=self.dynamic_failure_callbacks,
                 global_callbacks=litellm.failure_callback,
@@ -2778,6 +2794,9 @@ class Logging(LiteLLMLoggingBaseClass):
             self.has_run_logging(event_type="sync_failure")
             for callback in callbacks:
                 try:
+                    # Already invoked above so cooldown is not double-counted.
+                    if self._get_callback_name(callback) == "deployment_callback_on_failure":
+                        continue
                     should_run = self.should_run_callback(
                         callback=callback,
                         litellm_params=litellm_params,
@@ -3112,6 +3131,7 @@ class Logging(LiteLLMLoggingBaseClass):
             "_PROXY",
             "_service_logger.ServiceLogging",
             "sync_deployment_callback_on_success",
+            "deployment_callback_on_failure",
         ]
         if isinstance(cb, str):
             return False

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3131,7 +3131,6 @@ class Logging(LiteLLMLoggingBaseClass):
             "_PROXY",
             "_service_logger.ServiceLogging",
             "sync_deployment_callback_on_success",
-            "deployment_callback_on_failure",
         ]
         if isinstance(cb, str):
             return False

--- a/tests/router_unit_tests/test_router_cooldown_failure_dedup.py
+++ b/tests/router_unit_tests/test_router_cooldown_failure_dedup.py
@@ -1,0 +1,151 @@
+"""
+Regression for #32574:
+
+Router retries/fallbacks reuse the same Logging object. Observability failure
+callbacks are correctly deduplicated via has_logged_sync_failure, but
+deployment_callback_on_failure must still run for every failed deployment so
+cooldown state stays correct.
+"""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.litellm_core_utils.litellm_logging import Logging as LitellmLogging
+from litellm.router_utils.cooldown_handlers import _async_get_cooldown_deployments
+
+
+def _make_logging_obj() -> LitellmLogging:
+    return LitellmLogging(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="cooldown-dedup-test",
+        function_id="cooldown-dedup-test",
+    )
+
+
+def test_failure_handler_runs_cooldown_callback_on_each_attempt():
+    """Cooldown callback runs per attempt; observability callbacks stay deduped."""
+    logging_obj = _make_logging_obj()
+
+    cooldown_calls = []
+    observability_calls = []
+
+    def deployment_callback_on_failure(kwargs, completion_response, start_time, end_time):
+        cooldown_calls.append(kwargs.get("litellm_params", {}).get("model_info", {}).get("id"))
+
+    def observability_failure_callback(kwargs, completion_response, start_time, end_time):
+        observability_calls.append(True)
+
+    original_failure_callback = litellm.failure_callback
+    try:
+        litellm.failure_callback = [
+            deployment_callback_on_failure,
+            observability_failure_callback,
+        ]
+
+        # Attempt 1 — deployment A
+        logging_obj.model_call_details["litellm_params"] = {
+            "model_info": {"id": "deployment-a"},
+            "metadata": {"model_group": "test-group"},
+        }
+        logging_obj.failure_handler(
+            exception=Exception("A failed"),
+            traceback_exception="traceback-a",
+        )
+
+        # Attempt 2 — same Logging object, deployment B (would be skipped by dedup)
+        logging_obj.model_call_details["litellm_params"] = {
+            "model_info": {"id": "deployment-b"},
+            "metadata": {"model_group": "test-group"},
+        }
+        logging_obj.failure_handler(
+            exception=Exception("B failed"),
+            traceback_exception="traceback-b",
+        )
+
+        assert cooldown_calls == ["deployment-a", "deployment-b"]
+        assert len(observability_calls) == 1
+        assert logging_obj.should_run_logging(event_type="sync_failure") is False
+    finally:
+        litellm.failure_callback = original_failure_callback
+
+
+def test_deployment_callback_on_failure_is_internal_callback():
+    logging_obj = _make_logging_obj()
+    mock_cb = MagicMock()
+    mock_cb.__name__ = "deployment_callback_on_failure"
+    assert logging_obj._is_internal_litellm_proxy_callback(mock_cb) is True
+
+
+@pytest.mark.asyncio
+async def test_router_cools_down_each_failed_deployment_across_retries():
+    """End-to-end: each failed deployment in one request is added to cooldown."""
+    deployment_a = "deployment-a"
+    deployment_b = "deployment-b"
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "test-group",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "mock-key-a",
+                },
+                "model_info": {"id": deployment_a},
+            },
+            {
+                "model_name": "test-group",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "mock-key-b",
+                },
+                "model_info": {"id": deployment_b},
+            },
+        ],
+        num_retries=1,
+        allowed_fails=0,
+        cooldown_time=60,
+    )
+
+    rate_limit_error = litellm.RateLimitError(
+        message="upstream throttled",
+        llm_provider="openai",
+        model="openai/gpt-4o-mini",
+        response=httpx.Response(
+            status_code=429,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        ),
+    )
+
+    from unittest.mock import patch
+
+    with patch(
+        "litellm.llms.openai.openai.OpenAIChatCompletion.acompletion",
+        side_effect=rate_limit_error,
+    ):
+        with pytest.raises(litellm.RateLimitError):
+            await router.acompletion(
+                model="test-group",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    cooldown_ids = await _async_get_cooldown_deployments(
+        litellm_router_instance=router, parent_otel_span=None
+    )
+    assert deployment_a in cooldown_ids, (
+        f"Expected {deployment_a!r} in cooldown; got {cooldown_ids}"
+    )
+    assert deployment_b in cooldown_ids, (
+        f"Expected {deployment_b!r} in cooldown; got {cooldown_ids}"
+    )

--- a/tests/router_unit_tests/test_router_cooldown_failure_dedup.py
+++ b/tests/router_unit_tests/test_router_cooldown_failure_dedup.py
@@ -10,7 +10,6 @@ cooldown state stays correct.
 import os
 import sys
 import time
-from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -79,13 +78,6 @@ def test_failure_handler_runs_cooldown_callback_on_each_attempt():
         assert logging_obj.should_run_logging(event_type="sync_failure") is False
     finally:
         litellm.failure_callback = original_failure_callback
-
-
-def test_deployment_callback_on_failure_is_internal_callback():
-    logging_obj = _make_logging_obj()
-    mock_cb = MagicMock()
-    mock_cb.__name__ = "deployment_callback_on_failure"
-    assert logging_obj._is_internal_litellm_proxy_callback(mock_cb) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Router retries/fallbacks reuse the same `Logging` object, so `sync_failure` dedup in `failure_handler` skipped `deployment_callback_on_failure` after the first failure and left later failed deployments out of cooldown.
- Always invoke `deployment_callback_on_failure` before the dedup guard (routing infrastructure), while keeping observability failure callbacks once-per-request.
- Mark `deployment_callback_on_failure` as an internal callback alongside `sync_deployment_callback_on_success`.

Fixes #32574

## Test plan
- [x] `uv run pytest tests/router_unit_tests/test_router_cooldown_failure_dedup.py -v`
- [x] Nearby tests: `test_deployment_callback_on_failure`, `test_deployment_callback_respects_cooldown_time`, `test_logging_prevent_double_logging`, `test_responses_api_rate_limit_marks_deployment_for_cooldown`
- [ ] Manual: Router with 2 deployments in one group, both returning 429, `num_retries=1` — both deployment IDs should appear in cooldown after the request fails

