### PR TITLE
refactor(otel): move litellm error detail keys under the litellm.* namespace

### DIFF
--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -147,24 +147,21 @@ class Error:
     """OTel-defined error attribute keys, from the semconv ``error.*`` registry.
     ``MESSAGE`` is marked *Deprecated* upstream in favor of domain-specific
     error message keys plus ``exception.message`` on the exception event, but
-    is still defined and stamped by litellm's v1 integration; keeping it here
-    for byte-for-byte parity."""
+    litellm still stamps it."""
 
     TYPE: Final = "error.type"
     MESSAGE: Final = "error.message"
 
 
 class LiteLLMError:
-    """LiteLLM-specific error attribute keys. Emitted under the ``error.*``
-    namespace (not ``litellm.*``) for byte-for-byte compat with the v1
-    integration in ``opentelemetry.py``; consumers reading these keys on v1
-    spans read the same keys on v2 spans. OTel semconv does not define any of
-    these three, and per its extension rules a namespace may carry additional
-    vendor keys as long as they don't collide with defined names."""
+    """Detail keys for the mapped provider exception of a failed LLM call.
+    OTel semconv does not define these, so they live under the ``litellm.*``
+    vendor namespace rather than squatting on the semconv-owned ``error.*``
+    namespace."""
 
-    CODE: Final = "error.code"
-    STACK_TRACE: Final = "error.stack_trace"
-    LLM_PROVIDER: Final = "error.llm_provider"
+    CODE: Final = "litellm.provider.error.code"
+    STACK_TRACE: Final = "litellm.provider.error.stack_trace"
+    LLM_PROVIDER: Final = "litellm.provider.error.llm_provider"
 
 
 class ExceptionEvent:

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -604,8 +604,7 @@ def test_error_details_stamped_as_span_attributes_for_labels_ingest():
     """OTel-defined keys and litellm-specific detail keys both ride span
     attributes so backends that flatten attrs into label indexes (Elastic APM
     ``labels.*``, Datadog span tags) render them. The exception event with the
-    full untruncated message stays alongside — both places, matching v1's
-    shape."""
+    full untruncated message stays alongside."""
     from litellm.integrations.otel.model.semconv import Error, ExceptionEvent, LiteLLMError
     from litellm.integrations.otel.emitter import SpanEmitter
 
@@ -638,8 +637,8 @@ def test_error_details_stamped_as_span_attributes_for_labels_ingest():
     # OTel-defined keys (from the ``error.*`` semconv registry).
     assert span.attributes[Error.TYPE] == "litellm.BadRequestError"
     assert span.attributes[Error.MESSAGE] == "400: violated moderation policy"
-    # LiteLLM-specific detail keys — vendor-namespaced under ``error.*``
-    # for v1-parity, not defined by OTel semconv.
+    # LiteLLM-specific detail keys, under the ``litellm.provider.error.*``
+    # vendor namespace, not defined by OTel semconv.
     assert span.attributes[LiteLLMError.CODE] == "400"
     assert span.attributes[LiteLLMError.STACK_TRACE] == "File proxy_server.py line 8570 ..."
     assert span.attributes[LiteLLMError.LLM_PROVIDER] == "openai"
@@ -666,19 +665,18 @@ def test_error_details_omitted_when_span_error_carries_only_message():
     assert LiteLLMError.LLM_PROVIDER not in span.attributes
 
 
-def test_v2_error_attribute_keys_match_v1_error_attributes_byte_for_byte():
-    """v1 (``opentelemetry.py``) and v2 (``otel/`` package) stamp identical
-    span-attribute keys so consumers reading ``labels.error_message`` don't
-    care which integration produced the span. Renaming either side is a
-    breaking change for downstream dashboards; this test locks the vocabulary."""
-    from litellm.integrations._types.open_inference import ErrorAttributes
+def test_error_attribute_keys_are_pinned():
+    """``error.type`` and ``error.message`` come from the semconv ``error.*``
+    registry; the litellm-specific detail keys are vendor keys under
+    ``litellm.provider.error.*``. Pins the exact strings so the emitted
+    vocabulary can't drift silently."""
     from litellm.integrations.otel.model.semconv import Error, LiteLLMError
 
-    assert Error.TYPE == ErrorAttributes.ERROR_TYPE
-    assert Error.MESSAGE == ErrorAttributes.ERROR_MESSAGE
-    assert LiteLLMError.CODE == ErrorAttributes.ERROR_CODE
-    assert LiteLLMError.STACK_TRACE == ErrorAttributes.ERROR_STACK_TRACE
-    assert LiteLLMError.LLM_PROVIDER == ErrorAttributes.ERROR_LLM_PROVIDER
+    assert Error.TYPE == "error.type"
+    assert Error.MESSAGE == "error.message"
+    assert LiteLLMError.CODE == "litellm.provider.error.code"
+    assert LiteLLMError.STACK_TRACE == "litellm.provider.error.stack_trace"
+    assert LiteLLMError.LLM_PROVIDER == "litellm.provider.error.llm_provider"
 
 
 def test_error_message_falls_back_to_error_type_when_message_absent():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -147,8 +147,6 @@ def test_attribute_keys_are_unique_across_namespaces():
     from litellm.integrations.otel import MCP, Client, JsonRpc, LiteLLMError, Network
 
     # prefixes are allowed to be substrings; exact keys must not collide.
-    # ``LiteLLMError`` shares the ``error.*`` prefix with ``Error`` by design
-    # (v1-parity); the assert below is the guarantee they never overlap.
     exact = set()
     for cls in (GenAI, Error, LiteLLMError, Server, HTTP, DB, MCP, JsonRpc, Network, Client):
         for key in _all_constants(cls):


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy with the v2 OTel integration and console exporter, hitting the real OpenAI API. The request is oversized on purpose so OpenAI returns a 400 and the proxy emits an error span:

```bash
LITELLM_OTEL_V2=true OTEL_EXPORTER=console python litellm/proxy/proxy_cli.py --config config.yaml --port 4187

curl -sS http://localhost:4187/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 999999999}'
```

Before (captured at 142d5aa12b), the litellm-specific detail keys squat on the semconv `error.*` namespace:

```json
"error.type": "BadRequestError",
"error.message": "litellm.BadRequestError: OpenAIException - max_tokens is too large: 999999999. ...",
"error.code": "invalid_value",
"error.stack_trace": "  File \"litellm/utils.py\", line 1689, in wrapper_async ...",
"error.llm_provider": "openai"
```

After (captured at 6258d317e4), the same span carries them under the `litellm.*` vendor namespace while the semconv-defined `error.type` and `error.message` stay put:

```json
"error.type": "BadRequestError",
"error.message": "litellm.BadRequestError: OpenAIException - max_tokens is too large: 999999999. ...",
"litellm.provider.error.code": "invalid_value",
"litellm.provider.error.stack_trace": "  File \"litellm/utils.py\", line 1689, in wrapper_async ...",
"litellm.provider.error.llm_provider": "openai"
```

## Type

🧹 Refactoring

## Changes

The v2 OTel integration stamped its litellm-specific error detail attributes as `error.code`, `error.stack_trace`, and `error.llm_provider`, which places vendor keys inside the semconv-owned `error.*` namespace. This PR moves them to `litellm.provider.error.code`, `litellm.provider.error.stack_trace`, and `litellm.provider.error.llm_provider`, alongside the rest of the `litellm.*` vendor-extension keys. These details describe the mapped provider exception of a failed LLM call, hence the `litellm.provider.error.*` prefix. The semconv-defined `error.type` and `error.message` are unchanged

The `test_error_attribute_keys_are_pinned` test pins all five key strings as literals so the vocabulary cannot drift silently; it fails on the previous `error.*` values

This changes the keys emitted on v2 spans, so any dashboard reading the old detail keys off v2 spans would need updating. The v2 integration is gated behind the `LITELLM_OTEL_V2` env flag and has no public docs yet, so real-world exposure is minimal; the v1 integration keeps emitting the old keys and its tests are untouched
